### PR TITLE
Skip trivia on go-to-definition.

### DIFF
--- a/internal/ls/definition.go
+++ b/internal/ls/definition.go
@@ -25,7 +25,7 @@ func (l *LanguageService) ProvideDefinitions(fileName string, position int) []Lo
 		for _, decl := range symbol.Declarations {
 			file := ast.GetSourceFileOfNode(decl)
 			loc := decl.Loc
-			pos := scanner.SkipTrivia(file.Text, loc.Pos())
+			pos := scanner.GetTokenPosOfNode(decl, file, false /*includeJsDoc*/)
 
 			locations = append(locations, Location{
 				FileName: file.FileName(),


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/4d391d14-444d-48b0-83bc-8f0b197f5a95)

After:
![image](https://github.com/user-attachments/assets/95a07833-a941-4e38-8f1a-1564bd68804a)

Happy to hoist the logic into a helper since we'll need it almost everywhere anyway (though I'm not sure what we should call it. `get____LocationForRange`?).