### PR TITLE
Fix case of noImplicitReferences config access

### DIFF
--- a/internal/testutil/runner/compiler_runner.go
+++ b/internal/testutil/runner/compiler_runner.go
@@ -247,7 +247,7 @@ func newCompilerTest(
 		// If the last file in a test uses require or a triple slash reference we'll assume all other files will be brought in via references,
 		// otherwise, assume all files are just meant to be in the same compilation session without explicit references to one another.
 
-		if testCaseContentWithConfig.configuration["noImplicitReferences"] != "" ||
+		if testCaseContentWithConfig.configuration["noimplicitreferences"] != "" ||
 			strings.Contains(lastUnit.content, requireStr) ||
 			referencesRegex.MatchString(lastUnit.content) {
 			toBeCompiled = append(toBeCompiled, createHarnessTestFile(lastUnit, currentDirectory))


### PR DESCRIPTION
Corsa baselines lowercase test directives, Strada does not, or does it later than `newCompilerTest`.

Fixes #302 

Note that the test case for #302 still doesn't match the Strada result, probably because it doesn't support the `@link` directive.