### PR TITLE
More regex error recovery in reScanSlashToken

### DIFF
--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -881,7 +881,7 @@ func (s *Scanner) ReScanSlashToken() ast.Kind {
 					break
 				}
 			}
-			s.errorAt(diagnostics.Unterminated_regular_expression_literal, s.tokenStart, s.pos - s.tokenStart);
+			s.errorAt(diagnostics.Unterminated_regular_expression_literal, s.tokenStart, s.pos-s.tokenStart)
 		} else {
 			// Consume the slash character
 			s.pos++


### PR DESCRIPTION
This still does NOT include the ability to log diagnostics from https://github.com/microsoft/TypeScript/pull/55600. But it does match tsc's smarter regex-end detection for unterminated regexes (which you get a lot when parsing JSX as JS).

Note that `s.pos++` gets pulled back out of the main loop into the post-loop processing, where it was in tsc.