### PR TITLE
Fix scanIdentifier's fastpath

### DIFF
--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -984,7 +984,7 @@ func (s *Scanner) scanIdentifier(prefixLength int) bool {
 				break
 			}
 		}
-		if ch <= 0x7F || ch != '\\' {
+		if ch <= 0x7F && ch != '\\' {
 			s.tokenValue = s.text[start:s.pos]
 			return true
 		}


### PR DESCRIPTION
It is supposed to fall back to the slow path if the character after the fast path is '\\', because that could be the start of a unicode escape.

It doesn't because the carve-out for '\\' uses `||` instead of `&&` by mistake.