### PR TITLE
Make compilerOptions merging align with old compiler

### DIFF
--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -116,7 +116,7 @@ func NewProgram(options ProgramOptions) *Program {
 			tsConfigSourceFile,
 			p.host,
 			p.host.GetCurrentDirectory(),
-			nil,
+			p.compilerOptions,
 			p.configFilePath,
 			/*resolutionStack*/ nil,
 			/*extraFileExtensions*/ nil,
@@ -128,8 +128,7 @@ func NewProgram(options ProgramOptions) *Program {
 			return p
 		}
 
-		// !!! this modifies p.compilerOptions
-		tsoptions.MergeCompilerOptions(p.compilerOptions, parseConfigFileContent.CompilerOptions())
+		p.compilerOptions = parseConfigFileContent.CompilerOptions()
 
 		if rootFiles == nil {
 			// !!! merge? override? this?


### PR DESCRIPTION
This aligns how we merge `CompilerOptions` from tsconfig.json with options from the command line to match `tsc` (i.e., command line options override tsconfig.json options) by passing the command line compiler options to `ParseJsonSourceFileConfigFileContent` and then overwriting the program options with the result.

