### PR TITLE
Ensure coverage data from multiple tasks don't overwrite each other

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
           use_oidc: true
           disable_search: true
           name: ${{ matrix.name || matrix.os }}
-          files: ./coverage
+          directory: ./coverage
 
       - run: git diff --staged --exit-code --stat
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,6 @@ jobs:
         if: ${{ always() && matrix.coverage }}
         with:
           use_oidc: true
-          disable_search: true
           name: ${{ matrix.name || matrix.os }}
           directory: ./coverage
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
           use_oidc: true
           disable_search: true
           name: ${{ matrix.name || matrix.os }}
-          files: ./coverage.out
+          files: ./coverage
 
       - run: git diff --staged --exit-code --stat
 

--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -215,12 +215,26 @@ export const generate = task({
     },
 });
 
-const goTestFlags = [
-    ...goBuildFlags,
-    ...goBuildTags(),
-    ...(options.tests ? [`-run=${options.tests}`] : []),
-    ...(options.coverage ? ["-coverprofile=coverage.out", "-coverpkg=./..."] : []),
-];
+const coverageDir = path.join(__dirname, "coverage");
+
+const ensureCoverageDirExists = memoize(() => {
+    if (options.coverage) {
+        fs.mkdirSync(coverageDir, { recursive: true });
+    }
+});
+
+/**
+ * @param {string} taskName
+ */
+function goTestFlags(taskName) {
+    ensureCoverageDirExists();
+    return [
+        ...goBuildFlags,
+        ...goBuildTags(),
+        ...(options.tests ? [`-run=${options.tests}`] : []),
+        ...(options.coverage ? [`-coverprofile=${path.join(coverageDir, "coverage." + taskName + ".out")}`, "-coverpkg=./..."] : []),
+    ];
+}
 
 const goTestEnv = {
     ...(options.concurrentTestPrograms ? { TS_TEST_PROGRAM_SINGLE_THREADED: "false" } : {}),
@@ -236,18 +250,24 @@ const goTestSumFlags = [
 
 const $test = $({ env: goTestEnv });
 
-const gotestsum = memoize(() => {
+/**
+ * @param {string} taskName
+ */
+function gotestsum(taskName) {
     const args = isInstalled("gotestsum") ? ["gotestsum", ...goTestSumFlags, "--"] : ["go", "test"];
-    return args.concat(goTestFlags);
-});
+    return args.concat(goTestFlags(taskName));
+}
 
-const goTest = memoize(() => {
-    return ["go", "test"].concat(goTestFlags);
-});
+/**
+ * @param {string} taskName
+ */
+function goTest(taskName) {
+    return ["go", "test"].concat(goTestFlags(taskName));
+}
 
 async function runTests() {
     warnIfTypeScriptSubmoduleNotCloned();
-    await $test`${gotestsum()} ./... ${isCI ? ["--timeout=45m"] : []}`;
+    await $test`${gotestsum("tests")} ./... ${isCI ? ["--timeout=45m"] : []}`;
 }
 
 export const test = task({
@@ -258,7 +278,7 @@ export const test = task({
 async function runTestBenchmarks() {
     warnIfTypeScriptSubmoduleNotCloned();
     // Run the benchmarks once to ensure they compile and run without errors.
-    await $test`${goTest()} -run=- -bench=. -benchtime=1x ./...`;
+    await $test`${goTest("benchmarks")} -run=- -bench=. -benchtime=1x ./...`;
 }
 
 export const testBenchmarks = task({
@@ -267,7 +287,7 @@ export const testBenchmarks = task({
 });
 
 async function runTestTools() {
-    await $test({ cwd: path.join(__dirname, "_tools") })`${gotestsum()} ./...`;
+    await $test({ cwd: path.join(__dirname, "_tools") })`${gotestsum("tools")} ./...`;
 }
 
 export const testTools = task({


### PR DESCRIPTION
The coverage we list is wrong because I forgot that we pass coverage flags to multiple different tests, so whichever runs last ends up winning. Oops.