### PR TITLE
Align LabeledStatement emit with Strada

### DIFF
--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -3157,7 +3157,15 @@ func (p *Printer) emitLabeledStatement(node *ast.LabeledStatement) {
 	p.enterNode(node.AsNode())
 	p.emitLabelIdentifier(node.Label.AsIdentifier())
 	p.emitTokenWithComment(ast.KindColonToken, node.Label.End(), WriteKindPunctuation, node.AsNode())
-	p.emitEmbeddedStatement(node.AsNode(), node.Statement)
+
+	// TODO: use emitEmbeddedStatement rather than writeSpace/emitStatement here after Strada migration as it is
+	//       more consistent with similar emit elsewhere. writeSpace/emitStatement is used here to reduce spurious
+	//       diffs when testing the Strada migration.
+	////p.emitEmbeddedStatement(node.AsNode(), node.Statement)
+
+	p.writeSpace()
+	p.emitStatement(node.Statement)
+
 	p.exitNode(node.AsNode())
 }
 

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -211,7 +211,7 @@ func TestEmit(t *testing.T) {
 		{title: "CaseClause#2", input: `switch (a) {case b:;}`, output: "switch (a) {\n    case b: ;\n}"},
 		{title: "DefaultClause#1", input: `switch (a) {default:}`, output: "switch (a) {\n    default:\n}"},
 		{title: "DefaultClause#2", input: `switch (a) {default:;}`, output: "switch (a) {\n    default: ;\n}"},
-		{title: "LabeledStatement", input: `a:;`, output: "a:\n    ;"},
+		{title: "LabeledStatement", input: `a:;`, output: "a: ;"},
 		{title: "ThrowStatement", input: `throw a`, output: "throw a;"},
 		{title: "TryStatement#1", input: `try {} catch {}`, output: "try { }\ncatch { }"},
 		{title: "TryStatement#2", input: `try {} finally {}`, output: "try { }\nfinally { }"},


### PR DESCRIPTION
Strada doesn't currently use `emitEmbeddedStatemen` for `LabeledStatement`, though that would be more consistent with similar statements (`if`, `do`, `while`, etc.). This PR aligns our emit with Strada to reduce spurious diffs in future emit baselines.