### PR TITLE
Add a merge queue check workflow

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -14,11 +14,17 @@ defaults:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ['self-hosted', '1ES.Pool=TypeScript-1ES-GitHub-XL', '1ES.ImageOverride=mariner-2.0']
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: true
+      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        with:
+          node-version: 'lts/*'
       - uses: ./.github/actions/setup-go
         with:
           cache-name: merge-queue-build
 
-      - run: go test -c -o=/dev/null ./...
+      - run: npm ci
+      - run: npx hereby test:all


### PR DESCRIPTION
GitHub merge queues can precheck PRs before they go into main, which can prevent cases where two PRs race and break a build.

There's a balance between "how much is checked" and "how much delay is added to a the merge process"; this PR puts it as far towards speed as possible. This PR runs the tests on our largest runners.

(This requires a change in repo config, if we want to do it.)