### PR TITLE
Ensure tsgo is built on initial watch event

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -126,7 +126,6 @@ export const buildWatch = task({
     name: "build:watch",
     run: async () => {
         await watchDebounced("build:watch", async (paths, abortSignal) => {
-            console.log(paths);
             let libsChanged = false;
             let goChanged = false;
 


### PR DESCRIPTION
This explains why things weren't working; the initial event doesn't have any paths. Explicitly denote the initial run with an undefined path set.