### PR TITLE
Fixing nil pointer dereference

### DIFF
--- a/internal/tsoptions/tsconfigparsing.go
+++ b/internal/tsoptions/tsconfigparsing.go
@@ -140,7 +140,7 @@ func parseOwnConfigOfJsonSourceFile(
 		if option != nil && option != extendsOptionDeclaration {
 			value, propertySetErrors = convertTsConfigJsonOption(option, value, basePath, propertyAssignment, propertyAssignment.Initializer, sourceFile)
 		}
-		if parentOption.Name != "undefined" && value != nil {
+		if parentOption != nil && parentOption.Name != "undefined" && value != nil {
 			if option != nil && option.Name != "" {
 				commandLineOptionEnumMapVal := option.EnumMap()
 				if commandLineOptionEnumMapVal != nil {

--- a/internal/tsoptions/tsconfigparsing_test.go
+++ b/internal/tsoptions/tsconfigparsing_test.go
@@ -441,7 +441,7 @@ var parseJsonConfigFileTests = []struct {
 		}},
 	},
 	{
-		title:               "parses tsconfig with extends, files and include",
+		title:               "parses tsconfig with extends, files, include and other options",
 		noSubmoduleBaseline: true,
 		input: []testConfig{{
 			jsonText: `{
@@ -462,6 +462,12 @@ var parseJsonConfigFileTests = []struct {
 var tsconfigWithExtends = `{
   "files": ["/src/index.ts", "/src/app.ts"],
   "include": ["/src/**/*"],
+  "ts-node": {
+    "compilerOptions": {
+      "module": "commonjs"
+    },
+    "transpileOnly": true
+  }
 }`
 
 var tsconfigWithoutConfigDir = `{

--- a/testdata/baselines/reference/config/tsconfigParsing/parses tsconfig with extends, files, include and other options with json api.js
+++ b/testdata/baselines/reference/config/tsconfigParsing/parses tsconfig with extends, files, include and other options with json api.js
@@ -25,6 +25,12 @@ Fs::
 {
   "files": ["/src/index.ts", "/src/app.ts"],
   "include": ["/src/**/*"],
+  "ts-node": {
+    "compilerOptions": {
+      "module": "commonjs"
+    },
+    "transpileOnly": true
+  }
 }
 
 

--- a/testdata/baselines/reference/config/tsconfigParsing/parses tsconfig with extends, files, include and other options with jsonSourceFile api.js
+++ b/testdata/baselines/reference/config/tsconfigParsing/parses tsconfig with extends, files, include and other options with jsonSourceFile api.js
@@ -25,6 +25,12 @@ Fs::
 {
   "files": ["/src/index.ts", "/src/app.ts"],
   "include": ["/src/**/*"],
+  "ts-node": {
+    "compilerOptions": {
+      "module": "commonjs"
+    },
+    "transpileOnly": true
+  }
 }
 
 


### PR DESCRIPTION
This pr fixes `runtime error: invalid memory address or nil pointer dereference` for cases like https://gist.github.com/jakebailey/8cd8941d49bc0b601cedc0c9e2e5eba5#file-freecodecamp-txt. 

`parentOption` is nil when `objectOption` is nil, and hence `option` is nil in `convertObjectLiteralExpressionToJson`, when`convertPropertyValueToJson` is called. `objectOption` is nil because in the previous step, ` objectOption.ElementOptions` for `ts-node` is nil https://github.com/microsoft/typescript-go/blob/main/internal/tsoptions/tsconfigparsing.go#L649.