### PR TITLE
Fix some bugs related to type-only aliases

### DIFF
--- a/internal/binder/binder.go
+++ b/internal/binder/binder.go
@@ -706,10 +706,20 @@ func (b *Binder) bind(node *ast.Node) bool {
 		if node.Kind == ast.KindEndOfFile {
 			b.parent = node
 		}
+		b.bindJSDoc(node)
 		b.parent = saveParent
 	}
 	b.inStrictMode = saveInStrictMode
 	return false
+}
+
+func (b *Binder) bindJSDoc(node *ast.Node) {
+	// !!! if isInJSFile(node) {
+	// !!! else {
+	for _, jsdoc := range node.JSDoc(b.file) {
+		setParent(jsdoc, node)
+		ast.SetParentInChildren(jsdoc)
+	}
 }
 
 func (b *Binder) bindPropertyWorker(node *ast.Node) {
@@ -1466,6 +1476,7 @@ func (b *Binder) bindChildren(node *ast.Node) {
 	b.inAssignmentPattern = false
 	if b.checkUnreachable(node) {
 		b.bindEachChild(node)
+		b.bindJSDoc(node)
 		b.inAssignmentPattern = saveInAssignmentPattern
 		return
 	}
@@ -1553,6 +1564,7 @@ func (b *Binder) bindChildren(node *ast.Node) {
 	default:
 		b.bindEachChild(node)
 	}
+	b.bindJSDoc(node)
 	b.inAssignmentPattern = saveInAssignmentPattern
 }
 

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -13863,10 +13863,10 @@ func (c *Checker) markSymbolOfAliasDeclarationIfTypeOnlyWorker(aliasDeclarationL
 		if exportSymbol == nil {
 			exportSymbol = target
 		}
-		typeOnly := core.Some(exportSymbol.Declarations, isTypeOnlyImportOrExportDeclaration)
 		aliasDeclarationLinks.typeOnlyDeclarationResolved = true
-		aliasDeclarationLinks.typeOnlyDeclaration = nil
-		if typeOnly {
+		if typeOnly := core.Find(exportSymbol.Declarations, isTypeOnlyImportOrExportDeclaration); typeOnly != nil {
+			aliasDeclarationLinks.typeOnlyDeclaration = typeOnly
+		} else {
 			aliasDeclarationLinks.typeOnlyDeclaration = c.aliasSymbolLinks.Get(exportSymbol).typeOnlyDeclaration
 		}
 	}

--- a/internal/checker/utilities.go
+++ b/internal/checker/utilities.go
@@ -437,7 +437,7 @@ func isShorthandAmbientModule(node *ast.Node) bool {
 }
 
 func getAliasDeclarationFromName(node *ast.Node) *ast.Node {
-	switch node.Kind {
+	switch node.Parent.Kind {
 	case ast.KindImportClause, ast.KindImportSpecifier, ast.KindNamespaceImport, ast.KindExportSpecifier, ast.KindExportAssignment,
 		ast.KindImportEqualsDeclaration, ast.KindNamespaceExport:
 		return node.Parent

--- a/internal/testutil/runner/compiler_runner.go
+++ b/internal/testutil/runner/compiler_runner.go
@@ -89,7 +89,6 @@ func (r *CompilerBaselineRunner) RunTests(t *testing.T) {
 	r.cleanUpLocal(t)
 	files := r.EnumerateTestFiles()
 	skippedTests := []string{
-		"chained2.ts",                     // Corsa bug related to multi/single-threaded mode.
 		"mappedTypeRecursiveInference.ts", // Needed until we have type printer with truncation limit.
 	}
 	deprecatedTests := []string{

--- a/testdata/baselines/reference/submodule/conformance/chained2.symbols
+++ b/testdata/baselines/reference/submodule/conformance/chained2.symbols
@@ -1,0 +1,51 @@
+//// [tests/cases/conformance/externalModules/typeOnly/chained2.ts] ////
+
+=== /a.ts ===
+class A { a!: string }
+>A : Symbol(A, Decl(a.ts, 0, 0))
+>a : Symbol(a, Decl(a.ts, 0, 9))
+
+export type { A as default };
+>A : Symbol(A, Decl(a.ts, 0, 0))
+>default : Symbol(default, Decl(a.ts, 1, 13))
+
+=== /b.ts ===
+import A from './a';
+>A : Symbol(A, Decl(b.ts, 0, 6))
+
+import type { default as B } from './a';
+>default : Symbol(default, Decl(a.ts, 1, 13))
+>B : Symbol(B, Decl(b.ts, 1, 13))
+
+export { A, B };
+>A : Symbol(A, Decl(b.ts, 2, 8))
+>B : Symbol(B, Decl(b.ts, 2, 11))
+
+=== /c.ts ===
+import * as types from './b';
+>types : Symbol(types, Decl(c.ts, 0, 6))
+
+export { types as default };
+>types : Symbol(types, Decl(c.ts, 0, 6))
+>default : Symbol(default, Decl(c.ts, 1, 8))
+
+=== /d.ts ===
+import types from './c';
+>types : Symbol(types, Decl(d.ts, 0, 6))
+
+new types.A();
+>types : Symbol(types, Decl(d.ts, 0, 6))
+
+new types.B();
+>types : Symbol(types, Decl(d.ts, 0, 6))
+
+const a: types.A = {};
+>a : Symbol(a, Decl(d.ts, 3, 5))
+>types : Symbol(types, Decl(d.ts, 0, 6))
+>A : Symbol(A, Decl(b.ts, 2, 8))
+
+const b: types.B = {};
+>b : Symbol(b, Decl(d.ts, 4, 5))
+>types : Symbol(types, Decl(d.ts, 0, 6))
+>B : Symbol(B, Decl(b.ts, 2, 11))
+

--- a/testdata/baselines/reference/submodule/conformance/chained2.symbols.diff
+++ b/testdata/baselines/reference/submodule/conformance/chained2.symbols.diff
@@ -1,0 +1,24 @@
+--- old.chained2.symbols
++++ new.chained2.symbols
+@@= skipped -2, +2 lines =@@
+ === /a.ts ===
+ class A { a!: string }
+ >A : Symbol(A, Decl(a.ts, 0, 0))
+->a : Symbol(A.a, Decl(a.ts, 0, 9))
++>a : Symbol(a, Decl(a.ts, 0, 9))
+ 
+ export type { A as default };
+ >A : Symbol(A, Decl(a.ts, 0, 0))
+@@= skipped -39, +39 lines =@@
+ const a: types.A = {};
+ >a : Symbol(a, Decl(d.ts, 3, 5))
+ >types : Symbol(types, Decl(d.ts, 0, 6))
+->A : Symbol(types.A, Decl(b.ts, 2, 8))
++>A : Symbol(A, Decl(b.ts, 2, 8))
+ 
+ const b: types.B = {};
+ >b : Symbol(b, Decl(d.ts, 4, 5))
+ >types : Symbol(types, Decl(d.ts, 0, 6))
+->B : Symbol(types.B, Decl(b.ts, 2, 11))
++>B : Symbol(B, Decl(b.ts, 2, 11))
+ 


### PR DESCRIPTION
1. node -> node.Parent in getAliasDeclarationForName
2. Correct value for typeOnlyDeclaration in markSymbolOfAliasDeclarationIfTypeOnlyWorker (it had the local type-only case swapped and the alias type-only case missing).
3. Set JSDoc parents in the binder. jsdocLinkTag tests previously passed by mistake because getAliasDeclarationForName wasn't checking the correct node for names.

This might be slower to bind now that we're setting parent pointers on JSDoc, but it's a required change when there are `@link` and `@see` tags.