### PR TITLE
Refactor to use go mod tidy -diff in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,11 +154,8 @@ jobs:
         with:
           cache-name: tidy
 
-      - run: go mod tidy
-      - run: go -C ./_tools mod tidy
-
-      - run: git add .
-      - run: git diff --staged --exit-code --stat
+      - run: go mod tidy -diff
+      - run: go -C ./_tools mod tidy -diff
 
   smoke:
     runs-on: ubuntu-latest


### PR DESCRIPTION
From Go 1.23, the diff flag was added to go mod tidy, which exits with a non-zero status if there are differences.
I refactored the GitHub Actions workflow to use `go mod tidy -diff`.

cf. [Go 1.23 Release Notes - The Go Programming Language](https://tip.golang.org/doc/go1.23#go-command)
> The new go mod tidy -diff flag causes the command not to modify the files but instead print the necessary changes as a unified diff. It exits with a non-zero code if updates are needed.