### PR TITLE
Use iterator for line starts during emit

### DIFF
--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -314,33 +314,42 @@ func Coalesce[T *U, U any](a T, b T) T {
 
 func ComputeLineStarts(text string) []TextPos {
 	result := make([]TextPos, 0, strings.Count(text, "\n")+1)
-	pos := 0
-	lineStart := 0
-	for pos < len(text) {
-		b := text[pos]
-		if b < 0x7F {
-			pos++
-			switch b {
-			case '\r':
-				if pos < len(text) && text[pos] == '\n' {
-					pos++
+	return slices.AppendSeq(result, ComputeLineStartsSeq(text))
+}
+
+func ComputeLineStartsSeq(text string) iter.Seq[TextPos] {
+	return func(yield func(TextPos) bool) {
+		pos := 0
+		lineStart := 0
+		for pos < len(text) {
+			b := text[pos]
+			if b < 0x7F {
+				pos++
+				switch b {
+				case '\r':
+					if pos < len(text) && text[pos] == '\n' {
+						pos++
+					}
+					fallthrough
+				case '\n':
+					if !yield(TextPos(lineStart)) {
+						return
+					}
+					lineStart = pos
 				}
-				fallthrough
-			case '\n':
-				result = append(result, TextPos(lineStart))
-				lineStart = pos
-			}
-		} else {
-			ch, size := utf8.DecodeRuneInString(text[pos:])
-			pos += size
-			if stringutil.IsLineBreak(ch) {
-				result = append(result, TextPos(lineStart))
-				lineStart = pos
+			} else {
+				ch, size := utf8.DecodeRuneInString(text[pos:])
+				pos += size
+				if stringutil.IsLineBreak(ch) {
+					if !yield(TextPos(lineStart)) {
+						return
+					}
+					lineStart = pos
+				}
 			}
 		}
+		yield(TextPos(lineStart))
 	}
-	result = append(result, TextPos(lineStart))
-	return result
 }
 
 func PositionToLineAndCharacter(position int, lineStarts []TextPos) (line int, character int) {

--- a/internal/printer/textwriter.go
+++ b/internal/printer/textwriter.go
@@ -86,11 +86,18 @@ func (w *textWriter) RawWrite(s string) {
 }
 
 func (w *textWriter) updateLineCountAndPosFor(s string) {
-	lineStartsOfS := core.ComputeLineStarts(s)
-	if len(lineStartsOfS) > 1 {
-		w.lineCount += len(lineStartsOfS) - 1
+	var count int
+	var lastLineStart core.TextPos
+
+	for lineStart := range core.ComputeLineStartsSeq(s) {
+		count++
+		lastLineStart = lineStart
+	}
+
+	if count > 1 {
+		w.lineCount += count - 1
 		curLen := w.builder.Len()
-		w.linePos = curLen - len(s) + int(lineStartsOfS[len(lineStartsOfS)-1])
+		w.linePos = curLen - len(s) + int(lastLineStart)
 		w.lineStart = (w.linePos - curLen) == 0
 		return
 	}


### PR DESCRIPTION
The `ComputeLineStarts` calls in the emitter are the source of 50% of its allocations; but it only ever cares about how many lines were scanned and the position of the last one. If we switch the implementation to an iterator, we don't need to allocate an array for every element.

Running `tsgo` on vscode, this reduces the overall allocations from 39063016 to 29706541, which is 24% of all allocations.

Best viewed without whitespace: https://github.com/microsoft/typescript-go/pull/407/files?w=1