### PR TITLE
Modify setup-go cache key to work better with merge queues

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -28,7 +28,6 @@ runs:
         key: ts-setup-go-${{ runner.os }}-${{ steps.install-go.outputs.go-version }}-${{ hashFiles('**/go.sum', '**/Herebyfile.mjs', '**/.custom-gcl.yml') }}-${{ github.workflow }}-${{ inputs.cache-name }}
         restore-keys: |
           ts-setup-go-${{ runner.os }}-${{ steps.install-go.outputs.go-version }}-${{ hashFiles('**/go.sum', '**/Herebyfile.mjs', '**/.custom-gcl.yml') }}
-          ts-setup-go-${{ runner.os }}-${{ steps.install-go.outputs.go-version }}
         path: |
           ~/go/pkg/mod
           ~/.cache/go-build


### PR DESCRIPTION
Merge queues work by creating a new branch on the repo to run CI on. Unfortunately, the caches are not shared between branches, so CI is always slower there than needed.

But, GHA _can_ restore caches that come from `main`; this normally works, but the cache key I set up for our `setup-go` action was scoped per workflow, so we'd never grab it from say, the main CI build.

Reconfigure this to try and restore caches a bit more.