### PR TITLE
Fix misspell lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,6 +30,7 @@ linters:
     - intrange
     - makezero
     - mirror
+    - misspell
     - musttag
     - nolintlint
     - paralleltest
@@ -63,6 +64,13 @@ linters-settings:
   custom:
     customlint:
       type: module
+
+  misspell:
+    locale: US
+    ignore-words:
+      - behaviour
+      - cancelled
+      - misspelt
 
 #   revive:
 #     enable-all-rules: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,13 +65,6 @@ linters-settings:
     customlint:
       type: module
 
-  misspell:
-    locale: US
-    ignore-words:
-      - behaviour
-      - cancelled
-      - misspelt
-
 #   revive:
 #     enable-all-rules: true
 #     rules:

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -17983,7 +17983,7 @@ func (c *Checker) getSignaturesOfSymbol(symbol *ast.Symbol) []*Signature {
 			}
 		}
 		// If this is a function or method declaration, get the signature from the @type tag for the sake of optional parameters.
-		// Exclude contextually-typed kinds because we already apply the @type tag to the context, plus applying it here to the initializer would supress checks that the two are compatible.
+		// Exclude contextually-typed kinds because we already apply the @type tag to the context, plus applying it here to the initializer would suppress checks that the two are compatible.
 		result = append(result, c.getSignatureFromDeclaration(decl))
 	}
 	return result
@@ -20228,7 +20228,7 @@ func (c *Checker) instantiateTypeWithAlias(t *Type, m *TypeMapper, alias *TypeAl
 	}
 	if c.instantiationDepth == 100 || c.instantiationCount >= 5_000_000 {
 		// We have reached 100 recursive type instantiations, or 5M type instantiations caused by the same statement
-		// or expression. There is a very high likelyhood we're dealing with a combination of infinite generic types
+		// or expression. There is a very high likelihood we're dealing with a combination of infinite generic types
 		// that perpetually generate new type identities, so we stop the recursion here by yielding the error type.
 		c.error(c.currentNode, diagnostics.Type_instantiation_is_excessively_deep_and_possibly_infinite)
 		return c.errorType

--- a/internal/checker/emitresolver.go
+++ b/internal/checker/emitresolver.go
@@ -97,7 +97,7 @@ func (r *emitResolver) isAliasResolvedToValue(symbol *ast.Symbol, excludeTypeOnl
 		if container := ast.GetSourceFileOfNode(symbol.ValueDeclaration); container != nil {
 			fileSymbol := c.getSymbolOfDeclaration(container.AsNode())
 			// Ensures cjs export assignment is setup, since this symbol may point at, and merge with, the file itself.
-			// If we don't, the merge may not have yet occured, and the flags check below will be missing flags that
+			// If we don't, the merge may not have yet occurred, and the flags check below will be missing flags that
 			// are added as a result of the merge.
 			c.resolveExternalModuleSymbol(fileSymbol, false /*dontResolveAlias*/)
 		}

--- a/internal/checker/relater.go
+++ b/internal/checker/relater.go
@@ -3753,7 +3753,7 @@ func (r *Relater) structuredTypeRelatedToWorker(source *Type, target *Type, repo
 			// type references (which are intended by be compared structurally). Obtain the variance
 			// information for the type parameters and relate the type arguments accordingly.
 			variances := r.c.getVariances(source.Target())
-			// We return Ternary.Maybe for a recursive invocation of getVariances (signalled by emptyArray). This
+			// We return Ternary.Maybe for a recursive invocation of getVariances (signaled by emptyArray). This
 			// effectively means we measure variance only from type parameter occurrences that aren't nested in
 			// recursive instantiations of the generic type.
 			if len(variances) == 0 {

--- a/internal/testutil/jstest/node.go
+++ b/internal/testutil/jstest/node.go
@@ -25,7 +25,7 @@ var getNodeExeOnce = sync.OnceValue(func() string {
 	return exe
 })
 
-// EvalNodeScript imports a Node.js script that deafult-exports a single function,
+// EvalNodeScript imports a Node.js script that default-exports a single function,
 // calls it with the provided arguments, and unmarshals the JSON-stringified
 // awaited return value into T.
 func EvalNodeScript[T any](t testing.TB, script string, dir string, args ...string) (result T, err error) {

--- a/internal/transformers/esmodule.go
+++ b/internal/transformers/esmodule.go
@@ -196,7 +196,7 @@ func (tx *ESModuleTransformer) visitExportDeclaration(node *ast.ExportDeclaratio
 
 	updatedModuleSpecifier := rewriteModuleSpecifier(tx.emitContext, node.ModuleSpecifier, tx.compilerOptions)
 	if tx.compilerOptions.ModuleKind > core.ModuleKindES2015 || node.ExportClause == nil || !ast.IsNamespaceExport(node.ExportClause) {
-		// Either ill-formed or don't need to be tranformed.
+		// Either ill-formed or don't need to be transformed.
 		return tx.factory.UpdateExportDeclaration(
 			node,
 			nil,   /*modifiers*/


### PR DESCRIPTION
The PR enables `misspell` linter and fixes up spelling issues.