### PR TITLE
Switch tsgo duration stats to seconds

### DIFF
--- a/cmd/tsgo/main.go
+++ b/cmd/tsgo/main.go
@@ -273,8 +273,7 @@ func (t *table) print() {
 }
 
 func formatDuration(d time.Duration) string {
-	seconds := d.Seconds()
-	return fmt.Sprintf("%.3fs", seconds)
+	return fmt.Sprintf("%.3fs", d.Seconds())
 }
 
 func listFiles(p *ts.Program) {


### PR DESCRIPTION
Was:

```
Files:            226
Types:           5218
Parse time:  39.913ms
Bind time:    5.292ms
Check time:  10.699ms
Emit time:    1.159ms
Total time:  57.115ms
Memory used:   34862K
```

Now:

```
Files:          226
Types:         5218
Parse time:  0.027s
Bind time:   0.009s
Check time:  0.012s
Emit time:   0.001s
Total time:  0.048s
Memory used: 34879K
```

I'm not sure if I like it better, but @ahejlsberg suggested it for better readability and it does match our old compiler (but with one more decimal place).