### PR TITLE
Replace deprecated tenv with usetesting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,11 +36,11 @@ linters:
     - perfsprint
     - predeclared
     - reassign
-    - tenv
     - testableexamples
     - tparallel
     - unconvert
     - usestdlibvars
+    - usetesting
     - whitespace
 
     - customlint


### PR DESCRIPTION
Since tenv has been deprecated since golangci-lint v1.64.0, I have replaced it with usetesting.

```
$ hereby lint
> WARN The linter 'tenv' is deprecated (since v1.64.0) due to: Duplicate feature in another linter. Replaced by usetesting. 
```

 ### Appendix
- [golangci-lint - tenv](https://golangci-lint.run/usage/linters/#tenv)
- [golangci-lint - usetesting](https://golangci-lint.run/usage/linters/#usetesting)