### PR TITLE
isIdentifierPart should not allow colon or dash

### DIFF
--- a/internal/compiler/scanner.go
+++ b/internal/compiler/scanner.go
@@ -818,7 +818,7 @@ func (s *Scanner) ReScanSlashToken() SyntaxKind {
 		}
 		for {
 			ch, size := s.charAndSize()
-			if size == 0 || !isIdentifierPart(ch, s.languageVersion, s.languageVariant) {
+			if size == 0 || !isIdentifierPart(ch, s.languageVersion) {
 				break
 			}
 			s.pos += size
@@ -978,7 +978,7 @@ func (s *Scanner) scanIdentifier(prefixLength int) bool {
 		for {
 			s.pos += size
 			ch, size = s.charAndSize()
-			if !isIdentifierPart(ch, s.languageVersion, s.languageVariant) {
+			if !isIdentifierPart(ch, s.languageVersion) {
 				break
 			}
 		}
@@ -996,13 +996,13 @@ func (s *Scanner) scanIdentifierParts() string {
 	start := s.pos
 	for {
 		ch, size := s.charAndSize()
-		if isIdentifierPart(ch, s.languageVersion, s.languageVariant) {
+		if isIdentifierPart(ch, s.languageVersion) {
 			s.pos += size
 			continue
 		}
 		if ch == '\\' {
 			escaped := s.peekUnicodeEscape()
-			if escaped >= 0 && isIdentifierPart(escaped, s.languageVersion, s.languageVariant) {
+			if escaped >= 0 && isIdentifierPart(escaped, s.languageVersion) {
 				sb.WriteString(s.text[start:s.pos])
 				sb.WriteString(string(s.scanUnicodeEscape(true)))
 				start = s.pos
@@ -1210,7 +1210,7 @@ func (s *Scanner) scanEscapeSequence(flags EscapeSequenceScanningFlags) string {
 		// case CharacterCodes.paragraphSeparator !!!
 		return ""
 	default:
-		if flags&EscapeSequenceScanningFlagsAnyUnicodeMode != 0 || flags&EscapeSequenceScanningFlagsRegularExpression != 0 && flags&EscapeSequenceScanningFlagsAnnexB == 0 && isIdentifierPart(ch, s.languageVersion, LanguageVariantStandard) {
+		if flags&EscapeSequenceScanningFlagsAnyUnicodeMode != 0 || flags&EscapeSequenceScanningFlagsRegularExpression != 0 && flags&EscapeSequenceScanningFlagsAnnexB == 0 && isIdentifierPart(ch, s.languageVersion) {
 			s.errorAt(diagnostics.This_character_cannot_be_escaped_in_a_regular_expression, s.pos-2, 2)
 		}
 		return string(rune(ch))
@@ -1600,11 +1600,8 @@ func isIdentifierStart(ch rune, languageVersion ScriptTarget) bool {
 	return isASCIILetter(ch) || ch == '_' || ch == '$' || ch > 0x7F && isUnicodeIdentifierStart(ch, languageVersion)
 }
 
-func isIdentifierPart(ch rune, languageVersion ScriptTarget, identifierVariant LanguageVariant) bool {
-	return isWordCharacter(ch) || ch == '$' ||
-		// "-" and ":" are valid in JSX Identifiers
-		identifierVariant == LanguageVariantJSX && (ch == '-' || ch == ':') ||
-		ch > 0x7F && isUnicodeIdentifierPart(ch, languageVersion)
+func isIdentifierPart(ch rune, languageVersion ScriptTarget) bool {
+	return isWordCharacter(ch) || ch == '$' || ch > 0x7F && isUnicodeIdentifierPart(ch, languageVersion)
 }
 
 func isUnicodeIdentifierStart(ch rune, languageVersion ScriptTarget) bool {


### PR DESCRIPTION
tsgo incorrectly lexes non-ascii identifiers followed by colon as a single identifier -- in non-TS files only. That is, 'x:' instead of 'x' ':' (where x is non-ascii). This is incorrect in some, probably most, cases. The place I noticed it was an object literal:

```ts
f({ 県: '大阪府' });
```

That's because `isIdentifierPart` allows colon in identifiers for JSX when languageVariant is provided.
However, in tsc, languageVariant is optional and is only provided in 3 calls from services. All other calls disallow colon, even in JSX files. In tsgo, languageVariant is always provided, and non-TS files are treated as JSX.

isIdentifierPart should not allow colons and dashes, and the calls from services should check for JSX another way. It's likely that the checks are unneeded in the first place.

I haven't checked in a test with this PR. A type or symbol baseline will easily display it when we have those, and the test case I provided above shows it off.
