### PR TITLE
Fix initialType in getFlowTypeOfReference

### DIFF
--- a/internal/checker/flow.go
+++ b/internal/checker/flow.go
@@ -73,7 +73,7 @@ func (c *Checker) getFlowTypeOfReferenceEx(reference *ast.Node, declaredType *Ty
 	f := &c.flowStates[flowStateCount]
 	f.reference = reference
 	f.declaredType = declaredType
-	f.initialType = initialType
+	f.initialType = core.Coalesce(initialType, declaredType)
 	f.flowContainer = flowContainer
 	f.sharedFlowStart = len(c.sharedFlows)
 	f.reduceLabels = f.reduceLabelsBuffer[:0]


### PR DESCRIPTION
The original code had the parameter `initialType = declaredType`, but the ported code left `initialType` as-is, so it could be nil.

This fixes a crash https://github.com/labring/FastGPT/blob/7aacce8b0be42ecea95fa286f3f051b87bd79ae0/tsconfig.json.