### PR TITLE
Refactor: Consolidate type mapping functions for improved maintainabi…

### DIFF
--- a/internal/checker/mapper.go
+++ b/internal/checker/mapper.go
@@ -53,17 +53,22 @@ func mergeTypeMappers(m1 *TypeMapper, m2 *TypeMapper) *TypeMapper {
 }
 
 func prependTypeMapping(source *Type, target *Type, mapper *TypeMapper) *TypeMapper {
-	if mapper == nil {
-		return newSimpleTypeMapper(source, target)
-	}
-	return newMergedTypeMapper(newSimpleTypeMapper(source, target), mapper)
+	return mergeTypeMapping(mapper, source, target, true)
 }
 
 func appendTypeMapping(mapper *TypeMapper, source *Type, target *Type) *TypeMapper {
+	return mergeTypeMapping(mapper, source, target, false)
+}
+
+func mergeTypeMapping(mapper *TypeMapper, source *Type, target *Type, prepend bool) *TypeMapper {
+	newMapper := newSimpleTypeMapper(source, target)
 	if mapper == nil {
-		return newSimpleTypeMapper(source, target)
+		return newMapper
 	}
-	return newMergedTypeMapper(mapper, newSimpleTypeMapper(source, target))
+	if prepend {
+		return newMergedTypeMapper(newMapper, mapper)
+	}
+	return newMergedTypeMapper(mapper, newMapper)
 }
 
 // Maps forward-references to later types parameters to the empty object type.

--- a/internal/checker/printer.go
+++ b/internal/checker/printer.go
@@ -61,10 +61,10 @@ func (c *Checker) symbolToString(s *ast.Symbol) string {
 }
 
 func (c *Checker) TypeToString(t *Type) string {
-	return c.typeToStringEx(t, nil, TypeFormatFlagsNone)
+	return c.typeToStringEx(t, TypeFormatFlagsNone)
 }
 
-func (c *Checker) typeToStringEx(t *Type, enclosingDeclaration *ast.Node, flags TypeFormatFlags) string {
+func (c *Checker) typeToStringEx(t *Type, flags TypeFormatFlags) string {
 	p := c.newPrinter(flags)
 	p.printType(t)
 	return p.string()


### PR DESCRIPTION
### Refactor: Consolidate type mapping functions for improved maintainability

#### Summary:
This PR introduces a refactor to eliminate redundant logic in `prependTypeMapping` and `appendTypeMapping` by introducing a new helper function, `mergeTypeMapping`. 

#### Changes:
- Created `mergeTypeMapping` to handle both prepend and append operations using a boolean flag.
- Removed duplicate logic in `prependTypeMapping` and `appendTypeMapping`.
- Improved code readability, maintainability, and reusability.

#### Why this change?
- Reduces duplication and makes future modifications easier.
- Keeps the logic centralized in a single function, avoiding inconsistencies.
- Improves overall code clarity without altering functionality.

#### Testing:
- Verified that `prependTypeMapping` and `appendTypeMapping` maintain the expected behavior.
- Ensured the existing tests pass successfully.

