### PR TITLE
Perform shallow clones on the TypeScript submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,5 @@
 [submodule "_submodules/TypeScript"]
 	path = _submodules/TypeScript
 	url = https://github.com/microsoft/TypeScript.git
+	shallow = true
+


### PR DESCRIPTION
This should make clones of the TypeScript repo way quicker, since we really don't need full history available.