### PR TITLE
chore: change empty interface to using any predefine type

### DIFF
--- a/_tools/customlint/emptycase.go
+++ b/_tools/customlint/emptycase.go
@@ -19,7 +19,7 @@ var emptyCaseAnalyzer = &analysis.Analyzer{
 	},
 }
 
-func runEmptyCase(pass *analysis.Pass) (interface{}, error) {
+func runEmptyCase(pass *analysis.Pass) (any, error) {
 	inspect := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
 
 	nodeFilter := []ast.Node{

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -516,7 +516,7 @@ type Program interface {
 	GetResolvedModule(currentSourceFile *ast.SourceFile, moduleReference string) *ast.SourceFile
 }
 
-type Host interface{}
+type Host any
 
 // Checker
 

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -516,7 +516,7 @@ type Program interface {
 	GetResolvedModule(currentSourceFile *ast.SourceFile, moduleReference string) *ast.SourceFile
 }
 
-type Host any
+type Host interface{}
 
 // Checker
 

--- a/internal/project/service.go
+++ b/internal/project/service.go
@@ -540,7 +540,7 @@ func (s *Service) loadConfiguredProject(project *Project) {
 
 		s.logf("Config: %s : %s",
 			project.configFileName,
-			core.Must(core.StringifyJson(map[string]interface{}{
+			core.Must(core.StringifyJson(map[string]any{
 				"rootNames":         parsedCommandLine.FileNames(),
 				"options":           parsedCommandLine.CompilerOptions(),
 				"projectReferences": parsedCommandLine.ProjectReferences(),
@@ -608,6 +608,6 @@ func (s *Service) log(msg string) {
 	s.options.Logger.Info(msg)
 }
 
-func (s *Service) logf(format string, args ...interface{}) {
+func (s *Service) logf(format string, args ...any) {
 	s.log(fmt.Sprintf(format, args...))
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -11,7 +11,7 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func AssertPanics(tb testing.TB, fn func(), expected any, msgAndArgs ...interface{}) {
+func AssertPanics(tb testing.TB, fn func(), expected any, msgAndArgs ...any) {
 	tb.Helper()
 
 	var got any


### PR DESCRIPTION
Using predefined `any` for empty interface