### PR TITLE
Recognize identifier reference in template literal

### DIFF
--- a/internal/transformers/commonjsmodule_test.go
+++ b/internal/transformers/commonjsmodule_test.go
@@ -970,6 +970,17 @@ const isNotOverloadAndNotAccessor = (0, ts_js_1.and)(isNotOverload, isNotAccesso
 		},
 
 		{
+			title: "Identifier#6 (in template literal)",
+			input: `export var x = 1;
+` + "`" + `${x}` + "`" + `;`,
+			output: `"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.x = void 0;
+exports.x = 1;
+` + "`" + `${exports.x}` + "`" + `;`,
+		},
+
+		{
 			title: "Other",
 			input: `export const a = class {
     p = 10;

--- a/internal/transformers/runtimesyntax_test.go
+++ b/internal/transformers/runtimesyntax_test.go
@@ -383,6 +383,15 @@ func TestNamespaceTransformer(t *testing.T) {
 (function (N) {
     ({ x: N.x } = { x: 1 });
 })(N || (N = {}));`},
+
+		{title: "identifier reference in template", input: `namespace N {
+    export var x = 1;
+    ` + "`" + `${x}` + "`" + `
+}`, output: `var N;
+(function (N) {
+    N.x = 1;
+    ` + "`" + `${N.x}` + "`" + `;
+})(N || (N = {}));`},
 	}
 
 	for _, rec := range data {

--- a/internal/transformers/utilities.go
+++ b/internal/transformers/utilities.go
@@ -157,7 +157,8 @@ func isIdentifierReference(name *ast.IdentifierNode, parent *ast.Node) bool {
 		ast.KindThrowStatement,
 		ast.KindExpressionStatement,
 		ast.KindExportAssignment,
-		ast.KindPropertyAccessExpression:
+		ast.KindPropertyAccessExpression,
+		ast.KindTemplateSpan:
 		// only an `Expression()` child that can be `Identifier` would be an instance of `IdentifierReference`
 		return parent.Expression() == name
 	case ast.KindVariableDeclaration,


### PR DESCRIPTION
This amends `isIdentifierReference` to recognize identifiers whose parent is a `TemplateSpan`.