### PR TITLE
Fix BenchmarkGetNormalizedAbsolutePath

### DIFF
--- a/internal/tspath/path_test.go
+++ b/internal/tspath/path_test.go
@@ -463,8 +463,8 @@ func BenchmarkGetNormalizedAbsolutePath(b *testing.B) {
 			for fnName, fn := range funcs {
 				b.Run(fnName, func(b *testing.B) {
 					b.ReportAllocs()
-					for _, test := range tests {
-						for b.Loop() {
+					for b.Loop() {
+						for _, test := range tests {
 							fn(test[0], test[1])
 						}
 					}


### PR DESCRIPTION
`b.Loop` shouldn't itself be called multiple times. Invert this test loop.