### PR TITLE
fix: remove double runtime.GC call

### DIFF
--- a/cmd/tsgo/main.go
+++ b/cmd/tsgo/main.go
@@ -227,7 +227,6 @@ func main() {
 
 	var memStats runtime.MemStats
 	runtime.GC()
-	runtime.GC()
 	runtime.ReadMemStats(&memStats)
 
 	if !opts.devel.quiet && len(diagnostics) != 0 {


### PR DESCRIPTION
I realized reading the code that in `cmd/tsgo/main.go` on line 230, that the function `runtime.GC()` is called twice, this commit will remove that redundancy

if it's intended to be called twice, would be glad with the reasoning for it to be done