### PR TITLE
Ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,6 @@ custom-gcl.exe
 custom-gcl.hash
 
 /built
+
+# macOS Finder metadata
+.DS_Store


### PR DESCRIPTION
macOS generates .DS_Store to store Finder metadata, and that should be ignored. 