### PR TITLE
Move parsing onto compiler host

### DIFF
--- a/internal/compiler/fileloader.go
+++ b/internal/compiler/fileloader.go
@@ -11,7 +11,6 @@ import (
 	"github.com/microsoft/typescript-go/internal/binder"
 	"github.com/microsoft/typescript-go/internal/compiler/module"
 	"github.com/microsoft/typescript-go/internal/core"
-	"github.com/microsoft/typescript-go/internal/parser"
 	"github.com/microsoft/typescript-go/internal/tsoptions"
 	"github.com/microsoft/typescript-go/internal/tspath"
 )
@@ -217,13 +216,7 @@ func (t *parseTask) start(loader *fileLoader) {
 
 func (p *fileLoader) parseSourceFile(fileName string) *ast.SourceFile {
 	path := tspath.ToPath(fileName, p.host.GetCurrentDirectory(), p.host.FS().UseCaseSensitiveFileNames())
-	text, _ := p.host.FS().ReadFile(fileName)
-	var sourceFile *ast.SourceFile
-	if tspath.FileExtensionIs(fileName, tspath.ExtensionJson) {
-		sourceFile = parser.ParseJSONText(fileName, text)
-	} else {
-		sourceFile = parser.ParseSourceFile(fileName, text, p.compilerOptions.GetEmitScriptTarget())
-	}
+	sourceFile := p.host.GetSourceFile(fileName, p.compilerOptions.GetEmitScriptTarget())
 	sourceFile.SetPath(path)
 	return sourceFile
 }

--- a/internal/compiler/host.go
+++ b/internal/compiler/host.go
@@ -1,7 +1,10 @@
 package compiler
 
 import (
+	"github.com/microsoft/typescript-go/internal/ast"
 	"github.com/microsoft/typescript-go/internal/core"
+	"github.com/microsoft/typescript-go/internal/parser"
+	"github.com/microsoft/typescript-go/internal/tspath"
 	"github.com/microsoft/typescript-go/internal/vfs"
 )
 
@@ -10,6 +13,7 @@ type CompilerHost interface {
 	GetCurrentDirectory() string
 	NewLine() string
 	Trace(msg string)
+	GetSourceFile(fileName string, languageVersion core.ScriptTarget) *ast.SourceFile
 }
 
 type FileInfo struct {
@@ -50,4 +54,12 @@ func (h *compilerHost) NewLine() string {
 
 func (h *compilerHost) Trace(msg string) {
 	//!!! TODO: implement
+}
+
+func (h *compilerHost) GetSourceFile(fileName string, languageVersion core.ScriptTarget) *ast.SourceFile {
+	text, _ := h.FS().ReadFile(fileName)
+	if tspath.FileExtensionIs(fileName, tspath.ExtensionJson) {
+		return parser.ParseJSONText(fileName, text)
+	}
+	return parser.ParseSourceFile(fileName, text, languageVersion)
 }


### PR DESCRIPTION
This will allow programs managed by a language service to pull from a source file cache.