### PR TITLE
Completely replace JSDocNonNullableType parsing with OptionalType

### DIFF
--- a/internal/compiler/parser.go
+++ b/internal/compiler/parser.go
@@ -2262,7 +2262,7 @@ func (p *Parser) parsePostfixTypeOrHigher() *ast.Node {
 
 func (p *Parser) nextIsStartOfType() bool {
 	p.nextToken()
-	return p.isStartOfType(false /*inStartOfParameters*/)
+	return p.isStartOfType(false /*inStartOfParameter*/)
 }
 
 func (p *Parser) parseNonArrayType() *ast.Node {


### PR DESCRIPTION
Fixes https://github.com/microsoft/typescript-go/pull/34's parsing of OptionalTypeNode. Previously, `T?` was always parsed as JSDocNullableType and then parseTupleElementType would throw away the nullable type node and construct a OptionalTypeNode. Now `T?` is always an optional type. The code is slightly simpler.

I didn't change the way it's parsed, even though it's not really in an obvious location. I really wanted to parse `T?` *only* in tuple position, inside `parseTupleElementType`, but by that point `T?` has already been parsed as the start of a malformed conditional type. There might be a way to move the construction of OptionalTypeNode to conditional type parsing, but that's not much better than where it is now.