### PR TITLE
Remove gci lint rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,6 @@ linters:
     - errname
     - errorlint
     - fatcontext
-    - gci
     - gocheckcompilerdirectives
     - goprintffuncname
     - gosimple


### PR DESCRIPTION
We are already formatting with gofumpt, which covers these rules. No need to have the linter also be mad in CI when the file just needs a fmt.