### PR TITLE
Add test that verifies all of TS parses

### DIFF
--- a/internal/compiler/parser_test.go
+++ b/internal/compiler/parser_test.go
@@ -41,11 +41,7 @@ func TestParseTypeScriptSrc(t *testing.T) {
 			return err
 		}
 
-		if d.IsDir() {
-			return nil
-		}
-
-		if ext := tspath.TryExtractTSExtension(path); ext == "" {
+		if d.IsDir() || tspath.TryExtractTSExtension(path) == "" {
 			return nil
 		}
 


### PR DESCRIPTION
We've been burned a couple times now; add a test which verifies that all of `TypeScript/src` parses.

This is a very fast test, just 176ms on my machine.