### PR TITLE
s/Js/JS/g

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -9467,35 +9467,35 @@ func (node *JSDocTypedefTag) Clone(f *NodeFactory) *Node {
 type JSDocTypeLiteral struct {
 	TypeNodeBase
 	DeclarationBase
-	JsDocPropertyTags []*Node
+	JSDocPropertyTags []*Node
 	IsArrayType       bool
 }
 
-func (f *NodeFactory) NewJSDocTypeLiteral(jsDocPropertyTags []*Node, isArrayType bool) *Node {
+func (f *NodeFactory) NewJSDocTypeLiteral(jsdocPropertyTags []*Node, isArrayType bool) *Node {
 	data := &JSDocTypeLiteral{}
-	data.JsDocPropertyTags = jsDocPropertyTags
+	data.JSDocPropertyTags = jsdocPropertyTags
 	data.IsArrayType = isArrayType
 	return newNode(KindJSDocTypeLiteral, data, f.hooks)
 }
 
-func (f *NodeFactory) UpdateJSDocTypeLiteral(node *JSDocTypeLiteral, jsDocPropertyTags []*Node, isArrayType bool) *Node {
-	if !core.Same(jsDocPropertyTags, node.JsDocPropertyTags) || isArrayType != node.IsArrayType {
-		return updateNode(f.NewJSDocTypeLiteral(jsDocPropertyTags, isArrayType), node.AsNode(), f.hooks)
+func (f *NodeFactory) UpdateJSDocTypeLiteral(node *JSDocTypeLiteral, jsdocPropertyTags []*Node, isArrayType bool) *Node {
+	if !core.Same(jsdocPropertyTags, node.JSDocPropertyTags) || isArrayType != node.IsArrayType {
+		return updateNode(f.NewJSDocTypeLiteral(jsdocPropertyTags, isArrayType), node.AsNode(), f.hooks)
 	}
 	return node.AsNode()
 }
 
 func (node *JSDocTypeLiteral) ForEachChild(v Visitor) bool {
-	return visitNodes(v, node.JsDocPropertyTags)
+	return visitNodes(v, node.JSDocPropertyTags)
 }
 
 func (node *JSDocTypeLiteral) VisitEachChild(v *NodeVisitor) *Node {
-	jsdocPropertyTags := core.SameMap(node.JsDocPropertyTags, func(n *Node) *Node { return v.visitNode(n) })
+	jsdocPropertyTags := core.SameMap(node.JSDocPropertyTags, func(n *Node) *Node { return v.visitNode(n) })
 	return v.Factory.UpdateJSDocTypeLiteral(node, jsdocPropertyTags, node.IsArrayType)
 }
 
 func (node *JSDocTypeLiteral) Clone(f *NodeFactory) *Node {
-	return cloneNode(f.NewJSDocTypeLiteral(node.JsDocPropertyTags, node.IsArrayType), node.AsNode(), f.hooks)
+	return cloneNode(f.NewJSDocTypeLiteral(node.JSDocPropertyTags, node.IsArrayType), node.AsNode(), f.hooks)
 }
 
 // JSDocSignature
@@ -9657,9 +9657,9 @@ type SourceFile struct {
 
 	// !!!
 
-	CommonJsModuleIndicator *Node
+	CommonJSModuleIndicator *Node
 	ExternalModuleIndicator *Node
-	JsGlobalAugmentations   SymbolTable
+	JSGlobalAugmentations   SymbolTable
 }
 
 func (f *NodeFactory) NewSourceFile(text string, fileName string, path tspath.Path, statements *NodeList) *Node {
@@ -9741,9 +9741,9 @@ func (node *SourceFile) copyFrom(other *SourceFile) {
 	node.ReferencedFiles = other.ReferencedFiles
 	node.TypeReferenceDirectives = other.TypeReferenceDirectives
 	node.LibReferenceDirectives = other.LibReferenceDirectives
-	node.CommonJsModuleIndicator = other.CommonJsModuleIndicator
+	node.CommonJSModuleIndicator = other.CommonJSModuleIndicator
 	node.ExternalModuleIndicator = other.ExternalModuleIndicator
-	node.JsGlobalAugmentations = other.JsGlobalAugmentations
+	node.JSGlobalAugmentations = other.JSGlobalAugmentations
 	node.Flags |= other.Flags
 }
 

--- a/internal/ast/utilities.go
+++ b/internal/ast/utilities.go
@@ -1455,17 +1455,17 @@ func IsExternalModule(file *SourceFile) bool {
 	return file.ExternalModuleIndicator != nil
 }
 
-func IsExternalOrCommonJsModule(file *SourceFile) bool {
-	return file.ExternalModuleIndicator != nil || file.CommonJsModuleIndicator != nil
+func IsExternalOrCommonJSModule(file *SourceFile) bool {
+	return file.ExternalModuleIndicator != nil || file.CommonJSModuleIndicator != nil
 }
 
-// TODO: Should we deprecate `IsExternalOrCommonJsModule` in favor of this function?
+// TODO: Should we deprecate `IsExternalOrCommonJSModule` in favor of this function?
 func IsEffectiveExternalModule(node *SourceFile, compilerOptions *core.CompilerOptions) bool {
-	return IsExternalModule(node) || (isCommonJSContainingModuleKind(compilerOptions.GetEmitModuleKind()) && node.CommonJsModuleIndicator != nil)
+	return IsExternalModule(node) || (isCommonJSContainingModuleKind(compilerOptions.GetEmitModuleKind()) && node.CommonJSModuleIndicator != nil)
 }
 
 func IsEffectiveExternalModuleWorker(node *SourceFile, moduleKind core.ModuleKind) bool {
-	return IsExternalModule(node) || (isCommonJSContainingModuleKind(moduleKind) && node.CommonJsModuleIndicator != nil)
+	return IsExternalModule(node) || (isCommonJSContainingModuleKind(moduleKind) && node.CommonJSModuleIndicator != nil)
 }
 
 func isCommonJSContainingModuleKind(kind core.ModuleKind) bool {
@@ -2290,7 +2290,7 @@ func IsConstTypeReference(node *Node) bool {
 }
 
 func IsGlobalSourceFile(node *Node) bool {
-	return node.Kind == KindSourceFile && !IsExternalOrCommonJsModule(node.AsSourceFile())
+	return node.Kind == KindSourceFile && !IsExternalOrCommonJSModule(node.AsSourceFile())
 }
 
 func IsParameterLikeOrReturnTag(node *Node) bool {
@@ -2467,9 +2467,9 @@ func GetNodeAtPosition(file *SourceFile, position int, isJavaScriptFile bool) *N
 	for {
 		var child *Node
 		if isJavaScriptFile {
-			for _, jsDoc := range current.JSDoc(file) {
-				if nodeContainsPosition(jsDoc, position) {
-					child = jsDoc
+			for _, jsdoc := range current.JSDoc(file) {
+				if nodeContainsPosition(jsdoc, position) {
+					child = jsdoc
 					break
 				}
 			}

--- a/internal/astnav/tokens.go
+++ b/internal/astnav/tokens.go
@@ -191,7 +191,7 @@ func getPosition(node *ast.Node, sourceFile *ast.SourceFile, allowPositionInLead
 	if allowPositionInLeadingTrivia {
 		return node.Pos()
 	}
-	return scanner.GetTokenPosOfNode(node, sourceFile, true /*includeJsDoc*/)
+	return scanner.GetTokenPosOfNode(node, sourceFile, true /*includeJSDoc*/)
 }
 
 func findRightmostNode(node *ast.Node) *ast.Node {
@@ -236,11 +236,11 @@ func findRightmostNode(node *ast.Node) *ast.Node {
 
 func visitEachChildAndJSDoc(node *ast.Node, sourceFile *ast.SourceFile, visitor *ast.NodeVisitor) {
 	if node.Flags&ast.NodeFlagsHasJSDoc != 0 {
-		for _, jsDoc := range node.JSDoc(sourceFile) {
+		for _, jsdoc := range node.JSDoc(sourceFile) {
 			if visitor.Hooks.VisitNode != nil {
-				visitor.Hooks.VisitNode(jsDoc, visitor)
+				visitor.Hooks.VisitNode(jsdoc, visitor)
 			} else {
-				visitor.VisitNode(jsDoc)
+				visitor.VisitNode(jsdoc)
 			}
 		}
 	}

--- a/internal/binder/binder.go
+++ b/internal/binder/binder.go
@@ -1113,7 +1113,7 @@ func (b *Binder) bindBlockScopedDeclaration(node *ast.Node, symbolFlags ast.Symb
 	case ast.KindModuleDeclaration:
 		b.declareModuleMember(node, symbolFlags, symbolExcludes)
 	case ast.KindSourceFile:
-		if ast.IsExternalOrCommonJsModule(b.container.AsSourceFile()) {
+		if ast.IsExternalOrCommonJSModule(b.container.AsSourceFile()) {
 			b.declareModuleMember(node, symbolFlags, symbolExcludes)
 			break
 		}
@@ -1156,7 +1156,7 @@ func (b *Binder) lookupName(name string, container *ast.Node) *ast.Symbol {
 		}
 	}
 	if ast.IsSourceFile(container) {
-		local := container.AsSourceFile().JsGlobalAugmentations[name]
+		local := container.AsSourceFile().JSGlobalAugmentations[name]
 		if local != nil {
 			return local
 		}

--- a/internal/binder/nameresolver.go
+++ b/internal/binder/nameresolver.go
@@ -90,7 +90,7 @@ loop:
 		withinDeferredContext = withinDeferredContext || getIsDeferredContext(location, lastLocation)
 		switch location.Kind {
 		case ast.KindSourceFile:
-			if !ast.IsExternalOrCommonJsModule(location.AsSourceFile()) {
+			if !ast.IsExternalOrCommonJSModule(location.AsSourceFile()) {
 				break
 			}
 			fallthrough

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -1035,7 +1035,7 @@ func createFileIndexMap(files []*ast.SourceFile) map[*ast.SourceFile]int {
 func countGlobalSymbols(files []*ast.SourceFile) int {
 	count := 0
 	for _, file := range files {
-		if !ast.IsExternalOrCommonJsModule(file) {
+		if !ast.IsExternalOrCommonJSModule(file) {
 			count += len(file.Locals)
 		}
 	}
@@ -1197,7 +1197,7 @@ func (c *Checker) initializeChecker() {
 	// Initialize global symbol table
 	augmentations := make([][]*ast.Node, 0, len(c.files))
 	for _, file := range c.files {
-		if !ast.IsExternalOrCommonJsModule(file) {
+		if !ast.IsExternalOrCommonJSModule(file) {
 			c.mergeSymbolTable(c.globals, file.Locals, false, nil)
 		}
 		c.patternAmbientModules = append(c.patternAmbientModules, file.PatternAmbientModules...)
@@ -1651,7 +1651,7 @@ func (c *Checker) getSpellingSuggestionForName(name string, symbols []*ast.Symbo
 
 func (c *Checker) onSuccessfullyResolvedSymbol(errorLocation *ast.Node, result *ast.Symbol, meaning ast.SymbolFlags, lastLocation *ast.Node, associatedDeclarationForContainingInitializerOrBindingName *ast.Node, withinDeferredContext bool) {
 	name := result.Name
-	isInExternalModule := lastLocation != nil && ast.IsSourceFile(lastLocation) && ast.IsExternalOrCommonJsModule(lastLocation.AsSourceFile())
+	isInExternalModule := lastLocation != nil && ast.IsSourceFile(lastLocation) && ast.IsExternalOrCommonJSModule(lastLocation.AsSourceFile())
 	// Only check for block-scoped variable if we have an error location and are looking for the
 	// name with variable meaning
 	//      For example,
@@ -2042,7 +2042,7 @@ func (c *Checker) checkSourceFile(sourceFile *ast.SourceFile) {
 		c.checkSourceElements(sourceFile.Statements.Nodes)
 		c.checkDeferredNodes(sourceFile)
 		c.checkJSDocNodes(sourceFile)
-		if ast.IsExternalOrCommonJsModule(sourceFile) {
+		if ast.IsExternalOrCommonJSModule(sourceFile) {
 			c.checkExternalModuleExports(sourceFile.AsNode())
 			c.registerForUnusedIdentifiersCheck(sourceFile.AsNode())
 		}
@@ -7344,7 +7344,7 @@ func (c *Checker) checkSuperExpression(node *ast.Node) *Type {
 	// 		// block scope containers so that we can report potential collisions with
 	// 		// `Reflect`.
 	// 		forEachEnclosingBlockScopeContainer(node.Parent, func(current *ast.Node) {
-	// 			if !isSourceFile(current) || isExternalOrCommonJsModule(current) {
+	// 			if !isSourceFile(current) || isExternalOrCommonJSModule(current) {
 	// 				c.getNodeLinks(current).flags |= NodeCheckFlagsContainsSuperPropertyInStaticInitializer
 	// 			}
 	// 		})
@@ -9906,7 +9906,7 @@ func (c *Checker) checkCollisionWithRequireExportsInGeneratedCode(node *ast.Node
 	}
 	// In case of variable declaration, node.parent is variable statement so look at the variable statement's parent
 	parent := ast.GetDeclarationContainer(node)
-	if ast.IsSourceFile(parent) && ast.IsExternalOrCommonJsModule(parent.AsSourceFile()) {
+	if ast.IsSourceFile(parent) && ast.IsExternalOrCommonJSModule(parent.AsSourceFile()) {
 		// If the declaration happens to be in external module, report error that require and exports are reserved keywords
 		c.error(name, diagnostics.Duplicate_identifier_0_Compiler_reserves_name_1_in_top_level_scope_of_a_module, scanner.DeclarationNameToString(name), scanner.DeclarationNameToString(name))
 	}
@@ -10641,7 +10641,7 @@ func (c *Checker) checkPropertyAccessExpressionOrQualifiedName(node *ast.Node, l
 			}
 			// !!!
 			// containingClass := getContainingClassExcludingClassDecorators(right)
-			// if containingClass && isPlainJsFile(ast.GetSourceFileOfNode(containingClass), c.compilerOptions.checkJs) {
+			// if containingClass && isPlainJSFile(ast.GetSourceFileOfNode(containingClass), c.compilerOptions.checkJs) {
 			// 	c.grammarErrorOnNode(right, diagnostics.Private_field_0_must_be_declared_in_an_enclosing_class, right.Text())
 			// }
 		} else {
@@ -13375,10 +13375,10 @@ func (c *Checker) reportMergeSymbolError(target *ast.Symbol, source *ast.Symbol)
 	// 			"secondFileLocations": []never{},
 	// 		})
 	// 	})
-	// 	if !isSourcePlainJs {
+	// 	if !isSourcePlainJS {
 	// 		addDuplicateLocations(conflictingSymbolInfo.firstFileLocations, source)
 	// 	}
-	// 	if !isTargetPlainJs {
+	// 	if !isTargetPlainJS {
 	// 		addDuplicateLocations(conflictingSymbolInfo.secondFileLocations, target)
 	// 	}
 	// } else {
@@ -14293,7 +14293,7 @@ func (c *Checker) tryFindAmbientModule(moduleName string, withAugmentations bool
 func (c *Checker) resolveExternalModuleSymbol(moduleSymbol *ast.Symbol, dontResolveAlias bool) *ast.Symbol {
 	if moduleSymbol != nil {
 		exportEquals := c.resolveSymbolEx(moduleSymbol.Exports[ast.InternalSymbolNameExportEquals], dontResolveAlias)
-		exported := c.getMergedSymbol(c.getCommonJsExportEquals(c.getMergedSymbol(exportEquals), c.getMergedSymbol(moduleSymbol)))
+		exported := c.getMergedSymbol(c.getCommonJSExportEquals(c.getMergedSymbol(exportEquals), c.getMergedSymbol(moduleSymbol)))
 		if exported != nil {
 			return exported
 		}
@@ -14301,7 +14301,7 @@ func (c *Checker) resolveExternalModuleSymbol(moduleSymbol *ast.Symbol, dontReso
 	return moduleSymbol
 }
 
-func (c *Checker) getCommonJsExportEquals(exported *ast.Symbol, moduleSymbol *ast.Symbol) *ast.Symbol {
+func (c *Checker) getCommonJSExportEquals(exported *ast.Symbol, moduleSymbol *ast.Symbol) *ast.Symbol {
 	if exported == nil || exported == c.unknownSymbol || exported == moduleSymbol || len(moduleSymbol.Exports) == 1 || exported.Flags&ast.SymbolFlagsAlias != 0 {
 		return exported
 	}

--- a/internal/checker/utilities.go
+++ b/internal/checker/utilities.go
@@ -1669,7 +1669,7 @@ func isInNameOfExpressionWithTypeArguments(node *ast.Node) bool {
 	return node.Parent.Kind == ast.KindExpressionWithTypeArguments
 }
 
-func getTypeParameterFromJsDoc(node *ast.Node) *ast.Node {
+func getTypeParameterFromJSDoc(node *ast.Node) *ast.Node {
 	name := node.Name().Text()
 	typeParameters := node.Parent.Parent.Parent.TypeParameters()
 	return core.Find(typeParameters, func(p *ast.Node) bool { return p.Name().Text() == name })
@@ -1788,34 +1788,34 @@ func skipTypeChecking(sourceFile *ast.SourceFile, options *core.CompilerOptions)
 
 func canIncludeBindAndCheckDiagnostics(sourceFile *ast.SourceFile, options *core.CompilerOptions) bool {
 	// !!!
-	// if (!!sourceFile.checkJsDirective && sourceFile.checkJsDirective.enabled === false) return false;
+	// if (!!sourceFile.checkJSDirective && sourceFile.checkJSDirective.enabled === false) return false;
 
 	if sourceFile.ScriptKind == core.ScriptKindTS || sourceFile.ScriptKind == core.ScriptKindTSX || sourceFile.ScriptKind == core.ScriptKindExternal {
 		return true
 	}
 
-	isJs := sourceFile.ScriptKind == core.ScriptKindJS || sourceFile.ScriptKind == core.ScriptKindJSX
-	isCheckJs := isJs && isCheckJsEnabledForFile(sourceFile, options)
-	isPlainJs := isPlainJsFile(sourceFile, options.CheckJs)
+	isJS := sourceFile.ScriptKind == core.ScriptKindJS || sourceFile.ScriptKind == core.ScriptKindJSX
+	isCheckJS := isJS && isCheckJSEnabledForFile(sourceFile, options)
+	isPlainJS := isPlainJSFile(sourceFile, options.CheckJs)
 
 	// By default, only type-check .ts, .tsx, Deferred, plain JS, checked JS and External
 	// - plain JS: .js files with no // ts-check and checkJs: undefined
 	// - check JS: .js files with either // ts-check or checkJs: true
 	// - external: files that are added by plugins
-	return isPlainJs || isCheckJs || sourceFile.ScriptKind == core.ScriptKindDeferred
+	return isPlainJS || isCheckJS || sourceFile.ScriptKind == core.ScriptKindDeferred
 }
 
-func isCheckJsEnabledForFile(sourceFile *ast.SourceFile, compilerOptions *core.CompilerOptions) bool {
+func isCheckJSEnabledForFile(sourceFile *ast.SourceFile, compilerOptions *core.CompilerOptions) bool {
 	// !!!
-	// if sourceFile.CheckJsDirective != nil {
-	// 	return sourceFile.CheckJsDirective.Enabled
+	// if sourceFile.CheckJSDirective != nil {
+	// 	return sourceFile.CheckJSDirective.Enabled
 	// }
 	return compilerOptions.CheckJs == core.TSTrue
 }
 
-func isPlainJsFile(file *ast.SourceFile, checkJs core.Tristate) bool {
+func isPlainJSFile(file *ast.SourceFile, checkJs core.Tristate) bool {
 	// !!!
-	// return file != nil && (file.ScriptKind == core.ScriptKindJS || file.ScriptKind == core.ScriptKindJSX) && file.CheckJsDirective == nil && checkJs == core.TSUnknown
+	// return file != nil && (file.ScriptKind == core.ScriptKindJS || file.ScriptKind == core.ScriptKindJSX) && file.CheckJSDirective == nil && checkJs == core.TSUnknown
 	return file != nil && (file.ScriptKind == core.ScriptKindJS || file.ScriptKind == core.ScriptKindJSX) && checkJs == core.TSUnknown
 }
 

--- a/internal/compiler/emitter.go
+++ b/internal/compiler/emitter.go
@@ -33,7 +33,7 @@ type emitter struct {
 
 func (e *emitter) emit() {
 	// !!! tracing
-	e.emitJsFile(e.sourceFile, e.paths.jsFilePath, e.paths.sourceMapFilePath)
+	e.emitJSFile(e.sourceFile, e.paths.jsFilePath, e.paths.sourceMapFilePath)
 	e.emitDeclarationFile(e.sourceFile, e.paths.declarationFilePath, e.paths.declarationMapPath)
 	e.emitBuildInfo(e.paths.buildInfoPath)
 }
@@ -93,7 +93,7 @@ func (e *emitter) getScriptTransformers(emitContext *printer.EmitContext, source
 	return tx
 }
 
-func (e *emitter) emitJsFile(sourceFile *ast.SourceFile, jsFilePath string, sourceMapFilePath string) {
+func (e *emitter) emitJSFile(sourceFile *ast.SourceFile, jsFilePath string, sourceMapFilePath string) {
 	options := e.host.Options()
 
 	if sourceFile == nil || e.emitOnly != emitAll && e.emitOnly != emitOnlyJs || len(jsFilePath) == 0 {

--- a/internal/compiler/fileloader.go
+++ b/internal/compiler/fileloader.go
@@ -297,7 +297,7 @@ func (p *fileLoader) resolveImportsAndModuleAugmentations(file *ast.SourceFile) 
 			// - module name comes from the list of imports
 			// - it's not a top level JavaScript module that exceeded the search max
 
-			// const elideImport = isJsFileFromNodeModules && currentNodeModulesDepth > maxNodeModuleJsDepth;
+			// const elideImport = isJSFileFromNodeModules && currentNodeModulesDepth > maxNodeModuleJsDepth;
 
 			// Don't add the file if it has a bad extension (e.g. 'tsx' if we don't have '--allowJs')
 			// This may still end up being an untyped module -- the file won't be included but imports will be allowed.

--- a/internal/compiler/module/resolver.go
+++ b/internal/compiler/module/resolver.go
@@ -506,7 +506,7 @@ func (r *resolutionState) loadModuleFromSelfNameReference() *resolved {
 	// to ensure that self-name imports of their own package can resolve back to their
 	// input JS files via `tryLoadInputFileForPath` at a higher priority than their output
 	// declaration files, so we need to do a single pass with all extensions for that case.
-	if r.compilerOptions.GetAllowJs() && !strings.Contains(r.containingDirectory, "/node_modules/") {
+	if r.compilerOptions.GetAllowJS() && !strings.Contains(r.containingDirectory, "/node_modules/") {
 		return r.loadModuleFromExports(scope, r.extensions, subpath)
 	}
 	priorityExtensions := r.extensions & (extensionsTypeScript | extensionsDeclaration)

--- a/internal/core/compileroptions.go
+++ b/internal/core/compileroptions.go
@@ -207,7 +207,7 @@ func (options *CompilerOptions) ShouldPreserveConstEnums() bool {
 	return options.PreserveConstEnums == TSTrue || options.IsolatedModules == TSTrue
 }
 
-func (options *CompilerOptions) GetAllowJs() bool {
+func (options *CompilerOptions) GetAllowJS() bool {
 	if options.AllowJs != TSUnknown {
 		return options.AllowJs == TSTrue
 	}

--- a/internal/ls/definition.go
+++ b/internal/ls/definition.go
@@ -26,7 +26,7 @@ func (l *LanguageService) ProvideDefinitions(fileName string, position int) []Lo
 		for _, decl := range symbol.Declarations {
 			file := ast.GetSourceFileOfNode(decl)
 			loc := decl.Loc
-			pos := scanner.GetTokenPosOfNode(decl, file, false /*includeJsDoc*/)
+			pos := scanner.GetTokenPosOfNode(decl, file, false /*includeJSDoc*/)
 
 			locations = append(locations, Location{
 				FileName: file.FileName(),

--- a/internal/parser/jsdoc.go
+++ b/internal/parser/jsdoc.go
@@ -40,15 +40,15 @@ func (p *Parser) withJSDoc(node *ast.Node, hasJSDoc bool) {
 	p.hasDeprecatedTag = false
 	ranges := getJSDocCommentRanges(&p.factory, p.jsdocCommentRangesSpace, node, p.sourceText)
 	p.jsdocCommentRangesSpace = ranges[:0]
-	jsDoc := p.nodeSlicePool.NewSlice(len(ranges))[:0]
+	jsdoc := p.nodeSlicePool.NewSlice(len(ranges))[:0]
 	pos := node.Pos()
 	for _, comment := range ranges {
 		if parsed := p.parseJSDocComment(node, comment.Pos(), comment.End(), pos); parsed != nil {
-			jsDoc = append(jsDoc, parsed)
+			jsdoc = append(jsdoc, parsed)
 			pos = parsed.End()
 		}
 	}
-	if len(jsDoc) != 0 {
+	if len(jsdoc) != 0 {
 		if node.Flags&ast.NodeFlagsHasJSDoc == 0 {
 			node.Flags |= ast.NodeFlagsHasJSDoc
 		}
@@ -56,7 +56,7 @@ func (p *Parser) withJSDoc(node *ast.Node, hasJSDoc bool) {
 			p.hasDeprecatedTag = false
 			node.Flags |= ast.NodeFlagsDeprecated
 		}
-		p.jsdocCache[node] = jsDoc
+		p.jsdocCache[node] = jsdoc
 	}
 }
 
@@ -847,7 +847,7 @@ func (p *Parser) parseImportTag(start int, tagName *ast.IdentifierNode, margin i
 		identifier = p.parseIdentifier()
 	}
 
-	importClause := p.tryParseImportClause(identifier, afterImportTagPos, true /*isTypeOnly*/, true /*skipJsDocLeadingAsterisks*/)
+	importClause := p.tryParseImportClause(identifier, afterImportTagPos, true /*isTypeOnly*/, true /*skipJSDocLeadingAsterisks*/)
 	moduleSpecifier := p.parseModuleSpecifier()
 	attributes := p.tryParseImportAttributes()
 
@@ -861,9 +861,9 @@ func (p *Parser) parseExpressionWithTypeArgumentsForAugments() *ast.Node {
 	usedBrace := p.parseOptional(ast.KindOpenBraceToken)
 	pos := p.nodePos()
 	expression := p.parsePropertyAccessEntityNameExpression()
-	p.scanner.SetSkipJsDocLeadingAsterisks(true)
+	p.scanner.SetSkipJSDocLeadingAsterisks(true)
 	typeArguments := p.parseTypeArguments()
-	p.scanner.SetSkipJsDocLeadingAsterisks(false)
+	p.scanner.SetSkipJSDocLeadingAsterisks(false)
 	node := p.factory.NewExpressionWithTypeArguments(expression, typeArguments)
 	res := node
 	p.finishNode(node, pos)
@@ -911,7 +911,7 @@ func (p *Parser) parseTypedefTag(start int, tagName *ast.IdentifierNode, indent 
 	if typeExpression == nil || isObjectOrObjectArrayTypeReference(typeExpression.Type()) {
 		var child *ast.Node
 		var childTypeTag *ast.JSDocTypeTag
-		var jsDocPropertyTags []*ast.Node
+		var jsdocPropertyTags []*ast.Node
 		for {
 			state := p.mark()
 			child = p.parseChildPropertyTag(indent)
@@ -935,12 +935,12 @@ func (p *Parser) parseTypedefTag(start int, tagName *ast.IdentifierNode, indent 
 					break
 				}
 			} else {
-				jsDocPropertyTags = append(jsDocPropertyTags, child)
+				jsdocPropertyTags = append(jsdocPropertyTags, child)
 			}
 		}
 		if hasChildren {
 			isArrayType := typeExpression != nil && typeExpression.Type().Kind == ast.KindArrayType
-			jsdocTypeLiteral := p.factory.NewJSDocTypeLiteral(jsDocPropertyTags, isArrayType)
+			jsdocTypeLiteral := p.factory.NewJSDocTypeLiteral(jsdocPropertyTags, isArrayType)
 			if childTypeTag != nil && childTypeTag.TypeExpression != nil && !isObjectOrObjectArrayTypeReference(childTypeTag.TypeExpression.Type()) {
 				typeExpression = childTypeTag.TypeExpression
 			} else {
@@ -979,9 +979,9 @@ func (p *Parser) parseJSDocTypeNameWithNamespace(nested bool) *ast.Node {
 	typeNameOrNamespaceName := p.parseJSDocIdentifierName(nil)
 	if p.parseOptional(ast.KindDotToken) {
 		body := p.parseJSDocTypeNameWithNamespace(true)
-		jsDocNamespaceNode := p.factory.NewModuleDeclaration(nil /*modifiers*/, ast.KindModuleKeyword, typeNameOrNamespaceName, body)
-		p.finishNode(jsDocNamespaceNode, start)
-		return jsDocNamespaceNode
+		jsdocNamespaceNode := p.factory.NewModuleDeclaration(nil /*modifiers*/, ast.KindModuleKeyword, typeNameOrNamespaceName, body)
+		p.finishNode(jsdocNamespaceNode, start)
+		return jsdocNamespaceNode
 	}
 
 	return typeNameOrNamespaceName

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -2108,7 +2108,7 @@ func (p *Parser) parseImportDeclarationOrImportEqualsDeclaration(pos int, hasJSD
 		p.statementHasAwaitIdentifier = saveHasAwaitIdentifier // Import= declaration is always parsed in an Await context, no need to reparse
 		return importEquals
 	}
-	importClause := p.tryParseImportClause(identifier, afterImportPos, isTypeOnly, false /*skipJsDocLeadingAsterisks*/)
+	importClause := p.tryParseImportClause(identifier, afterImportPos, isTypeOnly, false /*skipJSDocLeadingAsterisks*/)
 	p.statementHasAwaitIdentifier = saveHasAwaitIdentifier // import clause is always parsed in an Await context
 	moduleSpecifier := p.parseModuleSpecifier()
 	attributes := p.tryParseImportAttributes()
@@ -2175,19 +2175,19 @@ func (p *Parser) parseModuleSpecifier() *ast.Expression {
 	return p.parseExpression()
 }
 
-func (p *Parser) tryParseImportClause(identifier *ast.Node, pos int, isTypeOnly bool, skipJsDocLeadingAsterisks bool) *ast.Node {
+func (p *Parser) tryParseImportClause(identifier *ast.Node, pos int, isTypeOnly bool, skipJSDocLeadingAsterisks bool) *ast.Node {
 	// ImportDeclaration:
 	//  import ImportClause from ModuleSpecifier ;
 	//  import ModuleSpecifier;
 	if identifier != nil || p.token == ast.KindAsteriskToken || p.token == ast.KindOpenBraceToken {
-		importClause := p.parseImportClause(identifier, pos, isTypeOnly, skipJsDocLeadingAsterisks)
+		importClause := p.parseImportClause(identifier, pos, isTypeOnly, skipJSDocLeadingAsterisks)
 		p.parseExpected(ast.KindFromKeyword)
 		return importClause
 	}
 	return nil
 }
 
-func (p *Parser) parseImportClause(identifier *ast.Node, pos int, isTypeOnly bool, skipJsDocLeadingAsterisks bool) *ast.Node {
+func (p *Parser) parseImportClause(identifier *ast.Node, pos int, isTypeOnly bool, skipJSDocLeadingAsterisks bool) *ast.Node {
 	// ImportClause:
 	//  ImportedDefaultBinding
 	//  NameSpaceImport
@@ -2199,16 +2199,16 @@ func (p *Parser) parseImportClause(identifier *ast.Node, pos int, isTypeOnly boo
 	var namedBindings *ast.Node
 	saveHasAwaitIdentifier := p.statementHasAwaitIdentifier
 	if identifier == nil || p.parseOptional(ast.KindCommaToken) {
-		if skipJsDocLeadingAsterisks {
-			p.scanner.SetSkipJsDocLeadingAsterisks(true)
+		if skipJSDocLeadingAsterisks {
+			p.scanner.SetSkipJSDocLeadingAsterisks(true)
 		}
 		if p.token == ast.KindAsteriskToken {
 			namedBindings = p.parseNamespaceImport()
 		} else {
 			namedBindings = p.parseNamedImports()
 		}
-		if skipJsDocLeadingAsterisks {
-			p.scanner.SetSkipJsDocLeadingAsterisks(false)
+		if skipJSDocLeadingAsterisks {
+			p.scanner.SetSkipJSDocLeadingAsterisks(false)
 		}
 	}
 	result := p.factory.NewImportClause(isTypeOnly, identifier, namedBindings)
@@ -2716,12 +2716,12 @@ func (p *Parser) parseJSDocNullableType() *ast.Node {
 }
 
 func (p *Parser) parseJSDocType() *ast.TypeNode {
-	p.scanner.SetSkipJsDocLeadingAsterisks(true)
+	p.scanner.SetSkipJSDocLeadingAsterisks(true)
 	pos := p.nodePos()
 
 	hasDotDotDot := p.parseOptional(ast.KindDotDotDotToken)
 	t := p.parseTypeOrTypePredicate()
-	p.scanner.SetSkipJsDocLeadingAsterisks(false)
+	p.scanner.SetSkipJSDocLeadingAsterisks(false)
 	if hasDotDotDot {
 		t = p.factory.NewJSDocVariadicType(t)
 		p.finishNode(t, pos)

--- a/internal/parser/references.go
+++ b/internal/parser/references.go
@@ -12,9 +12,9 @@ func collectExternalModuleReferences(file *ast.SourceFile) {
 	// !!!
 	// If we are importing helpers, we need to add a synthetic reference to resolve the
 	// helpers library. (A JavaScript file without `externalModuleIndicator` set might be
-	// a CommonJS module; `commonJsModuleIndicator` doesn't get set until the binder has
+	// a CommonJS module; `commonJSModuleIndicator` doesn't get set until the binder has
 	// run. We synthesize a helpers import for it just in case; it will never be used if
-	// the binder doesn't find and set a `commonJsModuleIndicator`.)
+	// the binder doesn't find and set a `commonJSModuleIndicator`.)
 	// if (isJavaScriptFile || (!file.isDeclarationFile && (getIsolatedModules(options) || isExternalModule(file)))) {
 	// 	if (options.importHelpers) {
 	// 		// synthesize 'import "tslib"' declaration

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -42,7 +42,7 @@ type PrinterOptions struct {
 	// InlineSources                 bool
 	OmitBraceSourceMapPositions bool
 	// ExtendedDiagnostics           bool
-	OnlyPrintJsDocStyle bool
+	OnlyPrintJSDocStyle bool
 	// NeverAsciiEscape              bool
 	// StripInternal                 bool
 	PreserveSourceNewlines bool
@@ -707,7 +707,7 @@ func (p *Printer) shouldEmitComments(node *ast.Node) bool {
 }
 
 func (p *Printer) shouldWriteComment(comment ast.CommentRange) bool {
-	return !p.Options.OnlyPrintJsDocStyle ||
+	return !p.Options.OnlyPrintJSDocStyle ||
 		p.currentSourceFile != nil && isJSDocLikeText(p.currentSourceFile.Text, comment) ||
 		p.currentSourceFile != nil && isPinnedComment(p.currentSourceFile.Text, comment)
 }

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -322,7 +322,7 @@ func (s *Scanner) ResetPos(pos int) {
 	s.tokenStart = pos
 }
 
-func (scanner *Scanner) SetSkipJsDocLeadingAsterisks(skip bool) {
+func (scanner *Scanner) SetSkipJSDocLeadingAsterisks(skip bool) {
 	if skip {
 		scanner.skipJSDocLeadingAsterisks += 1
 	} else {
@@ -2247,7 +2247,7 @@ func GetRangeOfTokenAtPosition(sourceFile *ast.SourceFile, pos int) core.TextRan
 	return core.NewTextRange(s.tokenStart, s.pos)
 }
 
-func GetTokenPosOfNode(node *ast.Node, sourceFile *ast.SourceFile, includeJsDoc bool) int {
+func GetTokenPosOfNode(node *ast.Node, sourceFile *ast.SourceFile, includeJSDoc bool) int {
 	// With nodes that have no width (i.e. 'Missing' nodes), we actually *don't*
 	// want to skip trivia because this will launch us forward to the next token.
 	if ast.NodeIsMissing(node) {
@@ -2259,8 +2259,8 @@ func GetTokenPosOfNode(node *ast.Node, sourceFile *ast.SourceFile, includeJsDoc 
 		return SkipTriviaEx(sourceFile.Text, node.Pos(), &SkipTriviaOptions{StopAtComments: true})
 	}
 
-	if includeJsDoc && len(node.JSDoc(sourceFile)) > 0 {
-		return GetTokenPosOfNode(node.JSDoc(sourceFile)[0], sourceFile, false /*includeJsDoc*/)
+	if includeJSDoc && len(node.JSDoc(sourceFile)) > 0 {
+		return GetTokenPosOfNode(node.JSDoc(sourceFile)[0], sourceFile, false /*includeJSDoc*/)
 	}
 
 	return SkipTriviaEx(

--- a/internal/testrunner/compiler_runner.go
+++ b/internal/testrunner/compiler_runner.go
@@ -358,7 +358,7 @@ func (c *compilerTest) verifyJavaScriptOutput(t *testing.T, suiteName string, is
 			headerComponents = headerComponents[4:] // Strip "./../_submodules/TypeScript" prefix
 		}
 		header := tspath.GetPathFromPathComponents(headerComponents)
-		tsbaseline.DoJsEmitBaseline(
+		tsbaseline.DoJSEmitBaseline(
 			t,
 			c.configuredName,
 			header,

--- a/internal/testutil/harnessutil/harnessutil.go
+++ b/internal/testutil/harnessutil/harnessutil.go
@@ -532,8 +532,8 @@ type CompilationResult struct {
 	Program          *compiler.Program
 	Options          *core.CompilerOptions
 	HarnessOptions   *HarnessOptions
-	Js               collections.OrderedMap[string, *TestFile]
-	Dts              collections.OrderedMap[string, *TestFile]
+	JS               collections.OrderedMap[string, *TestFile]
+	DTS              collections.OrderedMap[string, *TestFile]
 	Maps             collections.OrderedMap[string, *TestFile]
 	Symlinks         map[string]string
 	Repeat           func(TestConfiguration) *CompilationResult
@@ -544,8 +544,8 @@ type CompilationResult struct {
 
 type CompilationOutput struct {
 	Inputs []*TestFile
-	Js     *TestFile
-	Dts    *TestFile
+	JS     *TestFile
+	DTS    *TestFile
 	Map    *TestFile
 }
 
@@ -595,22 +595,22 @@ func newCompilationResult(
 					extname := core.GetOutputExtension(sourceFile.FileName(), options.Jsx)
 					outputs := &CompilationOutput{
 						Inputs: []*TestFile{input},
-						Js:     js.GetOrZero(c.getOutputPath(sourceFile.FileName(), extname)),
-						Dts:    dts.GetOrZero(c.getOutputPath(sourceFile.FileName(), tspath.GetDeclarationEmitExtensionForPath(sourceFile.FileName()))),
+						JS:     js.GetOrZero(c.getOutputPath(sourceFile.FileName(), extname)),
+						DTS:    dts.GetOrZero(c.getOutputPath(sourceFile.FileName(), tspath.GetDeclarationEmitExtensionForPath(sourceFile.FileName()))),
 						Map:    maps.GetOrZero(c.getOutputPath(sourceFile.FileName(), extname+".map")),
 					}
 					c.inputsAndOutputs.Set(sourceFile.FileName(), outputs)
-					if outputs.Js != nil {
-						c.inputsAndOutputs.Set(outputs.Js.UnitName, outputs)
-						c.Js.Set(outputs.Js.UnitName, outputs.Js)
-						js.Delete(outputs.Js.UnitName)
-						c.outputs = append(c.outputs, outputs.Js)
+					if outputs.JS != nil {
+						c.inputsAndOutputs.Set(outputs.JS.UnitName, outputs)
+						c.JS.Set(outputs.JS.UnitName, outputs.JS)
+						js.Delete(outputs.JS.UnitName)
+						c.outputs = append(c.outputs, outputs.JS)
 					}
-					if outputs.Dts != nil {
-						c.inputsAndOutputs.Set(outputs.Dts.UnitName, outputs)
-						c.Dts.Set(outputs.Dts.UnitName, outputs.Dts)
-						dts.Delete(outputs.Dts.UnitName)
-						c.outputs = append(c.outputs, outputs.Dts)
+					if outputs.DTS != nil {
+						c.inputsAndOutputs.Set(outputs.DTS.UnitName, outputs)
+						c.DTS.Set(outputs.DTS.UnitName, outputs.DTS)
+						dts.Delete(outputs.DTS.UnitName)
+						c.outputs = append(c.outputs, outputs.DTS)
 					}
 					if outputs.Map != nil {
 						c.inputsAndOutputs.Set(outputs.Map.UnitName, outputs)
@@ -624,10 +624,10 @@ func newCompilationResult(
 
 		// add any unhandled outputs, ordered by unit name
 		for _, document := range slices.SortedFunc(js.Values(), compareTestFiles) {
-			c.Js.Set(document.UnitName, document)
+			c.JS.Set(document.UnitName, document)
 		}
 		for _, document := range slices.SortedFunc(dts.Values(), compareTestFiles) {
-			c.Dts.Set(document.UnitName, document)
+			c.DTS.Set(document.UnitName, document)
 		}
 		for _, document := range slices.SortedFunc(maps.Values(), compareTestFiles) {
 			c.Maps.Set(document.UnitName, document)
@@ -675,10 +675,10 @@ func (r *CompilationResult) FS() vfs.FS {
 
 func (r *CompilationResult) GetNumberOfJSFiles(includeJson bool) int {
 	if includeJson {
-		return r.Js.Size()
+		return r.JS.Size()
 	}
 	count := 0
-	for file := range r.Js.Values() {
+	for file := range r.JS.Values() {
 		if !tspath.FileExtensionIs(file.UnitName, tspath.ExtensionJson) {
 			count++
 		}
@@ -711,9 +711,9 @@ func (c *CompilationResult) GetOutput(path string, kind string /*"js" | "dts" | 
 	if outputs != nil {
 		switch kind {
 		case "js":
-			return outputs.Js
+			return outputs.JS
 		case "dts":
-			return outputs.Dts
+			return outputs.DTS
 		case "map":
 			return outputs.Map
 		}

--- a/internal/testutil/tsbaseline/js_emit_baseline.go
+++ b/internal/testutil/tsbaseline/js_emit_baseline.go
@@ -12,7 +12,7 @@ import (
 	"github.com/microsoft/typescript-go/internal/tspath"
 )
 
-func DoJsEmitBaseline(
+func DoJSEmitBaseline(
 	t *testing.T,
 	baselinePath string,
 	header string,
@@ -24,7 +24,7 @@ func DoJsEmitBaseline(
 	harnessSettings *harnessutil.HarnessOptions,
 	opts baseline.Options,
 ) {
-	if options.GetAllowJs() {
+	if options.GetAllowJS() {
 		t.Skip("AllowJS is not supported")
 		return
 	}
@@ -33,7 +33,7 @@ func DoJsEmitBaseline(
 		return
 	}
 
-	if !options.NoEmit.IsTrue() && !options.EmitDeclarationOnly.IsTrue() && result.Js.Size() == 0 && len(result.Diagnostics) == 0 {
+	if !options.NoEmit.IsTrue() && !options.EmitDeclarationOnly.IsTrue() && result.JS.Size() == 0 && len(result.Diagnostics) == 0 {
 		panic("Expected at least one js file to be emitted or at least one error to be created.")
 	}
 
@@ -55,7 +55,7 @@ func DoJsEmitBaseline(
 	}
 
 	var jsCode strings.Builder
-	for file := range result.Js.Values() {
+	for file := range result.JS.Values() {
 		if jsCode.Len() > 0 && !strings.HasSuffix(jsCode.String(), "\n") {
 			jsCode.WriteString("\r\n")
 		}
@@ -138,8 +138,8 @@ func DoJsEmitBaseline(
 	////			}
 	////		}
 	////	}
-	////	compareResultFileSets(withoutChecking.Dts, result.Dts)
-	////	compareResultFileSets(withoutChecking.Js, result.Js)
+	////	compareResultFileSets(withoutChecking.DTS, result.DTS)
+	////	compareResultFileSets(withoutChecking.JS, result.JS)
 	////}
 
 	if tspath.FileExtensionIsOneOf(baselinePath, []string{tspath.ExtensionTs, tspath.ExtensionTsx}) {
@@ -185,10 +185,10 @@ func prepareDeclarationCompilationContext(
 ) *declarationCompilationContext {
 	if options.Declaration.IsTrue() && len(result.Diagnostics) == 0 {
 		if options.EmitDeclarationOnly.IsTrue() {
-			if result.Js.Size() > 0 || (result.Dts.Size() == 0 && !options.NoEmit.IsTrue()) {
+			if result.JS.Size() > 0 || (result.DTS.Size() == 0 && !options.NoEmit.IsTrue()) {
 				panic("Only declaration files should be generated when emitDeclarationOnly:true")
 			}
-		} else if result.Dts.Size() != result.GetNumberOfJSFiles(false /*includeJson*/) {
+		} else if result.DTS.Size() != result.GetNumberOfJSFiles(false /*includeJson*/) {
 			panic("There were no errors and declFiles generated did not match number of js files generated")
 		}
 	}
@@ -228,13 +228,13 @@ func prepareDeclarationCompilationContext(
 		////}
 
 		dTsFileName := tspath.RemoveFileExtension(sourceFileName) + tspath.GetDeclarationEmitExtensionForPath(sourceFileName)
-		return result.Dts.GetOrZero(dTsFileName)
+		return result.DTS.GetOrZero(dTsFileName)
 	}
 
 	addDtsFile := func(file *harnessutil.TestFile, dtsFiles []*harnessutil.TestFile) []*harnessutil.TestFile {
 		if tspath.IsDeclarationFileName(file.UnitName) || tspath.HasJSONFileExtension(file.UnitName) {
 			dtsFiles = append(dtsFiles, file)
-		} else if tspath.HasTSFileExtension(file.UnitName) || (tspath.HasJSFileExtension(file.UnitName) && options.GetAllowJs()) {
+		} else if tspath.HasTSFileExtension(file.UnitName) || (tspath.HasJSFileExtension(file.UnitName) && options.GetAllowJS()) {
 			declFile := findResultCodeFile(file.UnitName)
 			if declFile != nil && findUnit(declFile.UnitName, declInputFiles) == nil && findUnit(declFile.UnitName, declOtherFiles) == nil {
 				dtsFiles = append(dtsFiles, &harnessutil.TestFile{
@@ -247,7 +247,7 @@ func prepareDeclarationCompilationContext(
 	}
 
 	// if the .d.ts is non-empty, confirm it compiles correctly as well
-	if options.Declaration.IsTrue() && len(result.Diagnostics) == 0 && result.Dts.Size() > 0 {
+	if options.Declaration.IsTrue() && len(result.Diagnostics) == 0 && result.DTS.Size() > 0 {
 		for _, file := range inputFiles {
 			declInputFiles = addDtsFile(file, declInputFiles)
 		}

--- a/internal/transformers/commonjsmodule.go
+++ b/internal/transformers/commonjsmodule.go
@@ -242,7 +242,7 @@ func (tx *CommonJSModuleTransformer) visitSourceFile(node *ast.SourceFile) *ast.
 
 func (tx *CommonJSModuleTransformer) shouldEmitUnderscoreUnderscoreESModule() bool {
 	if tspath.FileExtensionIsOneOf(tx.currentSourceFile.FileName(), tspath.SupportedJSExtensionsFlat) &&
-		tx.currentSourceFile.CommonJsModuleIndicator != nil &&
+		tx.currentSourceFile.CommonJSModuleIndicator != nil &&
 		(tx.currentSourceFile.ExternalModuleIndicator == nil /*|| tx.currentSourceFile.ExternalModuleIndicator == true*/) { // !!!
 		return false
 	}
@@ -1709,7 +1709,7 @@ func (tx *CommonJSModuleTransformer) visitImportCallExpression(node *ast.CallExp
 func (tx *CommonJSModuleTransformer) createImportCallExpressionCommonJS(arg *ast.Expression) *ast.Expression {
 	// import(x)
 	// emit as
-	// Promise.resolve(`${x}`).then((s) => require(s)) /*CommonJs Require*/
+	// Promise.resolve(`${x}`).then((s) => require(s)) /*CommonJS Require*/
 	// We have to wrap require in then callback so that require is done in asynchronously
 	// if we simply do require in resolve callback in Promise constructor. We will execute the loading immediately
 	// If the arg is not inlineable, we have to evaluate and ToString() it in the current scope

--- a/internal/tsoptions/tsconfigparsing.go
+++ b/internal/tsoptions/tsconfigparsing.go
@@ -1518,16 +1518,16 @@ func getFileNamesFromConfigSpecs(
 }
 
 func GetSupportedExtensions(options *core.CompilerOptions, extraFileExtensions []fileExtensionInfo) [][]string {
-	needJsExtensions := options.GetAllowJs()
+	needJSExtensions := options.GetAllowJS()
 	if len(extraFileExtensions) == 0 {
-		if needJsExtensions {
+		if needJSExtensions {
 			return tspath.AllSupportedExtensions
 		} else {
 			return tspath.SupportedTSExtensions
 		}
 	}
 	var builtins [][]string
-	if needJsExtensions {
+	if needJSExtensions {
 		builtins = tspath.AllSupportedExtensions
 	} else {
 		builtins = tspath.SupportedTSExtensions
@@ -1535,7 +1535,7 @@ func GetSupportedExtensions(options *core.CompilerOptions, extraFileExtensions [
 	flatBuiltins := core.Flatten(builtins)
 	var result [][]string
 	for _, x := range extraFileExtensions {
-		if x.scriptKind == core.ScriptKindDeferred || (needJsExtensions && (x.scriptKind == core.ScriptKindJS || x.scriptKind == core.ScriptKindJSX)) && !slices.Contains(flatBuiltins, x.extension) {
+		if x.scriptKind == core.ScriptKindDeferred || (needJSExtensions && (x.scriptKind == core.ScriptKindJS || x.scriptKind == core.ScriptKindJSX)) && !slices.Contains(flatBuiltins, x.extension) {
 			result = append(result, []string{x.extension})
 		}
 	}


### PR DESCRIPTION
I chose the spellings

- `jsdoc` not `jsDoc`
- `JS` not `Js`
- `CommonJS` not `CommonJs`


I am OK with Js instead of JS, but I like JS better and I am the one typing it all the time right now.

- I didn't change compiler options since those are external facing
- I didn't change the tspath Extension enum because there are lot of related Ts, Dts, Dcts, ... entries.
- I didn't change JSX, but only because I'm typing JS all the time right now, not JSX.
- I changed harnessutils because, in the triple `{ Js, Dts, Maps }`, only one of those is plural, which was enough additional justification for a change.
