### PR TITLE
Deduplicate unchecked extensions on warning message

### DIFF
--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -161,7 +161,9 @@ func NewProgram(options ProgramOptions) *Program {
 	for _, file := range p.files {
 		extension := tspath.TryGetExtensionFromPath(file.FileName())
 		if extension == tspath.ExtensionTsx || slices.Contains(tspath.SupportedJSExtensionsFlat, extension) {
-			p.unsupportedExtensions = append(p.unsupportedExtensions, extension)
+			if !slices.Contains(p.unsupportedExtensions, extension) {
+				p.unsupportedExtensions = append(p.unsupportedExtensions, extension)
+			}
 		}
 	}
 

--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -161,9 +161,7 @@ func NewProgram(options ProgramOptions) *Program {
 	for _, file := range p.files {
 		extension := tspath.TryGetExtensionFromPath(file.FileName())
 		if extension == tspath.ExtensionTsx || slices.Contains(tspath.SupportedJSExtensionsFlat, extension) {
-			if !slices.Contains(p.unsupportedExtensions, extension) {
-				p.unsupportedExtensions = append(p.unsupportedExtensions, extension)
-			}
+			p.unsupportedExtensions = core.AppendIfUnique(p.unsupportedExtensions, extension)
 		}
 	}
 


### PR DESCRIPTION
Deduplicates unsupported extensions. Currently, running `tsgo` in a large project results in a massive warning message:

```
Warning: The project contains unsupported file types (.tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, .tsx, ..., .js, .mjs), which are currently not fully type-checked.
```

This makes the message shorter:

```
Warning: The project contains unsupported file types (.tsx, .js, .mjs), which are currently not fully type-checked.
```