### PR TITLE
Fix BindingElement visit order

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -1923,7 +1923,7 @@ func (f *NodeFactory) NewBindingElement(dotDotDotToken *TokenNode, propertyName 
 }
 
 func (node *BindingElement) ForEachChild(v Visitor) bool {
-	return visit(v, node.PropertyName) || visit(v, node.DotDotDotToken) || visit(v, node.name) || visit(v, node.Initializer)
+	return visit(v, node.DotDotDotToken) || visit(v, node.PropertyName) || visit(v, node.name) || visit(v, node.Initializer)
 }
 
 func (node *BindingElement) Name() *DeclarationName {


### PR DESCRIPTION
`...` should always be first. This is only visible when both PropertyName and DotDotDotToken are defined, which is a parse error&mdash;but the visit will be incorrect in that case.
