### PR TITLE
Enable virtual terminal processing on Windows

### DIFF
--- a/cmd/tsgo/enablevtprocessing_other.go
+++ b/cmd/tsgo/enablevtprocessing_other.go
@@ -1,0 +1,5 @@
+//go:build !windows
+
+package main
+
+func enableVirtualTerminalProcessing() {}

--- a/cmd/tsgo/enablevtprocessing_windows.go
+++ b/cmd/tsgo/enablevtprocessing_windows.go
@@ -1,5 +1,3 @@
-//go:build windows
-
 package main
 
 import (

--- a/cmd/tsgo/enablevtprocessing_windows.go
+++ b/cmd/tsgo/enablevtprocessing_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package main
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+func enableVirtualTerminalProcessing() {
+	hStdout, err := windows.GetStdHandle(windows.STD_OUTPUT_HANDLE)
+	if err == nil && hStdout != windows.InvalidHandle {
+		var mode uint32
+		err = windows.GetConsoleMode(windows.Handle(hStdout), &mode)
+		if err == nil {
+			windows.SetConsoleMode(windows.Handle(hStdout), mode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+		}
+	}
+}

--- a/cmd/tsgo/main.go
+++ b/cmd/tsgo/main.go
@@ -135,7 +135,7 @@ func enableVirtualTerminalProcessing() {
 
 func main() {
 	if runtime.GOOS == "windows" {
-		// TypeScript uses ANSI escape sequences which cmd.exe won't parse without enabling virtual terminal mode.
+		// TypeScript uses ANSI escape sequences which cmd.exe won't parse without enabling virtual terminal processing.
 		enableVirtualTerminalProcessing()
 	}
 

--- a/cmd/tsgo/main.go
+++ b/cmd/tsgo/main.go
@@ -24,8 +24,6 @@ import (
 	"github.com/microsoft/typescript-go/internal/scanner"
 	"github.com/microsoft/typescript-go/internal/tspath"
 	"github.com/microsoft/typescript-go/internal/vfs/osvfs"
-
-	"golang.org/x/sys/windows"
 )
 
 func printDiagnostic(d *ast.Diagnostic, level int, comparePathOptions tspath.ComparePathsOptions) {
@@ -122,22 +120,9 @@ func parseArgs() *cliOptions {
 	return opts
 }
 
-func enableVirtualTerminalProcessing() {
-	hStdout, err := windows.GetStdHandle(windows.STD_OUTPUT_HANDLE)
-	if err == nil && hStdout != windows.InvalidHandle {
-		var mode uint32
-		err = windows.GetConsoleMode(windows.Handle(hStdout), &mode)
-		if err == nil {
-			windows.SetConsoleMode(windows.Handle(hStdout), mode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
-		}
-	}
-}
-
 func main() {
-	if runtime.GOOS == "windows" {
-		// TypeScript uses ANSI escape sequences which cmd.exe won't parse without enabling virtual terminal processing.
-		enableVirtualTerminalProcessing()
-	}
+	// TypeScript uses ANSI escape sequences which cmd.exe won't parse without enabling virtual terminal processing.
+	enableVirtualTerminalProcessing()
 
 	if args := os.Args[1:]; len(args) > 0 {
 		switch args[0] {

--- a/cmd/tsgo/main.go
+++ b/cmd/tsgo/main.go
@@ -12,7 +12,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/microsoft/typescript-go/internal/ast"
@@ -124,8 +123,8 @@ func parseArgs() *cliOptions {
 }
 
 func enableVirtualTerminalProcessing() {
-	hStdout, err := syscall.GetStdHandle(syscall.STD_OUTPUT_HANDLE)
-	if err == nil && hStdout != syscall.InvalidHandle {
+	hStdout, err := windows.GetStdHandle(windows.STD_OUTPUT_HANDLE)
+	if err == nil && hStdout != windows.InvalidHandle {
 		var mode uint32
 		err = windows.GetConsoleMode(windows.Handle(hStdout), &mode)
 		if err == nil {


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/2252a43a-36be-4f5b-97a4-32b3baa0994b)

After:
![image](https://github.com/user-attachments/assets/f3e55775-6684-4b04-b239-f2f4ff8cd86a)

Fixes #480

(I've never used Go before and I didn't verify this works on MacOS or Linux.)