### PR TITLE
Make 'tidy' job required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,7 @@ jobs:
       - lint
       - format
       - generate
+      - tidy
 
     steps:
       - name: Check required jobs


### PR DESCRIPTION
I mistakenly forgot to mark this job as required.