### PR TITLE
Pool Binders like we do Parsers

### DIFF
--- a/internal/binder/binder.go
+++ b/internal/binder/binder.go
@@ -42,8 +42,8 @@ type Binder struct {
 	options                 *core.CompilerOptions
 	languageVersion         core.ScriptTarget
 	bindFunc                func(*ast.Node) bool
-	unreachableFlow         ast.FlowNode
-	reportedUnreachableFlow ast.FlowNode
+	unreachableFlow         *ast.FlowNode
+	reportedUnreachableFlow *ast.FlowNode
 
 	parent                 *ast.Node
 	container              *ast.Node
@@ -116,8 +116,8 @@ func bindSourceFile(file *ast.SourceFile, options *core.CompilerOptions) {
 		b.file = file
 		b.options = options
 		b.languageVersion = options.GetEmitScriptTarget()
-		b.unreachableFlow.Flags = ast.FlowFlagsUnreachable
-		b.reportedUnreachableFlow.Flags = ast.FlowFlagsUnreachable
+		b.unreachableFlow = b.newFlowNode(ast.FlowFlagsUnreachable)
+		b.reportedUnreachableFlow = b.newFlowNode(ast.FlowFlagsUnreachable)
 		b.bind(file.AsNode())
 		file.SymbolCount = b.symbolCount
 		file.ClassifiableNames = b.classifiableNames
@@ -479,10 +479,10 @@ func (b *Binder) createFlowCondition(flags ast.FlowFlags, antecedent *ast.FlowNo
 		if flags&ast.FlowFlagsTrueCondition != 0 {
 			return antecedent
 		}
-		return &b.unreachableFlow
+		return b.unreachableFlow
 	}
 	if (expression.Kind == ast.KindTrueKeyword && flags&ast.FlowFlagsFalseCondition != 0 || expression.Kind == ast.KindFalseKeyword && flags&ast.FlowFlagsTrueCondition != 0) && !ast.IsExpressionOfOptionalChainRoot(expression) && !ast.IsNullishCoalesce(expression.Parent) {
-		return &b.unreachableFlow
+		return b.unreachableFlow
 	}
 	if !isNarrowingExpression(expression) {
 		return antecedent
@@ -560,7 +560,7 @@ func (b *Binder) addAntecedent(label *ast.FlowLabel, antecedent *ast.FlowNode) {
 
 func (b *Binder) finishFlowLabel(label *ast.FlowLabel) *ast.FlowNode {
 	if label.Antecedents == nil {
-		return &b.unreachableFlow
+		return b.unreachableFlow
 	}
 	if label.Antecedents.Next == nil {
 		return label.Antecedents.Flow
@@ -1613,7 +1613,7 @@ func (b *Binder) checkUnreachable(node *ast.Node) bool {
 	if b.currentFlow.Flags&ast.FlowFlagsUnreachable == 0 {
 		return false
 	}
-	if b.currentFlow == &b.unreachableFlow {
+	if b.currentFlow == b.unreachableFlow {
 		// report errors on all statements except empty ones
 		// report errors on class declarations
 		// report errors on enums with preserved emit
@@ -1623,7 +1623,7 @@ func (b *Binder) checkUnreachable(node *ast.Node) bool {
 			isEnumDeclarationWithPreservedEmit(node, b.options) ||
 			ast.IsModuleDeclaration(node) && b.shouldReportErrorOnModuleDeclaration(node)
 		if reportError {
-			b.currentFlow = &b.reportedUnreachableFlow
+			b.currentFlow = b.reportedUnreachableFlow
 			if b.options.AllowUnreachableCode != core.TSTrue {
 				// unreachable code is reported if
 				// - user has explicitly asked about it AND
@@ -1863,14 +1863,14 @@ func (b *Binder) bindReturnStatement(node *ast.Node) {
 	if b.currentReturnTarget != nil {
 		b.addAntecedent(b.currentReturnTarget, b.currentFlow)
 	}
-	b.currentFlow = &b.unreachableFlow
+	b.currentFlow = b.unreachableFlow
 	b.hasExplicitReturn = true
 	b.hasFlowEffects = true
 }
 
 func (b *Binder) bindThrowStatement(node *ast.Node) {
 	b.bind(node.AsThrowStatement().Expression)
-	b.currentFlow = &b.unreachableFlow
+	b.currentFlow = b.unreachableFlow
 	b.hasFlowEffects = true
 }
 
@@ -1907,7 +1907,7 @@ func (b *Binder) findActiveLabel(name string) *ActiveLabel {
 func (b *Binder) bindBreakOrContinueFlow(flowLabel *ast.FlowLabel) {
 	if flowLabel != nil {
 		b.addAntecedent(flowLabel, b.currentFlow)
-		b.currentFlow = &b.unreachableFlow
+		b.currentFlow = b.unreachableFlow
 		b.hasFlowEffects = true
 	}
 }
@@ -1967,7 +1967,7 @@ func (b *Binder) bindTryStatement(node *ast.Node) {
 		b.bind(stmt.FinallyBlock)
 		if b.currentFlow.Flags&ast.FlowFlagsUnreachable != 0 {
 			// If the end of the finally block is unreachable, the end of the entire try statement is unreachable.
-			b.currentFlow = &b.unreachableFlow
+			b.currentFlow = b.unreachableFlow
 		} else {
 			// If we have an IIFE return target and return statements in the try or catch blocks, add a control
 			// flow that goes back through the finally block and back through only the return statements.
@@ -1985,7 +1985,7 @@ func (b *Binder) bindTryStatement(node *ast.Node) {
 			if normalExitLabel.Antecedents != nil {
 				b.currentFlow = b.createReduceLabel(finallyLabel, normalExitLabel.Antecedents, b.currentFlow)
 			} else {
-				b.currentFlow = &b.unreachableFlow
+				b.currentFlow = b.unreachableFlow
 			}
 		}
 	} else {
@@ -2018,11 +2018,11 @@ func (b *Binder) bindCaseBlock(node *ast.Node) {
 	switchStatement := node.Parent
 	clauses := node.AsCaseBlock().Clauses.Nodes
 	isNarrowingSwitch := switchStatement.Expression().Kind == ast.KindTrueKeyword || isNarrowingExpression(switchStatement.Expression())
-	var fallthroughFlow *ast.FlowNode = &b.unreachableFlow
+	var fallthroughFlow *ast.FlowNode = b.unreachableFlow
 	for i := 0; i < len(clauses); i++ {
 		clauseStart := i
 		for len(clauses[i].AsCaseOrDefaultClause().Statements.Nodes) == 0 && i+1 < len(clauses) {
-			if fallthroughFlow == &b.unreachableFlow {
+			if fallthroughFlow == b.unreachableFlow {
 				b.currentFlow = b.preSwitchCaseFlow
 			}
 			b.bind(clauses[i])
@@ -2395,7 +2395,7 @@ func (b *Binder) bindInitializer(node *ast.Node) {
 	}
 	entryFlow := b.currentFlow
 	b.bind(node)
-	if entryFlow == &b.unreachableFlow || entryFlow == b.currentFlow {
+	if entryFlow == b.unreachableFlow || entryFlow == b.currentFlow {
 		return
 	}
 	exitFlow := b.createBranchLabel()


### PR DESCRIPTION
This is a very good binder win.

```
goos: linux
goarch: amd64
pkg: github.com/microsoft/typescript-go/internal/binder
cpu: Intel(R) Core(TM) i9-10900K CPU @ 3.70GHz
                                                     │   old.txt    │               new.txt                │
                                                     │    sec/op    │    sec/op     vs base                │
Bind/empty.ts-20                                       417.6n ± 25%   280.0n ± 21%  -32.94% (p=0.000 n=10)
Bind/checker.ts-20                                     18.46m ±  4%   17.22m ±  1%   -6.74% (p=0.000 n=10)
Bind/dom.generated.d.ts-20                             7.713m ±  3%   7.440m ±  2%   -3.54% (p=0.002 n=10)
Bind/Herebyfile.mjs-20                                 307.5µ ±  2%   302.0µ ±  4%        ~ (p=0.353 n=10)
Bind/jsxComplexSignatureHasApplicabilityError.tsx-20   156.6µ ±  4%   153.1µ ±  3%   -2.24% (p=0.043 n=10)
geomean                                                310.0µ         277.9µ        -10.35%
```
```
                                                     │   old.txt    │               new.txt                │
                                                     │     B/op     │     B/op      vs base                │
Bind/empty.ts-20                                         432.0 ± 0%     192.0 ± 0%  -55.56% (p=0.000 n=10)
Bind/checker.ts-20                                     7.206Mi ± 0%   7.206Mi ± 0%   -0.00% (p=0.000 n=10)
Bind/dom.generated.d.ts-20                             4.873Mi ± 0%   4.873Mi ± 0%   -0.01% (p=0.000 n=10)
Bind/Herebyfile.mjs-20                                 174.2Ki ± 0%   173.8Ki ± 0%   -0.21% (p=0.000 n=10)
Bind/jsxComplexSignatureHasApplicabilityError.tsx-20   114.8Ki ± 0%   114.4Ki ± 0%   -0.31% (p=0.000 n=10)
geomean                                                198.8Ki        168.9Ki       -15.06%
```
```
                                                     │   old.txt   │               new.txt               │
                                                     │  allocs/op  │  allocs/op   vs base                │
Bind/empty.ts-20                                        3.000 ± 0%    2.000 ± 0%  -33.33% (p=0.000 n=10)
Bind/checker.ts-20                                     13.69k ± 0%   13.69k ± 0%   -0.01% (p=0.000 n=10)
Bind/dom.generated.d.ts-20                             14.68k ± 0%   14.68k ± 0%   -0.01% (p=0.000 n=10)
Bind/Herebyfile.mjs-20                                  344.0 ± 0%    342.0 ± 0%   -0.58% (p=0.000 n=10)
Bind/jsxComplexSignatureHasApplicabilityError.tsx-20    280.0 ± 0%    278.0 ± 0%   -0.71% (p=0.000 n=10)
geomean                                                 565.9         520.5        -8.03%
```