### PR TITLE
Align error for invalid enum option with strada

### DIFF
--- a/internal/tsoptions/tsconfigparsing.go
+++ b/internal/tsoptions/tsconfigparsing.go
@@ -394,6 +394,9 @@ func convertJsonOption(
 			return normalizeNonListOptionValue(opt, basePath, validatedValue), errors
 		}
 	} else {
+		if opt.Kind == CommandLineOptionTypeEnum {
+			return nil, []*ast.Diagnostic{createDiagnosticForInvalidEnumType(opt, sourceFile, valueExpression)}
+		}
 		return nil, []*ast.Diagnostic{createDiagnosticForNodeInSourceFileOrCompilerDiagnostic(sourceFile, valueExpression, diagnostics.Compiler_option_0_requires_a_value_of_type_1, opt.Name, getCompilerOptionValueTypeString(opt))}
 	}
 }


### PR DESCRIPTION
If we provide a invalid value to an `enum` option, `tsc` will report a `TS6046` error and `tsgo` will report a `TS5024` error. This PR aligns the `tsgo` with `tsc`.

tsc Version 5.8.2:

![tsc](https://github.com/user-attachments/assets/3dd8756c-8e10-4bc7-9427-bcd9cec5eb4c)

Before:

![before](https://github.com/user-attachments/assets/a0e11d26-9fa9-42b6-baba-1c6a3eb6bf6d)

After:

![after](https://github.com/user-attachments/assets/03347738-3ceb-42f1-a7e3-d5208245f05a)
