### PR TITLE
Reduce binary size using trimpath and ldflags

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -54,7 +54,7 @@ function goBuildTags(...extra) {
 const goBuildFlags = [
     ...(options.race ? ["-race"] : []),
     // https://github.com/go-delve/delve/blob/62cd2d423c6a85991e49d6a70cc5cb3e97d6ceef/Documentation/usage/dlv_exec.md?plain=1#L12
-    ...(options.debug ? ["-gcflags=all=-N -l"] : []),
+    ...(options.debug ? ["-gcflags=all=-N -l"] : ["-trimpath", "-ldflags=-s -w"]),
 ];
 
 /**


### PR DESCRIPTION
Reduce binary size 16M to 11M.
I used ldflags to exclude debug information and trimpath to prevent build environment filesystem information from being included in the binary.

### Appendix

- [cmd/link - flags](https://pkg.go.dev/cmd/link)
> -s Omit the symbol table and debug information.
-w Omit the DWARF symbol table.

- [Compile packages and dependencies - build flags](https://pkg.go.dev/cmd/go#hdr-Compile_packages_and_dependencies)
> -trimpath remove all file system paths from the resulting executable.
	Instead of absolute file system paths, the recorded file names
	will begin either a module path@version (when using modules),
	or a plain import path (when using the standard library, or GOPATH).


<details><summary> comparison.log</summary>

normal
```sh
# $ go clean -cache
$ time hereby build
> go build '-tags=noembed' -o ./built/local/ ./cmd/tsgo
> hereby build  58.73s user 6.03s system 212% cpu 30.459 total
$ du -h built/local/tsgo
> 16M built/local/tsgo
```
use trimpath and ldflags
```sh
# $ go clean -cache
$ time hereby build
> go build -trimpath '-ldflags=-s -w' '-tags=noembed' -o ./built/local/ ./cmd/tsgo
hereby build  57.08s user 6.01s system 215% cpu 29.322 total
$ du -h built/local/tsgo
> 11M built/local/tsgo
```

</details>