### PR TITLE
Return errors instead of panics

### DIFF
--- a/internal/ls/definition.go
+++ b/internal/ls/definition.go
@@ -1,17 +1,22 @@
 package ls
 
 import (
+	"fmt"
 	"github.com/microsoft/typescript-go/internal/ast"
 	"github.com/microsoft/typescript-go/internal/astnav"
 	"github.com/microsoft/typescript-go/internal/core"
 	"github.com/microsoft/typescript-go/internal/scanner"
 )
 
-func (l *LanguageService) ProvideDefinitions(fileName string, position int) []Location {
-	program, file := l.getProgramAndFile(fileName)
+func (l *LanguageService) ProvideDefinitions(fileName string, position int) ([]Location, error) {
+	program, file, err := l.getProgramAndFile(fileName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get program and file: %w", err)
+	}
+
 	node := astnav.GetTouchingPropertyName(file, position)
 	if node.Kind == ast.KindSourceFile {
-		return nil
+		return nil, nil
 	}
 
 	checker := program.GetTypeChecker()
@@ -33,7 +38,7 @@ func (l *LanguageService) ProvideDefinitions(fileName string, position int) []Lo
 				Range:    core.NewTextRange(pos, loc.End()),
 			})
 		}
-		return locations
+		return locations, nil
 	}
-	return nil
+	return nil, nil
 }

--- a/internal/ls/diagnostics.go
+++ b/internal/ls/diagnostics.go
@@ -1,14 +1,18 @@
 package ls
 
 import (
+	"fmt"
 	"slices"
 
 	"github.com/microsoft/typescript-go/internal/ast"
 )
 
-func (l *LanguageService) GetDocumentDiagnostics(fileName string) []*ast.Diagnostic {
-	program, file := l.getProgramAndFile(fileName)
+func (l *LanguageService) GetDocumentDiagnostics(fileName string) ([]*ast.Diagnostic, error) {
+	program, file, err := l.getProgramAndFile(fileName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get program and file for diagnostics: %w", err)
+	}
 	syntaxDiagnostics := program.GetSyntacticDiagnostics(file)
 	semanticDiagnostics := program.GetSemanticDiagnostics(file)
-	return slices.Concat(syntaxDiagnostics, semanticDiagnostics)
+	return slices.Concat(syntaxDiagnostics, semanticDiagnostics), nil
 }

--- a/internal/ls/hover.go
+++ b/internal/ls/hover.go
@@ -1,23 +1,28 @@
 package ls
 
 import (
+	"fmt"
+
 	"github.com/microsoft/typescript-go/internal/ast"
 	"github.com/microsoft/typescript-go/internal/astnav"
 )
 
-func (l *LanguageService) ProvideHover(fileName string, position int) string {
-	program, file := l.getProgramAndFile(fileName)
+func (l *LanguageService) ProvideHover(fileName string, position int) (string, error) {
+	program, file, err := l.getProgramAndFile(fileName)
+	if err != nil {
+		return "", fmt.Errorf("failed to get program and file for hover: %w", err)
+	}
 	node := astnav.GetTouchingPropertyName(file, position)
 	if node.Kind == ast.KindSourceFile {
 		// Avoid giving quickInfo for the sourceFile as a whole.
-		return ""
+		return "", nil
 	}
 
 	checker := program.GetTypeChecker()
 	if symbol := checker.GetSymbolAtLocation(node); symbol != nil {
 		if t := checker.GetTypeOfSymbolAtLocation(symbol, node); t != nil {
-			return checker.TypeToString(t)
+			return checker.TypeToString(t), nil
 		}
 	}
-	return ""
+	return "", nil
 }

--- a/internal/ls/languageservice.go
+++ b/internal/ls/languageservice.go
@@ -1,6 +1,8 @@
 package ls
 
 import (
+	"fmt"
+
 	"github.com/microsoft/typescript-go/internal/ast"
 	"github.com/microsoft/typescript-go/internal/compiler"
 	"github.com/microsoft/typescript-go/internal/core"
@@ -55,11 +57,11 @@ func (l *LanguageService) GetProgram() *compiler.Program {
 	return l.host.GetProgram()
 }
 
-func (l *LanguageService) getProgramAndFile(fileName string) (*compiler.Program, *ast.SourceFile) {
+func (l *LanguageService) getProgramAndFile(fileName string) (*compiler.Program, *ast.SourceFile, error) {
 	program := l.GetProgram()
 	file := program.GetSourceFile(fileName)
 	if file == nil {
-		panic("file not found")
+		return nil, nil, fmt.Errorf("file not found")
 	}
-	return program, file
+	return program, file, nil
 }

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -303,7 +303,11 @@ func (s *Server) handleDidClose(req *lsproto.RequestMessage) error {
 func (s *Server) handleDocumentDiagnostic(req *lsproto.RequestMessage) error {
 	params := req.Params.(*lsproto.DocumentDiagnosticParams)
 	file, project := s.getFileAndProject(params.TextDocument.Uri)
-	diagnostics := project.LanguageService().GetDocumentDiagnostics(file.FileName())
+	diagnostics, err := project.LanguageService().GetDocumentDiagnostics(file.FileName())
+	if err != nil {
+		return s.sendError(req.ID, err)
+	}
+
 	lspDiagnostics := make([]lsproto.Diagnostic, len(diagnostics))
 	for i, diag := range diagnostics {
 		if lspDiagnostic, err := s.converters.toLspDiagnostic(diag); err != nil {
@@ -330,7 +334,11 @@ func (s *Server) handleHover(req *lsproto.RequestMessage) error {
 		return s.sendError(req.ID, err)
 	}
 
-	hoverText := project.LanguageService().ProvideHover(file.FileName(), pos)
+	hoverText, err := project.LanguageService().ProvideHover(file.FileName(), pos)
+	if err != nil {
+		return s.sendError(req.ID, err)
+	}
+
 	return s.sendResult(req.ID, &lsproto.Hover{
 		Contents: lsproto.MarkupContentOrMarkedStringOrMarkedStrings{
 			MarkupContent: &lsproto.MarkupContent{
@@ -349,7 +357,11 @@ func (s *Server) handleDefinition(req *lsproto.RequestMessage) error {
 		return s.sendError(req.ID, err)
 	}
 
-	locations := project.LanguageService().ProvideDefinitions(file.FileName(), pos)
+	locations, err := project.LanguageService().ProvideDefinitions(file.FileName(), pos)
+	if err != nil {
+		return s.sendError(req.ID, err)
+	}
+
 	lspLocations := make([]lsproto.Location, len(locations))
 	for i, loc := range locations {
 		if lspLocation, err := s.converters.toLspLocation(loc); err != nil {


### PR DESCRIPTION
tsgo heavily overuses panics, that can lead to the situations mentioned in #631:
```
The typescript-go-lsp server crashed 5 times in the last 3 minutes. The server will not be restarted. See the output for more information.
```

PR is intended to start moving the codebase towards more idiomatic error handling.
Atm, I've changed 2 panics and we probably need to agree on the approach: I can keep adding changes to this PR, but it'll be big and hard to follow, or I can create a separate PRs to keep them small and simple.