### PR TITLE
Simplify program load file finding

### DIFF
--- a/internal/compiler/host.go
+++ b/internal/compiler/host.go
@@ -11,11 +11,6 @@ type CompilerHost interface {
 	Trace(msg string)
 }
 
-type FileInfo struct {
-	Name string
-	Size int64
-}
-
 var _ CompilerHost = (*compilerHost)(nil)
 
 type compilerHost struct {


### PR DESCRIPTION
Now that we are doing real concurrent program load, we don't really need to sort files by size anymore. Eventually, we'll not do the fake recursive walk in favor of real tsconfig file matching, which will make it not worth it either.

Remove this code and simplify; I measure no performance change in any metric (time, cpu cycles, branch misses, anything).