### PR TITLE
Error in tsgo on positional args

### DIFF
--- a/cmd/tsgo/main.go
+++ b/cmd/tsgo/main.go
@@ -113,7 +113,7 @@ func parseArgs() *cliOptions {
 	flag.Parse()
 
 	if len(flag.Args()) > 0 {
-		fmt.Fprintf(os.Stderr, "Unknown positional arguments %v; try tsgo tsc <args>\n", flag.Args())
+		fmt.Fprintf(os.Stderr, "Unknown positional arguments %v. Current compiler is not identical to tsc but can be partially emulated by running:\n\ntsgo tsc <args>\n", flag.Args())
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Our CLI doesn't do anything with positional args; only the subcommands do.

Eventually, this current debugging CLI will go away and we'll make `tsc` the entrypoint, but for now, error on extra args so people who try out the CLI aren't confused.