### PR TITLE
Print warning in tsgo on currently unsupported file types

### DIFF
--- a/cmd/tsgo/main.go
+++ b/cmd/tsgo/main.go
@@ -232,7 +232,7 @@ func main() {
 	var unsupportedExtensions []string
 	for _, file := range program.SourceFiles() {
 		extension := tspath.TryGetExtensionFromPath(file.FileName())
-		if extension == ".tsx" || slices.Contains(tspath.SupportedJSExtensionsFlat, extension) {
+		if extension == tspath.ExtensionTsx || slices.Contains(tspath.SupportedJSExtensionsFlat, extension) {
 			unsupportedExtensions = core.AppendIfUnique(unsupportedExtensions, extension)
 		}
 	}


### PR DESCRIPTION
This is a temporary measure pre-launch; printing this message should help people realize that their react projects may only be compiling "super fast" because we're not actually checking any of the JSX.