### PR TITLE
Convert runtime.Caller filename slashes

### DIFF
--- a/internal/repo/paths.go
+++ b/internal/repo/paths.go
@@ -15,6 +15,7 @@ func init() {
 	if !ok {
 		panic("could not get current filename")
 	}
+	filename = filepath.FromSlash(filename) // runtime.Caller always returns forward slashes; https://go.dev/issues/3335, https://go.dev/cl/603275
 	RootPath = findGoMod(filepath.Dir(filename))
 	TypeScriptSubmodulePath = filepath.Join(RootPath, "_submodules", "TypeScript")
 	TestDataPath = filepath.Join(RootPath, "testdata")


### PR DESCRIPTION
I saw https://go-review.googlesource.com/c/go/+/603275 go in just today; `runtime.Caller` returns `/` separated paths regardless of platform, so It'd be best to convert them to platform specific paths for consistency.

Technically, Windows can do both, but it is moderately odd to have it set paths to something like:

`D:/work/typescript-go\_submodules\TypeScript\...`