### PR TITLE
Replace some b.N with b.Loop

### DIFF
--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -86,9 +86,8 @@ func BenchmarkNewChecker(b *testing.B) {
 	p := compiler.NewProgram(opts)
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for range b.N {
+	for b.Loop() {
 		checker.NewChecker(p)
 	}
 }

--- a/internal/tspath/path_test.go
+++ b/internal/tspath/path_test.go
@@ -464,7 +464,7 @@ func BenchmarkGetNormalizedAbsolutePath(b *testing.B) {
 				b.Run(fnName, func(b *testing.B) {
 					b.ReportAllocs()
 					for _, test := range tests {
-						for range b.N {
+						for b.Loop() {
 							fn(test[0], test[1])
 						}
 					}


### PR DESCRIPTION
`b.Loop()` replaces `b.N` and `b.ResetTimer`. These were missed in my Go 1.24 PR.