### PR TITLE
Disable test caching on Windows, hide gotestsum skipped tests outside CI

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -209,6 +209,7 @@ const goTestFlags = [
 
 const goTestEnv = {
     ...(options.concurrentTestPrograms ? { TS_TEST_PROGRAM_SINGLE_THREADED: "false" } : {}),
+    ...(process.platform === "win32" ? { GOFLAGS: "-count=1" } : {}), // Go test caching takes a long time on Windows.
 };
 
 const $test = $({ env: goTestEnv });

--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -221,7 +221,9 @@ const goTestFlags = [
 
 const goTestEnv = {
     ...(options.concurrentTestPrograms ? { TS_TEST_PROGRAM_SINGLE_THREADED: "false" } : {}),
-    ...(process.platform === "win32" ? { GOFLAGS: "-count=1" } : {}), // Go test caching takes a long time on Windows.
+    // Go test caching takes a long time on Windows.
+    // https://github.com/golang/go/issues/72992
+    ...(process.platform === "win32" ? { GOFLAGS: "-count=1" } : {}),
 };
 
 const goTestSumFlags = [

--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -212,10 +212,15 @@ const goTestEnv = {
     ...(process.platform === "win32" ? { GOFLAGS: "-count=1" } : {}), // Go test caching takes a long time on Windows.
 };
 
+const goTestSumFlags = [
+    "--format-hide-empty-pkg",
+    ...(!isCI ? ["--hide-summary", "skipped"] : []),
+];
+
 const $test = $({ env: goTestEnv });
 
 const gotestsum = memoize(() => {
-    const args = isInstalled("gotestsum") ? ["gotestsum", "--format-hide-empty-pkg", "--"] : ["go", "test"];
+    const args = isInstalled("gotestsum") ? ["gotestsum", ...goTestSumFlags, "--"] : ["go", "test"];
     return args.concat(goTestFlags);
 });
 


### PR DESCRIPTION
We've discovered that the go test cache makes `go test ./internal/testrunner` 4-5x slower on Windows:

```console
$ go clean -testcache
$ Measure-Command { go test ./internal/testrunner | Out-Default }
ok      github.com/microsoft/typescript-go/internal/testrunner  13.584s

Days              : 0
Hours             : 0
Minutes           : 1
Seconds           : 5
Milliseconds      : 364
Ticks             : 653649277
TotalDays         : 0.000756538515046296
TotalHours        : 0.0181569243611111
TotalMinutes      : 1.08941546166667
TotalSeconds      : 65.3649277
TotalMilliseconds : 65364.9277
```
```console
$ Measure-Command { go test -count=1 ./internal/testrunner | Out-Default }
ok      github.com/microsoft/typescript-go/internal/testrunner  11.726s

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 15
Milliseconds      : 296
Ticks             : 152960956
TotalDays         : 0.000177038143518519
TotalHours        : 0.00424891544444444
TotalMinutes      : 0.254934926666667
TotalSeconds      : 15.2960956
TotalMilliseconds : 15296.0956
````

Disable it for `hereby test` on Windows by setting `-count=1` for now until we can report this upstream.

Additionally, we have \>1000 skipped tests, which spam the gotestsum output. Outside CI, hide this text by default. (I had originally _not_ used skipped tests for the test runner for this reason, which I could change back again instead. Instead this PR will explicitly print a warning about not having the submodule cloned, which is the only place we had skipped tests previously.)