### PR TITLE
Fix dprint when formatting go code from the editor

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -39,9 +39,9 @@
     },
     "exec": {
         "cwd": "${configDir}",
-        "cacheKey": "3",
+        "cacheKey": "4",
         "commands": [
-            { "command": "gofumpt {{file_path}}", "exts": ["go"], "stdin": false }
+            { "command": "gofumpt -lang=go1.23", "exts": ["go"] }
         ]
     },
     "excludes": [


### PR DESCRIPTION
Within reason, everyone should be using `gopls` to format. But, I had configured `dprint` to also be able to format too, for use at the CLI.

In #142 I changed the way `dprint` calls the formatter to instead pass a path in, with the goal of allowing `gofumpt` to infer the Go language version (which affects formatting since newer syntax can be used in simplifying rules).

This had a bad effect when using the editor and dprint together; without using `stdin`, it always formatted using the file on disk, and then that overwrote everything that was unsaved.

I never noticed because I never ran dprint in my editor for Go, but due to a different VS Code bug (?), bad user settings could mean that our `settings.json` language preferences were not applied.

Fix the issue by manually specifying the language version, and going back to using stdin.