### PR TITLE
wire up jsx-runtime import synthesis

### DIFF
--- a/internal/astnav/tokens_test.go
+++ b/internal/astnav/tokens_test.go
@@ -52,7 +52,7 @@ func TestGetTokenAtPosition(t *testing.T) {
 				return 0;
 			}
 		`
-		file := parser.ParseSourceFile("/file.ts", "/file.ts", fileText, core.ScriptTargetLatest, scanner.JSDocParsingModeParseAll)
+		file := parser.ParseSourceFile("/file.ts", "/file.ts", fileText, core.ScriptTargetLatest, scanner.JSDocParsingModeParseAll, nil)
 		assert.Equal(t, astnav.GetTokenAtPosition(file, 0), astnav.GetTokenAtPosition(file, 0))
 	})
 }
@@ -86,7 +86,7 @@ func baselineTokens(t *testing.T, testName string, getTSTokens func(fileText str
 				positions[i] = i
 			}
 			tsTokens := getTSTokens(string(fileText), positions)
-			file := parser.ParseSourceFile("/file.ts", "/file.ts", string(fileText), core.ScriptTargetLatest, scanner.JSDocParsingModeParseAll)
+			file := parser.ParseSourceFile("/file.ts", "/file.ts", string(fileText), core.ScriptTargetLatest, scanner.JSDocParsingModeParseAll, nil)
 
 			var output strings.Builder
 			currentRange := core.NewTextRange(0, 0)

--- a/internal/binder/binder_test.go
+++ b/internal/binder/binder_test.go
@@ -24,7 +24,7 @@ func BenchmarkBind(b *testing.B) {
 
 			sourceFiles := make([]*ast.SourceFile, b.N)
 			for i := range b.N {
-				sourceFiles[i] = parser.ParseSourceFile(fileName, path, sourceText, core.ScriptTargetESNext, scanner.JSDocParsingModeParseAll)
+				sourceFiles[i] = parser.ParseSourceFile(fileName, path, sourceText, core.ScriptTargetESNext, scanner.JSDocParsingModeParseAll, nil)
 			}
 
 			compilerOptions := &core.CompilerOptions{Target: core.ScriptTargetESNext, ModuleKind: core.ModuleKindNodeNext}

--- a/internal/checker/jsx.go
+++ b/internal/checker/jsx.go
@@ -1246,7 +1246,7 @@ func (c *Checker) getJsxNamespaceContainerForImplicitImport(location *ast.Node) 
 	if links != nil && links.jsxImplicitImportContainer != nil {
 		return core.IfElse(links.jsxImplicitImportContainer == c.unknownSymbol, nil, links.jsxImplicitImportContainer)
 	}
-	runtimeImportSpecifier := getJSXRuntimeImport(getJSXImplicitImportBase(c.compilerOptions, file), c.compilerOptions)
+	runtimeImportSpecifier := GetJSXRuntimeImport(GetJSXImplicitImportBase(c.compilerOptions, file), c.compilerOptions)
 	if runtimeImportSpecifier == "" {
 		return nil
 	}
@@ -1274,7 +1274,7 @@ func (c *Checker) getJSXRuntimeImportSpecifier(file *ast.SourceFile, specifierTe
 	return specifier
 }
 
-func getJSXImplicitImportBase(compilerOptions *core.CompilerOptions, file *ast.SourceFile) string {
+func GetJSXImplicitImportBase(compilerOptions *core.CompilerOptions, file *ast.SourceFile) string {
 	jsxImportSourcePragma := getPragmaFromSourceFile(file, "jsximportsource")
 	jsxRuntimePragma := getPragmaFromSourceFile(file, "jsxruntime")
 	if getPragmaArgument(jsxRuntimePragma, "factory") == "classic" {
@@ -1297,7 +1297,7 @@ func getJSXImplicitImportBase(compilerOptions *core.CompilerOptions, file *ast.S
 	return ""
 }
 
-func getJSXRuntimeImport(base string, options *core.CompilerOptions) string {
+func GetJSXRuntimeImport(base string, options *core.CompilerOptions) string {
 	if base == "" {
 		return base
 	}

--- a/internal/compiler/host.go
+++ b/internal/compiler/host.go
@@ -73,5 +73,5 @@ func (h *compilerHost) GetSourceFile(fileName string, path tspath.Path, language
 	if tspath.FileExtensionIs(fileName, tspath.ExtensionJson) {
 		return parser.ParseJSONText(fileName, path, text)
 	}
-	return parser.ParseSourceFile(fileName, path, text, languageVersion, scanner.JSDocParsingModeParseForTypeErrors)
+	return parser.ParseSourceFile(fileName, path, text, languageVersion, scanner.JSDocParsingModeParseForTypeErrors, h.options)
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -335,7 +335,7 @@ func (p *Parser) parseSourceFileWorker() *ast.SourceFile {
 	}
 	p.jsdocCache = nil
 	p.possibleAwaitSpans = []int{}
-	collectExternalModuleReferences(result)
+	p.collectExternalModuleReferences(result)
 	return result
 }
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -94,12 +94,12 @@ func putParser(p *Parser) {
 	parserPool.Put(p)
 }
 
-func ParseSourceFile(fileName string, path tspath.Path, sourceText string, languageVersion core.ScriptTarget, jsdocParsingMode scanner.JSDocParsingMode) *ast.SourceFile {
+func ParseSourceFile(fileName string, path tspath.Path, sourceText string, languageVersion core.ScriptTarget, jsdocParsingMode scanner.JSDocParsingMode, compilerOptions *core.CompilerOptions) *ast.SourceFile {
 	p := getParser()
 	defer putParser(p)
 	p.initializeState(fileName, path, sourceText, languageVersion, core.ScriptKindUnknown, jsdocParsingMode)
 	p.nextToken()
-	return p.parseSourceFileWorker()
+	return p.parseSourceFileWorker(compilerOptions)
 }
 
 func ParseJSONText(fileName string, path tspath.Path, sourceText string) *ast.SourceFile {
@@ -310,7 +310,7 @@ func (p *Parser) hasPrecedingJSDocComment() bool {
 	return p.scanner.HasPrecedingJSDocComment()
 }
 
-func (p *Parser) parseSourceFileWorker() *ast.SourceFile {
+func (p *Parser) parseSourceFileWorker(compilerOptions *core.CompilerOptions) *ast.SourceFile {
 	isDeclarationFile := tspath.IsDeclarationFileName(p.fileName)
 	if isDeclarationFile {
 		p.contextFlags |= ast.NodeFlagsAmbient
@@ -335,7 +335,7 @@ func (p *Parser) parseSourceFileWorker() *ast.SourceFile {
 	}
 	p.jsdocCache = nil
 	p.possibleAwaitSpans = []int{}
-	p.collectExternalModuleReferences(result)
+	p.collectExternalModuleReferences(result, compilerOptions)
 	return result
 }
 

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -39,7 +39,7 @@ func BenchmarkParse(b *testing.B) {
 				b.Run(jsdoc.name, func(b *testing.B) {
 					jsdocMode := jsdoc.mode
 					for b.Loop() {
-						ParseSourceFile(fileName, path, sourceText, core.ScriptTargetESNext, jsdocMode)
+						ParseSourceFile(fileName, path, sourceText, core.ScriptTargetESNext, jsdocMode, nil)
 					}
 				})
 			}
@@ -82,7 +82,7 @@ func TestParseTypeScriptRepo(t *testing.T) {
 					if strings.HasSuffix(f.name, ".json") {
 						sourceFile = ParseJSONText(fileName, path, string(sourceText))
 					} else {
-						sourceFile = ParseSourceFile(fileName, path, string(sourceText), core.ScriptTargetESNext, scanner.JSDocParsingModeParseAll)
+						sourceFile = ParseSourceFile(fileName, path, string(sourceText), core.ScriptTargetESNext, scanner.JSDocParsingModeParseAll, nil)
 					}
 
 					if !test.ignoreErrors {
@@ -179,6 +179,6 @@ func FuzzParser(f *testing.F) {
 			return
 		}
 
-		ParseSourceFile(fileName, path, sourceText, scriptTarget, jsdocParsingMode)
+		ParseSourceFile(fileName, path, sourceText, scriptTarget, jsdocParsingMode, nil)
 	})
 }

--- a/internal/parser/references.go
+++ b/internal/parser/references.go
@@ -35,7 +35,7 @@ func (p *Parser) collectExternalModuleReferences(file *ast.SourceFile) {
 	// run. We synthesize a helpers import for it just in case; it will never be used if
 	// the binder doesn't find and set a `commonJSModuleIndicator`.)
 	if isJavaScriptFile || (!file.IsDeclarationFile && (options.GetIsolatedModules() || isExternalModuleFile)) {
-		if options.ImportHelpers == core.TSTrue {
+		if options.ImportHelpers.IsTrue() {
 			// synthesize 'import "tslib"' declaration
 			file.Imports = append(file.Imports, p.createSyntheticImport("tslib", file))
 		}

--- a/internal/project/documentregistry.go
+++ b/internal/project/documentregistry.go
@@ -92,7 +92,7 @@ func (r *documentRegistry) getDocumentWorker(
 		// the script snapshot. If so, update it appropriately.
 		entry := entryAny.(*registryEntry)
 		if entry.sourceFile.Version != scriptInfo.version {
-			sourceFile := parser.ParseSourceFile(scriptInfo.fileName, scriptInfo.path, scriptInfo.text, scriptTarget, scanner.JSDocParsingModeParseAll)
+			sourceFile := parser.ParseSourceFile(scriptInfo.fileName, scriptInfo.path, scriptInfo.text, scriptTarget, scanner.JSDocParsingModeParseAll, compilerOptions)
 			sourceFile.Version = scriptInfo.version
 			entry.mu.Lock()
 			defer entry.mu.Unlock()
@@ -102,7 +102,7 @@ func (r *documentRegistry) getDocumentWorker(
 		return entry.sourceFile
 	} else {
 		// Have never seen this file with these settings. Create a new source file for it.
-		sourceFile := parser.ParseSourceFile(scriptInfo.fileName, scriptInfo.path, scriptInfo.text, scriptTarget, scanner.JSDocParsingModeParseAll)
+		sourceFile := parser.ParseSourceFile(scriptInfo.fileName, scriptInfo.path, scriptInfo.text, scriptTarget, scanner.JSDocParsingModeParseAll, compilerOptions)
 		sourceFile.Version = scriptInfo.version
 		entryAny, _ := r.documents.LoadOrStore(key, &registryEntry{
 			sourceFile: sourceFile,

--- a/internal/testutil/harnessutil/harnessutil.go
+++ b/internal/testutil/harnessutil/harnessutil.go
@@ -460,7 +460,7 @@ func (h *cachedCompilerHost) GetSourceFile(fileName string, path tspath.Path, la
 		sourceFile = parser.ParseJSONText(fileName, path, text)
 	} else {
 		// !!! JSDocParsingMode
-		sourceFile = parser.ParseSourceFile(fileName, path, text, languageVersion, scanner.JSDocParsingModeParseAll)
+		sourceFile = parser.ParseSourceFile(fileName, path, text, languageVersion, scanner.JSDocParsingModeParseAll, h.options)
 	}
 
 	result, _ := sourceFileCache.LoadOrStore(key, sourceFile)

--- a/internal/testutil/parsetestutil/parsetestutil.go
+++ b/internal/testutil/parsetestutil/parsetestutil.go
@@ -15,7 +15,7 @@ import (
 // Simplifies parsing an input string into a SourceFile for testing purposes.
 func ParseTypeScript(text string, jsx bool) *ast.SourceFile {
 	fileName := core.IfElse(jsx, "/main.tsx", "/main.ts")
-	file := parser.ParseSourceFile(fileName, tspath.Path(fileName), text, core.ScriptTargetESNext, scanner.JSDocParsingModeParseNone)
+	file := parser.ParseSourceFile(fileName, tspath.Path(fileName), text, core.ScriptTargetESNext, scanner.JSDocParsingModeParseNone, nil)
 	ast.SetParentInChildren(file.AsNode())
 	return file
 }

--- a/internal/testutil/tsbaseline/js_emit_baseline.go
+++ b/internal/testutil/tsbaseline/js_emit_baseline.go
@@ -65,7 +65,8 @@ func DoJSEmitBaseline(
 				tspath.Path(file.UnitName),
 				file.Content,
 				options.GetEmitScriptTarget(),
-				scanner.JSDocParsingModeParseAll)
+				scanner.JSDocParsingModeParseAll,
+				nil)
 			if len(fileParseResult.Diagnostics()) > 0 {
 				jsCode.WriteString(getErrorBaseline(t, []*harnessutil.TestFile{file}, fileParseResult.Diagnostics(), false /*pretty*/))
 				continue


### PR DESCRIPTION
wire up jsxImportSource

currently two blockers:

- `compilerOptions` is not available in `internal/parser` within `collectExternalModuleReferences`
- import cycle trying to access checker from parser
    ```
    package github.com/microsoft/typescript-go/cmd/tsgo
        imports github.com/microsoft/typescript-go/internal/compiler from main.go
        imports github.com/microsoft/typescript-go/internal/checker from program.go
        imports github.com/microsoft/typescript-go/internal/parser from jsx.go
        imports github.com/microsoft/typescript-go/internal/checker from references.go: import cycle not allowed
    ```

fixes #765 #767
