### PR TITLE
Optimize lookAhead to avoid extra closures over Parser

### DIFF
--- a/internal/parser/jsdoc.go
+++ b/internal/parser/jsdoc.go
@@ -338,7 +338,7 @@ func (p *Parser) isNextNonwhitespaceTokenEndOfFile() bool {
 
 func (p *Parser) skipWhitespace() {
 	if p.token == ast.KindWhitespaceTrivia || p.token == ast.KindNewLineTrivia {
-		if p.lookAhead(p.isNextNonwhitespaceTokenEndOfFile) {
+		if p.lookAhead((*Parser).isNextNonwhitespaceTokenEndOfFile) {
 			return
 			// Don't skip whitespace prior to EoF (or end of comment) - that shouldn't be included in any node's range
 		}
@@ -350,7 +350,7 @@ func (p *Parser) skipWhitespace() {
 
 func (p *Parser) skipWhitespaceOrAsterisk() string {
 	if p.token == ast.KindWhitespaceTrivia || p.token == ast.KindNewLineTrivia {
-		if p.lookAhead(p.isNextNonwhitespaceTokenEndOfFile) {
+		if p.lookAhead((*Parser).isNextNonwhitespaceTokenEndOfFile) {
 			return ""
 			// Don't skip whitespace prior to EoF (or end of comment) - that shouldn't be included in any node's range
 		}
@@ -725,7 +725,7 @@ func (p *Parser) parseParameterOrPropertyTag(start int, tagName *ast.IdentifierN
 	name, isBracketed := p.parseBracketNameInPropertyAndParamTag()
 	indentText := p.skipWhitespaceOrAsterisk()
 
-	if isNameFirst && p.lookAhead(func() bool { _, ok := p.parseJSDocLinkPrefix(); return !ok }) {
+	if isNameFirst && p.lookAhead(func(p *Parser) bool { _, ok := p.parseJSDocLinkPrefix(); return !ok }) {
 		typeExpression = p.tryParseTypeExpression()
 	}
 
@@ -802,7 +802,7 @@ func (p *Parser) parseTypeTag(previousTags []*ast.Node, start int, tagName *ast.
 }
 
 func (p *Parser) parseSeeTag(start int, tagName *ast.IdentifierNode, indent int, indentText string) *ast.Node {
-	isMarkdownOrJSDocLink := p.token == ast.KindOpenBracketToken || p.lookAhead(func() bool {
+	isMarkdownOrJSDocLink := p.token == ast.KindOpenBracketToken || p.lookAhead(func(p *Parser) bool {
 		return p.nextTokenJSDoc() == ast.KindAtToken && tokenIsIdentifierOrKeyword(p.nextTokenJSDoc()) && isJSDocLinkTag(p.scanner.TokenValue())
 	})
 	var nameExpression *ast.Node


### PR DESCRIPTION
Similar to #391 and #3.

```
goos: linux
goarch: amd64
pkg: github.com/microsoft/typescript-go/internal/parser
cpu: Intel(R) Core(TM) i9-10900K CPU @ 3.70GHz
                                                             │   old.txt   │              new.txt               │
                                                             │   sec/op    │   sec/op     vs base               │
Parse/empty.ts/tsc-20                                          466.6n ± 0%   459.4n ± 1%  -1.53% (p=0.000 n=10)
Parse/empty.ts/server-20                                       465.1n ± 1%   461.8n ± 1%  -0.71% (p=0.002 n=10)
Parse/checker.ts/tsc-20                                        41.84m ± 2%   41.56m ± 1%       ~ (p=0.190 n=10)
Parse/checker.ts/server-20                                     42.81m ± 1%   42.96m ± 1%       ~ (p=0.912 n=10)
Parse/dom.generated.d.ts/tsc-20                                13.13m ± 2%   13.04m ± 1%  -0.70% (p=0.003 n=10)
Parse/dom.generated.d.ts/server-20                             19.33m ± 1%   19.05m ± 1%  -1.43% (p=0.011 n=10)
Parse/Herebyfile.mjs/tsc-20                                    714.6µ ± 1%   699.9µ ± 1%  -2.06% (p=0.000 n=10)
Parse/Herebyfile.mjs/server-20                                 716.1µ ± 1%   700.4µ ± 1%  -2.20% (p=0.000 n=10)
Parse/jsxComplexSignatureHasApplicabilityError.tsx/tsc-20      251.6µ ± 1%   250.6µ ± 1%  -0.42% (p=0.035 n=10)
Parse/jsxComplexSignatureHasApplicabilityError.tsx/server-20   382.0µ ± 1%   381.8µ ± 1%       ~ (p=0.912 n=10)
geomean                                                        586.9µ        581.4µ       -0.95%
```
```
                                                             │   old.txt    │                new.txt                │
                                                             │     B/op     │     B/op      vs base                 │
Parse/empty.ts/tsc-20                                            816.0 ± 0%     816.0 ± 0%       ~ (p=1.000 n=10) ¹
Parse/empty.ts/server-20                                         816.0 ± 0%     816.0 ± 0%       ~ (p=1.000 n=10) ¹
Parse/checker.ts/tsc-20                                        24.21Mi ± 0%   24.21Mi ± 0%       ~ (p=0.143 n=10)
Parse/checker.ts/server-20                                     24.39Mi ± 0%   24.39Mi ± 0%       ~ (p=0.315 n=10)
Parse/dom.generated.d.ts/tsc-20                                8.638Mi ± 0%   8.639Mi ± 0%       ~ (p=0.393 n=10)
Parse/dom.generated.d.ts/server-20                             11.00Mi ± 0%   11.00Mi ± 0%       ~ (p=0.579 n=10)
Parse/Herebyfile.mjs/tsc-20                                    428.9Ki ± 0%   429.0Ki ± 0%       ~ (p=0.853 n=10)
Parse/Herebyfile.mjs/server-20                                 428.8Ki ± 0%   428.9Ki ± 0%       ~ (p=0.448 n=10)
Parse/jsxComplexSignatureHasApplicabilityError.tsx/tsc-20      159.7Ki ± 0%   159.7Ki ± 0%       ~ (p=0.592 n=10)
Parse/jsxComplexSignatureHasApplicabilityError.tsx/server-20   236.7Ki ± 0%   236.7Ki ± 0%       ~ (p=0.971 n=10)
geomean                                                        440.1Ki        440.1Ki       +0.01%
¹ all samples are equal
```
```
                                                             │   old.txt   │               new.txt                │
                                                             │  allocs/op  │  allocs/op   vs base                 │
Parse/empty.ts/tsc-20                                           4.000 ± 0%    4.000 ± 0%       ~ (p=1.000 n=10) ¹
Parse/empty.ts/server-20                                        4.000 ± 0%    4.000 ± 0%       ~ (p=1.000 n=10) ¹
Parse/checker.ts/tsc-20                                        28.83k ± 0%   28.83k ± 0%       ~ (p=0.235 n=10)
Parse/checker.ts/server-20                                     29.44k ± 0%   29.44k ± 0%       ~ (p=0.250 n=10)
Parse/dom.generated.d.ts/tsc-20                                21.05k ± 0%   21.05k ± 0%       ~ (p=1.000 n=10)
Parse/dom.generated.d.ts/server-20                             27.98k ± 0%   27.98k ± 0%       ~ (p=1.000 n=10)
Parse/Herebyfile.mjs/tsc-20                                    1.354k ± 0%   1.354k ± 0%       ~ (p=1.000 n=10) ¹
Parse/Herebyfile.mjs/server-20                                 1.354k ± 0%   1.354k ± 0%       ~ (p=1.000 n=10) ¹
Parse/jsxComplexSignatureHasApplicabilityError.tsx/tsc-20       352.0 ± 0%    352.0 ± 0%       ~ (p=1.000 n=10) ¹
Parse/jsxComplexSignatureHasApplicabilityError.tsx/server-20    618.0 ± 0%    618.0 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                        1.123k        1.123k       +0.00%
¹ all samples are equal
```