### PR TITLE
Add JSX support to printer

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -4531,10 +4531,10 @@ type JsxNamespacedName struct {
 	Namespace *IdentifierNode // IdentifierNode
 }
 
-func (f *NodeFactory) NewJsxNamespacedName(name *IdentifierNode, namespace *IdentifierNode) *Node {
+func (f *NodeFactory) NewJsxNamespacedName(namespace *IdentifierNode, name *IdentifierNode) *Node {
 	data := &JsxNamespacedName{}
-	data.name = name
 	data.Namespace = namespace
+	data.name = name
 	return newNode(KindJsxNamespacedName, data)
 }
 
@@ -4659,6 +4659,10 @@ func (f *NodeFactory) NewJsxAttribute(name *JsxAttributeName, initializer *JsxAt
 	data.name = name
 	data.Initializer = initializer
 	return newNode(KindJsxAttribute, data)
+}
+
+func (node *JsxAttribute) Name() *JsxAttributeName {
+	return node.name
 }
 
 func (node *JsxAttribute) ForEachChild(v Visitor) bool {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -239,6 +239,9 @@ func (p *Parser) parseSourceFileWorker() *ast.SourceFile {
 	result.SetDiagnostics(attachFileToDiagnostics(p.diagnostics, result))
 	result.ExternalModuleIndicator = isFileProbablyExternalModule(result)
 	result.IsDeclarationFile = isDeclarationFile
+	result.LanguageVersion = p.languageVersion
+	result.LanguageVariant = p.languageVariant
+	result.ScriptKind = p.scriptKind
 	return result
 }
 


### PR DESCRIPTION
This adds JSX support to the printer, as well as a few small fixes to `ast`, notably that the parameters for `JsxNamespacedName` were backwards (the first parameter is the namespace, not the name), and that `JsxAttribute` was missing a `Name()` method.