### PR TITLE
Return unknownSymbol from resolveEntityName

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -12040,7 +12040,7 @@ func (c *Checker) resolveEntityName(name *ast.Node, meaning ast.SymbolFlags, ign
 	default:
 		panic("Unknown entity name kind")
 	}
-	if symbol != nil {
+	if symbol != nil && symbol != c.unknownSymbol {
 		if !ast.NodeIsSynthesized(name) && ast.IsEntityName(name) && (symbol.Flags&ast.SymbolFlagsAlias != 0 || name.Parent.Kind == ast.KindExportAssignment) {
 			c.markSymbolOfAliasDeclarationIfTypeOnly(getAliasDeclarationFromName(name), symbol, nil /*finalTarget*/, true /*overwriteEmpty*/, nil, "")
 		}


### PR DESCRIPTION
The refactor that created resolveQualifiedName broke the immediate return of unknownSymbol when the left side of a qualified name doesn't resolve. Now resolveEntityName has to check for it and return it.