### PR TITLE
Do not elide `?.` when updating call expression in cjs transform

### DIFF
--- a/internal/transformers/commonjsmodule.go
+++ b/internal/transformers/commonjsmodule.go
@@ -1664,7 +1664,7 @@ func (tx *CommonJSModuleTransformer) visitCallExpression(node *ast.CallExpressio
 		updated := tx.factory.UpdateCallExpression(
 			node,
 			expression,
-			nil, /*questionDotToken*/
+			node.QuestionDotToken,
 			nil, /*typeArguments*/
 			tx.visitor.VisitNodes(node.Arguments),
 		)

--- a/internal/transformers/commonjsmodule_test.go
+++ b/internal/transformers/commonjsmodule_test.go
@@ -894,6 +894,14 @@ const tslib_1 = require("tslib");
 Promise.resolve(` + "`" + `${tslib_1.__rewriteRelativeImportExtension(x)}` + "`" + `).then(s => require(s));`,
 			options: core.CompilerOptions{RewriteRelativeImportExtensions: core.TSTrue, ImportHelpers: core.TSTrue},
 		},
+		{
+			title: "CallExpression#7",
+			input: `export {};
+a?.()`,
+			output: `"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+a?.();`,
+		},
 
 		// TaggedTemplateExpression
 		{


### PR DESCRIPTION
Fixes a typo in `visitCallExpression` in the CommonJS module transform.