### PR TITLE
Normalize paths, trim trailing slashes in VFS

### DIFF
--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -161,7 +161,8 @@ func rootLength(p string) int {
 	return l
 }
 
-func splitRoot(p string) (rootName, rest string) {
+func splitPath(p string) (rootName, rest string) {
+	p = tspath.NormalizePath(p)
 	l := rootLength(p)
 	rootName, rest = p[:l], p[l:]
 	rest = tspath.RemoveTrailingDirectorySeparator(rest)
@@ -169,7 +170,7 @@ func splitRoot(p string) (rootName, rest string) {
 }
 
 func (v *vfs) rootAndPath(path string) (fsys fs.FS, rootName string, rest string) {
-	rootName, rest = splitRoot(path)
+	rootName, rest = splitPath(path)
 	if rest == "" {
 		rest = "."
 	}

--- a/internal/vfs/vfs_test.go
+++ b/internal/vfs/vfs_test.go
@@ -67,6 +67,7 @@ func TestIOFS(t *testing.T) {
 		assert.Assert(t, fs.DirectoryExists("/"))
 		assert.Assert(t, fs.DirectoryExists("/dir1"))
 		assert.Assert(t, fs.DirectoryExists("/dir1/"))
+		assert.Assert(t, fs.DirectoryExists("/dir1/./"))
 		assert.Assert(t, !fs.DirectoryExists("/bar"))
 	})
 


### PR DESCRIPTION
The underlying `io/fs.FS` does not expect these to be passed through.