### PR TITLE
Unify the way anonymous class symbols are printed in error messages

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -10845,7 +10845,7 @@ func (c *Checker) checkPrivateIdentifierPropertyAccess(leftType *Type, right *as
 				return true
 			}
 		}
-		c.error(right, diagnostics.Property_0_is_not_accessible_outside_class_1_because_it_has_a_private_identifier, diagName, scanner.DeclarationNameToString(typeClass.Name()))
+		c.error(right, diagnostics.Property_0_is_not_accessible_outside_class_1_because_it_has_a_private_identifier, diagName, classDeclarationNameToString(typeClass.Symbol().ValueDeclaration))
 		return true
 	}
 	return false

--- a/internal/checker/relater.go
+++ b/internal/checker/relater.go
@@ -10,7 +10,6 @@ import (
 	"github.com/microsoft/typescript-go/internal/compiler/diagnostics"
 	"github.com/microsoft/typescript-go/internal/core"
 	"github.com/microsoft/typescript-go/internal/jsnum"
-	"github.com/microsoft/typescript-go/internal/scanner"
 )
 
 type SignatureCheckMode uint32
@@ -4272,8 +4271,8 @@ func (r *Relater) reportUnmatchedProperty(source *Type, target *Type, unmatchedP
 		privateIdentifierDescription := unmatchedProperty.ValueDeclaration.Name().Text()
 		symbolTableKey := binder.GetSymbolNameForPrivateIdentifier(source.symbol, privateIdentifierDescription)
 		if r.c.getPropertyOfType(source, symbolTableKey) != nil {
-			sourceName := scanner.DeclarationNameToString(ast.GetNameOfDeclaration(source.symbol.ValueDeclaration))
-			targetName := scanner.DeclarationNameToString(ast.GetNameOfDeclaration(target.symbol.ValueDeclaration))
+			sourceName := classDeclarationNameToString(source.symbol.ValueDeclaration)
+			targetName := classDeclarationNameToString(target.symbol.ValueDeclaration)
 			r.reportError(diagnostics.Property_0_in_type_1_refers_to_a_different_member_that_cannot_be_accessed_from_within_type_2, privateIdentifierDescription, sourceName, targetName)
 			return
 		}

--- a/internal/checker/utilities.go
+++ b/internal/checker/utilities.go
@@ -2165,3 +2165,11 @@ func allDeclarationsInSameSourceFile(symbol *ast.Symbol) bool {
 	}
 	return true
 }
+
+func classDeclarationNameToString(declaration *ast.Node) string {
+	name := ast.GetNameOfDeclaration(declaration)
+	if name == nil {
+		return "(Anonymous class)"
+	}
+	return scanner.DeclarationNameToString(name)
+}

--- a/testdata/baselines/reference/compiler/privateNameMethodClassExpression2.errors.txt
+++ b/testdata/baselines/reference/compiler/privateNameMethodClassExpression2.errors.txt
@@ -1,0 +1,19 @@
+privateNameMethodClassExpression2.ts(5,6): error TS18013: Property '#method' is not accessible outside class '(Anonymous class)' because it has a private identifier.
+privateNameMethodClassExpression2.ts(9,6): error TS18013: Property '#field' is not accessible outside class '(Anonymous class)' because it has a private identifier.
+
+
+==== privateNameMethodClassExpression2.ts (2 errors) ====
+    new (class {
+      #method() {
+        return 42;
+      }
+    })().#method; // error
+         ~~~~~~~
+!!! error TS18013: Property '#method' is not accessible outside class '(Anonymous class)' because it has a private identifier.
+    
+    new (class {
+      #field = 42;
+    })().#field; // error
+         ~~~~~~
+!!! error TS18013: Property '#field' is not accessible outside class '(Anonymous class)' because it has a private identifier.
+    

--- a/testdata/baselines/reference/compiler/privateNameMethodClassExpression2.symbols
+++ b/testdata/baselines/reference/compiler/privateNameMethodClassExpression2.symbols
@@ -1,0 +1,17 @@
+//// [tests/cases/compiler/privateNameMethodClassExpression2.ts] ////
+
+=== privateNameMethodClassExpression2.ts ===
+new (class {
+  #method() {
+>#method : Symbol(#method, Decl(privateNameMethodClassExpression2.ts, 0, 12))
+
+    return 42;
+  }
+})().#method; // error
+
+new (class {
+  #field = 42;
+>#field : Symbol(#field, Decl(privateNameMethodClassExpression2.ts, 6, 12))
+
+})().#field; // error
+

