### PR TITLE
perf: use append instead of Concat in appendLookupLocations

### DIFF
--- a/internal/compiler/module/cache.go
+++ b/internal/compiler/module/cache.go
@@ -1,7 +1,6 @@
 package module
 
 import (
-	"slices"
 	"strings"
 	"sync"
 
@@ -96,9 +95,9 @@ func (c *resolutionCache[T]) appendLookupLocations(resolved T, failedLookupLocat
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	lookupLocations := c.lookupLocations[resolved]
-	lookupLocations.FailedLookupLocations = slices.Concat(lookupLocations.FailedLookupLocations, failedLookupLocations)
-	lookupLocations.AffectingLocations = slices.Concat(lookupLocations.AffectingLocations, affectingLocations)
-	lookupLocations.ResolutionDiagnostics = slices.Concat(lookupLocations.ResolutionDiagnostics, resolutionDiagnostics)
+	lookupLocations.FailedLookupLocations = append(lookupLocations.FailedLookupLocations, failedLookupLocations...)
+	lookupLocations.AffectingLocations = append(lookupLocations.AffectingLocations, affectingLocations...)
+	lookupLocations.ResolutionDiagnostics = append(lookupLocations.ResolutionDiagnostics, resolutionDiagnostics...)
 }
 
 type perDirectoryResolutionCache[T any] struct {


### PR DESCRIPTION
This reduces alloc/GC churn as append in theory can expand a slice without having to copy the original. Loosely this appears to massively improve performance inside ResolveModuleName. In one example running the LSP locally it drops initialization time from ~90 seconds to ~20 seconds.

I believe this is still safe given the usage of mutex's, but also my understanding of go threading is not the best, so if this isn't safe lemme know. But it appears to be fine both locally and in the test suite.

**Before**
![image](https://github.com/user-attachments/assets/2c91e439-698b-4748-84cf-53976208e694)

**After**
![image](https://github.com/user-attachments/assets/b03f966e-3a15-43d7-b624-5e7957dd671a)
