### PR TITLE
Adds `NodeVisitor` and `ParenthesizerRules`

### DIFF
--- a/internal/compiler/debug.go
+++ b/internal/compiler/debug.go
@@ -1,0 +1,189 @@
+package compiler
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+	"slices"
+	"strings"
+)
+
+// TODO(rbuckton): If we want some of these assertions to only be part of a checked/debug build, we could
+// use build tags (i.e., `go build --tags DEBUG ...`) and split out debug-only assertions into two files:
+//
+// debug_checked.go:
+//
+//		// +BUILD DEBUG
+//		func assertFoo() { /* implementation*/ }
+//
+// debug_release.go:
+//
+//		// +BUILD !DEBUG
+//		func assertFoo() {} // no implementation
+
+// TODO(rbuckton): Ideally this would be in a subpackage except that it would introduce a circular dependency with
+// ast.go. If necessary, these could be made to be generic, e.g.:
+//
+//	type NodeLike interface {
+//		Pos() int
+//		End() int
+//		Kind() SyntaxKind
+//	}
+//	type NodeLikeTest[T NodeLike] func (node T) bool
+//
+//	func assertNode[T NodeLike](node T, fns ...NodeLikeTest[T]) {
+//		assert(!isNil(node), "Expected node to be present")
+//		if len(fns) > 0 {
+//			for _, fn := range fns {
+//				if fn(node) {
+//					return
+//				}
+//			}
+//			assertFail("Node of %v did not pass the expected node tests: %v", node.Kind(), strings.Join(mapf(fns, getFunctionName), ", "))
+//		}
+//	}
+
+func isNil[T any](v T) bool {
+	switch r := reflect.ValueOf(v); r.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return r.IsNil()
+	default:
+		return false
+	}
+}
+
+// TODO(rbuckton): Rename or make _assert public as it now conflicts with "gotest.tools/v3/assert"
+
+// Asserts 'cond' is true or panics with a formatted message
+func _assert(cond bool, a ...any) {
+	if !cond {
+		if len(a) > 0 {
+			panic(fmt.Sprintf(fmt.Sprint(a[0]), a[1:]...))
+		} else {
+			panic("assert failed")
+		}
+	}
+}
+
+// Panics with a formatted message
+func assertFail(a ...any) {
+	_assert(false, a...)
+}
+
+// Asserts 'x' is nil
+func assertMissing(x any) {
+	_assert(isNil(x), "Expected node to be missing")
+}
+
+func assertDefined(x any) {
+	_assert(!isNil(x), "Expected node to be present")
+}
+
+func checkDefined[T any](x T) T {
+	assertDefined(x)
+	return x
+}
+
+// Asserts 'kind' is one of the expected values
+//
+//	assertKind(kind, SyntaxKindQuestionToken, SyntaxKindExclamationToken)
+//	assertKind(kind, SyntaxKindCaseClause, SyntaxKindDefaultClause)
+func assertKind(kind SyntaxKind, expected ...SyntaxKind) {
+	_assert(slices.Contains(expected, kind), "kind '%v' was not one of the expected values: %v", kind, expected)
+}
+
+// Asserts 'node' is not nil and is a Token with one of the expected 'kinds'
+//
+//	assertToken(asteriskToken)
+//	assertToken(postfixToken, SyntaxKindQuestionToken, SyntaxKindExclamationToken)
+func assertToken(node *Node, kinds ...SyntaxKind) {
+	assertDefined(node)
+	_assert(node.kind >= SyntaxKindFirstToken && node.kind <= SyntaxKindLastToken, "Node of %v was not a token", node.kind)
+	_assert(len(kinds) == 0 || nodeKindIs(node, kinds...), "Token '%v' did not have one of the expected kinds: %v", kinds)
+}
+
+// Asserts 'node' is either nil or a Token with one of the expected kinds
+//
+//	assertTokenOpt(asteriskToken)
+//	assertTokenOpt(postfixToken, SyntaxKindQuestionToken, SyntaxKindExclamationToken)
+func assertTokenOpt(node *Node, kinds ...SyntaxKind) {
+	if node != nil {
+		assertToken(node, kinds...)
+	}
+}
+
+// Asserts 'node' is not nil and matches one of the provided node tests
+//
+//	assertNode(node, isExpression)
+//	assertNode(node, isIdentifierName, isStringLiteral)
+func assertNode(node *Node, fns ...NodeTest) {
+	assertDefined(node)
+	if len(fns) > 0 {
+		for _, fn := range fns {
+			if fn(node) {
+				return
+			}
+		}
+		assertFail("Node of %v did not pass the expected node tests: %v", node.kind, strings.Join(mapf(fns, getFunctionName), ", "))
+	}
+}
+
+// Asserts 'node' is either nil or matches one of the provided node tests
+//
+//	assertNodeOpt(node, isTypeNode)
+//	assertNodeOpt(node, isFunctionBody, isExpression)
+func assertNodeOpt(node *Node, fns ...NodeTest) {
+	if node != nil {
+		assertNode(node, fns...)
+	}
+}
+
+// Asserts 'nodes' is not nil and that every element matches one of the provided node tests
+//
+//	assertNodes(arguments, isExpression)
+//	assertNodes(properties, isObjectLiteralElement)
+func assertNodes(nodes []*Node, fns ...NodeTest) {
+	_assert(nodes != nil, "Expected nodes to be present")
+	for _, node := range nodes {
+		assertNode(node, fns...)
+	}
+}
+
+// Asserts 'nodes' is either nil or that every element matches one of the provided node tests
+//
+//	assertNodesOpt(arguments, isExpression) // e.g., for a NewExpression like `new Foo`
+func assertNodesOpt(nodes []*Node, fns ...NodeTest) {
+	if nodes != nil {
+		assertNodes(nodes, fns...)
+	}
+}
+
+// Asserts 'nodes' is not nil, has at least one element, and that every element matches one of the provided node tests
+//
+//	assertNonEmptyNodes(types, isTypeNode)
+func assertNonEmptyNodes(nodes []*Node, fns ...NodeTest) {
+	_assert(nodes != nil, "Expected nodes to be present")
+	_assert(len(nodes) > 0, "Expected nodes to be non-empty")
+	assertNodes(nodes, fns...)
+}
+
+// Asserts 'node' is not nil and matches one of the provided node tests
+//
+//	assertNode(node, isExpression)
+//	assertNode(node, isIdentifierName, isStringLiteral)
+func assertNotNode(node *Node, fns ...NodeTest) {
+	assertDefined(node)
+	_assert(len(fns) > 0, "Expected one or more test functions")
+	for _, fn := range fns {
+		if fn(node) {
+			assertFail("Node of %v did not pass the expected node tests: %v", node.kind, strings.Join(mapf(fns, getFunctionName), ", "))
+		}
+	}
+}
+
+func getFunctionName[T any](fn T) string {
+	v := reflect.ValueOf(fn)
+	_assert(v.Kind() == reflect.Func, "Expected fn to be a Func")
+	name := runtime.FuncForPC(v.Pointer()).Name()
+	return name[strings.LastIndex(name, ".")+1:]
+}

--- a/internal/compiler/factory.go
+++ b/internal/compiler/factory.go
@@ -1,0 +1,119 @@
+package compiler
+
+import "slices"
+
+func findSpanEnd[T any](slice []T, test func(value T) bool, start int) int {
+	i := start
+	for i < len(slice) && test(slice[i]) {
+		i++
+	}
+	return i
+}
+
+func (f *NodeFactory) MergeLexicalEnvironment(statements []*Statement, declarations []*Statement) []*Statement {
+	if len(declarations) == 0 {
+		return statements
+	}
+	if len(statements) == 0 {
+		return declarations
+	}
+
+	// When we merge new lexical statements into an existing statement list, we merge them in the following manner:
+	//
+	// Given:
+	//
+	// | Left                               | Right                               |
+	// |------------------------------------|-------------------------------------|
+	// | [standard prologues (left)]        | [standard prologues (right)]        |
+	// | [hoisted functions (left)]         | [hoisted functions (right)]         |
+	// | [hoisted variables (left)]         | [hoisted variables (right)]         |
+	// | [lexical init statements (left)]   | [lexical init statements (right)]   |
+	// | [other statements (left)]          |                                     |
+	//
+	// The resulting statement list will be:
+	//
+	// | Result                              |
+	// |-------------------------------------|
+	// | [standard prologues (right)]        |
+	// | [standard prologues (left)]         |
+	// | [hoisted functions (right)]         |
+	// | [hoisted functions (left)]          |
+	// | [hoisted variables (right)]         |
+	// | [hoisted variables (left)]          |
+	// | [lexical init statements (right)]   |
+	// | [lexical init statements (left)]    |
+	// | [other statements (left)]           |
+	//
+	// NOTE: It is expected that new lexical init statements must be evaluated before existing lexical init statements,
+	// as the prior transformation may depend on the evaluation of the lexical init statements to be in the correct state.
+
+	// find standard prologues on left in the following order: standard directives, hoisted functions, hoisted variables, other custom
+	leftStandardPrologueEnd := findSpanEnd(statements, isPrologueDirective, 0)
+	leftHoistedFunctionsEnd := findSpanEnd(statements, isHoistedFunction, leftStandardPrologueEnd)
+	leftHoistedVariablesEnd := findSpanEnd(statements, isHoistedVariableStatement, leftHoistedFunctionsEnd)
+
+	// find standard prologues on right in the following order: standard directives, hoisted functions, hoisted variables, other custom
+	rightStandardPrologueEnd := findSpanEnd(declarations, isPrologueDirective, 0)
+	rightHoistedFunctionsEnd := findSpanEnd(declarations, isHoistedFunction, rightStandardPrologueEnd)
+	rightHoistedVariablesEnd := findSpanEnd(declarations, isHoistedVariableStatement, rightHoistedFunctionsEnd)
+	rightCustomPrologueEnd := findSpanEnd(declarations, isCustomPrologue, rightHoistedVariablesEnd)
+	_assert(rightCustomPrologueEnd == len(declarations), "Expected declarations to be valid standard or custom prologues")
+
+	// splice prologues from the right into the left. We do this in reverse order
+	// so that we don't need to recompute the index on the left when we insert items.
+	left := make([]*Statement, len(statements))
+	copy(left, statements)
+
+	// splice other custom prologues from right into left
+	if rightCustomPrologueEnd > rightHoistedVariablesEnd {
+		left = slices.Insert(left, leftHoistedVariablesEnd, declarations[rightHoistedVariablesEnd:rightCustomPrologueEnd]...)
+	}
+
+	// splice hoisted variables from right into left
+	if rightHoistedVariablesEnd > rightHoistedFunctionsEnd {
+		left = slices.Insert(left, leftHoistedFunctionsEnd, declarations[rightHoistedFunctionsEnd:rightHoistedVariablesEnd]...)
+	}
+
+	// splice hoisted functions from right into left
+	if rightHoistedFunctionsEnd > rightStandardPrologueEnd {
+		left = slices.Insert(left, leftStandardPrologueEnd, declarations[rightStandardPrologueEnd:rightHoistedFunctionsEnd]...)
+	}
+
+	// splice standard prologues from right into left (that are not already in left)
+	if rightStandardPrologueEnd > 0 {
+		if leftStandardPrologueEnd == 0 {
+			left = slices.Insert(left, 0, declarations[:rightStandardPrologueEnd]...)
+		} else {
+			var leftPrologues set[string]
+			for i := 0; i < leftStandardPrologueEnd; i++ {
+				leftPrologue := statements[i]
+				leftPrologues.add(leftPrologue.AsExpressionStatement().expression.Text())
+			}
+			for i := rightStandardPrologueEnd - 1; i >= 0; i-- {
+				rightPrologue := declarations[i]
+				if !leftPrologues.has(rightPrologue.AsExpressionStatement().expression.Text()) {
+					left = slices.Insert(left, 0, rightPrologue)
+				}
+			}
+		}
+	}
+
+	return left
+}
+
+func (f *NodeFactory) LiftToBlock(nodes []*Statement) *Statement {
+	if len(nodes) == 1 {
+		return nodes[0]
+	}
+	return f.NewBlock(nodes, false /*multiline*/)
+}
+
+func (f *NodeFactory) GetGeneratedNameForNode(node *Node) *Node {
+	// TODO(rbuckton): To be implemented
+	return nil
+}
+
+func (f *NodeFactory) CloneNode(node *Node) *Node {
+	// TODO(rbuckton): To be implemented
+	return nil
+}

