### PR TITLE
Use gofmt -s for formatting

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -40,7 +40,7 @@
     "exec": {
         "cwd": "${configDir}",
         "commands": [
-            { "command": "gofmt", "exts": ["go"] }
+            { "command": "gofmt -s", "exts": ["go"] }
         ]
     },
     "excludes": [

--- a/internal/compiler/checker.go
+++ b/internal/compiler/checker.go
@@ -3585,7 +3585,7 @@ func (c *Checker) resolveObjectTypeMembers(t *Type, source *Type, typeParameters
 			if instantiatedBaseType != c.anyType {
 				inheritedIndexInfos = c.getIndexInfosOfType(instantiatedBaseType)
 			} else {
-				inheritedIndexInfos = []*IndexInfo{&IndexInfo{keyType: c.stringType, valueType: c.anyType}}
+				inheritedIndexInfos = []*IndexInfo{{keyType: c.stringType, valueType: c.anyType}}
 			}
 			indexInfos = concatenate(indexInfos, filter(inheritedIndexInfos, func(info *IndexInfo) bool {
 				return findIndexInfo(indexInfos, info.keyType) != nil


### PR DESCRIPTION
`-s` is "simplify", which removes unnecessary syntax.