### PR TITLE
Replace exists with explicit nil check

### DIFF
--- a/internal/compiler/ast.go
+++ b/internal/compiler/ast.go
@@ -1,7 +1,5 @@
 package compiler
 
-import "reflect"
-
 // Visitor
 
 type Visitor func(*Node) bool
@@ -20,12 +18,6 @@ func visitNodes(v Visitor, nodes []*Node) bool {
 		}
 	}
 	return false
-}
-
-// In situations where conversions from a pointer type may produce a typed nil, this function can be used
-// to check that the interface truly references an existing struct.
-func exists(i interface{}) bool {
-	return !(i == nil || reflect.ValueOf(i).IsNil())
 }
 
 // NodeFactory

--- a/internal/compiler/binder.go
+++ b/internal/compiler/binder.go
@@ -572,7 +572,7 @@ func finishFlowLabel(label *FlowLabel) *FlowNode {
 }
 
 func (b *Binder) bind(node *Node) bool {
-	if !exists(node) {
+	if node == nil {
 		return false
 	}
 	node.parent = b.parent

--- a/internal/compiler/utilities.go
+++ b/internal/compiler/utilities.go
@@ -1000,7 +1000,7 @@ func isClassLike(node *Node) bool {
 }
 
 func declarationNameToString(name *Node) string {
-	if !exists(name) || name.Pos() == name.End() {
+	if name == nil || name.Pos() == name.End() {
 		return "(Missing)"
 	}
 	return getTextOfNode(name)


### PR DESCRIPTION
This function was useful when we were using interfaces and didn't want to care about boxing nil, but now we're all concrete so I don't think we need this function anymore.

This saves a good 5% in bind.

```
goos: linux
goarch: amd64
pkg: github.com/microsoft/typescript-go/internal/compiler
cpu: Intel(R) Core(TM) i9-10900K CPU @ 3.70GHz
         │   old.txt   │              new.txt               │
         │   sec/op    │   sec/op     vs base               │
Bind-20    24.58m ± 1%   23.45m ± 2%  -4.58% (p=0.000 n=10)
Parse-20   45.97m ± 1%   46.25m ± 3%       ~ (p=0.063 n=10)
geomean    33.61m        32.93m       -2.01%

         │   old.txt    │               new.txt               │
         │     B/op     │     B/op      vs base               │
Bind-20    9.776Mi ± 0%   9.776Mi ± 0%       ~ (p=0.912 n=10)
Parse-20   23.59Mi ± 0%   23.59Mi ± 0%       ~ (p=0.684 n=10)
geomean    15.19Mi        15.19Mi       +0.00%

         │   old.txt   │              new.txt               │
         │  allocs/op  │  allocs/op   vs base               │
Bind-20    102.6k ± 0%   102.6k ± 0%       ~ (p=0.670 n=10)
Parse-20   239.1k ± 0%   239.1k ± 0%       ~ (p=0.896 n=10)
geomean    156.6k        156.6k       -0.00%
```