### PR TITLE
Add precedence and printing for JSDoc types

### DIFF
--- a/internal/ast/precedence.go
+++ b/internal/ast/precedence.go
@@ -414,6 +414,12 @@ const (
 	//
 	TypePrecedenceConditional TypePrecedence = iota
 
+	// JSDoc precedence (optional and variadic types)
+	//
+	//    JSDocType:
+	//      `...`? Type `=`?
+	TypePrecedenceJSDoc
+
 	// Function precedence
 	//
 	//   Type[Extends]:
@@ -651,6 +657,8 @@ func GetTypeNodePrecedence(n *TypeNode) TypePrecedence {
 	switch n.Kind {
 	case KindConditionalType:
 		return TypePrecedenceConditional
+	case KindJSDocOptionalType, KindJSDocVariadicType:
+		return TypePrecedenceJSDoc
 	case KindFunctionType, KindConstructorType:
 		return TypePrecedenceFunction
 	case KindUnionType:
@@ -684,6 +692,9 @@ func GetTypeNodePrecedence(n *TypeNode) TypePrecedence {
 		KindObjectKeyword,
 		KindIntrinsicKeyword,
 		KindVoidKeyword,
+		KindJSDocAllType,
+		KindJSDocNullableType,
+		KindJSDocNonNullableType,
 		KindLiteralType,
 		KindTypePredicate,
 		KindTypeReference,

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -2258,13 +2258,16 @@ func (p *Printer) emitTypeNode(node *ast.TypeNode, precedence ast.TypePrecedence
 		// !!! Should this actually be considered a type?
 		p.emitExpressionWithTypeArguments(node.AsExpressionWithTypeArguments())
 
-	case ast.KindJSDocAllType,
-		ast.KindJSDocNullableType,
-		ast.KindJSDocNonNullableType,
-		ast.KindJSDocOptionalType,
-		ast.KindJSDocVariadicType:
-		// TODO
-		panic("not implemented")
+	case ast.KindJSDocAllType:
+		p.emitJSDocAllType(node)
+	case ast.KindJSDocNonNullableType:
+		p.emitJSDocNonNullableType(node.AsJSDocNonNullableType())
+	case ast.KindJSDocNullableType:
+		p.emitJSDocNullableType(node.AsJSDocNullableType())
+	case ast.KindJSDocOptionalType:
+		p.emitJSDocOptionalType(node.AsJSDocOptionalType())
+	case ast.KindJSDocVariadicType:
+		p.emitJSDocVariadicType(node.AsJSDocVariadicType())
 
 	default:
 		panic(fmt.Sprintf("unhandled TypeNode: %v", node.Kind))
@@ -2315,6 +2318,38 @@ func (p *Printer) emitBindingElement(node *ast.BindingElement) {
 
 func (p *Printer) emitBindingElementNode(node *ast.BindingElementNode) {
 	p.emitBindingElement(node.AsBindingElement())
+}
+
+func (p *Printer) emitJSDocAllType(node *ast.Node) {
+	p.emitKeywordNode(node)
+}
+
+func (p *Printer) emitJSDocNonNullableType(node *ast.JSDocNonNullableType) {
+	state := p.enterNode(node.AsNode())
+	p.writePunctuation("!")
+	p.emitTypeNode(node.Type, ast.TypePrecedenceNonArray)
+	p.exitNode(node.AsNode(), state)
+}
+
+func (p *Printer) emitJSDocNullableType(node *ast.JSDocNullableType) {
+	state := p.enterNode(node.AsNode())
+	p.writePunctuation("?")
+	p.emitTypeNode(node.Type, ast.TypePrecedenceNonArray)
+	p.exitNode(node.AsNode(), state)
+}
+
+func (p *Printer) emitJSDocOptionalType(node *ast.JSDocOptionalType) {
+	state := p.enterNode(node.AsNode())
+	p.emitTypeNode(node.Type, ast.TypePrecedenceJSDoc)
+	p.writePunctuation("=")
+	p.exitNode(node.AsNode(), state)
+}
+
+func (p *Printer) emitJSDocVariadicType(node *ast.JSDocVariadicType) {
+	state := p.enterNode(node.AsNode())
+	p.writePunctuation("...")
+	p.emitTypeNode(node.Type, ast.TypePrecedenceJSDoc)
+	p.exitNode(node.AsNode(), state)
 }
 
 //


### PR DESCRIPTION
This is needed to avoid a panic in a test once CommonJS import/exports are available.

I've guessed at the right thing to do here but I don't have a solid idea.

I haven't added tests because I'm not sure how:
- Submodule tests only cover `*`
- `*`, `!T` and `?T` are testable outside JSDoc.
- `...T` and `T=` are only parsed in JSDoc.