### PR TITLE
Ignore bundled libs in CodeQL

### DIFF
--- a/.github/codeql/codeql-configuration.yml
+++ b/.github/codeql/codeql-configuration.yml
@@ -3,3 +3,4 @@ name: CodeQL Configuration
 paths-ignore:
   - _submodules/**
   - '**/testdata/**'
+  - 'internal/bundled/libs/**'


### PR DESCRIPTION
CodeQL's TypeScript parser cannot handle the `intrinsic` keyword, apparently. But also, it's a waste of time to scan these files. They're ignored in the main TS repo too.