### PR TITLE
Fix embedded file paths

### DIFF
--- a/internal/bundled/embed.go
+++ b/internal/bundled/embed.go
@@ -12,7 +12,7 @@ import (
 
 const embedded = true
 
-const scheme = "bundled:"
+const scheme = "bundled:///"
 
 func splitPath(path string) (root string, rest string, ok bool) {
 	rest, ok = strings.CutPrefix(path, scheme)

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"fmt"
-	"path"
 	"regexp"
 	"strings"
 	"sync"
@@ -141,7 +140,7 @@ func ParseJSONText(fileName string, sourceText string) *ast.SourceFile {
 
 func (p *Parser) initializeState(fileName string, sourceText string, languageVersion core.ScriptTarget, scriptKind core.ScriptKind) {
 	p.scanner = scanner.NewScanner()
-	p.fileName = path.Clean(fileName)
+	p.fileName = fileName
 	p.sourceText = sourceText
 	p.languageVersion = languageVersion
 	p.scriptKind = ensureScriptKind(fileName, scriptKind)


### PR DESCRIPTION
This one stray `path.Clean` messed with the source file path and confused me when I was working with the bundled PR. Fixing that means that I can use a more "normal" rooted URI, like `bundled:///` for the paths, which then fixes an issue @EricCornelson is having.