### PR TITLE
Reimplement diagnosticPullOptions match function for unopened files

### DIFF
--- a/_extension/src/extension.ts
+++ b/_extension/src/extension.ts
@@ -4,7 +4,9 @@ import * as vscode from "vscode";
 import {
     LanguageClient,
     LanguageClientOptions,
+    NotebookDocumentFilter,
     ServerOptions,
+    TextDocumentFilter,
     TransportKind,
 } from "vscode-languageclient/node";
 
@@ -55,14 +57,45 @@ export function activate(context: vscode.ExtensionContext) {
             onSave: true,
             onTabs: true,
             match(documentSelector, resource) {
-                if (resource.scheme === "file" && /\.(?:[cm]?[jt]s|[tj]sx)$/.test(resource.path)) {
-                    return true;
+                // This function is called when diagnostics are requested but
+                // only the URI itself is known (e.g. open but not yet focused tabs),
+                // so will not be present in vscode.workspace.textDocuments.
+                // See if this file matches without consulting vscode.languages.match
+                // (which requires a TextDocument).
+
+                const language = getLanguageForUri(resource);
+
+                for (const selector of documentSelector) {
+                    if (typeof selector === "string") {
+                        if (selector === language) {
+                            return true;
+                        }
+                        continue;
+                    }
+                    if (NotebookDocumentFilter.is(selector)) {
+                        continue;
+                    }
+                    if (TextDocumentFilter.is(selector)) {
+                        if (selector.language !== undefined && selector.language !== language) {
+                            continue;
+                        }
+
+                        if (selector.scheme !== undefined && selector.scheme !== resource.scheme) {
+                            continue;
+                        }
+
+                        if (selector.pattern !== undefined) {
+                            // VS Code's glob matcher is not available via the API;
+                            // see: https://github.com/microsoft/vscode/issues/237304
+                            // But, we're only called on selectors passed above, so just ignore this for now.
+                            throw new Error("Not implemented");
+                        }
+
+                        return true;
+                    }
                 }
-                const document = vscode.workspace.textDocuments.find(doc => doc.uri.toString() === resource.toString());
-                if (!document) {
-                    return false;
-                }
-                return vscode.languages.match(documentSelector, document) > 0;
+
+                return false;
             },
         },
     };
@@ -83,4 +116,24 @@ export function deactivate(): Thenable<void> | undefined {
         return undefined;
     }
     return client.stop();
+}
+
+function getLanguageForUri(uri: vscode.Uri): string | undefined {
+    const ext = path.posix.extname(uri.path);
+    switch (ext) {
+        case ".ts":
+        case ".mts":
+        case ".cts":
+            return "typescript";
+        case ".js":
+        case ".mjs":
+        case ".cjs":
+            return "javascript";
+        case ".tsx":
+            return "typescriptreact";
+        case ".jsx":
+            return "javascriptreact";
+        default:
+            return undefined;
+    }
 }


### PR DESCRIPTION
Tabs that haven't been clicked on are not present in `vscode.workspace.textDocuments`, but diagnostics can still be requested for them thanks to `onTabs: true`. We can't ask VS Code for a `TextDocument` to then run `vscode.languages.match` since that's an async operation and would be slow (not to mention impossible because the matcher is synchronous).

Reading the docs for `match`, this function is _exclusively_ run for files that aren't in `vscode.workspace.textDocuments` where we only have URIs, so the current code seemingly will never succeed.

Instead, reimplement language selector matching using only the URI itself, which fixes the problem; upon reloading a window, diagnostics appear in tabs that haven't been focused yet.