### PR TITLE
Fix copy/paste error

### DIFF
--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -4294,7 +4294,7 @@ func (p *Printer) hasTrailingComma(parentNode *ast.Node, children *ast.NodeList)
 	case ast.KindNamedImports:
 		originalList = originalParent.AsNamedImports().Elements
 	case ast.KindNamedExports:
-		originalList = originalParent.AsNamedImports().Elements
+		originalList = originalParent.AsNamedExports().Elements
 	case ast.KindImportAttributes:
 		originalList = originalParent.AsImportAttributes().Attributes
 	}


### PR DESCRIPTION
In `printer.go` the switch statement handling each AST node type seems to have had a copy/paste error where handling `KindNamedExports` is being handled as `AsNamedImports`