### PR TITLE
Do not allow per-file JSDoc parsing mode customization

### DIFF
--- a/cmd/tsgo/main.go
+++ b/cmd/tsgo/main.go
@@ -153,7 +153,6 @@ func main() {
 		Options:            compilerOptions,
 		SingleThreaded:     opts.devel.singleThreaded,
 		Host:               host,
-		JSDocParsingMode:   scanner.JSDocParsingModeParseForTypeErrors,
 		DefaultLibraryPath: defaultLibraryPath,
 	})
 	parseTime := time.Since(parseStart)

--- a/internal/compiler/fileloader.go
+++ b/internal/compiler/fileloader.go
@@ -215,7 +215,7 @@ func (t *parseTask) start(loader *fileLoader) {
 
 func (p *fileLoader) parseSourceFile(fileName string) *ast.SourceFile {
 	path := tspath.ToPath(fileName, p.host.GetCurrentDirectory(), p.host.FS().UseCaseSensitiveFileNames())
-	sourceFile := p.host.GetSourceFile(fileName, p.compilerOptions.GetEmitScriptTarget(), p.programOptions.JSDocParsingMode)
+	sourceFile := p.host.GetSourceFile(fileName, p.compilerOptions.GetEmitScriptTarget())
 	sourceFile.SetPath(path)
 	return sourceFile
 }

--- a/internal/compiler/host.go
+++ b/internal/compiler/host.go
@@ -14,7 +14,7 @@ type CompilerHost interface {
 	GetCurrentDirectory() string
 	NewLine() string
 	Trace(msg string)
-	GetSourceFile(fileName string, languageVersion core.ScriptTarget, jsdocParsingMode scanner.JSDocParsingMode) *ast.SourceFile
+	GetSourceFile(fileName string, languageVersion core.ScriptTarget) *ast.SourceFile
 }
 
 type FileInfo struct {
@@ -57,10 +57,10 @@ func (h *compilerHost) Trace(msg string) {
 	//!!! TODO: implement
 }
 
-func (h *compilerHost) GetSourceFile(fileName string, languageVersion core.ScriptTarget, jsdocParsingMode scanner.JSDocParsingMode) *ast.SourceFile {
+func (h *compilerHost) GetSourceFile(fileName string, languageVersion core.ScriptTarget) *ast.SourceFile {
 	text, _ := h.FS().ReadFile(fileName)
 	if tspath.FileExtensionIs(fileName, tspath.ExtensionJson) {
 		return parser.ParseJSONText(fileName, text)
 	}
-	return parser.ParseSourceFile(fileName, text, languageVersion, jsdocParsingMode)
+	return parser.ParseSourceFile(fileName, text, languageVersion, scanner.JSDocParsingModeParseForTypeErrors)
 }

--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -27,7 +27,6 @@ type ProgramOptions struct {
 	SingleThreaded     bool
 	ProjectReference   []core.ProjectReference
 	DefaultLibraryPath string
-	JSDocParsingMode   scanner.JSDocParsingMode
 }
 
 type Program struct {


### PR DESCRIPTION
Or even per-Program customization—that would make the source file caches in #261 needlessly more complicated. We should be fine to let each compiler host implementation set its own JSDoc parsing mode for all files it encounters. N.B. `compilerHost` is really only for `tsc` and should probably move out of the `compiler` package eventually—it’s not used by #261 at all.