### PR TITLE
Make SourceFileAffectingCompilerOptions hold fully computed values, use in binder

### DIFF
--- a/internal/binder/binder.go
+++ b/internal/binder/binder.go
@@ -40,7 +40,7 @@ const (
 
 type Binder struct {
 	file                    *ast.SourceFile
-	options                 *core.CompilerOptions
+	options                 *core.SourceFileAffectingCompilerOptions
 	languageVersion         core.ScriptTarget
 	bindFunc                func(*ast.Node) bool
 	unreachableFlow         *ast.FlowNode
@@ -86,7 +86,7 @@ type ActiveLabel struct {
 func (label *ActiveLabel) BreakTarget() *ast.FlowNode    { return label.breakTarget }
 func (label *ActiveLabel) ContinueTarget() *ast.FlowNode { return label.continueTarget }
 
-func BindSourceFile(file *ast.SourceFile, options *core.CompilerOptions) {
+func BindSourceFile(file *ast.SourceFile, options *core.SourceFileAffectingCompilerOptions) {
 	// This is constructed this way to make the compiler "out-line" the function,
 	// avoiding most work in the common case where the file has already been bound.
 	if !file.IsBound() {
@@ -111,14 +111,14 @@ func putBinder(b *Binder) {
 	binderPool.Put(b)
 }
 
-func bindSourceFile(file *ast.SourceFile, options *core.CompilerOptions) {
+func bindSourceFile(file *ast.SourceFile, options *core.SourceFileAffectingCompilerOptions) {
 	file.BindOnce(func() {
 		b := getBinder()
 		defer putBinder(b)
 		b.file = file
 		b.options = options
-		b.languageVersion = options.GetEmitScriptTarget()
-		b.inStrictMode = (options.AlwaysStrict.IsTrue() || options.Strict.IsTrue()) && !file.IsDeclarationFile || ast.IsExternalModule(file)
+		b.languageVersion = options.EmitScriptTarget
+		b.inStrictMode = options.BindInStrictMode && !file.IsDeclarationFile || ast.IsExternalModule(file)
 		b.unreachableFlow = b.newFlowNode(ast.FlowFlagsUnreachable)
 		b.reportedUnreachableFlow = b.newFlowNode(ast.FlowFlagsUnreachable)
 		b.bind(file.AsNode())
@@ -1331,7 +1331,7 @@ func (b *Binder) checkStrictModeWithStatement(node *ast.Node) {
 
 func (b *Binder) checkStrictModeLabeledStatement(node *ast.Node) {
 	// Grammar checking for labeledStatement
-	if b.inStrictMode && b.options.Target >= core.ScriptTargetES2015 {
+	if b.inStrictMode && b.options.EmitScriptTarget >= core.ScriptTargetES2015 {
 		data := node.AsLabeledStatement()
 		if ast.IsDeclarationStatement(data.Statement) || ast.IsVariableStatement(data.Statement) {
 			b.errorOnFirstToken(data.Label, diagnostics.A_label_is_not_allowed_here)
@@ -1665,7 +1665,7 @@ func (b *Binder) checkUnreachable(node *ast.Node) bool {
 
 func (b *Binder) shouldReportErrorOnModuleDeclaration(node *ast.Node) bool {
 	instanceState := ast.GetModuleInstanceState(node)
-	return instanceState == ast.ModuleInstanceStateInstantiated || (instanceState == ast.ModuleInstanceStateConstEnumOnly && b.options.ShouldPreserveConstEnums())
+	return instanceState == ast.ModuleInstanceStateInstantiated || (instanceState == ast.ModuleInstanceStateConstEnumOnly && b.options.ShouldPreserveConstEnums)
 }
 
 func (b *Binder) errorOnEachUnreachableRange(node *ast.Node, isError bool) {
@@ -2421,8 +2421,8 @@ func (b *Binder) bindInitializer(node *ast.Node) {
 	b.currentFlow = b.finishFlowLabel(exitFlow)
 }
 
-func isEnumDeclarationWithPreservedEmit(node *ast.Node, options *core.CompilerOptions) bool {
-	return node.Kind == ast.KindEnumDeclaration && (!ast.IsEnumConst(node) || options.ShouldPreserveConstEnums())
+func isEnumDeclarationWithPreservedEmit(node *ast.Node, options *core.SourceFileAffectingCompilerOptions) bool {
+	return node.Kind == ast.KindEnumDeclaration && (!ast.IsEnumConst(node) || options.ShouldPreserveConstEnums)
 }
 
 func setFlowNode(node *ast.Node, flowNode *ast.FlowNode) {
@@ -2746,11 +2746,11 @@ func isFunctionSymbol(symbol *ast.Symbol) bool {
 	return false
 }
 
-func unreachableCodeIsError(options *core.CompilerOptions) bool {
+func unreachableCodeIsError(options *core.SourceFileAffectingCompilerOptions) bool {
 	return options.AllowUnreachableCode == core.TSFalse
 }
 
-func unusedLabelIsError(options *core.CompilerOptions) bool {
+func unusedLabelIsError(options *core.SourceFileAffectingCompilerOptions) bool {
 	return options.AllowUnusedLabels == core.TSFalse
 }
 

--- a/internal/binder/binder_test.go
+++ b/internal/binder/binder_test.go
@@ -28,6 +28,7 @@ func BenchmarkBind(b *testing.B) {
 			}
 
 			compilerOptions := &core.CompilerOptions{Target: core.ScriptTargetESNext, ModuleKind: core.ModuleKindNodeNext}
+			sourceAffecting := compilerOptions.SourceFileAffecting()
 
 			// The above parses do a lot of work; ensure GC is finished before we start collecting performance data.
 			// GC must be called twice to allow things to settle.
@@ -36,7 +37,7 @@ func BenchmarkBind(b *testing.B) {
 
 			b.ResetTimer()
 			for i := range b.N {
-				BindSourceFile(sourceFiles[i], compilerOptions)
+				BindSourceFile(sourceFiles[i], sourceAffecting)
 			}
 		})
 	}

--- a/internal/core/compileroptions.go
+++ b/internal/core/compileroptions.go
@@ -269,34 +269,25 @@ func (options *CompilerOptions) HasJsonModuleEmitEnabled() bool {
 	return true
 }
 
-// SourceFileAffectingCompilerOptions are the CompilerOptions values that when
-// changed require a new SourceFile be created.
+// SourceFileAffectingCompilerOptions are the precomputed CompilerOptions values which
+// affect the parse and bind of a source file.
 type SourceFileAffectingCompilerOptions struct {
-	// !!! generate this
-	Target               ScriptTarget
-	Jsx                  JsxEmit
-	JsxImportSource      string
-	ImportHelpers        Tristate
-	AlwaysStrict         Tristate
-	ModuleDetection      ModuleDetectionKind
-	AllowUnreachableCode Tristate
-	AllowUnusedLabels    Tristate
-	PreserveConstEnums   Tristate
-	IsolatedModules      Tristate
+	AllowUnreachableCode       Tristate
+	AllowUnusedLabels          Tristate
+	BindInStrictMode           bool
+	EmitScriptTarget           ScriptTarget
+	NoFallthroughCasesInSwitch Tristate
+	ShouldPreserveConstEnums   bool
 }
 
-func (options *CompilerOptions) SourceFileAffecting() SourceFileAffectingCompilerOptions {
-	return SourceFileAffectingCompilerOptions{
-		Target:               options.Target,
-		Jsx:                  options.Jsx,
-		JsxImportSource:      options.JsxImportSource,
-		ImportHelpers:        options.ImportHelpers,
-		AlwaysStrict:         options.AlwaysStrict,
-		ModuleDetection:      options.ModuleDetection,
-		AllowUnreachableCode: options.AllowUnreachableCode,
-		AllowUnusedLabels:    options.AllowUnusedLabels,
-		PreserveConstEnums:   options.PreserveConstEnums,
-		IsolatedModules:      options.IsolatedModules,
+func (options *CompilerOptions) SourceFileAffecting() *SourceFileAffectingCompilerOptions {
+	return &SourceFileAffectingCompilerOptions{
+		AllowUnreachableCode:       options.AllowUnreachableCode,
+		AllowUnusedLabels:          options.AllowUnusedLabels,
+		BindInStrictMode:           options.AlwaysStrict.IsTrue() || options.Strict.IsTrue(),
+		EmitScriptTarget:           options.GetEmitScriptTarget(),
+		NoFallthroughCasesInSwitch: options.NoFallthroughCasesInSwitch,
+		ShouldPreserveConstEnums:   options.ShouldPreserveConstEnums(),
 	}
 }
 

--- a/internal/printer/namegenerator_test.go
+++ b/internal/printer/namegenerator_test.go
@@ -11,6 +11,8 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+var defaultSourceFileAffectingOptions = (&core.CompilerOptions{}).SourceFileAffecting()
+
 func TestTempVariable1(t *testing.T) {
 	t.Parallel()
 
@@ -257,7 +259,7 @@ func TestGeneratedNameForIdentifier1(t *testing.T) {
 	ec := printer.NewEmitContext()
 
 	file := parsetestutil.ParseTypeScript("function f() {}", false /*jsx*/)
-	binder.BindSourceFile(file, &core.CompilerOptions{})
+	binder.BindSourceFile(file, defaultSourceFileAffectingOptions)
 
 	n := file.Statements.Nodes[0].Name()
 	name1 := ec.NewGeneratedNameForNode(n, printer.AutoGenerateOptions{})
@@ -274,7 +276,7 @@ func TestGeneratedNameForIdentifier2(t *testing.T) {
 	ec := printer.NewEmitContext()
 
 	file := parsetestutil.ParseTypeScript("function f() {}", false /*jsx*/)
-	binder.BindSourceFile(file, &core.CompilerOptions{})
+	binder.BindSourceFile(file, defaultSourceFileAffectingOptions)
 
 	n := file.Statements.Nodes[0].Name()
 	name1 := ec.NewGeneratedNameForNode(n, printer.AutoGenerateOptions{
@@ -294,7 +296,7 @@ func TestGeneratedNameForIdentifier3(t *testing.T) {
 	ec := printer.NewEmitContext()
 
 	file := parsetestutil.ParseTypeScript("function f() {}", false /*jsx*/)
-	binder.BindSourceFile(file, &core.CompilerOptions{})
+	binder.BindSourceFile(file, defaultSourceFileAffectingOptions)
 
 	n := file.Statements.Nodes[0].Name()
 	name1 := ec.NewGeneratedNameForNode(n, printer.AutoGenerateOptions{
@@ -316,7 +318,7 @@ func TestGeneratedNameForNamespace1(t *testing.T) {
 	ec := printer.NewEmitContext()
 
 	file := parsetestutil.ParseTypeScript("namespace foo { }", false /*jsx*/)
-	binder.BindSourceFile(file, &core.CompilerOptions{})
+	binder.BindSourceFile(file, defaultSourceFileAffectingOptions)
 
 	ns1 := file.Statements.Nodes[0]
 	name1 := ec.NewGeneratedNameForNode(ns1, printer.AutoGenerateOptions{})
@@ -334,7 +336,7 @@ func TestGeneratedNameForNamespace2(t *testing.T) {
 	ec := printer.NewEmitContext()
 
 	file := parsetestutil.ParseTypeScript("namespace foo { var foo; }", false /*jsx*/)
-	binder.BindSourceFile(file, &core.CompilerOptions{})
+	binder.BindSourceFile(file, defaultSourceFileAffectingOptions)
 
 	ns1 := file.Statements.Nodes[0]
 	name1 := ec.NewGeneratedNameForNode(ns1, printer.AutoGenerateOptions{})
@@ -352,7 +354,7 @@ func TestGeneratedNameForNamespace3(t *testing.T) {
 	ec := printer.NewEmitContext()
 
 	file := parsetestutil.ParseTypeScript("namespace ns1 { namespace foo { var foo; } } namespace ns2 { namespace foo { var foo; } }", false /*jsx*/)
-	binder.BindSourceFile(file, &core.CompilerOptions{})
+	binder.BindSourceFile(file, defaultSourceFileAffectingOptions)
 
 	ns1 := file.Statements.Nodes[0].AsModuleDeclaration().Body.AsModuleBlock().Statements.Nodes[0]
 	ns2 := file.Statements.Nodes[1].AsModuleDeclaration().Body.AsModuleBlock().Statements.Nodes[0]
@@ -374,7 +376,7 @@ func TestGeneratedNameForNamespace4(t *testing.T) {
 	ec := printer.NewEmitContext()
 
 	file := parsetestutil.ParseTypeScript("namespace ns1 { namespace foo { var foo; } } namespace ns2 { namespace foo { var foo; } }", false /*jsx*/)
-	binder.BindSourceFile(file, &core.CompilerOptions{})
+	binder.BindSourceFile(file, defaultSourceFileAffectingOptions)
 
 	ns1 := file.Statements.Nodes[0].AsModuleDeclaration().Body.AsModuleBlock().Statements.Nodes[0]
 	ns2 := file.Statements.Nodes[1].AsModuleDeclaration().Body.AsModuleBlock().Statements.Nodes[0]
@@ -400,7 +402,7 @@ func TestGeneratedNameForNodeCached(t *testing.T) {
 	ec := printer.NewEmitContext()
 
 	file := parsetestutil.ParseTypeScript("namespace foo { var foo; }", false /*jsx*/)
-	binder.BindSourceFile(file, &core.CompilerOptions{})
+	binder.BindSourceFile(file, defaultSourceFileAffectingOptions)
 
 	ns1 := file.Statements.Nodes[0]
 	name1 := ec.NewGeneratedNameForNode(ns1, printer.AutoGenerateOptions{})
@@ -420,7 +422,7 @@ func TestGeneratedNameForImport(t *testing.T) {
 	ec := printer.NewEmitContext()
 
 	file := parsetestutil.ParseTypeScript("import * as foo from 'foo'", false /*jsx*/)
-	binder.BindSourceFile(file, &core.CompilerOptions{})
+	binder.BindSourceFile(file, defaultSourceFileAffectingOptions)
 
 	n := file.Statements.Nodes[0]
 	name1 := ec.NewGeneratedNameForNode(n, printer.AutoGenerateOptions{})
@@ -437,7 +439,7 @@ func TestGeneratedNameForExport(t *testing.T) {
 	ec := printer.NewEmitContext()
 
 	file := parsetestutil.ParseTypeScript("export * as foo from 'foo'", false /*jsx*/)
-	binder.BindSourceFile(file, &core.CompilerOptions{})
+	binder.BindSourceFile(file, defaultSourceFileAffectingOptions)
 
 	n := file.Statements.Nodes[0]
 	name1 := ec.NewGeneratedNameForNode(n, printer.AutoGenerateOptions{})
@@ -454,7 +456,7 @@ func TestGeneratedNameForFunctionDeclaration1(t *testing.T) {
 	ec := printer.NewEmitContext()
 
 	file := parsetestutil.ParseTypeScript("export function f() {}", false /*jsx*/)
-	binder.BindSourceFile(file, &core.CompilerOptions{})
+	binder.BindSourceFile(file, defaultSourceFileAffectingOptions)
 
 	n := file.Statements.Nodes[0]
 	name1 := ec.NewGeneratedNameForNode(n, printer.AutoGenerateOptions{})
@@ -471,7 +473,7 @@ func TestGeneratedNameForFunctionDeclaration2(t *testing.T) {
 	ec := printer.NewEmitContext()
 
 	file := parsetestutil.ParseTypeScript("export default function () {}", false /*jsx*/)
-	binder.BindSourceFile(file, &core.CompilerOptions{})
+	binder.BindSourceFile(file, defaultSourceFileAffectingOptions)
 
 	n := file.Statements.Nodes[0]
 	name1 := ec.NewGeneratedNameForNode(n, printer.AutoGenerateOptions{})
@@ -488,7 +490,7 @@ func TestGeneratedNameForClassDeclaration1(t *testing.T) {
 	ec := printer.NewEmitContext()
 
 	file := parsetestutil.ParseTypeScript("export class C {}", false /*jsx*/)
-	binder.BindSourceFile(file, &core.CompilerOptions{})
+	binder.BindSourceFile(file, defaultSourceFileAffectingOptions)
 
 	n := file.Statements.Nodes[0]
 	name1 := ec.NewGeneratedNameForNode(n, printer.AutoGenerateOptions{})
@@ -505,7 +507,7 @@ func TestGeneratedNameForClassDeclaration2(t *testing.T) {
 	ec := printer.NewEmitContext()
 
 	file := parsetestutil.ParseTypeScript("export default class {}", false /*jsx*/)
-	binder.BindSourceFile(file, &core.CompilerOptions{})
+	binder.BindSourceFile(file, defaultSourceFileAffectingOptions)
 
 	n := file.Statements.Nodes[0]
 	name1 := ec.NewGeneratedNameForNode(n, printer.AutoGenerateOptions{})
@@ -522,7 +524,7 @@ func TestGeneratedNameForExportAssignment(t *testing.T) {
 	ec := printer.NewEmitContext()
 
 	file := parsetestutil.ParseTypeScript("export default 0", false /*jsx*/)
-	binder.BindSourceFile(file, &core.CompilerOptions{})
+	binder.BindSourceFile(file, defaultSourceFileAffectingOptions)
 
 	n := file.Statements.Nodes[0]
 	name1 := ec.NewGeneratedNameForNode(n, printer.AutoGenerateOptions{})
@@ -539,7 +541,7 @@ func TestGeneratedNameForClassExpression(t *testing.T) {
 	ec := printer.NewEmitContext()
 
 	file := parsetestutil.ParseTypeScript("(class {})", false /*jsx*/)
-	binder.BindSourceFile(file, &core.CompilerOptions{})
+	binder.BindSourceFile(file, defaultSourceFileAffectingOptions)
 
 	n := file.Statements.Nodes[0].AsExpressionStatement().Expression.AsParenthesizedExpression().Expression
 	name1 := ec.NewGeneratedNameForNode(n, printer.AutoGenerateOptions{})
@@ -556,7 +558,7 @@ func TestGeneratedNameForMethod1(t *testing.T) {
 	ec := printer.NewEmitContext()
 
 	file := parsetestutil.ParseTypeScript("class C { m() {} }", false /*jsx*/)
-	binder.BindSourceFile(file, &core.CompilerOptions{})
+	binder.BindSourceFile(file, defaultSourceFileAffectingOptions)
 
 	n := file.Statements.Nodes[0].AsClassDeclaration().Members.Nodes[0]
 	name1 := ec.NewGeneratedNameForNode(n, printer.AutoGenerateOptions{})
@@ -573,7 +575,7 @@ func TestGeneratedNameForMethod2(t *testing.T) {
 	ec := printer.NewEmitContext()
 
 	file := parsetestutil.ParseTypeScript("class C { 0() {} }", false /*jsx*/)
-	binder.BindSourceFile(file, &core.CompilerOptions{})
+	binder.BindSourceFile(file, defaultSourceFileAffectingOptions)
 
 	n := file.Statements.Nodes[0].AsClassDeclaration().Members.Nodes[0]
 	name1 := ec.NewGeneratedNameForNode(n, printer.AutoGenerateOptions{})
@@ -590,7 +592,7 @@ func TestGeneratedPrivateNameForMethod(t *testing.T) {
 	ec := printer.NewEmitContext()
 
 	file := parsetestutil.ParseTypeScript("class C { m() {} }", false /*jsx*/)
-	binder.BindSourceFile(file, &core.CompilerOptions{})
+	binder.BindSourceFile(file, defaultSourceFileAffectingOptions)
 
 	n := file.Statements.Nodes[0].AsClassDeclaration().Members.Nodes[0]
 	name1 := ec.NewGeneratedPrivateNameForNode(n, printer.AutoGenerateOptions{})
@@ -607,7 +609,7 @@ func TestGeneratedNameForComputedPropertyName(t *testing.T) {
 	ec := printer.NewEmitContext()
 
 	file := parsetestutil.ParseTypeScript("class C { [x] }", false /*jsx*/)
-	binder.BindSourceFile(file, &core.CompilerOptions{})
+	binder.BindSourceFile(file, defaultSourceFileAffectingOptions)
 
 	n := file.Statements.Nodes[0].AsClassDeclaration().Members.Nodes[0].Name()
 	name1 := ec.NewGeneratedNameForNode(n, printer.AutoGenerateOptions{})
@@ -624,7 +626,7 @@ func TestGeneratedNameForOther(t *testing.T) {
 	ec := printer.NewEmitContext()
 
 	file := parsetestutil.ParseTypeScript("class C { [x] }", false /*jsx*/)
-	binder.BindSourceFile(file, &core.CompilerOptions{})
+	binder.BindSourceFile(file, defaultSourceFileAffectingOptions)
 
 	n := ec.Factory.NewObjectLiteralExpression(
 		ec.Factory.NewNodeList([]*ast.Node{}),

--- a/internal/project/documentregistry.go
+++ b/internal/project/documentregistry.go
@@ -19,7 +19,7 @@ type registryKey struct {
 
 func newRegistryKey(options *core.CompilerOptions, path tspath.Path, scriptKind core.ScriptKind) registryKey {
 	return registryKey{
-		SourceFileAffectingCompilerOptions: options.SourceFileAffecting(),
+		SourceFileAffectingCompilerOptions: *options.SourceFileAffecting(),
 		path:                               path,
 		scriptKind:                         scriptKind,
 	}

--- a/internal/project/service_test.go
+++ b/internal/project/service_test.go
@@ -179,8 +179,11 @@ func TestService(t *testing.T) {
 			filesCopy := maps.Clone(files)
 			filesCopy["/home/projects/TS/p2/tsconfig.json"] = `{
 				"compilerOptions": {
-					"module": "nodenext"
-				}
+					"noLib": true,
+					"module": "nodenext",
+					"strict": true,
+					"noCheck" true // Added
+				},
 			}`
 			filesCopy["/home/projects/TS/p2/src/index.ts"] = `import { x } from "../../p1/src/x";`
 			service, _ := setup(filesCopy)

--- a/internal/project/service_test.go
+++ b/internal/project/service_test.go
@@ -182,7 +182,7 @@ func TestService(t *testing.T) {
 					"noLib": true,
 					"module": "nodenext",
 					"strict": true,
-					"noCheck" true // Added
+					"noCheck": true // Added
 				},
 			}`
 			filesCopy["/home/projects/TS/p2/src/index.ts"] = `import { x } from "../../p1/src/x";`

--- a/internal/testutil/harnessutil/harnessutil.go
+++ b/internal/testutil/harnessutil/harnessutil.go
@@ -444,7 +444,7 @@ func (h *cachedCompilerHost) GetSourceFile(fileName string, path tspath.Path, la
 	text, _ := h.FS().ReadFile(fileName)
 
 	key := sourceFileCacheKey{
-		SourceFileAffectingCompilerOptions: h.options.SourceFileAffecting(),
+		SourceFileAffectingCompilerOptions: *h.options.SourceFileAffecting(),
 		fileName:                           fileName,
 		path:                               path,
 		languageVersion:                    languageVersion,

--- a/internal/transformers/commonjsmodule_test.go
+++ b/internal/transformers/commonjsmodule_test.go
@@ -1020,16 +1020,17 @@ exports.a = a;`,
 
 			compilerOptions := rec.options
 			compilerOptions.ModuleKind = core.ModuleKindCommonJS
+			sourceFileAffecting := compilerOptions.SourceFileAffecting()
 
 			file := parsetestutil.ParseTypeScript(rec.input, rec.jsx)
 			parsetestutil.CheckDiagnostics(t, file)
-			binder.BindSourceFile(file, &compilerOptions)
+			binder.BindSourceFile(file, sourceFileAffecting)
 
 			var other *ast.SourceFile
 			if len(rec.other) > 0 {
 				other = parsetestutil.ParseTypeScript(rec.other, rec.jsx)
 				parsetestutil.CheckDiagnostics(t, other)
-				binder.BindSourceFile(other, &compilerOptions)
+				binder.BindSourceFile(other, sourceFileAffecting)
 			}
 
 			emitContext := printer.NewEmitContext()

--- a/internal/transformers/esmodule_test.go
+++ b/internal/transformers/esmodule_test.go
@@ -220,15 +220,16 @@ var __rewriteRelativeImportExtension;`,
 			t.Parallel()
 
 			compilerOptions := rec.options
+			sourceFileAffecting := compilerOptions.SourceFileAffecting()
 			file := parsetestutil.ParseTypeScript(rec.input, rec.jsx)
 			parsetestutil.CheckDiagnostics(t, file)
-			binder.BindSourceFile(file, &compilerOptions)
+			binder.BindSourceFile(file, sourceFileAffecting)
 
 			var other *ast.SourceFile
 			if len(rec.other) > 0 {
 				other = parsetestutil.ParseTypeScript(rec.other, rec.jsx)
 				parsetestutil.CheckDiagnostics(t, other)
-				binder.BindSourceFile(other, &compilerOptions)
+				binder.BindSourceFile(other, sourceFileAffecting)
 			}
 
 			emitContext := printer.NewEmitContext()

--- a/internal/transformers/importelision_test.go
+++ b/internal/transformers/importelision_test.go
@@ -35,7 +35,7 @@ func (p *fakeProgram) BindSourceFiles() {
 	for _, file := range p.files {
 		if !file.IsBound() {
 			wg.Queue(func() {
-				binder.BindSourceFile(file, p.compilerOptions)
+				binder.BindSourceFile(file, p.compilerOptions.SourceFileAffecting())
 			})
 		}
 	}

--- a/internal/transformers/runtimesyntax_test.go
+++ b/internal/transformers/runtimesyntax_test.go
@@ -233,7 +233,7 @@ var E;
 			options := &core.CompilerOptions{}
 			file := parsetestutil.ParseTypeScript(rec.input, false /*jsx*/)
 			parsetestutil.CheckDiagnostics(t, file)
-			binder.BindSourceFile(file, options)
+			binder.BindSourceFile(file, options.SourceFileAffecting())
 			emitContext := printer.NewEmitContext()
 			resolver := binder.NewReferenceResolver(options, binder.ReferenceResolverHooks{})
 			emittestutil.CheckEmit(t, emitContext, NewRuntimeSyntaxTransformer(emitContext, options, resolver).TransformSourceFile(file), rec.output)
@@ -411,7 +411,7 @@ func TestNamespaceTransformer(t *testing.T) {
 			options := &core.CompilerOptions{}
 			file := parsetestutil.ParseTypeScript(rec.input, false /*jsx*/)
 			parsetestutil.CheckDiagnostics(t, file)
-			binder.BindSourceFile(file, options)
+			binder.BindSourceFile(file, options.SourceFileAffecting())
 			emitContext := printer.NewEmitContext()
 			resolver := binder.NewReferenceResolver(options, binder.ReferenceResolverHooks{})
 			emittestutil.CheckEmit(t, emitContext, NewRuntimeSyntaxTransformer(emitContext, options, resolver).TransformSourceFile(file), rec.output)
@@ -447,7 +447,7 @@ func TestParameterPropertyTransformer(t *testing.T) {
 			options := &core.CompilerOptions{}
 			file := parsetestutil.ParseTypeScript(rec.input, false /*jsx*/)
 			parsetestutil.CheckDiagnostics(t, file)
-			binder.BindSourceFile(file, options)
+			binder.BindSourceFile(file, options.SourceFileAffecting())
 			emitContext := printer.NewEmitContext()
 			resolver := binder.NewReferenceResolver(options, binder.ReferenceResolverHooks{})
 			file = NewTypeEraserTransformer(emitContext, options).TransformSourceFile(file)


### PR DESCRIPTION
This PR makes `SourceFileAffectingCompilerOptions` consist of only _fully computed_ values (in prep for some other changes).

- We can now prove that the binder (and in the future, parser) only touch things that they need.
- The values can be computed once and reused.
- `SourceFileAffectingCompilerOptions` is smaller, allowing much more AST reuse.

The AST reuse results in the tests running 20-25% faster, and using 1GB less peak memory.

psrecord before:

![old](https://github.com/user-attachments/assets/8d7bcdc6-6609-4340-a8ac-57fb55aaf879)

psrecord after:

![new](https://github.com/user-attachments/assets/46ee16a0-2f51-4fa5-ab21-32e9c9ffda10)

Before, it's maybe 8GB, before maybe 7GB.