### PR TITLE
add back node to moduleresolution (for now)

### DIFF
--- a/internal/tsoptions/enummaps.go
+++ b/internal/tsoptions/enummaps.go
@@ -117,7 +117,7 @@ var moduleResolutionOptionMap = collections.NewOrderedMapFromList([]collections.
 	{Key: "node16", Value: core.ModuleResolutionKindNode16},
 	{Key: "nodenext", Value: core.ModuleResolutionKindNodeNext},
 	{Key: "bundler", Value: core.ModuleResolutionKindBundler},
-	{Key: "node", Value: core.ModuleResolutionKindNode16}, // todo remove when node is fully deprecated -- this is helpful for testing porting
+	{Key: "node", Value: core.ModuleResolutionKindBundler}, // TODO: remove when node is fully deprecated -- this is helpful for testing porting
 })
 
 var targetOptionMap = collections.NewOrderedMapFromList([]collections.MapEntry[string, any]{


### PR DESCRIPTION
Allows `node` to parse as an alias for `bundler`. https://github.com/microsoft/typescript-go/pull/207#issuecomment-2606145871-- allowing this makes it easier for us to test the port. 