### PR TITLE
Fix TaggedTemplateExpression's factory: wrong kind returned

### DIFF
--- a/internal/compiler/ast.go
+++ b/internal/compiler/ast.go
@@ -2878,7 +2878,7 @@ func (f *NodeFactory) NewTaggedTemplateExpression(tag *Node, questionDotToken *N
 	data.questionDotToken = questionDotToken
 	data.typeArguments = typeArguments
 	data.template = template
-	node := f.NewNode(SyntaxKindTemplateExpression, data)
+	node := f.NewNode(SyntaxKindTaggedTemplateExpression, data)
 	node.flags |= flags & NodeFlagsOptionalChain
 	return node
 }


### PR DESCRIPTION
another one from the tests