### PR TITLE
Fix scanIdentifier's exit of fastpath

### DIFF
--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -55,11 +55,6 @@ func TestParseTypeScriptRepo(t *testing.T) {
 				t.Run(f.name, func(t *testing.T) {
 					t.Parallel()
 
-					// !!! TODO: Fix this bug
-					if f.name == "compiler/unicodeEscapesInNames01.ts" {
-						t.Skip("times out")
-					}
-
 					sourceText, err := os.ReadFile(f.path)
 					assert.NilError(t, err)
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1202,7 +1202,7 @@ func (s *Scanner) scanIdentifier(prefixLength int) bool {
 			s.tokenValue = s.text[start:s.pos]
 			return true
 		}
-		s.pos = start
+		s.pos = start + prefixLength
 	}
 	ch, size := s.charAndSize()
 	if isIdentifierStart(ch, s.languageVersion) {


### PR DESCRIPTION
scanIdentifier has a fastpath for non-UTF8, non-Unicode-escaped identifiers. When it sees UTF8 or a Unicode escape, it resets and does a full identifier scan.

It also passes a prefixLength of already-scanned characters, used only with private identifiers (#). The function's setup skips over the already-scanned characters, but the reset doesn't. This PR fixes that.

Aside: prefixLength makes the code read smoothly but hides the fact that it is really only for private identifiers and will always be length 1. There's a magic offset here, but the code reads like it could be arbitrary, for arbitrary reasons. `if isPrivate { s.pos++ }` is ugly but reflects the truth.  Of course, I suppose the JS committee could introduce `##` or `#@` prefixes -- and the spec is the real source of the ugliness, so I guess it's fine for us to smooth it over in our code.