### PR TITLE
Fix minor harness bugs

### DIFF
--- a/internal/testutil/harnessutil/harnessutil.go
+++ b/internal/testutil/harnessutil/harnessutil.go
@@ -516,11 +516,13 @@ func GetFileBasedTestConfigurations(t *testing.T, settings map[string]string, va
 					t.Fatal("Provided test options exceeded the maximum number of variations")
 				}
 				optionEntries = append(optionEntries, append([]string{option}, entries...))
-				continue
+			} else if len(entries) == 1 {
+				nonVariyingOptions[option] = entries[0]
 			}
+		} else {
+			// Variation is not supported for the option
+			nonVariyingOptions[option] = value
 		}
-		// Variation is not supported or not needed for the option
-		nonVariyingOptions[option] = value
 	}
 
 	var configurations []*NamedTestConfiguration

--- a/internal/testutil/runner/compiler_runner.go
+++ b/internal/testutil/runner/compiler_runner.go
@@ -108,7 +108,7 @@ func getCompilerVaryByMap() map[string]struct{} {
 		"isolatedModules")
 	varyByMap := make(map[string]struct{})
 	for _, option := range varyByOptions {
-		varyByMap[option] = struct{}{}
+		varyByMap[strings.ToLower(option)] = struct{}{}
 	}
 	return varyByMap
 }

--- a/internal/testutil/runner/test_case_parser.go
+++ b/internal/testutil/runner/test_case_parser.go
@@ -161,7 +161,7 @@ func extractCompilerSettings(content string) rawCompilerSettings {
 	opts := make(map[string]string)
 
 	for _, match := range optionRegex.FindAllStringSubmatch(content, -1) {
-		opts[strings.ToLower(match[1])] = strings.TrimSpace(match[2])
+		opts[strings.ToLower(match[1])] = strings.TrimSuffix(strings.TrimSpace(match[2]), ";")
 	}
 
 	return opts

--- a/testdata/tests/cases/compiler/settingsSimpleTest.ts
+++ b/testdata/tests/cases/compiler/settingsSimpleTest.ts
@@ -1,5 +1,7 @@
 // @strict: *
 // @target: es2020
+// @strictBuiltinIteratorReturn: *, !true
+// @declaration: true;
 
 export {};
 const x: string = undefined;


### PR DESCRIPTION
- Some Strada tests had trailing ; after an options declaration, like this: `@declaration: true;`, so I'm stripping that now.
- Normalize the names of the varying compiler options that we accept.
- Yet another fix for processing varying options (hopefully the last now).