### PR TITLE
Remove unnecessary configurations from .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -64,10 +64,6 @@ linters-settings:
     customlint:
       type: module
 
-  wrapcheck:
-    ignorePackageGlobs:
-      - encoding/*
-      - github.com/go-json-experiment/*
 #   revive:
 #     enable-all-rules: true
 #     rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,3 +73,8 @@ linters-settings:
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
+
+  exclude:
+    - '^could not import'
+    - '^: #'
+    - 'imported and not used$'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,8 +73,3 @@ linters-settings:
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
-
-  exclude:
-    - '^could not import'
-    - '^: #'
-    - 'imported and not used$'


### PR DESCRIPTION
The configuration for wrapcheck was left behind even though it was disabled, so I have removed it.

### Appendix
- [Add FS wrapper to correctly emulate case insensitivity in testing #112](https://github.com/microsoft/typescript-go/pull/112)
  - The PR disabled wrapcheck.