### PR TITLE
Fix missing break statement in ParseJSONText

### DIFF
--- a/internal/compiler/parser.go
+++ b/internal/compiler/parser.go
@@ -94,6 +94,7 @@ func ParseJSONText(fileName string, sourceText string) *SourceFile {
 		case SyntaxKindNumericLiteral, SyntaxKindStringLiteral:
 			if p.lookAhead(func() bool { return p.nextToken() != SyntaxKindColonToken }) {
 				expression = p.parseLiteralExpression()
+				break
 			}
 			fallthrough
 		default:


### PR DESCRIPTION
In working on #17, the linter reported that the assignment here was ineffectual; indeed, the original code has a break in this position:

```ts
case SyntaxKind.NumericLiteral:
case SyntaxKind.StringLiteral:
    if (lookAhead(() => nextToken() !== SyntaxKind.ColonToken)) {
        expression = parseLiteralNode() as StringLiteral | NumericLiteral;
        break;
    }
    // falls through
default:
    expression = parseObjectLiteralExpression();
    break;
```