### PR TITLE
Update to golangci-lint v2

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://golangci-lint.run/jsonschema/custom-gcl.jsonschema.json
 
-version: v1.64.6
+version: v2.0.2
 
 destination: ./_tools
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,8 +66,6 @@ linters:
   exclusions:
     presets:
       - comments
-      - common-false-positives
-      - legacy
       - std-error-handling
 
 issues:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -64,16 +64,11 @@ linters:
         type: module
 
   exclusions:
-    generated: lax
     presets:
       - comments
       - common-false-positives
       - legacy
       - std-error-handling
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
 
 issues:
   max-issues-per-linter: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ linters:
     - bodyclose
     - canonicalheader
     - copyloopvar
+    - customlint
     - durationcheck
     - errcheck
     - errchkjson
@@ -42,9 +43,6 @@ linters:
     - unconvert
     - usestdlibvars
     - usetesting
-    - whitespace
-
-    - customlint
 
     # Need to add headers
     # - goheader
@@ -58,6 +56,7 @@ linters:
     # - testifylint
     # - unparam
     # - unused
+
   settings:
     custom:
       customlint:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,17 +1,15 @@
 # yaml-language-server: $schema=https://golangci-lint.run/jsonschema/golangci.jsonschema.json
 
+version: '2'
+
 run:
   allow-parallel-runners: true
-  timeout: 180s
 
 linters:
-  disable-all: true
+  default: none
   enable:
     # Enabled
     - asasalint
-    - inamedparam
-    - nakedret
-    - govet
     - bidichk
     - bodyclose
     - canonicalheader
@@ -24,14 +22,16 @@ linters:
     - fatcontext
     - gocheckcompilerdirectives
     - goprintffuncname
-    - gosimple
+    - govet
     - grouper
+    - inamedparam
     - ineffassign
     - intrange
     - makezero
     - mirror
     - misspell
     - musttag
+    - nakedret
     - nolintlint
     - paralleltest
     - perfsprint
@@ -55,27 +55,26 @@ linters:
     # - gosec
     # - revive
     # - staticcheck
-    # - stylecheck
     # - testifylint
     # - unparam
     # - unused
+  settings:
+    custom:
+      customlint:
+        type: module
 
-linters-settings:
-  custom:
-    customlint:
-      type: module
-
-#   revive:
-#     enable-all-rules: true
-#     rules:
-#       - name: unused-parameter
-#         disabled: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
-
-  exclude:
-    - '^could not import'
-    - '^: #'
-    - 'imported and not used$'


### PR DESCRIPTION
Notable changes:

- `gosimple`/`stylecheck`/`staticcheck` were all merged into a single `staticcheck` linter, so I disabled that for now since we're not ready to enable it.
- Most flags / timeouts we set are now the defaults, so they go away.
- I disabled the `whitespace` linter, which is surprisingly slow (not new).