### PR TITLE
Run benchmarks in CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,6 +29,8 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: true
+          filter: blob:none # https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/
+          fetch-depth: 0 # Default is 1; need to set to 0 to get the benefits of blob:none.
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:


### PR DESCRIPTION
This adds a simple workflow which benchmarks a change and its parent, displaying / uploading the `benchstat` results. These benchmarks run on a larger runner.

We'll see how noisy this is given it's on a VM (and we aren't using dedicated hardware for this), but Go benchmarks are a lot less noisy especially given how many runs we can get. (Compared to fully-fledged benchmarks of `tsc` in JS).