### PR TITLE
docs: Add missing @returns tag to goBuildTags JSDoc

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -44,7 +44,7 @@ const defaultGoBuildTags = [
 
 /**
  * @param  {...string} extra
- * @returns
+ * @returns {string[]}
  */
 function goBuildTags(...extra) {
     const tags = new Set(defaultGoBuildTags.concat(extra));


### PR DESCRIPTION
This PR improves the JSDoc comment for the `goBuildTags()` function by adding a missing `@returns {string[]}` tag.

### Why this matters:
- Helps IDEs provide better autocomplete and type inference.
- Improves developer experience, especially when using `// @ts-check`.
- Enhances documentation clarity for future contributors.
