### PR TITLE
Fix code for parsing `import { type default as ... }`.

### DIFF
--- a/internal/compiler/parser.go
+++ b/internal/compiler/parser.go
@@ -1948,7 +1948,7 @@ func (p *Parser) parseImportOrExportSpecifier(kind ast.Kind) (isTypeOnly bool, p
 	// let checkIdentifierEnd = scanner.getTokenEnd();
 	canParseAsKeyword := true
 	disallowKeywords := kind == ast.KindImportSpecifier
-	nameOk := true
+	var nameOk bool
 	name, nameOk = p.parseModuleExportName(disallowKeywords)
 	if name.Kind == ast.KindIdentifier && name.AsIdentifier().Text == "type" {
 		// If the first token of an import specifier is 'type', there are a lot of possibilities,


### PR DESCRIPTION
This change amends errors for the following code sample:

<details>
<summary>Code Sample</summary>

```ts
export { default } from "foo"
export { as } from "foo";
export { as as } from "foo";
export { as as as } from "foo";
export { foo } from "foo";
export { default } from "foo";
export { continue } from "foo";
export { default as } from "foo";
export { continue as } from "foo";
export { default as foo } from "foo";
export { continue as foo } from "foo";
export { default as default } from "foo";
export { continue as continue } from "foo";
export { type } from "foo";
export { type as } from "foo";
export { type as as } from "foo";
export { type as as as } from "foo";
export { type foo } from "foo";
export { type default } from "foo";
export { type continue } from "foo";
export { type default as } from "foo";
export { type continue as } from "foo";
export { type default as foo } from "foo";
export { type continue as foo } from "foo";
export { type default as default } from "foo";
export { type continue as continue } from "foo";

import { default } from "foo"
import { as } from "foo";
import { as as } from "foo";
import { as as as } from "foo";
import { foo } from "foo";
import { default } from "foo";
import { continue } from "foo";
import { default as } from "foo";
import { continue as } from "foo";
import { default as foo } from "foo";
import { continue as foo } from "foo";
import { default as default } from "foo";
import { continue as continue } from "foo";
import { type } from "foo";
import { type as } from "foo";
import { type as as } from "foo";
import { type as as as } from "foo";
import { type foo } from "foo";
import { type default } from "foo";
import { type continue } from "foo";
import { type default as } from "foo";
import { type continue as } from "foo";
import { type default as foo } from "foo";
import { type continue as foo } from "foo";
import { type default as default } from "foo";
import { type continue as continue } from "foo";
```

</details>

The errors produced are now consistent with the current TypeScript compiler, with the following delta:

```diff
 /workspaces/typescript-go/blah/foo.ts(3,16): error TS1003: Identifier expected.
 /workspaces/typescript-go/blah/foo.ts(8,21): error TS1003: Identifier expected.
 /workspaces/typescript-go/blah/foo.ts(9,22): error TS1003: Identifier expected.
-/workspaces/typescript-go/blah/foo.ts(19,15): error TS1003: Identifier expected.
-/workspaces/typescript-go/blah/foo.ts(20,15): error TS1003: Identifier expected.
-/workspaces/typescript-go/blah/foo.ts(21,15): error TS1003: Identifier expected.
 /workspaces/typescript-go/blah/foo.ts(21,26): error TS1003: Identifier expected.
-/workspaces/typescript-go/blah/foo.ts(22,15): error TS1003: Identifier expected.
 /workspaces/typescript-go/blah/foo.ts(22,27): error TS1003: Identifier expected.
-/workspaces/typescript-go/blah/foo.ts(23,15): error TS1003: Identifier expected.
-/workspaces/typescript-go/blah/foo.ts(24,15): error TS1003: Identifier expected.
-/workspaces/typescript-go/blah/foo.ts(25,15): error TS1003: Identifier expected.
-/workspaces/typescript-go/blah/foo.ts(26,15): error TS1003: Identifier expected.
+/workspaces/typescript-go/blah/foo.ts(28,10): error TS1003: Identifier expected.
 /workspaces/typescript-go/blah/foo.ts(30,16): error TS1003: Identifier expected.
+/workspaces/typescript-go/blah/foo.ts(33,10): error TS1003: Identifier expected.
+/workspaces/typescript-go/blah/foo.ts(34,10): error TS1003: Identifier expected.
 /workspaces/typescript-go/blah/foo.ts(35,21): error TS1003: Identifier expected.
 /workspaces/typescript-go/blah/foo.ts(36,22): error TS1003: Identifier expected.
 /workspaces/typescript-go/blah/foo.ts(39,21): error TS1003: Identifier expected.
 /workspaces/typescript-go/blah/foo.ts(40,22): error TS1003: Identifier expected.
 /workspaces/typescript-go/blah/foo.ts(46,15): error TS1003: Identifier expected.
 /workspaces/typescript-go/blah/foo.ts(47,15): error TS1003: Identifier expected.
-/workspaces/typescript-go/blah/foo.ts(48,15): error TS1003: Identifier expected.
 /workspaces/typescript-go/blah/foo.ts(48,26): error TS1003: Identifier expected.
-/workspaces/typescript-go/blah/foo.ts(49,15): error TS1003: Identifier expected.
 /workspaces/typescript-go/blah/foo.ts(49,27): error TS1003: Identifier expected.
-/workspaces/typescript-go/blah/foo.ts(50,15): error TS1003: Identifier expected.
-/workspaces/typescript-go/blah/foo.ts(51,15): error TS1003: Identifier expected.
-/workspaces/typescript-go/blah/foo.ts(52,15): error TS1003: Identifier expected.
 /workspaces/typescript-go/blah/foo.ts(52,26): error TS1003: Identifier expected.
-/workspaces/typescript-go/blah/foo.ts(53,15): error TS1003: Identifier expected.
 /workspaces/typescript-go/blah/foo.ts(53,27): error TS1003: Identifier expected.
```

This is because the code unconditionally reported an error when encountering a keyword; however, in the original code, subsequent calls to `parseModuleExportName` would call `parseNameWithKeywordCheck`, which resets the state on whether to *later* error.