### PR TITLE
Make isFileSystemCaseSensitive more reliable

### DIFF
--- a/internal/vfs/os.go
+++ b/internal/vfs/os.go
@@ -42,8 +42,12 @@ var isFileSystemCaseSensitive = func() bool {
 	}
 
 	// If the current executable exists under a different case, we must be case-insensitve.
-	if _, err := os.Stat(swapCase(exe)); os.IsNotExist(err) {
-		return false
+	swapped := swapCase(exe)
+	if _, err := os.Stat(swapped); err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+		panic(fmt.Sprintf("vfs: failed to stat %q: %v", swapped, err))
 	}
 	return true
 }()


### PR DESCRIPTION
- Use `os.Exectuable`, which works even if someone has launched us with a modified `os.Args[0]`.
- Run the check right at startup instead of lazily, to help minimize the window in which the binary could move or be removed from the FS.
- Document things a bit.

#173 will conflict with this, but I can fix it no matter what.

