### PR TITLE
Pass the 'handles escaped characters in strings correctly' test case

### DIFF
--- a/internal/tsoptions/tsconfigparsing_test.go
+++ b/internal/tsoptions/tsconfigparsing_test.go
@@ -88,25 +88,21 @@ var parseConfigFileTextToJsonTests = []struct {
         }`,
 		},
 	},
-	// { todo: fix this test
-	// 	title: "handles escaped characters in strings correctly",
-	// 	input: []string{
-	// 		`{
-	// 			"exclude": [
-	// 				"xx\\"//files"
-	// 			]
-	// 		}`,
-	// 		`{
-	// 			"exclude": [
-	// 				"xx\\\\" // end of line comment
-	// 			]
-	// 		}`,
-	// 	},
-	// 	output: []map[string]any{
-	// 		{"exclude": []string{"xx\"//files"}},
-	// 		{"exclude": []string{"xx\\"}},
-	// 	},
-	// },
+	{
+		title: "handles escaped characters in strings correctly",
+		input: []string{
+			`{
+            "exclude": [
+                "xx\"//files"
+            ]
+        }`,
+			`{
+            "exclude": [
+                "xx\\" // end of line comment
+            ]
+        }`,
+		},
+	},
 	{
 		title: "returns object when users correctly specify library",
 		input: []string{


### PR DESCRIPTION
I modified the test code to pass the test case for "handles escaped characters in strings correctly."

## Appendix
- [typescript-go / Tsconfig parsing implementation #207](https://github.com/microsoft/typescript-go/pull/207)
- [TypeScript / handles escaped characters in strings correctly jsonParse.js](https://github.com/microsoft/TypeScript/blob/52c59dbcbee274e523ef39e6c8be1bd5e110c2f1/tests/baselines/reference/config/tsconfigParsing/handles%20escaped%20characters%20in%20strings%20correctly%20jsonParse.js)