### PR TITLE
Align gutter width with old compiler

### DIFF
--- a/internal/diagnosticwriter/diagnosticwriter.go
+++ b/internal/diagnosticwriter/diagnosticwriter.go
@@ -90,7 +90,7 @@ func writeCodeSnippet(writer io.Writer, sourceFile *ast.SourceFile, start int, l
 	lastLineOfFile, _ := scanner.GetLineAndCharacterOfPosition(sourceFile, len(sourceFile.Text))
 
 	hasMoreThanFiveLines := lastLine-firstLine >= 4
-	gutterWidth := len(strconv.Itoa(lastLineOfFile + 1 + len("")))
+	gutterWidth := len(strconv.Itoa(lastLine + 1))
 	if hasMoreThanFiveLines {
 		gutterWidth = max(len(ellipsis), gutterWidth)
 	}

--- a/testdata/baselines/reference/submodule/compiler/deeplyNestedAssignabilityIssue.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/deeplyNestedAssignabilityIssue.errors.txt
@@ -4,12 +4,12 @@
 [7m  [0m [91m                ~~~~~[0m
 
   [96mdeeplyNestedAssignabilityIssue.ts[0m:[93m2[0m:[93m5[0m - 'a' is declared here.
-    [7m 2[0m     a: number;
-    [7m  [0m [96m    ~[0m
+    [7m2[0m     a: number;
+    [7m [0m [96m    ~[0m
 
   [96mdeeplyNestedAssignabilityIssue.ts[0m:[93m9[0m:[93m17[0m - The expected type comes from property 'thing' which is declared here on type '{ thing: A; }'
-    [7m 9[0m                 thing: A;
-    [7m  [0m [96m                ~~~~~[0m
+    [7m9[0m                 thing: A;
+    [7m [0m [96m                ~~~~~[0m
 
 [96mdeeplyNestedAssignabilityIssue.ts[0m:[93m25[0m:[93m17[0m - [91merror[0m[90m TS2741: [0mProperty 'a' is missing in type '{}' but required in type 'A'.
 
@@ -17,8 +17,8 @@
 [7m  [0m [91m                ~~~~~~~[0m
 
   [96mdeeplyNestedAssignabilityIssue.ts[0m:[93m2[0m:[93m5[0m - 'a' is declared here.
-    [7m 2[0m     a: number;
-    [7m  [0m [96m    ~[0m
+    [7m2[0m     a: number;
+    [7m [0m [96m    ~[0m
 
   [96mdeeplyNestedAssignabilityIssue.ts[0m:[93m12[0m:[93m17[0m - The expected type comes from property 'another' which is declared here on type '{ another: A; }'
     [7m12[0m                 another: A;

--- a/testdata/baselines/reference/submodule/compiler/deeplyNestedAssignabilityIssue.errors.txt.diff
+++ b/testdata/baselines/reference/submodule/compiler/deeplyNestedAssignabilityIssue.errors.txt.diff
@@ -5,20 +5,16 @@
  [7m  [0m [91m                ~~~~~[0m
  
 -  [96mdeeplyNestedAssignabilityIssue.ts[0m:[93m2[0m:[93m5[0m
--    [7m2[0m     a: number;
--    [7m [0m [96m    ~[0m
++  [96mdeeplyNestedAssignabilityIssue.ts[0m:[93m2[0m:[93m5[0m - 'a' is declared here.
+     [7m2[0m     a: number;
+     [7m [0m [96m    ~[0m
 -    'a' is declared here.
 -  [96mdeeplyNestedAssignabilityIssue.ts[0m:[93m9[0m:[93m17[0m
--    [7m9[0m                 thing: A;
--    [7m [0m [96m                ~~~~~[0m
--    The expected type comes from property 'thing' which is declared here on type '{ thing: A; }'
-+  [96mdeeplyNestedAssignabilityIssue.ts[0m:[93m2[0m:[93m5[0m - 'a' is declared here.
-+    [7m 2[0m     a: number;
-+    [7m  [0m [96m    ~[0m
 +
 +  [96mdeeplyNestedAssignabilityIssue.ts[0m:[93m9[0m:[93m17[0m - The expected type comes from property 'thing' which is declared here on type '{ thing: A; }'
-+    [7m 9[0m                 thing: A;
-+    [7m  [0m [96m                ~~~~~[0m
+     [7m9[0m                 thing: A;
+     [7m [0m [96m                ~~~~~[0m
+-    The expected type comes from property 'thing' which is declared here on type '{ thing: A; }'
 +
  [96mdeeplyNestedAssignabilityIssue.ts[0m:[93m25[0m:[93m17[0m - [91merror[0m[90m TS2741: [0mProperty 'a' is missing in type '{}' but required in type 'A'.
  
@@ -26,13 +22,11 @@
  [7m  [0m [91m                ~~~~~~~[0m
  
 -  [96mdeeplyNestedAssignabilityIssue.ts[0m:[93m2[0m:[93m5[0m
--    [7m2[0m     a: number;
--    [7m [0m [96m    ~[0m
++  [96mdeeplyNestedAssignabilityIssue.ts[0m:[93m2[0m:[93m5[0m - 'a' is declared here.
+     [7m2[0m     a: number;
+     [7m [0m [96m    ~[0m
 -    'a' is declared here.
 -  [96mdeeplyNestedAssignabilityIssue.ts[0m:[93m12[0m:[93m17[0m
-+  [96mdeeplyNestedAssignabilityIssue.ts[0m:[93m2[0m:[93m5[0m - 'a' is declared here.
-+    [7m 2[0m     a: number;
-+    [7m  [0m [96m    ~[0m
 +
 +  [96mdeeplyNestedAssignabilityIssue.ts[0m:[93m12[0m:[93m17[0m - The expected type comes from property 'another' which is declared here on type '{ another: A; }'
      [7m12[0m                 another: A;

--- a/testdata/baselines/reference/submodule/compiler/duplicateIdentifierRelatedSpans2.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/duplicateIdentifierRelatedSpans2.errors.txt
@@ -4,8 +4,8 @@
 [7m [0m [91m      ~[0m
 
   [96mfile2.ts[0m:[93m1[0m:[93m7[0m - 'A' was also declared here.
-    [7m 1[0m class A { }
-    [7m  [0m [96m      ~[0m
+    [7m1[0m class A { }
+    [7m [0m [96m      ~[0m
 
 [96mfile1.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'B'.
 
@@ -13,8 +13,8 @@
 [7m [0m [91m      ~[0m
 
   [96mfile2.ts[0m:[93m2[0m:[93m7[0m - 'B' was also declared here.
-    [7m 2[0m class B { }
-    [7m  [0m [96m      ~[0m
+    [7m2[0m class B { }
+    [7m [0m [96m      ~[0m
 
 [96mfile1.ts[0m:[93m3[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'C'.
 
@@ -22,8 +22,8 @@
 [7m [0m [91m      ~[0m
 
   [96mfile2.ts[0m:[93m3[0m:[93m7[0m - 'C' was also declared here.
-    [7m 3[0m class C { }
-    [7m  [0m [96m      ~[0m
+    [7m3[0m class C { }
+    [7m [0m [96m      ~[0m
 
 [96mfile1.ts[0m:[93m4[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'D'.
 
@@ -31,8 +31,8 @@
 [7m [0m [91m      ~[0m
 
   [96mfile2.ts[0m:[93m4[0m:[93m7[0m - 'D' was also declared here.
-    [7m 4[0m class D { }
-    [7m  [0m [96m      ~[0m
+    [7m4[0m class D { }
+    [7m [0m [96m      ~[0m
 
 [96mfile1.ts[0m:[93m5[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'E'.
 
@@ -40,8 +40,8 @@
 [7m [0m [91m      ~[0m
 
   [96mfile2.ts[0m:[93m5[0m:[93m7[0m - 'E' was also declared here.
-    [7m 5[0m class E { }
-    [7m  [0m [96m      ~[0m
+    [7m5[0m class E { }
+    [7m [0m [96m      ~[0m
 
 [96mfile1.ts[0m:[93m6[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'F'.
 
@@ -49,8 +49,8 @@
 [7m [0m [91m      ~[0m
 
   [96mfile2.ts[0m:[93m6[0m:[93m7[0m - 'F' was also declared here.
-    [7m 6[0m class F { }
-    [7m  [0m [96m      ~[0m
+    [7m6[0m class F { }
+    [7m [0m [96m      ~[0m
 
 [96mfile1.ts[0m:[93m7[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'G'.
 
@@ -58,8 +58,8 @@
 [7m [0m [91m      ~[0m
 
   [96mfile2.ts[0m:[93m7[0m:[93m7[0m - 'G' was also declared here.
-    [7m 7[0m class G { }
-    [7m  [0m [96m      ~[0m
+    [7m7[0m class G { }
+    [7m [0m [96m      ~[0m
 
 [96mfile1.ts[0m:[93m8[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'H'.
 
@@ -67,8 +67,8 @@
 [7m [0m [91m      ~[0m
 
   [96mfile2.ts[0m:[93m8[0m:[93m7[0m - 'H' was also declared here.
-    [7m 8[0m class H { }
-    [7m  [0m [96m      ~[0m
+    [7m8[0m class H { }
+    [7m [0m [96m      ~[0m
 
 [96mfile1.ts[0m:[93m9[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'I'.
 
@@ -76,13 +76,13 @@
 [7m [0m [91m      ~[0m
 
   [96mfile2.ts[0m:[93m9[0m:[93m7[0m - 'I' was also declared here.
-    [7m 9[0m class I { }
-    [7m  [0m [96m      ~[0m
+    [7m9[0m class I { }
+    [7m [0m [96m      ~[0m
 
 [96mfile2.ts[0m:[93m1[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'A'.
 
-[7m 1[0m class A { }
-[7m  [0m [91m      ~[0m
+[7m1[0m class A { }
+[7m [0m [91m      ~[0m
 
   [96mfile1.ts[0m:[93m1[0m:[93m7[0m - 'A' was also declared here.
     [7m1[0m class A { }
@@ -90,8 +90,8 @@
 
 [96mfile2.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'B'.
 
-[7m 2[0m class B { }
-[7m  [0m [91m      ~[0m
+[7m2[0m class B { }
+[7m [0m [91m      ~[0m
 
   [96mfile1.ts[0m:[93m2[0m:[93m7[0m - 'B' was also declared here.
     [7m2[0m class B { }
@@ -99,8 +99,8 @@
 
 [96mfile2.ts[0m:[93m3[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'C'.
 
-[7m 3[0m class C { }
-[7m  [0m [91m      ~[0m
+[7m3[0m class C { }
+[7m [0m [91m      ~[0m
 
   [96mfile1.ts[0m:[93m3[0m:[93m7[0m - 'C' was also declared here.
     [7m3[0m class C { }
@@ -108,8 +108,8 @@
 
 [96mfile2.ts[0m:[93m4[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'D'.
 
-[7m 4[0m class D { }
-[7m  [0m [91m      ~[0m
+[7m4[0m class D { }
+[7m [0m [91m      ~[0m
 
   [96mfile1.ts[0m:[93m4[0m:[93m7[0m - 'D' was also declared here.
     [7m4[0m class D { }
@@ -117,8 +117,8 @@
 
 [96mfile2.ts[0m:[93m5[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'E'.
 
-[7m 5[0m class E { }
-[7m  [0m [91m      ~[0m
+[7m5[0m class E { }
+[7m [0m [91m      ~[0m
 
   [96mfile1.ts[0m:[93m5[0m:[93m7[0m - 'E' was also declared here.
     [7m5[0m class E { }
@@ -126,8 +126,8 @@
 
 [96mfile2.ts[0m:[93m6[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'F'.
 
-[7m 6[0m class F { }
-[7m  [0m [91m      ~[0m
+[7m6[0m class F { }
+[7m [0m [91m      ~[0m
 
   [96mfile1.ts[0m:[93m6[0m:[93m7[0m - 'F' was also declared here.
     [7m6[0m class F { }
@@ -135,8 +135,8 @@
 
 [96mfile2.ts[0m:[93m7[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'G'.
 
-[7m 7[0m class G { }
-[7m  [0m [91m      ~[0m
+[7m7[0m class G { }
+[7m [0m [91m      ~[0m
 
   [96mfile1.ts[0m:[93m7[0m:[93m7[0m - 'G' was also declared here.
     [7m7[0m class G { }
@@ -144,8 +144,8 @@
 
 [96mfile2.ts[0m:[93m8[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'H'.
 
-[7m 8[0m class H { }
-[7m  [0m [91m      ~[0m
+[7m8[0m class H { }
+[7m [0m [91m      ~[0m
 
   [96mfile1.ts[0m:[93m8[0m:[93m7[0m - 'H' was also declared here.
     [7m8[0m class H { }
@@ -153,8 +153,8 @@
 
 [96mfile2.ts[0m:[93m9[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'I'.
 
-[7m 9[0m class I { }
-[7m  [0m [91m      ~[0m
+[7m9[0m class I { }
+[7m [0m [91m      ~[0m
 
   [96mfile1.ts[0m:[93m9[0m:[93m7[0m - 'I' was also declared here.
     [7m9[0m class I { }

--- a/testdata/baselines/reference/submodule/compiler/duplicateIdentifierRelatedSpans2.errors.txt.diff
+++ b/testdata/baselines/reference/submodule/compiler/duplicateIdentifierRelatedSpans2.errors.txt.diff
@@ -9,25 +9,21 @@
 +[7m [0m [91m      ~[0m
  
 -  [96mfile2.ts[0m:[93m1[0m:[93m1[0m
--    [7m1[0m class A { }
++  [96mfile2.ts[0m:[93m1[0m:[93m7[0m - 'A' was also declared here.
+     [7m1[0m class A { }
 -    [7m [0m [96m~~~~~[0m
 -    Conflicts are in this file.
 -[96mfile2.ts[0m:[93m1[0m:[93m1[0m - [91merror[0m[90m TS6200: [0mDefinitions of the following identifiers conflict with those in another file: A, B, C, D, E, F, G, H, I
-+  [96mfile2.ts[0m:[93m1[0m:[93m7[0m - 'A' was also declared here.
-+    [7m 1[0m class A { }
-+    [7m  [0m [96m      ~[0m
++    [7m [0m [96m      ~[0m
  
--[7m1[0m class A { }
--[7m [0m [91m~~~~~[0m
 +[96mfile1.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'B'.
- 
--  [96mfile1.ts[0m:[93m1[0m:[93m1[0m
++
 +[7m2[0m class B { }
 +[7m [0m [91m      ~[0m
 +
 +  [96mfile2.ts[0m:[93m2[0m:[93m7[0m - 'B' was also declared here.
-+    [7m 2[0m class B { }
-+    [7m  [0m [96m      ~[0m
++    [7m2[0m class B { }
++    [7m [0m [96m      ~[0m
 +
 +[96mfile1.ts[0m:[93m3[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'C'.
 +
@@ -35,8 +31,8 @@
 +[7m [0m [91m      ~[0m
 +
 +  [96mfile2.ts[0m:[93m3[0m:[93m7[0m - 'C' was also declared here.
-+    [7m 3[0m class C { }
-+    [7m  [0m [96m      ~[0m
++    [7m3[0m class C { }
++    [7m [0m [96m      ~[0m
 +
 +[96mfile1.ts[0m:[93m4[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'D'.
 +
@@ -44,8 +40,8 @@
 +[7m [0m [91m      ~[0m
 +
 +  [96mfile2.ts[0m:[93m4[0m:[93m7[0m - 'D' was also declared here.
-+    [7m 4[0m class D { }
-+    [7m  [0m [96m      ~[0m
++    [7m4[0m class D { }
++    [7m [0m [96m      ~[0m
 +
 +[96mfile1.ts[0m:[93m5[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'E'.
 +
@@ -53,8 +49,8 @@
 +[7m [0m [91m      ~[0m
 +
 +  [96mfile2.ts[0m:[93m5[0m:[93m7[0m - 'E' was also declared here.
-+    [7m 5[0m class E { }
-+    [7m  [0m [96m      ~[0m
++    [7m5[0m class E { }
++    [7m [0m [96m      ~[0m
 +
 +[96mfile1.ts[0m:[93m6[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'F'.
 +
@@ -62,8 +58,8 @@
 +[7m [0m [91m      ~[0m
 +
 +  [96mfile2.ts[0m:[93m6[0m:[93m7[0m - 'F' was also declared here.
-+    [7m 6[0m class F { }
-+    [7m  [0m [96m      ~[0m
++    [7m6[0m class F { }
++    [7m [0m [96m      ~[0m
 +
 +[96mfile1.ts[0m:[93m7[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'G'.
 +
@@ -71,8 +67,8 @@
 +[7m [0m [91m      ~[0m
 +
 +  [96mfile2.ts[0m:[93m7[0m:[93m7[0m - 'G' was also declared here.
-+    [7m 7[0m class G { }
-+    [7m  [0m [96m      ~[0m
++    [7m7[0m class G { }
++    [7m [0m [96m      ~[0m
 +
 +[96mfile1.ts[0m:[93m8[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'H'.
 +
@@ -80,8 +76,8 @@
 +[7m [0m [91m      ~[0m
 +
 +  [96mfile2.ts[0m:[93m8[0m:[93m7[0m - 'H' was also declared here.
-+    [7m 8[0m class H { }
-+    [7m  [0m [96m      ~[0m
++    [7m8[0m class H { }
++    [7m [0m [96m      ~[0m
 +
 +[96mfile1.ts[0m:[93m9[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'I'.
 +
@@ -89,14 +85,16 @@
 +[7m [0m [91m      ~[0m
 +
 +  [96mfile2.ts[0m:[93m9[0m:[93m7[0m - 'I' was also declared here.
-+    [7m 9[0m class I { }
-+    [7m  [0m [96m      ~[0m
++    [7m9[0m class I { }
++    [7m [0m [96m      ~[0m
 +
 +[96mfile2.ts[0m:[93m1[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'A'.
 +
-+[7m 1[0m class A { }
-+[7m  [0m [91m      ~[0m
-+
+ [7m1[0m class A { }
+-[7m [0m [91m~~~~~[0m
++[7m [0m [91m      ~[0m
+ 
+-  [96mfile1.ts[0m:[93m1[0m:[93m1[0m
 +  [96mfile1.ts[0m:[93m1[0m:[93m7[0m - 'A' was also declared here.
      [7m1[0m class A { }
 -    [7m [0m [96m~~~~~[0m
@@ -106,8 +104,8 @@
 +[96mfile2.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'B'.
  
 -==== file1.ts (1 errors) ====
-+[7m 2[0m class B { }
-+[7m  [0m [91m      ~[0m
++[7m2[0m class B { }
++[7m [0m [91m      ~[0m
 +
 +  [96mfile1.ts[0m:[93m2[0m:[93m7[0m - 'B' was also declared here.
 +    [7m2[0m class B { }
@@ -115,8 +113,8 @@
 +
 +[96mfile2.ts[0m:[93m3[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'C'.
 +
-+[7m 3[0m class C { }
-+[7m  [0m [91m      ~[0m
++[7m3[0m class C { }
++[7m [0m [91m      ~[0m
 +
 +  [96mfile1.ts[0m:[93m3[0m:[93m7[0m - 'C' was also declared here.
 +    [7m3[0m class C { }
@@ -124,8 +122,8 @@
 +
 +[96mfile2.ts[0m:[93m4[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'D'.
 +
-+[7m 4[0m class D { }
-+[7m  [0m [91m      ~[0m
++[7m4[0m class D { }
++[7m [0m [91m      ~[0m
 +
 +  [96mfile1.ts[0m:[93m4[0m:[93m7[0m - 'D' was also declared here.
 +    [7m4[0m class D { }
@@ -133,8 +131,8 @@
 +
 +[96mfile2.ts[0m:[93m5[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'E'.
 +
-+[7m 5[0m class E { }
-+[7m  [0m [91m      ~[0m
++[7m5[0m class E { }
++[7m [0m [91m      ~[0m
 +
 +  [96mfile1.ts[0m:[93m5[0m:[93m7[0m - 'E' was also declared here.
 +    [7m5[0m class E { }
@@ -142,8 +140,8 @@
 +
 +[96mfile2.ts[0m:[93m6[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'F'.
 +
-+[7m 6[0m class F { }
-+[7m  [0m [91m      ~[0m
++[7m6[0m class F { }
++[7m [0m [91m      ~[0m
 +
 +  [96mfile1.ts[0m:[93m6[0m:[93m7[0m - 'F' was also declared here.
 +    [7m6[0m class F { }
@@ -151,8 +149,8 @@
 +
 +[96mfile2.ts[0m:[93m7[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'G'.
 +
-+[7m 7[0m class G { }
-+[7m  [0m [91m      ~[0m
++[7m7[0m class G { }
++[7m [0m [91m      ~[0m
 +
 +  [96mfile1.ts[0m:[93m7[0m:[93m7[0m - 'G' was also declared here.
 +    [7m7[0m class G { }
@@ -160,8 +158,8 @@
 +
 +[96mfile2.ts[0m:[93m8[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'H'.
 +
-+[7m 8[0m class H { }
-+[7m  [0m [91m      ~[0m
++[7m8[0m class H { }
++[7m [0m [91m      ~[0m
 +
 +  [96mfile1.ts[0m:[93m8[0m:[93m7[0m - 'H' was also declared here.
 +    [7m8[0m class H { }
@@ -169,8 +167,8 @@
 +
 +[96mfile2.ts[0m:[93m9[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'I'.
 +
-+[7m 9[0m class I { }
-+[7m  [0m [91m      ~[0m
++[7m9[0m class I { }
++[7m [0m [91m      ~[0m
 +
 +  [96mfile1.ts[0m:[93m9[0m:[93m7[0m - 'I' was also declared here.
 +    [7m9[0m class I { }

--- a/testdata/baselines/reference/submodule/compiler/duplicateIdentifierRelatedSpans4.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/duplicateIdentifierRelatedSpans4.errors.txt
@@ -1,146 +1,146 @@
 [96mfile1.ts[0m:[93m2[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate1'.
 
-[7m 2[0m     duplicate1: () => string;
-[7m  [0m [91m    ~~~~~~~~~~[0m
+[7m2[0m     duplicate1: () => string;
+[7m [0m [91m    ~~~~~~~~~~[0m
 
   [96mfile2.ts[0m:[93m2[0m:[93m5[0m - 'duplicate1' was also declared here.
-    [7m 2[0m     duplicate1(): number;
-    [7m  [0m [96m    ~~~~~~~~~~[0m
+    [7m2[0m     duplicate1(): number;
+    [7m [0m [96m    ~~~~~~~~~~[0m
 
 [96mfile1.ts[0m:[93m3[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate2'.
 
-[7m 3[0m     duplicate2: () => string;
-[7m  [0m [91m    ~~~~~~~~~~[0m
+[7m3[0m     duplicate2: () => string;
+[7m [0m [91m    ~~~~~~~~~~[0m
 
   [96mfile2.ts[0m:[93m3[0m:[93m5[0m - 'duplicate2' was also declared here.
-    [7m 3[0m     duplicate2(): number;
-    [7m  [0m [96m    ~~~~~~~~~~[0m
+    [7m3[0m     duplicate2(): number;
+    [7m [0m [96m    ~~~~~~~~~~[0m
 
 [96mfile1.ts[0m:[93m4[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate3'.
 
-[7m 4[0m     duplicate3: () => string;
-[7m  [0m [91m    ~~~~~~~~~~[0m
+[7m4[0m     duplicate3: () => string;
+[7m [0m [91m    ~~~~~~~~~~[0m
 
   [96mfile2.ts[0m:[93m4[0m:[93m5[0m - 'duplicate3' was also declared here.
-    [7m 4[0m     duplicate3(): number;
-    [7m  [0m [96m    ~~~~~~~~~~[0m
+    [7m4[0m     duplicate3(): number;
+    [7m [0m [96m    ~~~~~~~~~~[0m
 
 [96mfile1.ts[0m:[93m5[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate4'.
 
-[7m 5[0m     duplicate4: () => string;
-[7m  [0m [91m    ~~~~~~~~~~[0m
+[7m5[0m     duplicate4: () => string;
+[7m [0m [91m    ~~~~~~~~~~[0m
 
   [96mfile2.ts[0m:[93m5[0m:[93m5[0m - 'duplicate4' was also declared here.
-    [7m 5[0m     duplicate4(): number;
-    [7m  [0m [96m    ~~~~~~~~~~[0m
+    [7m5[0m     duplicate4(): number;
+    [7m [0m [96m    ~~~~~~~~~~[0m
 
 [96mfile1.ts[0m:[93m6[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate5'.
 
-[7m 6[0m     duplicate5: () => string;
-[7m  [0m [91m    ~~~~~~~~~~[0m
+[7m6[0m     duplicate5: () => string;
+[7m [0m [91m    ~~~~~~~~~~[0m
 
   [96mfile2.ts[0m:[93m6[0m:[93m5[0m - 'duplicate5' was also declared here.
-    [7m 6[0m     duplicate5(): number;
-    [7m  [0m [96m    ~~~~~~~~~~[0m
+    [7m6[0m     duplicate5(): number;
+    [7m [0m [96m    ~~~~~~~~~~[0m
 
 [96mfile1.ts[0m:[93m7[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate6'.
 
-[7m 7[0m     duplicate6: () => string;
-[7m  [0m [91m    ~~~~~~~~~~[0m
+[7m7[0m     duplicate6: () => string;
+[7m [0m [91m    ~~~~~~~~~~[0m
 
   [96mfile2.ts[0m:[93m7[0m:[93m5[0m - 'duplicate6' was also declared here.
-    [7m 7[0m     duplicate6(): number;
-    [7m  [0m [96m    ~~~~~~~~~~[0m
+    [7m7[0m     duplicate6(): number;
+    [7m [0m [96m    ~~~~~~~~~~[0m
 
 [96mfile1.ts[0m:[93m8[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate7'.
 
-[7m 8[0m     duplicate7: () => string;
-[7m  [0m [91m    ~~~~~~~~~~[0m
+[7m8[0m     duplicate7: () => string;
+[7m [0m [91m    ~~~~~~~~~~[0m
 
   [96mfile2.ts[0m:[93m8[0m:[93m5[0m - 'duplicate7' was also declared here.
-    [7m 8[0m     duplicate7(): number;
-    [7m  [0m [96m    ~~~~~~~~~~[0m
+    [7m8[0m     duplicate7(): number;
+    [7m [0m [96m    ~~~~~~~~~~[0m
 
 [96mfile1.ts[0m:[93m9[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate8'.
 
-[7m 9[0m     duplicate8: () => string;
-[7m  [0m [91m    ~~~~~~~~~~[0m
+[7m9[0m     duplicate8: () => string;
+[7m [0m [91m    ~~~~~~~~~~[0m
 
   [96mfile2.ts[0m:[93m9[0m:[93m5[0m - 'duplicate8' was also declared here.
-    [7m 9[0m     duplicate8(): number;
-    [7m  [0m [96m    ~~~~~~~~~~[0m
+    [7m9[0m     duplicate8(): number;
+    [7m [0m [96m    ~~~~~~~~~~[0m
 
 [96mfile2.ts[0m:[93m2[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate1'.
 
-[7m 2[0m     duplicate1(): number;
-[7m  [0m [91m    ~~~~~~~~~~[0m
+[7m2[0m     duplicate1(): number;
+[7m [0m [91m    ~~~~~~~~~~[0m
 
   [96mfile1.ts[0m:[93m2[0m:[93m5[0m - 'duplicate1' was also declared here.
-    [7m 2[0m     duplicate1: () => string;
-    [7m  [0m [96m    ~~~~~~~~~~[0m
+    [7m2[0m     duplicate1: () => string;
+    [7m [0m [96m    ~~~~~~~~~~[0m
 
 [96mfile2.ts[0m:[93m3[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate2'.
 
-[7m 3[0m     duplicate2(): number;
-[7m  [0m [91m    ~~~~~~~~~~[0m
+[7m3[0m     duplicate2(): number;
+[7m [0m [91m    ~~~~~~~~~~[0m
 
   [96mfile1.ts[0m:[93m3[0m:[93m5[0m - 'duplicate2' was also declared here.
-    [7m 3[0m     duplicate2: () => string;
-    [7m  [0m [96m    ~~~~~~~~~~[0m
+    [7m3[0m     duplicate2: () => string;
+    [7m [0m [96m    ~~~~~~~~~~[0m
 
 [96mfile2.ts[0m:[93m4[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate3'.
 
-[7m 4[0m     duplicate3(): number;
-[7m  [0m [91m    ~~~~~~~~~~[0m
+[7m4[0m     duplicate3(): number;
+[7m [0m [91m    ~~~~~~~~~~[0m
 
   [96mfile1.ts[0m:[93m4[0m:[93m5[0m - 'duplicate3' was also declared here.
-    [7m 4[0m     duplicate3: () => string;
-    [7m  [0m [96m    ~~~~~~~~~~[0m
+    [7m4[0m     duplicate3: () => string;
+    [7m [0m [96m    ~~~~~~~~~~[0m
 
 [96mfile2.ts[0m:[93m5[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate4'.
 
-[7m 5[0m     duplicate4(): number;
-[7m  [0m [91m    ~~~~~~~~~~[0m
+[7m5[0m     duplicate4(): number;
+[7m [0m [91m    ~~~~~~~~~~[0m
 
   [96mfile1.ts[0m:[93m5[0m:[93m5[0m - 'duplicate4' was also declared here.
-    [7m 5[0m     duplicate4: () => string;
-    [7m  [0m [96m    ~~~~~~~~~~[0m
+    [7m5[0m     duplicate4: () => string;
+    [7m [0m [96m    ~~~~~~~~~~[0m
 
 [96mfile2.ts[0m:[93m6[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate5'.
 
-[7m 6[0m     duplicate5(): number;
-[7m  [0m [91m    ~~~~~~~~~~[0m
+[7m6[0m     duplicate5(): number;
+[7m [0m [91m    ~~~~~~~~~~[0m
 
   [96mfile1.ts[0m:[93m6[0m:[93m5[0m - 'duplicate5' was also declared here.
-    [7m 6[0m     duplicate5: () => string;
-    [7m  [0m [96m    ~~~~~~~~~~[0m
+    [7m6[0m     duplicate5: () => string;
+    [7m [0m [96m    ~~~~~~~~~~[0m
 
 [96mfile2.ts[0m:[93m7[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate6'.
 
-[7m 7[0m     duplicate6(): number;
-[7m  [0m [91m    ~~~~~~~~~~[0m
+[7m7[0m     duplicate6(): number;
+[7m [0m [91m    ~~~~~~~~~~[0m
 
   [96mfile1.ts[0m:[93m7[0m:[93m5[0m - 'duplicate6' was also declared here.
-    [7m 7[0m     duplicate6: () => string;
-    [7m  [0m [96m    ~~~~~~~~~~[0m
+    [7m7[0m     duplicate6: () => string;
+    [7m [0m [96m    ~~~~~~~~~~[0m
 
 [96mfile2.ts[0m:[93m8[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate7'.
 
-[7m 8[0m     duplicate7(): number;
-[7m  [0m [91m    ~~~~~~~~~~[0m
+[7m8[0m     duplicate7(): number;
+[7m [0m [91m    ~~~~~~~~~~[0m
 
   [96mfile1.ts[0m:[93m8[0m:[93m5[0m - 'duplicate7' was also declared here.
-    [7m 8[0m     duplicate7: () => string;
-    [7m  [0m [96m    ~~~~~~~~~~[0m
+    [7m8[0m     duplicate7: () => string;
+    [7m [0m [96m    ~~~~~~~~~~[0m
 
 [96mfile2.ts[0m:[93m9[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate8'.
 
-[7m 9[0m     duplicate8(): number;
-[7m  [0m [91m    ~~~~~~~~~~[0m
+[7m9[0m     duplicate8(): number;
+[7m [0m [91m    ~~~~~~~~~~[0m
 
   [96mfile1.ts[0m:[93m9[0m:[93m5[0m - 'duplicate8' was also declared here.
-    [7m 9[0m     duplicate8: () => string;
-    [7m  [0m [96m    ~~~~~~~~~~[0m
+    [7m9[0m     duplicate8: () => string;
+    [7m [0m [96m    ~~~~~~~~~~[0m
 
 
 ==== file1.ts (8 errors) ====

--- a/testdata/baselines/reference/submodule/compiler/duplicateIdentifierRelatedSpans4.errors.txt.diff
+++ b/testdata/baselines/reference/submodule/compiler/duplicateIdentifierRelatedSpans4.errors.txt.diff
@@ -6,8 +6,8 @@
  
 -[7m1[0m interface TopLevel {
 -[7m [0m [91m~~~~~~~~~[0m
-+[7m 2[0m     duplicate1: () => string;
-+[7m  [0m [91m    ~~~~~~~~~~[0m
++[7m2[0m     duplicate1: () => string;
++[7m [0m [91m    ~~~~~~~~~~[0m
  
 -  [96mfile2.ts[0m:[93m1[0m:[93m1[0m
 -    [7m1[0m interface TopLevel {
@@ -15,8 +15,8 @@
 -    Conflicts are in this file.
 -[96mfile2.ts[0m:[93m1[0m:[93m1[0m - [91merror[0m[90m TS6200: [0mDefinitions of the following identifiers conflict with those in another file: duplicate1, duplicate2, duplicate3, duplicate4, duplicate5, duplicate6, duplicate7, duplicate8
 +  [96mfile2.ts[0m:[93m2[0m:[93m5[0m - 'duplicate1' was also declared here.
-+    [7m 2[0m     duplicate1(): number;
-+    [7m  [0m [96m    ~~~~~~~~~~[0m
++    [7m2[0m     duplicate1(): number;
++    [7m [0m [96m    ~~~~~~~~~~[0m
  
 -[7m1[0m interface TopLevel {
 -[7m [0m [91m~~~~~~~~~[0m
@@ -26,139 +26,139 @@
 -    [7m1[0m interface TopLevel {
 -    [7m [0m [96m~~~~~~~~~[0m
 -    Conflicts are in this file.
-+[7m 3[0m     duplicate2: () => string;
-+[7m  [0m [91m    ~~~~~~~~~~[0m
++[7m3[0m     duplicate2: () => string;
++[7m [0m [91m    ~~~~~~~~~~[0m
  
 +  [96mfile2.ts[0m:[93m3[0m:[93m5[0m - 'duplicate2' was also declared here.
-+    [7m 3[0m     duplicate2(): number;
-+    [7m  [0m [96m    ~~~~~~~~~~[0m
++    [7m3[0m     duplicate2(): number;
++    [7m [0m [96m    ~~~~~~~~~~[0m
  
 -==== file1.ts (1 errors) ====
 +[96mfile1.ts[0m:[93m4[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate3'.
 +
-+[7m 4[0m     duplicate3: () => string;
-+[7m  [0m [91m    ~~~~~~~~~~[0m
++[7m4[0m     duplicate3: () => string;
++[7m [0m [91m    ~~~~~~~~~~[0m
 +
 +  [96mfile2.ts[0m:[93m4[0m:[93m5[0m - 'duplicate3' was also declared here.
-+    [7m 4[0m     duplicate3(): number;
-+    [7m  [0m [96m    ~~~~~~~~~~[0m
++    [7m4[0m     duplicate3(): number;
++    [7m [0m [96m    ~~~~~~~~~~[0m
 +
 +[96mfile1.ts[0m:[93m5[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate4'.
 +
-+[7m 5[0m     duplicate4: () => string;
-+[7m  [0m [91m    ~~~~~~~~~~[0m
++[7m5[0m     duplicate4: () => string;
++[7m [0m [91m    ~~~~~~~~~~[0m
 +
 +  [96mfile2.ts[0m:[93m5[0m:[93m5[0m - 'duplicate4' was also declared here.
-+    [7m 5[0m     duplicate4(): number;
-+    [7m  [0m [96m    ~~~~~~~~~~[0m
++    [7m5[0m     duplicate4(): number;
++    [7m [0m [96m    ~~~~~~~~~~[0m
 +
 +[96mfile1.ts[0m:[93m6[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate5'.
 +
-+[7m 6[0m     duplicate5: () => string;
-+[7m  [0m [91m    ~~~~~~~~~~[0m
++[7m6[0m     duplicate5: () => string;
++[7m [0m [91m    ~~~~~~~~~~[0m
 +
 +  [96mfile2.ts[0m:[93m6[0m:[93m5[0m - 'duplicate5' was also declared here.
-+    [7m 6[0m     duplicate5(): number;
-+    [7m  [0m [96m    ~~~~~~~~~~[0m
++    [7m6[0m     duplicate5(): number;
++    [7m [0m [96m    ~~~~~~~~~~[0m
 +
 +[96mfile1.ts[0m:[93m7[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate6'.
 +
-+[7m 7[0m     duplicate6: () => string;
-+[7m  [0m [91m    ~~~~~~~~~~[0m
++[7m7[0m     duplicate6: () => string;
++[7m [0m [91m    ~~~~~~~~~~[0m
 +
 +  [96mfile2.ts[0m:[93m7[0m:[93m5[0m - 'duplicate6' was also declared here.
-+    [7m 7[0m     duplicate6(): number;
-+    [7m  [0m [96m    ~~~~~~~~~~[0m
++    [7m7[0m     duplicate6(): number;
++    [7m [0m [96m    ~~~~~~~~~~[0m
 +
 +[96mfile1.ts[0m:[93m8[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate7'.
 +
-+[7m 8[0m     duplicate7: () => string;
-+[7m  [0m [91m    ~~~~~~~~~~[0m
++[7m8[0m     duplicate7: () => string;
++[7m [0m [91m    ~~~~~~~~~~[0m
 +
 +  [96mfile2.ts[0m:[93m8[0m:[93m5[0m - 'duplicate7' was also declared here.
-+    [7m 8[0m     duplicate7(): number;
-+    [7m  [0m [96m    ~~~~~~~~~~[0m
++    [7m8[0m     duplicate7(): number;
++    [7m [0m [96m    ~~~~~~~~~~[0m
 +
 +[96mfile1.ts[0m:[93m9[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate8'.
 +
-+[7m 9[0m     duplicate8: () => string;
-+[7m  [0m [91m    ~~~~~~~~~~[0m
++[7m9[0m     duplicate8: () => string;
++[7m [0m [91m    ~~~~~~~~~~[0m
 +
 +  [96mfile2.ts[0m:[93m9[0m:[93m5[0m - 'duplicate8' was also declared here.
-+    [7m 9[0m     duplicate8(): number;
-+    [7m  [0m [96m    ~~~~~~~~~~[0m
++    [7m9[0m     duplicate8(): number;
++    [7m [0m [96m    ~~~~~~~~~~[0m
 +
 +[96mfile2.ts[0m:[93m2[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate1'.
 +
-+[7m 2[0m     duplicate1(): number;
-+[7m  [0m [91m    ~~~~~~~~~~[0m
++[7m2[0m     duplicate1(): number;
++[7m [0m [91m    ~~~~~~~~~~[0m
 +
 +  [96mfile1.ts[0m:[93m2[0m:[93m5[0m - 'duplicate1' was also declared here.
-+    [7m 2[0m     duplicate1: () => string;
-+    [7m  [0m [96m    ~~~~~~~~~~[0m
++    [7m2[0m     duplicate1: () => string;
++    [7m [0m [96m    ~~~~~~~~~~[0m
 +
 +[96mfile2.ts[0m:[93m3[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate2'.
 +
-+[7m 3[0m     duplicate2(): number;
-+[7m  [0m [91m    ~~~~~~~~~~[0m
++[7m3[0m     duplicate2(): number;
++[7m [0m [91m    ~~~~~~~~~~[0m
 +
 +  [96mfile1.ts[0m:[93m3[0m:[93m5[0m - 'duplicate2' was also declared here.
-+    [7m 3[0m     duplicate2: () => string;
-+    [7m  [0m [96m    ~~~~~~~~~~[0m
++    [7m3[0m     duplicate2: () => string;
++    [7m [0m [96m    ~~~~~~~~~~[0m
 +
 +[96mfile2.ts[0m:[93m4[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate3'.
 +
-+[7m 4[0m     duplicate3(): number;
-+[7m  [0m [91m    ~~~~~~~~~~[0m
++[7m4[0m     duplicate3(): number;
++[7m [0m [91m    ~~~~~~~~~~[0m
 +
 +  [96mfile1.ts[0m:[93m4[0m:[93m5[0m - 'duplicate3' was also declared here.
-+    [7m 4[0m     duplicate3: () => string;
-+    [7m  [0m [96m    ~~~~~~~~~~[0m
++    [7m4[0m     duplicate3: () => string;
++    [7m [0m [96m    ~~~~~~~~~~[0m
 +
 +[96mfile2.ts[0m:[93m5[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate4'.
 +
-+[7m 5[0m     duplicate4(): number;
-+[7m  [0m [91m    ~~~~~~~~~~[0m
++[7m5[0m     duplicate4(): number;
++[7m [0m [91m    ~~~~~~~~~~[0m
 +
 +  [96mfile1.ts[0m:[93m5[0m:[93m5[0m - 'duplicate4' was also declared here.
-+    [7m 5[0m     duplicate4: () => string;
-+    [7m  [0m [96m    ~~~~~~~~~~[0m
++    [7m5[0m     duplicate4: () => string;
++    [7m [0m [96m    ~~~~~~~~~~[0m
 +
 +[96mfile2.ts[0m:[93m6[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate5'.
 +
-+[7m 6[0m     duplicate5(): number;
-+[7m  [0m [91m    ~~~~~~~~~~[0m
++[7m6[0m     duplicate5(): number;
++[7m [0m [91m    ~~~~~~~~~~[0m
 +
 +  [96mfile1.ts[0m:[93m6[0m:[93m5[0m - 'duplicate5' was also declared here.
-+    [7m 6[0m     duplicate5: () => string;
-+    [7m  [0m [96m    ~~~~~~~~~~[0m
++    [7m6[0m     duplicate5: () => string;
++    [7m [0m [96m    ~~~~~~~~~~[0m
 +
 +[96mfile2.ts[0m:[93m7[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate6'.
 +
-+[7m 7[0m     duplicate6(): number;
-+[7m  [0m [91m    ~~~~~~~~~~[0m
++[7m7[0m     duplicate6(): number;
++[7m [0m [91m    ~~~~~~~~~~[0m
 +
 +  [96mfile1.ts[0m:[93m7[0m:[93m5[0m - 'duplicate6' was also declared here.
-+    [7m 7[0m     duplicate6: () => string;
-+    [7m  [0m [96m    ~~~~~~~~~~[0m
++    [7m7[0m     duplicate6: () => string;
++    [7m [0m [96m    ~~~~~~~~~~[0m
 +
 +[96mfile2.ts[0m:[93m8[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate7'.
 +
-+[7m 8[0m     duplicate7(): number;
-+[7m  [0m [91m    ~~~~~~~~~~[0m
++[7m8[0m     duplicate7(): number;
++[7m [0m [91m    ~~~~~~~~~~[0m
 +
 +  [96mfile1.ts[0m:[93m8[0m:[93m5[0m - 'duplicate7' was also declared here.
-+    [7m 8[0m     duplicate7: () => string;
-+    [7m  [0m [96m    ~~~~~~~~~~[0m
++    [7m8[0m     duplicate7: () => string;
++    [7m [0m [96m    ~~~~~~~~~~[0m
 +
 +[96mfile2.ts[0m:[93m9[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate8'.
 +
-+[7m 9[0m     duplicate8(): number;
-+[7m  [0m [91m    ~~~~~~~~~~[0m
++[7m9[0m     duplicate8(): number;
++[7m [0m [91m    ~~~~~~~~~~[0m
 +
 +  [96mfile1.ts[0m:[93m9[0m:[93m5[0m - 'duplicate8' was also declared here.
-+    [7m 9[0m     duplicate8: () => string;
-+    [7m  [0m [96m    ~~~~~~~~~~[0m
++    [7m9[0m     duplicate8: () => string;
++    [7m [0m [96m    ~~~~~~~~~~[0m
 +
 +
 +==== file1.ts (8 errors) ====

--- a/testdata/baselines/reference/submodule/compiler/duplicateIdentifierRelatedSpans5.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/duplicateIdentifierRelatedSpans5.errors.txt
@@ -4,8 +4,8 @@
 [7m [0m [91m        ~~~~~~~~~~[0m
 
   [96mfile2.ts[0m:[93m4[0m:[93m9[0m - 'duplicate1' was also declared here.
-    [7m 4[0m         duplicate1(): number;
-    [7m  [0m [96m        ~~~~~~~~~~[0m
+    [7m4[0m         duplicate1(): number;
+    [7m [0m [96m        ~~~~~~~~~~[0m
 
 [96mfile1.ts[0m:[93m4[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate2'.
 
@@ -13,8 +13,8 @@
 [7m [0m [91m        ~~~~~~~~~~[0m
 
   [96mfile2.ts[0m:[93m5[0m:[93m9[0m - 'duplicate2' was also declared here.
-    [7m 5[0m         duplicate2(): number;
-    [7m  [0m [96m        ~~~~~~~~~~[0m
+    [7m5[0m         duplicate2(): number;
+    [7m [0m [96m        ~~~~~~~~~~[0m
 
 [96mfile1.ts[0m:[93m5[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate3'.
 
@@ -22,13 +22,13 @@
 [7m [0m [91m        ~~~~~~~~~~[0m
 
   [96mfile2.ts[0m:[93m6[0m:[93m9[0m - 'duplicate3' was also declared here.
-    [7m 6[0m         duplicate3(): number;
-    [7m  [0m [96m        ~~~~~~~~~~[0m
+    [7m6[0m         duplicate3(): number;
+    [7m [0m [96m        ~~~~~~~~~~[0m
 
 [96mfile2.ts[0m:[93m4[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate1'.
 
-[7m 4[0m         duplicate1(): number;
-[7m  [0m [91m        ~~~~~~~~~~[0m
+[7m4[0m         duplicate1(): number;
+[7m [0m [91m        ~~~~~~~~~~[0m
 
   [96mfile1.ts[0m:[93m3[0m:[93m9[0m - 'duplicate1' was also declared here.
     [7m3[0m         duplicate1: () => string;
@@ -36,8 +36,8 @@
 
 [96mfile2.ts[0m:[93m5[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate2'.
 
-[7m 5[0m         duplicate2(): number;
-[7m  [0m [91m        ~~~~~~~~~~[0m
+[7m5[0m         duplicate2(): number;
+[7m [0m [91m        ~~~~~~~~~~[0m
 
   [96mfile1.ts[0m:[93m4[0m:[93m9[0m - 'duplicate2' was also declared here.
     [7m4[0m         duplicate2: () => string;
@@ -45,8 +45,8 @@
 
 [96mfile2.ts[0m:[93m6[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate3'.
 
-[7m 6[0m         duplicate3(): number;
-[7m  [0m [91m        ~~~~~~~~~~[0m
+[7m6[0m         duplicate3(): number;
+[7m [0m [91m        ~~~~~~~~~~[0m
 
   [96mfile1.ts[0m:[93m5[0m:[93m9[0m - 'duplicate3' was also declared here.
     [7m5[0m         duplicate3: () => string;

--- a/testdata/baselines/reference/submodule/compiler/duplicateIdentifierRelatedSpans5.errors.txt.diff
+++ b/testdata/baselines/reference/submodule/compiler/duplicateIdentifierRelatedSpans5.errors.txt.diff
@@ -5,12 +5,10 @@
  [7m [0m [91m        ~~~~~~~~~~[0m
  
 -  [96mfile2.ts[0m:[93m4[0m:[93m9[0m
--    [7m4[0m         duplicate1(): number;
--    [7m [0m [96m        ~~~~~~~~~~[0m
--    'duplicate1' was also declared here.
 +  [96mfile2.ts[0m:[93m4[0m:[93m9[0m - 'duplicate1' was also declared here.
-+    [7m 4[0m         duplicate1(): number;
-+    [7m  [0m [96m        ~~~~~~~~~~[0m
+     [7m4[0m         duplicate1(): number;
+     [7m [0m [96m        ~~~~~~~~~~[0m
+-    'duplicate1' was also declared here.
 +
  [96mfile1.ts[0m:[93m4[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate2'.
  
@@ -18,12 +16,10 @@
  [7m [0m [91m        ~~~~~~~~~~[0m
  
 -  [96mfile2.ts[0m:[93m5[0m:[93m9[0m
--    [7m5[0m         duplicate2(): number;
--    [7m [0m [96m        ~~~~~~~~~~[0m
--    'duplicate2' was also declared here.
 +  [96mfile2.ts[0m:[93m5[0m:[93m9[0m - 'duplicate2' was also declared here.
-+    [7m 5[0m         duplicate2(): number;
-+    [7m  [0m [96m        ~~~~~~~~~~[0m
+     [7m5[0m         duplicate2(): number;
+     [7m [0m [96m        ~~~~~~~~~~[0m
+-    'duplicate2' was also declared here.
 +
  [96mfile1.ts[0m:[93m5[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate3'.
  
@@ -31,19 +27,15 @@
  [7m [0m [91m        ~~~~~~~~~~[0m
  
 -  [96mfile2.ts[0m:[93m6[0m:[93m9[0m
--    [7m6[0m         duplicate3(): number;
--    [7m [0m [96m        ~~~~~~~~~~[0m
--    'duplicate3' was also declared here.
 +  [96mfile2.ts[0m:[93m6[0m:[93m9[0m - 'duplicate3' was also declared here.
-+    [7m 6[0m         duplicate3(): number;
-+    [7m  [0m [96m        ~~~~~~~~~~[0m
+     [7m6[0m         duplicate3(): number;
+     [7m [0m [96m        ~~~~~~~~~~[0m
+-    'duplicate3' was also declared here.
 +
  [96mfile2.ts[0m:[93m4[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate1'.
  
--[7m4[0m         duplicate1(): number;
--[7m [0m [91m        ~~~~~~~~~~[0m
-+[7m 4[0m         duplicate1(): number;
-+[7m  [0m [91m        ~~~~~~~~~~[0m
+ [7m4[0m         duplicate1(): number;
+ [7m [0m [91m        ~~~~~~~~~~[0m
  
 -  [96mfile1.ts[0m:[93m3[0m:[93m9[0m
 +  [96mfile1.ts[0m:[93m3[0m:[93m9[0m - 'duplicate1' was also declared here.
@@ -53,10 +45,8 @@
 +
  [96mfile2.ts[0m:[93m5[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate2'.
  
--[7m5[0m         duplicate2(): number;
--[7m [0m [91m        ~~~~~~~~~~[0m
-+[7m 5[0m         duplicate2(): number;
-+[7m  [0m [91m        ~~~~~~~~~~[0m
+ [7m5[0m         duplicate2(): number;
+ [7m [0m [91m        ~~~~~~~~~~[0m
  
 -  [96mfile1.ts[0m:[93m4[0m:[93m9[0m
 +  [96mfile1.ts[0m:[93m4[0m:[93m9[0m - 'duplicate2' was also declared here.
@@ -66,10 +56,8 @@
 +
  [96mfile2.ts[0m:[93m6[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate3'.
  
--[7m6[0m         duplicate3(): number;
--[7m [0m [91m        ~~~~~~~~~~[0m
-+[7m 6[0m         duplicate3(): number;
-+[7m  [0m [91m        ~~~~~~~~~~[0m
+ [7m6[0m         duplicate3(): number;
+ [7m [0m [91m        ~~~~~~~~~~[0m
  
 -  [96mfile1.ts[0m:[93m5[0m:[93m9[0m
 +  [96mfile1.ts[0m:[93m5[0m:[93m9[0m - 'duplicate3' was also declared here.

--- a/testdata/baselines/reference/submodule/compiler/duplicateIdentifierRelatedSpans6.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/duplicateIdentifierRelatedSpans6.errors.txt
@@ -1,7 +1,7 @@
 [96mfile2.ts[0m:[93m3[0m:[93m16[0m - [91merror[0m[90m TS2664: [0mInvalid module name in augmentation, module 'someMod' cannot be found.
 
-[7m 3[0m declare module "someMod" {
-[7m  [0m [91m               ~~~~~~~~~[0m
+[7m3[0m declare module "someMod" {
+[7m [0m [91m               ~~~~~~~~~[0m
 
 
 ==== file2.ts (1 errors) ====

--- a/testdata/baselines/reference/submodule/compiler/duplicateIdentifierRelatedSpans6.errors.txt.diff
+++ b/testdata/baselines/reference/submodule/compiler/duplicateIdentifierRelatedSpans6.errors.txt.diff
@@ -6,8 +6,8 @@
  
 -[7m3[0m         duplicate1: () => string;
 -[7m [0m [91m        ~~~~~~~~~~[0m
-+[7m 3[0m declare module "someMod" {
-+[7m  [0m [91m               ~~~~~~~~~[0m
++[7m3[0m declare module "someMod" {
++[7m [0m [91m               ~~~~~~~~~[0m
  
 -  [96mfile2.ts[0m:[93m5[0m:[93m9[0m
 -    [7m5[0m         duplicate1(): number;

--- a/testdata/baselines/reference/submodule/compiler/duplicateIdentifierRelatedSpans7.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/duplicateIdentifierRelatedSpans7.errors.txt
@@ -1,7 +1,7 @@
 [96mfile2.ts[0m:[93m3[0m:[93m16[0m - [91merror[0m[90m TS2664: [0mInvalid module name in augmentation, module 'someMod' cannot be found.
 
-[7m 3[0m declare module "someMod" {
-[7m  [0m [91m               ~~~~~~~~~[0m
+[7m3[0m declare module "someMod" {
+[7m [0m [91m               ~~~~~~~~~[0m
 
 
 ==== file2.ts (1 errors) ====

--- a/testdata/baselines/reference/submodule/compiler/duplicateIdentifierRelatedSpans7.errors.txt.diff
+++ b/testdata/baselines/reference/submodule/compiler/duplicateIdentifierRelatedSpans7.errors.txt.diff
@@ -6,23 +6,22 @@
  
 -[7m1[0m declare module "someMod" {
 -[7m [0m [91m~~~~~~~[0m
-+[7m 3[0m declare module "someMod" {
-+[7m  [0m [91m               ~~~~~~~~~[0m
- 
+-
 -  [96mfile2.ts[0m:[93m3[0m:[93m1[0m
 -    [7m3[0m declare module "someMod" {
 -    [7m [0m [96m~~~~~~~[0m
 -    Conflicts are in this file.
 -[96mfile2.ts[0m:[93m3[0m:[93m1[0m - [91merror[0m[90m TS6200: [0mDefinitions of the following identifiers conflict with those in another file: duplicate1, duplicate2, duplicate3, duplicate4, duplicate5, duplicate6, duplicate7, duplicate8, duplicate9
- 
--[7m3[0m declare module "someMod" {
--[7m [0m [91m~~~~~~~[0m
 -
+ [7m3[0m declare module "someMod" {
+-[7m [0m [91m~~~~~~~[0m
++[7m [0m [91m               ~~~~~~~~~[0m
+ 
 -  [96mfile1.ts[0m:[93m1[0m:[93m1[0m
 -    [7m1[0m declare module "someMod" {
 -    [7m [0m [96m~~~~~~~[0m
 -    Conflicts are in this file.
--
+ 
 -
  ==== file2.ts (1 errors) ====
      /// <reference path="./file1" />


### PR DESCRIPTION
tsc 5.8.2:

![tsc](https://github.com/user-attachments/assets/07f31001-df4d-494d-b090-1ca15ae5eee5)

Before:

![before](https://github.com/user-attachments/assets/d61ca32e-9f73-45e8-96e3-d2325b1a4e0a)

After:

![after](https://github.com/user-attachments/assets/f6b8a1d4-a74d-4722-a651-92b97e62d9cf)
