### PR TITLE
Fixed Uri length

### DIFF
--- a/internal/lsp/converters.go
+++ b/internal/lsp/converters.go
@@ -153,7 +153,7 @@ func documentUriToFileName(uri lsproto.DocumentUri) string {
 		if len(path) >= 4 {
 			if nextSlash := strings.IndexByte(path[1:], '/'); nextSlash != -1 {
 				if possibleDrive, _ := url.PathUnescape(path[1 : nextSlash+2]); strings.HasSuffix(possibleDrive, ":/") {
-					return possibleDrive + path[len(possibleDrive)+3:]
+					return possibleDrive + path[len(possibleDrive)+1:]
 				}
 			}
 		}


### PR DESCRIPTION
`documentUriToFileName` was returning an incorrect when the Uri contained a drive letter. ie:: 

`file:///C:/Folder1/file.ts` --> `C:/lder1/file.ts`