### PR TITLE
Preserve Loc when emitting module prefix

### DIFF
--- a/internal/transformers/commonjsmodule.go
+++ b/internal/transformers/commonjsmodule.go
@@ -1910,6 +1910,7 @@ func (tx *CommonJSModuleTransformer) visitExpressionIdentifier(node *ast.Identif
 				ast.NodeFlagsNone,
 			)
 			tx.emitContext.AssignCommentAndSourceMapRanges(reference, node)
+			reference.Loc = node.Loc
 			return reference
 		}
 
@@ -1923,6 +1924,7 @@ func (tx *CommonJSModuleTransformer) visitExpressionIdentifier(node *ast.Identif
 					ast.NodeFlagsNone,
 				)
 				tx.emitContext.AssignCommentAndSourceMapRanges(reference, node)
+				reference.Loc = node.Loc
 				return reference
 			}
 			if ast.IsImportSpecifier(importDeclaration) {
@@ -1946,6 +1948,7 @@ func (tx *CommonJSModuleTransformer) visitExpressionIdentifier(node *ast.Identif
 					)
 				}
 				tx.emitContext.AssignCommentAndSourceMapRanges(reference, node)
+				reference.Loc = node.Loc
 				return reference
 			}
 		}

--- a/internal/transformers/commonjsmodule_test.go
+++ b/internal/transformers/commonjsmodule_test.go
@@ -947,6 +947,17 @@ var E;
 })(E || (exports.E = E = {}));
 E.A;`,
 		},
+		{
+			title: "Identifier#4 (preserve location)",
+			input: `import { a } from "other";
+x ||
+  a`,
+			output: `"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const other_1 = require("other");
+x ||
+    other_1.a;`,
+		},
 
 		{
 			title: "Other",


### PR DESCRIPTION
This copies the `.Loc` information from a module reference to the qualified property access (i.e., `exports.x`, `module_1.x`, etc.) so that we properly preserve line terminators during emit.