### PR TITLE
Fix CI matrix to include regular ubuntu, no gotestsum, in race mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,8 @@ jobs:
 
       - run: go install gotest.tools/gotestsum@latest
         # Installing gotestsum is super slow on Windows.
-        if: ${{ matrix.os != 'windows-latest' }}
+        # Also, avoid using it in race mode so we get the full output.
+        if: ${{ matrix.os != 'windows-latest' && !matrix.race }}
 
       - name: Tests
         id: test


### PR DESCRIPTION
Noticed while looking at other builds; for some reason `ubuntu-latest` without any extra options was missing.