--- a/testdata/baselines/reference/compiler/privateNameMethodClassExpression2.types
+++ b/testdata/baselines/reference/compiler/privateNameMethodClassExpression2.types
@@ -1,0 +1,29 @@
+//// [tests/cases/compiler/privateNameMethodClassExpression2.ts] ////
+
+=== privateNameMethodClassExpression2.ts ===
+new (class {
+>new (class {  #method() {    return 42;  }})().#method : any
+>new (class {  #method() {    return 42;  }})() : (Anonymous class)
+>(class {  #method() {    return 42;  }}) : typeof (Anonymous class)
+>class {  #method() {    return 42;  }} : typeof (Anonymous class)
+
+  #method() {
+>#method : () => number
+
+    return 42;
+>42 : 42
+  }
+})().#method; // error
+
+new (class {
+>new (class {  #field = 42;})().#field : any
+>new (class {  #field = 42;})() : (Anonymous class)
+>(class {  #field = 42;}) : typeof (Anonymous class)
+>class {  #field = 42;} : typeof (Anonymous class)
+
+  #field = 42;
+>#field : number
+>42 : 42
+
+})().#field; // error
+

--- a/testdata/baselines/reference/compiler/privateNamesUnique-6.errors.txt
+++ b/testdata/baselines/reference/compiler/privateNamesUnique-6.errors.txt
@@ -1,0 +1,17 @@
+privateNamesUnique-6.ts(6,7): error TS2322: Type '(Anonymous class)' is not assignable to type 'A'.
+  Property '#foo' in type '(Anonymous class)' refers to a different member that cannot be accessed from within type 'A'.
+
+
+==== privateNamesUnique-6.ts (1 errors) ====
+    class A {
+      #foo: number;
+    }
+    
+    // error
+    const test: A = new (class {
+          ~~~~
+!!! error TS2322: Type '(Anonymous class)' is not assignable to type 'A'.
+!!! error TS2322:   Property '#foo' in type '(Anonymous class)' refers to a different member that cannot be accessed from within type 'A'.
+      #foo: number;
+    })();
+    

--- a/testdata/baselines/reference/compiler/privateNamesUnique-6.symbols
+++ b/testdata/baselines/reference/compiler/privateNamesUnique-6.symbols
@@ -1,0 +1,20 @@
+//// [tests/cases/compiler/privateNamesUnique-6.ts] ////
+
+=== privateNamesUnique-6.ts ===
+class A {
+>A : Symbol(A, Decl(privateNamesUnique-6.ts, 0, 0))
+
+  #foo: number;
+>#foo : Symbol(#foo, Decl(privateNamesUnique-6.ts, 0, 9))
+}
+
+// error
+const test: A = new (class {
+>test : Symbol(test, Decl(privateNamesUnique-6.ts, 5, 5))
+>A : Symbol(A, Decl(privateNamesUnique-6.ts, 0, 0))
+
+  #foo: number;
+>#foo : Symbol(#foo, Decl(privateNamesUnique-6.ts, 5, 28))
+
+})();
+

--- a/testdata/baselines/reference/compiler/privateNamesUnique-6.types
+++ b/testdata/baselines/reference/compiler/privateNamesUnique-6.types
@@ -1,0 +1,22 @@
+//// [tests/cases/compiler/privateNamesUnique-6.ts] ////
+
+=== privateNamesUnique-6.ts ===
+class A {
+>A : A
+
+  #foo: number;
+>#foo : number
+}
+
+// error
+const test: A = new (class {
+>test : A
+>new (class {  #foo: number;})() : (Anonymous class)
+>(class {  #foo: number;}) : typeof (Anonymous class)
+>class {  #foo: number;} : typeof (Anonymous class)
+
+  #foo: number;
+>#foo : number
+
+})();
+

--- a/testdata/baselines/reference/submodule/conformance/privateNameMethodClassExpression.errors.txt
+++ b/testdata/baselines/reference/submodule/conformance/privateNameMethodClassExpression.errors.txt
@@ -1,5 +1,5 @@
-privateNameMethodClassExpression.ts(9,17): error TS18013: Property '#method' is not accessible outside class '(Missing)' because it has a private identifier.
-privateNameMethodClassExpression.ts(10,17): error TS18013: Property '#field' is not accessible outside class '(Missing)' because it has a private identifier.
+privateNameMethodClassExpression.ts(9,17): error TS18013: Property '#method' is not accessible outside class 'C' because it has a private identifier.
+privateNameMethodClassExpression.ts(10,17): error TS18013: Property '#field' is not accessible outside class 'C' because it has a private identifier.
 
 
 ==== privateNameMethodClassExpression.ts (2 errors) ====
@@ -13,9 +13,9 @@ privateNameMethodClassExpression.ts(10,17): error TS18013: Property '#field' is 
     console.log(C.getInstance().getField());
     C.getInstance().#method; // Error
                     ~~~~~~~
-!!! error TS18013: Property '#method' is not accessible outside class '(Missing)' because it has a private identifier.
+!!! error TS18013: Property '#method' is not accessible outside class 'C' because it has a private identifier.
     C.getInstance().#field; // Error
                     ~~~~~~
-!!! error TS18013: Property '#field' is not accessible outside class '(Missing)' because it has a private identifier.
+!!! error TS18013: Property '#field' is not accessible outside class 'C' because it has a private identifier.
     
     

--- a/testdata/baselines/reference/submodule/conformance/privateNameMethodClassExpression.errors.txt.diff
+++ b/testdata/baselines/reference/submodule/conformance/privateNameMethodClassExpression.errors.txt.diff
@@ -3,8 +3,8 @@
 @@= skipped -0, +0 lines =@@
 -privateNameMethodClassExpression.ts(9,17): error TS18013: Property '#method' is not accessible outside class '(anonymous)' because it has a private identifier.
 -privateNameMethodClassExpression.ts(10,17): error TS18013: Property '#field' is not accessible outside class '(anonymous)' because it has a private identifier.
-+privateNameMethodClassExpression.ts(9,17): error TS18013: Property '#method' is not accessible outside class '(Missing)' because it has a private identifier.
-+privateNameMethodClassExpression.ts(10,17): error TS18013: Property '#field' is not accessible outside class '(Missing)' because it has a private identifier.
++privateNameMethodClassExpression.ts(9,17): error TS18013: Property '#method' is not accessible outside class 'C' because it has a private identifier.
++privateNameMethodClassExpression.ts(10,17): error TS18013: Property '#field' is not accessible outside class 'C' because it has a private identifier.
  
  
  ==== privateNameMethodClassExpression.ts (2 errors) ====
@@ -13,10 +13,10 @@
      C.getInstance().#method; // Error
                      ~~~~~~~
 -!!! error TS18013: Property '#method' is not accessible outside class '(anonymous)' because it has a private identifier.
-+!!! error TS18013: Property '#method' is not accessible outside class '(Missing)' because it has a private identifier.
++!!! error TS18013: Property '#method' is not accessible outside class 'C' because it has a private identifier.
      C.getInstance().#field; // Error
                      ~~~~~~
 -!!! error TS18013: Property '#field' is not accessible outside class '(anonymous)' because it has a private identifier.
-+!!! error TS18013: Property '#field' is not accessible outside class '(Missing)' because it has a private identifier.
++!!! error TS18013: Property '#field' is not accessible outside class 'C' because it has a private identifier.
      
      

--- a/testdata/tests/cases/compiler/privateNameMethodClassExpression2.ts
+++ b/testdata/tests/cases/compiler/privateNameMethodClassExpression2.ts
@@ -1,0 +1,13 @@
+// @strict: true
+// @target: es2015
+// @noEmit: true
+
+new (class {
+  #method() {
+    return 42;
+  }
+})().#method; // error
+
+new (class {
+  #field = 42;
+})().#field; // error

--- a/testdata/tests/cases/compiler/privateNamesUnique-6.ts
+++ b/testdata/tests/cases/compiler/privateNamesUnique-6.ts
@@ -1,0 +1,13 @@
+// @strict: true
+// @strictPropertyInitialization: false
+// @target: es6
+// @noEmit: true
+
+class A {
+  #foo: number;
+}
+
+// error
+const test: A = new (class {
+  #foo: number;
+})();


### PR DESCRIPTION
This is slightly different from Strada in two ways:
1. `GetNameOfDeclaration` is preferred now
2. `(anonymous)` becomes `(Anonymous class)` - which is just more consistent