### PR TITLE
Ignore `moduleResolution` options `classic` and `node10`

### DIFF
--- a/internal/testutil/harnessutil/harnessutil.go
+++ b/internal/testutil/harnessutil/harnessutil.go
@@ -314,9 +314,6 @@ func parseHarnessOption(t *testing.T, key string, value any, options *HarnessOpt
 }
 
 func getOptionValue(t *testing.T, option *tsoptions.CommandLineOption, value string) tsoptions.CompilerOptionsValue {
-	if option.Name == "moduleResolution" && (value == "classic" || value == "node10") { // Deprecated, ignore it for now to avoid errors
-		return core.ModuleResolutionKindUnknown
-	}
 	switch option.Kind {
 	case tsoptions.CommandLineOptionTypeString:
 		return value

--- a/internal/tsoptions/commandlineoption.go
+++ b/internal/tsoptions/commandlineoption.go
@@ -175,7 +175,7 @@ var commandLineOptionEnumMap = map[string]*collections.OrderedMap[string, any]{
 
 // CommandLineOption.DeprecatedKeys()
 var commandLineOptionDeprecated = map[string]*core.Set[string]{
-	"moduleResolution": core.NewSetFromItems[string]("node"),
+	"moduleResolution": core.NewSetFromItems[string]("node", "classic", "node10"),
 	"target":           core.NewSetFromItems[string]("es3"),
 }
 

--- a/internal/tsoptions/enummaps.go
+++ b/internal/tsoptions/enummaps.go
@@ -117,7 +117,9 @@ var moduleResolutionOptionMap = collections.NewOrderedMapFromList([]collections.
 	{Key: "node16", Value: core.ModuleResolutionKindNode16},
 	{Key: "nodenext", Value: core.ModuleResolutionKindNodeNext},
 	{Key: "bundler", Value: core.ModuleResolutionKindBundler},
-	{Key: "node", Value: core.ModuleResolutionKindBundler}, // TODO: remove when node is fully deprecated -- this is helpful for testing porting
+	{Key: "node", Value: core.ModuleResolutionKindBundler},    // TODO: remove when node is fully deprecated -- this is helpful for testing porting
+	{Key: "classic", Value: core.ModuleResolutionKindBundler}, // TODO: remove when fully deprecated
+	{Key: "node10", Value: core.ModuleResolutionKindBundler},  // TODO: remove when fully deprecated
 })
 
 var targetOptionMap = collections.NewOrderedMapFromList([]collections.MapEntry[string, any]{


### PR DESCRIPTION
Those are deprecated and were not added to Corsa. Ignoring them for now to avoid crashing, at some point we should either remove the usage of those options in the tests, or remove the test entirely if they really mean to test those options.