### PR TITLE
Speed up CI with more jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
       - run: npm ci
 
       - run: go install gotest.tools/gotestsum@latest
+        # Installing gotestsum is super slow on Windows.
+        if: ${{ matrix.os != 'windows-latest' }}
 
       - run: npx hereby test:all
         if: ${{ !matrix.race }}


### PR DESCRIPTION
This should give test results faster, and avoid running race mode on a slower builder like Windows.