### PR TITLE
Avoid smartening error spans on calls.

### DIFF
--- a/internal/binder/binder.go
+++ b/internal/binder/binder.go
@@ -2802,16 +2802,6 @@ func GetErrorRangeForNode(sourceFile *ast.SourceFile, node *ast.Node) core.TextR
 		ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindTypeAliasDeclaration, ast.KindPropertyDeclaration,
 		ast.KindPropertySignature, ast.KindNamespaceImport:
 		errorNode = ast.GetNameOfDeclaration(node)
-	case ast.KindCallExpression, ast.KindNewExpression:
-		errorNode = node.Expression()
-		if ast.IsPropertyAccessExpression(errorNode) {
-			errorNode = errorNode.Name()
-		}
-	case ast.KindTaggedTemplateExpression:
-		errorNode = node.AsTaggedTemplateExpression().Tag
-		if ast.IsPropertyAccessExpression(errorNode) {
-			errorNode = errorNode.Name()
-		}
 	case ast.KindArrowFunction:
 		return getErrorRangeForArrowFunction(sourceFile, node)
 	case ast.KindCaseClause, ast.KindDefaultClause:


### PR DESCRIPTION
Found in #425. This should help align with test cases like `interfaceMayNotBeExtendedWitACall` (where I would argue the older behavior made more sense).