### PR TITLE
Fix emit for reference to exported enum

### DIFF
--- a/internal/binder/referenceresolver.go
+++ b/internal/binder/referenceresolver.go
@@ -153,7 +153,7 @@ func (r *referenceResolver) GetReferencedExportContainer(node *ast.IdentifierNod
 			// we prefix depends on the kind of entity. SymbolFlags.ExportHasLocal encompasses all the
 			// kinds that we do NOT prefix.
 			exportSymbol := r.getMergedSymbol(symbol.ExportSymbol)
-			if !prefixLocals && exportSymbol.Flags&(ast.SymbolFlagsExportHasLocal|ast.SymbolFlagsVariable) == 0 {
+			if !prefixLocals && exportSymbol.Flags&ast.SymbolFlagsExportHasLocal != 0 && exportSymbol.Flags&ast.SymbolFlagsVariable == 0 {
 				return nil
 			}
 			symbol = exportSymbol

--- a/internal/transformers/commonjsmodule.go
+++ b/internal/transformers/commonjsmodule.go
@@ -1897,7 +1897,7 @@ func (tx *CommonJSModuleTransformer) visitIdentifier(node *ast.IdentifierNode) *
 
 // Visits an identifier in an expression position that might reference an imported or exported symbol.
 func (tx *CommonJSModuleTransformer) visitExpressionIdentifier(node *ast.IdentifierNode) *ast.Node {
-	if info := tx.emitContext.GetAutoGenerateInfo(node); !(info != nil && info.Flags.HasAllowNameSubstitution()) &&
+	if info := tx.emitContext.GetAutoGenerateInfo(node); !(info != nil && !info.Flags.HasAllowNameSubstitution()) &&
 		!isHelperName(tx.emitContext, node) &&
 		!isLocalName(tx.emitContext, node) &&
 		!isDeclarationNameOfEnumOrNamespace(tx.emitContext, node) {

--- a/internal/transformers/commonjsmodule_test.go
+++ b/internal/transformers/commonjsmodule_test.go
@@ -936,6 +936,19 @@ exports.a = void 0;
 exports.a = 0;
 exports.a;`,
 		},
+		{
+			title: "Identifier#3 (from enum)",
+			input: `export enum E { A }
+E.A`,
+			output: `"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.E = void 0;
+var E;
+(function (E) {
+    E[E["A"] = 0] = "A";
+})(E || (exports.E = E = {}));
+E.A;`,
+		},
 
 		{
 			title: "Other",


### PR DESCRIPTION
This fixes a minor emit issue for local references to the name of an exported `enum`. Due to a typo in `GetReferencedExportContainer`, we were emitting `exports.` in front of local references to an exported enum. While this isn't a runtime error, it does unintentionally differ from Strada emit.

This also fixes a small issue noticed while debugging where generated identifiers were unintentionally passing through the initial condition in `visitExpressionIdentifier`, resulting in following a more expensive code path for generated identifiers.