--- a/internal/compiler/parenthesizerRules.go
+++ b/internal/compiler/parenthesizerRules.go
@@ -1,0 +1,792 @@
+package compiler
+
+type ParenthesizerRules interface {
+	GetParenthesizeLeftSideOfBinaryForOperator(binaryOperator SyntaxKind) func(leftSide *Expression) *Expression
+	GetParenthesizeRightSideOfBinaryForOperator(binaryOperator SyntaxKind) func(rightSide *Expression) *Expression
+	ParenthesizeLeftSideOfBinary(binaryOperator SyntaxKind, leftSide *Expression) *Expression
+	ParenthesizeRightSideOfBinary(binaryOperator SyntaxKind, leftSide *Expression, rightSide *Expression) *Expression
+	ParenthesizeExpressionOfComputedPropertyName(expression *Expression) *Expression
+	ParenthesizeConditionOfConditionalExpression(condition *Expression) *Expression
+	ParenthesizeBranchOfConditionalExpression(branch *Expression) *Expression
+	ParenthesizeExpressionOfExportDefault(expression *Expression) *Expression
+	ParenthesizeExpressionOfNew(expression *Expression) *Expression
+	ParenthesizeLeftSideOfAccess(expression *Expression, optionalChain bool) *Expression
+	ParenthesizeOperandOfPostfixUnary(operand *Expression) *Expression
+	ParenthesizeOperandOfPrefixUnary(operand *Expression) *Expression
+	ParenthesizeExpressionsOfCommaDelimitedList(elements []*Expression) []*Expression
+	ParenthesizeExpressionForDisallowedComma(expression *Expression) *Expression
+	ParenthesizeExpressionOfExpressionStatement(expression *Expression) *Expression
+	ParenthesizeConciseBodyOfArrowFunction(body *BlockOrExpression) *BlockOrExpression
+	ParenthesizeCheckTypeOfConditionalType(typeNode *TypeNode) *TypeNode
+	ParenthesizeExtendsTypeOfConditionalType(typeNode *TypeNode) *TypeNode
+	ParenthesizeOperandOfTypeOperator(typeNode *TypeNode) *TypeNode
+	ParenthesizeOperandOfReadonlyTypeOperator(typeNode *TypeNode) *TypeNode
+	ParenthesizeNonArrayTypeOfPostfixType(typeNode *TypeNode) *TypeNode
+	ParenthesizeElementTypesOfTupleType(types []*Node) []*Node
+	ParenthesizeElementTypeOfTupleType(typeNode *Node) *Node
+	ParenthesizeTypeOfOptionalType(typeNode *TypeNode) *TypeNode
+	ParenthesizeConstituentTypeOfUnionType(typeNode *TypeNode) *TypeNode
+	ParenthesizeConstituentTypesOfUnionType(constituents []*TypeNode) []*TypeNode
+	ParenthesizeConstituentTypeOfIntersectionType(typeNode *TypeNode) *TypeNode
+	ParenthesizeConstituentTypesOfIntersectionType(constituents []*TypeNode) []*TypeNode
+	ParenthesizeLeadingTypeArgument(typeNode *TypeNode) *TypeNode
+	ParenthesizeTypeArguments(typeArguments *TypeArgumentListNode) *TypeArgumentListNode
+}
+
+type parenthesizerRules struct {
+	factory                                       *NodeFactory
+	parenthesizeExpressionForDisallowedComma      func(expression *Expression) *Expression
+	parenthesizeElementTypeOfTupleType            func(typeNode *Node) *Node
+	parenthesizeConstituentTypeOfUnionType        func(typeNode *TypeNode) *TypeNode
+	parenthesizeConstituentTypeOfIntersectionType func(typeNode *TypeNode) *TypeNode
+	parenthesizeOrdinalTypeArgument               func(node *TypeNode, i int) *TypeNode
+	binaryLeftOperandParenthesizerCache           map[SyntaxKind]func(node *Expression) *Expression
+	binaryRightOperandParenthesizerCache          map[SyntaxKind]func(node *Expression) *Expression
+}
+
+func NewParenthesizerRules(factory *NodeFactory) ParenthesizerRules {
+	rules := &parenthesizerRules{}
+	rules.factory = factory
+	rules.parenthesizeExpressionForDisallowedComma = rules.ParenthesizeExpressionForDisallowedComma
+	rules.parenthesizeElementTypeOfTupleType = rules.ParenthesizeElementTypeOfTupleType
+	rules.parenthesizeConstituentTypeOfUnionType = rules.ParenthesizeConstituentTypeOfUnionType
+	rules.parenthesizeConstituentTypeOfIntersectionType = rules.ParenthesizeConstituentTypeOfIntersectionType
+	rules.parenthesizeOrdinalTypeArgument = rules.parenthesizeOrdinalTypeArgumentWorker
+	return rules
+}
+
+func (p *parenthesizerRules) GetParenthesizeLeftSideOfBinaryForOperator(operatorKind SyntaxKind) func(leftSide *Expression) *Expression {
+	if len(p.binaryLeftOperandParenthesizerCache) == 0 {
+		p.binaryLeftOperandParenthesizerCache = make(map[SyntaxKind]func(node *Node) *Node)
+	}
+
+	parenthesizerRule, ok := p.binaryLeftOperandParenthesizerCache[operatorKind]
+	if !ok {
+		parenthesizerRule = func(node *Expression) *Expression {
+			return p.ParenthesizeLeftSideOfBinary(operatorKind, node)
+		}
+		p.binaryLeftOperandParenthesizerCache[operatorKind] = parenthesizerRule
+	}
+	return parenthesizerRule
+}
+
+func (p *parenthesizerRules) GetParenthesizeRightSideOfBinaryForOperator(operatorKind SyntaxKind) func(rightSide *Expression) *Expression {
+	if len(p.binaryRightOperandParenthesizerCache) == 0 {
+		p.binaryRightOperandParenthesizerCache = make(map[SyntaxKind]func(node *Node) *Node)
+	}
+
+	parenthesizerRule, ok := p.binaryRightOperandParenthesizerCache[operatorKind]
+	if !ok {
+		parenthesizerRule = func(node *Expression) *Expression {
+			return p.ParenthesizeRightSideOfBinary(operatorKind, nil /*leftSide*/, node)
+		}
+		p.binaryRightOperandParenthesizerCache[operatorKind] = parenthesizerRule
+	}
+	return parenthesizerRule
+}
+
+// Determines whether the operand to a BinaryExpression needs to be parenthesized.
+//   - binaryOperator - The operator for the BinaryExpression.
+//   - operand - The operand for the BinaryExpression.
+//   - isLeftSideOfBinary - A value indicating whether the operand is the left side of the BinaryExpression.
+func (p *parenthesizerRules) binaryOperandNeedsParentheses(binaryOperator SyntaxKind, operand *Expression, isLeftSideOfBinary bool, leftOperand *Expression) bool {
+	// If the operand has lower precedence, then it needs to be parenthesized to preserve the
+	// intent of the expression. For example, if the operand is `a + b` and the operator is
+	// `*`, then we need to parenthesize the operand to preserve the intended order of
+	// operations: `(a + b) * x`.
+	//
+	// If the operand has higher precedence, then it does not need to be parenthesized. For
+	// example, if the operand is `a * b` and the operator is `+`, then we do not need to
+	// parenthesize to preserve the intended order of operations: `a * b + x`.
+	//
+	// If the operand has the same precedence, then we need to check the associativity of
+	// the operator based on whether this is the left or right operand of the expression.
+	//
+	// For example, if `a / d` is on the right of operator `*`, we need to parenthesize
+	// to preserve the intended order of operations: `x * (a / d)`
+	//
+	// If `a ** d` is on the left of operator `**`, we need to parenthesize to preserve
+	// the intended order of operations: `(a ** b) ** c`
+	binaryOperatorPrecedence := getOperatorPrecedence(SyntaxKindBinaryExpression, binaryOperator, false /*hasArguments*/)
+	binaryOperatorAssociativity := getOperatorAssociativity(SyntaxKindBinaryExpression, binaryOperator, false /*hasArguments*/)
+	emittedOperand := skipPartiallyEmittedExpressions(operand)
+	if !isLeftSideOfBinary && operand.kind == SyntaxKindArrowFunction && binaryOperatorPrecedence > OperatorPrecedenceAssignment {
+		// We need to parenthesize arrow functions on the right side to avoid it being
+		// parsed as parenthesized expression: `a && (() => {})`
+		return true
+	}
+	operandPrecedence := getExpressionPrecedence(emittedOperand)
+
+	switch {
+	case operandPrecedence < binaryOperatorPrecedence:
+		// If the operand is the right side of a right-associative binary operation
+		// and is a yield expression, then we do not need parentheses.
+		if !isLeftSideOfBinary &&
+			binaryOperatorAssociativity == AssociativityRight &&
+			operand.kind == SyntaxKindYieldExpression {
+			return false
+		}
+
+		return true
+
+	case operandPrecedence > binaryOperatorPrecedence:
+		return false
+
+	default:
+		if isLeftSideOfBinary {
+			// No need to parenthesize the left operand when the binary operator is
+			// left associative:
+			//  (a*b)/x    -> a*b/x
+			//  (a**b)/x   -> a**b/x
+			//
+			// Parentheses are needed for the left operand when the binary operator is
+			// right associative:
+			//  (a/b)**x   -> (a/b)**x
+			//  (a**b)**x  -> (a**b)**x
+			return binaryOperatorAssociativity == AssociativityRight
+		} else {
+			if isBinaryExpression(emittedOperand) &&
+				emittedOperand.AsBinaryExpression().operatorToken.kind == binaryOperator {
+				// No need to parenthesize the right operand when the binary operator and
+				// operand are the same and one of the following:
+				//  x*(a*b)     => x*a*b
+				//  x|(a|b)     => x|a|b
+				//  x&(a&b)     => x&a&b
+				//  x^(a^b)     => x^a^b
+				if p.operatorHasAssociativeProperty(binaryOperator) {
+					return false
+				}
+
+				// No need to parenthesize the right operand when the binary operator
+				// is plus (+) if both the left and right operands consist solely of either
+				// literals of the same kind or binary plus (+) expressions for literals of
+				// the same kind (recursively).
+				//  "a"+(1+2)       => "a"+(1+2)
+				//  "a"+("b"+"c")   => "a"+"b"+"c"
+				if binaryOperator == SyntaxKindPlusToken {
+					leftKind := SyntaxKindUnknown
+					if leftOperand != nil {
+						leftKind = p.getLiteralKindOfBinaryPlusOperand(leftOperand)
+					}
+					if isLiteralKind(leftKind) && leftKind == p.getLiteralKindOfBinaryPlusOperand(emittedOperand) {
+						return false
+					}
+				}
+			}
+
+			// No need to parenthesize the right operand when the operand is right
+			// associative:
+			//  x/(a**b)    -> x/a**b
+			//  x**(a**b)   -> x**a**b
+			//
+			// Parentheses are needed for the right operand when the operand is left
+			// associative:
+			//  x/(a*b)     -> x/(a*b)
+			//  x**(a/b)    -> x**(a/b)
+			operandAssociativity := getExpressionAssociativity(emittedOperand)
+			return operandAssociativity == AssociativityLeft
+		}
+	}
+}
+
+// Determines whether a binary operator is mathematically associative.
+func (p *parenthesizerRules) operatorHasAssociativeProperty(binaryOperator SyntaxKind) bool {
+	// The following operators are associative in JavaScript:
+	//  (a*b)*c     -> a*(b*c)  -> a*b*c
+	//  (a|b)|c     -> a|(b|c)  -> a|b|c
+	//  (a&b)&c     -> a&(b&c)  -> a&b&c
+	//  (a^b)^c     -> a^(b^c)  -> a^b^c
+	//  (a,b),c     -> a,(b,c)  -> a,b,c
+	//
+	// While addition is associative in mathematics, JavaScript's `+` is not
+	// guaranteed to be associative as it is overloaded with string concatenation.
+	return binaryOperator == SyntaxKindAsteriskToken ||
+		binaryOperator == SyntaxKindBarToken ||
+		binaryOperator == SyntaxKindAmpersandToken ||
+		binaryOperator == SyntaxKindCaretToken ||
+		binaryOperator == SyntaxKindCommaToken
+}
+
+// This function determines whether an expression consists of a homogeneous set of
+// literal expressions or binary plus expressions that all share the same literal kind.
+// It is used to determine whether the right-hand operand of a binary plus expression can be
+// emitted without parentheses.
+func (p *parenthesizerRules) getLiteralKindOfBinaryPlusOperand(node *Expression) SyntaxKind {
+	node = skipPartiallyEmittedExpressions(node)
+
+	if isLiteralKind(node.kind) {
+		return node.kind
+	}
+
+	if node.kind == SyntaxKindBinaryExpression {
+		if n := node.AsBinaryExpression(); n.operatorToken.kind == SyntaxKindPlusToken {
+			// TODO(rbuckton): Determine if caching this is worthwhile over recomputing
+			// if n.cachedLiteralKind != SyntaxKindUnknown {
+			// 	return n.cachedLiteralKind;
+			// }
+
+			leftKind := p.getLiteralKindOfBinaryPlusOperand(n.left)
+			literalKind := SyntaxKindUnknown
+			if isLiteralKind(leftKind) && leftKind == p.getLiteralKindOfBinaryPlusOperand(n.right) {
+				literalKind = leftKind
+			}
+
+			// n.cachedLiteralKind = literalKind;
+			return literalKind
+		}
+	}
+
+	return SyntaxKindUnknown
+}
+
+// Wraps the operand to a BinaryExpression in parentheses if they are needed to preserve the intended order of operations.
+//   - binaryOperator - The operator for the BinaryExpression.
+//   - operand - The operand for the BinaryExpression.
+//   - isLeftSideOfBinary - A value indicating whether the operand is the left side of the BinaryExpression.
+func (p *parenthesizerRules) parenthesizeBinaryOperand(binaryOperator SyntaxKind, operand *Expression, isLeftSideOfBinary bool, leftOperand *Expression) *Expression {
+	skipped := skipPartiallyEmittedExpressions(operand)
+
+	// If the resulting expression is already parenthesized, we do not need to do any further processing.
+	if skipped.kind == SyntaxKindParenthesizedExpression {
+		return operand
+	}
+
+	if p.binaryOperandNeedsParentheses(binaryOperator, operand, isLeftSideOfBinary, leftOperand) {
+		return p.factory.NewParenthesizedExpression(operand)
+	}
+
+	return operand
+}
+
+func (p *parenthesizerRules) ParenthesizeLeftSideOfBinary(binaryOperator SyntaxKind, leftSide *Expression) *Expression {
+	return p.parenthesizeBinaryOperand(binaryOperator, leftSide, true /*isLeftSideOfBinary*/, nil /*leftOperand*/)
+}
+
+func (p *parenthesizerRules) ParenthesizeRightSideOfBinary(binaryOperator SyntaxKind, leftSide *Expression, rightSide *Expression) *Expression {
+	return p.parenthesizeBinaryOperand(binaryOperator, rightSide, false /*isLeftSideOfBinary*/, leftSide)
+}
+
+func (p *parenthesizerRules) ParenthesizeExpressionOfComputedPropertyName(expression *Expression) *Expression {
+	if isCommaSequence(expression) {
+		return p.factory.NewParenthesizedExpression(expression)
+	}
+	return expression
+}
+
+func (p *parenthesizerRules) ParenthesizeConditionOfConditionalExpression(condition *Expression) *Expression {
+	conditionalPrecedence := getOperatorPrecedence(SyntaxKindConditionalExpression, SyntaxKindQuestionToken, false /*hasArguments*/)
+	emittedCondition := skipPartiallyEmittedExpressions(condition)
+	conditionPrecedence := getExpressionPrecedence(emittedCondition)
+	if conditionPrecedence <= conditionalPrecedence {
+		return p.factory.NewParenthesizedExpression(condition)
+	}
+	return condition
+}
+
+func (p *parenthesizerRules) ParenthesizeBranchOfConditionalExpression(branch *Expression) *Expression {
+	// per ES grammar both 'whenTrue' and 'whenFalse' parts of conditional expression are assignment expressions
+	// so in case when comma expression is introduced as a part of previous transformations
+	// if should be wrapped in parens since comma operator has the lowest precedence
+	emittedExpression := skipPartiallyEmittedExpressions(branch)
+	if isCommaSequence(emittedExpression) {
+		p.factory.NewParenthesizedExpression(branch)
+	}
+	return branch
+}
+
+// [Per the spec](https://tc39.github.io/ecma262/#prod-ExportDeclaration), `export default` accepts _AssigmentExpression_ but
+// has a lookahead restriction for `function`, `async function`, and `class`.
+//
+// Basically, that means we need to parenthesize in the following cases:
+//
+// - BinaryExpression of CommaToken
+// - CommaList (synthetic list of multiple comma expressions)
+// - FunctionExpression
+// - ClassExpression
+func (p *parenthesizerRules) ParenthesizeExpressionOfExportDefault(expression *Expression) *Expression {
+	check := skipPartiallyEmittedExpressions(expression)
+	needsParens := isCommaSequence(check)
+	if !needsParens {
+		switch getLeftmostExpression(check, false /*stopAtCallExpressions*/).kind {
+		case SyntaxKindClassExpression, SyntaxKindFunctionExpression:
+			needsParens = true
+		}
+	}
+	if needsParens {
+		return p.factory.NewParenthesizedExpression(expression)
+	}
+	return expression
+}
+
+// Wraps an expression in parentheses if it is needed in order to use the expression
+// as the expression of a `NewExpression` node.
+func (p *parenthesizerRules) ParenthesizeExpressionOfNew(expression *Expression) *Expression {
+	leftmostExpr := getLeftmostExpression(expression /*stopAtCallExpressions*/, true)
+	switch leftmostExpr.kind {
+	case SyntaxKindCallExpression:
+		return p.factory.NewParenthesizedExpression(expression)
+
+	case SyntaxKindNewExpression:
+		if leftmostExpr.AsNewExpression().arguments == nil {
+			return p.factory.NewParenthesizedExpression(expression)
+		}
+		return expression
+	}
+
+	return p.ParenthesizeLeftSideOfAccess(expression, false /*optionalChain*/)
+}
+
+// Wraps an expression in parentheses if it is needed in order to use the expression for
+// property or element access.
+func (p *parenthesizerRules) ParenthesizeLeftSideOfAccess(expression *Expression, optionalChain bool) *Expression {
+	// isLeftHandSideExpression is almost the correct criterion for when it is not necessary
+	// to parenthesize the expression before a dot. The known exception is:
+	//
+	//    NewExpression:
+	//       new C.x        -> not the same as (new C).x
+	//
+	emittedExpression := skipPartiallyEmittedExpressions(expression)
+	if isLeftHandSideExpression(emittedExpression) &&
+		(emittedExpression.kind != SyntaxKindNewExpression || emittedExpression.AsNewExpression().arguments != nil) &&
+		(optionalChain || !isOptionalChain(emittedExpression)) {
+		return expression
+	}
+
+	result := p.factory.NewParenthesizedExpression(expression)
+	result.loc = expression.loc
+	return result
+}
+
+func (p *parenthesizerRules) ParenthesizeOperandOfPostfixUnary(operand *Expression) *Expression {
+	if isLeftHandSideExpression(operand) {
+		return operand
+	}
+	result := p.factory.NewParenthesizedExpression(operand)
+	result.loc = operand.loc
+	return result
+}
+
+func (p *parenthesizerRules) ParenthesizeOperandOfPrefixUnary(operand *Expression) *Expression {
+	if isUnaryExpression(operand) {
+		return operand
+	}
+	result := p.factory.NewParenthesizedExpression(operand)
+	result.loc = operand.loc
+	return result
+}
+
+func (p *parenthesizerRules) ParenthesizeExpressionsOfCommaDelimitedList(elements []*Expression) []*Expression {
+	return sameMap(elements, p.parenthesizeExpressionForDisallowedComma)
+}
+
+func (p *parenthesizerRules) ParenthesizeExpressionForDisallowedComma(expression *Expression) *Expression {
+	emittedExpression := skipPartiallyEmittedExpressions(expression)
+	expressionPrecedence := getExpressionPrecedence(emittedExpression)
+	commaPrecedence := getOperatorPrecedence(SyntaxKindBinaryExpression, SyntaxKindCommaToken, false /*hasArguments*/)
+	if expressionPrecedence > commaPrecedence {
+		return expression
+	}
+	result := p.factory.NewParenthesizedExpression(expression)
+	result.loc = expression.loc
+	return result
+}
+
+func (p *parenthesizerRules) ParenthesizeExpressionOfExpressionStatement(expression *Expression) *Expression {
+	emittedExpression := skipPartiallyEmittedExpressions(expression)
+	if isCallExpression(emittedExpression) {
+		callExpression := emittedExpression.AsCallExpression()
+		callee := callExpression.expression
+		kind := skipPartiallyEmittedExpressions(callee).kind
+		if kind == SyntaxKindFunctionExpression || kind == SyntaxKindArrowFunction {
+			parenthesizedCallee := p.factory.NewParenthesizedExpression(callee)
+			parenthesizedCallee.loc = callee.loc
+			updated := p.factory.UpdateCallExpression(
+				emittedExpression,
+				parenthesizedCallee,
+				nil, /*questionDotToken*/
+				callExpression.typeArguments,
+				callExpression.arguments)
+			return p.factory.RestoreOuterExpressions(expression, updated, OEKPartiallyEmittedExpressions)
+		}
+	}
+
+	leftmostExpressionKind := getLeftmostExpression(emittedExpression, false /*stopAtCallExpressions*/).kind
+	if leftmostExpressionKind == SyntaxKindObjectLiteralExpression || leftmostExpressionKind == SyntaxKindFunctionExpression {
+		result := p.factory.NewParenthesizedExpression(expression)
+		result.loc = expression.loc
+		return result
+	}
+
+	return expression
+}
+
+func (p *parenthesizerRules) ParenthesizeConciseBodyOfArrowFunction(body *BlockOrExpression) *BlockOrExpression {
+	if !isBlock(body) && (isCommaSequence(body) || getLeftmostExpression(body, false /*stopAtCallExpressions*/).kind == SyntaxKindObjectLiteralExpression) {
+		result := p.factory.NewParenthesizedExpression(body)
+		result.loc = body.loc
+		return result
+	}
+	return body
+}
+
+// Type[Extends] :
+//     FunctionOrConstructorType
+//     ConditionalType[?Extends]
+
+// ConditionalType[Extends] :
+//
+//	UnionType[?Extends]
+//	[~Extends] UnionType[~Extends] `extends` Type[+Extends] `?` Type[~Extends] `:` Type[~Extends]
+//
+// - The check type (the `UnionType`, above) does not allow function, constructor, or conditional types (they must be parenthesized)
+// - The extends type (the first `Type`, above) does not allow conditional types (they must be parenthesized). Function and constructor types are fine.
+// - The true and false branch types (the second and third `Type` non-terminals, above) allow any type
+func (p *parenthesizerRules) ParenthesizeCheckTypeOfConditionalType(checkType *TypeNode) *TypeNode {
+	switch checkType.kind {
+	case SyntaxKindFunctionType:
+	case SyntaxKindConstructorType:
+	case SyntaxKindConditionalType:
+		return p.factory.NewParenthesizedTypeNode(checkType)
+	}
+	return checkType
+}
+
+func (p *parenthesizerRules) ParenthesizeExtendsTypeOfConditionalType(extendsType *TypeNode) *TypeNode {
+	switch extendsType.kind {
+	case SyntaxKindConditionalType:
+		return p.factory.NewParenthesizedTypeNode(extendsType)
+	}
+	return extendsType
+}
+
+// TypeOperator[Extends] :
+//
+//	PostfixType
+//	InferType[?Extends]
+//	`keyof` TypeOperator[?Extends]
+//	`unique` TypeOperator[?Extends]
+//	`readonly` TypeOperator[?Extends]
+func (p *parenthesizerRules) ParenthesizeOperandOfTypeOperator(typeNode *TypeNode) *TypeNode {
+	switch typeNode.kind {
+	case SyntaxKindIntersectionType:
+		return p.factory.NewParenthesizedTypeNode(typeNode)
+	}
+	return p.ParenthesizeConstituentTypeOfIntersectionType(typeNode)
+}
+
+func (p *parenthesizerRules) ParenthesizeOperandOfReadonlyTypeOperator(typeNode *TypeNode) *TypeNode {
+	switch typeNode.kind {
+	case SyntaxKindTypeOperator:
+		return p.factory.NewParenthesizedTypeNode(typeNode)
+	}
+	return p.ParenthesizeOperandOfTypeOperator(typeNode)
+}
+
+// PostfixType :
+//
+//	NonArrayType
+//	NonArrayType [no LineTerminator here] `!` // JSDoc
+//	NonArrayType [no LineTerminator here] `?` // JSDoc
+//	IndexedAccessType
+//	ArrayType
+//
+// IndexedAccessType :
+//
+//	NonArrayType `[` Type[~Extends] `]`
+//
+// ArrayType :
+//
+//	NonArrayType `[` `]`
+func (p *parenthesizerRules) ParenthesizeNonArrayTypeOfPostfixType(typeNode *TypeNode) *TypeNode {
+	switch typeNode.kind {
+	case SyntaxKindInferType:
+	case SyntaxKindTypeOperator:
+	case SyntaxKindTypeQuery: // Not strictly necessary, but makes generated output more readable and avoids breaks in DT tests
+		return p.factory.NewParenthesizedTypeNode(typeNode)
+	}
+	return p.ParenthesizeOperandOfTypeOperator(typeNode)
+}
+
+// TupleType :
+//
+//	`[` Elision? `]`
+//	`[` NamedTupleElementTypes `]`
+//	`[` NamedTupleElementTypes `,` Elision? `]`
+//	`[` TupleElementTypes `]`
+//	`[` TupleElementTypes `,` Elision? `]`
+//
+// NamedTupleElementTypes :
+//
+//	Elision? NamedTupleMember
+//	NamedTupleElementTypes `,` Elision? NamedTupleMember
+//
+// NamedTupleMember :
+//
+//	Identifier `?`? `:` Type[~Extends]
+//	`...` Identifier `:` Type[~Extends]
+//
+// TupleElementTypes :
+//
+//	Elision? TupleElementType
+//	TupleElementTypes `,` Elision? TupleElementType
+//
+// TupleElementType :
+//
+//	Type[~Extends] // NOTE: Needs cover grammar to disallow JSDoc postfix-optional
+//	OptionalType
+//	RestType
+//
+// OptionalType :
+//
+//	Type[~Extends] `?` // NOTE: Needs cover grammar to disallow JSDoc postfix-optional
+//
+// RestType :
+//
+//	`...` Type[~Extends]
+func (p *parenthesizerRules) ParenthesizeElementTypesOfTupleType(types []*Node) []*Node {
+	return sameMap(types, p.parenthesizeElementTypeOfTupleType)
+}
+
+func (p *parenthesizerRules) hasJSDocPostfixQuestion(typeNode *Node) bool {
+	if typeNode != nil {
+		switch typeNode.kind {
+		case SyntaxKindJSDocNullableType:
+			return typeNode.AsJSDocNullableType().postfix
+		case SyntaxKindNamedTupleMember:
+			return p.hasJSDocPostfixQuestion(typeNode.AsNamedTupleMember().typeNode)
+		case SyntaxKindFunctionType, SyntaxKindConstructorType:
+			return p.hasJSDocPostfixQuestion(typeNode.ReturnType())
+		case SyntaxKindTypeOperator:
+			return p.hasJSDocPostfixQuestion(typeNode.AsTypeOperatorNode().typeNode)
+		case SyntaxKindConditionalType:
+			return p.hasJSDocPostfixQuestion(typeNode.AsConditionalTypeNode().falseType)
+		case SyntaxKindUnionType:
+			return p.hasJSDocPostfixQuestion(lastElement(typeNode.AsUnionTypeNode().types))
+		case SyntaxKindIntersectionType:
+			return p.hasJSDocPostfixQuestion(lastElement(typeNode.AsIntersectionTypeNode().types))
+		case SyntaxKindInferType:
+			return p.hasJSDocPostfixQuestion(typeNode.AsInferTypeNode().typeParameter.AsTypeParameter().constraint)
+		}
+	}
+	return false
+}
+
+func (p *parenthesizerRules) ParenthesizeElementTypeOfTupleType(typeNode *Node) *Node {
+	if p.hasJSDocPostfixQuestion(typeNode) {
+		return p.factory.NewParenthesizedTypeNode(typeNode)
+	}
+	return typeNode
+}
+
+func (p *parenthesizerRules) ParenthesizeTypeOfOptionalType(typeNode *TypeNode) *TypeNode {
+	if p.hasJSDocPostfixQuestion(typeNode) {
+		return p.factory.NewParenthesizedTypeNode(typeNode)
+	}
+	return p.ParenthesizeNonArrayTypeOfPostfixType(typeNode)
+}
+
+// UnionType[Extends] :
+//
+//	`|`? IntersectionType[?Extends]
+//	UnionType[?Extends] `|` IntersectionType[?Extends]
+//
+// - A union type constituent has the same precedence as the check type of a conditional type
+func (p *parenthesizerRules) ParenthesizeConstituentTypeOfUnionType(typeNode *TypeNode) *TypeNode {
+	switch typeNode.kind {
+	case SyntaxKindUnionType: // Not strictly necessary, but a union containing a union should have been flattened
+	case SyntaxKindIntersectionType: // Not strictly necessary, but makes generated output more readable and avoids breaks in DT tests
+		return p.factory.NewParenthesizedTypeNode(typeNode)
+	}
+	return p.ParenthesizeCheckTypeOfConditionalType(typeNode)
+}
+
+func (p *parenthesizerRules) ParenthesizeConstituentTypesOfUnionType(constituents []*TypeNode) []*TypeNode {
+	return sameMap(constituents, p.parenthesizeConstituentTypeOfUnionType)
+}
+
+// IntersectionType[Extends] :
+//
+//	`&`? TypeOperator[?Extends]
+//	IntersectionType[?Extends] `&` TypeOperator[?Extends]
+//
+// - An intersection type constituent does not allow function, constructor, conditional, or union types (they must be parenthesized)
+func (p *parenthesizerRules) ParenthesizeConstituentTypeOfIntersectionType(typeNode *TypeNode) *TypeNode {
+	switch typeNode.kind {
+	case SyntaxKindUnionType:
+	case SyntaxKindIntersectionType: // Not strictly necessary, but an intersection containing an intersection should have been flattened
+		return p.factory.NewParenthesizedTypeNode(typeNode)
+	}
+	return p.parenthesizeConstituentTypeOfUnionType(typeNode)
+}
+
+func (p *parenthesizerRules) ParenthesizeConstituentTypesOfIntersectionType(constituents []*TypeNode) []*TypeNode {
+	return sameMap(constituents, p.parenthesizeConstituentTypeOfIntersectionType)
+}
+
+func (p *parenthesizerRules) ParenthesizeLeadingTypeArgument(typeNode *TypeNode) *TypeNode {
+	switch typeNode.kind {
+	case SyntaxKindFunctionType, SyntaxKindConstructorType:
+		if typeNode.TypeParameters() != nil {
+			return p.factory.NewParenthesizedTypeNode(typeNode)
+		}
+	}
+	return typeNode
+}
+
+func (p *parenthesizerRules) parenthesizeOrdinalTypeArgumentWorker(node *TypeNode, i int) *TypeNode {
+	if i == 0 {
+		return p.ParenthesizeLeadingTypeArgument(node)
+	}
+	return node
+}
+
+func (p *parenthesizerRules) ParenthesizeTypeArguments(typeArguments *TypeArgumentListNode) *TypeArgumentListNode {
+	if typeArguments != nil {
+		typeArgumentList := typeArguments.AsTypeArgumentList()
+		arguments, _ := sameMapIndex(typeArgumentList.arguments, p.parenthesizeOrdinalTypeArgument)
+		return p.factory.UpdateTypeArgumentList(typeArguments, arguments)
+	}
+	return nil
+}
+
+type nullParenthesizerRules struct {
+	identity func(node *Expression) *Expression
+}
+
+func NewNullParenthesizerRules() ParenthesizerRules {
+	rules := &nullParenthesizerRules{}
+	rules.identity = func(node *Expression) *Expression { return node }
+	return rules
+}
+
+func (p *nullParenthesizerRules) GetParenthesizeLeftSideOfBinaryForOperator(operatorKind SyntaxKind) func(leftSide *Expression) *Expression {
+	return p.identity
+}
+
+func (p *nullParenthesizerRules) GetParenthesizeRightSideOfBinaryForOperator(operatorKind SyntaxKind) func(rightSide *Expression) *Expression {
+	return p.identity
+}
+
+func (p *nullParenthesizerRules) ParenthesizeLeftSideOfBinary(binaryOperator SyntaxKind, leftSide *Expression) *Expression {
+	return leftSide
+}
+
+func (p *nullParenthesizerRules) ParenthesizeRightSideOfBinary(binaryOperator SyntaxKind, leftSide *Expression, rightSide *Expression) *Expression {
+	return rightSide
+}
+
+func (p *nullParenthesizerRules) ParenthesizeExpressionOfComputedPropertyName(expression *Expression) *Expression {
+	return expression
+}
+
+func (p *nullParenthesizerRules) ParenthesizeConditionOfConditionalExpression(condition *Expression) *Expression {
+	return condition
+}
+
+func (p *nullParenthesizerRules) ParenthesizeBranchOfConditionalExpression(branch *Expression) *Expression {
+	return branch
+}
+
+func (p *nullParenthesizerRules) ParenthesizeExpressionOfExportDefault(expression *Expression) *Expression {
+	return expression
+}
+
+func (p *nullParenthesizerRules) ParenthesizeExpressionOfNew(expression *Expression) *Expression {
+	if !isLeftHandSideExpression(expression) {
+		panic("Expected expression to be a valid LeftHandSideExpression")
+	}
+	return expression
+}
+
+func (p *nullParenthesizerRules) ParenthesizeLeftSideOfAccess(expression *Expression, optionalChain bool) *Expression {
+	if !isLeftHandSideExpression(expression) {
+		panic("Expected expression to be a valid LeftHandSideExpression")
+	}
+	return expression
+}
+
+func (p *nullParenthesizerRules) ParenthesizeOperandOfPostfixUnary(operand *Expression) *Expression {
+	if !isLeftHandSideExpression(operand) {
+		panic("Expected expression to be a valid LeftHandSideExpression")
+	}
+	return operand
+}
+
+func (p *nullParenthesizerRules) ParenthesizeOperandOfPrefixUnary(operand *Expression) *Expression {
+	if !isUnaryExpression(operand) {
+		panic("Expected expression to be a valid UnaryExpression")
+	}
+	return operand
+}
+
+func (p *nullParenthesizerRules) ParenthesizeExpressionsOfCommaDelimitedList(elements []*Expression) []*Expression {
+	return elements
+}
+
+func (p *nullParenthesizerRules) ParenthesizeExpressionForDisallowedComma(expression *Expression) *Expression {
+	return expression
+}
+
+func (p *nullParenthesizerRules) ParenthesizeExpressionOfExpressionStatement(expression *Expression) *Expression {
+	return expression
+}
+
+func (p *nullParenthesizerRules) ParenthesizeConciseBodyOfArrowFunction(body *BlockOrExpression) *BlockOrExpression {
+	return body
+}
+
+func (p *nullParenthesizerRules) ParenthesizeCheckTypeOfConditionalType(checkType *TypeNode) *TypeNode {
+	return checkType
+}
+
+func (p *nullParenthesizerRules) ParenthesizeExtendsTypeOfConditionalType(extendsType *TypeNode) *TypeNode {
+	return extendsType
+}
+
+func (p *nullParenthesizerRules) ParenthesizeOperandOfTypeOperator(typeNode *TypeNode) *TypeNode {
+	return typeNode
+}
+
+func (p *nullParenthesizerRules) ParenthesizeOperandOfReadonlyTypeOperator(typeNode *TypeNode) *TypeNode {
+	return typeNode
+}
+
+func (p *nullParenthesizerRules) ParenthesizeNonArrayTypeOfPostfixType(typeNode *TypeNode) *TypeNode {
+	return typeNode
+}
+
+func (p *nullParenthesizerRules) ParenthesizeElementTypesOfTupleType(types []*Node) []*Node {
+	return types
+}
+
+func (p *nullParenthesizerRules) ParenthesizeElementTypeOfTupleType(typeNode *Node) *Node {
+	return typeNode
+}
+
+func (p *nullParenthesizerRules) ParenthesizeTypeOfOptionalType(typeNode *TypeNode) *TypeNode {
+	return typeNode
+}
+
+func (p *nullParenthesizerRules) ParenthesizeConstituentTypeOfUnionType(typeNode *TypeNode) *TypeNode {
+	return typeNode
+}
+
+func (p *nullParenthesizerRules) ParenthesizeConstituentTypesOfUnionType(constituents []*TypeNode) []*TypeNode {
+	return constituents
+}
+
+func (p *nullParenthesizerRules) ParenthesizeConstituentTypeOfIntersectionType(typeNode *TypeNode) *TypeNode {
+	return typeNode
+}
+
+func (p *nullParenthesizerRules) ParenthesizeConstituentTypesOfIntersectionType(constituents []*TypeNode) []*TypeNode {
+	return constituents
+}
+
+func (p *nullParenthesizerRules) ParenthesizeLeadingTypeArgument(typeNode *TypeNode) *TypeNode {
+	return typeNode
+}
+
+func (p *nullParenthesizerRules) ParenthesizeTypeArguments(typeArguments *TypeArgumentListNode) *TypeArgumentListNode {
+	return typeArguments
+}

