### PR TITLE
Limit trailing comma preservation

### DIFF
--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -1294,7 +1294,7 @@ func (p *Printer) emitTypeParameters(parentNode *ast.Node, nodes *ast.TypeParame
 		return
 	}
 
-	p.emitList((*Printer).emitTypeParameterNode, parentNode, nodes, LFTypeParameters|core.IfElse(p.shouldAllowTrailingComma(parentNode, nodes), LFAllowTrailingComma, LFNone))
+	p.emitList((*Printer).emitTypeParameterNode, parentNode, nodes, LFTypeParameters|core.IfElse(ast.IsArrowFunction(parentNode) /*p.shouldAllowTrailingComma(parentNode, nodes)*/, LFAllowTrailingComma, LFNone)) // TODO: preserve trailing comma after Strada migration
 }
 
 func (p *Printer) emitTypeAnnotation(node *ast.TypeNode) {
@@ -1320,7 +1320,7 @@ func (p *Printer) emitInitializer(node *ast.Expression, equalTokenPos int, conte
 
 func (p *Printer) emitParameters(parentNode *ast.Node, parameters *ast.ParameterList) {
 	p.generateAllNames(parameters)
-	p.emitList((*Printer).emitParameterNode, parentNode, parameters, LFParameters|core.IfElse(p.shouldAllowTrailingComma(parentNode, parameters), LFAllowTrailingComma, LFNone))
+	p.emitList((*Printer).emitParameterNode, parentNode, parameters, LFParameters /*|core.IfElse(p.shouldAllowTrailingComma(parentNode, parameters), LFAllowTrailingComma, LFNone)*/) // TODO: preserve trailing comma after Strada migration
 }
 
 func canEmitSimpleArrowHead(parentNode *ast.Node, parameters *ast.ParameterList) bool {
@@ -1656,7 +1656,7 @@ func (p *Printer) emitTypeArguments(parentNode *ast.Node, nodes *ast.TypeArgumen
 	if nodes == nil {
 		return
 	}
-	p.emitList((*Printer).emitTypeArgument, parentNode, nodes, LFTypeArguments|core.IfElse(p.shouldAllowTrailingComma(parentNode, nodes), LFAllowTrailingComma, LFNone) /*, typeArgumentParenthesizerRuleSelector */)
+	p.emitList((*Printer).emitTypeArgument, parentNode, nodes, LFTypeArguments /*|core.IfElse(p.shouldAllowTrailingComma(parentNode, nodes), LFAllowTrailingComma, LFNone)*/) // TODO: preserve trailing comma after Strada migration
 }
 
 func (p *Printer) emitTypeReference(node *ast.TypeReferenceNode) {

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -58,7 +58,7 @@ func TestEmit(t *testing.T) {
 		{title: "CallExpression#9", input: `a?.(b).c`, output: `a?.(b).c;`},
 		{title: "CallExpression#10", input: `a?.<T>(b).c`, output: `a?.<T>(b).c;`},
 		{title: "CallExpression#11", input: `a<T, U>()`, output: `a<T, U>();`},
-		{title: "CallExpression#12", input: `a<T,>()`, output: `a<T,>();`},
+		// {title: "CallExpression#12", input: `a<T,>()`, output: `a<T,>();`}, // TODO: preserve trailing comma after Strada migration
 		{title: "CallExpression#13", input: `a?.b()`, output: `a?.b();`},
 		{title: "NewExpression#1", input: `new a`, output: `new a;`},
 		{title: "NewExpression#2", input: `new a.b`, output: `new a.b;`},
@@ -507,7 +507,7 @@ func TestEmit(t *testing.T) {
 		{title: "ParameterDeclaration#4", input: "function f(a?)", output: "function f(a?);"},
 		{title: "ParameterDeclaration#5", input: "function f(...a)", output: "function f(...a);"},
 		{title: "ParameterDeclaration#6", input: "function f(this)", output: "function f(this);"},
-		{title: "ParameterDeclaration#7", input: "function f(a,)", output: "function f(a,);"},
+		// {title: "ParameterDeclaration#7", input: "function f(a,)", output: "function f(a,);"}, // TODO: preserve trailing comma after Strada migration
 		{title: "ObjectBindingPattern#1", input: "function f({})", output: "function f({});"},
 		{title: "ObjectBindingPattern#2", input: "function f({a})", output: "function f({ a });"},
 		{title: "ObjectBindingPattern#3", input: "function f({a = b})", output: "function f({ a = b });"},
@@ -535,7 +535,7 @@ func TestEmit(t *testing.T) {
 		{title: "TypeParameterDeclaration#4", input: "function f<T = U>();", output: "function f<T = U>();"},
 		{title: "TypeParameterDeclaration#5", input: "function f<T extends U = V>();", output: "function f<T extends U = V>();"},
 		{title: "TypeParameterDeclaration#6", input: "function f<T, U>();", output: "function f<T, U>();"},
-		{title: "TypeParameterDeclaration#7", input: "function f<T,>();", output: "function f<T,>();"},
+		// {title: "TypeParameterDeclaration#7", input: "function f<T,>();", output: "function f<T,>();"}, // TODO: preserve trailing comma after Strada migration
 		{title: "JsxElement1", input: "<a></a>", output: "<a></a>;", jsx: true},
 		{title: "JsxElement2", input: "<this></this>", output: "<this></this>;", jsx: true},
 		{title: "JsxElement3", input: "<a:b></a:b>", output: "<a:b></a:b>;", jsx: true},


### PR DESCRIPTION
The new printer in Corsa does a better job at preserving trailing commas in some places than the emitter in Strada, which will result in spurious diffs while testing the new compiler. This temporarily disables the improved support to make testing easier.