### PR TITLE
Ensure the parser always consumes an end-of-file (EOF) token.

### DIFF
--- a/internal/compiler/parser.go
+++ b/internal/compiler/parser.go
@@ -78,6 +78,7 @@ func ParseJSONText(fileName string, sourceText string) *SourceFile {
 	p.nextToken()
 	pos := p.nodePos()
 	var expressions []*Node
+
 	for p.token != SyntaxKindEndOfFile {
 		var expression *Node
 		switch p.token {
@@ -116,7 +117,9 @@ func ParseJSONText(fileName string, sourceText string) *SourceFile {
 		p.finishNode(arr, pos)
 		statement = p.factory.NewExpressionStatement(arr)
 	}
+
 	p.finishNode(statement, pos)
+	p.parseExpectedToken(SyntaxKindEndOfFile)
 	node := p.factory.NewSourceFile(p.sourceText, p.fileName, []*Node{statement})
 	p.finishNode(node, pos)
 	result := node.AsSourceFile()
@@ -215,6 +218,10 @@ func (p *Parser) parseSourceFileWorker() *SourceFile {
 	}
 	pos := p.nodePos()
 	statements := p.parseList(PCSourceElements, (*Parser).parseStatement)
+	eof := p.parseTokenNode()
+	if eof.kind != SyntaxKindEndOfFile {
+		panic("Expected end of file token from scanner.")
+	}
 	node := p.factory.NewSourceFile(p.sourceText, p.fileName, statements)
 	p.finishNode(node, pos)
 	result := node.AsSourceFile()


### PR DESCRIPTION
When running

```
./bin/tsgo "/workspaces/typescript-go/_submodules/TypeScript/tests/cases/compiler/exportInFunction.ts"
```

the compiler would crash with the following stack trace:

```
panic: runtime error: slice bounds out of range [33:31]

goroutine 1 [running]:
github.com/microsoft/typescript-go/internal/compiler.writeCodeSnippet(0xc000014020, 0xc0000d61a0, 0x21, 0x0, {0x67ad52, 0x5}, 0xc000113e98)
        /workspaces/typescript-go/internal/compiler/error_reporting.go:111 +0x16a5
github.com/microsoft/typescript-go/internal/compiler.FormatDiagnosticsWithColorAndContext(0xc000014020, {0xc00009a088, 0x1, 0x0?}, 0xc000113e98)
        /workspaces/typescript-go/internal/compiler/error_reporting.go:58 +0x645
main.main()
        /workspaces/typescript-go/cmd/tsgo/main.go:97 +0x525
```

This is because while the file start was correctly `33`, the file end was mysteriously `31`. Basically, the remaining trivia leading up to the end of the file was not getting factored in, and so len(sourceFile.text)` was not identical to `sourceFile.loc.end`.

This change adds back the missing token read for plain `SourceFile`s and JSON `SourceFile`s.

As an aside, I *think* the current code captures the semantics missing from the original JSON parsing with these lines:

```
	// !!!
	// if (token() === SyntaxKind.EndOfFileToken) {
	// 	statements = createNodeArray([], pos, pos);
	// 	endOfFileToken = parseTokenNode<EndOfFileToken>();
	// }
```