### PR TITLE
Add PartiallyEmittedExpression to preserve newlines after type erasure

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -302,6 +302,8 @@ func (n *Node) Expression() *Node {
 		return n.AsAwaitExpression().Expression
 	case KindYieldExpression:
 		return n.AsYieldExpression().Expression
+	case KindPartiallyEmittedExpression:
+		return n.AsPartiallyEmittedExpression().Expression
 	case KindIfStatement:
 		return n.AsIfStatement().Expression
 	case KindDoStatement:
@@ -1190,6 +1192,10 @@ func (n *Node) AsTemplateExpression() *TemplateExpression {
 
 func (n *Node) AsYieldExpression() *YieldExpression {
 	return n.data.(*YieldExpression)
+}
+
+func (n *Node) AsPartiallyEmittedExpression() *PartiallyEmittedExpression {
+	return n.data.(*PartiallyEmittedExpression)
 }
 
 func (n *Node) AsSpreadElement() *SpreadElement {
@@ -6949,6 +6955,42 @@ func (node *SyntheticExpression) Clone(f *NodeFactory) *Node {
 
 func IsSyntheticExpression(node *Node) bool {
 	return node.Kind == KindSyntheticExpression
+}
+
+// PartiallyEmittedExpression
+
+type PartiallyEmittedExpression struct {
+	ExpressionBase
+	Expression *Expression // Expression
+}
+
+func (f *NodeFactory) NewPartiallyEmittedExpression(expression *Expression) *Node {
+	data := &PartiallyEmittedExpression{}
+	data.Expression = expression
+	return newNode(KindPartiallyEmittedExpression, data, f.hooks)
+}
+
+func (f *NodeFactory) UpdatePartiallyEmittedExpression(node *PartiallyEmittedExpression, expression *Expression) *Node {
+	if expression != node.Expression {
+		return updateNode(f.NewPartiallyEmittedExpression(expression), node.AsNode(), f.hooks)
+	}
+	return node.AsNode()
+}
+
+func (node *PartiallyEmittedExpression) ForEachChild(v Visitor) bool {
+	return visit(v, node.Expression)
+}
+
+func (node *PartiallyEmittedExpression) VisitEachChild(v *NodeVisitor) *Node {
+	return v.Factory.UpdatePartiallyEmittedExpression(node, v.visitNode(node.Expression))
+}
+
+func (node *PartiallyEmittedExpression) Clone(f *NodeFactory) *Node {
+	return cloneNode(f.NewPartiallyEmittedExpression(node.Expression), node.AsNode(), f.hooks)
+}
+
+func IsPartiallyEmittedExpression(node *Node) bool {
+	return node.Kind == KindPartiallyEmittedExpression
 }
 
 /// A JSX expression of the form <TagName attrs>...</TagName>

--- a/internal/ast/utilities.go
+++ b/internal/ast/utilities.go
@@ -790,6 +790,8 @@ func IsOuterExpression(node *Expression, kinds OuterExpressionKinds) bool {
 		return kinds&OEKExpressionsWithTypeArguments != 0
 	case KindNonNullExpression:
 		return kinds&OEKNonNullAssertions != 0
+	case KindPartiallyEmittedExpression:
+		return kinds&OEKPartiallyEmittedExpressions != 0
 	}
 	return false
 }

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -2866,7 +2866,7 @@ func (p *Printer) emitExpression(node *ast.Expression, precedence ast.OperatorPr
 	case ast.KindSyntaxList:
 		panic("SyntaxList should not be printed")
 
-	//Transformation nodes
+	// Transformation nodes
 	case ast.KindNotEmittedStatement:
 		return
 	case ast.KindPartiallyEmittedExpression:

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -2713,6 +2713,27 @@ func (p *Printer) emitMetaProperty(node *ast.MetaProperty) {
 	p.exitNode(node.AsNode())
 }
 
+func (p *Printer) emitPartiallyEmittedExpression(node *ast.PartiallyEmittedExpression, precedence ast.OperatorPrecedence) {
+	// avoid reprinting parens for nested partially emitted expressions
+	var stack core.Stack[*ast.PartiallyEmittedExpression]
+	for {
+		stack.Push(node)
+		p.enterNode(node.AsNode())
+		if !ast.IsPartiallyEmittedExpression(node.Expression) {
+			break
+		}
+		node = node.Expression.AsPartiallyEmittedExpression()
+	}
+
+	p.emitExpression(node.Expression, precedence)
+
+	// unwind stack
+	for stack.Len() > 0 {
+		p.exitNode(node.AsNode())
+		node = stack.Pop()
+	}
+}
+
 func (p *Printer) willEmitLeadingNewLine(node *ast.Expression) bool {
 	return false // !!! check if node will emit a leading comment that contains a trailing newline
 }
@@ -2845,16 +2866,17 @@ func (p *Printer) emitExpression(node *ast.Expression, precedence ast.OperatorPr
 	case ast.KindSyntaxList:
 		panic("SyntaxList should not be printed")
 
-		// !!!
-		//////Transformation nodes
-		////case ast.KindNotEmittedStatement:
-		////	return
-		////case ast.KindPartiallyEmittedExpression:
-		////	p.emitPartiallyEmittedExpression(node.AsPartiallyEmittedExpression())
-		////case ast.KindCommaListExpression:
-		////	p.emitCommaList(node.AsCommaListExpression())
-		////case ast.KindSyntheticReferenceExpression:
-		////	return Debug.fail("SyntheticReferenceExpression should not be printed")
+	//Transformation nodes
+	case ast.KindNotEmittedStatement:
+		return
+	case ast.KindPartiallyEmittedExpression:
+		p.emitPartiallyEmittedExpression(node.AsPartiallyEmittedExpression(), precedence)
+
+	// !!!
+	////case ast.KindCommaListExpression:
+	////	p.emitCommaList(node.AsCommaListExpression())
+	////case ast.KindSyntheticReferenceExpression:
+	////	return Debug.fail("SyntheticReferenceExpression should not be printed")
 
 	default:
 		panic(fmt.Sprintf("unexpected Expression: %v", node.Kind))

--- a/internal/transformers/commonjsmodule.go
+++ b/internal/transformers/commonjsmodule.go
@@ -158,9 +158,8 @@ func (tx *CommonJSModuleTransformer) visitNoStack(node *ast.Node, resultIsDiscar
 		node = tx.visitVoidExpression(node.AsVoidExpression())
 	case ast.KindParenthesizedExpression:
 		node = tx.visitParenthesizedExpression(node.AsParenthesizedExpression(), resultIsDiscarded)
-	// !!! To support comment emit
-	////case ast.KindPartiallyEmittedExpression:
-	////	node = tx.visitPartiallyEmittedExpression(node.AsPartiallyEmittedExpression(), resultIsDiscarded)
+	case ast.KindPartiallyEmittedExpression:
+		node = tx.visitPartiallyEmittedExpression(node.AsPartiallyEmittedExpression(), resultIsDiscarded)
 	case ast.KindCallExpression:
 		node = tx.visitCallExpression(node.AsCallExpression())
 	case ast.KindTaggedTemplateExpression:
@@ -1322,6 +1321,12 @@ func (tx *CommonJSModuleTransformer) visitVoidExpression(node *ast.VoidExpressio
 func (tx *CommonJSModuleTransformer) visitParenthesizedExpression(node *ast.ParenthesizedExpression, resultIsDiscarded bool) *ast.Node {
 	expression := core.IfElse(resultIsDiscarded, tx.discardedValueVisitor, tx.visitor).VisitNode(node.Expression)
 	return tx.factory.UpdateParenthesizedExpression(node, expression)
+}
+
+// Visits a partially emitted expression whose value may be discarded at runtime.
+func (tx *CommonJSModuleTransformer) visitPartiallyEmittedExpression(node *ast.PartiallyEmittedExpression, resultIsDiscarded bool) *ast.Node {
+	expression := core.IfElse(resultIsDiscarded, tx.discardedValueVisitor, tx.visitor).VisitNode(node.Expression)
+	return tx.factory.UpdatePartiallyEmittedExpression(node, expression)
 }
 
 // Visits a binary expression whose value may be discarded, or which might contain an assignment to an exported

--- a/internal/transformers/typeeraser.go
+++ b/internal/transformers/typeeraser.go
@@ -183,28 +183,20 @@ func (tx *TypeEraserTransformer) visit(node *ast.Node) *ast.Node {
 		n := node.AsTaggedTemplateExpression()
 		return tx.factory.UpdateTaggedTemplateExpression(n, tx.visitor.VisitNode(n.Tag), n.QuestionDotToken, nil, tx.visitor.VisitNode(n.Template))
 
-	case ast.KindNonNullExpression:
-		// !!! Use PartiallyEmittedExpression to preserve comments
-		return tx.visitor.VisitNode(node.AsNonNullExpression().Expression)
-
-	case ast.KindTypeAssertionExpression:
-		// !!! Use PartiallyEmittedExpression to preserve comments
-		return tx.visitor.VisitNode(node.AsTypeAssertion().Expression)
-
-	case ast.KindAsExpression:
-		// !!! Use PartiallyEmittedExpression to preserve comments
-		return tx.visitor.VisitNode(node.AsAsExpression().Expression)
-
-	case ast.KindSatisfiesExpression:
-		// !!! Use PartiallyEmittedExpression to preserve comments
-		return tx.visitor.VisitNode(node.AsSatisfiesExpression().Expression)
+	case ast.KindNonNullExpression, ast.KindTypeAssertionExpression, ast.KindAsExpression, ast.KindSatisfiesExpression:
+		partial := tx.factory.NewPartiallyEmittedExpression(tx.visitor.VisitNode(node.Expression()))
+		tx.emitContext.SetOriginal(partial, node)
+		partial.Loc = node.Loc
+		return partial
 
 	case ast.KindParenthesizedExpression:
 		n := node.AsParenthesizedExpression()
 		expression := ast.SkipOuterExpressions(n.Expression, ^(ast.OEKTypeAssertions | ast.OEKExpressionsWithTypeArguments))
 		if ast.IsAssertionExpression(expression) || ast.IsSatisfiesExpression(expression) {
-			// !!! Use PartiallyEmittedExpression to preserve comments
-			return tx.visitor.VisitNode(n.Expression)
+			partial := tx.factory.NewPartiallyEmittedExpression(tx.visitor.VisitNode(n.Expression))
+			tx.emitContext.SetOriginal(partial, node)
+			partial.Loc = node.Loc
+			return partial
 		}
 		return tx.visitor.VisitEachChild(node)
 


### PR DESCRIPTION
This ports `PartiallyEmittedExpression` from Strada to preserve newline emit as a result of type erasure. `PartiallyEmittedExpression` will also eventually be used to preserve source maps and comments, as it does in Strada.