### PR TITLE
Verify that tests pass even without TS submodule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           - os: ubuntu-latest
             submodules: false
 
-    name: Test on ${{ matrix.os }}${{ (!matrix.submodules && ' without submodules') || '' }}
+    name: test (${{ matrix.os }}${{ (!matrix.submodules && ' without submodules') || '' }})
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
This is a good invariant to have; tests which want to touch the subrepo should skip instead.