### PR TITLE
fix: correct spelling errors in comments and documentation

### DIFF
--- a/_tools/customlint/testdata/shadow/shadow.go
+++ b/_tools/customlint/testdata/shadow/shadow.go
@@ -268,7 +268,7 @@ func F17(read func() (v any, err error), sendError func(error) error) error {
 		v, err := read()
 		if err != nil {
 			if err == errSome {
-				// OK: use after asignnent above; switching to = below would not be observable.
+				// OK: use after assignment above; switching to = below would not be observable.
 				if err := sendError(err); err != nil {
 					return err
 				}
@@ -287,7 +287,7 @@ func F17b(read func() (v any, err error), sendError func(error) error) error {
 			return err
 		}
 		if v == "bad value" {
-			// OK: use after asignnent above; switching to = below would not be observable.
+			// OK: use after assignment above; switching to = below would not be observable.
 			if err := sendError(err); err != nil {
 				return err
 			}
@@ -302,7 +302,7 @@ func F18(index int) int {
 		}
 
 		if index == 1 {
-			// Dubuious; did this mean to keep the value for another execution?
+			// Dubious; did this mean to keep the value for another execution?
 			index := 2
 			println(index)
 			return index

--- a/internal/ast/precedence.go
+++ b/internal/ast/precedence.go
@@ -58,7 +58,7 @@ const (
 	OperatorPrecedenceLogicalOR
 	// LogicalANDExpression:
 	//     BitwiseORExpression
-	//     LogicalANDExprerssion `&&` BitwiseORExpression
+	//     LogicalANDExpression `&&` BitwiseORExpression
 	OperatorPrecedenceLogicalAND
 	// BitwiseORExpression:
 	//     BitwiseXORExpression

--- a/internal/ast/symbolflags.go
+++ b/internal/ast/symbolflags.go
@@ -59,7 +59,7 @@ const (
 	SymbolFlagsPropertyExcludes                    = SymbolFlagsValue & ^SymbolFlagsProperty
 	SymbolFlagsEnumMemberExcludes                  = SymbolFlagsValue | SymbolFlagsType
 	SymbolFlagsFunctionExcludes                    = SymbolFlagsValue & ^(SymbolFlagsFunction | SymbolFlagsValueModule | SymbolFlagsClass)
-	SymbolFlagsClassExcludes                       = (SymbolFlagsValue | SymbolFlagsType) & ^(SymbolFlagsValueModule | SymbolFlagsInterface | SymbolFlagsFunction) // class-interface mergability done in checker.ts
+	SymbolFlagsClassExcludes                       = (SymbolFlagsValue | SymbolFlagsType) & ^(SymbolFlagsValueModule | SymbolFlagsInterface | SymbolFlagsFunction) // class-interface mergeability done in checker.ts
 	SymbolFlagsInterfaceExcludes                   = SymbolFlagsType & ^(SymbolFlagsInterface | SymbolFlagsClass)
 	SymbolFlagsRegularEnumExcludes                 = (SymbolFlagsValue | SymbolFlagsType) & ^(SymbolFlagsRegularEnum | SymbolFlagsValueModule) // regular enums merge only with regular enums and modules
 	SymbolFlagsConstEnumExcludes                   = (SymbolFlagsValue | SymbolFlagsType) & ^SymbolFlagsConstEnum                              // const enums merge only with const enums

--- a/internal/ast/utilities.go
+++ b/internal/ast/utilities.go
@@ -454,7 +454,7 @@ func IsCommaExpression(node *Node) bool {
 
 func IsCommaSequence(node *Node) bool {
 	// !!!
-	// New compiler just has binary expressinons.
+	// New compiler just has binary expressions.
 	// Maybe this should consider KindCommaListExpression even though we don't generate them.
 	return IsCommaExpression(node)
 }

--- a/internal/checker/emitresolver.go
+++ b/internal/checker/emitresolver.go
@@ -97,7 +97,7 @@ func (r *emitResolver) isAliasResolvedToValue(symbol *ast.Symbol, excludeTypeOnl
 		if container := ast.GetSourceFileOfNode(symbol.ValueDeclaration); container != nil {
 			fileSymbol := c.getSymbolOfDeclaration(container.AsNode())
 			// Ensures cjs export assignment is setup, since this symbol may point at, and merge with, the file itself.
-			// If we don't, the merge may not have yet occured, and the flags check below will be missing flags that
+			// If we don't, the merge may not have yet occurred, and the flags check below will be missing flags that
 			// are added as a result of the merge.
 			c.resolveExternalModuleSymbol(fileSymbol, false /*dontResolveAlias*/)
 		}

--- a/internal/checker/inference.go
+++ b/internal/checker/inference.go
@@ -198,7 +198,7 @@ func (c *Checker) inferFromTypes(n *InferenceState, source *Type, target *Type) 
 		} else if target.flags&TypeFlagsIndexedAccess != 0 {
 			indexType := c.getSimplifiedType(target.AsIndexedAccessType().indexType, false /*writing*/)
 			// Generally simplifications of instantiable indexes are avoided to keep relationship checking correct, however if our target is an access, we can consider
-			// that key of that access to be "instantiated", since we're looking to find the infernce goal in any way we can.
+			// that key of that access to be "instantiated", since we're looking to find the inference goal in any way we can.
 			if indexType.flags&TypeFlagsInstantiable != 0 {
 				simplified := c.distributeIndexOverObjectType(c.getSimplifiedType(target.AsIndexedAccessType().objectType, false /*writing*/), indexType, false /*writing*/)
 				if simplified != nil && simplified != target {
@@ -1039,7 +1039,7 @@ func (c *Checker) resolveReverseMappedTypeMembers(t *Type) {
 		if constraintTarget.flags&TypeFlagsIndexedAccess != 0 && constraintTarget.AsIndexedAccessType().objectType.flags&TypeFlagsTypeParameter != 0 && constraintTarget.AsIndexedAccessType().indexType.flags&TypeFlagsTypeParameter != 0 {
 			// A reverse mapping of `{[K in keyof T[K_1]]: T[K_1]}` is the same as that of `{[K in keyof T]: T}`, since all we care about is
 			// inferring to the "type parameter" (or indexed access) shared by the constraint and template. So, to reduce the number of
-			// type identities produced, we simplify such indexed access occurences
+			// type identities produced, we simplify such indexed access occurrences
 			newTypeParam := constraintTarget.AsIndexedAccessType().objectType
 			newMappedType := c.replaceIndexedAccess(r.mappedType, constraintTarget, newTypeParam)
 			links.mappedType = newMappedType

--- a/internal/checker/relater.go
+++ b/internal/checker/relater.go
@@ -2297,7 +2297,7 @@ func (c *Checker) getEffectiveConstraintOfIntersection(types []*Type, targetIsUn
 }
 
 func (c *Checker) templateLiteralTypesDefinitelyUnrelated(source *TemplateLiteralType, target *TemplateLiteralType) bool {
-	// Two template literal types with diffences in their starting or ending text spans are definitely unrelated.
+	// Two template literal types with differences in their starting or ending text spans are definitely unrelated.
 	sourceStart := source.texts[0]
 	targetStart := target.texts[0]
 	sourceEnd := source.texts[len(source.texts)-1]
@@ -2680,7 +2680,7 @@ func (r *Relater) hasExcessProperties(source *Type, target *Type, reportErrors b
 					}
 					if ast.IsJsxAttributes(r.errorNode) || isJsxOpeningLikeElement(r.errorNode) || isJsxOpeningLikeElement(r.errorNode.Parent) {
 						// !!!
-						// // JsxAttributes has an object-literal flag and undergo same type-assignablity check as normal object-literal.
+						// // JsxAttributes has an object-literal flag and undergo same type-assignability check as normal object-literal.
 						// // However, using an object-literal error message will be very confusing to the users so we give different a message.
 						// if prop.valueDeclaration && isJsxAttribute(prop.valueDeclaration) && ast.GetSourceFileOfNode(errorNode) == ast.GetSourceFileOfNode(prop.valueDeclaration.name) {
 						// 	// Note that extraneous children (as in `<NoChild>extra</NoChild>`) don't pass this check,
@@ -4728,7 +4728,7 @@ func (r *Relater) reportError(message *diagnostics.Message, args ...any) {
 			return
 		}
 		// Transform a property incompatibility message for property 'x' followed by some elaboration message
-		// followed by a signature return type incompatibility message into a single return type incompatiblity
+		// followed by a signature return type incompatibility message into a single return type incompatibility
 		// message for 'x()' or 'x(...)'
 		var arg string
 		switch r.getChainMessage(1) {


### PR DESCRIPTION
Fixes typos in:
_tools/customlint/testdata/shadow/shadow.go
internal/ast/precedence.go
internal/ast/symbolflags.go
internal/ast/utilities.go
internal/checker/emitresolver.go
internal/checker/inference.go
internal/checker/relater.go