### PR TITLE
Preserve trailing comma when rewriting shorthand assignment

### DIFF
--- a/internal/transformers/commonjsmodule.go
+++ b/internal/transformers/commonjsmodule.go
@@ -1880,6 +1880,7 @@ func (tx *CommonJSModuleTransformer) visitShorthandPropertyAssignment(node *ast.
 			)
 		}
 		assignment := tx.factory.NewPropertyAssignment(nil /*modifiers*/, name, nil /*postfixToken*/, expression)
+		assignment.Loc = node.Loc
 		tx.emitContext.AssignCommentAndSourceMapRanges(assignment, node.AsNode())
 		return assignment
 	}

--- a/internal/transformers/commonjsmodule_test.go
+++ b/internal/transformers/commonjsmodule_test.go
@@ -810,6 +810,19 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const other_1 = require("other");
 ({ a: other_1.a });`,
 		},
+		{
+			title: "ShorthandPropertyAssignment#2",
+			input: `import { a } from "other"
+({
+    a,
+})`,
+			output: `"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const other_1 = require("other");
+({
+    a: other_1.a,
+});`,
+		},
 
 		// CallExpression
 		{


### PR DESCRIPTION
This properly sets `.Loc` when transforming a shorthand property assignment during the CJS module transform.