### PR TITLE
Capture bind method just once

### DIFF
--- a/internal/compiler/binder.go
+++ b/internal/compiler/binder.go
@@ -63,6 +63,7 @@ type Binder struct {
 	flowNodePool           Pool[FlowNode]
 	flowListPool           Pool[FlowList]
 	singleDeclarations     []*Node
+	bind_                  func(node *Node) bool
 }
 
 type ModuleInstanceState int32
@@ -1692,7 +1693,10 @@ func (b *Binder) bindChildren(node *Node) {
 }
 
 func (b *Binder) bindEachChild(node *Node) {
-	node.ForEachChild(b.bind)
+	if b.bind_ == nil {
+		b.bind_ = b.bind
+	}
+	node.ForEachChild(b.bind_)
 }
 
 func (b *Binder) bindEachExpression(nodes []*Node) {


### PR DESCRIPTION
I was profiling the benchmarks from #5; one thing that stuck out to me was that the most allocations happened here:

![image](https://github.com/user-attachments/assets/8bb44bd6-ab9e-4197-8853-158ee4ef6fe7)

This is weird, why would that line allocate? Then I remembered the cost of bound method wrappers... By binding `b.bind` with a receiver just once, we avoid quite literally 86% of all allocations during bind, save 14% of the memory, and save 17% of the time.

```
goos: linux
goarch: amd64
pkg: github.com/microsoft/typescript-go/internal/compiler
cpu: Intel(R) Core(TM) i9-10900K CPU @ 3.70GHz
         │   old.txt   │               new.txt               │
         │   sec/op    │   sec/op     vs base                │
Bind-20    24.74m ± 2%   20.55m ± 1%  -16.94% (p=0.000 n=10)
Parse-20   46.17m ± 1%   46.07m ± 2%        ~ (p=0.684 n=10)
geomean    33.80m        30.77m        -8.96%

         │   old.txt    │               new.txt                │
         │     B/op     │     B/op      vs base                │
Bind-20    9.776Mi ± 0%   8.420Mi ± 0%  -13.87% (p=0.000 n=10)
Parse-20   23.59Mi ± 0%   23.59Mi ± 0%        ~ (p=0.579 n=10)
geomean    15.19Mi        14.09Mi        -7.19%

         │   old.txt    │               new.txt               │
         │  allocs/op   │  allocs/op   vs base                │
Bind-20    102.56k ± 0%   13.69k ± 0%  -86.65% (p=0.000 n=10)
Parse-20    239.1k ± 0%   239.1k ± 0%        ~ (p=0.537 n=10)
geomean     156.6k        57.22k       -63.46%
```

This PR is in no way final (I just made the "zero value" usable, not that it is already without `bindSourceFile`), but it really shows the cost of binding methods like this.