### PR TITLE
Fix Loc of synthetic JSX closing elements

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -5429,8 +5429,7 @@ func (p *Parser) internIdentifier(text string) {
 }
 
 func (p *Parser) finishNode(node *ast.Node, pos int) {
-	node.Loc = core.NewTextRange(pos, p.nodePos())
-	node.Flags |= p.contextFlags
+	p.finishNodeWithEnd(node, pos, p.nodePos())
 }
 
 func (p *Parser) finishNodeWithEnd(node *ast.Node, pos int, end int) {


### PR DESCRIPTION
In malformed JSX, some synthetic elements are invented after parsing has finished and inserted earlier in the tree to attempt to close unclosed elements. These elements need to specify both a saved pos and saved end, so I created a new function `finishNodeWithEnd` for that.

I remember also creating this function for parsing JSDoc, which occasionally does the same thing, so I expect it'll be used more later.