### PR TITLE
Fix name generation for nodes

### DIFF
--- a/internal/transformers/commonjsmodule_test.go
+++ b/internal/transformers/commonjsmodule_test.go
@@ -958,6 +958,16 @@ const other_1 = require("other");
 x ||
     other_1.a;`,
 		},
+		{
+			title: "Identifier#5 (from import specifier)",
+			input: `import { and } from "./_namespaces/ts.js";
+const isNotOverloadAndNotAccessor = and(isNotOverload, isNotAccessor);
+`,
+			output: `"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const ts_js_1 = require("./_namespaces/ts.js");
+const isNotOverloadAndNotAccessor = (0, ts_js_1.and)(isNotOverload, isNotAccessor);`,
+		},
 
 		{
 			title: "Other",


### PR DESCRIPTION
This fixes an issue with name generation for nodes when the node in question may go through successive transformations. This now more closely matches Strada which utilized `original` pointers to resolve the underlying node and ensures repeated calls to `NewGeneratedNameForNode` against updated versions of the same node will produce the same generated name.