### PR TITLE
Remove code for JSDocFunctionType

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -1491,7 +1491,7 @@ type (
 	LeftHandSideExpression      = Node // subset of Expression
 	JSDocComment                = Node // JSDocText | JSDocLink | JSDocLinkCode | JSDocLinkPlain;
 	JSDocTag                    = Node // Node with JSDocTagBase
-	SignatureDeclaration        = Node // CallSignatureDeclaration | ConstructSignatureDeclaration | MethodSignature | IndexSignatureDeclaration | FunctionTypeNode | ConstructorTypeNode | JSDocFunctionType | FunctionDeclaration | MethodDeclaration | ConstructorDeclaration | AccessorDeclaration | FunctionExpression | ArrowFunction;
+	SignatureDeclaration        = Node // CallSignatureDeclaration | ConstructSignatureDeclaration | MethodSignature | IndexSignatureDeclaration | FunctionTypeNode | ConstructorTypeNode | FunctionDeclaration | MethodDeclaration | ConstructorDeclaration | AccessorDeclaration | FunctionExpression | ArrowFunction;
 )
 
 // Aliases for node singletons

--- a/internal/binder/binder.go
+++ b/internal/binder/binder.go
@@ -659,7 +659,6 @@ func (b *Binder) bind(node *ast.Node) bool {
 	case ast.KindSetAccessor:
 		b.bindPropertyOrMethodOrAccessor(node, ast.SymbolFlagsSetAccessor, ast.SymbolFlagsSetAccessorExcludes)
 	case ast.KindFunctionType, ast.KindConstructorType:
-		// !!! KindJSDocFunctionType
 		// !!! KindJSDocSignature
 		b.bindFunctionOrConstructorType(node)
 	case ast.KindTypeLiteral, ast.KindMappedType:

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -1187,11 +1187,6 @@ func (p *Printer) emitTypeParameterNode(node *ast.TypeParameterDeclarationNode) 
 }
 
 func (p *Printer) emitParameterName(node *ast.BindingName) {
-	// A JSDocFunctionType may have a parameter with a Name that is nil
-	if node == nil {
-		return
-	}
-
 	savedWriteKind := p.writeKind
 	p.writeKind = WriteKindParameter
 	p.emitBindingName(node)


### PR DESCRIPTION
It's not supported in Corsa so doesn't need to be handled in the printer. Also removed future-looking comments in the binder and ast which reference it.