### PR TITLE
Fail in CI if files are modified/added/removed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - run: npx hereby test --race
 
       - run: git add .
-      - run: git diff --exit-code
+      - run: git diff --exit-code --stat
 
   lint:
     runs-on: ubuntu-latest
@@ -103,7 +103,7 @@ jobs:
       - run: npx hereby generate
 
       - run: git add .
-      - run: git diff --exit-code
+      - run: git diff --exit-code --stat
 
   tidy:
     runs-on: ubuntu-latest
@@ -116,7 +116,7 @@ jobs:
       - run: go mod tidy
 
       - run: git add .
-      - run: git diff --exit-code
+      - run: git diff --exit-code --stat
 
   required:
     runs-on: ubuntu-latest


### PR DESCRIPTION
To ensure all files are up to date, and we are not forgetting any gitignores, etc, error in CI if test/generate/tidy update anything.