### PR TITLE
Check whether ResolveModuleName-cached result is usable for ResolveTypeReferenceDirective

### DIFF
--- a/internal/compiler/module/resolver.go
+++ b/internal/compiler/module/resolver.go
@@ -27,6 +27,10 @@ func (r *resolved) shouldContinueSearching() bool {
 	return r == nil
 }
 
+func (r *resolved) isResolved() bool {
+	return r != nil && r.path != ""
+}
+
 func unresolved() *resolved {
 	return &resolved{}
 }
@@ -789,8 +793,10 @@ func (r *resolutionState) loadModuleFromNearestNodeModulesDirectoryWorker(ext ex
 		func(directory string) (result *resolved, stop bool) {
 			// !!! stop at global cache
 			if tspath.GetBaseFileName(directory) != "node_modules" {
-				if resolutionFromCache := r.tryFindNonRelativeModuleNameInCache(ModeAwareCacheKey{r.name, mode}, directory); !resolutionFromCache.shouldContinueSearching() && extensionIsOk(ext, resolutionFromCache.extension) {
-					return resolutionFromCache, true
+				if resolutionFromCache := r.tryFindNonRelativeModuleNameInCache(ModeAwareCacheKey{r.name, mode}, directory); !resolutionFromCache.shouldContinueSearching() {
+					if !resolutionFromCache.isResolved() || extensionIsOk(ext, resolutionFromCache.extension) {
+						return resolutionFromCache, true
+					}
 				}
 				result := r.loadModuleFromImmediateNodeModulesDirectory(ext, directory, typesScopeOnly)
 				return result, !result.shouldContinueSearching()


### PR DESCRIPTION
In Strada, this code path didn’t use the cache at all. It just needs this check to use it safely. Fixes the expo/expo panic in https://gist.github.com/jakebailey/8cd8941d49bc0b601cedc0c9e2e5eba5