### PR TITLE
Re-introduce preemptive caching of CouldContainTypeVariables

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -20451,7 +20451,7 @@ func (c *Checker) getObjectTypeInstantiation(t *Type, m *TypeMapper, alias *Type
 			result = c.instantiateAnonymousType(target, newMapper, newAlias)
 		}
 		data.instantiations[key] = result
-		if (result.flags&TypeFlagsObjectFlagsType != 0) && (result.objectFlags&ObjectFlagsCouldContainTypeVariablesComputed == 0) {
+		if result.flags&TypeFlagsObjectFlagsType != 0 && result.objectFlags&ObjectFlagsCouldContainTypeVariablesComputed == 0 {
 			// if `result` is one of the object types we tried to make (it may not be, due to how `instantiateMappedType` works), we can carry forward the type variable containment check from the input type arguments
 			resultCouldContainObjectFlags := core.Some(typeArguments, c.couldContainTypeVariables)
 			if result.objectFlags&ObjectFlagsCouldContainTypeVariablesComputed == 0 {

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -20451,6 +20451,20 @@ func (c *Checker) getObjectTypeInstantiation(t *Type, m *TypeMapper, alias *Type
 			result = c.instantiateAnonymousType(target, newMapper, newAlias)
 		}
 		data.instantiations[key] = result
+		if (result.flags&TypeFlagsObjectFlagsType != 0) && (result.objectFlags&ObjectFlagsCouldContainTypeVariablesComputed == 0) {
+			// if `result` is one of the object types we tried to make (it may not be, due to how `instantiateMappedType` works), we can carry forward the type variable containment check from the input type arguments
+			resultCouldContainObjectFlags := core.Some(typeArguments, c.couldContainTypeVariables)
+			if result.objectFlags&ObjectFlagsCouldContainTypeVariablesComputed == 0 {
+				if result.objectFlags&(ObjectFlagsMapped|ObjectFlagsAnonymous|ObjectFlagsReference) != 0 {
+					result.objectFlags |= ObjectFlagsCouldContainTypeVariablesComputed | core.IfElse(resultCouldContainObjectFlags, ObjectFlagsCouldContainTypeVariables, 0)
+				} else {
+					// If none of the type arguments for the outer type parameters contain type variables, it follows
+					// that the instantiated type doesn't reference type variables.
+					// Intrinsics have `CouldContainTypeVariablesComputed` pre-set, so this should only cover unions and intersections resulting from `instantiateMappedType`
+					result.objectFlags |= core.IfElse(!resultCouldContainObjectFlags, ObjectFlagsCouldContainTypeVariablesComputed, 0)
+				}
+			}
+		}
 	}
 	return result
 }


### PR DESCRIPTION
Addresses #609 

## Summary

The base Typescript implementation of `getObjectTypeInstantiation` includes a mechanism to preemptively cache `CouldContainTypeVariable` when it instantiates a type that it knows can have no type variables. 

The golang implementation is currently missing this optimization, which can trigger different control flow and a higher number of calls to `instantiateAliasedType` than `tsc`, which in turn leads to differing behavior with regard to instantiation depth restrictions.

This PR reintroduces this logic into the golang codebase.

## Reference

The original Typescript can be found [here](https://github.com/microsoft/TypeScript/blob/52c59dbcbee274e523ef39e6c8be1bd5e110c2f1/src/compiler/checker.ts#L20375)

For simplicity, the relevant code is this:

```ts
const resultObjectFlags = getObjectFlags(result);
if (result.flags & TypeFlags.ObjectFlagsType && !(resultObjectFlags & ObjectFlags.CouldContainTypeVariablesComputed)) {
    const resultCouldContainTypeVariables = some(typeArguments, couldContainTypeVariables); // one of the input type arguments might be or contain the result
    if (!(getObjectFlags(result) & ObjectFlags.CouldContainTypeVariablesComputed)) {
        // if `result` is one of the object types we tried to make (it may not be, due to how `instantiateMappedType` works), we can carry forward the type variable containment check from the input type arguments
        if (resultObjectFlags & (ObjectFlags.Mapped | ObjectFlags.Anonymous | ObjectFlags.Reference)) {
            (result as ObjectFlagsType).objectFlags |= ObjectFlags.CouldContainTypeVariablesComputed | (resultCouldContainTypeVariables ? ObjectFlags.CouldContainTypeVariables : 0);
        }
        // If none of the type arguments for the outer type parameters contain type variables, it follows
        // that the instantiated type doesn't reference type variables.
        // Intrinsics have `CouldContainTypeVariablesComputed` pre-set, so this should only cover unions and intersections resulting from `instantiateMappedType`
        else {
            (result as ObjectFlagsType).objectFlags |= !resultCouldContainTypeVariables ? ObjectFlags.CouldContainTypeVariablesComputed : 0;
        }
    }
}
```