### PR TITLE
Fix shorthand property assignment type resolution

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -15014,7 +15014,7 @@ func (c *Checker) getTypeOfVariableOrParameterOrPropertyWorker(symbol *ast.Symbo
 	case ast.KindPropertyAssignment:
 		result = c.checkPropertyAssignment(declaration, CheckModeNormal)
 	case ast.KindShorthandPropertyAssignment:
-		result = c.checkExpressionForMutableLocation(declaration, CheckModeNormal)
+		result = c.checkExpressionForMutableLocation(declaration.Name(), CheckModeNormal)
 	case ast.KindMethodDeclaration:
 		result = c.checkObjectLiteralMethod(declaration, CheckModeNormal)
 	case ast.KindExportAssignment:


### PR DESCRIPTION
If you try to call `getTypeOfSymbol` on `foo` (shorthand property assignment), `error` type will be returned.

```typescript
const foo = 1

const res = { foo }
//            ^^^
```

---

On line 11973 in checker.ts, `declaration.name` (not just `declaration`) is passed to `checkExpressionForMutableLocation`

```typescript
    function getTypeOfVariableOrParameterOrPropertyWorker(symbol: Symbol): Type {
        // ...
        else if (isShorthandPropertyAssignment(declaration)) {
            type = tryGetTypeFromEffectiveTypeNode(declaration) || checkExpressionForMutableLocation(declaration.name, CheckMode.Normal);
        }
        // ...
    }
```