### PR TITLE
Switch back to go flags lib

### DIFF
--- a/cmd/tsgo/main.go
+++ b/cmd/tsgo/main.go
@@ -2,7 +2,7 @@
 package main
 
 import (
-	"errors"
+	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jessevdk/go-flags"
 	"github.com/microsoft/typescript-go/internal/ast"
 	"github.com/microsoft/typescript-go/internal/bundled"
 	ts "github.com/microsoft/typescript-go/internal/compiler"
@@ -46,40 +45,40 @@ func printMessageChain(messageChain []*ast.Diagnostic, level int) {
 
 type cliOptions struct {
 	Tsc struct {
-		Pretty    bool   `long:"pretty" description:"Get prettier errors (default: true)"`
-		ListFiles bool   `long:"listFiles" description:"List files in the program"`
-		NoLib     bool   `long:"noLib" description:"Do not load lib.d.ts files"`
-		OutDir    string `long:"outDir" description:"Emit to the given directory"`
-	} `group:"tsc options"`
+		Pretty    bool
+		ListFiles bool
+		NoLib     bool
+		OutDir    string
+	}
 
 	Devel struct {
-		Quiet            bool   `short:"q" long:"quiet" description:"Do not print diagnostics"`
-		SingleThreaded   bool   `long:"singleThreaded" description:"Run in single threaded mode"`
-		ParseAndBindOnly bool   `long:"parseAndBindOnly" description:"Parse and bind only"`
-		PrintTypes       bool   `long:"printTypes" description:"Print types defined in main.ts"`
-		PprofDir         string `long:"pprofDir" description:"Generate pprof CPU/memory profiles to the given directory"`
-	} `group:"tsgo development options"`
+		Quiet            bool
+		SingleThreaded   bool
+		ParseAndBindOnly bool
+		PrintTypes       bool
+		PprofDir         string
+	}
 
 	Args struct {
-		Root string `positional-arg-name:"project root"`
-	} `positional-args:"yes"`
+		Root string
+	}
 }
 
 func parseArgs() *cliOptions {
 	opts := &cliOptions{}
-	opts.Tsc.Pretty = true
+	flag.BoolVar(&opts.Tsc.Pretty, "pretty", true, "Get prettier errors")
+	flag.BoolVar(&opts.Tsc.ListFiles, "listFiles", false, "List files in the program")
+	flag.BoolVar(&opts.Tsc.NoLib, "noLib", false, "Do not load lib.d.ts files")
+	flag.StringVar(&opts.Tsc.OutDir, "outDir", "", "Emit to the given directory")
 
-	parser := flags.NewParser(opts, flags.HelpFlag)
-	if _, err := parser.Parse(); err != nil {
-		var parseErr *flags.Error
-		if errors.As(err, &parseErr) && parseErr.Type == flags.ErrHelp {
-			fmt.Fprintln(os.Stdout, err)
-			os.Exit(0)
-		} else {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
-		}
-	}
+	flag.BoolVar(&opts.Devel.Quiet, "q", false, "Do not print diagnostics")
+	flag.BoolVar(&opts.Devel.SingleThreaded, "singleThreaded", false, "Run in single threaded mode")
+	flag.BoolVar(&opts.Devel.ParseAndBindOnly, "parseAndBindOnly", false, "Parse and bind only")
+	flag.BoolVar(&opts.Devel.PrintTypes, "printTypes", false, "Print types defined in main.ts")
+	flag.StringVar(&opts.Devel.PprofDir, "pprofDir", "", "Generate pprof CPU/memory profiles to the given directory")
+	flag.Parse()
+
+	opts.Args.Root = flag.Arg(0)
 
 	return opts
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.23.3
 require (
 	github.com/go-json-experiment/json v0.0.0-20241127185351-9802db03f36a
 	github.com/google/go-cmp v0.6.0
-	github.com/jessevdk/go-flags v1.6.1
 	golang.org/x/sys v0.27.0
 	golang.org/x/tools v0.27.0
 	gotest.tools/v3 v3.5.1

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/go-json-experiment/json v0.0.0-20241127185351-9802db03f36a h1:W/o3DbE
 github.com/go-json-experiment/json v0.0.0-20241127185351-9802db03f36a/go.mod h1:BWmvoE1Xia34f3l/ibJweyhrT+aROb/FQ6d+37F0e2s=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/jessevdk/go-flags v1.6.1 h1:Cvu5U8UGrLay1rZfv/zP7iLpSHGUZ/Ou68T0iX1bBK4=
-github.com/jessevdk/go-flags v1.6.1/go.mod h1:Mk8T1hIAWpOiJiHa9rJASDK2UGWji0EuPGBnNLMooyc=
 golang.org/x/mod v0.22.0 h1:D4nJWe9zXqHOmWqj4VMOJhvzj7bEZg4wEYa759z1pH4=
 golang.org/x/mod v0.22.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/sync v0.9.0 h1:fEo0HyrW1GIgZdpbhCRO0PkJajUS5H9IFUztCgEo2jQ=


### PR DESCRIPTION
The flag parser I introduced was overly strict and mistakenly handled `/` as a flag starter (which can only be disabled with a build tag, which is not helpful).

Just restore us back to using Go's flag parser, and we can replace it all once `executeCommandLine` is a thing.

I'll do a fancier thing with Go's flag parser later for the functionality I need in the "it works" PR.