### PR TITLE
Check JSDoc types

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -20903,8 +20903,21 @@ func (c *Checker) getTypeFromTypeNode(node *ast.Node) *Type {
 
 func (c *Checker) getTypeFromTypeNodeWorker(node *ast.Node) *Type {
 	switch node.Kind {
-	case ast.KindAnyKeyword:
+	case ast.KindAnyKeyword, ast.KindJSDocAllType:
 		return c.anyType
+	case ast.KindJSDocNonNullableType:
+		return c.getTypeFromTypeNode(node.AsJSDocNonNullableType().Type)
+	case ast.KindJSDocNullableType:
+		t := c.getTypeFromTypeNode(node.AsJSDocNullableType().Type)
+		if c.strictNullChecks {
+			return c.getNullableType(t, TypeFlagsNull)
+		} else {
+			return t
+		}
+	case ast.KindJSDocVariadicType:
+		return c.createArrayType(c.getTypeFromTypeNode(node.AsJSDocOptionalType().Type))
+	case ast.KindJSDocOptionalType:
+		return c.addOptionality(c.getTypeFromTypeNode(node.AsJSDocOptionalType().Type))
 	case ast.KindUnknownKeyword:
 		return c.unknownType
 	case ast.KindStringKeyword:

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -20915,7 +20915,7 @@ func (c *Checker) getTypeFromTypeNodeWorker(node *ast.Node) *Type {
 			return t
 		}
 	case ast.KindJSDocVariadicType:
-		return c.createArrayType(c.getTypeFromTypeNode(node.AsJSDocOptionalType().Type))
+		return c.createArrayType(c.getTypeFromTypeNode(node.AsJSDocVariadicType().Type))
 	case ast.KindJSDocOptionalType:
 		return c.addOptionality(c.getTypeFromTypeNode(node.AsJSDocOptionalType().Type))
 	case ast.KindUnknownKeyword:

--- a/testdata/baselines/reference/submodule/compiler/expressionWithJSDocTypeArguments.types
+++ b/testdata/baselines/reference/submodule/compiler/expressionWithJSDocTypeArguments.types
@@ -31,8 +31,8 @@ const HuhFoo = foo<string?>;
 > : any
 
 const NopeFoo = foo<?string>;
->NopeFoo : (x: any) => any
->foo<?string> : (x: any) => any
+>NopeFoo : (x: string | null) => string | null
+>foo<?string> : (x: string | null) => string | null
 >foo : <T>(x: T) => T
 
 const ComeOnFoo = foo<?string?>;
@@ -61,11 +61,11 @@ type THuhFoo = typeof foo<string?>;
 > : any
 
 type TNopeFoo = typeof foo<?string>;
->TNopeFoo : (x: any) => any
+>TNopeFoo : (x: string | null) => string | null
 >foo : <T>(x: T) => T
 
 type TComeOnFoo = typeof foo<?string?>;
->TComeOnFoo : (x: any) => any
+>TComeOnFoo : (x: string | null) => string | null
 >foo : <T>(x: T) => T
 >> : boolean
 > : any
@@ -88,8 +88,8 @@ const HuhBar = Bar<string?>;
 > : any
 
 const NopeBar = Bar<?string>;
->NopeBar : { new (x: any): Bar<any>; prototype: Bar<any>; }
->Bar<?string> : { new (x: any): Bar<any>; prototype: Bar<any>; }
+>NopeBar : { new (x: string | null): Bar<string | null>; prototype: Bar<any>; }
+>Bar<?string> : { new (x: string | null): Bar<string | null>; prototype: Bar<any>; }
 >Bar : typeof Bar
 
 const ComeOnBar = Bar<?string?>;
@@ -118,11 +118,11 @@ type THuhBar = typeof Bar<string?>;
 > : any
 
 type TNopeBar = typeof Bar<?string>;
->TNopeBar : { new (x: any): Bar<any>; prototype: Bar<any>; }
+>TNopeBar : { new (x: string | null): Bar<string | null>; prototype: Bar<any>; }
 >Bar : typeof Bar
 
 type TComeOnBar = typeof Bar<?string?>;
->TComeOnBar : { new (x: any): Bar<any>; prototype: Bar<any>; }
+>TComeOnBar : { new (x: string | null): Bar<string | null>; prototype: Bar<any>; }
 >Bar : typeof Bar
 >> : boolean
 > : any

--- a/testdata/baselines/reference/submodule/compiler/expressionWithJSDocTypeArguments.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/expressionWithJSDocTypeArguments.types.diff
@@ -17,10 +17,8 @@
 +> : any
  
  const NopeFoo = foo<?string>;
-->NopeFoo : (x: string | null) => string | null
-->foo<?string> : (x: string | null) => string | null
-+>NopeFoo : (x: any) => any
-+>foo<?string> : (x: any) => any
+ >NopeFoo : (x: string | null) => string | null
+@@= skipped -10, +16 lines =@@
  >foo : <T>(x: T) => T
  
  const ComeOnFoo = foo<?string?>;
@@ -54,12 +52,12 @@
  
  type TNopeFoo = typeof foo<?string>;
 ->TNopeFoo : typeof foo<string | null>
-+>TNopeFoo : (x: any) => any
++>TNopeFoo : (x: string | null) => string | null
  >foo : <T>(x: T) => T
  
  type TComeOnFoo = typeof foo<?string?>;
 ->TComeOnFoo : typeof foo<(string | null) | null>
-+>TComeOnFoo : (x: any) => any
++>TComeOnFoo : (x: string | null) => string | null
  >foo : <T>(x: T) => T
 +>> : boolean
 +> : any
@@ -67,7 +65,7 @@
  
  const WhatBar = Bar<?>;
  >WhatBar : { new (x: any): Bar<any>; prototype: Bar<any>; }
-@@= skipped -36, +57 lines =@@
+@@= skipped -26, +41 lines =@@
  >Bar : typeof Bar
  
  const HuhBar = Bar<string?>;
@@ -84,10 +82,8 @@
 +> : any
  
  const NopeBar = Bar<?string>;
-->NopeBar : { new (x: string | null): Bar<string | null>; prototype: Bar<any>; }
-->Bar<?string> : { new (x: string | null): Bar<string | null>; prototype: Bar<any>; }
-+>NopeBar : { new (x: any): Bar<any>; prototype: Bar<any>; }
-+>Bar<?string> : { new (x: any): Bar<any>; prototype: Bar<any>; }
+ >NopeBar : { new (x: string | null): Bar<string | null>; prototype: Bar<any>; }
+@@= skipped -10, +16 lines =@@
  >Bar : typeof Bar
  
  const ComeOnBar = Bar<?string?>;
@@ -121,12 +117,12 @@
  
  type TNopeBar = typeof Bar<?string>;
 ->TNopeBar : typeof Bar<string | null>
-+>TNopeBar : { new (x: any): Bar<any>; prototype: Bar<any>; }
++>TNopeBar : { new (x: string | null): Bar<string | null>; prototype: Bar<any>; }
  >Bar : typeof Bar
  
  type TComeOnBar = typeof Bar<?string?>;
 ->TComeOnBar : typeof Bar<(string | null) | null>
-+>TComeOnBar : { new (x: any): Bar<any>; prototype: Bar<any>; }
++>TComeOnBar : { new (x: string | null): Bar<string | null>; prototype: Bar<any>; }
  >Bar : typeof Bar
 +>> : boolean
 +> : any

--- a/testdata/baselines/reference/submodule/compiler/parseInvalidNonNullableTypes.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/parseInvalidNonNullableTypes.errors.txt
@@ -8,13 +8,14 @@ parseInvalidNonNullableTypes.ts(10,22): error TS7006: Parameter '(Missing)' impl
 parseInvalidNonNullableTypes.ts(10,22): error TS1005: ',' expected.
 parseInvalidNonNullableTypes.ts(15,22): error TS1144: '{' or ';' expected.
 parseInvalidNonNullableTypes.ts(15,24): error TS2872: This kind of expression is always truthy.
+parseInvalidNonNullableTypes.ts(16,16): error TS2355: A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.
 parseInvalidNonNullableTypes.ts(18,19): error TS1005: ',' expected.
 parseInvalidNonNullableTypes.ts(18,20): error TS1109: Expression expected.
 parseInvalidNonNullableTypes.ts(19,16): error TS1005: ',' expected.
 parseInvalidNonNullableTypes.ts(19,18): error TS1109: Expression expected.
 
 
-==== parseInvalidNonNullableTypes.ts (14 errors) ====
+==== parseInvalidNonNullableTypes.ts (15 errors) ====
     function f1(a: string): a is string! {
                                        ~
 !!! error TS1144: '{' or ';' expected.
@@ -53,6 +54,8 @@ parseInvalidNonNullableTypes.ts(19,18): error TS1109: Expression expected.
                            ~~
 !!! error TS2872: This kind of expression is always truthy.
     function f8(): !string {}
+                   ~~~~~~~
+!!! error TS2355: A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.
     
     const a = 1 as any!;
                       ~

--- a/testdata/baselines/reference/submodule/compiler/parseInvalidNonNullableTypes.errors.txt.diff
+++ b/testdata/baselines/reference/submodule/compiler/parseInvalidNonNullableTypes.errors.txt.diff
@@ -9,12 +9,6 @@
 -parseInvalidNonNullableTypes.ts(13,16): error TS17020: '!' at the start of a type is not valid TypeScript syntax. Did you mean to write 'number'?
 -parseInvalidNonNullableTypes.ts(15,16): error TS2355: A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.
 -parseInvalidNonNullableTypes.ts(15,16): error TS17019: '!' at the end of a type is not valid TypeScript syntax. Did you mean to write 'string'?
--parseInvalidNonNullableTypes.ts(16,16): error TS2355: A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.
--parseInvalidNonNullableTypes.ts(16,16): error TS17020: '!' at the start of a type is not valid TypeScript syntax. Did you mean to write 'string'?
--parseInvalidNonNullableTypes.ts(18,16): error TS17019: '!' at the end of a type is not valid TypeScript syntax. Did you mean to write 'any'?
--parseInvalidNonNullableTypes.ts(19,10): error TS17019: '!' at the end of a type is not valid TypeScript syntax. Did you mean to write 'number'?
--parseInvalidNonNullableTypes.ts(21,16): error TS17020: '!' at the start of a type is not valid TypeScript syntax. Did you mean to write 'any'?
--parseInvalidNonNullableTypes.ts(22,10): error TS17020: '!' at the start of a type is not valid TypeScript syntax. Did you mean to write 'number'?
 +parseInvalidNonNullableTypes.ts(1,36): error TS1144: '{' or ';' expected.
 +parseInvalidNonNullableTypes.ts(1,38): error TS2872: This kind of expression is always truthy.
 +parseInvalidNonNullableTypes.ts(2,12): error TS1005: ':' expected.
@@ -25,13 +19,20 @@
 +parseInvalidNonNullableTypes.ts(10,22): error TS1005: ',' expected.
 +parseInvalidNonNullableTypes.ts(15,22): error TS1144: '{' or ';' expected.
 +parseInvalidNonNullableTypes.ts(15,24): error TS2872: This kind of expression is always truthy.
+ parseInvalidNonNullableTypes.ts(16,16): error TS2355: A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.
+-parseInvalidNonNullableTypes.ts(16,16): error TS17020: '!' at the start of a type is not valid TypeScript syntax. Did you mean to write 'string'?
+-parseInvalidNonNullableTypes.ts(18,16): error TS17019: '!' at the end of a type is not valid TypeScript syntax. Did you mean to write 'any'?
+-parseInvalidNonNullableTypes.ts(19,10): error TS17019: '!' at the end of a type is not valid TypeScript syntax. Did you mean to write 'number'?
+-parseInvalidNonNullableTypes.ts(21,16): error TS17020: '!' at the start of a type is not valid TypeScript syntax. Did you mean to write 'any'?
+-parseInvalidNonNullableTypes.ts(22,10): error TS17020: '!' at the start of a type is not valid TypeScript syntax. Did you mean to write 'number'?
 +parseInvalidNonNullableTypes.ts(18,19): error TS1005: ',' expected.
 +parseInvalidNonNullableTypes.ts(18,20): error TS1109: Expression expected.
 +parseInvalidNonNullableTypes.ts(19,16): error TS1005: ',' expected.
 +parseInvalidNonNullableTypes.ts(19,18): error TS1109: Expression expected.
  
  
- ==== parseInvalidNonNullableTypes.ts (14 errors) ====
+-==== parseInvalidNonNullableTypes.ts (14 errors) ====
++==== parseInvalidNonNullableTypes.ts (15 errors) ====
      function f1(a: string): a is string! {
 -                                 ~~~~~~~
 -!!! error TS17019: '!' at the end of a type is not valid TypeScript syntax. Did you mean to write 'string'?
@@ -86,8 +87,8 @@
 +                           ~~
 +!!! error TS2872: This kind of expression is always truthy.
      function f8(): !string {}
--                   ~~~~~~~
--!!! error TS2355: A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.
+                    ~~~~~~~
+ !!! error TS2355: A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.
 -                   ~~~~~~~
 -!!! error TS17020: '!' at the start of a type is not valid TypeScript syntax. Did you mean to write 'string'?
      

--- a/testdata/baselines/reference/submodule/compiler/parseInvalidNonNullableTypes.types
+++ b/testdata/baselines/reference/submodule/compiler/parseInvalidNonNullableTypes.types
@@ -13,7 +13,7 @@ function f1(a: string): a is string! {
 }
 
 function f2(a: string): a is !string {
->f2 : (a: string) => a is any
+>f2 : (a: string) => a is string
 >a : string
 
     return true;
@@ -31,12 +31,12 @@ function f4(a: number!) {}
 > : any
 
 function f5(a: !string) {}
->f5 : (a: any) => void
->a : any
+>f5 : (a: string) => void
+>a : string
 
 function f6(a: !number) {}
->f6 : (a: any) => void
->a : any
+>f6 : (a: number) => void
+>a : number
 
 function f7(): string! {}
 >f7 : () => string
@@ -44,7 +44,7 @@ function f7(): string! {}
 >{} : {}
 
 function f8(): !string {}
->f8 : () => any
+>f8 : () => string
 
 const a = 1 as any!;
 >a : any
@@ -65,6 +65,6 @@ const c = 1 as !any;
 >1 : 1
 
 const d: !number = 1;
->d : any
+>d : number
 >1 : 1
 

--- a/testdata/baselines/reference/submodule/compiler/parseInvalidNonNullableTypes.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/parseInvalidNonNullableTypes.types.diff
@@ -12,12 +12,6 @@
  >true : true
  }
  
- function f2(a: string): a is !string {
-->f2 : (a: string) => a is string
-+>f2 : (a: string) => a is any
- >a : string
- 
-     return true;
 @@= skipped -14, +17 lines =@@
  }
  
@@ -34,16 +28,8 @@
 +> : any
  
  function f5(a: !string) {}
-->f5 : (a: string) => void
-->a : string
-+>f5 : (a: any) => void
-+>a : any
- 
- function f6(a: !number) {}
-->f6 : (a: number) => void
-->a : number
-+>f6 : (a: any) => void
-+>a : any
+ >f5 : (a: string) => void
+@@= skipped -17, +19 lines =@@
  
  function f7(): string! {}
  >f7 : () => string
@@ -51,8 +37,7 @@
 +>{} : {}
  
  function f8(): !string {}
-->f8 : () => string
-+>f8 : () => any
+ >f8 : () => string
  
  const a = 1 as any!;
  >a : any
@@ -69,11 +54,3 @@
  >1 : 1
  
  const c = 1 as !any;
-@@= skipped -36, +44 lines =@@
- >1 : 1
- 
- const d: !number = 1;
-->d : number
-+>d : any
- >1 : 1
- 

--- a/testdata/baselines/reference/submodule/compiler/parseInvalidNullableTypes.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/parseInvalidNullableTypes.errors.txt
@@ -1,7 +1,11 @@
+parseInvalidNullableTypes.ts(1,30): error TS2677: A type predicate's type must be assignable to its parameter's type.
+  Type 'string | null' is not assignable to type 'string'.
+    Type 'null' is not assignable to type 'string'.
 parseInvalidNullableTypes.ts(5,22): error TS1005: ',' expected.
 parseInvalidNullableTypes.ts(5,22): error TS7006: Parameter '(Missing)' implicitly has an 'any' type.
 parseInvalidNullableTypes.ts(6,22): error TS1005: ',' expected.
 parseInvalidNullableTypes.ts(6,22): error TS7006: Parameter '(Missing)' implicitly has an 'any' type.
+parseInvalidNullableTypes.ts(12,5): error TS2322: Type 'boolean' is not assignable to type 'string'.
 parseInvalidNullableTypes.ts(15,20): error TS1109: Expression expected.
 parseInvalidNullableTypes.ts(16,16): error TS1005: ',' expected.
 parseInvalidNullableTypes.ts(16,18): error TS1134: Variable declaration expected.
@@ -12,8 +16,12 @@ parseInvalidNullableTypes.ts(23,12): error TS1005: ',' expected.
 parseInvalidNullableTypes.ts(24,17): error TS1005: ',' expected.
 
 
-==== parseInvalidNullableTypes.ts (12 errors) ====
+==== parseInvalidNullableTypes.ts (14 errors) ====
     function f1(a: string): a is ?string {
+                                 ~~~~~~~
+!!! error TS2677: A type predicate's type must be assignable to its parameter's type.
+!!! error TS2677:   Type 'string | null' is not assignable to type 'string'.
+!!! error TS2677:     Type 'null' is not assignable to type 'string'.
         return true;
     }
     
@@ -33,6 +41,8 @@ parseInvalidNullableTypes.ts(24,17): error TS1005: ',' expected.
     
     function f6(a: string): ?string {
         return true;
+        ~~~~~~
+!!! error TS2322: Type 'boolean' is not assignable to type 'string'.
     }
     
     const a = 1 as any?;

--- a/testdata/baselines/reference/submodule/compiler/parseInvalidNullableTypes.errors.txt.diff
+++ b/testdata/baselines/reference/submodule/compiler/parseInvalidNullableTypes.errors.txt.diff
@@ -1,16 +1,20 @@
 --- old.parseInvalidNullableTypes.errors.txt
 +++ new.parseInvalidNullableTypes.errors.txt
 @@= skipped -0, +0 lines =@@
--parseInvalidNullableTypes.ts(1,30): error TS2677: A type predicate's type must be assignable to its parameter's type.
--  Type 'string | null' is not assignable to type 'string'.
--    Type 'null' is not assignable to type 'string'.
+ parseInvalidNullableTypes.ts(1,30): error TS2677: A type predicate's type must be assignable to its parameter's type.
+   Type 'string | null' is not assignable to type 'string'.
+     Type 'null' is not assignable to type 'string'.
 -parseInvalidNullableTypes.ts(1,30): error TS17020: '?' at the start of a type is not valid TypeScript syntax. Did you mean to write 'string | null | undefined'?
 -parseInvalidNullableTypes.ts(5,16): error TS17019: '?' at the end of a type is not valid TypeScript syntax. Did you mean to write 'string | undefined'?
 -parseInvalidNullableTypes.ts(6,16): error TS17019: '?' at the end of a type is not valid TypeScript syntax. Did you mean to write 'number | undefined'?
 -parseInvalidNullableTypes.ts(8,16): error TS17020: '?' at the start of a type is not valid TypeScript syntax. Did you mean to write 'string | null | undefined'?
 -parseInvalidNullableTypes.ts(9,16): error TS17020: '?' at the start of a type is not valid TypeScript syntax. Did you mean to write 'number | null | undefined'?
 -parseInvalidNullableTypes.ts(11,25): error TS17020: '?' at the start of a type is not valid TypeScript syntax. Did you mean to write 'string | null | undefined'?
--parseInvalidNullableTypes.ts(12,5): error TS2322: Type 'boolean' is not assignable to type 'string'.
++parseInvalidNullableTypes.ts(5,22): error TS1005: ',' expected.
++parseInvalidNullableTypes.ts(5,22): error TS7006: Parameter '(Missing)' implicitly has an 'any' type.
++parseInvalidNullableTypes.ts(6,22): error TS1005: ',' expected.
++parseInvalidNullableTypes.ts(6,22): error TS7006: Parameter '(Missing)' implicitly has an 'any' type.
+ parseInvalidNullableTypes.ts(12,5): error TS2322: Type 'boolean' is not assignable to type 'string'.
 -parseInvalidNullableTypes.ts(15,16): error TS17019: '?' at the end of a type is not valid TypeScript syntax. Did you mean to write 'any'?
 -parseInvalidNullableTypes.ts(16,10): error TS17019: '?' at the end of a type is not valid TypeScript syntax. Did you mean to write 'number | undefined'?
 -parseInvalidNullableTypes.ts(18,16): error TS17020: '?' at the start of a type is not valid TypeScript syntax. Did you mean to write 'any'?
@@ -19,10 +23,6 @@
 -parseInvalidNullableTypes.ts(22,8): error TS17019: '?' at the end of a type is not valid TypeScript syntax. Did you mean to write 'never'?
 -parseInvalidNullableTypes.ts(23,8): error TS17019: '?' at the end of a type is not valid TypeScript syntax. Did you mean to write 'void'?
 -parseInvalidNullableTypes.ts(24,8): error TS17019: '?' at the end of a type is not valid TypeScript syntax. Did you mean to write 'undefined'?
-+parseInvalidNullableTypes.ts(5,22): error TS1005: ',' expected.
-+parseInvalidNullableTypes.ts(5,22): error TS7006: Parameter '(Missing)' implicitly has an 'any' type.
-+parseInvalidNullableTypes.ts(6,22): error TS1005: ',' expected.
-+parseInvalidNullableTypes.ts(6,22): error TS7006: Parameter '(Missing)' implicitly has an 'any' type.
 +parseInvalidNullableTypes.ts(15,20): error TS1109: Expression expected.
 +parseInvalidNullableTypes.ts(16,16): error TS1005: ',' expected.
 +parseInvalidNullableTypes.ts(16,18): error TS1134: Variable declaration expected.
@@ -34,12 +34,12 @@
  
  
 -==== parseInvalidNullableTypes.ts (16 errors) ====
-+==== parseInvalidNullableTypes.ts (12 errors) ====
++==== parseInvalidNullableTypes.ts (14 errors) ====
      function f1(a: string): a is ?string {
--                                 ~~~~~~~
--!!! error TS2677: A type predicate's type must be assignable to its parameter's type.
--!!! error TS2677:   Type 'string | null' is not assignable to type 'string'.
--!!! error TS2677:     Type 'null' is not assignable to type 'string'.
+                                  ~~~~~~~
+ !!! error TS2677: A type predicate's type must be assignable to its parameter's type.
+ !!! error TS2677:   Type 'string | null' is not assignable to type 'string'.
+ !!! error TS2677:     Type 'null' is not assignable to type 'string'.
 -                                 ~~~~~~~
 -!!! error TS17020: '?' at the start of a type is not valid TypeScript syntax. Did you mean to write 'string | null | undefined'?
          return true;
@@ -71,8 +71,8 @@
 -                            ~~~~~~~
 -!!! error TS17020: '?' at the start of a type is not valid TypeScript syntax. Did you mean to write 'string | null | undefined'?
          return true;
--        ~~~~~~
--!!! error TS2322: Type 'boolean' is not assignable to type 'string'.
+         ~~~~~~
+ !!! error TS2322: Type 'boolean' is not assignable to type 'string'.
      }
      
      const a = 1 as any?;

--- a/testdata/baselines/reference/submodule/compiler/parseInvalidNullableTypes.types
+++ b/testdata/baselines/reference/submodule/compiler/parseInvalidNullableTypes.types
@@ -2,7 +2,7 @@
 
 === parseInvalidNullableTypes.ts ===
 function f1(a: string): a is ?string {
->f1 : (a: string) => a is any
+>f1 : (a: string) => a is string | null
 >a : string
 
     return true;
@@ -20,15 +20,15 @@ function f3(a: number?) {}
 > : any
 
 function f4(a: ?string) {}
->f4 : (a: any) => void
->a : any
+>f4 : (a: string | null) => void
+>a : string | null
 
 function f5(a: ?number) {}
->f5 : (a: any) => void
->a : any
+>f5 : (a: number | null) => void
+>a : number | null
 
 function f6(a: string): ?string {
->f6 : (a: string) => any
+>f6 : (a: string) => string | null
 >a : string
 
     return true;
@@ -53,7 +53,7 @@ const c = 1 as ?any;
 >1 : 1
 
 const d: ?number = 1;
->d : any
+>d : number | null
 >1 : 1
 
 let e: unknown?;

--- a/testdata/baselines/reference/submodule/compiler/parseInvalidNullableTypes.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/parseInvalidNullableTypes.types.diff
@@ -1,15 +1,6 @@
 --- old.parseInvalidNullableTypes.types
 +++ new.parseInvalidNullableTypes.types
-@@= skipped -1, +1 lines =@@
- 
- === parseInvalidNullableTypes.ts ===
- function f1(a: string): a is ?string {
-->f1 : (a: string) => a is string | null
-+>f1 : (a: string) => a is any
- >a : string
- 
-     return true;
-@@= skipped -8, +8 lines =@@
+@@= skipped -9, +9 lines =@@
  }
  
  function f2(a: string?) {}
@@ -27,23 +18,7 @@
 +> : any
  
  function f4(a: ?string) {}
-->f4 : (a: string | null) => void
-->a : string | null
-+>f4 : (a: any) => void
-+>a : any
- 
- function f5(a: ?number) {}
-->f5 : (a: number | null) => void
-->a : number | null
-+>f5 : (a: any) => void
-+>a : any
- 
- function f6(a: string): ?string {
-->f6 : (a: string) => string | null
-+>f6 : (a: string) => any
- >a : string
- 
-     return true;
+ >f4 : (a: string | null) => void
 @@= skipped -26, +28 lines =@@
  const a = 1 as any?;
  >a : any
@@ -59,15 +34,7 @@
  >1 : 1
  
  const c = 1 as ?any;
-@@= skipped -12, +15 lines =@@
- >1 : 1
- 
- const d: ?number = 1;
-->d : number | null
-+>d : any
- >1 : 1
- 
- let e: unknown?;
+@@= skipped -19, +22 lines =@@
  >e : unknown
  
  let f: never?;

--- a/testdata/baselines/reference/submodule/conformance/jsdocDisallowedInTypescript.types
+++ b/testdata/baselines/reference/submodule/conformance/jsdocDisallowedInTypescript.types
@@ -10,15 +10,15 @@ var ara: Array.<number> = [1,2,3];
 >3 : 3
 
 function f(x: ?number, y: Array.<number>) {
->f : (x: any, y: number[]) => any
->x : any
+>f : (x: number | null, y: number[]) => number
+>x : number | null
 >y : number[]
 
     return x ? x + y[1] : y[0];
->x ? x + y[1] : y[0] : any
->x : any
->x + y[1] : any
->x : any
+>x ? x + y[1] : y[0] : number
+>x : number | null
+>x + y[1] : number
+>x : number
 >y[1] : number
 >y : number[]
 >1 : 1
@@ -50,8 +50,8 @@ function hof2(f: function(this: number, string): string) {
 > : any
 
     return f(12, 'hullo');
->f(12, 'hullo') : any
->f : (x: any, y: number[]) => any
+>f(12, 'hullo') : number
+>f : (x: number | null, y: number[]) => number
 >12 : 12
 >'hullo' : "hullo"
 }
@@ -79,7 +79,7 @@ var g: function(number, number): number = (n,m) => n + m;
 >m : any
 
 var most: !string = 'definite';
->most : any
+>most : string
 >'definite' : "definite"
 
 var postfixdef: number! = 101;
@@ -93,10 +93,10 @@ var postfixopt: number? = undefined;
 >undefined : any
 
 var nns: Array<?number>;
->nns : any[]
+>nns : (number | null)[]
 
 var dns: Array<!number>;
->dns : any[]
+>dns : number[]
 
 var anys: Array<*>;
 >anys : any[]

--- a/testdata/baselines/reference/submodule/conformance/jsdocDisallowedInTypescript.types.diff
+++ b/testdata/baselines/reference/submodule/conformance/jsdocDisallowedInTypescript.types.diff
@@ -5,23 +5,10 @@
  
  function f(x: ?number, y: Array.<number>) {
 ->f : (x: number | null, y: Array<number>) => number
-->x : number | null
-+>f : (x: any, y: number[]) => any
-+>x : any
++>f : (x: number | null, y: number[]) => number
+ >x : number | null
  >y : number[]
  
-     return x ? x + y[1] : y[0];
-->x ? x + y[1] : y[0] : number
-->x : number | null
-->x + y[1] : number
-->x : number
-+>x ? x + y[1] : y[0] : any
-+>x : any
-+>x + y[1] : any
-+>x : any
- >y[1] : number
- >y : number[]
- >1 : 1
 @@= skipped -17, +17 lines =@@
  >0 : 0
  }
@@ -58,8 +45,8 @@
      return f(12, 'hullo');
 ->f(12, 'hullo') : string
 ->f : (this: number, arg1: string) => string
-+>f(12, 'hullo') : any
-+>f : (x: any, y: number[]) => any
++>f(12, 'hullo') : number
++>f : (x: number | null, y: number[]) => number
  >12 : 12
  >'hullo' : "hullo"
  }
@@ -89,9 +76,8 @@
 +>m : any
  
  var most: !string = 'definite';
-->most : string
-+>most : any
- >'definite' : "definite"
+ >most : string
+@@= skipped -14, +20 lines =@@
  
  var postfixdef: number! = 101;
  >postfixdef : number
@@ -106,12 +92,4 @@
 +>undefined : any
  
  var nns: Array<?number>;
-->nns : (number | null)[]
-+>nns : any[]
- 
- var dns: Array<!number>;
-->dns : number[]
-+>dns : any[]
- 
- var anys: Array<*>;
- >anys : any[]
+ >nns : (number | null)[]


### PR DESCRIPTION
Type checks the JSDoc types

- `* = any`
- `!T = T`
- `?T = T | null`
- `...T = T[]`
- `T= = T | undefined`

Only improves a few TS tests since I don't have `@param` or `@type` contributing type annotations in JS.

The rules for JSVariadicType (`...T`) are simplified: it's now always a synonym for `T[]`. Previously it was only `T[]` when used correctly: as a rest parameter, and was `T | undefined` otherwise.

This makes no sense.

And it turns out that signature help in Strada has always used the simpler `...T = T[]` rule anyway, so that's what JS users are used to seeing as long as they don't have checkJs turned on. What `...` is still used is in random JS code that is going to be mostly viewed rather than edited, so a simplification is overdue.