### PR TITLE
Shebang error parsing: compatibility with tsc

### DIFF
--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -707,8 +707,8 @@ func (s *Scanner) Scan() ast.Kind {
 			if s.charAt(1) == '!' {
 				if s.pos == 0 {
 					s.pos += 2
-					for s.char() >= 0 && !stringutil.IsLineBreak(s.char()) {
-						s.pos++
+					for ch, size := s.charAndSize(); size > 0 && !stringutil.IsLineBreak(ch); ch, size = s.charAndSize() {
+						s.pos += size
 					}
 					continue
 				}


### PR DESCRIPTION
In tsc, `#!` anywhere except pos=0 in a file gives an error and increments past `#`. In tsgo, it was incrementing past `#!`. tsc's behaviour seems bad, but not bad enough to differ from, especially since the parse tree will be wrong either way.