### PR TITLE
Fix OptionalType and RestType pos

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -3158,8 +3158,8 @@ func (p *Parser) nextTokenIsColonOrQuestionColon() bool {
 }
 
 func (p *Parser) parseTupleElementType() *ast.TypeNode {
+	pos := p.nodePos()
 	if p.parseOptional(ast.KindDotDotDotToken) {
-		pos := p.nodePos()
 		result := p.factory.NewRestTypeNode(p.parseType())
 		p.finishNode(result, pos)
 		return result
@@ -3167,7 +3167,6 @@ func (p *Parser) parseTupleElementType() *ast.TypeNode {
 	typeNode := p.parseType()
 	// If next token is start of a type we have a conditional type and not an optional type
 	if p.token == ast.KindQuestionToken && !p.lookAhead(p.nextIsStartOfType) {
-		pos := p.nodePos()
 		p.nextToken()
 		typeNode = p.factory.NewOptionalTypeNode(typeNode)
 		p.finishNode(typeNode, pos)


### PR DESCRIPTION
They currently exclude the first part the type: the type itself for OptionalType and `...` for RestType.

This change makes the pos the same as the old compiler.