### PR TITLE
Use homedir for realpath test

### DIFF
--- a/internal/vfs/osvfs/os_test.go
+++ b/internal/vfs/osvfs/os_test.go
@@ -18,11 +18,11 @@ func TestOS(t *testing.T) {
 
 	fs := osvfs.FS()
 
-	goMod := filepath.Join(repo.RootPath, "go.mod")
-	goModPath := tspath.NormalizePath(goMod)
-
 	t.Run("ReadFile", func(t *testing.T) {
 		t.Parallel()
+
+		goMod := filepath.Join(repo.RootPath, "go.mod")
+		goModPath := tspath.NormalizePath(goMod)
 
 		expectedRaw, err := os.ReadFile(goMod)
 		assert.NilError(t, err)

--- a/internal/vfs/osvfs/os_test.go
+++ b/internal/vfs/osvfs/os_test.go
@@ -36,12 +36,18 @@ func TestOS(t *testing.T) {
 	t.Run("Realpath", func(t *testing.T) {
 		t.Parallel()
 
-		expected := goModPath
+		home, err := os.UserHomeDir()
+		if err != nil {
+			t.Skip(err)
+		}
+		home = tspath.NormalizePath(home)
+
+		expected := home
 		if runtime.GOOS == "windows" {
 			// Windows drive letters can be lowercase, but realpath will always return uppercase.
 			expected = strings.ToUpper(expected[:1]) + expected[1:]
 		}
-		realpath := fs.Realpath(goModPath)
+		realpath := fs.Realpath(home)
 		assert.Equal(t, realpath, expected)
 	})
 


### PR DESCRIPTION
Fixes #493

All I need is some path that isn't going to be a symlink. It seems very unlikely that someone will have symlinked their homedir itself.