### PR TITLE
Add missing Name methods

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -2972,6 +2972,9 @@ func (node *MetaProperty) ForEachChild(v Visitor) bool {
 	return visit(v, node.name)
 }
 
+func (node *MetaProperty) Name() *DeclarationName {
+	return node.name
+}
 func IsMetaProperty(node *Node) bool {
 	return node.Kind == KindMetaProperty
 }
@@ -3781,6 +3784,9 @@ func (node *NamedTupleMember) ForEachChild(v Visitor) bool {
 	return visit(v, node.DotDotDotToken) || visit(v, node.name) || visit(v, node.QuestionToken) || visit(v, node.TypeNode)
 }
 
+func (node *NamedTupleMember) Name() *DeclarationName {
+	return node.name
+}
 func IsNamedTupleMember(node *Node) bool {
 	return node.Kind == KindNamedTupleMember
 }
@@ -4040,6 +4046,10 @@ func (f *NodeFactory) NewJsxNamespacedName(name *IdentifierNode, namespace *Iden
 
 func (node *JsxNamespacedName) ForEachChild(v Visitor) bool {
 	return visit(v, node.name) || visit(v, node.Namespace)
+}
+
+func (node *JsxNamespacedName) Name() *DeclarationName {
+	return node.name
 }
 
 func IsJsxNamespacedName(node *Node) bool {


### PR DESCRIPTION
The parser crashes without these. Discovered by running #24