### PR TITLE
Move scanner into independent package

### DIFF
--- a/cmd/tsgo/main.go
+++ b/cmd/tsgo/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/microsoft/typescript-go/internal/ast"
 	ts "github.com/microsoft/typescript-go/internal/compiler"
 	"github.com/microsoft/typescript-go/internal/core"
+	"github.com/microsoft/typescript-go/internal/scanner"
 	"github.com/microsoft/typescript-go/internal/tspath"
 )
 
@@ -25,7 +26,7 @@ var pretty = true
 func printDiagnostic(d *ast.Diagnostic, level int) {
 	file := d.File()
 	if file != nil {
-		line, character := ts.GetLineAndCharacterOfPosition(file, d.Loc().Pos())
+		line, character := scanner.GetLineAndCharacterOfPosition(file, d.Loc().Pos())
 		fmt.Printf("%v%v(%v,%v): error TS%v: %v\n", strings.Repeat(" ", level*2), file.FileName(), line+1, character+1, d.Code(), d.Message())
 	} else {
 		fmt.Printf("%verror TS%v: %v\n", strings.Repeat(" ", level*2), d.Code(), d.Message())

--- a/internal/ast/utilities.go
+++ b/internal/ast/utilities.go
@@ -14,7 +14,12 @@ func NodeIsPresent(node *Node) bool {
 
 // Determines if a node contains synthetic positions
 func NodeIsSynthesized(node *Node) bool {
-	return node.Loc.Pos() < 0 || node.Loc.End() < 0
+	return PositionIsSynthesized(node.Loc.Pos()) || PositionIsSynthesized(node.Loc.End())
+}
+
+// Determines whether a position is synthetic
+func PositionIsSynthesized(pos int) bool {
+	return pos < 0
 }
 
 func NodeKindIs(node *Node, kinds ...Kind) bool {

--- a/internal/compiler/error_reporting.go
+++ b/internal/compiler/error_reporting.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/microsoft/typescript-go/internal/ast"
 	"github.com/microsoft/typescript-go/internal/compiler/diagnostics"
+	"github.com/microsoft/typescript-go/internal/scanner"
 	"github.com/microsoft/typescript-go/internal/tspath"
 )
 
@@ -79,10 +80,10 @@ func FormatDiagnosticsWithColorAndContext(output *strings.Builder, diags []*ast.
 }
 
 func writeCodeSnippet(writer *strings.Builder, sourceFile *ast.SourceFile, start int, length int, squiggleColor string, formatOpts *DiagnosticsFormattingOptions) {
-	firstLine, firstLineChar := GetLineAndCharacterOfPosition(sourceFile, start)
-	lastLine, lastLineChar := GetLineAndCharacterOfPosition(sourceFile, start+length)
+	firstLine, firstLineChar := scanner.GetLineAndCharacterOfPosition(sourceFile, start)
+	lastLine, lastLineChar := scanner.GetLineAndCharacterOfPosition(sourceFile, start+length)
 
-	lastLineOfFile, _ := GetLineAndCharacterOfPosition(sourceFile, len(sourceFile.Text))
+	lastLineOfFile, _ := scanner.GetLineAndCharacterOfPosition(sourceFile, len(sourceFile.Text))
 
 	hasMoreThanFiveLines := lastLine-firstLine >= 4
 	gutterWidth := len(strconv.Itoa(lastLineOfFile + 1))
@@ -101,10 +102,10 @@ func writeCodeSnippet(writer *strings.Builder, sourceFile *ast.SourceFile, start
 			i = lastLine - 1
 		}
 
-		lineStart := GetPositionOfLineAndCharacter(sourceFile, i, 0)
+		lineStart := scanner.GetPositionOfLineAndCharacter(sourceFile, i, 0)
 		var lineEnd int
 		if i < lastLineOfFile {
-			lineEnd = GetPositionOfLineAndCharacter(sourceFile, i+1, 0)
+			lineEnd = scanner.GetPositionOfLineAndCharacter(sourceFile, i+1, 0)
 		} else {
 			lineEnd = sourceFile.Loc.End()
 		}
@@ -195,7 +196,7 @@ func writeWithStyleAndReset(output *strings.Builder, text string, formatStyle st
 }
 
 func WriteLocation(output *strings.Builder, file *ast.SourceFile, pos int, formatOpts *DiagnosticsFormattingOptions, writeWithStyleAndReset FormattedWriter) {
-	firstLine, firstChar := GetLineAndCharacterOfPosition(file, pos)
+	firstLine, firstChar := scanner.GetLineAndCharacterOfPosition(file, pos)
 	var relativeFileName string
 	if formatOpts != nil {
 		relativeFileName = tspath.ConvertToRelativePath(file.Path(), formatOpts.ComparePathsOptions)
@@ -329,7 +330,7 @@ func writeTabularErrorsDisplay(output *strings.Builder, errorSummary *ErrorSumma
 }
 
 func prettyPathForFileError(file *ast.SourceFile, fileErrors []*ast.Diagnostic, formatOpts *DiagnosticsFormattingOptions) string {
-	line, _ := GetLineAndCharacterOfPosition(file, fileErrors[0].Loc().Pos())
+	line, _ := scanner.GetLineAndCharacterOfPosition(file, fileErrors[0].Loc().Pos())
 	fileName := file.FileName()
 	if tspath.PathIsAbsolute(fileName) && tspath.PathIsAbsolute(formatOpts.CurrentDirectory) {
 		fileName = tspath.ConvertToRelativePath(file.Path(), formatOpts.ComparePathsOptions)
@@ -350,7 +351,7 @@ func WriteFormatDiagnostics(output *strings.Builder, diagnostics []*ast.Diagnost
 
 func WriteFormatDiagnostic(output *strings.Builder, diagnostic *ast.Diagnostic, formatOpts *DiagnosticsFormattingOptions) {
 	if diagnostic.File() != nil {
-		line, character := GetLineAndCharacterOfPosition(diagnostic.File(), diagnostic.Loc().Pos())
+		line, character := scanner.GetLineAndCharacterOfPosition(diagnostic.File(), diagnostic.Loc().Pos())
 		fileName := diagnostic.File().FileName()
 		relativeFileName := tspath.ConvertToRelativePath(fileName, formatOpts.ComparePathsOptions)
 		fmt.Fprintf(output, "%s(%d,%d): ", relativeFileName, line+1, character+1)

--- a/internal/compiler/printer.go
+++ b/internal/compiler/printer.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/microsoft/typescript-go/internal/ast"
 	"github.com/microsoft/typescript-go/internal/core"
+	"github.com/microsoft/typescript-go/internal/scanner"
 )
 
 type TypePrecedence int32
@@ -188,7 +189,7 @@ func (p *Printer) printNumberLiteral(f float64) {
 }
 
 func (p *Printer) printBooleanLiteral(b bool) {
-	p.print(ifElse(b, "true", "false"))
+	p.print(core.IfElse(b, "true", "false"))
 }
 
 func (p *Printer) printBigIntLiteral(b PseudoBigInt) {
@@ -477,9 +478,9 @@ func (p *Printer) printSourceFileWithTypes(sourceFile *ast.SourceFile) {
 	var pos int
 	var visit func(*ast.Node) bool
 	var typesPrinted bool
-	lineStarts := getLineStarts(sourceFile)
+	lineStarts := scanner.GetLineStarts(sourceFile)
 	printLinesBefore := func(node *ast.Node) {
-		line := computeLineOfPosition(lineStarts, SkipTrivia(sourceFile.Text, node.Pos()))
+		line := scanner.ComputeLineOfPosition(lineStarts, scanner.SkipTrivia(sourceFile.Text, node.Pos()))
 		var nextLineStart int
 		if line+1 < len(lineStarts) {
 			nextLineStart = int(lineStarts[line+1])

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -3,6 +3,7 @@ package core
 import (
 	"fmt"
 	"iter"
+	"math"
 	"regexp"
 	"slices"
 	"strconv"
@@ -280,4 +281,28 @@ func FormatStringFromArgs(text string, args []any) string {
 		}
 		return fmt.Sprintf("%v", args[int(index)])
 	})
+}
+
+// Returns whenTrue if b is true; otherwise, returns whenFalse. IfElse should only be used when branches are either
+// constant or precomputed as both branches will be evaluated regardless as to the value of b.
+func IfElse[T any](b bool, whenTrue T, whenFalse T) T {
+	if b {
+		return whenTrue
+	}
+	return whenFalse
+}
+
+// This function should behave identically to the expression `"" + f` in JS
+func NumberToString(f float64) string {
+	return strconv.FormatFloat(f, 'g', -1, 64)
+}
+
+// This function should behave identically to the expression `+s` in JS, including parsing binary, octal, and hex
+// numeric strings
+func StringToNumber(s string) float64 {
+	value, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return math.NaN()
+	}
+	return value
 }

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1,4 +1,4 @@
-package compiler
+package scanner
 
 import (
 	"fmt"
@@ -240,6 +240,10 @@ func (s *Scanner) Text() string {
 
 func (s *Scanner) Token() ast.Kind {
 	return s.token
+}
+
+func (s *Scanner) TokenFlags() ast.TokenFlags {
+	return s.tokenFlags
 }
 
 func (s *Scanner) TokenFullStart() int {
@@ -690,7 +694,7 @@ func (s *Scanner) Scan() ast.Kind {
 			cp := s.peekUnicodeEscape()
 			if cp >= 0 && isIdentifierStart(cp, s.languageVersion) {
 				s.tokenValue = string(s.scanUnicodeEscape(true)) + s.scanIdentifierParts()
-				s.token = getIdentifierToken(s.tokenValue)
+				s.token = GetIdentifierToken(s.tokenValue)
 			} else {
 				s.scanInvalidCharacter()
 			}
@@ -730,7 +734,7 @@ func (s *Scanner) Scan() ast.Kind {
 				break
 			}
 			if s.scanIdentifier(0) {
-				s.token = getIdentifierToken(s.tokenValue)
+				s.token = GetIdentifierToken(s.tokenValue)
 				break
 			}
 			ch, size := s.charAndSize()
@@ -843,18 +847,18 @@ func (s *Scanner) ReScanSlashToken() ast.Kind {
 	return s.token
 }
 
-func (s *Scanner) reScanJsxToken(allowMultilineJsxText bool) ast.Kind {
+func (s *Scanner) ReScanJsxToken(allowMultilineJsxText bool) ast.Kind {
 	s.pos = s.fullStartPos
 	s.tokenStart = s.fullStartPos
-	s.token = s.scanJsxTokenEx(allowMultilineJsxText)
+	s.token = s.ScanJsxTokenEx(allowMultilineJsxText)
 	return s.token
 }
 
-func (s *Scanner) scanJsxToken() ast.Kind {
-	return s.scanJsxTokenEx(true /*allowMultilineJsxText*/)
+func (s *Scanner) ScanJsxToken() ast.Kind {
+	return s.ScanJsxTokenEx(true /*allowMultilineJsxText*/)
 }
 
-func (s *Scanner) scanJsxTokenEx(allowMultilineJsxText bool) ast.Kind {
+func (s *Scanner) ScanJsxTokenEx(allowMultilineJsxText bool) ast.Kind {
 	s.fullStartPos = s.pos
 	s.tokenStart = s.pos
 	ch := s.char()
@@ -922,7 +926,7 @@ func (s *Scanner) scanJsxTokenEx(allowMultilineJsxText bool) ast.Kind {
 }
 
 // Scans a JSX identifier; these differ from normal identifiers in that they allow dashes
-func (s *Scanner) scanJsxIdentifier() ast.Kind {
+func (s *Scanner) ScanJsxIdentifier() ast.Kind {
 	if tokenIsIdentifierOrKeyword(s.token) {
 		// An identifier or keyword has already been parsed - check for a `-` or a single instance of `:` and then append it and
 		// everything after it to the token
@@ -944,12 +948,12 @@ func (s *Scanner) scanJsxIdentifier() ast.Kind {
 				break
 			}
 		}
-		s.token = getIdentifierToken(s.tokenValue)
+		s.token = GetIdentifierToken(s.tokenValue)
 	}
 	return s.token
 }
 
-func (s *Scanner) scanJsxAttributeValue() ast.Kind {
+func (s *Scanner) ScanJsxAttributeValue() ast.Kind {
 	s.fullStartPos = s.pos
 	switch s.char() {
 	case '"', '\'':
@@ -962,10 +966,10 @@ func (s *Scanner) scanJsxAttributeValue() ast.Kind {
 	}
 }
 
-func (s *Scanner) reScanJsxAttributeValue() ast.Kind {
+func (s *Scanner) ReScanJsxAttributeValue() ast.Kind {
 	s.pos = s.fullStartPos
 	s.tokenStart = s.fullStartPos
-	return s.scanJsxAttributeValue()
+	return s.ScanJsxAttributeValue()
 }
 
 func (s *Scanner) scanIdentifier(prefixLength int) bool {
@@ -1080,18 +1084,18 @@ func (s *Scanner) scanTemplateAndSetTokenValue(shouldEmitInvalidEscapeError bool
 				s.tokenFlags |= ast.TokenFlagsUnterminated
 				s.error(diagnostics.Unterminated_template_literal)
 			}
-			token = ifElse(startedWithBacktick, ast.KindNoSubstitutionTemplateLiteral, ast.KindTemplateTail)
+			token = core.IfElse(startedWithBacktick, ast.KindNoSubstitutionTemplateLiteral, ast.KindTemplateTail)
 			break
 		}
 		if ch == '$' && s.charAt(1) == '{' {
 			contents += s.text[start:s.pos]
 			s.pos += 2
-			token = ifElse(startedWithBacktick, ast.KindTemplateHead, ast.KindTemplateMiddle)
+			token = core.IfElse(startedWithBacktick, ast.KindTemplateHead, ast.KindTemplateMiddle)
 			break
 		}
 		if ch == '\\' {
 			contents += s.text[start:s.pos]
-			contents += s.scanEscapeSequence(EscapeSequenceScanningFlagsString | ifElse(shouldEmitInvalidEscapeError, EscapeSequenceScanningFlagsReportErrors, 0))
+			contents += s.scanEscapeSequence(EscapeSequenceScanningFlagsString | core.IfElse(shouldEmitInvalidEscapeError, EscapeSequenceScanningFlagsReportErrors, 0))
 			start = s.pos
 			continue
 		}
@@ -1344,14 +1348,14 @@ func (s *Scanner) scanNumber() ast.Kind {
 	}
 	if s.tokenFlags&ast.TokenFlagsContainsLeadingZero != 0 {
 		s.errorAt(diagnostics.Decimals_with_leading_zeros_are_not_allowed, start, s.pos-start)
-		s.tokenValue = numberToString(stringToNumber(s.tokenValue))
+		s.tokenValue = core.NumberToString(core.StringToNumber(s.tokenValue))
 		return ast.KindNumericLiteral
 	}
 	var result ast.Kind
 	if fixedPartEnd == s.pos {
 		result = s.scanBigIntSuffix()
 	} else {
-		s.tokenValue = numberToString(stringToNumber(s.tokenValue))
+		s.tokenValue = core.NumberToString(core.StringToNumber(s.tokenValue))
 		result = ast.KindNumericLiteral
 	}
 	ch, _ := s.charAndSize()
@@ -1509,7 +1513,7 @@ func (s *Scanner) scanBigIntSuffix() ast.Kind {
 			return ast.KindNumericLiteral
 		}
 	}
-	s.tokenValue = numberToString(stringToNumber(s.tokenValue))
+	s.tokenValue = core.NumberToString(core.StringToNumber(s.tokenValue))
 	return ast.KindNumericLiteral
 }
 
@@ -1520,7 +1524,7 @@ func (s *Scanner) scanInvalidCharacter() {
 	s.token = ast.KindUnknown
 }
 
-func getIdentifierToken(str string) ast.Kind {
+func GetIdentifierToken(str string) ast.Kind {
 	if len(str) >= 2 && len(str) <= 12 && str[0] >= 'a' && str[0] <= 'z' {
 		keyword := textToKeyword[str]
 		if keyword != ast.KindUnknown {
@@ -1544,11 +1548,11 @@ func isIdentifierPart(ch rune, languageVersion core.ScriptTarget) bool {
 }
 
 func isUnicodeIdentifierStart(ch rune, languageVersion core.ScriptTarget) bool {
-	return isInUnicodeRanges(ch, ifElse(languageVersion >= core.ScriptTargetES2015, unicodeESNextIdentifierStart, unicodeES5IdentifierStart))
+	return isInUnicodeRanges(ch, core.IfElse(languageVersion >= core.ScriptTargetES2015, unicodeESNextIdentifierStart, unicodeES5IdentifierStart))
 }
 
 func isUnicodeIdentifierPart(ch rune, languageVersion core.ScriptTarget) bool {
-	return isInUnicodeRanges(ch, ifElse(languageVersion >= core.ScriptTargetES2015, unicodeESNextIdentifierPart, unicodeES5IdentifierPart))
+	return isInUnicodeRanges(ch, core.IfElse(languageVersion >= core.ScriptTargetES2015, unicodeESNextIdentifierPart, unicodeES5IdentifierPart))
 }
 
 func isInUnicodeRanges(cp rune, ranges []rune) bool {
@@ -1617,7 +1621,7 @@ func SkipTrivia(text string, pos int) int {
 	return skipTriviaEx(text, pos, nil)
 }
 func skipTriviaEx(text string, pos int, options *skipTriviaOptions) int {
-	if positionIsSynthesized(pos) {
+	if ast.PositionIsSynthesized(pos) {
 		return pos
 	}
 	if options == nil {
@@ -1786,7 +1790,7 @@ func scanShebangTrivia(text string, pos int) int {
 	return pos
 }
 
-func getScannerForSourceFile(sourceFile *ast.SourceFile, pos int) *Scanner {
+func GetScannerForSourceFile(sourceFile *ast.SourceFile, pos int) *Scanner {
 	s := NewScanner()
 	s.text = sourceFile.Text
 	s.pos = pos
@@ -1796,12 +1800,12 @@ func getScannerForSourceFile(sourceFile *ast.SourceFile, pos int) *Scanner {
 	return s
 }
 
-func getRangeOfTokenAtPosition(sourceFile *ast.SourceFile, pos int) core.TextRange {
-	s := getScannerForSourceFile(sourceFile, pos)
+func GetRangeOfTokenAtPosition(sourceFile *ast.SourceFile, pos int) core.TextRange {
+	s := GetScannerForSourceFile(sourceFile, pos)
 	return core.NewTextRange(s.tokenStart, s.pos)
 }
 
-func computeLineOfPosition(lineStarts []core.TextPos, pos int) int {
+func ComputeLineOfPosition(lineStarts []core.TextPos, pos int) int {
 	low := 0
 	high := len(lineStarts) - 1
 	for low <= high {
@@ -1818,7 +1822,7 @@ func computeLineOfPosition(lineStarts []core.TextPos, pos int) int {
 	return low - 1
 }
 
-func getLineStarts(sourceFile *ast.SourceFile) []core.TextPos {
+func GetLineStarts(sourceFile *ast.SourceFile) []core.TextPos {
 	if sourceFile.LineMap == nil {
 		sourceFile.LineMap = stringutil.ComputeLineStarts(sourceFile.Text)
 	}
@@ -1826,13 +1830,13 @@ func getLineStarts(sourceFile *ast.SourceFile) []core.TextPos {
 }
 
 func GetLineAndCharacterOfPosition(sourceFile *ast.SourceFile, pos int) (line int, character int) {
-	line = computeLineOfPosition(getLineStarts(sourceFile), pos)
+	line = ComputeLineOfPosition(GetLineStarts(sourceFile), pos)
 	character = utf8.RuneCountInString(sourceFile.Text[sourceFile.LineMap[line]:pos])
 	return
 }
 
-func getEndLinePosition(sourceFile *ast.SourceFile, line int) int {
-	pos := int(getLineStarts(sourceFile)[line])
+func GetEndLinePosition(sourceFile *ast.SourceFile, line int) int {
+	pos := int(GetLineStarts(sourceFile)[line])
 	for {
 		ch, size := utf8.DecodeRuneInString(sourceFile.Text[pos:])
 		if size == 0 || stringutil.IsLineBreak(ch) {
@@ -1843,7 +1847,7 @@ func getEndLinePosition(sourceFile *ast.SourceFile, line int) int {
 }
 
 func GetPositionOfLineAndCharacter(sourceFile *ast.SourceFile, line int, character int) int {
-	return ComputePositionOfLineAndCharacter(getLineStarts(sourceFile), line, character)
+	return ComputePositionOfLineAndCharacter(GetLineStarts(sourceFile), line, character)
 }
 
 func ComputePositionOfLineAndCharacter(lineStarts []core.TextPos, line int, character int) int {
@@ -1875,7 +1879,7 @@ func ComputePositionOfLineAndCharacter(lineStarts []core.TextPos, line int, char
 	return res
 }
 
-func getLeadingCommentRanges(text string, pos int) iter.Seq[ast.CommentRange] {
+func GetLeadingCommentRanges(text string, pos int) iter.Seq[ast.CommentRange] {
 	return iterateCommentRanges(text, pos, false)
 }
 

--- a/internal/scanner/utilities.go
+++ b/internal/scanner/utilities.go
@@ -1,0 +1,31 @@
+package scanner
+
+import "github.com/microsoft/typescript-go/internal/ast"
+
+func tokenIsIdentifierOrKeyword(token ast.Kind) bool {
+	return token >= ast.KindIdentifier
+}
+
+func IdentifierToKeywordKind(node *ast.Identifier) ast.Kind {
+	return textToKeyword[node.Text]
+}
+
+func GetSourceTextOfNodeFromSourceFile(sourceFile *ast.SourceFile, node *ast.Node, includeTrivia bool) string {
+	return GetTextOfNodeFromSourceText(sourceFile.Text, node, includeTrivia)
+}
+
+func GetTextOfNodeFromSourceText(sourceText string, node *ast.Node, includeTrivia bool) string {
+	if ast.NodeIsMissing(node) {
+		return ""
+	}
+	pos := node.Pos()
+	if !includeTrivia {
+		pos = SkipTrivia(sourceText, pos)
+	}
+	text := sourceText[pos:node.End()]
+	// if (isJSDocTypeExpressionOrChild(node)) {
+	//     // strip space + asterisk at line start
+	//     text = text.split(/\r\n|\n|\r/).map(line => line.replace(/^\s*\*/, "").trimStart()).join("\n");
+	// }
+	return text
+}

--- a/internal/testutil/runner/test_case_parser.go
+++ b/internal/testutil/runner/test_case_parser.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/microsoft/typescript-go/internal/compiler"
+	"github.com/microsoft/typescript-go/internal/scanner"
 	"github.com/microsoft/typescript-go/internal/tspath"
 )
 
@@ -82,7 +82,7 @@ func makeUnitsFromTest(code string, fileName string, settings compilerSettings) 
 			} else {
 				// First metadata marker in the file
 				currentFileName = strings.TrimSpace(testMetaData[2])
-				if currentFileContent.Len() != 0 && compiler.SkipTrivia(currentFileContent.String(), 0) != currentFileContent.Len() {
+				if currentFileContent.Len() != 0 && scanner.SkipTrivia(currentFileContent.String(), 0) != currentFileContent.Len() {
 					panic("Non-comment test content appears before the first '// @Filename' directive")
 				}
 			}


### PR DESCRIPTION
This moves `scanner.go` into its own `scanner` package.