### PR TITLE
Fix a couple of small wasm issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,7 @@ dist
 *.dll
 *.so
 *.dylib
+*.wasm
 
 # Test binary, built with `go test -c`
 *.test

--- a/internal/vfs/osvfs/os.go
+++ b/internal/vfs/osvfs/os.go
@@ -36,6 +36,11 @@ var isFileSystemCaseSensitive = func() bool {
 		return false
 	}
 
+	if runtime.GOARCH == "wasm" {
+		// !!! Who knows; this depends on the host implementation.
+		return true
+	}
+
 	// As a proxy for case-insensitivity, we check if the current executable exists under a different case.
 	// This is not entirely correct, since different OSs can have differing case sensitivity in different paths,
 	// but this is largely good enough for our purposes (and what sys.ts used to do with __filename).


### PR DESCRIPTION
On wasm, we can't get the current executable, so the FS will fail for WASI. Just assume case sensitive on `GOARCH=wasm` for now.

That and gitignore `*.wasm` files like we do `*.exe`.