### PR TITLE
Avoid calculating spread indices multiple times per array literal

### DIFF
--- a/internal/compiler/checker.go
+++ b/internal/compiler/checker.go
@@ -17751,7 +17751,6 @@ func (c *Checker) createSyntheticExpression(parent *ast.Node, t *Type, isSpread 
 func (c *Checker) getSpreadIndices(node *ast.Node) (int, int) {
 	links := c.arrayLiteralLinks.get(node)
 	if !links.indicesComputed {
-		links.indicesComputed = true
 		first, last := -1, -1
 		for i, element := range node.AsArrayLiteralExpression().Elements.Nodes {
 			if ast.IsSpreadElement(element) {
@@ -17762,6 +17761,7 @@ func (c *Checker) getSpreadIndices(node *ast.Node) (int, int) {
 			}
 		}
 		links.firstSpreadIndex, links.lastSpreadIndex = first, last
+		links.indicesComputed = true
 	}
 	return links.firstSpreadIndex, links.lastSpreadIndex
 }


### PR DESCRIPTION
It looks like `indicesComputed` was added to `ArrayLiteralLinks`, but is never set. This PR sets the flag to true after calculating the indices the first time, which saves a significant amount of time (tested on vscode src with -q).

![image](https://github.com/user-attachments/assets/bf0e9318-9024-4300-8a44-8c3d6f6f9bc7)

Before:
![image](https://github.com/user-attachments/assets/9a68abb9-d692-4e3c-896e-bdc0214236fb)

After:
![image](https://github.com/user-attachments/assets/a526bc32-e815-47b2-80f3-9c80fbaae8e9)