--- a/internal/compiler/parser.go
+++ b/internal/compiler/parser.go
@@ -61,6 +61,7 @@ type Parser struct {
 
 func NewParser() *Parser {
 	p := &Parser{}
+	p.factory.parenthesizerRules = NewNullParenthesizerRules()
 	p.scanner = NewScanner()
 	return p
 }
@@ -4894,7 +4895,7 @@ func (p *Parser) parseMemberExpressionRest(pos int, expression *Expression, allo
 		if questionDotToken == nil {
 			if p.token == SyntaxKindExclamationToken && !p.hasPrecedingLineBreak() {
 				p.nextToken()
-				expression = p.factory.NewNonNullExpression(expression)
+				expression = p.factory.NewNonNullExpression(expression, NodeFlagsNone)
 				p.finishNode(expression, pos)
 				continue
 			}
@@ -5859,17 +5860,6 @@ func (p *Parser) inAwaitContext() bool {
 
 func (p *Parser) skipRangeTrivia(textRange TextRange) TextRange {
 	return NewTextRange(skipTrivia(p.sourceText, textRange.Pos()), textRange.End())
-}
-
-func isModifierKind(token SyntaxKind) bool {
-	switch token {
-	case SyntaxKindAbstractKeyword, SyntaxKindAccessorKeyword, SyntaxKindAsyncKeyword, SyntaxKindConstKeyword, SyntaxKindDeclareKeyword,
-		SyntaxKindDefaultKeyword, SyntaxKindExportKeyword, SyntaxKindImmediateKeyword, SyntaxKindInKeyword, SyntaxKindPublicKeyword,
-		SyntaxKindPrivateKeyword, SyntaxKindProtectedKeyword, SyntaxKindReadonlyKeyword, SyntaxKindStaticKeyword, SyntaxKindOutKeyword,
-		SyntaxKindOverrideKeyword:
-		return true
-	}
-	return false
 }
 
 func isClassMemberModifier(token SyntaxKind) bool {

--- a/internal/compiler/visitor.go
+++ b/internal/compiler/visitor.go
@@ -1,0 +1,1452 @@
+package compiler
+
+// NodeVisitor
+
+type NodeVisitor interface {
+	VisitNode(node *Node) *Node
+	VisitNodes(nodes []*Node) []*Node
+	// Tokens
+	VisitToken(node *Token) *Node
+	// Literals
+	VisitNumericLiteral(node *NumericLiteral) *Node
+	VisitBigIntLiteral(node *BigIntLiteral) *Node
+	VisitStringLiteral(node *StringLiteral) *Node
+	VisitJsxText(node *JsxText) *Node
+	VisitRegularExpressionLiteral(node *RegularExpressionLiteral) *Node
+	VisitNoSubstitutionTemplateLiteral(node *NoSubstitutionTemplateLiteral) *Node
+	// Pseudo-literals
+	VisitTemplateHead(node *TemplateHead) *Node
+	VisitTemplateMiddle(node *TemplateMiddle) *Node
+	VisitTemplateTail(node *TemplateTail) *Node
+	// Identifiers
+	VisitIdentifier(node *Identifier) *Node
+	VisitPrivateIdentifier(node *PrivateIdentifier) *Node
+	// Names
+	VisitQualifiedName(node *QualifiedName) *Node
+	VisitComputedPropertyName(node *ComputedPropertyName) *Node
+	// Lists
+	VisitModifierList(node *ModifierList) *Node
+	VisitTypeParameterList(node *TypeParameterList) *Node
+	VisitTypeArgumentList(node *TypeArgumentList) *Node
+	// Signature elements
+	VisitTypeParameterDeclaration(node *TypeParameterDeclaration) *Node
+	VisitParameterDeclaration(node *ParameterDeclaration) *Node
+	VisitDecorator(node *Decorator) *Node
+	// Type members
+	VisitPropertySignatureDeclaration(node *PropertySignatureDeclaration) *Node
+	VisitPropertyDeclaration(node *PropertyDeclaration) *Node
+	VisitMethodSignatureDeclaration(node *MethodSignatureDeclaration) *Node
+	VisitMethodDeclaration(node *MethodDeclaration) *Node
+	VisitClassStaticBlockDeclaration(node *ClassStaticBlockDeclaration) *Node
+	VisitConstructorDeclaration(node *ConstructorDeclaration) *Node
+	VisitGetAccessorDeclaration(node *GetAccessorDeclaration) *Node
+	VisitSetAccessorDeclaration(node *SetAccessorDeclaration) *Node
+	VisitCallSignatureDeclaration(node *CallSignatureDeclaration) *Node
+	VisitConstructSignatureDeclaration(node *ConstructSignatureDeclaration) *Node
+	VisitIndexSignatureDeclaration(node *IndexSignatureDeclaration) *Node
+	// Types
+	VisitTypePredicateNode(node *TypePredicateNode) *Node
+	VisitTypeReferenceNode(node *TypeReferenceNode) *Node
+	VisitFunctionTypeNode(node *FunctionTypeNode) *Node
+	VisitConstructorTypeNode(node *ConstructorTypeNode) *Node
+	VisitTypeQueryNode(node *TypeQueryNode) *Node
+	VisitTypeLiteralNode(node *TypeLiteralNode) *Node
+	VisitArrayTypeNode(node *ArrayTypeNode) *Node
+	VisitTupleTypeNode(node *TupleTypeNode) *Node
+	VisitOptionalTypeNode(node *OptionalTypeNode) *Node
+	VisitRestTypeNode(node *RestTypeNode) *Node
+	VisitUnionTypeNode(node *UnionTypeNode) *Node
+	VisitIntersectionTypeNode(node *IntersectionTypeNode) *Node
+	VisitConditionalTypeNode(node *ConditionalTypeNode) *Node
+	VisitInferTypeNode(node *InferTypeNode) *Node
+	VisitParenthesizedTypeNode(node *ParenthesizedTypeNode) *Node
+	VisitThisTypeNode(node *ThisTypeNode) *Node
+	VisitTypeOperatorNode(node *TypeOperatorNode) *Node
+	VisitIndexedAccessTypeNode(node *IndexedAccessTypeNode) *Node
+	VisitMappedTypeNode(node *MappedTypeNode) *Node
+	VisitLiteralTypeNode(node *LiteralTypeNode) *Node
+	VisitNamedTupleMember(node *NamedTupleMember) *Node
+	VisitTemplateLiteralTypeNode(node *TemplateLiteralTypeNode) *Node
+	VisitTemplateLiteralTypeSpan(node *TemplateLiteralTypeSpan) *Node
+	VisitImportTypeNode(node *ImportTypeNode) *Node
+	// Binding patterns
+	VisitObjectBindingPattern(node *BindingPattern) *Node
+	VisitArrayBindingPattern(node *BindingPattern) *Node
+	VisitBindingElement(node *BindingElement) *Node
+	// Expression
+	VisitArrayLiteralExpression(node *ArrayLiteralExpression) *Node
+	VisitObjectLiteralExpression(node *ObjectLiteralExpression) *Node
+	VisitPropertyAccessExpression(node *PropertyAccessExpression) *Node
+	VisitElementAccessExpression(node *ElementAccessExpression) *Node
+	VisitCallExpression(node *CallExpression) *Node
+	VisitNewExpression(node *NewExpression) *Node
+	VisitTaggedTemplateExpression(node *TaggedTemplateExpression) *Node
+	VisitTypeAssertion(node *TypeAssertion) *Node
+	VisitParenthesizedExpression(node *ParenthesizedExpression) *Node
+	VisitFunctionExpression(node *FunctionExpression) *Node
+	VisitArrowFunction(node *ArrowFunction) *Node
+	VisitDeleteExpression(node *DeleteExpression) *Node
+	VisitTypeOfExpression(node *TypeOfExpression) *Node
+	VisitVoidExpression(node *VoidExpression) *Node
+	VisitAwaitExpression(node *AwaitExpression) *Node
+	VisitPrefixUnaryExpression(node *PrefixUnaryExpression) *Node
+	VisitPostfixUnaryExpression(node *PostfixUnaryExpression) *Node
+	VisitBinaryExpression(node *BinaryExpression) *Node
+	VisitConditionalExpression(node *ConditionalExpression) *Node
+	VisitTemplateExpression(node *TemplateExpression) *Node
+	VisitYieldExpression(node *YieldExpression) *Node
+	VisitSpreadElement(node *SpreadElement) *Node
+	VisitClassExpression(node *ClassExpression) *Node
+	VisitOmittedExpression(node *OmittedExpression) *Node
+	VisitExpressionWithTypeArguments(node *ExpressionWithTypeArguments) *Node
+	VisitAsExpression(node *AsExpression) *Node
+	VisitNonNullExpression(node *NonNullExpression) *Node
+	VisitMetaProperty(node *MetaProperty) *Node
+	// VisitSyntheticExpression(node *SyntheticExpression) *Node
+	VisitSatisfiesExpression(node *SatisfiesExpression) *Node
+	// Misc
+	VisitTemplateSpan(node *TemplateSpan) *Node
+	VisitSemicolonClassElement(node *SemicolonClassElement) *Node
+	// Element
+	VisitBlock(node *Block) *Node
+	VisitEmptyStatement(node *EmptyStatement) *Node
+	VisitVariableStatement(node *VariableStatement) *Node
+	VisitExpressionStatement(node *ExpressionStatement) *Node
+	VisitIfStatement(node *IfStatement) *Node
+	VisitDoStatement(node *DoStatement) *Node
+	VisitWhileStatement(node *WhileStatement) *Node
+	VisitForStatement(node *ForStatement) *Node
+	VisitForInStatement(node *ForInOrOfStatement) *Node
+	VisitForOfStatement(node *ForInOrOfStatement) *Node
+	VisitContinueStatement(node *ContinueStatement) *Node
+	VisitBreakStatement(node *BreakStatement) *Node
+	VisitReturnStatement(node *ReturnStatement) *Node
+	VisitWithStatement(node *WithStatement) *Node
+	VisitSwitchStatement(node *SwitchStatement) *Node
+	VisitLabeledStatement(node *LabeledStatement) *Node
+	VisitThrowStatement(node *ThrowStatement) *Node
+	VisitTryStatement(node *TryStatement) *Node
+	VisitDebuggerStatement(node *DebuggerStatement) *Node
+	VisitVariableDeclaration(node *VariableDeclaration) *Node
+	VisitVariableDeclarationList(node *VariableDeclarationList) *Node
+	VisitFunctionDeclaration(node *FunctionDeclaration) *Node
+	VisitClassDeclaration(node *ClassDeclaration) *Node
+	VisitInterfaceDeclaration(node *InterfaceDeclaration) *Node
+	VisitTypeAliasDeclaration(node *TypeAliasDeclaration) *Node
+	VisitEnumDeclaration(node *EnumDeclaration) *Node
+	VisitModuleDeclaration(node *ModuleDeclaration) *Node
+	VisitModuleBlock(node *ModuleBlock) *Node
+	VisitCaseBlock(node *CaseBlock) *Node
+	VisitNamespaceExportDeclaration(node *NamespaceExportDeclaration) *Node
+	VisitImportEqualsDeclaration(node *ImportEqualsDeclaration) *Node
+	VisitImportDeclaration(node *ImportDeclaration) *Node
+	VisitImportClause(node *ImportClause) *Node
+	VisitNamespaceImport(node *NamespaceImport) *Node
+	VisitNamedImports(node *NamedImports) *Node
+	VisitImportSpecifier(node *ImportSpecifier) *Node
+	VisitExportAssignment(node *ExportAssignment) *Node
+	VisitExportDeclaration(node *ExportDeclaration) *Node
+	VisitNamedExports(node *NamedExports) *Node
+	VisitNamespaceExport(node *NamespaceExport) *Node
+	VisitExportSpecifier(node *ExportSpecifier) *Node
+	VisitMissingDeclaration(node *MissingDeclaration) *Node
+	// Module references
+	VisitExternalModuleReference(node *ExternalModuleReference) *Node
+	// JSX
+	VisitJsxElement(node *JsxElement) *Node
+	VisitJsxSelfClosingElement(node *JsxSelfClosingElement) *Node
+	VisitJsxOpeningElement(node *JsxOpeningElement) *Node
+	VisitJsxClosingElement(node *JsxClosingElement) *Node
+	VisitJsxFragment(node *JsxFragment) *Node
+	VisitJsxOpeningFragment(node *JsxOpeningFragment) *Node
+	VisitJsxClosingFragment(node *JsxClosingFragment) *Node
+	VisitJsxAttribute(node *JsxAttribute) *Node
+	VisitJsxAttributes(node *JsxAttributes) *Node
+	VisitJsxSpreadAttribute(node *JsxSpreadAttribute) *Node
+	VisitJsxExpression(node *JsxExpression) *Node
+	VisitJsxNamespacedName(node *JsxNamespacedName) *Node
+	// Clauses
+	VisitCaseClause(node *CaseOrDefaultClause) *Node
+	VisitDefaultClause(node *CaseOrDefaultClause) *Node
+	VisitHeritageClause(node *HeritageClause) *Node
+	VisitCatchClause(node *CatchClause) *Node
+	// Import attributes
+	VisitImportAttributes(node *ImportAttributes) *Node
+	VisitImportAttribute(node *ImportAttribute) *Node
+	// Property assignments
+	VisitPropertyAssignment(node *PropertyAssignment) *Node
+	VisitShorthandPropertyAssignment(node *ShorthandPropertyAssignment) *Node
+	VisitSpreadAssignment(node *SpreadAssignment) *Node
+	// Enum
+	VisitEnumMember(node *EnumMember) *Node
+	// Top-level nodes
+	VisitSourceFile(node *SourceFile) *Node
+	// VisitBundle(node *Bundle) *Node
+	// JSDoc nodes
+	// VisitJSDocTypeExpression(node *JSDocTypeExpression) *Node
+	// VisitJSDocNameReference(node *JSDocNameReference) *Node
+	// VisitJSDocMemberName(node *JSDocMemberName) *Node
+	// VisitJSDocAllType(node *JSDocAllType) *Node
+	// VisitJSDocUnknownType(node *JSDocUnknownType) *Node
+	VisitJSDocNullableType(node *JSDocNullableType) *Node
+	VisitJSDocNonNullableType(node *JSDocNonNullableType) *Node
+	// VisitJSDocOptionalType(node *JSDocOptionalType) *Node
+	// VisitJSDocFunctionType(node *JSDocFunctionType) *Node
+	// VisitJSDocVariadicType(node *JSDocVariadicType) *Node
+	// VisitJSDocNamepathType(node *JSDocNamepathType) *Node
+	// VisitJSDoc(node *JSDoc) *Node
+	// VisitJSDocText(node *JSDocText) *Node
+	// VisitJSDocTypeLiteral(node *JSDocTypeLiteral) *Node
+	// VisitJSDocSignature(node *JSDocSignature) *Node
+	// VisitJSDocLink(node *JSDocLink) *Node
+	// VisitJSDocLinkCode(node *JSDocLinkCode) *Node
+	// VisitJSDocLinkPlain(node *JSDocLinkPlain) *Node
+	// VisitJSDocTag(node *JSDocTag) *Node
+	// VisitJSDocAugmentsTag(node *JSDocAugmentsTag) *Node
+	// VisitJSDocImplementsTag(node *JSDocImplementsTag) *Node
+	// VisitJSDocAuthorTag(node *JSDocAuthorTag) *Node
+	// VisitJSDocDeprecatedTag(node *JSDocDeprecatedTag) *Node
+	// VisitJSDocImmediateTag(node *JSDocImmediateTag) *Node
+	// VisitJSDocClassTag(node *JSDocClassTag) *Node
+	// VisitJSDocPublicTag(node *JSDocPublicTag) *Node
+	// VisitJSDocPrivateTag(node *JSDocPrivateTag) *Node
+	// VisitJSDocProtectedTag(node *JSDocProtectedTag) *Node
+	// VisitJSDocReadonlyTag(node *JSDocReadonlyTag) *Node
+	// VisitJSDocOverrideTag(node *JSDocOverrideTag) *Node
+	// VisitJSDocCallbackTag(node *JSDocCallbackTag) *Node
+	// VisitJSDocOverloadTag(node *JSDocOverloadTag) *Node
+	// VisitJSDocEnumTag(node *JSDocEnumTag) *Node
+	// VisitJSDocParameterTag(node *JSDocParameterTag) *Node
+	// VisitJSDocReturnTag(node *JSDocReturnTag) *Node
+	// VisitJSDocThisTag(node *JSDocThisTag) *Node
+	// VisitJSDocTypeTag(node *JSDocTypeTag) *Node
+	// VisitJSDocTemplateTag(node *JSDocTemplateTag) *Node
+	// VisitJSDocTypedefTag(node *JSDocTypedefTag) *Node
+	// VisitJSDocSeeTag(node *JSDocSeeTag) *Node
+	// VisitJSDocPropertyTag(node *JSDocPropertyTag) *Node
+	// VisitJSDocThrowsTag(node *JSDocThrowsTag) *Node
+	// VisitJSDocSatisfiesTag(node *JSDocSatisfiesTag) *Node
+	// VisitJSDocImportTag(node *JSDocImportTag) *Node
+	// // Transformation nodes
+	// VisitNotEmittedStatement(node *NotEmittedStatement) *Node
+	// VisitPartiallyEmittedExpression(node *PartiallyEmittedExpression) *Node
+	// VisitCommaListExpression(node *CommaListExpression) *Node
+	// VisitSyntheticReferenceExpression(node *SyntheticReferenceExpression) *Node
+
+	// Unhandled
+	VisitOther(node *Node) *Node
+}
+
+type NodeVisitorBase struct {
+	factory NodeFactory
+}
+
+func extractSingleNode(nodes []*Node) *Node {
+	_assert(len(nodes) == 1, "Expected only a single node to be written to output")
+	return nodes[0]
+}
+
+func (v *NodeVisitorBase) VisitNode(node *Node) *Node {
+	return v.VisitAndLift(node, extractSingleNode)
+}
+
+func (v *NodeVisitorBase) VisitAndLift(node *Node, lift func(nodes []*Node) *Node) *Node {
+	if node == nil {
+		return nil
+	}
+	visited := node.Accept(v)
+	if visited == nil {
+		return nil
+	}
+	if visited.kind == SyntaxKindSyntaxList {
+		visited = lift(visited.AsSyntaxList().children)
+		_assert(visited.kind != SyntaxKindSyntaxList, "The result of visiting and lifting a Node may not be SyntaxList")
+	}
+	return visited
+}
+
+func (v *NodeVisitorBase) VisitNodes(nodes []*Node) []*Node {
+	if nodes == nil {
+		return nil
+	}
+
+	var updated []*Node = nil
+	for i, node := range nodes {
+		visited := node.Accept(v)
+		if updated != nil || visited == nil || visited != node {
+			if updated == nil {
+				updated = make([]*Node, i)
+				copy(updated, nodes[:i])
+			}
+			switch {
+			case visited == nil: // do nothing
+			case visited.kind == SyntaxKindSyntaxList:
+				updated = append(updated, visited.AsSyntaxList().children...)
+			default:
+				updated = append(updated, visited)
+			}
+		}
+	}
+	if updated != nil {
+		return updated
+	}
+	return nodes
+}
+
+// Tokens
+func (v *NodeVisitorBase) VisitToken(node *Token) *Node {
+	return node.AsNode()
+}
+
+// Literals
+func (v *NodeVisitorBase) VisitNumericLiteral(node *NumericLiteral) *Node {
+	return node.AsNode()
+}
+func (v *NodeVisitorBase) VisitBigIntLiteral(node *BigIntLiteral) *Node {
+	return node.AsNode()
+}
+func (v *NodeVisitorBase) VisitStringLiteral(node *StringLiteral) *Node {
+	return node.AsNode()
+}
+func (v *NodeVisitorBase) VisitJsxText(node *JsxText) *Node {
+	return node.AsNode()
+}
+func (v *NodeVisitorBase) VisitRegularExpressionLiteral(node *RegularExpressionLiteral) *Node {
+	return node.AsNode()
+}
+func (v *NodeVisitorBase) VisitNoSubstitutionTemplateLiteral(node *NoSubstitutionTemplateLiteral) *Node {
+	return node.AsNode()
+}
+
+// Pseudo-literals
+func (v *NodeVisitorBase) VisitTemplateHead(node *TemplateHead) *Node {
+	return node.AsNode()
+}
+func (v *NodeVisitorBase) VisitTemplateMiddle(node *TemplateMiddle) *Node {
+	return node.AsNode()
+}
+func (v *NodeVisitorBase) VisitTemplateTail(node *TemplateTail) *Node {
+	return node.AsNode()
+}
+
+// Identifiers
+func (v *NodeVisitorBase) VisitIdentifier(node *Identifier) *Node {
+	return node.AsNode()
+}
+func (v *NodeVisitorBase) VisitPrivateIdentifier(node *PrivateIdentifier) *Node {
+	return node.AsNode()
+}
+
+// Names
+func (v *NodeVisitorBase) VisitQualifiedName(node *QualifiedName) *Node {
+	return v.factory.UpdateQualifiedName(
+		node.AsNode(),
+		v.VisitNode(node.left),
+		v.VisitNode(node.right),
+	)
+}
+func (v *NodeVisitorBase) VisitComputedPropertyName(node *ComputedPropertyName) *Node {
+	return v.factory.UpdateComputedPropertyName(
+		node.AsNode(),
+		v.VisitNode(node.expression),
+	)
+}
+
+// Lists
+func (v *NodeVisitorBase) VisitModifierList(node *ModifierList) *Node {
+	return v.factory.UpdateModifierList(
+		node.AsNode(),
+		v.VisitNodes(node.modifiers),
+	)
+}
+func (v *NodeVisitorBase) VisitTypeParameterList(node *TypeParameterList) *Node {
+	return v.factory.UpdateTypeParameterList(
+		node.AsNode(),
+		v.VisitNodes(node.parameters),
+	)
+}
+func (v *NodeVisitorBase) VisitTypeArgumentList(node *TypeArgumentList) *Node {
+	return v.factory.UpdateTypeArgumentList(
+		node.AsNode(),
+		v.VisitNodes(node.arguments),
+	)
+}
+
+// Signature elements
+func (v *NodeVisitorBase) VisitTypeParameterDeclaration(node *TypeParameterDeclaration) *Node {
+	return v.factory.UpdateTypeParameterDeclaration(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+		v.VisitNode(node.name),
+		v.VisitNode(node.constraint),
+		v.VisitNode(node.defaultType),
+	)
+}
+func (v *NodeVisitorBase) VisitParameterDeclaration(node *ParameterDeclaration) *Node {
+	return v.factory.UpdateParameterDeclaration(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+		v.VisitNode(node.dotDotDotToken),
+		v.VisitNode(node.name),
+		v.VisitNode(node.questionToken),
+		v.VisitNode(node.typeNode),
+		v.VisitNode(node.initializer),
+	)
+}
+func (v *NodeVisitorBase) VisitDecorator(node *Decorator) *Node {
+	return v.factory.UpdateDecorator(
+		node.AsNode(),
+		v.VisitNode(node.expression),
+	)
+}
+
+// Type members
+func (v *NodeVisitorBase) VisitPropertySignatureDeclaration(node *PropertySignatureDeclaration) *Node {
+	return v.factory.UpdatePropertySignatureDeclaration(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+		v.VisitNode(node.name),
+		v.VisitNode(node.postfixToken),
+		v.VisitNode(node.typeNode),
+		v.VisitNode(node.initializer),
+	)
+}
+func (v *NodeVisitorBase) VisitPropertyDeclaration(node *PropertyDeclaration) *Node {
+	return v.factory.UpdatePropertyDeclaration(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+		v.VisitNode(node.name),
+		v.VisitNode(node.postfixToken),
+		v.VisitNode(node.typeNode),
+		v.VisitNode(node.initializer),
+	)
+}
+func (v *NodeVisitorBase) VisitMethodSignatureDeclaration(node *MethodSignatureDeclaration) *Node {
+	return v.factory.UpdateMethodSignatureDeclaration(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+		v.VisitNode(node.name),
+		v.VisitNode(node.postfixToken),
+		v.VisitNode(node.typeParameters),
+		v.VisitNodes(node.parameters),
+		v.VisitNode(node.returnType),
+	)
+}
+func (v *NodeVisitorBase) VisitMethodDeclaration(node *MethodDeclaration) *Node {
+	return v.factory.UpdateMethodDeclaration(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+		v.VisitNode(node.asteriskToken),
+		v.VisitNode(node.name),
+		v.VisitNode(node.postfixToken),
+		v.VisitNode(node.typeParameters),
+		v.VisitParameters(node.parameters),
+		v.VisitNode(node.returnType),
+		v.VisitFunctionBody(node.body),
+	)
+}
+func (v *NodeVisitorBase) VisitClassStaticBlockDeclaration(node *ClassStaticBlockDeclaration) *Node {
+	// A `static {}` Block does not have parameters, but we must still ensure we enter the lexical scope
+	v.VisitParameters(nil)
+	return v.factory.UpdateClassStaticBlockDeclaration(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+		v.VisitFunctionBody(node.body),
+	)
+}
+func (v *NodeVisitorBase) VisitConstructorDeclaration(node *ConstructorDeclaration) *Node {
+	return v.factory.UpdateConstructorDeclaration(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+		v.VisitNode(node.typeParameters),
+		v.VisitParameters(node.parameters),
+		v.VisitNode(node.returnType),
+		v.VisitFunctionBody(node.body),
+	)
+}
+func (v *NodeVisitorBase) VisitGetAccessorDeclaration(node *GetAccessorDeclaration) *Node {
+	return v.factory.UpdateGetAccessorDeclaration(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+		v.VisitNode(node.name),
+		v.VisitNode(node.typeParameters),
+		v.VisitParameters(node.parameters),
+		v.VisitNode(node.returnType),
+		v.VisitFunctionBody(node.body),
+	)
+}
+func (v *NodeVisitorBase) VisitSetAccessorDeclaration(node *SetAccessorDeclaration) *Node {
+	return v.factory.UpdateSetAccessorDeclaration(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+		v.VisitNode(node.name),
+		v.VisitNode(node.typeParameters),
+		v.VisitParameters(node.parameters),
+		v.VisitNode(node.returnType),
+		v.VisitFunctionBody(node.body),
+	)
+}
+func (v *NodeVisitorBase) VisitCallSignatureDeclaration(node *CallSignatureDeclaration) *Node {
+	return v.factory.UpdateCallSignatureDeclaration(
+		node.AsNode(),
+		v.VisitNode(node.typeParameters),
+		v.VisitNodes(node.parameters),
+		v.VisitNode(node.returnType),
+	)
+}
+func (v *NodeVisitorBase) VisitConstructSignatureDeclaration(node *ConstructSignatureDeclaration) *Node {
+	return v.factory.UpdateConstructSignatureDeclaration(
+		node.AsNode(),
+		v.VisitNode(node.typeParameters),
+		v.VisitNodes(node.parameters),
+		v.VisitNode(node.returnType),
+	)
+}
+func (v *NodeVisitorBase) VisitIndexSignatureDeclaration(node *IndexSignatureDeclaration) *Node {
+	return v.factory.UpdateIndexSignatureDeclaration(
+		node.AsNode(),
+		v.VisitNode(node.typeParameters),
+		v.VisitNodes(node.parameters),
+		v.VisitNode(node.returnType),
+	)
+}
+
+// Types
+func (v *NodeVisitorBase) VisitTypePredicateNode(node *TypePredicateNode) *Node {
+	return v.factory.UpdateTypePredicateNode(
+		node.AsNode(),
+		v.VisitNode(node.assertsModifier),
+		v.VisitNode(node.parameterName),
+		v.VisitNode(node.typeNode),
+	)
+}
+func (v *NodeVisitorBase) VisitTypeReferenceNode(node *TypeReferenceNode) *Node {
+	return v.factory.UpdateTypeReferenceNode(
+		node.AsNode(),
+		v.VisitNode(node.typeName),
+		v.VisitNode(node.typeArguments),
+	)
+}
+func (v *NodeVisitorBase) VisitFunctionTypeNode(node *FunctionTypeNode) *Node {
+	return v.factory.UpdateFunctionTypeNode(
+		node.AsNode(),
+		v.VisitNode(node.typeParameters),
+		v.VisitNodes(node.parameters),
+		v.VisitNode(node.returnType),
+	)
+}
+func (v *NodeVisitorBase) VisitConstructorTypeNode(node *ConstructorTypeNode) *Node {
+	return v.factory.UpdateConstructorTypeNode(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+		v.VisitNode(node.typeParameters),
+		v.VisitNodes(node.parameters),
+		v.VisitNode(node.returnType),
+	)
+}
+func (v *NodeVisitorBase) VisitTypeQueryNode(node *TypeQueryNode) *Node {
+	return v.factory.UpdateTypeQueryNode(
+		node.AsNode(),
+		v.VisitNode(node.exprName),
+		v.VisitNode(node.typeArguments),
+	)
+}
+func (v *NodeVisitorBase) VisitTypeLiteralNode(node *TypeLiteralNode) *Node {
+	return v.factory.UpdateTypeLiteralNode(
+		node.AsNode(),
+		v.VisitNodes(node.members),
+	)
+}
+func (v *NodeVisitorBase) VisitArrayTypeNode(node *ArrayTypeNode) *Node {
+	return v.factory.UpdateArrayTypeNode(
+		node.AsNode(),
+		v.VisitNode(node.elementType),
+	)
+}
+func (v *NodeVisitorBase) VisitTupleTypeNode(node *TupleTypeNode) *Node {
+	return v.factory.UpdateTupleTypeNode(
+		node.AsNode(),
+		v.VisitNodes(node.elements),
+	)
+}
+func (v *NodeVisitorBase) VisitOptionalTypeNode(node *OptionalTypeNode) *Node {
+	return v.factory.UpdateOptionalTypeNode(
+		node.AsNode(),
+		v.VisitNode(node.typeNode),
+	)
+}
+func (v *NodeVisitorBase) VisitRestTypeNode(node *RestTypeNode) *Node {
+	return v.factory.UpdateRestTypeNode(
+		node.AsNode(),
+		v.VisitNode(node.typeNode),
+	)
+}
+func (v *NodeVisitorBase) VisitUnionTypeNode(node *UnionTypeNode) *Node {
+	return v.factory.UpdateUnionTypeNode(
+		node.AsNode(),
+		v.VisitNodes(node.types),
+	)
+}
+func (v *NodeVisitorBase) VisitIntersectionTypeNode(node *IntersectionTypeNode) *Node {
+	return v.factory.UpdateIntersectionTypeNode(
+		node.AsNode(),
+		v.VisitNodes(node.types),
+	)
+}
+func (v *NodeVisitorBase) VisitConditionalTypeNode(node *ConditionalTypeNode) *Node {
+	return v.factory.UpdateConditionalTypeNode(
+		node.AsNode(),
+		v.VisitNode(node.checkType),
+		v.VisitNode(node.extendsType),
+		v.VisitNode(node.trueType),
+		v.VisitNode(node.falseType),
+	)
+}
+func (v *NodeVisitorBase) VisitInferTypeNode(node *InferTypeNode) *Node {
+	return v.factory.UpdateInferTypeNode(
+		node.AsNode(),
+		v.VisitNode(node.typeParameter),
+	)
+}
+func (v *NodeVisitorBase) VisitParenthesizedTypeNode(node *ParenthesizedTypeNode) *Node {
+	return v.factory.UpdateParenthesizedTypeNode(
+		node.AsNode(),
+		v.VisitNode(node.typeNode),
+	)
+}
+func (v *NodeVisitorBase) VisitThisTypeNode(node *ThisTypeNode) *Node {
+	return node.AsNode()
+}
+func (v *NodeVisitorBase) VisitTypeOperatorNode(node *TypeOperatorNode) *Node {
+	return v.factory.UpdateTypeOperatorNode(
+		node.AsNode(),
+		v.VisitNode(node.typeNode),
+	)
+}
+func (v *NodeVisitorBase) VisitIndexedAccessTypeNode(node *IndexedAccessTypeNode) *Node {
+	return v.factory.UpdateIndexedAccessTypeNode(
+		node.AsNode(),
+		v.VisitNode(node.objectType),
+		v.VisitNode(node.indexType),
+	)
+}
+func (v *NodeVisitorBase) VisitMappedTypeNode(node *MappedTypeNode) *Node {
+	return v.factory.UpdateMappedTypeNode(
+		node.AsNode(),
+		v.VisitNode(node.readonlyToken),
+		v.VisitNode(node.typeParameter),
+		v.VisitNode(node.nameType),
+		v.VisitNode(node.questionToken),
+		v.VisitNode(node.typeNode),
+		v.VisitNodes(node.members),
+	)
+}
+func (v *NodeVisitorBase) VisitLiteralTypeNode(node *LiteralTypeNode) *Node {
+	return v.factory.UpdateLiteralTypeNode(
+		node.AsNode(),
+		v.VisitNode(node.literal),
+	)
+}
+func (v *NodeVisitorBase) VisitNamedTupleMember(node *NamedTupleMember) *Node {
+	return v.factory.UpdateNamedTupleMember(
+		node.AsNode(),
+		v.VisitNode(node.dotDotDotToken),
+		v.VisitNode(node.name),
+		v.VisitNode(node.questionToken),
+		v.VisitNode(node.typeNode),
+	)
+}
+func (v *NodeVisitorBase) VisitTemplateLiteralTypeNode(node *TemplateLiteralTypeNode) *Node {
+	return v.factory.UpdateTemplateLiteralTypeNode(
+		node.AsNode(),
+		v.VisitNode(node.head),
+		v.VisitNodes(node.templateSpans),
+	)
+}
+func (v *NodeVisitorBase) VisitTemplateLiteralTypeSpan(node *TemplateLiteralTypeSpan) *Node {
+	return v.factory.UpdateTemplateLiteralTypeSpan(
+		node.AsNode(),
+		v.VisitNode(node.typeNode),
+		v.VisitNode(node.literal),
+	)
+}
+func (v *NodeVisitorBase) VisitImportTypeNode(node *ImportTypeNode) *Node {
+	return v.factory.UpdateImportTypeNode(
+		node.AsNode(),
+		node.isTypeOf,
+		v.VisitNode(node.argument),
+		v.VisitNode(node.attributes),
+		v.VisitNode(node.qualifier),
+		v.VisitNode(node.typeArguments),
+	)
+}
+
+// Binding patterns
+func (v *NodeVisitorBase) VisitObjectBindingPattern(node *BindingPattern) *Node {
+	return v.factory.UpdateBindingPattern(
+		node.AsNode(),
+		v.VisitNodes(node.elements),
+	)
+}
+func (v *NodeVisitorBase) VisitArrayBindingPattern(node *BindingPattern) *Node {
+	return v.factory.UpdateBindingPattern(
+		node.AsNode(),
+		v.VisitNodes(node.elements),
+	)
+}
+func (v *NodeVisitorBase) VisitBindingElement(node *BindingElement) *Node {
+	return v.factory.UpdateBindingElement(
+		node.AsNode(),
+		v.VisitNode(node.dotDotDotToken),
+		v.VisitNode(node.propertyName),
+		v.VisitNode(node.name),
+		v.VisitNode(node.initializer),
+	)
+}
+
+// Expression
+func (v *NodeVisitorBase) VisitArrayLiteralExpression(node *ArrayLiteralExpression) *Node {
+	return v.factory.UpdateArrayLiteralExpression(
+		node.AsNode(),
+		v.VisitNodes(node.elements),
+	)
+}
+func (v *NodeVisitorBase) VisitObjectLiteralExpression(node *ObjectLiteralExpression) *Node {
+	return v.factory.UpdateObjectLiteralExpression(
+		node.AsNode(),
+		v.VisitNodes(node.properties),
+	)
+}
+func (v *NodeVisitorBase) VisitPropertyAccessExpression(node *PropertyAccessExpression) *Node {
+	return v.factory.UpdatePropertyAccessExpression(
+		node.AsNode(),
+		v.VisitNode(node.expression),
+		v.VisitNode(node.questionDotToken),
+		v.VisitNode(node.name),
+	)
+}
+func (v *NodeVisitorBase) VisitElementAccessExpression(node *ElementAccessExpression) *Node {
+	return v.factory.UpdateElementAccessExpression(
+		node.AsNode(),
+		v.VisitNode(node.expression),
+		v.VisitNode(node.questionDotToken),
+		v.VisitNode(node.argumentExpression),
+	)
+}
+func (v *NodeVisitorBase) VisitCallExpression(node *CallExpression) *Node {
+	return v.factory.UpdateCallExpression(
+		node.AsNode(),
+		v.VisitNode(node.expression),
+		v.VisitNode(node.questionDotToken),
+		v.VisitNode(node.typeArguments),
+		v.VisitNodes(node.arguments),
+	)
+}
+func (v *NodeVisitorBase) VisitNewExpression(node *NewExpression) *Node {
+	return v.factory.UpdateNewExpression(
+		node.AsNode(),
+		v.VisitNode(node.expression),
+		v.VisitNode(node.typeArguments),
+		v.VisitNodes(node.arguments),
+	)
+}
+func (v *NodeVisitorBase) VisitTaggedTemplateExpression(node *TaggedTemplateExpression) *Node {
+	return v.factory.UpdateTaggedTemplateExpression(
+		node.AsNode(),
+		v.VisitNode(node.tag),
+		v.VisitNode(node.questionDotToken),
+		v.VisitNode(node.typeArguments),
+		v.VisitNode(node.template),
+	)
+}
+func (v *NodeVisitorBase) VisitTypeAssertion(node *TypeAssertion) *Node {
+	return v.factory.UpdateTypeAssertion(
+		node.AsNode(),
+		v.VisitNode(node.typeNode),
+		v.VisitNode(node.expression),
+	)
+}
+func (v *NodeVisitorBase) VisitParenthesizedExpression(node *ParenthesizedExpression) *Node {
+	return v.factory.UpdateParenthesizedExpression(
+		node.AsNode(),
+		v.VisitNode(node.expression),
+	)
+}
+func (v *NodeVisitorBase) VisitFunctionExpression(node *FunctionExpression) *Node {
+	return v.factory.UpdateFunctionExpression(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+		v.VisitNode(node.asteriskToken),
+		v.VisitNode(node.name),
+		v.VisitNode(node.typeParameters),
+		v.VisitParameters(node.parameters),
+		v.VisitNode(node.returnType),
+		v.VisitFunctionBody(node.body),
+	)
+}
+func (v *NodeVisitorBase) VisitArrowFunction(node *ArrowFunction) *Node {
+	return v.factory.UpdateArrowFunction(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+		v.VisitNode(node.typeParameters),
+		v.VisitParameters(node.parameters),
+		v.VisitNode(node.returnType),
+		v.VisitNode(node.equalsGreaterThanToken),
+		v.VisitFunctionBody(node.body),
+	)
+}
+func (v *NodeVisitorBase) VisitDeleteExpression(node *DeleteExpression) *Node {
+	return v.factory.UpdateDeleteExpression(
+		node.AsNode(),
+		v.VisitNode(node.expression),
+	)
+}
+func (v *NodeVisitorBase) VisitTypeOfExpression(node *TypeOfExpression) *Node {
+	return v.factory.UpdateTypeOfExpression(
+		node.AsNode(),
+		v.VisitNode(node.expression),
+	)
+}
+func (v *NodeVisitorBase) VisitVoidExpression(node *VoidExpression) *Node {
+	return v.factory.UpdateVoidExpression(
+		node.AsNode(),
+		v.VisitNode(node.expression),
+	)
+}
+func (v *NodeVisitorBase) VisitAwaitExpression(node *AwaitExpression) *Node {
+	return v.factory.UpdateAwaitExpression(
+		node.AsNode(),
+		v.VisitNode(node.expression),
+	)
+}
+func (v *NodeVisitorBase) VisitPrefixUnaryExpression(node *PrefixUnaryExpression) *Node {
+	return v.factory.UpdatePrefixUnaryExpression(
+		node.AsNode(),
+		v.VisitNode(node.operand),
+	)
+}
+func (v *NodeVisitorBase) VisitPostfixUnaryExpression(node *PostfixUnaryExpression) *Node {
+	return v.factory.UpdatePostfixUnaryExpression(
+		node.AsNode(),
+		v.VisitNode(node.operand),
+	)
+}
+func (v *NodeVisitorBase) VisitBinaryExpression(node *BinaryExpression) *Node {
+	return v.factory.UpdateBinaryExpression(
+		node.AsNode(),
+		v.VisitNode(node.left),
+		v.VisitNode(node.operatorToken),
+		v.VisitNode(node.right),
+	)
+}
+func (v *NodeVisitorBase) VisitConditionalExpression(node *ConditionalExpression) *Node {
+	return v.factory.UpdateConditionalExpression(
+		node.AsNode(),
+		v.VisitNode(node.condition),
+		v.VisitNode(node.questionToken),
+		v.VisitNode(node.whenTrue),
+		v.VisitNode(node.colonToken),
+		v.VisitNode(node.whenFalse),
+	)
+}
+func (v *NodeVisitorBase) VisitTemplateExpression(node *TemplateExpression) *Node {
+	return v.factory.UpdateTemplateExpression(
+		node.AsNode(),
+		v.VisitNode(node.head),
+		v.VisitNodes(node.templateSpans),
+	)
+}
+func (v *NodeVisitorBase) VisitYieldExpression(node *YieldExpression) *Node {
+	return v.factory.UpdateYieldExpression(
+		node.AsNode(),
+		v.VisitNode(node.asteriskToken),
+		v.VisitNode(node.expression),
+	)
+}
+func (v *NodeVisitorBase) VisitSpreadElement(node *SpreadElement) *Node {
+	return v.factory.UpdateSpreadElement(
+		node.AsNode(),
+		v.VisitNode(node.expression),
+	)
+}
+func (v *NodeVisitorBase) VisitClassExpression(node *ClassExpression) *Node {
+	return v.factory.UpdateClassExpression(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+		v.VisitNode(node.name),
+		v.VisitNode(node.typeParameters),
+		v.VisitNodes(node.heritageClauses),
+		v.VisitNodes(node.members),
+	)
+}
+func (v *NodeVisitorBase) VisitOmittedExpression(node *OmittedExpression) *Node {
+	return node.AsNode()
+}
+func (v *NodeVisitorBase) VisitExpressionWithTypeArguments(node *ExpressionWithTypeArguments) *Node {
+	return v.factory.UpdateExpressionWithTypeArguments(
+		node.AsNode(),
+		v.VisitNode(node.expression),
+		v.VisitNode(node.typeArguments),
+	)
+}
+func (v *NodeVisitorBase) VisitAsExpression(node *AsExpression) *Node {
+	return v.factory.UpdateAsExpression(
+		node.AsNode(),
+		v.VisitNode(node.expression),
+		v.VisitNode(node.typeNode),
+	)
+}
+func (v *NodeVisitorBase) VisitNonNullExpression(node *NonNullExpression) *Node {
+	return v.factory.UpdateNonNullExpression(
+		node.AsNode(),
+		v.VisitNode(node.expression),
+	)
+}
+func (v *NodeVisitorBase) VisitMetaProperty(node *MetaProperty) *Node {
+	return v.factory.UpdateMetaProperty(
+		node.AsNode(),
+		v.VisitNode(node.name),
+	)
+}
+
+// VisitSyntheticExpression(node *SyntheticExpression) *Node
+func (v *NodeVisitorBase) VisitSatisfiesExpression(node *SatisfiesExpression) *Node {
+	return v.factory.UpdateSatisfiesExpression(
+		node.AsNode(),
+		v.VisitNode(node.expression),
+		v.VisitNode(node.typeNode),
+	)
+}
+
+// Misc
+func (v *NodeVisitorBase) VisitTemplateSpan(node *TemplateSpan) *Node {
+	return v.factory.UpdateTemplateSpan(
+		node.AsNode(),
+		v.VisitNode(node.expression),
+		v.VisitNode(node.literal),
+	)
+}
+func (v *NodeVisitorBase) VisitSemicolonClassElement(node *SemicolonClassElement) *Node {
+	return node.AsNode()
+}
+
+// Element
+func (v *NodeVisitorBase) VisitBlock(node *Block) *Node {
+	return v.factory.UpdateBlock(
+		node.AsNode(),
+		v.VisitNodes(node.statements),
+	)
+}
+func (v *NodeVisitorBase) VisitEmptyStatement(node *EmptyStatement) *Node {
+	return node.AsNode()
+}
+func (v *NodeVisitorBase) VisitVariableStatement(node *VariableStatement) *Node {
+	return v.factory.UpdateVariableStatement(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+		v.VisitNode(node.declarationList),
+	)
+}
+func (v *NodeVisitorBase) VisitExpressionStatement(node *ExpressionStatement) *Node {
+	return v.factory.UpdateExpressionStatement(
+		node.AsNode(),
+		v.VisitNode(node.expression),
+	)
+}
+func (v *NodeVisitorBase) VisitIfStatement(node *IfStatement) *Node {
+	return v.factory.UpdateIfStatement(
+		node.AsNode(),
+		v.VisitNode(node.expression),
+		v.VisitNode(node.thenStatement),
+		v.VisitNode(node.elseStatement),
+	)
+}
+func (v *NodeVisitorBase) VisitDoStatement(node *DoStatement) *Node {
+	return v.factory.UpdateDoStatement(
+		node.AsNode(),
+		v.VisitIterationBody(node.statement),
+		v.VisitNode(node.expression),
+	)
+}
+func (v *NodeVisitorBase) VisitWhileStatement(node *WhileStatement) *Node {
+	return v.factory.UpdateWhileStatement(
+		node.AsNode(),
+		v.VisitNode(node.expression),
+		v.VisitIterationBody(node.statement),
+	)
+}
+func (v *NodeVisitorBase) VisitForStatement(node *ForStatement) *Node {
+	return v.factory.UpdateForStatement(
+		node.AsNode(),
+		v.VisitNode(node.initializer),
+		v.VisitNode(node.condition),
+		v.VisitNode(node.incrementor),
+		v.VisitIterationBody(node.statement),
+	)
+}
+func (v *NodeVisitorBase) VisitForInStatement(node *ForInOrOfStatement) *Node {
+	return v.factory.UpdateForInOrOfStatement(
+		node.AsNode(),
+		nil,
+		v.VisitNode(node.initializer),
+		v.VisitNode(node.expression),
+		v.VisitIterationBody(node.statement),
+	)
+}
+func (v *NodeVisitorBase) VisitForOfStatement(node *ForInOrOfStatement) *Node {
+	return v.factory.UpdateForInOrOfStatement(
+		node.AsNode(),
+		v.VisitNode(node.awaitModifier),
+		v.VisitNode(node.initializer),
+		v.VisitNode(node.expression),
+		v.VisitIterationBody(node.statement),
+	)
+}
+func (v *NodeVisitorBase) VisitContinueStatement(node *ContinueStatement) *Node {
+	return v.factory.UpdateContinueStatement(
+		node.AsNode(),
+		v.VisitNode(node.label),
+	)
+}
+func (v *NodeVisitorBase) VisitBreakStatement(node *BreakStatement) *Node {
+	return v.factory.UpdateBreakStatement(
+		node.AsNode(),
+		v.VisitNode(node.label),
+	)
+}
+func (v *NodeVisitorBase) VisitReturnStatement(node *ReturnStatement) *Node {
+	return v.factory.UpdateReturnStatement(
+		node.AsNode(),
+		v.VisitNode(node.expression),
+	)
+}
+func (v *NodeVisitorBase) VisitWithStatement(node *WithStatement) *Node {
+	return v.factory.UpdateWithStatement(
+		node.AsNode(),
+		v.VisitNode(node.expression),
+		v.VisitNode(node.statement),
+	)
+}
+func (v *NodeVisitorBase) VisitSwitchStatement(node *SwitchStatement) *Node {
+	return v.factory.UpdateSwitchStatement(
+		node.AsNode(),
+		v.VisitNode(node.expression),
+		v.VisitNode(node.caseBlock),
+	)
+}
+func (v *NodeVisitorBase) VisitLabeledStatement(node *LabeledStatement) *Node {
+	return v.factory.UpdateLabeledStatement(
+		node.AsNode(),
+		v.VisitNode(node.label),
+		v.VisitNode(node.statement),
+	)
+}
+func (v *NodeVisitorBase) VisitThrowStatement(node *ThrowStatement) *Node {
+	return v.factory.UpdateThrowStatement(
+		node.AsNode(),
+		v.VisitNode(node.expression),
+	)
+}
+func (v *NodeVisitorBase) VisitTryStatement(node *TryStatement) *Node {
+	return v.factory.UpdateTryStatement(
+		node.AsNode(),
+		v.VisitNode(node.tryBlock),
+		v.VisitNode(node.catchClause),
+		v.VisitNode(node.finallyBlock),
+	)
+}
+func (v *NodeVisitorBase) VisitDebuggerStatement(node *DebuggerStatement) *Node {
+	return node.AsNode()
+}
+func (v *NodeVisitorBase) VisitVariableDeclaration(node *VariableDeclaration) *Node {
+	return v.factory.UpdateVariableDeclaration(
+		node.AsNode(),
+		v.VisitNode(node.name),
+		v.VisitNode(node.exclamationToken),
+		v.VisitNode(node.typeNode),
+		v.VisitNode(node.initializer),
+	)
+}
+func (v *NodeVisitorBase) VisitVariableDeclarationList(node *VariableDeclarationList) *Node {
+	return v.factory.UpdateVariableDeclarationList(
+		node.AsNode(),
+		v.VisitNodes(node.declarations),
+	)
+}
+func (v *NodeVisitorBase) VisitFunctionDeclaration(node *FunctionDeclaration) *Node {
+	return v.factory.UpdateFunctionDeclaration(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+		v.VisitNode(node.asteriskToken),
+		v.VisitNode(node.name),
+		v.VisitNode(node.typeParameters),
+		v.VisitParameters(node.parameters),
+		v.VisitNode(node.returnType),
+		v.VisitFunctionBody(node.body),
+	)
+}
+func (v *NodeVisitorBase) VisitClassDeclaration(node *ClassDeclaration) *Node {
+	return v.factory.UpdateClassDeclaration(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+		v.VisitNode(node.name),
+		v.VisitNode(node.typeParameters),
+		v.VisitNodes(node.heritageClauses),
+		v.VisitNodes(node.members),
+	)
+}
+func (v *NodeVisitorBase) VisitInterfaceDeclaration(node *InterfaceDeclaration) *Node {
+	return v.factory.UpdateInterfaceDeclaration(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+		v.VisitNode(node.name),
+		v.VisitNode(node.typeParameters),
+		v.VisitNodes(node.heritageClauses),
+		v.VisitNodes(node.members),
+	)
+}
+func (v *NodeVisitorBase) VisitTypeAliasDeclaration(node *TypeAliasDeclaration) *Node {
+	return v.factory.UpdateTypeAliasDeclaration(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+		v.VisitNode(node.name),
+		v.VisitNode(node.typeParameters),
+		v.VisitNode(node.typeNode),
+	)
+}
+func (v *NodeVisitorBase) VisitEnumDeclaration(node *EnumDeclaration) *Node {
+	return v.factory.UpdateEnumDeclaration(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+		v.VisitNode(node.name),
+		v.VisitNodes(node.members),
+	)
+}
+func (v *NodeVisitorBase) VisitModuleDeclaration(node *ModuleDeclaration) *Node {
+	return v.factory.UpdateModuleDeclaration(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+		v.VisitNode(node.name),
+		v.VisitNode(node.body),
+	)
+}
+func (v *NodeVisitorBase) VisitModuleBlock(node *ModuleBlock) *Node {
+	return v.factory.UpdateModuleBlock(
+		node.AsNode(),
+		v.VisitNodes(node.statements),
+	)
+}
+func (v *NodeVisitorBase) VisitCaseBlock(node *CaseBlock) *Node {
+	return v.factory.UpdateCaseBlock(
+		node.AsNode(),
+		v.VisitNodes(node.clauses),
+	)
+}
+func (v *NodeVisitorBase) VisitNamespaceExportDeclaration(node *NamespaceExportDeclaration) *Node {
+	return v.factory.UpdateNamespaceExportDeclaration(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+		v.VisitNode(node.name),
+	)
+}
+func (v *NodeVisitorBase) VisitImportEqualsDeclaration(node *ImportEqualsDeclaration) *Node {
+	return v.factory.UpdateImportEqualsDeclaration(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+		node.isTypeOnly,
+		v.VisitNode(node.name),
+		v.VisitNode(node.moduleReference),
+	)
+}
+func (v *NodeVisitorBase) VisitImportDeclaration(node *ImportDeclaration) *Node {
+	return v.factory.UpdateImportDeclaration(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+		v.VisitNode(node.importClause),
+		v.VisitNode(node.moduleSpecifier),
+		v.VisitNode(node.attributes),
+	)
+}
+func (v *NodeVisitorBase) VisitImportClause(node *ImportClause) *Node {
+	return v.factory.UpdateImportClause(
+		node.AsNode(),
+		node.isTypeOnly,
+		v.VisitNode(node.name),
+		v.VisitNode(node.namedBindings),
+	)
+}
+func (v *NodeVisitorBase) VisitNamespaceImport(node *NamespaceImport) *Node {
+	return v.factory.UpdateNamespaceImport(
+		node.AsNode(),
+		v.VisitNode(node.name),
+	)
+}
+func (v *NodeVisitorBase) VisitNamedImports(node *NamedImports) *Node {
+	return v.factory.UpdateNamedImports(
+		node.AsNode(),
+		v.VisitNodes(node.elements),
+	)
+}
+func (v *NodeVisitorBase) VisitImportSpecifier(node *ImportSpecifier) *Node {
+	return v.factory.UpdateImportSpecifier(
+		node.AsNode(),
+		node.isTypeOnly,
+		v.VisitNode(node.propertyName),
+		v.VisitNode(node.name),
+	)
+}
+func (v *NodeVisitorBase) VisitExportAssignment(node *ExportAssignment) *Node {
+	return v.factory.UpdateExportAssignment(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+		v.VisitNode(node.expression),
+	)
+}
+func (v *NodeVisitorBase) VisitExportDeclaration(node *ExportDeclaration) *Node {
+	return v.factory.UpdateExportDeclaration(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+		node.isTypeOnly,
+		v.VisitNode(node.exportClause),
+		v.VisitNode(node.moduleSpecifier),
+		v.VisitNode(node.attributes),
+	)
+}
+func (v *NodeVisitorBase) VisitNamedExports(node *NamedExports) *Node {
+	return v.factory.UpdateNamedExports(
+		node.AsNode(),
+		v.VisitNodes(node.elements),
+	)
+}
+func (v *NodeVisitorBase) VisitNamespaceExport(node *NamespaceExport) *Node {
+	return v.factory.UpdateNamespaceExport(
+		node.AsNode(),
+		v.VisitNode(node.name),
+	)
+}
+func (v *NodeVisitorBase) VisitExportSpecifier(node *ExportSpecifier) *Node {
+	return v.factory.UpdateExportSpecifier(
+		node.AsNode(),
+		node.isTypeOnly,
+		v.VisitNode(node.propertyName),
+		v.VisitNode(node.name),
+	)
+}
+func (v *NodeVisitorBase) VisitMissingDeclaration(node *MissingDeclaration) *Node {
+	return v.factory.UpdateMissingDeclaration(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+	)
+}
+
+// Module references
+func (v *NodeVisitorBase) VisitExternalModuleReference(node *ExternalModuleReference) *Node {
+	return v.factory.UpdateExternalModuleReference(
+		node.AsNode(),
+		v.VisitNode(node.expression),
+	)
+}
+
+// JSX
+func (v *NodeVisitorBase) VisitJsxElement(node *JsxElement) *Node {
+	return v.factory.UpdateJsxElement(
+		node.AsNode(),
+		v.VisitNode(node.openingElement),
+		v.VisitNodes(node.children),
+		v.VisitNode(node.closingElement),
+	)
+}
+func (v *NodeVisitorBase) VisitJsxSelfClosingElement(node *JsxSelfClosingElement) *Node {
+	return v.factory.UpdateJsxSelfClosingElement(
+		node.AsNode(),
+		v.VisitNode(node.tagName),
+		v.VisitNode(node.typeArguments),
+		v.VisitNode(node.attributes),
+	)
+}
+func (v *NodeVisitorBase) VisitJsxOpeningElement(node *JsxOpeningElement) *Node {
+	return v.factory.UpdateJsxOpeningElement(
+		node.AsNode(),
+		v.VisitNode(node.tagName),
+		v.VisitNode(node.typeArguments),
+		v.VisitNode(node.attributes),
+	)
+}
+func (v *NodeVisitorBase) VisitJsxClosingElement(node *JsxClosingElement) *Node {
+	return v.factory.UpdateJsxClosingElement(
+		node.AsNode(),
+		v.VisitNode(node.tagName),
+	)
+}
+func (v *NodeVisitorBase) VisitJsxFragment(node *JsxFragment) *Node {
+	return v.factory.UpdateJsxFragment(
+		node.AsNode(),
+		v.VisitNode(node.openingFragment),
+		v.VisitNodes(node.children),
+		v.VisitNode(node.closingFragment),
+	)
+}
+func (v *NodeVisitorBase) VisitJsxOpeningFragment(node *JsxOpeningFragment) *Node {
+	return node.AsNode()
+}
+func (v *NodeVisitorBase) VisitJsxClosingFragment(node *JsxClosingFragment) *Node {
+	return node.AsNode()
+}
+func (v *NodeVisitorBase) VisitJsxAttribute(node *JsxAttribute) *Node {
+	return v.factory.UpdateJsxAttribute(
+		node.AsNode(),
+		v.VisitNode(node.name),
+		v.VisitNode(node.initializer),
+	)
+}
+func (v *NodeVisitorBase) VisitJsxAttributes(node *JsxAttributes) *Node {
+	return v.factory.UpdateJsxAttributes(
+		node.AsNode(),
+		v.VisitNodes(node.properties),
+	)
+}
+func (v *NodeVisitorBase) VisitJsxSpreadAttribute(node *JsxSpreadAttribute) *Node {
+	return v.factory.UpdateJsxSpreadAttribute(
+		node.AsNode(),
+		v.VisitNode(node.expression),
+	)
+}
+func (v *NodeVisitorBase) VisitJsxExpression(node *JsxExpression) *Node {
+	return v.factory.UpdateJsxExpression(
+		node.AsNode(),
+		v.VisitNode(node.dotDotDotToken),
+		v.VisitNode(node.expression),
+	)
+}
+func (v *NodeVisitorBase) VisitJsxNamespacedName(node *JsxNamespacedName) *Node {
+	return v.factory.UpdateJsxNamespacedName(
+		node.AsNode(),
+		v.VisitNode(node.name),
+		v.VisitNode(node.namespace),
+	)
+}
+
+// Clauses
+func (v *NodeVisitorBase) VisitCaseClause(node *CaseOrDefaultClause) *Node {
+	return v.factory.UpdateCaseOrDefaultClause(
+		node.AsNode(),
+		v.VisitNode(node.expression),
+		v.VisitNodes(node.statements),
+	)
+}
+func (v *NodeVisitorBase) VisitDefaultClause(node *CaseOrDefaultClause) *Node {
+	return v.factory.UpdateCaseOrDefaultClause(
+		node.AsNode(),
+		nil,
+		v.VisitNodes(node.statements),
+	)
+}
+func (v *NodeVisitorBase) VisitHeritageClause(node *HeritageClause) *Node {
+	return v.factory.UpdateHeritageClause(
+		node.AsNode(),
+		v.VisitNodes(node.types),
+	)
+}
+func (v *NodeVisitorBase) VisitCatchClause(node *CatchClause) *Node {
+	return v.factory.UpdateCatchClause(
+		node.AsNode(),
+		v.VisitNode(node.variableDeclaration),
+		v.VisitNode(node.block),
+	)
+}
+
+// Import attributes
+func (v *NodeVisitorBase) VisitImportAttributes(node *ImportAttributes) *Node {
+	return v.factory.UpdateImportAttributes(
+		node.AsNode(),
+		v.VisitNodes(node.attributes),
+	)
+}
+func (v *NodeVisitorBase) VisitImportAttribute(node *ImportAttribute) *Node {
+	return v.factory.UpdateImportAttribute(
+		node.AsNode(),
+		v.VisitNode(node.name),
+		v.VisitNode(node.value),
+	)
+}
+
+// Property assignments
+func (v *NodeVisitorBase) VisitPropertyAssignment(node *PropertyAssignment) *Node {
+	return v.factory.UpdatePropertyAssignment(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+		v.VisitNode(node.name),
+		v.VisitNode(node.postfixToken),
+		v.VisitNode(node.initializer),
+	)
+}
+func (v *NodeVisitorBase) VisitShorthandPropertyAssignment(node *ShorthandPropertyAssignment) *Node {
+	return v.factory.UpdateShorthandPropertyAssignment(
+		node.AsNode(),
+		v.VisitNode(node.modifiers),
+		v.VisitNode(node.name),
+		v.VisitNode(node.postfixToken),
+		v.VisitNode(node.objectAssignmentInitializer),
+	)
+}
+func (v *NodeVisitorBase) VisitSpreadAssignment(node *SpreadAssignment) *Node {
+	return v.factory.UpdateSpreadAssignment(
+		node.AsNode(),
+		v.VisitNode(node.expression),
+	)
+}
+
+// Enum
+func (v *NodeVisitorBase) VisitEnumMember(node *EnumMember) *Node {
+	return v.factory.UpdateEnumMember(
+		node.AsNode(),
+		v.VisitNode(node.name),
+		v.VisitNode(node.initializer),
+	)
+}
+
+// Top-level nodes
+func (v *NodeVisitorBase) VisitSourceFile(node *SourceFile) *Node {
+	return v.factory.UpdateSourceFile(
+		node.AsNode(),
+		v.VisitNodes(node.statements),
+	)
+}
+
+// JSDoc nodes
+func (v *NodeVisitorBase) VisitJSDocNullableType(node *JSDocNullableType) *Node {
+	return v.factory.UpdateJSDocNullableType(
+		node.AsNode(),
+		v.VisitNode(node.typeNode),
+	)
+}
+func (v *NodeVisitorBase) VisitJSDocNonNullableType(node *JSDocNonNullableType) *Node {
+	return v.factory.UpdateJSDocNonNullableType(
+		node.AsNode(),
+		v.VisitNode(node.typeNode),
+	)
+}
+
+func (v *NodeVisitorBase) VisitOther(node *Node) *Node {
+	return node
+}
+
+// Starts a new lexical environment and visits a parameter list, suspending the lexical
+// environment upon completion.
+func (v *NodeVisitorBase) VisitParameters(nodes []*ParameterDeclarationNode) []*ParameterDeclarationNode {
+	// TODO(rbuckton): To be implemented
+	return v.VisitNodes(nodes)
+}
+
+// Resumes a suspended lexical environment and visits a function body, ending the lexical
+// environment and merging hoisted declarations upon completion.
+func (v *NodeVisitorBase) VisitFunctionBody(node *BlockOrExpression) *Node {
+	// TODO(rbuckton): To be implemented
+	return v.VisitNode(node)
+}
+
+// Visits an iteration body, adding any block-scoped variables required by the transformation.
+func (v *NodeVisitorBase) VisitIterationBody(body *Statement) *Statement {
+	// TODO(rbuckton): To be implemented
+	return v.VisitNode(body)
+}


### PR DESCRIPTION
This adds `ParenthesizerRules` and `NodeVisitor`. `NodeVisitor` encompasses the current `visitNode`, `visitNodes`, and `visitEachChild` functions in a way that is more conducive to Golang, avoiding the numerous overloads and optional parameters, and will help to cut down on closures we would have other generated when visiting/transforming:

```js
// js
function visitor(node: Node): VisitResult<Node> {
  switch (node.kind) {
    case SyntaxKind.ClassExpression: return visitClassExpression(node as ClassExpression);
    ...
  }
}
function visitClassExpression(node: ClassExpression) { ... }
```

```go
struct MyNodeVisitor {
  NodeVisitorBase
}
func (v *MyNodeVisitor) VisitClassExpression(node *ClassExpression) *Node { ... }
```

Note that this simplifies `VisitNode` as it no longer accepts a `test` callback. This validation would instead be handled more consistently in the various `New` methods on `NodeFactory`.

Also note that this PR is currently a draft. It intends to depend on #57 and the version of `debug.go` in that PR, and will be rebased once #57 and #54 are merged.