### PR TITLE
`createNodeBuilder` and associated utility port

### DIFF
--- a/internal/ast/utilities.go
+++ b/internal/ast/utilities.go
@@ -1435,10 +1435,10 @@ func IsDynamicName(name *Node) bool {
 }
 
 func IsEntityNameExpression(node *Node) bool {
-	return node.Kind == KindIdentifier || isPropertyAccessEntityNameExpression(node)
+	return node.Kind == KindIdentifier || IsPropertyAccessEntityNameExpression(node)
 }
 
-func isPropertyAccessEntityNameExpression(node *Node) bool {
+func IsPropertyAccessEntityNameExpression(node *Node) bool {
 	if node.Kind == KindPropertyAccessExpression {
 		expr := node.AsPropertyAccessExpression()
 		return expr.Name().Kind == KindIdentifier && IsEntityNameExpression(expr.Expression)

--- a/internal/checker/nodebuilder.go
+++ b/internal/checker/nodebuilder.go
@@ -1,0 +1,1927 @@
+package checker
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/core"
+	"github.com/microsoft/typescript-go/internal/jsnum"
+	"github.com/microsoft/typescript-go/internal/printer"
+	"github.com/microsoft/typescript-go/internal/scanner"
+)
+
+// NOTE: If modifying this enum, must modify `TypeFormatFlags` too!
+// dprint-ignore
+type NodeBuilderFlags int32
+
+const (
+	NodeBuilderFlagsNone NodeBuilderFlags = 0
+	// Options
+	NodeBuilderFlagsNoTruncation                        NodeBuilderFlags = 1 << 0
+	NodeBuilderFlagsWriteArrayAsGenericType             NodeBuilderFlags = 1 << 1
+	NodeBuilderFlagsGenerateNamesForShadowedTypeParams  NodeBuilderFlags = 1 << 2
+	NodeBuilderFlagsUseStructuralFallback               NodeBuilderFlags = 1 << 3
+	NodeBuilderFlagsForbidIndexedAccessSymbolReferences NodeBuilderFlags = 1 << 4
+	NodeBuilderFlagsWriteTypeArgumentsOfSignature       NodeBuilderFlags = 1 << 5
+	NodeBuilderFlagsUseFullyQualifiedType               NodeBuilderFlags = 1 << 6
+	NodeBuilderFlagsUseOnlyExternalAliasing             NodeBuilderFlags = 1 << 7
+	NodeBuilderFlagsSuppressAnyReturnType               NodeBuilderFlags = 1 << 8
+	NodeBuilderFlagsWriteTypeParametersInQualifiedName  NodeBuilderFlags = 1 << 9
+	NodeBuilderFlagsMultilineObjectLiterals             NodeBuilderFlags = 1 << 10
+	NodeBuilderFlagsWriteClassExpressionAsTypeLiteral   NodeBuilderFlags = 1 << 11
+	NodeBuilderFlagsUseTypeOfFunction                   NodeBuilderFlags = 1 << 12
+	NodeBuilderFlagsOmitParameterModifiers              NodeBuilderFlags = 1 << 13
+	NodeBuilderFlagsUseAliasDefinedOutsideCurrentScope  NodeBuilderFlags = 1 << 14
+	NodeBuilderFlagsUseSingleQuotesForStringLiteralType NodeBuilderFlags = 1 << 28
+	NodeBuilderFlagsNoTypeReduction                     NodeBuilderFlags = 1 << 29
+	NodeBuilderFlagsOmitThisParameter                   NodeBuilderFlags = 1 << 25
+	// Error handling
+	NodeBuilderFlagsAllowThisInObjectLiteral              NodeBuilderFlags = 1 << 15
+	NodeBuilderFlagsAllowQualifiedNameInPlaceOfIdentifier NodeBuilderFlags = 1 << 16
+	NodeBuilderFlagsAllowAnonymousIdentifier              NodeBuilderFlags = 1 << 17
+	NodeBuilderFlagsAllowEmptyUnionOrIntersection         NodeBuilderFlags = 1 << 18
+	NodeBuilderFlagsAllowEmptyTuple                       NodeBuilderFlags = 1 << 19
+	NodeBuilderFlagsAllowUniqueESSymbolType               NodeBuilderFlags = 1 << 20
+	NodeBuilderFlagsAllowEmptyIndexInfoType               NodeBuilderFlags = 1 << 21
+	// Errors (cont.)
+	NodeBuilderFlagsAllowNodeModulesRelativePaths NodeBuilderFlags = 1 << 26
+	NodeBuilderFlagsIgnoreErrors                  NodeBuilderFlags = NodeBuilderFlagsAllowThisInObjectLiteral | NodeBuilderFlagsAllowQualifiedNameInPlaceOfIdentifier | NodeBuilderFlagsAllowAnonymousIdentifier | NodeBuilderFlagsAllowEmptyUnionOrIntersection | NodeBuilderFlagsAllowEmptyTuple | NodeBuilderFlagsAllowEmptyIndexInfoType | NodeBuilderFlagsAllowNodeModulesRelativePaths
+	// State
+	NodeBuilderFlagsInObjectTypeLiteral NodeBuilderFlags = 1 << 22
+	NodeBuilderFlagsInTypeAlias         NodeBuilderFlags = 1 << 23
+	NodeBuilderFlagsInInitialEntityName NodeBuilderFlags = 1 << 24
+)
+
+/** @internal */
+// dprint-ignore
+
+type InternalNodeBuilderFlags int32
+
+const (
+	InternalNodeBuilderFlagsNone                    InternalNodeBuilderFlags = 0
+	InternalNodeBuilderFlagsWriteComputedProps      InternalNodeBuilderFlags = 1 << 0
+	InternalNodeBuilderFlagsNoSyntacticPrinter      InternalNodeBuilderFlags = 1 << 1
+	InternalNodeBuilderFlagsDoNotIncludeSymbolChain InternalNodeBuilderFlags = 1 << 2
+	InternalNodeBuilderFlagsAllowUnresolvedNames    InternalNodeBuilderFlags = 1 << 3
+)
+
+type CompositeSymbolIdentity struct {
+	isConstructorNode bool
+	symbolId          ast.SymbolId
+	nodeId            ast.NodeId
+}
+
+type TrackedSymbolArgs struct {
+	symbol               *ast.Symbol
+	enclosingDeclaration *ast.Node
+	meaning              ast.SymbolFlags
+}
+
+type SerializedTypeEntry struct {
+	node           *ast.Node
+	truncating     bool
+	addedLength    int
+	trackedSymbols []*TrackedSymbolArgs
+}
+
+type CompositeTypeCacheIdentity struct {
+	typeId        TypeId
+	flags         NodeBuilderFlags
+	internalFlags InternalNodeBuilderFlags
+}
+
+type NodeBuilderLinks struct {
+	serializedTypes                  map[CompositeTypeCacheIdentity]*SerializedTypeEntry // Collection of types serialized at this location
+	fakeScopeForSignatureDeclaration *string                                             // If present, this is a fake scope injected into an enclosing declaration chain.
+}
+
+type NodeBuilderContext struct {
+	tracker                         SymbolTracker
+	approximateLength               int
+	encounteredError                bool
+	truncating                      bool
+	reportedDiagnostic              bool
+	flags                           NodeBuilderFlags
+	internalFlags                   InternalNodeBuilderFlags
+	depth                           int
+	enclosingDeclaration            *ast.Node
+	enclosingFile                   *ast.SourceFile
+	inferTypeParameters             []*Type
+	visitedTypes                    map[TypeId]bool
+	symbolDepth                     map[CompositeSymbolIdentity]int
+	trackedSymbols                  []*TrackedSymbolArgs
+	mapper                          *TypeMapper
+	reverseMappedStack              []*ast.Symbol
+	enclosingSymbolTypes            map[ast.SymbolId]*Type
+	suppressReportInferenceFallback bool
+
+	// per signature scope state
+	mustCreateTypeParameterSymbolList     bool
+	mustCreateTypeParametersNamesLookups  bool
+	typeParameterNames                    any
+	typeParameterNamesByText              any
+	typeParameterNamesByTextNextNameCount any
+	typeParameterSymbolList               any
+}
+
+type NodeBuilder struct {
+	// host members
+	f  *ast.NodeFactory
+	ch *Checker
+	e  *printer.EmitContext
+
+	// cache
+	links core.LinkStore[*ast.Node, NodeBuilderLinks]
+
+	// closures
+	typeToTypeNodeClosure               func(t *Type) *ast.TypeNode
+	typeReferenceToTypeNodeClosure      func(t *Type) *ast.TypeNode
+	conditionalTypeToTypeNodeClosure    func(t *Type) *ast.TypeNode
+	createTypeNodeFromObjectTypeClosure func(t *Type) *ast.TypeNode
+	isStringNamedClosure                func(d *ast.Declaration) bool
+	isSingleQuotedStringNamedClosure    func(d *ast.Declaration) bool
+
+	// state
+	ctx *NodeBuilderContext
+}
+
+const defaultMaximumTruncationLength = 160
+const noTruncationMaximumTruncationLength = 1_000_000
+
+// Node builder utility functions
+
+// You probably don't mean to use this - use `NewNodeBuilderAPI` instead
+func NewNodeBuilder(ch *Checker, e *printer.EmitContext) NodeBuilder {
+	result := NodeBuilder{f: e.Factory, ch: ch, e: e, typeToTypeNodeClosure: nil, typeReferenceToTypeNodeClosure: nil, conditionalTypeToTypeNodeClosure: nil, ctx: nil}
+	result.initializeClosures()
+	return result
+}
+
+func (b *NodeBuilder) initializeClosures() {
+	b.typeToTypeNodeClosure = b.typeToTypeNode
+	b.typeReferenceToTypeNodeClosure = b.typeReferenceToTypeNode
+	b.conditionalTypeToTypeNodeClosure = b.conditionalTypeToTypeNode
+	b.createTypeNodeFromObjectTypeClosure = b.createTypeNodeFromObjectType
+	b.isStringNamedClosure = b.isStringNamed
+	b.isSingleQuotedStringNamedClosure = b.isSingleQuotedStringNamed
+}
+
+func (b *NodeBuilder) saveRestoreFlags() func() {
+	flags := b.ctx.flags
+	internalFlags := b.ctx.internalFlags
+	depth := b.ctx.depth
+
+	return func() {
+		b.ctx.flags = flags
+		b.ctx.internalFlags = internalFlags
+		b.ctx.depth = depth
+	}
+}
+
+func (b *NodeBuilder) checkTruncationLength() bool {
+	if b.ctx.truncating {
+		return b.ctx.truncating
+	}
+	b.ctx.truncating = b.ctx.approximateLength > (core.IfElse((b.ctx.flags&NodeBuilderFlagsNoTruncation != 0), noTruncationMaximumTruncationLength, defaultMaximumTruncationLength))
+	return b.ctx.truncating
+}
+
+func (b *NodeBuilder) appendReferenceToType(root *ast.TypeNode, ref *ast.TypeNode) *ast.TypeNode {
+	if ast.IsImportTypeNode(root) {
+		// first shift type arguments
+
+		// !!! In the old emitter, an Identifier could have type arguments for use with quickinfo:
+		// typeArguments := root.TypeArguments
+		// qualifier := root.AsImportTypeNode().Qualifier
+		// if qualifier != nil {
+		// 	if ast.IsIdentifier(qualifier) {
+		// 		if typeArguments != getIdentifierTypeArguments(qualifier) {
+		// 			qualifier = setIdentifierTypeArguments(b.f.CloneNode(qualifier), typeArguments)
+		// 		}
+		// 	} else {
+		// 		if typeArguments != getIdentifierTypeArguments(qualifier.Right) {
+		// 			qualifier = b.f.UpdateQualifiedName(qualifier, qualifier.Left, setIdentifierTypeArguments(b.f.cloneNode(qualifier.Right), typeArguments))
+		// 		}
+		// 	}
+		// }
+		// !!! Without the above, nested type args are silently elided
+		imprt := root.AsImportTypeNode()
+		// then move qualifiers
+		ids := getAccessStack(ref)
+		var qualifier *ast.Node
+		for _, id := range ids {
+			if qualifier != nil {
+				qualifier = b.f.NewQualifiedName(qualifier, id)
+			} else {
+				qualifier = id
+			}
+		}
+		return b.f.UpdateImportTypeNode(imprt, imprt.IsTypeOf, imprt.Argument, imprt.Attributes, qualifier, ref.AsTypeReferenceNode().TypeArguments)
+	} else {
+		// first shift type arguments
+		// !!! In the old emitter, an Identifier could have type arguments for use with quickinfo:
+		// typeArguments := root.TypeArguments
+		// typeName := root.AsTypeReferenceNode().TypeName
+		// if ast.IsIdentifier(typeName) {
+		// 	if typeArguments != getIdentifierTypeArguments(typeName) {
+		// 		typeName = setIdentifierTypeArguments(b.f.cloneNode(typeName), typeArguments)
+		// 	}
+		// } else {
+		// 	if typeArguments != getIdentifierTypeArguments(typeName.Right) {
+		// 		typeName = b.f.UpdateQualifiedName(typeName, typeName.Left, setIdentifierTypeArguments(b.f.cloneNode(typeName.Right), typeArguments))
+		// 	}
+		// }
+		// !!! Without the above, nested type args are silently elided
+		// then move qualifiers
+		ids := getAccessStack(ref)
+		var typeName *ast.Node = root.AsTypeReferenceNode().TypeName
+		for _, id := range ids {
+			typeName = b.f.NewQualifiedName(typeName, id)
+		}
+		return b.f.UpdateTypeReferenceNode(root.AsTypeReferenceNode(), typeName, ref.AsTypeReferenceNode().TypeArguments)
+	}
+}
+
+func getAccessStack(ref *ast.Node) []*ast.Node {
+	var state *ast.Node = ref.AsTypeReferenceNode().TypeName
+	ids := []*ast.Node{}
+	for !ast.IsIdentifier(state) {
+		entity := state.AsQualifiedName()
+		ids = append([]*ast.Node{entity.Right}, ids...)
+		state = entity.Left
+	}
+	ids = append([]*ast.Node{state}, ids...)
+	return ids
+}
+
+func isClassInstanceSide(c *Checker, t *Type) bool {
+	return t.symbol != nil && t.symbol.Flags&ast.SymbolFlagsClass != 0 && (t == c.getDeclaredTypeOfClassOrInterface(t.symbol) || (t.flags&TypeFlagsObject != 0 && t.objectFlags&ObjectFlagsIsClassInstanceClone != 0))
+}
+
+func (b *NodeBuilder) createElidedInformationPlaceholder() *ast.TypeNode {
+	b.ctx.approximateLength += 3
+	if b.ctx.flags&NodeBuilderFlagsNoTruncation == 0 {
+		return b.f.NewTypeReferenceNode(b.f.NewIdentifier("..."), nil /*typeArguments*/)
+	}
+	// addSyntheticLeadingComment(b.f.NewKeywordTypeNode(ast.KindAnyKeyword), ast.KindMultiLineCommentTrivia, "elided") // !!!
+	return b.f.NewKeywordTypeNode(ast.KindAnyKeyword)
+}
+
+func (b *NodeBuilder) mapToTypeNodes(list []*Type) *ast.NodeList {
+	if len(list) == 0 {
+		return nil
+	}
+	contents := core.Map(list, b.typeToTypeNodeClosure)
+	return b.f.NewNodeList(contents)
+}
+
+func (b *NodeBuilder) setCommentRange(node *ast.Node, range_ *ast.Node) {
+	if range_ != nil && b.ctx.enclosingFile != nil && b.ctx.enclosingFile == ast.GetSourceFileOfNode(range_) {
+		// Copy comments to node for declaration emit
+		b.e.AssignCommentRange(node, range_)
+	}
+}
+
+func (b *NodeBuilder) tryReuseExistingTypeNodeHelper(existing *ast.TypeNode) *ast.TypeNode {
+	return nil // !!!
+}
+
+func containsNonMissingUndefinedType(c *Checker, t *Type) bool {
+	var candidate *Type
+	if t.flags&TypeFlagsUnion != 0 {
+		candidate = t.AsUnionType().types[0]
+	} else {
+		candidate = t
+	}
+	return candidate.flags&TypeFlagsUndefined != 0 && candidate != c.missingType
+}
+
+func (b *NodeBuilder) tryReuseExistingTypeNode(typeNode *ast.TypeNode, t *Type, host *ast.Node, addUndefined bool) *ast.TypeNode {
+	originalType := t
+	if addUndefined {
+		t = b.ch.getOptionalType(t, !ast.IsParameter(host))
+	}
+	clone := b.tryReuseExistingNonParameterTypeNode(typeNode, t, host, nil)
+	if clone != nil {
+		// explicitly add `| undefined` if it's missing from the input type nodes and the type contains `undefined` (and not the missing type)
+		if addUndefined && containsNonMissingUndefinedType(b.ch, t) && !someType(b.getTypeFromTypeNode(typeNode, false), func(t *Type) bool {
+			return t.flags&TypeFlagsUndefined != 0
+		}) {
+			return b.f.NewUnionTypeNode(b.f.NewNodeList([]*ast.TypeNode{clone, b.f.NewKeywordTypeNode(ast.KindUndefinedKeyword)}))
+		}
+		return clone
+	}
+	if addUndefined && originalType != t {
+		cloneMissingUndefined := b.tryReuseExistingNonParameterTypeNode(typeNode, originalType, host, nil)
+		if cloneMissingUndefined != nil {
+			return b.f.NewUnionTypeNode(b.f.NewNodeList([]*ast.TypeNode{cloneMissingUndefined, b.f.NewKeywordTypeNode(ast.KindUndefinedKeyword)}))
+		}
+	}
+	return nil
+}
+
+func (b *NodeBuilder) typeNodeIsEquivalentToType(annotatedDeclaration *ast.Node, t *Type, typeFromTypeNode *Type) bool {
+	if typeFromTypeNode == t {
+		return true
+	}
+	if annotatedDeclaration == nil {
+		return false
+	}
+	// !!!
+	// used to be hasEffectiveQuestionToken for JSDoc
+	if isOptionalDeclaration(annotatedDeclaration) {
+		return b.ch.getTypeWithFacts(t, TypeFactsNEUndefined) == typeFromTypeNode
+	}
+	return false
+}
+
+func (b *NodeBuilder) existingTypeNodeIsNotReferenceOrIsReferenceWithCompatibleTypeArgumentCount(existing *ast.TypeNode, t *Type) bool {
+	// In JS, you can say something like `Foo` and get a `Foo<any>` implicitly - we don't want to preserve that original `Foo` in these cases, though.
+	if t.objectFlags&ObjectFlagsReference == 0 {
+		return true
+	}
+	if !ast.IsTypeReferenceNode(existing) {
+		return true
+	}
+	// `type` is a reference type, and `existing` is a type reference node, but we still need to make sure they refer to the _same_ target type
+	// before we go comparing their type argument counts.
+	b.ch.getTypeFromTypeReference(existing)
+	// call to ensure symbol is resolved
+	links := b.ch.symbolNodeLinks.TryGet(existing)
+	if links == nil {
+		return true
+	}
+	symbol := links.resolvedSymbol
+	if symbol == nil {
+		return true
+	}
+	existingTarget := b.ch.getDeclaredTypeOfSymbol(symbol)
+	if existingTarget == nil || existingTarget != t.AsTypeReference().target {
+		return true
+	}
+	return len(existing.TypeArguments()) >= b.ch.getMinTypeArgumentCount(t.AsTypeReference().target.AsInterfaceType().TypeParameters())
+}
+
+func (b *NodeBuilder) tryReuseExistingNonParameterTypeNode(existing *ast.TypeNode, t *Type, host *ast.Node, annotationType *Type) *ast.TypeNode {
+	if host == nil {
+		host = b.ctx.enclosingDeclaration
+	}
+	if annotationType == nil {
+		annotationType = b.getTypeFromTypeNode(existing, true)
+	}
+	if annotationType != nil && b.typeNodeIsEquivalentToType(host, t, annotationType) && b.existingTypeNodeIsNotReferenceOrIsReferenceWithCompatibleTypeArgumentCount(existing, t) {
+		result := b.tryReuseExistingTypeNodeHelper(existing)
+		if result != nil {
+			return result
+		}
+	}
+	return nil
+}
+
+func (b *NodeBuilder) getResolvedTypeWithoutAbstractConstructSignatures(t *StructuredType) *Type {
+	if len(t.ConstructSignatures()) == 0 {
+		return t.AsType()
+	}
+	if t.objectTypeWithoutAbstractConstructSignatures != nil {
+		return t.objectTypeWithoutAbstractConstructSignatures
+	}
+	constructSignatures := core.Filter(t.ConstructSignatures(), func(signature *Signature) bool {
+		return signature.flags&SignatureFlagsAbstract == 0
+	})
+	if len(constructSignatures) == len(t.ConstructSignatures()) {
+		t.objectTypeWithoutAbstractConstructSignatures = t.AsType()
+		return t.AsType()
+	}
+	typeCopy := b.ch.newAnonymousType(t.symbol, t.members, t.CallSignatures(), core.IfElse(len(constructSignatures) > 0, constructSignatures, []*Signature{}), t.indexInfos)
+	t.objectTypeWithoutAbstractConstructSignatures = typeCopy
+	typeCopy.AsStructuredType().objectTypeWithoutAbstractConstructSignatures = typeCopy
+	return typeCopy
+}
+
+func (b *NodeBuilder) symbolToNode(symbol *ast.Symbol, meaning ast.SymbolFlags) *ast.Node {
+	panic("unimplemented") // !!!
+}
+
+func (b *NodeBuilder) symbolToName(symbol *ast.Symbol, meaning ast.SymbolFlags, false bool) *ast.Node {
+	panic("unimplemented") // !!!
+}
+
+func (b *NodeBuilder) symbolToEntityNameNode(symbol *ast.Symbol) *ast.EntityName {
+	panic("unimplemented") // !!!
+}
+
+func (b *NodeBuilder) symbolToTypeNode(symbol *ast.Symbol, mask ast.SymbolFlags, typeArguments *ast.NodeList) *ast.TypeNode {
+	panic("unimplemented") // !!!
+}
+
+func (b *NodeBuilder) symbolToExpression(symbol *ast.Symbol, mask ast.SymbolFlags) *ast.Expression {
+	panic("unimplemented") // !!!
+}
+
+func (b *NodeBuilder) typeParameterToDeclarationWithConstraint(typeParameter *Type, constraintNode *ast.TypeNode) *ast.TypeParameterDeclarationNode {
+	panic("unimplemented") // !!!
+}
+
+func (b *NodeBuilder) typeParameterToName(typeParameter *Type) *ast.Identifier {
+	panic("unimplemented") // !!!
+}
+
+func (b *NodeBuilder) createMappedTypeNodeFromType(type_ *Type) *ast.TypeNode {
+	panic("unimplemented") // !!!
+}
+
+func (b *NodeBuilder) typePredicateToTypePredicateNode(predicate *TypePredicate) *ast.Node {
+	panic("unimplemented") // !!!
+}
+
+func (b *NodeBuilder) typeParameterToDeclaration(parameter *Type) *ast.Node {
+	panic("unimplemented") // !!!
+}
+
+func (b *NodeBuilder) symbolToTypeParameterDeclarations(symbol *ast.Symbol) *ast.Node {
+	panic("unimplemented") // !!!
+}
+
+func (b *NodeBuilder) symbolToParameterDeclaration(symbol *ast.Symbol, preserveModifierFlags bool) *ast.Node {
+	panic("unimplemented") // !!!
+}
+
+func (b *NodeBuilder) symbolTableToDeclarationStatements(symbolTable *ast.SymbolTable) []*ast.Node {
+	panic("unimplemented") // !!!
+}
+
+func (b *NodeBuilder) serializeTypeForExpression(expr *ast.Node) *ast.Node {
+	panic("unimplemented") // !!!
+}
+
+func (b *NodeBuilder) serializeInferredReturnTypeForSignature(signature *Signature, returnType *Type) *ast.Node {
+	oldSuppressReportInferenceFallback := b.ctx.suppressReportInferenceFallback
+	b.ctx.suppressReportInferenceFallback = true
+	typePredicate := b.ch.getTypePredicateOfSignature(signature)
+	var returnTypeNode *ast.Node
+	if typePredicate != nil {
+		var predicate *TypePredicate
+		if b.ctx.mapper != nil {
+			predicate = b.ch.instantiateTypePredicate(typePredicate, b.ctx.mapper)
+		} else {
+			predicate = typePredicate
+		}
+		returnTypeNode = b.typePredicateToTypePredicateNodeHelper(predicate)
+	} else {
+		returnTypeNode = b.typeToTypeNodeClosure(returnType)
+	}
+	b.ctx.suppressReportInferenceFallback = oldSuppressReportInferenceFallback
+	return returnTypeNode
+}
+
+func (b *NodeBuilder) typePredicateToTypePredicateNodeHelper(typePredicate *TypePredicate) *ast.Node {
+	var assertsModifier *ast.Node
+	if typePredicate.kind == TypePredicateKindAssertsThis || typePredicate.kind == TypePredicateKindAssertsIdentifier {
+		assertsModifier = b.f.NewToken(ast.KindAssertsKeyword)
+	} else {
+		assertsModifier = nil
+	}
+	var parameterName *ast.Node
+	if typePredicate.kind == TypePredicateKindIdentifier || typePredicate.kind == TypePredicateKindAssertsIdentifier {
+		parameterName = b.f.NewIdentifier(typePredicate.parameterName)
+		b.e.SetEmitFlags(parameterName, printer.EFNoAsciiEscaping)
+	} else {
+		parameterName = b.f.NewThisTypeNode()
+	}
+	var typeNode *ast.Node
+	if typePredicate.t != nil {
+		typeNode = b.typeToTypeNodeClosure(typePredicate.t)
+	}
+	return b.f.NewTypePredicateNode(assertsModifier, parameterName, typeNode)
+}
+
+type SignatureToSignatureDeclarationOptions struct {
+	modifiers     []*ast.Node
+	name          *ast.PropertyName
+	questionToken *ast.Node
+}
+
+func (b *NodeBuilder) signatureToSignatureDeclarationHelper(signature *Signature, kind ast.Kind, options *SignatureToSignatureDeclarationOptions) *ast.Node {
+	var typeParameters *[]*ast.Node
+	var typeArguments *[]*ast.Node
+
+	expandedParams := b.ch.getExpandedParameters(signature, true /*skipUnionExpanding*/)[0]
+	cleanup := b.enterNewScope(signature.declaration, &expandedParams, &signature.typeParameters, &signature.parameters, signature.mapper)
+	b.ctx.approximateLength += 3
+	// Usually a signature contributes a few more characters than this, but 3 is the minimum
+
+	if b.ctx.flags&NodeBuilderFlagsWriteTypeArgumentsOfSignature != 0 && signature.target != nil && signature.mapper != nil && signature.target.typeParameters != nil {
+		for _, parameter := range signature.target.typeParameters {
+			node := b.typeToTypeNodeClosure(b.ch.instantiateType(parameter, signature.mapper))
+			if typeArguments == nil {
+				typeArguments = &[]*ast.Node{}
+			}
+			args := append(*typeArguments, node)
+			typeArguments = &args
+		}
+	} else if signature.typeParameters != nil {
+		for _, parameter := range signature.typeParameters {
+			node := b.typeParameterToDeclaration(parameter)
+			if typeParameters == nil {
+				typeParameters = &[]*ast.Node{}
+			}
+			args := append(*typeParameters, node)
+			typeParameters = &args
+		}
+	}
+
+	restoreFlags := b.saveRestoreFlags()
+	b.ctx.flags &^= NodeBuilderFlagsSuppressAnyReturnType
+	// If the expanded parameter list had a variadic in a non-trailing position, don't expand it
+	parameters := core.Map(core.IfElse(core.Some(expandedParams, func(p *ast.Symbol) bool {
+		return p != expandedParams[len(expandedParams)-1] && p.CheckFlags&ast.CheckFlagsRestParameter != 0
+	}), signature.parameters, expandedParams), func(parameter *ast.Symbol) *ast.Node {
+		return b.symbolToParameterDeclaration(parameter, kind == ast.KindConstructor)
+	})
+	var thisParameter *ast.Node
+	if b.ctx.flags&NodeBuilderFlagsOmitThisParameter != 0 {
+		thisParameter = nil
+	} else {
+		thisParameter = b.tryGetThisParameterDeclaration(signature)
+	}
+	if thisParameter != nil {
+		parameters = append([]*ast.Node{thisParameter}, parameters...)
+	}
+	restoreFlags()
+
+	returnTypeNode := b.serializeReturnTypeForSignature(signature)
+
+	var modifiers []*ast.Node
+	if options != nil {
+		modifiers = options.modifiers
+	}
+	if (kind == ast.KindConstructorType) && signature.flags&SignatureFlagsAbstract != 0 {
+		flags := ast.ModifiersToFlags(modifiers)
+		modifiers = createModifiersFromModifierFlags(flags|ast.ModifierFlagsAbstract, b.f.NewModifier)
+	}
+
+	paramList := b.f.NewNodeList(parameters)
+	var typeParamList *ast.NodeList
+	if typeParameters != nil {
+		typeParamList = b.f.NewNodeList(*typeParameters)
+	}
+	var modifierList *ast.ModifierList
+	if modifiers != nil && len(modifiers) > 0 {
+		modifierList = b.f.NewModifierList(modifiers)
+	}
+	var name *ast.Node
+	if options != nil {
+		name = options.name
+	}
+	if name == nil {
+		name = b.f.NewIdentifier("")
+	}
+
+	var node *ast.Node
+	switch {
+	case kind == ast.KindCallSignature:
+		node = b.f.NewCallSignatureDeclaration(typeParamList, paramList, returnTypeNode)
+	case kind == ast.KindConstructSignature:
+		node = b.f.NewConstructSignatureDeclaration(typeParamList, paramList, returnTypeNode)
+	case kind == ast.KindMethodSignature:
+		var questionToken *ast.Node
+		if options != nil {
+			questionToken = options.questionToken
+		}
+		node = b.f.NewMethodSignatureDeclaration(modifierList, name, questionToken, typeParamList, paramList, returnTypeNode)
+	case kind == ast.KindMethodDeclaration:
+		node = b.f.NewMethodDeclaration(modifierList, nil /*asteriskToken*/, name, nil /*questionToken*/, typeParamList, paramList, returnTypeNode, nil /*body*/)
+	case kind == ast.KindConstructor:
+		node = b.f.NewConstructorDeclaration(modifierList, nil /*typeParamList*/, paramList, nil /*returnTypeNode*/, nil /*body*/)
+	case kind == ast.KindGetAccessor:
+		node = b.f.NewGetAccessorDeclaration(modifierList, name, nil /*typeParamList*/, paramList, returnTypeNode, nil /*body*/)
+	case kind == ast.KindSetAccessor:
+		node = b.f.NewSetAccessorDeclaration(modifierList, name, nil /*typeParamList*/, paramList, nil /*returnTypeNode*/, nil /*body*/)
+	case kind == ast.KindIndexSignature:
+		node = b.f.NewIndexSignatureDeclaration(modifierList, paramList, returnTypeNode)
+	// !!! JSDoc Support
+	// case kind == ast.KindJSDocFunctionType:
+	// 	node = b.f.NewJSDocFunctionType(parameters, returnTypeNode)
+	case kind == ast.KindFunctionType:
+		if returnTypeNode == nil {
+			returnTypeNode = b.f.NewTypeReferenceNode(b.f.NewIdentifier(""), nil)
+		}
+		node = b.f.NewFunctionTypeNode(typeParamList, paramList, returnTypeNode)
+	case kind == ast.KindConstructorType:
+		if returnTypeNode == nil {
+			returnTypeNode = b.f.NewTypeReferenceNode(b.f.NewIdentifier(""), nil)
+		}
+		node = b.f.NewConstructorTypeNode(modifierList, typeParamList, paramList, returnTypeNode)
+	case kind == ast.KindFunctionDeclaration:
+		// TODO: assert name is Identifier
+		node = b.f.NewFunctionDeclaration(modifierList, nil /*asteriskToken*/, name, typeParamList, paramList, returnTypeNode, nil /*body*/)
+	case kind == ast.KindFunctionExpression:
+		// TODO: assert name is Identifier
+		node = b.f.NewFunctionExpression(modifierList, nil /*asteriskToken*/, name, typeParamList, paramList, returnTypeNode, b.f.NewBlock(b.f.NewNodeList([]*ast.Node{}), false))
+	case kind == ast.KindArrowFunction:
+		node = b.f.NewArrowFunction(modifierList, typeParamList, paramList, returnTypeNode, nil /*equalsGreaterThanToken*/, b.f.NewBlock(b.f.NewNodeList([]*ast.Node{}), false))
+	default:
+		panic("Unhandled kind in signatureToSignatureDeclarationHelper")
+	}
+
+	// !!! TODO: Smuggle type arguments of signatures out for quickinfo
+	// if typeArguments != nil {
+	// 	node.TypeArguments = b.f.NewNodeList(typeArguments)
+	// }
+	// !!! TODO: synthetic comment support
+	// if signature.declaration. /* ? */ kind == ast.KindJSDocSignature && signature.declaration.Parent.Kind == ast.KindJSDocOverloadTag {
+	// 	comment := getTextOfNode(signature.declaration.Parent.Parent, true /*includeTrivia*/).slice(2, -2).split(regexp.MustParse(`\r\n|\n|\r`)).map_(func(line string) string {
+	// 		return line.replace(regexp.MustParse(`^\s+`), " ")
+	// 	}).join("\n")
+	// 	addSyntheticLeadingComment(node, ast.KindMultiLineCommentTrivia, comment, true /*hasTrailingNewLine*/)
+	// }
+
+	cleanup()
+	return node
+}
+
+func createModifiersFromModifierFlags(flags ast.ModifierFlags, createModifier func(kind ast.Kind) *ast.Node) []*ast.Node {
+	var result []*ast.Node
+	if flags&ast.ModifierFlagsExport != 0 {
+		result = append(result, createModifier(ast.KindExportKeyword))
+	}
+	if flags&ast.ModifierFlagsAmbient != 0 {
+		result = append(result, createModifier(ast.KindDeclareKeyword))
+	}
+	if flags&ast.ModifierFlagsDefault != 0 {
+		result = append(result, createModifier(ast.KindDefaultKeyword))
+	}
+	if flags&ast.ModifierFlagsConst != 0 {
+		result = append(result, createModifier(ast.KindConstKeyword))
+	}
+	if flags&ast.ModifierFlagsPublic != 0 {
+		result = append(result, createModifier(ast.KindPublicKeyword))
+	}
+	if flags&ast.ModifierFlagsPrivate != 0 {
+		result = append(result, createModifier(ast.KindPrivateKeyword))
+	}
+	if flags&ast.ModifierFlagsProtected != 0 {
+		result = append(result, createModifier(ast.KindProtectedKeyword))
+	}
+	if flags&ast.ModifierFlagsAbstract != 0 {
+		result = append(result, createModifier(ast.KindAbstractKeyword))
+	}
+	if flags&ast.ModifierFlagsStatic != 0 {
+		result = append(result, createModifier(ast.KindStaticKeyword))
+	}
+	if flags&ast.ModifierFlagsOverride != 0 {
+		result = append(result, createModifier(ast.KindOverrideKeyword))
+	}
+	if flags&ast.ModifierFlagsReadonly != 0 {
+		result = append(result, createModifier(ast.KindReadonlyKeyword))
+	}
+	if flags&ast.ModifierFlagsAccessor != 0 {
+		result = append(result, createModifier(ast.KindAccessorKeyword))
+	}
+	if flags&ast.ModifierFlagsAsync != 0 {
+		result = append(result, createModifier(ast.KindAsyncKeyword))
+	}
+	if flags&ast.ModifierFlagsIn != 0 {
+		result = append(result, createModifier(ast.KindInKeyword))
+	}
+	if flags&ast.ModifierFlagsOut != 0 {
+		result = append(result, createModifier(ast.KindOutKeyword))
+	}
+	return result
+}
+
+func (c *Checker) getExpandedParameters(sig *Signature, skipUnionExpanding bool) [][]*ast.Symbol {
+	if signatureHasRestParameter(sig) {
+		restIndex := len(sig.parameters) - 1
+		restSymbol := sig.parameters[restIndex]
+		restType := c.getTypeOfSymbol(restSymbol)
+		getUniqAssociatedNamesFromTupleType := func(t *Type, restSymbol *ast.Symbol) []string {
+			names := core.MapIndex(t.AsTupleType().elementInfos, func(info TupleElementInfo, i int) string {
+				return c.getTupleElementLabel(info, restSymbol, i)
+			})
+			if len(names) > 0 {
+				duplicates := []int{}
+				uniqueNames := make(map[string]bool)
+				for i := 0; i < len(names); i++ {
+					name := names[i]
+					_, ok := uniqueNames[name]
+					if ok {
+						duplicates = append(duplicates, i)
+					} else {
+						uniqueNames[name] = true
+					}
+				}
+				counters := make(map[string]int)
+				for _, i := range duplicates {
+					counter, ok := counters[names[i]]
+					if !ok {
+						counter = 1
+					}
+					var name string
+					for true {
+						name = fmt.Sprintf("{}_{}", names[i], counter)
+						_, ok := uniqueNames[name]
+						if ok {
+							counter++
+							continue
+						} else {
+							uniqueNames[name] = true
+							break
+						}
+					}
+					names[i] = name
+					counters[names[i]] = counter + 1
+				}
+			}
+			return names
+		}
+		expandSignatureParametersWithTupleMembers := func(restType *Type, restIndex int, restSymbol *ast.Symbol) []*ast.Symbol {
+			elementTypes := c.getTypeArguments(restType)
+			associatedNames := getUniqAssociatedNamesFromTupleType(restType, restSymbol)
+			restParams := core.MapIndex(elementTypes, func(t *Type, i int) *ast.Symbol {
+				// Lookup the label from the individual tuple passed in before falling back to the signature `rest` parameter name
+				// TODO: getTupleElementLabel can no longer fail, investigate if this lack of falliability meaningfully changes output
+				// var name *string
+				// if associatedNames != nil && associatedNames[i] != nil {
+				// 	name = associatedNames[i]
+				// } else {
+				// 	name = c.getParameterNameAtPosition(sig, restIndex+i, restType)
+				// }
+				name := associatedNames[i]
+				flags := restType.AsTupleType().elementInfos[i].flags
+				var checkFlags ast.CheckFlags
+				switch {
+				case flags&ElementFlagsVariable != 0:
+					checkFlags = ast.CheckFlagsRestParameter
+				case flags&ElementFlagsOptional != 0:
+					checkFlags = ast.CheckFlagsOptionalParameter
+				default:
+					checkFlags = 0
+				}
+				symbol := c.newSymbolEx(ast.SymbolFlagsFunctionScopedVariable, name, checkFlags)
+				links := c.valueSymbolLinks.Get(symbol)
+				if flags&ElementFlagsRest != 0 {
+					links.resolvedType = c.createArrayType(t)
+				} else {
+					links.resolvedType = t
+				}
+				return symbol
+			})
+			return core.Concatenate(sig.parameters[0:restIndex], restParams)
+		}
+
+		if isTupleType(restType) {
+			return [][]*ast.Symbol{expandSignatureParametersWithTupleMembers(restType, restIndex, restSymbol)}
+		} else if !skipUnionExpanding && restType.flags&TypeFlagsUnion != 0 && core.Every(restType.AsUnionType().types, isTupleType) {
+			return core.Map(restType.AsUnionType().types, func(t *Type) []*ast.Symbol {
+				return expandSignatureParametersWithTupleMembers(t, restIndex, restSymbol)
+			})
+		}
+	}
+	return [][]*ast.Symbol{sig.parameters}
+
+}
+
+func (b *NodeBuilder) tryGetThisParameterDeclaration(signature *Signature) *ast.Node {
+	if signature.thisParameter != nil {
+		return b.symbolToParameterDeclaration(signature.thisParameter, false)
+	}
+	if signature.declaration != nil && ast.IsInJSFile(signature.declaration) {
+		// !!! JSDoc Support
+		// thisTag := getJSDocThisTag(signature.declaration)
+		// if (thisTag && thisTag.typeExpression) {
+		// 	return factory.createParameterDeclaration(
+		// 		/*modifiers*/ undefined,
+		// 		/*dotDotDotToken*/ undefined,
+		// 		"this",
+		// 		/*questionToken*/ undefined,
+		// 		typeToTypeNodeHelper(getTypeFromTypeNode(context, thisTag.typeExpression), context),
+		// 	);
+		// }
+	}
+	return nil
+}
+
+/**
+* Serializes the return type of the signature by first trying to use the syntactic printer if possible and falling back to the checker type if not.
+ */
+func (b *NodeBuilder) serializeReturnTypeForSignature(signature *Signature) *ast.Node {
+	suppressAny := b.ctx.flags&NodeBuilderFlagsSuppressAnyReturnType != 0
+	restoreFlags := b.saveRestoreFlags()
+	if suppressAny {
+		b.ctx.flags &= ^NodeBuilderFlagsSuppressAnyReturnType // suppress only toplevel `any`s
+	}
+	var returnTypeNode *ast.Node
+
+	returnType := b.ch.getReturnTypeOfSignature(signature)
+	if !(suppressAny && IsTypeAny(returnType)) {
+		// !!! IsolatedDeclaration support
+		// if signature.declaration != nil && !ast.NodeIsSynthesized(signature.declaration) {
+		// 	declarationSymbol := b.ch.getSymbolOfDeclaration(signature.declaration)
+		// 	restore := addSymbolTypeToContext(declarationSymbol, returnType)
+		// 	returnTypeNode = syntacticNodeBuilder.serializeReturnTypeForSignature(signature.declaration, declarationSymbol)
+		// 	restore()
+		// }
+		if returnTypeNode == nil {
+			returnTypeNode = b.serializeInferredReturnTypeForSignature(signature, returnType)
+		}
+	}
+
+	if returnTypeNode == nil && !suppressAny {
+		returnTypeNode = b.f.NewKeywordTypeNode(ast.KindAnyKeyword)
+	}
+	restoreFlags()
+	return returnTypeNode
+}
+
+func (b *NodeBuilder) indexInfoToIndexSignatureDeclarationHelper(indexInfo *IndexInfo, typeNode *ast.TypeNode) *ast.Node {
+	name := getNameFromIndexInfo(indexInfo)
+	indexerTypeNode := b.typeToTypeNodeClosure(indexInfo.keyType)
+
+	indexingParameter := b.f.NewParameterDeclaration(nil, nil, b.f.NewIdentifier(name), nil, indexerTypeNode, nil)
+	if typeNode == nil {
+		if indexInfo.valueType == nil {
+			typeNode = b.f.NewKeywordTypeNode(ast.KindAnyKeyword)
+		} else {
+			typeNode = b.typeToTypeNodeClosure(indexInfo.valueType)
+		}
+	}
+	if indexInfo.valueType == nil && b.ctx.flags&NodeBuilderFlagsAllowEmptyIndexInfoType == 0 {
+		b.ctx.encounteredError = true
+	}
+	b.ctx.approximateLength += len(name) + 4
+	var modifiers *ast.ModifierList
+	if indexInfo.isReadonly {
+		b.ctx.approximateLength += 9
+		modifiers = b.f.NewModifierList([]*ast.Node{b.f.NewModifier(ast.KindReadonlyKeyword)})
+	}
+	return b.f.NewIndexSignatureDeclaration(modifiers, b.f.NewNodeList([]*ast.Node{indexingParameter}), typeNode)
+}
+
+/**
+* Unlike `typeToTypeNodeHelper`, this handles setting up the `AllowUniqueESSymbolType` flag
+* so a `unique symbol` is returned when appropriate for the input symbol, rather than `typeof sym`
+* @param declaration - The preferred declaration to pull existing type nodes from (the symbol will be used as a fallback to find any annotated declaration)
+* @param type - The type to write; an existing annotation must match this type if it's used, otherwise this is the type serialized as a new type node
+* @param symbol - The symbol is used both to find an existing annotation if declaration is not provided, and to determine if `unique symbol` should be printed
+ */
+func (b *NodeBuilder) serializeTypeForDeclaration(declaration *ast.Declaration, t *Type, symbol *ast.Symbol) *ast.Node {
+	// !!! node reuse logic
+	restoreFlags := b.saveRestoreFlags()
+	if t.flags&TypeFlagsUniqueESSymbol != 0 && t.symbol == symbol && (b.ctx.enclosingDeclaration == nil || core.Some(symbol.Declarations, func(d *ast.Declaration) bool {
+		return ast.GetSourceFileOfNode(d) == b.ctx.enclosingFile
+	})) {
+		b.ctx.flags |= NodeBuilderFlagsAllowUniqueESSymbolType
+	}
+	result := b.typeToTypeNodeClosure(t) // !!! expressionOrTypeToTypeNode
+	restoreFlags()
+	return result
+}
+
+const MAX_REVERSE_MAPPED_NESTING_INSPECTION_DEPTH = 3
+
+func (b *NodeBuilder) shouldUsePlaceholderForProperty(propertySymbol *ast.Symbol) bool {
+	// Use placeholders for reverse mapped types we've either
+	// (1) already descended into, or
+	// (2) are nested reverse mappings within a mapping over a non-anonymous type, or
+	// (3) are deeply nested properties that originate from the same mapped type.
+	// Condition (2) is a restriction mostly just to
+	// reduce the blowup in printback size from doing, eg, a deep reverse mapping over `Window`.
+	// Since anonymous types usually come from expressions, this allows us to preserve the output
+	// for deep mappings which likely come from expressions, while truncating those parts which
+	// come from mappings over library functions.
+	// Condition (3) limits printing of possibly infinitely deep reverse mapped types.
+	if propertySymbol.CheckFlags&ast.CheckFlagsReverseMapped == 0 {
+		return false
+	}
+	// (1)
+	for _, elem := range b.ctx.reverseMappedStack {
+		if elem == propertySymbol {
+			return true
+		}
+	}
+	// (2)
+	if len(b.ctx.reverseMappedStack) > 0 {
+		last := b.ctx.reverseMappedStack[len(b.ctx.reverseMappedStack)-1]
+		if b.ch.ReverseMappedSymbolLinks.Has(last) {
+			links := b.ch.ReverseMappedSymbolLinks.TryGet(last)
+			propertyType := links.propertyType
+			if propertyType != nil && propertyType.objectFlags&ObjectFlagsAnonymous == 0 {
+				return true
+			}
+		}
+	}
+	// (3) - we only inspect the last MAX_REVERSE_MAPPED_NESTING_INSPECTION_DEPTH elements of the
+	// stack for approximate matches to catch tight infinite loops
+	// TODO: Why? Reasoning lost to time. this could probably stand to be improved?
+	if len(b.ctx.reverseMappedStack) < MAX_REVERSE_MAPPED_NESTING_INSPECTION_DEPTH {
+		return false
+	}
+	if !b.ch.ReverseMappedSymbolLinks.Has(propertySymbol) {
+		return false
+	}
+	propertyLinks := b.ch.ReverseMappedSymbolLinks.TryGet(propertySymbol)
+	propMappedType := propertyLinks.mappedType
+	if propMappedType == nil || propMappedType.symbol == nil {
+		return false
+	}
+	for i := range b.ctx.reverseMappedStack {
+		if i > MAX_REVERSE_MAPPED_NESTING_INSPECTION_DEPTH {
+			break
+		}
+		prop := b.ctx.reverseMappedStack[len(b.ctx.reverseMappedStack)-1-i]
+		if b.ch.ReverseMappedSymbolLinks.Has(prop) {
+			links := b.ch.ReverseMappedSymbolLinks.TryGet(prop)
+			mappedType := links.mappedType
+			if mappedType != nil && mappedType.symbol == propMappedType.symbol {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (b *NodeBuilder) trackComputedName(accessExpression *ast.Node, enclosingDeclaration *ast.Node) {
+	// get symbol of the first identifier of the entityName
+	firstIdentifier := ast.GetFirstIdentifier(accessExpression)
+	name := b.ch.resolveName(firstIdentifier, firstIdentifier.Text(), ast.SymbolFlagsValue|ast.SymbolFlagsExportValue, nil /*nameNotFoundMessage*/, true /*isUse*/, false)
+	if name != nil {
+		b.ctx.tracker.TrackSymbol(name, enclosingDeclaration, ast.SymbolFlagsValue)
+	}
+}
+
+func (b *NodeBuilder) createPropertyNameNodeForIdentifierOrLiteral(name string, target core.ScriptTarget, _singleQuote bool, stringNamed bool, isMethod bool) *ast.Node {
+	isMethodNamedNew := isMethod && name == "new"
+	if !isMethodNamedNew && scanner.IsIdentifierText(name, target) {
+		return b.f.NewIdentifier(name)
+	}
+	if !stringNamed && !isMethodNamedNew && isNumericLiteralName(name) && jsnum.FromString(name) >= 0 {
+		return b.f.NewNumericLiteral(name)
+	}
+	result := b.f.NewStringLiteral(name)
+	// !!! TODO: set singleQuote
+	return result
+}
+
+func (b *NodeBuilder) isStringNamed(d *ast.Declaration) bool {
+	name := ast.GetNameOfDeclaration(d)
+	if name == nil {
+		return false
+	}
+	if ast.IsComputedPropertyName(name) {
+		t := b.ch.checkExpression(name.AsComputedPropertyName().Expression)
+		return t.flags&TypeFlagsStringLike != 0
+	}
+	if ast.IsElementAccessExpression(name) {
+		t := b.ch.checkExpression(name.AsElementAccessExpression().ArgumentExpression)
+		return t.flags&TypeFlagsStringLike != 0
+	}
+	return ast.IsStringLiteral(name)
+}
+
+func (b *NodeBuilder) isSingleQuotedStringNamed(d *ast.Declaration) bool {
+	return false // !!!
+	// TODO: actually support single-quote-style-maintenance
+	// name := ast.GetNameOfDeclaration(d)
+	// return name != nil && ast.IsStringLiteral(name) && (name.AsStringLiteral().SingleQuote || !nodeIsSynthesized(name) && startsWith(getTextOfNode(name, false /*includeTrivia*/), "'"))
+}
+
+func (b *NodeBuilder) getPropertyNameNodeForSymbol(symbol *ast.Symbol) *ast.Node {
+	stringNamed := len(symbol.Declarations) != 0 && core.Every(symbol.Declarations, b.isStringNamedClosure)
+	singleQuote := len(symbol.Declarations) != 0 && core.Every(symbol.Declarations, b.isSingleQuotedStringNamedClosure)
+	isMethod := symbol.Flags&ast.SymbolFlagsMethod != 0
+	fromNameType := b.getPropertyNameNodeForSymbolFromNameType(symbol, singleQuote, stringNamed, isMethod)
+	if fromNameType != nil {
+		return fromNameType
+	}
+	return b.createPropertyNameNodeForIdentifierOrLiteral(symbol.Name, b.ch.compilerOptions.GetEmitScriptTarget(), singleQuote, stringNamed, isMethod)
+}
+
+// See getNameForSymbolFromNameType for a stringy equivalent
+func (b *NodeBuilder) getPropertyNameNodeForSymbolFromNameType(symbol *ast.Symbol, singleQuote bool, stringNamed bool, isMethod bool) *ast.Node {
+	if !b.ch.valueSymbolLinks.Has(symbol) {
+		return nil
+	}
+	nameType := b.ch.valueSymbolLinks.TryGet(symbol).nameType
+	if nameType == nil {
+		return nil
+	}
+	if nameType.flags&TypeFlagsStringOrNumberLiteral != 0 {
+		name := nameType.AsLiteralType().value.(string)
+		if !scanner.IsIdentifierText(name, b.ch.compilerOptions.GetEmitScriptTarget()) && (stringNamed || !isNumericLiteralName(name)) {
+			// !!! TODO: set singleQuote
+			return b.f.NewStringLiteral(name)
+		}
+		if isNumericLiteralName(name) && name[0] == '-' {
+			return b.f.NewComputedPropertyName(b.f.NewPrefixUnaryExpression(ast.KindMinusToken, b.f.NewNumericLiteral(name[1:])))
+		}
+		return b.createPropertyNameNodeForIdentifierOrLiteral(name, b.ch.compilerOptions.GetEmitScriptTarget(), singleQuote, stringNamed, isMethod)
+	}
+	if nameType.flags&TypeFlagsUniqueESSymbol != 0 {
+		return b.f.NewComputedPropertyName(b.symbolToExpression(nameType.AsUniqueESSymbolType().symbol, ast.SymbolFlagsValue))
+	}
+	return nil
+}
+
+func (b *NodeBuilder) addPropertyToElementList(propertySymbol *ast.Symbol, typeElements []*ast.TypeElement) []*ast.TypeElement {
+	propertyIsReverseMapped := propertySymbol.CheckFlags&ast.CheckFlagsReverseMapped != 0
+	var propertyType *Type
+	if b.shouldUsePlaceholderForProperty(propertySymbol) {
+		propertyType = b.ch.anyType
+	} else {
+		propertyType = b.ch.getNonMissingTypeOfSymbol(propertySymbol)
+	}
+	saveEnclosingDeclaration := b.ctx.enclosingDeclaration
+	b.ctx.enclosingDeclaration = nil
+	if isLateBoundName(propertySymbol.Name) {
+		if len(propertySymbol.Declarations) > 0 {
+			decl := propertySymbol.Declarations[0]
+			if b.ch.hasLateBindableName(decl) {
+				if ast.IsBinaryExpression(decl) {
+					name := ast.GetNameOfDeclaration(decl)
+					if name != nil && ast.IsElementAccessExpression(name) && ast.IsPropertyAccessEntityNameExpression(name.AsElementAccessExpression().ArgumentExpression) {
+						b.trackComputedName(name.AsElementAccessExpression().ArgumentExpression, saveEnclosingDeclaration)
+					}
+				} else {
+					b.trackComputedName(decl.Name().Expression(), saveEnclosingDeclaration)
+				}
+			}
+		} else {
+			b.ctx.tracker.ReportNonSerializableProperty(b.ch.symbolToString(propertySymbol))
+		}
+	}
+	if propertySymbol.ValueDeclaration != nil {
+		b.ctx.enclosingDeclaration = propertySymbol.ValueDeclaration
+	} else if len(propertySymbol.Declarations) > 0 && propertySymbol.Declarations[0] != nil {
+		b.ctx.enclosingDeclaration = propertySymbol.Declarations[0]
+	} else {
+		b.ctx.enclosingDeclaration = saveEnclosingDeclaration
+	}
+	propertyName := b.getPropertyNameNodeForSymbol(propertySymbol)
+	b.ctx.enclosingDeclaration = saveEnclosingDeclaration
+	b.ctx.approximateLength += len(ast.SymbolName(propertySymbol)) + 1
+
+	if propertySymbol.Flags&ast.SymbolFlagsAccessor != 0 {
+		writeType := b.ch.getWriteTypeOfSymbol(propertySymbol)
+		if propertyType != writeType && !b.ch.isErrorType(propertyType) && !b.ch.isErrorType(writeType) {
+			getterDeclaration := ast.GetDeclarationOfKind(propertySymbol, ast.KindGetAccessor)
+			getterSignature := b.ch.getSignatureFromDeclaration(getterDeclaration)
+			getter := b.signatureToSignatureDeclarationHelper(getterSignature, ast.KindGetAccessor, &SignatureToSignatureDeclarationOptions{
+				name: propertyName,
+			})
+			b.setCommentRange(getter, getterDeclaration)
+			typeElements = append(typeElements, getter)
+			setterDeclaration := ast.GetDeclarationOfKind(propertySymbol, ast.KindSetAccessor)
+			setterSignature := b.ch.getSignatureFromDeclaration(setterDeclaration)
+			setter := b.signatureToSignatureDeclarationHelper(setterSignature, ast.KindSetAccessor, &SignatureToSignatureDeclarationOptions{
+				name: propertyName,
+			})
+			b.setCommentRange(setter, setterDeclaration)
+			typeElements = append(typeElements, setter)
+			return typeElements
+		}
+	}
+
+	var optionalToken *ast.Node
+	if propertySymbol.Flags&ast.SymbolFlagsOptional != 0 {
+		optionalToken = b.f.NewToken(ast.KindQuestionToken)
+	} else {
+		optionalToken = nil
+	}
+	if propertySymbol.Flags&(ast.SymbolFlagsFunction|ast.SymbolFlagsMethod) != 0 && len(b.ch.getPropertiesOfObjectType(propertyType)) == 0 && !b.ch.isReadonlySymbol(propertySymbol) {
+		signatures := b.ch.getSignaturesOfType(b.ch.filterType(propertyType, func(t *Type) bool {
+			return t.flags&TypeFlagsUndefined == 0
+		}), SignatureKindCall)
+		for _, signature := range signatures {
+			methodDeclaration := b.signatureToSignatureDeclarationHelper(signature, ast.KindMethodSignature, &SignatureToSignatureDeclarationOptions{
+				name:          propertyName,
+				questionToken: optionalToken,
+			})
+			b.setCommentRange(methodDeclaration, propertySymbol.ValueDeclaration) // !!! missing JSDoc support formerly provided by preserveCommentsOn
+			typeElements = append(typeElements, methodDeclaration)
+		}
+		if len(signatures) != 0 || optionalToken == nil {
+			return typeElements
+		}
+	}
+	var propertyTypeNode *ast.TypeNode
+	if b.shouldUsePlaceholderForProperty(propertySymbol) {
+		propertyTypeNode = b.createElidedInformationPlaceholder()
+	} else {
+		if propertyIsReverseMapped {
+			b.ctx.reverseMappedStack = append(b.ctx.reverseMappedStack, propertySymbol)
+		}
+		if propertyType != nil {
+			propertyTypeNode = b.serializeTypeForDeclaration(nil /*declaration*/, propertyType, propertySymbol)
+		} else {
+			propertyTypeNode = b.f.NewKeywordTypeNode(ast.KindAnyKeyword)
+		}
+		if propertyIsReverseMapped {
+			b.ctx.reverseMappedStack = b.ctx.reverseMappedStack[:len(b.ctx.reverseMappedStack)-1]
+		}
+	}
+
+	var modifiers *ast.ModifierList
+	if b.ch.isReadonlySymbol(propertySymbol) {
+		modifiers = b.f.NewModifierList([]*ast.Node{b.f.NewModifier(ast.KindReadonlyKeyword)})
+		b.ctx.approximateLength += 9
+	}
+	propertySignature := b.f.NewPropertySignatureDeclaration(modifiers, propertyName, optionalToken, propertyTypeNode, nil)
+
+	b.setCommentRange(propertySignature, propertySymbol.ValueDeclaration) // !!! missing JSDoc support formerly provided by preserveCommentsOn
+	typeElements = append(typeElements, propertySignature)
+
+	return typeElements
+}
+
+func (b *NodeBuilder) createTypeNodesFromResolvedType(resolvedType *StructuredType) *ast.NodeList {
+	if b.checkTruncationLength() {
+		if b.ctx.flags&NodeBuilderFlagsNoTruncation != 0 {
+			panic("NotEmittedTypeElement not implemented") // !!!
+			// elem := b.f.NewNotEmittedTypeElement()
+			// b.e.addSyntheticTrailingComment(elem, ast.KindMultiLineCommentTrivia, "elided")
+			// return b.f.NewNodeList([]*ast.TypeElement{elem})
+		}
+		return b.f.NewNodeList([]*ast.Node{b.f.NewPropertySignatureDeclaration(nil, b.f.NewIdentifier("..."), nil, nil, nil)})
+	}
+	var typeElements []*ast.TypeElement
+	for _, signature := range resolvedType.CallSignatures() {
+		typeElements = append(typeElements, b.signatureToSignatureDeclarationHelper(signature, ast.KindCallSignature, nil))
+	}
+	for _, signature := range resolvedType.ConstructSignatures() {
+		if signature.flags&SignatureFlagsAbstract != 0 {
+			continue
+		}
+		typeElements = append(typeElements, b.signatureToSignatureDeclarationHelper(signature, ast.KindConstructSignature, nil))
+	}
+	for _, info := range resolvedType.indexInfos {
+		typeElements = append(typeElements, b.indexInfoToIndexSignatureDeclarationHelper(info, core.IfElse(resolvedType.objectFlags&ObjectFlagsReverseMapped != 0, b.createElidedInformationPlaceholder(), nil)))
+	}
+
+	properties := resolvedType.properties
+	if len(properties) == 0 {
+		return b.f.NewNodeList(typeElements)
+	}
+
+	i := 0
+	for _, propertySymbol := range properties {
+		i++
+		if b.ctx.flags&NodeBuilderFlagsWriteClassExpressionAsTypeLiteral != 0 {
+			if propertySymbol.Flags&ast.SymbolFlagsPrototype != 0 {
+				continue
+			}
+			if getDeclarationModifierFlagsFromSymbol(propertySymbol)&(ast.ModifierFlagsPrivate|ast.ModifierFlagsProtected) != 0 {
+				b.ctx.tracker.ReportPrivateInBaseOfClassExpression(propertySymbol.Name)
+			}
+		}
+		if b.checkTruncationLength() && (i+2 < len(properties)-1) {
+			if b.ctx.flags&NodeBuilderFlagsNoTruncation != 0 {
+				// !!! synthetic comment support - missing middle silently elided without
+				// typeElement := typeElements[len(typeElements) - 1].Clone()
+				// typeElements = typeElements[0:len(typeElements)-1]
+				// b.e.addSyntheticTrailingComment(typeElement, ast.KindMultiLineCommentTrivia, __TEMPLATE__("... ", properties.length-i, " more elided ..."))
+				// typeElements = append(typeElements, typeElement)
+			} else {
+				text := fmt.Sprintf("... %d more ...", len(properties)-i)
+				typeElements = append(typeElements, b.f.NewPropertySignatureDeclaration(nil, b.f.NewIdentifier(text), nil, nil, nil))
+			}
+			typeElements = b.addPropertyToElementList(properties[len(properties)-1], typeElements)
+			break
+		}
+		typeElements = b.addPropertyToElementList(propertySymbol, typeElements)
+	}
+	if len(typeElements) != 0 {
+		return b.f.NewNodeList(typeElements)
+	} else {
+		return nil
+	}
+}
+
+func (b *NodeBuilder) createTypeNodeFromObjectType(t *Type) *ast.TypeNode {
+	if b.ch.isGenericMappedType(t) || (t.objectFlags&ObjectFlagsMapped != 0 && t.AsMappedType().containsError) {
+		return b.createMappedTypeNodeFromType(t)
+	}
+
+	resolved := b.ch.resolveStructuredTypeMembers(t)
+	callSigs := resolved.CallSignatures()
+	ctorSigs := resolved.ConstructSignatures()
+	if len(resolved.properties) == 0 && len(resolved.indexInfos) == 0 {
+		if len(callSigs) == 0 && len(ctorSigs) == 0 {
+			b.ctx.approximateLength += 2
+			result := b.f.NewTypeLiteralNode(b.f.NewNodeList([]*ast.Node{}))
+			b.e.SetEmitFlags(result, printer.EFSingleLine)
+			return result
+		}
+
+		if len(callSigs) == 1 && len(ctorSigs) == 0 {
+			signature := callSigs[0]
+			signatureNode := b.signatureToSignatureDeclarationHelper(signature, ast.KindFunctionType, nil)
+			return signatureNode
+		}
+
+		if len(ctorSigs) == 1 && len(callSigs) == 0 {
+			signature := ctorSigs[0]
+			signatureNode := b.signatureToSignatureDeclarationHelper(signature, ast.KindConstructorType, nil)
+			return signatureNode
+		}
+	}
+
+	abstractSignatures := core.Filter(ctorSigs, func(signature *Signature) bool {
+		return signature.flags&SignatureFlagsAbstract != 0
+	})
+	if len(callSigs) > 0 {
+		types := core.Map(abstractSignatures, func(s *Signature) *Type {
+			return b.ch.getOrCreateTypeFromSignature(s, nil)
+		})
+		// count the number of type elements excluding abstract constructors
+		typeElementCount := len(callSigs) + (len(ctorSigs) - len(abstractSignatures)) + len(resolved.indexInfos) + (core.IfElse(b.ctx.flags&NodeBuilderFlagsWriteClassExpressionAsTypeLiteral != 0, core.CountWhere(resolved.properties, func(p *ast.Symbol) bool {
+			return p.Flags&ast.SymbolFlagsPrototype == 0
+		}), len(resolved.properties)))
+		// don't include an empty object literal if there were no other static-side
+		// properties to write, i.e. `abstract class C { }` becomes `abstract new () => {}`
+		// and not `(abstract new () => {}) & {}`
+		if typeElementCount != 0 {
+			// create a copy of the object type without any abstract construct signatures.
+			types = append(types, b.getResolvedTypeWithoutAbstractConstructSignatures(resolved))
+		}
+		return b.typeToTypeNodeClosure(b.ch.getIntersectionType(types))
+	}
+
+	restoreFlags := b.saveRestoreFlags()
+	b.ctx.flags |= NodeBuilderFlagsInObjectTypeLiteral
+	members := b.createTypeNodesFromResolvedType(resolved)
+	restoreFlags()
+	typeLiteralNode := b.f.NewTypeLiteralNode(members)
+	b.ctx.approximateLength += 2
+	b.e.SetEmitFlags(typeLiteralNode, core.IfElse((b.ctx.flags&NodeBuilderFlagsMultilineObjectLiterals != 0), 0, printer.EFSingleLine))
+	return typeLiteralNode
+}
+
+func getTypeAliasForTypeLiteral(c *Checker, t *Type) *ast.Symbol {
+	if t.symbol != nil && t.symbol.Flags&ast.SymbolFlagsTypeLiteral != 0 && t.symbol.Declarations != nil {
+		node := ast.WalkUpParenthesizedTypes(t.symbol.Declarations[0].Parent)
+		if ast.IsTypeAliasDeclaration(node) {
+			return c.getSymbolOfDeclaration(node)
+		}
+	}
+	return nil
+}
+
+func (b *NodeBuilder) shouldWriteTypeOfFunctionSymbol(symbol *ast.Symbol, typeId TypeId) bool {
+	isStaticMethodSymbol := symbol.Flags&ast.SymbolFlagsMethod != 0 && core.Some(symbol.Declarations, func(declaration *ast.Node) bool {
+		return ast.IsStatic(declaration)
+	})
+	isNonLocalFunctionSymbol := false
+	if symbol.Flags&ast.SymbolFlagsFunction != 0 {
+		if symbol.Parent != nil {
+			isNonLocalFunctionSymbol = true
+		} else {
+			for _, declaration := range symbol.Declarations {
+				if declaration.Parent.Kind == ast.KindSourceFile || declaration.Parent.Kind == ast.KindModuleBlock {
+					isNonLocalFunctionSymbol = true
+					break
+				}
+			}
+		}
+	}
+	if isStaticMethodSymbol || isNonLocalFunctionSymbol {
+		// typeof is allowed only for static/non local functions
+		_, visited := b.ctx.visitedTypes[typeId]
+		return (b.ctx.flags&NodeBuilderFlagsUseTypeOfFunction != 0 || visited) && (b.ctx.flags&NodeBuilderFlagsUseStructuralFallback == 0 || b.ch.IsValueSymbolAccessible(symbol, b.ctx.enclosingDeclaration))
+		// And the build is going to succeed without visibility error or there is no structural fallback allowed
+	}
+	return false
+}
+
+func (b *NodeBuilder) createAnonymousTypeNode(t *Type) *ast.TypeNode {
+	typeId := t.id
+	symbol := t.symbol
+	if symbol != nil {
+		isInstantiationExpressionType := t.objectFlags&ObjectFlagsInstantiationExpressionType != 0
+		if isInstantiationExpressionType {
+			instantiationExpressionType := t.AsInstantiationExpressionType()
+			existing := instantiationExpressionType.node
+			if ast.IsTypeQueryNode(existing) {
+				typeNode := b.tryReuseExistingNonParameterTypeNode(existing, t, nil, nil)
+				if typeNode != nil {
+					return typeNode
+				}
+			}
+			if _, ok := b.ctx.visitedTypes[typeId]; ok {
+				return b.createElidedInformationPlaceholder()
+			}
+			return b.visitAndTransformType(t, b.createTypeNodeFromObjectTypeClosure)
+		}
+		var isInstanceType ast.SymbolFlags
+		if isClassInstanceSide(b.ch, t) {
+			isInstanceType = ast.SymbolFlagsType
+		} else {
+			isInstanceType = ast.SymbolFlagsValue
+		}
+
+		// !!! JS support
+		// if c.isJSConstructor(symbol.ValueDeclaration) {
+		// 	// Instance and static types share the same symbol; only add 'typeof' for the static side.
+		// 	return b.symbolToTypeNode(symbol, isInstanceType, nil)
+		// } else
+		if symbol.Flags&ast.SymbolFlagsClass != 0 && b.ch.getBaseTypeVariableOfClass(symbol) == nil && !(symbol.ValueDeclaration != nil && ast.IsClassLike(symbol.ValueDeclaration) && b.ctx.flags&NodeBuilderFlagsWriteClassExpressionAsTypeLiteral != 0 && (!ast.IsClassDeclaration(symbol.ValueDeclaration) || b.ch.IsSymbolAccessible(symbol, b.ctx.enclosingDeclaration, isInstanceType, false /*shouldComputeAliasesToMakeVisible*/).accessibility != SymbolAccessibilityAccessible)) || symbol.Flags&(ast.SymbolFlagsEnum|ast.SymbolFlagsValueModule) != 0 || b.shouldWriteTypeOfFunctionSymbol(symbol, typeId) {
+			return b.symbolToTypeNode(symbol, isInstanceType, nil)
+		} else if _, ok := b.ctx.visitedTypes[typeId]; ok {
+			// If type is an anonymous type literal in a type alias declaration, use type alias name
+			typeAlias := getTypeAliasForTypeLiteral(b.ch, t)
+			if typeAlias != nil {
+				// The specified symbol flags need to be reinterpreted as type flags
+				return b.symbolToTypeNode(typeAlias, ast.SymbolFlagsType, nil)
+			} else {
+				return b.createElidedInformationPlaceholder()
+			}
+		} else {
+			return b.visitAndTransformType(t, b.createTypeNodeFromObjectTypeClosure)
+		}
+	} else {
+		// Anonymous types without a symbol are never circular.
+		return b.createTypeNodeFromObjectTypeClosure(t)
+	}
+
+}
+
+func (b *NodeBuilder) getTypeFromTypeNode(node *ast.TypeNode, noMappedTypes bool) *Type {
+	// !!! noMappedTypes optional param support
+	t := b.ch.getTypeFromTypeNode(node)
+	if b.ctx.mapper == nil {
+		return t
+	}
+
+	instantiated := b.ch.instantiateType(t, b.ctx.mapper)
+	if noMappedTypes && instantiated != t {
+		return nil
+	}
+	return instantiated
+}
+
+func (b *NodeBuilder) typeToTypeNodeOrCircularityElision(t *Type) *ast.TypeNode {
+	if t.flags&TypeFlagsUnion != 0 {
+		if _, ok := b.ctx.visitedTypes[t.id]; ok {
+			if b.ctx.flags&NodeBuilderFlagsAllowAnonymousIdentifier == 0 {
+				b.ctx.encounteredError = true
+				b.ctx.tracker.ReportCyclicStructureError()
+			}
+			return b.createElidedInformationPlaceholder()
+		}
+		return b.visitAndTransformType(t, b.typeToTypeNodeClosure)
+	}
+	return b.typeToTypeNodeClosure(t)
+}
+
+func (b *NodeBuilder) conditionalTypeToTypeNode(_t *Type) *ast.TypeNode {
+	t := _t.AsConditionalType()
+	checkTypeNode := b.typeToTypeNodeClosure(t.checkType)
+	b.ctx.approximateLength += 15
+	if b.ctx.flags&NodeBuilderFlagsGenerateNamesForShadowedTypeParams != 0 && t.root.isDistributive && t.checkType.flags&TypeFlagsTypeParameter == 0 {
+		newParam := b.ch.newTypeParameter(b.ch.newSymbol(ast.SymbolFlagsTypeParameter, "T" /* as __String */))
+		name := b.typeParameterToName(newParam)
+		newTypeVariable := b.f.NewTypeReferenceNode(name.AsNode(), nil)
+		b.ctx.approximateLength += 37
+		// 15 each for two added conditionals, 7 for an added infer type
+		newMapper := prependTypeMapping(t.root.checkType, newParam, t.mapper)
+		saveInferTypeParameters := b.ctx.inferTypeParameters
+		b.ctx.inferTypeParameters = t.root.inferTypeParameters
+		extendsTypeNode := b.typeToTypeNodeClosure(b.ch.instantiateType(t.root.extendsType, newMapper))
+		b.ctx.inferTypeParameters = saveInferTypeParameters
+		trueTypeNode := b.typeToTypeNodeOrCircularityElision(b.ch.instantiateType(b.getTypeFromTypeNode(t.root.node.TrueType, false), newMapper))
+		falseTypeNode := b.typeToTypeNodeOrCircularityElision(b.ch.instantiateType(b.getTypeFromTypeNode(t.root.node.FalseType, false), newMapper))
+
+		// outermost conditional makes `T` a type parameter, allowing the inner conditionals to be distributive
+		// second conditional makes `T` have `T & checkType` substitution, so it is correctly usable as the checkType
+		// inner conditional runs the check the user provided on the check type (distributively) and returns the result
+		// checkType extends infer T ? T extends checkType ? T extends extendsType<T> ? trueType<T> : falseType<T> : never : never;
+		// this is potentially simplifiable to
+		// checkType extends infer T ? T extends checkType & extendsType<T> ? trueType<T> : falseType<T> : never;
+		// but that may confuse users who read the output more.
+		// On the other hand,
+		// checkType extends infer T extends checkType ? T extends extendsType<T> ? trueType<T> : falseType<T> : never;
+		// may also work with `infer ... extends ...` in, but would produce declarations only compatible with the latest TS.
+		newId := newTypeVariable.AsTypeReferenceNode().TypeName.AsIdentifier().Clone(b.f)
+		syntheticExtendsNode := b.f.NewInferTypeNode(b.f.NewTypeParameterDeclaration(nil, newId, nil, nil))
+		innerCheckConditionalNode := b.f.NewConditionalTypeNode(newTypeVariable, extendsTypeNode, trueTypeNode, falseTypeNode)
+		syntheticTrueNode := b.f.NewConditionalTypeNode(b.f.NewTypeReferenceNode(name.Clone(b.f), nil), b.f.DeepCloneNode(checkTypeNode), innerCheckConditionalNode, b.f.NewKeywordTypeNode(ast.KindNeverKeyword))
+		return b.f.NewConditionalTypeNode(checkTypeNode, syntheticExtendsNode, syntheticTrueNode, b.f.NewKeywordTypeNode(ast.KindNeverKeyword))
+	}
+	saveInferTypeParameters := b.ctx.inferTypeParameters
+	b.ctx.inferTypeParameters = t.root.inferTypeParameters
+	extendsTypeNode := b.typeToTypeNodeClosure(t.extendsType)
+	b.ctx.inferTypeParameters = saveInferTypeParameters
+	trueTypeNode := b.typeToTypeNodeOrCircularityElision(b.ch.getTrueTypeFromConditionalType(_t))
+	falseTypeNode := b.typeToTypeNodeOrCircularityElision(b.ch.getFalseTypeFromConditionalType(_t))
+	return b.f.NewConditionalTypeNode(checkTypeNode, extendsTypeNode, trueTypeNode, falseTypeNode)
+}
+
+func (b *NodeBuilder) getParentSymbolOfTypeParameter(typeParameter *TypeParameter) *ast.Symbol {
+	tp := ast.GetDeclarationOfKind(typeParameter.symbol, ast.KindTypeParameter)
+	var host *ast.Node
+	// !!! JSDoc support
+	// if ast.IsJSDocTemplateTag(tp.Parent) {
+	// 	host = getEffectiveContainerForJSDocTemplateTag(tp.Parent)
+	// } else {
+	host = tp.Parent
+	// }
+	if host == nil {
+		return nil
+	}
+	return b.ch.getSymbolOfNode(host)
+}
+
+func (b *NodeBuilder) typeReferenceToTypeNode(t *Type) *ast.TypeNode {
+	var typeArguments []*Type = b.ch.getTypeArguments(t)
+	if t.Target() == b.ch.globalArrayType || t.Target() == b.ch.globalReadonlyArrayType {
+		if b.ctx.flags&NodeBuilderFlagsWriteArrayAsGenericType != 0 {
+			typeArgumentNode := b.typeToTypeNodeClosure(typeArguments[0])
+			return b.f.NewTypeReferenceNode(b.f.NewIdentifier(core.IfElse(t.Target() == b.ch.globalArrayType, "Array", "ReadonlyArray")), b.f.NewNodeList([]*ast.TypeNode{typeArgumentNode}))
+		}
+		elementType := b.typeToTypeNodeClosure(typeArguments[0])
+		arrayType := b.f.NewArrayTypeNode(elementType)
+		if t.Target() == b.ch.globalArrayType {
+			return arrayType
+		} else {
+			return b.f.NewTypeOperatorNode(ast.KindReadonlyKeyword, arrayType)
+		}
+	} else if t.Target().objectFlags&ObjectFlagsTuple != 0 {
+		typeArguments = core.SameMapIndex(typeArguments, func(t *Type, i int) *Type {
+			return b.ch.removeMissingType(t, t.Target().AsTupleType().elementInfos[i].flags&ElementFlagsOptional != 0)
+		})
+		if len(typeArguments) > 0 {
+			arity := b.ch.getTypeReferenceArity(t)
+			tupleConstituentNodes := b.mapToTypeNodes(typeArguments[0:arity])
+			if tupleConstituentNodes != nil {
+				for i := 0; i < len(tupleConstituentNodes.Nodes); i++ {
+					flags := t.Target().AsTupleType().elementInfos[i].flags
+					labeledElementDeclaration := t.Target().AsTupleType().elementInfos[i].labeledDeclaration
+
+					if labeledElementDeclaration != nil {
+						tupleConstituentNodes.Nodes[i] = b.f.NewNamedTupleMember(core.IfElse(flags&ElementFlagsVariable != 0, b.f.NewToken(ast.KindDotDotDotToken), nil), b.f.NewIdentifier(b.ch.getTupleElementLabel(t.Target().AsTupleType().elementInfos[i], nil, i)), core.IfElse(flags&ElementFlagsOptional != 0, b.f.NewToken(ast.KindQuestionToken), nil), core.IfElse(flags&ElementFlagsRest != 0, b.f.NewArrayTypeNode(tupleConstituentNodes.Nodes[i]), tupleConstituentNodes.Nodes[i]))
+					} else {
+						switch {
+						case flags&ElementFlagsVariable != 0:
+							tupleConstituentNodes.Nodes[i] = b.f.NewRestTypeNode(core.IfElse(flags&ElementFlagsRest != 0, b.f.NewArrayTypeNode(tupleConstituentNodes.Nodes[i]), tupleConstituentNodes.Nodes[i]))
+						case flags&ElementFlagsOptional != 0:
+							tupleConstituentNodes.Nodes[i] = b.f.NewOptionalTypeNode(tupleConstituentNodes.Nodes[i])
+						}
+					}
+				}
+				tupleTypeNode := b.f.NewTupleTypeNode(tupleConstituentNodes)
+				b.e.SetEmitFlags(tupleTypeNode, printer.EFSingleLine)
+				if t.Target().AsTupleType().readonly {
+					return b.f.NewTypeOperatorNode(ast.KindReadonlyKeyword, tupleTypeNode)
+				} else {
+					return tupleTypeNode
+				}
+			}
+		}
+		if b.ctx.encounteredError || (b.ctx.flags&NodeBuilderFlagsAllowEmptyTuple != 0) {
+			tupleTypeNode := b.f.NewTupleTypeNode(b.f.NewNodeList([]*ast.TypeNode{}))
+			b.e.SetEmitFlags(tupleTypeNode, printer.EFSingleLine)
+			if t.Target().AsTupleType().readonly {
+				return b.f.NewTypeOperatorNode(ast.KindReadonlyKeyword, tupleTypeNode)
+			} else {
+				return tupleTypeNode
+			}
+		}
+		b.ctx.encounteredError = true
+		return nil
+		// TODO: GH#18217
+	} else if b.ctx.flags&NodeBuilderFlagsWriteClassExpressionAsTypeLiteral != 0 && t.symbol.ValueDeclaration != nil && ast.IsClassLike(t.symbol.ValueDeclaration) && !b.ch.IsValueSymbolAccessible(t.symbol, b.ctx.enclosingDeclaration) {
+		return b.createAnonymousTypeNode(t)
+	} else {
+		outerTypeParameters := t.Target().AsInterfaceType().OuterTypeParameters()
+		i := 0
+		var resultType *ast.TypeNode
+		if outerTypeParameters != nil {
+			length := len(outerTypeParameters)
+			for i < length {
+				// Find group of type arguments for type parameters with the same declaring container.
+				start := i
+				parent := b.getParentSymbolOfTypeParameter(outerTypeParameters[i].AsTypeParameter())
+				for ok := true; ok; ok = i < length && b.getParentSymbolOfTypeParameter(outerTypeParameters[i].AsTypeParameter()) == parent { // do-while loop
+					i++
+				}
+				// When type parameters are their own type arguments for the whole group (i.e. we have
+				// the default outer type arguments), we don't show the group.
+
+				if !slices.Equal(outerTypeParameters[start:i], typeArguments[start:i]) {
+					typeArgumentSlice := b.mapToTypeNodes(typeArguments[start:i])
+					restoreFlags := b.saveRestoreFlags()
+					b.ctx.flags |= NodeBuilderFlagsForbidIndexedAccessSymbolReferences
+					ref := b.symbolToTypeNode(parent, ast.SymbolFlagsType, typeArgumentSlice)
+					restoreFlags()
+					if resultType == nil {
+						resultType = ref
+					} else {
+						resultType = b.appendReferenceToType(resultType, ref)
+					}
+				}
+			}
+		}
+		var typeArgumentNodes *ast.NodeList
+		if len(typeArguments) > 0 {
+			typeParameterCount := 0
+			typeParams := t.Target().AsInterfaceType().TypeParameters()
+			if typeParams != nil {
+				typeParameterCount = min(len(typeParams), len(typeArguments))
+
+				// Maybe we should do this for more types, but for now we only elide type arguments that are
+				// identical to their associated type parameters' defaults for `Iterable`, `IterableIterator`,
+				// `AsyncIterable`, and `AsyncIterableIterator` to provide backwards-compatible .d.ts emit due
+				// to each now having three type parameters instead of only one.
+				if b.ch.isReferenceToType(t, b.ch.getGlobalIterableType()) || b.ch.isReferenceToType(t, b.ch.getGlobalIterableIteratorType()) || b.ch.isReferenceToType(t, b.ch.getGlobalAsyncIterableType()) || b.ch.isReferenceToType(t, b.ch.getGlobalAsyncIterableIteratorType()) {
+					if t.AsInterfaceType().node == nil || !ast.IsTypeReferenceNode(t.AsInterfaceType().node) || t.AsInterfaceType().node.TypeArguments() == nil || len(t.AsInterfaceType().node.TypeArguments()) < typeParameterCount {
+						for typeParameterCount > 0 {
+							typeArgument := typeArguments[typeParameterCount-1]
+							typeParameter := t.Target().AsInterfaceType().TypeParameters()[typeParameterCount-1]
+							defaultType := b.ch.getDefaultFromTypeParameter(typeParameter)
+							if defaultType == nil || !b.ch.isTypeIdenticalTo(typeArgument, defaultType) {
+								break
+							}
+							typeParameterCount--
+						}
+					}
+				}
+			}
+
+			typeArgumentNodes = b.mapToTypeNodes(typeArguments[i:typeParameterCount])
+		}
+		restoreFlags := b.saveRestoreFlags()
+		b.ctx.flags |= NodeBuilderFlagsForbidIndexedAccessSymbolReferences
+		finalRef := b.symbolToTypeNode(t.symbol, ast.SymbolFlagsType, typeArgumentNodes)
+		restoreFlags()
+		if resultType == nil {
+			return finalRef
+		} else {
+			return b.appendReferenceToType(resultType, finalRef)
+		}
+	}
+}
+
+func (b *NodeBuilder) visitAndTransformType(t *Type, transform func(t *Type) *ast.TypeNode) *ast.TypeNode {
+	typeId := t.id
+	isConstructorObject := t.objectFlags&ObjectFlagsAnonymous != 0 && t.symbol != nil && t.symbol.Flags&ast.SymbolFlagsClass != 0
+	var id *CompositeSymbolIdentity
+	switch {
+	case t.objectFlags&ObjectFlagsReference != 0 && t.AsTypeReference().node != nil:
+		id = &CompositeSymbolIdentity{false, 0, ast.GetNodeId(t.AsTypeReference().node)}
+	case t.flags&TypeFlagsConditional != 0:
+		id = &CompositeSymbolIdentity{false, 0, ast.GetNodeId(t.AsConditionalType().root.node.AsNode())}
+	case t.symbol != nil:
+		id = &CompositeSymbolIdentity{isConstructorObject, ast.GetSymbolId(t.symbol), 0}
+	default:
+		id = nil
+	}
+	// Since instantiations of the same anonymous type have the same symbol, tracking symbols instead
+	// of types allows us to catch circular references to instantiations of the same anonymous type
+
+	key := CompositeTypeCacheIdentity{typeId, b.ctx.flags, b.ctx.internalFlags}
+	if b.links.Has(b.ctx.enclosingDeclaration) {
+		links := b.links.Get(b.ctx.enclosingDeclaration)
+		cachedResult, ok := links.serializedTypes[key]
+		if ok {
+			// TODO:: check if we instead store late painted statements associated with this?
+			for _, arg := range cachedResult.trackedSymbols {
+				b.ctx.tracker.TrackSymbol(arg.symbol, arg.enclosingDeclaration, arg.meaning)
+			}
+			if cachedResult.truncating {
+				b.ctx.truncating = true
+			}
+			b.ctx.approximateLength += cachedResult.addedLength
+			return b.f.DeepCloneNode(cachedResult.node)
+		}
+	}
+
+	var depth int
+	if id != nil {
+		depth = b.ctx.symbolDepth[*id]
+		if depth > 10 {
+			return b.createElidedInformationPlaceholder()
+		}
+		b.ctx.symbolDepth[*id] = depth + 1
+	}
+	b.ctx.visitedTypes[typeId] = true
+	prevTrackedSymbols := b.ctx.trackedSymbols
+	b.ctx.trackedSymbols = nil
+	startLength := b.ctx.approximateLength
+	result := transform(t)
+	addedLength := b.ctx.approximateLength - startLength
+	if !b.ctx.reportedDiagnostic && !b.ctx.encounteredError {
+		links := b.links.Get(b.ctx.enclosingDeclaration)
+		links.serializedTypes[key] = &SerializedTypeEntry{
+			node:           result,
+			truncating:     b.ctx.truncating,
+			addedLength:    addedLength,
+			trackedSymbols: b.ctx.trackedSymbols,
+		}
+	}
+	delete(b.ctx.visitedTypes, typeId)
+	if id != nil {
+		b.ctx.symbolDepth[*id] = depth
+	}
+	b.ctx.trackedSymbols = prevTrackedSymbols
+	return result
+
+	// !!! TODO: Attempt node reuse or parse nodes to minimize copying once text range setting is set up
+	// deepCloneOrReuseNode := func(node T) T {
+	// 	if !nodeIsSynthesized(node) && getParseTreeNode(node) == node {
+	// 		return node
+	// 	}
+	// 	return setTextRange(b.ctx, b.f.cloneNode(visitEachChildWorker(node, deepCloneOrReuseNode, nil /*b.ctx*/, deepCloneOrReuseNodes, deepCloneOrReuseNode)), node)
+	// }
+
+	// deepCloneOrReuseNodes := func(nodes *NodeArray[*ast.Node], visitor Visitor, test func(node *ast.Node) bool, start number, count number) *NodeArray[*ast.Node] {
+	// 	if nodes != nil && nodes.length == 0 {
+	// 		// Ensure we explicitly make a copy of an empty array; visitNodes will not do this unless the array has elements,
+	// 		// which can lead to us reusing the same empty NodeArray more than once within the same AST during type noding.
+	// 		return setTextRangeWorker(b.f.NewNodeArray(nil, nodes.hasTrailingComma), nodes)
+	// 	}
+	// 	return visitNodes(nodes, visitor, test, start, count)
+	// }
+}
+
+func (b *NodeBuilder) typeToTypeNode(t *Type) *ast.TypeNode {
+
+	inTypeAlias := b.ctx.flags & NodeBuilderFlagsInTypeAlias
+	b.ctx.flags &^= NodeBuilderFlagsInTypeAlias
+
+	if t == nil {
+		if b.ctx.flags&NodeBuilderFlagsAllowEmptyUnionOrIntersection == 0 {
+			b.ctx.encounteredError = true
+			return nil
+			// TODO: GH#18217
+		}
+		b.ctx.approximateLength += 3
+		return b.f.NewKeywordTypeNode(ast.KindAnyKeyword)
+	}
+
+	if b.ctx.flags&NodeBuilderFlagsNoTypeReduction == 0 {
+		t = b.ch.getReducedType(t)
+	}
+
+	if t.flags&TypeFlagsAny != 0 {
+		if t.alias != nil {
+			return t.alias.ToTypeReferenceNode(b)
+		}
+		// !!! TODO: add comment once synthetic comment additions to nodes are supported
+		// if t == b.ch.unresolvedType {
+		// 	return e.AddSyntheticLeadingComment(b.f.NewKeywordTypeNode(ast.KindAnyKeyword), ast.KindMultiLineCommentTrivia, "unresolved")
+		// }
+		b.ctx.approximateLength += 3
+		return b.f.NewLiteralTypeNode(b.f.NewKeywordExpression(core.IfElse(t == b.ch.intrinsicMarkerType, ast.KindIntrinsicKeyword, ast.KindAnyKeyword)))
+	}
+	if t.flags&TypeFlagsUnknown != 0 {
+		return b.f.NewKeywordTypeNode(ast.KindUnknownKeyword)
+	}
+	if t.flags&TypeFlagsString != 0 {
+		b.ctx.approximateLength += 6
+		return b.f.NewKeywordTypeNode(ast.KindStringKeyword)
+	}
+	if t.flags&TypeFlagsNumber != 0 {
+		b.ctx.approximateLength += 6
+		return b.f.NewKeywordTypeNode(ast.KindNumberKeyword)
+	}
+	if t.flags&TypeFlagsBigInt != 0 {
+		b.ctx.approximateLength += 6
+		return b.f.NewKeywordTypeNode(ast.KindBigIntKeyword)
+	}
+	if t.flags&TypeFlagsBoolean != 0 && t.alias == nil {
+		b.ctx.approximateLength += 7
+		return b.f.NewKeywordTypeNode(ast.KindBooleanKeyword)
+	}
+	if t.flags&TypeFlagsEnumLike != 0 {
+		if t.symbol.Flags&ast.SymbolFlagsEnumMember != 0 {
+			parentSymbol := b.ch.getParentOfSymbol(t.symbol)
+			parentName := b.symbolToTypeNode(parentSymbol, ast.SymbolFlagsType, nil)
+			if b.ch.getDeclaredTypeOfSymbol(parentSymbol) == t {
+				return parentName
+			}
+			memberName := ast.SymbolName(t.symbol)
+			if scanner.IsIdentifierText(memberName, core.ScriptTargetES5) {
+				return b.appendReferenceToType(parentName /* as TypeReferenceNode | ImportTypeNode */, b.f.NewTypeReferenceNode(b.f.NewIdentifier(memberName), nil /*typeArguments*/))
+			}
+			if ast.IsImportTypeNode(parentName) {
+				parentName.AsImportTypeNode().IsTypeOf = true
+				// mutably update, node is freshly manufactured anyhow
+				return b.f.NewIndexedAccessTypeNode(parentName, b.f.NewLiteralTypeNode(b.f.NewStringLiteral(memberName)))
+			} else if ast.IsTypeReferenceNode(parentName) {
+				return b.f.NewIndexedAccessTypeNode(b.f.NewTypeQueryNode(parentName.AsTypeReferenceNode().TypeName, nil), b.f.NewLiteralTypeNode(b.f.NewStringLiteral(memberName)))
+			} else {
+				panic("Unhandled type node kind returned from `symbolToTypeNode`.")
+			}
+		}
+		return b.symbolToTypeNode(t.symbol, ast.SymbolFlagsType, nil)
+	}
+	if t.flags&TypeFlagsStringLiteral != 0 {
+		b.ctx.approximateLength += len(t.AsLiteralType().value.(string)) + 2
+		return b.f.NewLiteralTypeNode(b.f.NewStringLiteral(t.AsLiteralType().value.(string) /*, b.flags&NodeBuilderFlagsUseSingleQuotesForStringLiteralType != 0*/))
+	}
+	if t.flags&TypeFlagsNumberLiteral != 0 {
+		value := t.AsLiteralType().value.(jsnum.Number)
+		b.ctx.approximateLength += len(value.String())
+		return b.f.NewLiteralTypeNode(core.IfElse(value < 0, b.f.NewPrefixUnaryExpression(ast.KindMinusToken, b.f.NewNumericLiteral("-"+value.String())), b.f.NewNumericLiteral(value.String())))
+	}
+	if t.flags&TypeFlagsBigIntLiteral != 0 {
+		b.ctx.approximateLength += len(pseudoBigIntToString(getBigIntLiteralValue(t))) + 1
+		return b.f.NewLiteralTypeNode(b.f.NewBigIntLiteral(pseudoBigIntToString(getBigIntLiteralValue(t))))
+	}
+	if t.flags&TypeFlagsBooleanLiteral != 0 {
+		b.ctx.approximateLength += len(t.AsIntrinsicType().intrinsicName)
+		return b.f.NewLiteralTypeNode(core.IfElse(t.AsIntrinsicType().intrinsicName == "true", b.f.NewKeywordExpression(ast.KindTrueKeyword), b.f.NewKeywordExpression(ast.KindFalseKeyword)))
+	}
+	if t.flags&TypeFlagsUniqueESSymbol != 0 {
+		if b.ctx.flags&NodeBuilderFlagsAllowUniqueESSymbolType == 0 {
+			if b.ch.IsValueSymbolAccessible(t.symbol, b.ctx.enclosingDeclaration) {
+				b.ctx.approximateLength += 6
+				return b.symbolToTypeNode(t.symbol, ast.SymbolFlagsValue, nil)
+			}
+			b.ctx.tracker.ReportInaccessibleUniqueSymbolError()
+		}
+		b.ctx.approximateLength += 13
+		return b.f.NewTypeOperatorNode(ast.KindUniqueKeyword, b.f.NewKeywordTypeNode(ast.KindSymbolKeyword))
+	}
+	if t.flags&TypeFlagsVoid != 0 {
+		b.ctx.approximateLength += 4
+		return b.f.NewKeywordTypeNode(ast.KindVoidKeyword)
+	}
+	if t.flags&TypeFlagsUndefined != 0 {
+		b.ctx.approximateLength += 9
+		return b.f.NewKeywordTypeNode(ast.KindUndefinedKeyword)
+	}
+	if t.flags&TypeFlagsNull != 0 {
+		b.ctx.approximateLength += 4
+		return b.f.NewLiteralTypeNode(b.f.NewKeywordExpression(ast.KindNullKeyword))
+	}
+	if t.flags&TypeFlagsNever != 0 {
+		b.ctx.approximateLength += 5
+		return b.f.NewKeywordTypeNode(ast.KindNeverKeyword)
+	}
+	if t.flags&TypeFlagsESSymbol != 0 {
+		b.ctx.approximateLength += 6
+		return b.f.NewKeywordTypeNode(ast.KindSymbolKeyword)
+	}
+	if t.flags&TypeFlagsNonPrimitive != 0 {
+		b.ctx.approximateLength += 6
+		return b.f.NewKeywordTypeNode(ast.KindObjectKeyword)
+	}
+	if isThisTypeParameter(t) {
+		if b.ctx.flags&NodeBuilderFlagsInObjectTypeLiteral != 0 {
+			if !b.ctx.encounteredError && b.ctx.flags&NodeBuilderFlagsAllowThisInObjectLiteral == 0 {
+				b.ctx.encounteredError = true
+			}
+			b.ctx.tracker.ReportInaccessibleThisError()
+		}
+		b.ctx.approximateLength += 4
+		return b.f.NewThisTypeNode()
+	}
+
+	if inTypeAlias == 0 && t.alias != nil && (b.ctx.flags&NodeBuilderFlagsUseAliasDefinedOutsideCurrentScope != 0 || b.ch.IsTypeSymbolAccessible(t.alias.Symbol(), b.ctx.enclosingDeclaration)) {
+		sym := t.alias.Symbol()
+		typeArgumentNodes := b.mapToTypeNodes(t.alias.TypeArguments())
+		if isReservedMemberName(sym.Name) && sym.Flags&ast.SymbolFlagsClass == 0 {
+			return b.f.NewTypeReferenceNode(b.f.NewIdentifier(""), typeArgumentNodes)
+		}
+		if typeArgumentNodes != nil && len(typeArgumentNodes.Nodes) == 1 && sym == b.ch.globalArrayType.symbol {
+			return b.f.NewArrayTypeNode(typeArgumentNodes.Nodes[0])
+		}
+		return b.symbolToTypeNode(sym, ast.SymbolFlagsType, typeArgumentNodes)
+	}
+
+	objectFlags := t.objectFlags
+
+	if objectFlags&ObjectFlagsReference != 0 {
+		// Debug.assert(t.flags&TypeFlagsObject != 0) // !!!
+		if t.AsTypeReference().node != nil {
+			return b.visitAndTransformType(t, b.typeReferenceToTypeNodeClosure)
+		} else {
+			return b.typeReferenceToTypeNodeClosure(t)
+		}
+	}
+	if t.flags&TypeFlagsTypeParameter != 0 || objectFlags&ObjectFlagsClassOrInterface != 0 {
+		if t.flags&TypeFlagsTypeParameter != 0 && slices.Contains(b.ctx.inferTypeParameters, t) {
+			b.ctx.approximateLength += len(ast.SymbolName(t.symbol)) + 6
+			var constraintNode *ast.TypeNode
+			constraint := b.ch.getConstraintOfTypeParameter(t)
+			if constraint != nil {
+				// If the infer type has a constraint that is not the same as the constraint
+				// we would have normally inferred based on b, we emit the constraint
+				// using `infer T extends ?`. We omit inferred constraints from type references
+				// as they may be elided.
+				inferredConstraint := b.ch.getInferredTypeParameterConstraint(t, true /*omitTypeReferences*/)
+				if !(inferredConstraint != nil && b.ch.isTypeIdenticalTo(constraint, inferredConstraint)) {
+					b.ctx.approximateLength += 9
+					constraintNode = b.typeToTypeNodeClosure(constraint)
+				}
+			}
+			return b.f.NewInferTypeNode(b.typeParameterToDeclarationWithConstraint(t, constraintNode))
+		}
+		if b.ctx.flags&NodeBuilderFlagsGenerateNamesForShadowedTypeParams != 0 && t.flags&TypeFlagsTypeParameter != 0 {
+			name := b.typeParameterToName(t)
+			b.ctx.approximateLength += len(name.Text)
+			return b.f.NewTypeReferenceNode(b.f.NewIdentifier(name.Text), nil /*typeArguments*/)
+		}
+		// Ignore constraint/default when creating a usage (as opposed to declaration) of a type parameter.
+		if t.symbol != nil {
+			return b.symbolToTypeNode(t.symbol, ast.SymbolFlagsType, nil)
+		}
+		var name string
+		if (t == b.ch.markerSuperTypeForCheck || t == b.ch.markerSubTypeForCheck) && b.ch.varianceTypeParameter != nil && b.ch.varianceTypeParameter.symbol != nil {
+			name = (core.IfElse(t == b.ch.markerSubTypeForCheck, "sub-", "super-")) + ast.SymbolName(b.ch.varianceTypeParameter.symbol)
+		} else {
+			name = "?"
+		}
+		return b.f.NewTypeReferenceNode(b.f.NewIdentifier(name), nil /*typeArguments*/)
+	}
+	if t.flags&TypeFlagsUnion != 0 && t.AsUnionType().origin != nil {
+		t = t.AsUnionType().origin
+	}
+	if t.flags&(TypeFlagsUnion|TypeFlagsIntersection) != 0 {
+		var types []*Type
+		if t.flags&TypeFlagsUnion != 0 {
+			types = b.ch.formatUnionTypes(t.AsUnionType().types)
+		} else {
+			types = t.AsIntersectionType().types
+		}
+		if len(types) == 1 {
+			return b.typeToTypeNodeClosure(types[0])
+		}
+		typeNodes := b.mapToTypeNodes(types)
+		if typeNodes != nil && len(typeNodes.Nodes) > 0 {
+			if t.flags&TypeFlagsUnion != 0 {
+				return b.f.NewUnionTypeNode(typeNodes)
+			} else {
+				return b.f.NewIntersectionTypeNode(typeNodes)
+			}
+		} else {
+			if !b.ctx.encounteredError && b.ctx.flags&NodeBuilderFlagsAllowEmptyUnionOrIntersection == 0 {
+				b.ctx.encounteredError = true
+			}
+			return nil
+			// TODO: GH#18217
+		}
+	}
+	if objectFlags&(ObjectFlagsAnonymous|ObjectFlagsMapped) != 0 {
+		// Debug.assert(t.flags&TypeFlagsObject != 0) // !!!
+		// The type is an object literal type.
+		return b.createAnonymousTypeNode(t)
+	}
+	if t.flags&TypeFlagsIndex != 0 {
+		indexedType := t.Target()
+		b.ctx.approximateLength += 6
+		indexTypeNode := b.typeToTypeNodeClosure(indexedType)
+		return b.f.NewTypeOperatorNode(ast.KindKeyOfKeyword, indexTypeNode)
+	}
+	if t.flags&TypeFlagsTemplateLiteral != 0 {
+		texts := t.AsTemplateLiteralType().texts
+		types := t.AsTemplateLiteralType().types
+		templateHead := b.f.NewTemplateHead(texts[0], texts[0], ast.TokenFlagsNone)
+		templateSpans := b.f.NewNodeList(core.MapIndex(types, func(t *Type, i int) *ast.Node {
+			var res *ast.TemplateMiddleOrTail
+			if i < len(types)-1 {
+				res = b.f.NewTemplateMiddle(texts[i+1], texts[i+1], ast.TokenFlagsNone)
+			} else {
+				res = b.f.NewTemplateTail(texts[i+1], texts[i+1], ast.TokenFlagsNone)
+			}
+			return b.f.NewTemplateLiteralTypeSpan(b.typeToTypeNodeClosure(t), res)
+		}))
+		b.ctx.approximateLength += 2
+		return b.f.NewTemplateLiteralTypeNode(templateHead, templateSpans)
+	}
+	if t.flags&TypeFlagsStringMapping != 0 {
+		typeNode := b.typeToTypeNodeClosure(t.Target())
+		return b.symbolToTypeNode(t.AsStringMappingType().symbol, ast.SymbolFlagsType, b.f.NewNodeList([]*ast.Node{typeNode}))
+	}
+	if t.flags&TypeFlagsIndexedAccess != 0 {
+		objectTypeNode := b.typeToTypeNodeClosure(t.AsIndexedAccessType().objectType)
+		indexTypeNode := b.typeToTypeNodeClosure(t.AsIndexedAccessType().indexType)
+		b.ctx.approximateLength += 2
+		return b.f.NewIndexedAccessTypeNode(objectTypeNode, indexTypeNode)
+	}
+	if t.flags&TypeFlagsConditional != 0 {
+		return b.visitAndTransformType(t, b.conditionalTypeToTypeNodeClosure)
+	}
+	if t.flags&TypeFlagsSubstitution != 0 {
+		typeNode := b.typeToTypeNodeClosure(t.AsSubstitutionType().baseType)
+		if !b.ch.isNoInferType(t) {
+			return typeNode
+		}
+		noInferSymbol := b.ch.getGlobalTypeAliasSymbol("NoInfer", 1, false)
+		if noInferSymbol != nil {
+			return b.symbolToTypeNode(noInferSymbol, ast.SymbolFlagsType, b.f.NewNodeList([]*ast.Node{typeNode}))
+		} else {
+			return typeNode
+		}
+	}
+
+	panic("Should be unreachable.")
+}
+
+// Direct serialization core functions for types, type aliases, and symbols
+
+func (t *TypeAlias) ToTypeReferenceNode(b *NodeBuilder) *ast.Node {
+	return b.f.NewTypeReferenceNode(b.symbolToEntityNameNode(t.Symbol()), b.mapToTypeNodes(t.TypeArguments()))
+}

--- a/internal/checker/nodebuilderapi.go
+++ b/internal/checker/nodebuilderapi.go
@@ -1,0 +1,180 @@
+package checker
+
+import (
+	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/printer"
+)
+
+type NodeBuilderInterface interface {
+	typeToTypeNode(typ *Type, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) *ast.Node
+	typePredicateToTypePredicateNode(predicate *TypePredicate, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) *ast.Node
+	serializeTypeForDeclaration(declaration *ast.Node, symbol *ast.Symbol, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) *ast.Node
+	serializeReturnTypeForSignature(signatureDeclaration *ast.Node, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) *ast.Node
+	serializeTypeForExpression(expr *ast.Node, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) *ast.Node
+	indexInfoToIndexSignatureDeclaration(info *IndexInfo, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) *ast.Node
+	signatureToSignatureDeclaration(signature *Signature, kind ast.Kind, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) *ast.Node
+	symbolToEntityName(symbol *ast.Symbol, meaning ast.SymbolFlags, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) *ast.Node
+	symbolToExpression(symbol *ast.Symbol, meaning ast.SymbolFlags, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) *ast.Node
+	symbolToTypeParameterDeclarations(symbol *ast.Symbol, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) *ast.Node
+	symbolToParameterDeclaration(symbol *ast.Symbol, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) *ast.Node
+	typeParameterToDeclaration(parameter *Type, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) *ast.Node
+	symbolTableToDeclarationStatements(symbolTable *ast.SymbolTable, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) []*ast.Node
+	symbolToNode(symbol *ast.Symbol, meaning ast.SymbolFlags, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) *ast.Node
+}
+
+type NodeBuilderAPI struct {
+	ctxStack []*NodeBuilderContext
+	impl     *NodeBuilder
+}
+
+func (b *NodeBuilderAPI) enterContext(enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) {
+	b.impl.ctx = &NodeBuilderContext{
+		tracker:              tracker,
+		approximateLength:    0,
+		encounteredError:     false,
+		truncating:           false,
+		reportedDiagnostic:   false,
+		flags:                flags,
+		internalFlags:        internalFlags,
+		depth:                0,
+		enclosingDeclaration: enclosingDeclaration,
+		enclosingFile:        ast.GetSourceFileOfNode(enclosingDeclaration),
+		inferTypeParameters:  make([]*Type, 0),
+		visitedTypes:         make(map[TypeId]bool),
+		symbolDepth:          make(map[CompositeSymbolIdentity]int),
+		trackedSymbols:       make([]*TrackedSymbolArgs, 0),
+		mapper:               nil,
+		reverseMappedStack:   make([]*ast.Symbol, 0),
+	}
+	b.impl.initializeClosures() // recapture ctx
+	b.ctxStack = append(b.ctxStack, b.impl.ctx)
+}
+
+func (b *NodeBuilderAPI) popContext() {
+	b.impl.ctx = nil
+	if len(b.ctxStack) > 1 {
+		b.impl.ctx = b.ctxStack[len(b.ctxStack)-1]
+	}
+	b.ctxStack = b.ctxStack[0 : len(b.ctxStack)-1]
+}
+
+func (b *NodeBuilderAPI) exitContext(result *ast.Node) *ast.Node {
+	b.exitContextCheck()
+	defer b.popContext()
+	if b.impl.ctx.encounteredError {
+		return nil
+	}
+	return result
+}
+
+func (b *NodeBuilderAPI) exitContextSlice(result []*ast.Node) []*ast.Node {
+	b.exitContextCheck()
+	defer b.popContext()
+	if b.impl.ctx.encounteredError {
+		return nil
+	}
+	return result
+}
+
+func (b *NodeBuilderAPI) exitContextCheck() {
+	if b.impl.ctx.truncating && b.impl.ctx.flags&NodeBuilderFlagsNoTruncation != 0 {
+		b.impl.ctx.tracker.ReportTruncationError()
+	}
+}
+
+// indexInfoToIndexSignatureDeclaration implements NodeBuilderInterface.
+func (b *NodeBuilderAPI) indexInfoToIndexSignatureDeclaration(info *IndexInfo, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) *ast.Node {
+	b.enterContext(enclosingDeclaration, flags, internalFlags, tracker)
+	return b.exitContext(b.impl.indexInfoToIndexSignatureDeclarationHelper(info, nil))
+}
+
+// serializeReturnTypeForSignature implements NodeBuilderInterface.
+func (b *NodeBuilderAPI) serializeReturnTypeForSignature(signatureDeclaration *ast.Node, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) *ast.Node {
+	b.enterContext(enclosingDeclaration, flags, internalFlags, tracker)
+	signature := b.impl.ch.getSignatureFromDeclaration(signatureDeclaration)
+	symbol := b.impl.ch.getSymbolOfDeclaration(signatureDeclaration)
+	returnType, ok := b.impl.ctx.enclosingSymbolTypes[ast.GetSymbolId(symbol)]
+	if !ok || returnType == nil {
+		returnType = b.impl.ch.instantiateType(b.impl.ch.getReturnTypeOfSignature(signature), b.impl.ctx.mapper)
+	}
+	return b.exitContext(b.impl.serializeInferredReturnTypeForSignature(signature, returnType))
+}
+
+// serializeTypeForDeclaration implements NodeBuilderInterface.
+func (b *NodeBuilderAPI) serializeTypeForDeclaration(declaration *ast.Node, symbol *ast.Symbol, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) *ast.Node {
+	b.enterContext(enclosingDeclaration, flags, internalFlags, tracker)
+	return b.exitContext(b.impl.serializeTypeForDeclaration(declaration, nil, symbol))
+}
+
+// serializeTypeForExpression implements NodeBuilderInterface.
+func (b *NodeBuilderAPI) serializeTypeForExpression(expr *ast.Node, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) *ast.Node {
+	b.enterContext(enclosingDeclaration, flags, internalFlags, tracker)
+	return b.exitContext(b.impl.serializeTypeForExpression(expr))
+}
+
+// signatureToSignatureDeclaration implements NodeBuilderInterface.
+func (b *NodeBuilderAPI) signatureToSignatureDeclaration(signature *Signature, kind ast.Kind, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) *ast.Node {
+	b.enterContext(enclosingDeclaration, flags, internalFlags, tracker)
+	return b.exitContext(b.impl.signatureToSignatureDeclarationHelper(signature, kind, nil))
+}
+
+// symbolTableToDeclarationStatements implements NodeBuilderInterface.
+func (b *NodeBuilderAPI) symbolTableToDeclarationStatements(symbolTable *ast.SymbolTable, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) []*ast.Node {
+	b.enterContext(enclosingDeclaration, flags, internalFlags, tracker)
+	return b.exitContextSlice(b.impl.symbolTableToDeclarationStatements(symbolTable))
+}
+
+// symbolToEntityName implements NodeBuilderInterface.
+func (b *NodeBuilderAPI) symbolToEntityName(symbol *ast.Symbol, meaning ast.SymbolFlags, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) *ast.Node {
+	b.enterContext(enclosingDeclaration, flags, internalFlags, tracker)
+	return b.exitContext(b.impl.symbolToName(symbol, meaning, false))
+}
+
+// symbolToExpression implements NodeBuilderInterface.
+func (b *NodeBuilderAPI) symbolToExpression(symbol *ast.Symbol, meaning ast.SymbolFlags, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) *ast.Node {
+	b.enterContext(enclosingDeclaration, flags, internalFlags, tracker)
+	return b.exitContext(b.impl.symbolToExpression(symbol, meaning))
+}
+
+// symbolToNode implements NodeBuilderInterface.
+func (b *NodeBuilderAPI) symbolToNode(symbol *ast.Symbol, meaning ast.SymbolFlags, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) *ast.Node {
+	b.enterContext(enclosingDeclaration, flags, internalFlags, tracker)
+	return b.exitContext(b.impl.symbolToNode(symbol, meaning))
+}
+
+// symbolToParameterDeclaration implements NodeBuilderInterface.
+func (b NodeBuilderAPI) symbolToParameterDeclaration(symbol *ast.Symbol, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) *ast.Node {
+	b.enterContext(enclosingDeclaration, flags, internalFlags, tracker)
+	return b.exitContext(b.impl.symbolToParameterDeclaration(symbol, false))
+}
+
+// symbolToTypeParameterDeclarations implements NodeBuilderInterface.
+func (b *NodeBuilderAPI) symbolToTypeParameterDeclarations(symbol *ast.Symbol, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) *ast.Node {
+	b.enterContext(enclosingDeclaration, flags, internalFlags, tracker)
+	return b.exitContext(b.impl.symbolToTypeParameterDeclarations(symbol))
+}
+
+// typeParameterToDeclaration implements NodeBuilderInterface.
+func (b *NodeBuilderAPI) typeParameterToDeclaration(parameter *Type, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) *ast.Node {
+	b.enterContext(enclosingDeclaration, flags, internalFlags, tracker)
+	return b.exitContext(b.impl.typeParameterToDeclaration(parameter))
+}
+
+// typePredicateToTypePredicateNode implements NodeBuilderInterface.
+func (b *NodeBuilderAPI) typePredicateToTypePredicateNode(predicate *TypePredicate, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) *ast.Node {
+	b.enterContext(enclosingDeclaration, flags, internalFlags, tracker)
+	return b.exitContext(b.impl.typePredicateToTypePredicateNode(predicate))
+}
+
+// typeToTypeNode implements NodeBuilderInterface.
+func (b *NodeBuilderAPI) typeToTypeNode(typ *Type, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) *ast.Node {
+	b.enterContext(enclosingDeclaration, flags, internalFlags, tracker)
+	return b.exitContext(b.impl.typeToTypeNode(typ))
+}
+
+// var _ NodeBuilderInterface = NewNodeBuilderAPI(nil, nil)
+
+func NewNodeBuilderAPI(ch *Checker, e *printer.EmitContext) *NodeBuilderAPI {
+	impl := NewNodeBuilder(ch, e)
+	return &NodeBuilderAPI{impl: &impl, ctxStack: make([]*NodeBuilderContext, 0, 1)}
+}

--- a/internal/checker/nodebuilderscopes.go
+++ b/internal/checker/nodebuilderscopes.go
@@ -1,0 +1,230 @@
+package checker
+
+import (
+	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/core"
+)
+
+func cloneNodeBuilderContext(context *NodeBuilderContext) func() {
+	// Make type parameters created within this context not consume the name outside this context
+	// The symbol serializer ends up creating many sibling scopes that all need "separate" contexts when
+	// it comes to naming things - within a normal `typeToTypeNode` call, the node builder only ever descends
+	// through the type tree, so the only cases where we could have used distinct sibling scopes was when there
+	// were multiple generic overloads with similar generated type parameter names
+	// The effect:
+	// When we write out
+	// export const x: <T>(x: T) => T
+	// export const y: <T>(x: T) => T
+	// we write it out like that, rather than as
+	// export const x: <T>(x: T) => T
+	// export const y: <T_1>(x: T_1) => T_1
+	oldMustCreateTypeParameterSymbolList := context.mustCreateTypeParameterSymbolList
+	oldMustCreateTypeParametersNamesLookups := context.mustCreateTypeParametersNamesLookups
+	context.mustCreateTypeParameterSymbolList = true
+	context.mustCreateTypeParametersNamesLookups = true
+	oldTypeParameterNames := context.typeParameterNames
+	oldTypeParameterNamesByText := context.typeParameterNamesByText
+	oldTypeParameterNamesByTextNextNameCount := context.typeParameterNamesByTextNextNameCount
+	oldTypeParameterSymbolList := context.typeParameterSymbolList
+	return func() {
+		context.typeParameterNames = oldTypeParameterNames
+		context.typeParameterNamesByText = oldTypeParameterNamesByText
+		context.typeParameterNamesByTextNextNameCount = oldTypeParameterNamesByTextNextNameCount
+		context.typeParameterSymbolList = oldTypeParameterSymbolList
+		context.mustCreateTypeParameterSymbolList = oldMustCreateTypeParameterSymbolList
+		context.mustCreateTypeParametersNamesLookups = oldMustCreateTypeParametersNamesLookups
+	}
+}
+
+type localsRecord struct {
+	name      string
+	oldSymbol *ast.Symbol
+}
+
+func (b *NodeBuilder) enterNewScope(declaration *ast.Node, expandedParams *[]*ast.Symbol, typeParameters *[]*Type, originalParameters *[]*ast.Symbol, mapper *TypeMapper) func() {
+	cleanupContext := cloneNodeBuilderContext(b.ctx)
+	// For regular function/method declarations, the enclosing declaration will already be signature.declaration,
+	// so this is a no-op, but for arrow functions and function expressions, the enclosing declaration will be
+	// the declaration that the arrow function / function expression is assigned to.
+	//
+	// If the parameters or return type include "typeof globalThis.paramName", using the wrong scope will lead
+	// us to believe that we can emit "typeof paramName" instead, even though that would refer to the parameter,
+	// not the global. Make sure we are in the right scope by changing the enclosingDeclaration to the function.
+	//
+	// We can't use the declaration directly; it may be in another file and so we may lose access to symbols
+	// accessible to the current enclosing declaration, or gain access to symbols not accessible to the current
+	// enclosing declaration. To keep this chain accurate, insert a fake scope into the chain which makes the
+	// function's parameters visible.
+	var cleanupParams *func()
+	var cleanupTypeParams *func()
+	oldEnclosingDecl := b.ctx.enclosingDeclaration
+	oldMapper := b.ctx.mapper
+	if mapper != nil {
+		b.ctx.mapper = mapper
+	}
+	if b.ctx.enclosingDeclaration != nil && declaration != nil {
+		// As a performance optimization, reuse the same fake scope within this chain.
+		// This is especially needed when we are working on an excessively deep type;
+		// if we don't do this, then we spend all of our time adding more and more
+		// scopes that need to be searched in isSymbolAccessible later. Since all we
+		// really want to do is to mark certain names as unavailable, we can just keep
+		// all of the names we're introducing in one large table and push/pop from it as
+		// needed; isSymbolAccessible will walk upward and find the closest "fake" scope,
+		// which will conveniently report on any and all faked scopes in the chain.
+		//
+		// It'd likely be better to store this somewhere else for isSymbolAccessible, but
+		// since that API _only_ uses the enclosing declaration (and its parents), this is
+		// seems like the best way to inject names into that search process.
+		//
+		// Note that we only check the most immediate enclosingDeclaration; the only place we
+		// could potentially add another fake scope into the chain is right here, so we don't
+		// traverse all ancestors.
+		pushFakeScope := func(kind string, addAll func(addSymbol func(name string, symbol *ast.Symbol))) *func() {
+			// We only ever need to look two declarations upward.
+			// Debug.assert(context.enclosingDeclaration) // !!!
+			var existingFakeScope *ast.Node
+			if b.links.Has(b.ctx.enclosingDeclaration) {
+				links := b.links.Get(b.ctx.enclosingDeclaration)
+				if links.fakeScopeForSignatureDeclaration != nil && *links.fakeScopeForSignatureDeclaration == kind {
+					existingFakeScope = b.ctx.enclosingDeclaration
+				}
+			}
+			if existingFakeScope == nil && b.ctx.enclosingDeclaration.Parent != nil {
+				if b.links.Has(b.ctx.enclosingDeclaration.Parent) {
+					links := b.links.Get(b.ctx.enclosingDeclaration.Parent)
+					if links.fakeScopeForSignatureDeclaration != nil && *links.fakeScopeForSignatureDeclaration == kind {
+						existingFakeScope = b.ctx.enclosingDeclaration.Parent
+					}
+				}
+			}
+			// Debug.assertOptionalNode(existingFakeScope, isBlock) // !!!
+
+			var locals ast.SymbolTable
+			if existingFakeScope != nil {
+				locals = existingFakeScope.Locals()
+			} else {
+				locals = createSymbolTable([]*ast.Symbol{})
+			}
+			newLocals := []string{}
+			oldLocals := []localsRecord{}
+			addAll(func(name string, symbol *ast.Symbol) {
+				// Add cleanup information only if we don't own the fake scope
+				if existingFakeScope != nil {
+					oldSymbol, ok := locals[name]
+					if !ok || oldSymbol == nil {
+						newLocals = append(newLocals, name)
+					} else {
+						oldLocals = append(oldLocals, localsRecord{name, oldSymbol})
+					}
+				}
+				locals[name] = symbol
+			})
+
+			if existingFakeScope == nil {
+				// Use a Block for this; the type of the node doesn't matter so long as it
+				// has locals, and this is cheaper/easier than using a function-ish Node.
+				fakeScope := b.f.NewBlock(b.f.NewNodeList([]*ast.Node{}), false)
+				b.links.Get(fakeScope).fakeScopeForSignatureDeclaration = &kind
+				data := fakeScope.LocalsContainerData()
+				data.Locals = locals
+				fakeScope.Parent = b.ctx.enclosingDeclaration
+				b.ctx.enclosingDeclaration = fakeScope
+				return nil
+			} else {
+				// We did not create the current scope, so we have to clean it up
+				undo := func() {
+					for _, s := range newLocals {
+						delete(locals, s)
+					}
+					for _, s := range oldLocals {
+						locals[s.name] = s.oldSymbol
+					}
+				}
+				return &undo
+			}
+		}
+
+		if expandedParams == nil || !core.Some(*expandedParams, func(p *ast.Symbol) bool { return p != nil }) {
+			cleanupParams = nil
+		} else {
+			cleanupParams = pushFakeScope("params", func(add func(name string, symbol *ast.Symbol)) {
+				if expandedParams == nil {
+					return
+				}
+				for pIndex := 0; pIndex < len(*expandedParams); pIndex++ {
+					param := (*expandedParams)[pIndex]
+					originalParam := (*originalParameters)[pIndex]
+					if originalParameters != nil && originalParam != param {
+						// Can't reference parameters that come from an expansion
+						add(param.Name, b.ch.unknownSymbol)
+						// Can't reference the original expanded parameter either
+						if originalParam != nil {
+							add(originalParam.Name, b.ch.unknownSymbol)
+						}
+					} else if !core.Some(param.Declarations, func(d *ast.Node) bool {
+						var bindElement *(func(e *ast.BindingElement))
+						var bindPattern *(func(e *ast.BindingPattern))
+
+						bindPatternWorker := func(p *ast.BindingPattern) {
+							for _, e := range p.Elements.Nodes {
+								switch e.Kind {
+								case ast.KindOmittedExpression:
+									return
+								case ast.KindBindingElement:
+									(*bindElement)(e.AsBindingElement())
+									return
+								default:
+									panic("Unhandled binding element kind")
+								}
+							}
+						}
+
+						bindElementWorker := func(e *ast.BindingElement) {
+							if ast.IsBindingPattern(e.Name()) {
+								(*bindPattern)(e.Name().AsBindingPattern())
+								return
+							}
+							symbol := b.ch.getSymbolOfDeclaration(e.AsNode())
+							add(symbol.Name, symbol)
+						}
+						bindElement = &bindElementWorker
+						bindPattern = &bindPatternWorker
+
+						if ast.IsParameter(d) && ast.IsBindingPattern(d.Name()) {
+							(*bindPattern)(d.Name().AsBindingPattern())
+							return true
+						}
+						return false
+
+					}) {
+						add(param.Name, param)
+					}
+				}
+			})
+		}
+
+		if b.ctx.flags&NodeBuilderFlagsGenerateNamesForShadowedTypeParams != 0 && typeParameters != nil && core.Some(*typeParameters, func(p *Type) bool { return p != nil }) {
+			cleanupTypeParams = pushFakeScope("typeParams", func(add func(name string, symbol *ast.Symbol)) {
+				if typeParameters == nil {
+					return
+				}
+				for _, typeParam := range *typeParameters {
+					if typeParam == nil {
+						continue
+					}
+					typeParamName := b.typeParameterToName(typeParam).Text
+					add(typeParamName, typeParam.symbol)
+				}
+			})
+		}
+
+	}
+
+	return func() {
+		(*cleanupParams)()
+		(*cleanupTypeParams)()
+		cleanupContext()
+		b.ctx.enclosingDeclaration = oldEnclosingDecl
+		b.ctx.mapper = oldMapper
+	}
+}

--- a/internal/checker/printer.go
+++ b/internal/checker/printer.go
@@ -10,696 +10,218 @@ import (
 	"github.com/microsoft/typescript-go/internal/scanner"
 )
 
-func (c *Checker) getTypePrecedence(t *Type) ast.TypePrecedence {
-	if t.alias == nil {
-		switch {
-		case t.flags&TypeFlagsConditional != 0:
-			return ast.TypePrecedenceConditional
-		case t.flags&TypeFlagsIntersection != 0:
-			return ast.TypePrecedenceIntersection
-		case t.flags&TypeFlagsUnion != 0 && t.flags&TypeFlagsBoolean == 0:
-			return ast.TypePrecedenceUnion
-		case t.flags&TypeFlagsIndex != 0 || isInferTypeParameter(t):
-			return ast.TypePrecedenceTypeOperator
-		case c.isArrayType(t):
-			return ast.TypePrecedencePostfix
-		case t.objectFlags&ObjectFlagsClassOrInterface == 0 && c.getSingleCallOrConstructSignature(t) != nil:
-			return ast.TypePrecedenceFunction
-		}
+// TODO: Memoize once per checker to retain threadsafety
+func createPrinterWithDefaults() *printer.Printer {
+	return printer.NewPrinter(printer.PrinterOptions{}, printer.PrintHandlers{}, nil)
+}
+
+func createPrinterWithRemoveComments() *printer.Printer {
+	return printer.NewPrinter(printer.PrinterOptions{RemoveComments: true}, printer.PrintHandlers{}, nil)
+}
+
+func createPrinterWithRemoveCommentsOmitTrailingSemicolon() *printer.Printer {
+	// TODO: OmitTrailingSemicolon support
+	return printer.NewPrinter(printer.PrinterOptions{RemoveComments: true}, printer.PrintHandlers{}, nil)
+}
+
+func createPrinterWithRemoveCommentsNeverAsciiEscape() *printer.Printer {
+	// TODO: NeverAsciiEscape support
+	return printer.NewPrinter(printer.PrinterOptions{RemoveComments: true}, printer.PrintHandlers{}, nil)
+}
+
+func getTrailingSemicolonDeferringWriter(writer printer.EmitTextWriter) printer.EmitTextWriter {
+	// TODO: wrap arbitrary writer with writer that only commits semicolon writes on following write operations (is OmitTrailingSemicolon printer option redundant?)
+	return writer
+}
+
+func (c *Checker) TypeToString(type_ *Type) string {
+	return c.typeToStringEx(type_, nil, TypeFormatFlagsNone, nil)
+}
+
+func toNodeBuilderFlags(flags TypeFormatFlags) NodeBuilderFlags {
+	return NodeBuilderFlags(flags & TypeFormatFlagsNodeBuilderFlagsMask)
+}
+
+func (c *Checker) typeToStringEx(type_ *Type, enclosingDeclaration *ast.Node, flags TypeFormatFlags, writer printer.EmitTextWriter) string {
+	if writer == nil {
+		writer = printer.NewTextWriter("")
 	}
-	return ast.TypePrecedenceNonArray
+	noTruncation := (c.compilerOptions.NoErrorTruncation == core.TSTrue) || (flags&TypeFormatFlagsNoTruncation != 0)
+	combinedFlags := toNodeBuilderFlags(flags) | NodeBuilderFlagsIgnoreErrors
+	if noTruncation {
+		combinedFlags = combinedFlags | NodeBuilderFlagsNoTruncation
+	}
+	typeNode := c.nodeBuilder.typeToTypeNode(type_, enclosingDeclaration, combinedFlags, InternalNodeBuilderFlagsNone, nil)
+	if typeNode == nil {
+		panic("should always get typenode")
+	}
+	// The unresolved type gets a synthesized comment on `any` to hint to users that it's not a plain `any`.
+	// Otherwise, we always strip comments out.
+	var printer *printer.Printer
+	if type_ == c.unresolvedType {
+		printer = createPrinterWithDefaults()
+	} else {
+		printer = createPrinterWithRemoveComments()
+	}
+	var sourceFile *ast.SourceFile
+	if enclosingDeclaration != nil {
+		sourceFile = ast.GetSourceFileOfNode(enclosingDeclaration)
+	}
+	printer.Write(typeNode /*sourceFile*/, sourceFile, writer, nil)
+	result := writer.String()
+
+	maxLength := defaultMaximumTruncationLength * 2
+	if noTruncation {
+		maxLength = noTruncationMaximumTruncationLength * 2
+	}
+	if maxLength > 0 && result != "" && len(result) >= maxLength {
+		return result[0:maxLength-len("...")] + "..."
+	}
+	return result
 }
 
 func (c *Checker) SymbolToString(s *ast.Symbol) string {
 	return c.symbolToString(s)
 }
 
-func (c *Checker) symbolToString(s *ast.Symbol) string {
-	if scanner.IsValidIdentifier(s.Name, c.languageVersion) {
-		return s.Name
+func (c *Checker) symbolToString(symbol *ast.Symbol) string {
+	return ""
+}
+
+// TODO: port SymbolFormatFlags
+func (c *Checker) symbolToStringEx(symbol *ast.Symbol, enclosingDeclaration *ast.Node, meaning ast.SymbolFlags, flags SymbolFormatFlags, kind *SignatureKind, writer printer.EmitTextWriter) string {
+	if writer == nil {
+		writer = printer.SingleLineStringWriter
 	}
-	if s.ValueDeclaration != nil {
-		if ast.IsJsxAttribute(s.ValueDeclaration) {
-			return "\"" + s.Name + "\""
+
+	nodeFlags := NodeBuilderFlagsIgnoreErrors
+	internalNodeFlags := InternalNodeBuilderFlagsNone
+	if flags&SymbolFormatFlagsUseOnlyExternalAliasing != 0 {
+		nodeFlags |= NodeBuilderFlagsUseOnlyExternalAliasing
+	}
+	if flags&SymbolFormatFlagsWriteTypeParametersOrArguments != 0 {
+		nodeFlags |= NodeBuilderFlagsWriteTypeParametersInQualifiedName
+	}
+	if flags&SymbolFormatFlagsUseAliasDefinedOutsideCurrentScope != 0 {
+		nodeFlags |= NodeBuilderFlagsUseAliasDefinedOutsideCurrentScope
+	}
+	if flags&SymbolFormatFlagsDoNotIncludeSymbolChain != 0 {
+		internalNodeFlags |= InternalNodeBuilderFlagsDoNotIncludeSymbolChain
+	}
+	if flags&SymbolFormatFlagsWriteComputedProps != 0 {
+		internalNodeFlags |= InternalNodeBuilderFlagsWriteComputedProps
+	}
+
+	var sourceFile *ast.SourceFile
+	if enclosingDeclaration != nil {
+		sourceFile = ast.GetSourceFileOfNode(enclosingDeclaration)
+	}
+	if writer == printer.SingleLineStringWriter {
+		// handle uses of the single-line writer during an ongoing write
+		existing := writer.String()
+		defer writer.Clear()
+		if existing != "" {
+			defer writer.WriteKeyword(existing)
 		}
-		name := ast.GetNameOfDeclaration(s.ValueDeclaration)
-		if name != nil {
-			return scanner.GetTextOfNode(name)
+	}
+	var printer_ *printer.Printer
+	if enclosingDeclaration != nil && enclosingDeclaration.Kind == ast.KindSourceFile {
+		printer_ = createPrinterWithRemoveCommentsNeverAsciiEscape()
+	} else {
+		printer_ = createPrinterWithRemoveComments()
+	}
+
+	var builder func(symbol *ast.Symbol, meaning ast.SymbolFlags, enclosingDeclaration *ast.Node, flags NodeBuilderFlags, internalFlags InternalNodeBuilderFlags, tracker SymbolTracker) *ast.Node
+	if flags&SymbolFormatFlagsAllowAnyNodeKind != 0 {
+		builder = c.nodeBuilder.symbolToNode
+	} else {
+		builder = c.nodeBuilder.symbolToEntityName
+	}
+	entity := builder(symbol, meaning, enclosingDeclaration, nodeFlags, internalNodeFlags, nil)         // TODO: GH#18217
+	printer_.Write(entity /*sourceFile*/, sourceFile, getTrailingSemicolonDeferringWriter(writer), nil) // TODO: GH#18217
+	return writer.String()
+}
+
+func (c *Checker) signatureToString(signature *Signature) string {
+	return c.signatureToStringEx(signature, nil, TypeFormatFlagsNone, nil, nil)
+}
+
+func (c *Checker) signatureToStringEx(signature *Signature, enclosingDeclaration *ast.Node, flags TypeFormatFlags, kind *SignatureKind, writer printer.EmitTextWriter) string {
+	var sigOutput ast.Kind
+	if flags&TypeFormatFlagsWriteArrowStyleSignature != 0 {
+		if kind != nil && *kind == SignatureKindConstruct {
+			sigOutput = ast.KindConstructorType
+		} else {
+			sigOutput = ast.KindFunctionType
+		}
+	} else {
+		if kind != nil && *kind == SignatureKindConstruct {
+			sigOutput = ast.KindConstructSignature
+		} else {
+			sigOutput = ast.KindCallSignature
 		}
 	}
-	if len(s.Name) == 0 || s.Name[0] != '\xFE' {
-		return s.Name // !!! Implement escaping
+	if writer == nil {
+		writer = printer.SingleLineStringWriter
 	}
-	switch s.Name {
-	case ast.InternalSymbolNameClass:
-		return "(Anonymous class)"
-	case ast.InternalSymbolNameFunction:
-		return "(Anonymous function)"
-	case ast.InternalSymbolNameType, ast.InternalSymbolNameObject:
-		return "(Anonymous type)"
-	case ast.InternalSymbolNameComputed:
-		return "(Computed name)"
+	combinedFlags := toNodeBuilderFlags(flags) | NodeBuilderFlagsIgnoreErrors | NodeBuilderFlagsWriteTypeParametersInQualifiedName
+	sig := c.nodeBuilder.signatureToSignatureDeclaration(signature, sigOutput, enclosingDeclaration, combinedFlags, InternalNodeBuilderFlagsNone, nil)
+	printer_ := createPrinterWithRemoveCommentsOmitTrailingSemicolon()
+	var sourceFile *ast.SourceFile
+	if enclosingDeclaration != nil {
+		sourceFile = ast.GetSourceFileOfNode(enclosingDeclaration)
 	}
-	if len(s.Name) >= 2 && s.Name[1] == '@' {
-		return "(Unique symbol)"
+	if writer == printer.SingleLineStringWriter {
+		// handle uses of the single-line writer during an ongoing write
+		existing := writer.String()
+		defer writer.Clear()
+		if existing != "" {
+			defer writer.WriteKeyword(existing)
+		}
 	}
-	return "(Missing)"
+	printer_.Write(sig /*sourceFile*/, sourceFile, getTrailingSemicolonDeferringWriter(writer), nil) // TODO: GH#18217
+	return writer.String()
 }
 
-func (c *Checker) TypeToString(t *Type) string {
-	return c.typeToStringEx(t, nil, TypeFormatFlagsNone)
+func (c *Checker) typePredicateToString(typePredicate *TypePredicate) string {
+	return c.typePredicateToStringEx(typePredicate, nil, TypeFormatFlagsUseAliasDefinedOutsideCurrentScope, nil)
 }
 
-func (c *Checker) typeToStringEx(t *Type, enclosingDeclaration *ast.Node, flags TypeFormatFlags) string {
-	p := c.newPrinter(flags)
-	if flags&TypeFormatFlagsNoTypeReduction == 0 {
-		t = c.getReducedType(t)
+func (c *Checker) typePredicateToStringEx(typePredicate *TypePredicate, enclosingDeclaration *ast.Node, flags TypeFormatFlags, writer printer.EmitTextWriter) string {
+	if writer == nil {
+		writer = printer.SingleLineStringWriter
 	}
-	p.printType(t)
-	return p.string()
-}
-
-func (c *Checker) SourceFileWithTypes(sourceFile *ast.SourceFile) string {
-	p := c.newPrinter(TypeFormatFlagsInTypeAlias)
-	p.printSourceFileWithTypes(sourceFile)
-	return p.string()
-}
-
-func (c *Checker) signatureToString(s *Signature) string {
-	p := c.newPrinter(TypeFormatFlagsNone)
-	if s.flags&SignatureFlagsConstruct != 0 {
-		p.print("new ")
+	combinedFlags := toNodeBuilderFlags(flags) | NodeBuilderFlagsIgnoreErrors | NodeBuilderFlagsWriteTypeParametersInQualifiedName
+	predicate := c.nodeBuilder.typePredicateToTypePredicateNode(typePredicate, enclosingDeclaration, combinedFlags, InternalNodeBuilderFlagsNone, nil) // TODO: GH#18217
+	printer_ := createPrinterWithRemoveComments()
+	var sourceFile *ast.SourceFile
+	if enclosingDeclaration != nil {
+		sourceFile = ast.GetSourceFileOfNode(enclosingDeclaration)
 	}
-	p.printSignature(s, ": ")
-	return p.string()
-}
-
-func (c *Checker) typePredicateToString(t *TypePredicate) string {
-	p := c.newPrinter(TypeFormatFlagsNone)
-	p.printTypePredicate(t)
-	return p.string()
+	if writer == printer.SingleLineStringWriter {
+		// handle uses of the single-line writer during an ongoing write
+		existing := writer.String()
+		defer writer.Clear()
+		if existing != "" {
+			defer writer.WriteKeyword(existing)
+		}
+	}
+	printer_.Write(predicate /*sourceFile*/, sourceFile, writer, nil)
+	return writer.String()
 }
 
 func (c *Checker) valueToString(value any) string {
-	p := c.newPrinter(TypeFormatFlagsNone)
-	p.printValue(value)
-	return p.string()
-}
-
-type Printer struct {
-	c                *Checker
-	flags            TypeFormatFlags
-	sb               strings.Builder
-	printing         core.Set[*Type]
-	depth            int32
-	extendsTypeDepth int32
-}
-
-func (c *Checker) newPrinter(flags TypeFormatFlags) *Printer {
-	return &Printer{c: c, flags: flags}
-}
-
-func (p *Printer) string() string {
-	return p.sb.String()
-}
-
-func (p *Printer) print(s string) {
-	p.sb.WriteString(s)
-}
-
-func (p *Printer) printName(symbol *ast.Symbol) {
-	p.print(p.c.symbolToString(symbol))
-}
-
-func (p *Printer) printQualifiedName(symbol *ast.Symbol) {
-	if p.flags&TypeFormatFlagsUseFullyQualifiedType != 0 && symbol.Parent != nil {
-		p.printQualifiedName(symbol.Parent)
-		p.print(".")
-	}
-	if symbol.Flags&ast.SymbolFlagsModule != 0 && strings.HasPrefix(symbol.Name, "\"") {
-		p.print("import(")
-		p.print(symbol.Name)
-		p.print(")")
-		return
-	}
-	p.printName(symbol)
-}
-
-func (p *Printer) printTypeEx(t *Type, precedence ast.TypePrecedence) {
-	if p.c.getTypePrecedence(t) < precedence {
-		p.print("(")
-		p.printType(t)
-		p.print(")")
-	} else {
-		p.printType(t)
-	}
-}
-
-func (p *Printer) printType(t *Type) {
-	if p.sb.Len() > 1_000_000 {
-		p.print("...")
-		return
-	}
-
-	if t.alias != nil && (p.flags&TypeFormatFlagsInTypeAlias == 0 || p.depth > 0) {
-		p.printQualifiedName(t.alias.symbol)
-		p.printTypeArguments(t.alias.typeArguments)
-	} else {
-		p.printTypeNoAlias(t)
-	}
-}
-
-func (p *Printer) printTypeNoAlias(t *Type) {
-	p.depth++
-	switch {
-	case t.flags&TypeFlagsIntrinsic != 0:
-		p.print(t.AsIntrinsicType().intrinsicName)
-	case t.flags&(TypeFlagsLiteral|TypeFlagsEnum) != 0:
-		p.printLiteralType(t)
-	case t.flags&TypeFlagsUniqueESSymbol != 0:
-		p.printUniqueESSymbolType(t)
-	case t.flags&TypeFlagsUnion != 0:
-		p.printUnionType(t)
-	case t.flags&TypeFlagsIntersection != 0:
-		p.printIntersectionType(t)
-	case t.flags&TypeFlagsTypeParameter != 0:
-		p.printTypeParameter(t)
-	case t.flags&TypeFlagsObject != 0:
-		p.printRecursive(t, (*Printer).printObjectType)
-	case t.flags&TypeFlagsIndex != 0:
-		p.printRecursive(t, (*Printer).printIndexType)
-	case t.flags&TypeFlagsIndexedAccess != 0:
-		p.printRecursive(t, (*Printer).printIndexedAccessType)
-	case t.flags&TypeFlagsConditional != 0:
-		p.printRecursive(t, (*Printer).printConditionalType)
-	case t.flags&TypeFlagsTemplateLiteral != 0:
-		p.printTemplateLiteralType(t)
-	case t.flags&TypeFlagsStringMapping != 0:
-		p.printStringMappingType(t)
-	case t.flags&TypeFlagsSubstitution != 0:
-		if p.c.isNoInferType(t) {
-			if noInferSymbol := p.c.getGlobalNoInferSymbolOrNil(); noInferSymbol != nil {
-				p.printQualifiedName(noInferSymbol)
-				p.printTypeArguments([]*Type{t.AsSubstitutionType().baseType})
-				break
-			}
-		}
-		p.printType(t.AsSubstitutionType().baseType)
-	}
-	p.depth--
-}
-
-func (p *Printer) printRecursive(t *Type, f func(*Printer, *Type)) {
-	if !p.printing.Has(t) && p.depth < 10 {
-		p.printing.Add(t)
-		f(p, t)
-		p.printing.Delete(t)
-	} else {
-		p.print("???")
-	}
-}
-
-func (p *Printer) printLiteralType(t *Type) {
-	if t.flags&(TypeFlagsEnumLiteral|TypeFlagsEnum) != 0 {
-		p.printEnumLiteral(t)
-	} else {
-		p.printValue(t.AsLiteralType().value)
-	}
-}
-
-func (p *Printer) printValue(value any) {
 	switch value := value.(type) {
 	case string:
-		p.printStringLiteral(value)
+		return "\"" + printer.EscapeString(value, '"') + "\""
 	case jsnum.Number:
-		p.printNumberLiteral(value)
+		return value.String()
 	case bool:
-		p.printBooleanLiteral(value)
+		return core.IfElse(value, "true", "false")
 	case jsnum.PseudoBigInt:
-		p.printBigIntLiteral(value)
+		return value.String() + "n"
 	}
-}
-
-func (p *Printer) printStringLiteral(s string) {
-	p.print("\"")
-	p.print(printer.EscapeString(s, '"'))
-	p.print("\"")
-}
-
-func (p *Printer) printNumberLiteral(f jsnum.Number) {
-	p.print(f.String())
-}
-
-func (p *Printer) printBooleanLiteral(b bool) {
-	p.print(core.IfElse(b, "true", "false"))
-}
-
-func (p *Printer) printBigIntLiteral(b jsnum.PseudoBigInt) {
-	p.print(b.String() + "n")
-}
-
-func (p *Printer) printUniqueESSymbolType(t *Type) {
-	p.print("unique symbol")
-}
-
-func (p *Printer) printTemplateLiteralType(t *Type) {
-	texts := t.AsTemplateLiteralType().texts
-	types := t.AsTemplateLiteralType().types
-	p.print("`")
-	p.print(texts[0])
-	for i, t := range types {
-		p.print("${")
-		p.printType(t)
-		p.print("}")
-		p.print(texts[i+1])
-	}
-	p.print("`")
-}
-
-func (p *Printer) printStringMappingType(t *Type) {
-	p.printName(t.symbol)
-	p.print("<")
-	p.printType(t.AsStringMappingType().target)
-	p.print(">")
-}
-
-func (p *Printer) printEnumLiteral(t *Type) {
-	if parent := p.c.getParentOfSymbol(t.symbol); parent != nil {
-		p.printQualifiedName(parent)
-		if p.c.getDeclaredTypeOfSymbol(parent) != t {
-			p.print(".")
-			p.printName(t.symbol)
-		}
-		return
-	}
-	p.printQualifiedName(t.symbol)
-}
-
-func (p *Printer) printObjectType(t *Type) {
-	switch {
-	case t.objectFlags&ObjectFlagsReference != 0:
-		p.printParameterizedType(t)
-	case t.objectFlags&ObjectFlagsClassOrInterface != 0:
-		p.printQualifiedName(t.symbol)
-	case p.c.isGenericMappedType(t) || t.objectFlags&ObjectFlagsMapped != 0 && t.AsMappedType().containsError:
-		p.printMappedType(t)
-	default:
-		p.printAnonymousType(t)
-	}
-}
-
-func (p *Printer) printParameterizedType(t *Type) {
-	switch {
-	case p.c.isArrayType(t) && p.flags&TypeFormatFlagsWriteArrayAsGenericType == 0:
-		p.printArrayType(t)
-	case isTupleType(t):
-		p.printTupleType(t)
-	default:
-		p.printTypeReference(t)
-	}
-}
-
-func (p *Printer) printTypeReference(t *Type) {
-	p.printQualifiedName(t.symbol)
-	p.printTypeArguments(p.c.getTypeArguments(t)[:p.c.getTypeReferenceArity(t)])
-}
-
-func (p *Printer) printTypeArguments(typeArguments []*Type) {
-	if len(typeArguments) != 0 {
-		p.print("<")
-		var tail bool
-		for _, t := range typeArguments {
-			if tail {
-				p.print(", ")
-			}
-			p.printType(t)
-			tail = true
-		}
-		p.print(">")
-	}
-}
-
-func (p *Printer) printArrayType(t *Type) {
-	d := t.AsTypeReference()
-	if d.target != p.c.globalArrayType {
-		p.print("readonly ")
-	}
-	p.printTypeEx(p.c.getTypeArguments(t)[0], ast.TypePrecedencePostfix)
-	p.print("[]")
-}
-
-func (p *Printer) printTupleType(t *Type) {
-	if t.TargetTupleType().readonly {
-		p.print("readonly ")
-	}
-	p.print("[")
-	elementInfos := t.TargetTupleType().elementInfos
-	typeArguments := p.c.getTypeArguments(t)
-	var tail bool
-	for i, info := range elementInfos {
-		t := typeArguments[i]
-		if tail {
-			p.print(", ")
-		}
-		if info.flags&ElementFlagsVariable != 0 {
-			p.print("...")
-		}
-		if info.labeledDeclaration != nil {
-			p.print(info.labeledDeclaration.Name().Text())
-			if info.flags&ElementFlagsOptional != 0 {
-				p.print("?: ")
-				p.printType(p.c.removeMissingType(t, true))
-			} else {
-				p.print(": ")
-				if info.flags&ElementFlagsRest != 0 {
-					p.printTypeEx(t, ast.TypePrecedencePostfix)
-					p.print("[]")
-				} else {
-					p.printType(t)
-				}
-			}
-		} else {
-			if info.flags&ElementFlagsOptional != 0 {
-				p.printTypeEx(p.c.removeMissingType(t, true), ast.TypePrecedencePostfix)
-				p.print("?")
-			} else if info.flags&ElementFlagsRest != 0 {
-				p.printTypeEx(t, ast.TypePrecedencePostfix)
-				p.print("[]")
-			} else {
-				p.printType(t)
-			}
-		}
-		tail = true
-	}
-	p.print("]")
-}
-
-func (p *Printer) printAnonymousType(t *Type) {
-	if t.symbol != nil && len(t.symbol.Name) != 0 {
-		if t.symbol.Flags&(ast.SymbolFlagsClass|ast.SymbolFlagsEnum|ast.SymbolFlagsValueModule) != 0 {
-			if t == p.c.getTypeOfSymbol(t.symbol) {
-				p.print("typeof ")
-				p.printQualifiedName(t.symbol)
-				return
-			}
-		}
-	}
-	props := p.c.getPropertiesOfObjectType(t)
-	callSignatures := p.c.getSignaturesOfType(t, SignatureKindCall)
-	constructSignatures := p.c.getSignaturesOfType(t, SignatureKindConstruct)
-	if len(props) == 0 {
-		if len(callSignatures) == 1 && len(constructSignatures) == 0 {
-			p.printSignature(callSignatures[0], " => ")
-			return
-		}
-		if len(callSignatures) == 0 && len(constructSignatures) == 1 {
-			p.print("new ")
-			p.printSignature(constructSignatures[0], " => ")
-			return
-		}
-	}
-	p.print("{")
-	hasMembers := false
-	for _, sig := range callSignatures {
-		p.print(" ")
-		p.printSignature(sig, ": ")
-		p.print(";")
-		hasMembers = true
-	}
-	for _, sig := range constructSignatures {
-		p.print(" new ")
-		p.printSignature(sig, ": ")
-		p.print(";")
-		hasMembers = true
-	}
-	for _, info := range p.c.getIndexInfosOfType(t) {
-		if info.isReadonly {
-			p.print(" readonly")
-		}
-		p.print(" [")
-		p.print(getNameFromIndexInfo(info))
-		p.print(": ")
-		p.printType(info.keyType)
-		p.print("]: ")
-		p.printType(info.valueType)
-		p.print(";")
-		hasMembers = true
-	}
-	for _, prop := range props {
-		if p.c.isReadonlySymbol(prop) {
-			p.print(" readonly")
-		}
-		p.print(" ")
-		p.printName(prop)
-		if prop.Flags&ast.SymbolFlagsOptional != 0 {
-			p.print("?")
-		}
-		p.print(": ")
-		p.printType(p.c.getNonMissingTypeOfSymbol(prop))
-		p.print(";")
-		hasMembers = true
-	}
-	if hasMembers {
-		p.print(" ")
-	}
-	p.print("}")
-}
-
-func (p *Printer) printSignature(sig *Signature, returnSeparator string) {
-	if len(sig.typeParameters) != 0 {
-		p.print("<")
-		var tail bool
-		for _, tp := range sig.typeParameters {
-			if tail {
-				p.print(", ")
-			}
-			p.printTypeParameterAndConstraint(tp)
-			tail = true
-		}
-		p.print(">")
-	}
-	p.print("(")
-	var tail bool
-	if sig.thisParameter != nil {
-		p.print("this: ")
-		p.printType(p.c.getTypeOfSymbol(sig.thisParameter))
-		tail = true
-	}
-	expandedParameters := p.c.GetExpandedParameters(sig)
-	// If the expanded parameter list had a variadic in a non-trailing position, don't expand it
-	parameters := core.IfElse(core.Some(expandedParameters, func(s *ast.Symbol) bool {
-		return s != expandedParameters[len(expandedParameters)-1] && s.CheckFlags&ast.CheckFlagsRestParameter != 0
-	}), sig.parameters, expandedParameters)
-	for i, param := range parameters {
-		if tail {
-			p.print(", ")
-		}
-		if param.ValueDeclaration != nil && isRestParameter(param.ValueDeclaration) || param.CheckFlags&ast.CheckFlagsRestParameter != 0 {
-			p.print("...")
-			p.printName(param)
-		} else {
-			p.printName(param)
-			if i >= p.c.getMinArgumentCountEx(sig, MinArgumentCountFlagsVoidIsNonOptional) {
-				p.print("?")
-			}
-		}
-		p.print(": ")
-		p.printType(p.c.getTypeOfSymbol(param))
-		tail = true
-	}
-	p.print(")")
-	p.print(returnSeparator)
-	if pred := p.c.getTypePredicateOfSignature(sig); pred != nil {
-		p.printTypePredicate(pred)
-	} else {
-		p.printType(p.c.getReturnTypeOfSignature(sig))
-	}
-}
-
-func (p *Printer) printTypePredicate(pred *TypePredicate) {
-	if pred.kind == TypePredicateKindAssertsThis || pred.kind == TypePredicateKindAssertsIdentifier {
-		p.print("asserts ")
-	}
-	if pred.kind == TypePredicateKindThis || pred.kind == TypePredicateKindAssertsThis {
-		p.print("this")
-	} else {
-		p.print(pred.parameterName)
-	}
-	if pred.t != nil {
-		p.print(" is ")
-		p.printType(pred.t)
-	}
-}
-
-func (p *Printer) printTypeParameter(t *Type) {
-	switch {
-	case t.AsTypeParameter().isThisType:
-		p.print("this")
-	case p.extendsTypeDepth > 0 && isInferTypeParameter(t):
-		p.print("infer ")
-		p.printTypeParameterAndConstraint(t)
-	case t.symbol != nil:
-		p.printName(t.symbol)
-	default:
-		p.print("???")
-	}
-}
-
-func (p *Printer) printTypeParameterAndConstraint(t *Type) {
-	p.printName(t.symbol)
-	if constraint := p.c.getConstraintOfTypeParameter(t); constraint != nil {
-		p.print(" extends ")
-		p.printType(constraint)
-	}
-}
-
-func (p *Printer) printUnionType(t *Type) {
-	switch {
-	case t.flags&TypeFlagsBoolean != 0:
-		p.print("boolean")
-	case t.flags&TypeFlagsEnumLiteral != 0:
-		p.printQualifiedName(t.symbol)
-	default:
-		u := t.AsUnionType()
-		if u.origin != nil {
-			p.printType(u.origin)
-		} else {
-			var tail bool
-			for _, t := range p.c.formatUnionTypes(u.types) {
-				if tail {
-					p.print(" | ")
-				}
-				p.printTypeEx(t, ast.TypePrecedenceUnion)
-				tail = true
-			}
-		}
-	}
-}
-
-func (p *Printer) printIntersectionType(t *Type) {
-	var tail bool
-	for _, t := range t.AsIntersectionType().types {
-		if tail {
-			p.print(" & ")
-		}
-		p.printTypeEx(t, ast.TypePrecedenceIntersection)
-		tail = true
-	}
-}
-
-func (p *Printer) printIndexType(t *Type) {
-	p.print("keyof ")
-	p.printTypeEx(t.AsIndexType().target, ast.TypePrecedenceTypeOperator)
-}
-
-func (p *Printer) printIndexedAccessType(t *Type) {
-	p.printType(t.AsIndexedAccessType().objectType)
-	p.print("[")
-	p.printType(t.AsIndexedAccessType().indexType)
-	p.print("]")
-}
-
-func (p *Printer) printConditionalType(t *Type) {
-	p.printType(t.AsConditionalType().checkType)
-	p.print(" extends ")
-	p.extendsTypeDepth++
-	p.printType(t.AsConditionalType().extendsType)
-	p.extendsTypeDepth--
-	p.print(" ? ")
-	p.printType(p.c.getTrueTypeFromConditionalType(t))
-	p.print(" : ")
-	p.printType(p.c.getFalseTypeFromConditionalType(t))
-}
-
-func (p *Printer) printMappedType(t *Type) {
-	d := t.AsMappedType().declaration
-	p.print("{ ")
-	if d.ReadonlyToken != nil {
-		if d.ReadonlyToken.Kind != ast.KindReadonlyKeyword {
-			p.print(scanner.TokenToString(d.ReadonlyToken.Kind))
-		}
-		p.print("readonly ")
-	}
-	p.print("[")
-	p.printName(p.c.getTypeParameterFromMappedType(t).symbol)
-	p.print(" in ")
-	p.printType(p.c.getConstraintTypeFromMappedType(t))
-	nameType := p.c.getNameTypeFromMappedType(t)
-	if nameType != nil {
-		p.print(" as ")
-		p.printType(nameType)
-	}
-	p.print("]")
-	if d.QuestionToken != nil {
-		if d.QuestionToken.Kind != ast.KindQuestionToken {
-			p.print(scanner.TokenToString(d.QuestionToken.Kind))
-		}
-		p.print("?")
-	}
-	p.print(": ")
-	p.printType(p.c.getTemplateTypeFromMappedType(t))
-	p.print("; }")
-}
-
-func (p *Printer) printSourceFileWithTypes(sourceFile *ast.SourceFile) {
-	var pos int
-	var visit func(*ast.Node) bool
-	var typesPrinted bool
-	lineStarts := scanner.GetLineStarts(sourceFile)
-	printLinesBefore := func(node *ast.Node) {
-		line := scanner.ComputeLineOfPosition(lineStarts, scanner.SkipTrivia(sourceFile.Text(), node.Pos()))
-		var nextLineStart int
-		if line+1 < len(lineStarts) {
-			nextLineStart = int(lineStarts[line+1])
-		} else {
-			nextLineStart = sourceFile.Loc.End()
-		}
-		if pos < nextLineStart {
-			if typesPrinted {
-				p.print("\n")
-			}
-			p.print(sourceFile.Text()[pos:nextLineStart])
-			pos = nextLineStart
-			typesPrinted = false
-		}
-	}
-	visit = func(node *ast.Node) bool {
-		text, t, isDeclaration := p.c.getTextAndTypeOfNode(node)
-		if text != "" && !strings.Contains(text, "\n") {
-			printLinesBefore(node)
-			p.print(">")
-			p.print(text)
-			p.print(" : ")
-			p.printType(t)
-			if isDeclaration && t.flags&TypeFlagsEnumLiteral != 0 && t.flags&(TypeFlagsStringLiteral|TypeFlagsNumberLiteral) != 0 {
-				p.print(" = ")
-				p.printValue(t.AsLiteralType().value)
-			}
-			p.print("\n")
-			typesPrinted = true
-		}
-		return node.ForEachChild(visit)
-	}
-	visit(sourceFile.AsNode())
-	p.print(sourceFile.Text()[pos:sourceFile.End()])
-}
-
-func (c *Checker) getTextAndTypeOfNode(node *ast.Node) (string, *Type, bool) {
-	if ast.IsDeclarationNode(node) {
-		symbol := node.Symbol()
-		if symbol != nil && !isReservedMemberName(symbol.Name) {
-			if symbol.Flags&ast.SymbolFlagsValue != 0 {
-				return c.symbolToString(symbol), c.getTypeOfSymbol(symbol), true
-			}
-			if symbol.Flags&ast.SymbolFlagsTypeAlias != 0 {
-				return c.symbolToString(symbol), c.getDeclaredTypeOfTypeAlias(symbol), true
-			}
-		}
-	}
-	if ast.IsExpressionNode(node) && !isRightSideOfQualifiedNameOrPropertyAccess(node) {
-		return scanner.GetTextOfNode(node), c.getTypeOfExpression(node), false
-	}
-	return "", nil, false
+	panic("unhandled value type in valueToString")
 }
 
 func (c *Checker) formatUnionTypes(types []*Type) []*Type {
@@ -737,6 +259,65 @@ func (c *Checker) formatUnionTypes(types []*Type) []*Type {
 	return result
 }
 
-func isInferTypeParameter(t *Type) bool {
-	return t.flags&TypeFlagsTypeParameter != 0 && t.symbol != nil && core.Some(t.symbol.Declarations, func(d *ast.Node) bool { return ast.IsInferTypeNode(d.Parent) })
+func (c *Checker) SourceFileWithTypes(sourceFile *ast.SourceFile) string {
+	writer := printer.NewTextWriter("\n")
+	var pos int
+	var visit func(*ast.Node) bool
+	var typesPrinted bool
+	lineStarts := scanner.GetLineStarts(sourceFile)
+	printLinesBefore := func(node *ast.Node) {
+		line := scanner.ComputeLineOfPosition(lineStarts, scanner.SkipTrivia(sourceFile.Text(), node.Pos()))
+		var nextLineStart int
+		if line+1 < len(lineStarts) {
+			nextLineStart = int(lineStarts[line+1])
+		} else {
+			nextLineStart = sourceFile.Loc.End()
+		}
+		if pos < nextLineStart {
+			if typesPrinted {
+				writer.WriteLine()
+			}
+			writer.Write(sourceFile.Text()[pos:nextLineStart])
+			pos = nextLineStart
+			typesPrinted = false
+		}
+	}
+	visit = func(node *ast.Node) bool {
+		text, t, isDeclaration := c.getTextAndTypeOfNode(node)
+		if text != "" && !strings.Contains(text, "\n") {
+			printLinesBefore(node)
+			writer.Write(">")
+			writer.Write(text)
+			writer.Write(" : ")
+			c.typeToStringEx(t, nil, TypeFormatFlagsNone, writer)
+			if isDeclaration && t.flags&TypeFlagsEnumLiteral != 0 && t.flags&(TypeFlagsStringLiteral|TypeFlagsNumberLiteral) != 0 {
+				writer.Write(" = ")
+				writer.Write(c.valueToString(t.AsLiteralType().value))
+			}
+			writer.WriteLine()
+			typesPrinted = true
+		}
+		return node.ForEachChild(visit)
+	}
+	visit(sourceFile.AsNode())
+	writer.Write(sourceFile.Text()[pos:sourceFile.End()])
+	return writer.String()
+}
+
+func (c *Checker) getTextAndTypeOfNode(node *ast.Node) (string, *Type, bool) {
+	if ast.IsDeclarationNode(node) {
+		symbol := node.Symbol()
+		if symbol != nil && !isReservedMemberName(symbol.Name) {
+			if symbol.Flags&ast.SymbolFlagsValue != 0 {
+				return c.symbolToString(symbol), c.getTypeOfSymbol(symbol), true
+			}
+			if symbol.Flags&ast.SymbolFlagsTypeAlias != 0 {
+				return c.symbolToString(symbol), c.getDeclaredTypeOfTypeAlias(symbol), true
+			}
+		}
+	}
+	if ast.IsExpressionNode(node) && !isRightSideOfQualifiedNameOrPropertyAccess(node) {
+		return scanner.GetTextOfNode(node), c.getTypeOfExpression(node), false
+	}
+	return "", nil, false
 }

--- a/internal/checker/relater.go
+++ b/internal/checker/relater.go
@@ -1267,13 +1267,13 @@ func isNonPrimitiveType(t *Type) bool {
 func (c *Checker) getTypeNamesForErrorDisplay(left *Type, right *Type) (string, string) {
 	var leftStr string
 	if c.symbolValueDeclarationIsContextSensitive(left.symbol) {
-		leftStr = c.typeToStringEx(left, left.symbol.ValueDeclaration, TypeFormatFlagsNone)
+		leftStr = c.typeToStringEx(left, left.symbol.ValueDeclaration, TypeFormatFlagsNone, nil)
 	} else {
 		leftStr = c.TypeToString(left)
 	}
 	var rightStr string
 	if c.symbolValueDeclarationIsContextSensitive(right.symbol) {
-		rightStr = c.typeToStringEx(right, right.symbol.ValueDeclaration, TypeFormatFlagsNone)
+		rightStr = c.typeToStringEx(right, right.symbol.ValueDeclaration, TypeFormatFlagsNone, nil)
 	} else {
 		rightStr = c.TypeToString(right)
 	}
@@ -1285,7 +1285,7 @@ func (c *Checker) getTypeNamesForErrorDisplay(left *Type, right *Type) (string, 
 }
 
 func (c *Checker) getTypeNameForErrorDisplay(t *Type) string {
-	return c.typeToStringEx(t, nil /*enclosingDeclaration*/, TypeFormatFlagsUseFullyQualifiedType)
+	return c.typeToStringEx(t, nil /*enclosingDeclaration*/, TypeFormatFlagsUseFullyQualifiedType, nil)
 }
 
 func (c *Checker) symbolValueDeclarationIsContextSensitive(symbol *ast.Symbol) bool {
@@ -4645,7 +4645,7 @@ func (r *Relater) reportErrorResults(originalSource *Type, originalTarget *Type,
 			prop = core.Find(r.c.getPropertiesOfUnionOrIntersectionType(originalTarget), isConflictingPrivateProperty)
 		}
 		if prop != nil {
-			r.reportError(message, r.c.typeToStringEx(originalTarget, nil /*enclosingDeclaration*/, TypeFormatFlagsNoTypeReduction), r.c.symbolToString(prop))
+			r.reportError(message, r.c.typeToStringEx(originalTarget, nil /*enclosingDeclaration*/, TypeFormatFlagsNoTypeReduction, nil), r.c.symbolToString(prop))
 		}
 	}
 	r.reportRelationError(headMessage, source, target)

--- a/internal/checker/symbolaccessibility.go
+++ b/internal/checker/symbolaccessibility.go
@@ -1,0 +1,76 @@
+package checker
+
+import "github.com/microsoft/typescript-go/internal/ast"
+
+type SymbolAccessibility int32
+
+const (
+	SymbolAccessibilityAccessible SymbolAccessibility = iota
+	SymbolAccessibilityNotAccessible
+	SymbolAccessibilityCannotBeNamed
+	SymbolAccessibilityNotResolved
+)
+
+type SymbolAccessibilityResult struct {
+	accessibility        SymbolAccessibility
+	aliasesToMakeVisible []*ast.Node // aliases that need to have this symbol visible
+	errorSymbolName      string      // Optional symbol name that results in error
+	errorNode            *ast.Node   // optional node that results in error
+}
+
+func (ch *Checker) IsTypeSymbolAccessible(symbol *ast.Symbol, enclosingDeclaration *ast.Node) bool {
+	return false // !!!
+}
+
+func (ch *Checker) IsValueSymbolAccessible(symbol *ast.Symbol, enclosingDeclaration *ast.Node) bool {
+	return false // !!!
+}
+
+/**
+ * Check if the given symbol in given enclosing declaration is accessible and mark all associated alias to be visible if requested
+ *
+ * @param symbol a Symbol to check if accessible
+ * @param enclosingDeclaration a Node containing reference to the symbol
+ * @param meaning a SymbolFlags to check if such meaning of the symbol is accessible
+ * @param shouldComputeAliasToMakeVisible a boolean value to indicate whether to return aliases to be mark visible in case the symbol is accessible
+ */
+
+func (c *Checker) IsSymbolAccessible(symbol *ast.Symbol, enclosingDeclaration *ast.Node, meaning ast.SymbolFlags, shouldComputeAliasesToMakeVisible bool) SymbolAccessibilityResult {
+	return c.isSymbolAccessibleWorker(symbol, enclosingDeclaration, meaning, shouldComputeAliasesToMakeVisible, true /*allowModules*/)
+}
+
+func (c *Checker) isSymbolAccessibleWorker(symbol *ast.Symbol, enclosingDeclaration *ast.Node, meaning ast.SymbolFlags, shouldComputeAliasesToMakeVisible bool, allowModules bool) SymbolAccessibilityResult {
+	// if symbol != nil && enclosingDeclaration != nil {
+	// 	result := c.isAnySymbolAccessible([]*ast.Symbol{symbol}, enclosingDeclaration, symbol, meaning, shouldComputeAliasesToMakeVisible, allowModules)
+	// 	if result != nil {
+	// 		return result
+	// 	}
+
+	// 	// This could be a symbol that is not exported in the external module
+	// 	// or it could be a symbol from different external module that is not aliased and hence cannot be named
+	// 	symbolExternalModule := forEach(symbol.Declarations, c.getExternalModuleContainer)
+	// 	if symbolExternalModule != nil {
+	// 		enclosingExternalModule := c.getExternalModuleContainer(enclosingDeclaration)
+	// 		if symbolExternalModule != enclosingExternalModule {
+	// 			// name from different external module that is not visible
+	// 			return SymbolAccessibilityResult{
+	// 				accessibility:   SymbolAccessibilityCannotBeNamed,
+	// 				errorSymbolName: c.symbolToString(symbol, enclosingDeclaration, meaning),
+	// 				errorModuleName: c.symbolToString(symbolExternalModule),
+	// 				errorNode:       ifElse(isInJSFile(enclosingDeclaration), enclosingDeclaration, nil),
+	// 			}
+	// 		}
+	// 	}
+
+	// 	// Just a local name that is not accessible
+	// 	return SymbolAccessibilityResult{
+	// 		accessibility:   SymbolAccessibilityNotAccessible,
+	// 		errorSymbolName: c.symbolToString(symbol, enclosingDeclaration, meaning),
+	// 	}
+	// }
+
+	// return SymbolAccessibilityResult{
+	// 	accessibility: SymbolAccessibilityAccessible,
+	// }
+	return SymbolAccessibilityResult{} // !!!
+}

--- a/internal/checker/symboltracker.go
+++ b/internal/checker/symboltracker.go
@@ -1,0 +1,107 @@
+package checker
+
+import "github.com/microsoft/typescript-go/internal/ast"
+
+// TODO: previously all symboltracker methods were optional, but now they're required.
+type SymbolTracker interface {
+	GetModuleSpecifierGenerationHost() any // !!!
+
+	TrackSymbol(symbol *ast.Symbol, enclosingDeclaration *ast.Node, meaning ast.SymbolFlags) bool
+	ReportInaccessibleThisError()
+	ReportPrivateInBaseOfClassExpression(propertyName string)
+	ReportInaccessibleUniqueSymbolError()
+	ReportCyclicStructureError()
+	ReportLikelyUnsafeImportRequiredError(specifier string)
+	ReportTruncationError()
+	ReportNonlocalAugmentation(containingFile *ast.SourceFile, parentSymbol *ast.Symbol, augmentingSymbol *ast.Symbol)
+	ReportNonSerializableProperty(propertyName string)
+
+	ReportInferenceFallback(node *ast.Node)
+	PushErrorFallbackNode(node *ast.Node)
+	PopErrorFallbackNode()
+}
+
+type SymbolTrackerImpl struct {
+	context            NodeBuilderContext
+	inner              SymbolTracker
+	DisableTrackSymbol bool
+}
+
+func NewSymbolTrackerImpl(context NodeBuilderContext, tracker SymbolTracker) *SymbolTrackerImpl {
+	// TODO: unwrap `tracker` before setting `inner`
+	return &SymbolTrackerImpl{context, tracker, false}
+}
+
+func (this *SymbolTrackerImpl) GetModuleSpecifierGenerationHost() any {
+	return this.inner.GetModuleSpecifierGenerationHost()
+}
+
+func (this *SymbolTrackerImpl) TrackSymbol(symbol *ast.Symbol, enclosingDeclaration *ast.Node, meaning ast.SymbolFlags) bool {
+	if !this.DisableTrackSymbol {
+		if this.inner.TrackSymbol(symbol, enclosingDeclaration, meaning) {
+			this.onDiagnosticReported()
+			return true
+		}
+		// Skip recording type parameters as they dont contribute to late painted statements
+		if symbol.Flags&ast.SymbolFlagsTypeParameter == 0 {
+			this.context.trackedSymbols = append(this.context.trackedSymbols, &TrackedSymbolArgs{symbol, enclosingDeclaration, meaning})
+		}
+	}
+	return false
+}
+
+func (this *SymbolTrackerImpl) ReportInaccessibleThisError() {
+	this.onDiagnosticReported()
+	this.inner.ReportInaccessibleThisError()
+}
+
+func (this *SymbolTrackerImpl) ReportPrivateInBaseOfClassExpression(propertyName string) {
+	this.onDiagnosticReported()
+	this.inner.ReportPrivateInBaseOfClassExpression(propertyName)
+}
+
+func (this *SymbolTrackerImpl) ReportInaccessibleUniqueSymbolError() {
+	this.onDiagnosticReported()
+	this.inner.ReportInaccessibleUniqueSymbolError()
+}
+
+func (this *SymbolTrackerImpl) ReportCyclicStructureError() {
+	this.onDiagnosticReported()
+	this.inner.ReportCyclicStructureError()
+}
+
+func (this *SymbolTrackerImpl) ReportLikelyUnsafeImportRequiredError(specifier string) {
+	this.onDiagnosticReported()
+	this.inner.ReportLikelyUnsafeImportRequiredError(specifier)
+}
+
+func (this *SymbolTrackerImpl) ReportTruncationError() {
+	this.onDiagnosticReported()
+	this.inner.ReportTruncationError()
+}
+
+func (this *SymbolTrackerImpl) ReportNonlocalAugmentation(containingFile *ast.SourceFile, parentSymbol *ast.Symbol, augmentingSymbol *ast.Symbol) {
+	this.onDiagnosticReported()
+	this.inner.ReportNonlocalAugmentation(containingFile, parentSymbol, augmentingSymbol)
+}
+
+func (this *SymbolTrackerImpl) ReportNonSerializableProperty(propertyName string) {
+	this.onDiagnosticReported()
+	this.inner.ReportNonSerializableProperty(propertyName)
+}
+
+func (this *SymbolTrackerImpl) onDiagnosticReported() {
+	this.context.reportedDiagnostic = true
+}
+
+func (this *SymbolTrackerImpl) ReportInferenceFallback(node *ast.Node) {
+	this.inner.ReportInferenceFallback(node)
+}
+
+func (this *SymbolTrackerImpl) PushErrorFallbackNode(node *ast.Node) {
+	this.inner.PushErrorFallbackNode(node)
+}
+
+func (this *SymbolTrackerImpl) PopErrorFallbackNode() {
+	this.inner.PopErrorFallbackNode()
+}

--- a/internal/checker/types.go
+++ b/internal/checker/types.go
@@ -75,6 +75,37 @@ const (
 	TypeFormatFlagsInTypeAlias         TypeFormatFlags = 1 << 23 // Writing type in type alias declaration
 )
 
+const TypeFormatFlagsNodeBuilderFlagsMask = TypeFormatFlagsNoTruncation | TypeFormatFlagsWriteArrayAsGenericType | TypeFormatFlagsGenerateNamesForShadowedTypeParams | TypeFormatFlagsUseStructuralFallback | TypeFormatFlagsWriteTypeArgumentsOfSignature |
+	TypeFormatFlagsUseFullyQualifiedType | TypeFormatFlagsSuppressAnyReturnType | TypeFormatFlagsMultilineObjectLiterals | TypeFormatFlagsWriteClassExpressionAsTypeLiteral |
+	TypeFormatFlagsUseTypeOfFunction | TypeFormatFlagsOmitParameterModifiers | TypeFormatFlagsUseAliasDefinedOutsideCurrentScope | TypeFormatFlagsAllowUniqueESSymbolType | TypeFormatFlagsInTypeAlias |
+	TypeFormatFlagsUseSingleQuotesForStringLiteralType | TypeFormatFlagsNoTypeReduction | TypeFormatFlagsOmitThisParameter
+
+// dprint-ignore
+type SymbolFormatFlags int32
+
+const (
+	SymbolFormatFlagsNone SymbolFormatFlags = 0
+	// Write symbols's type argument if it is instantiated symbol
+	// eg. class C<T> { p: T }   <-- Show p as C<T>.p here
+	//     var a: C<number>;
+	//     var p = a.p; <--- Here p is property of C<number> so show it as C<number>.p instead of just C.p
+	SymbolFormatFlagsWriteTypeParametersOrArguments SymbolFormatFlags = 1 << 0
+	// Use only external alias information to get the symbol name in the given context
+	// eg.  module m { export class c { } } import x = m.c;
+	// When this flag is specified m.c will be used to refer to the class instead of alias symbol x
+	SymbolFormatFlagsUseOnlyExternalAliasing SymbolFormatFlags = 1 << 1
+	// Build symbol name using any nodes needed, instead of just components of an entity name
+	SymbolFormatFlagsAllowAnyNodeKind SymbolFormatFlags = 1 << 2
+	// Prefer aliases which are not directly visible
+	SymbolFormatFlagsUseAliasDefinedOutsideCurrentScope SymbolFormatFlags = 1 << 3
+	// { [E.A]: 1 }
+	/** @internal */
+	SymbolFormatFlagsWriteComputedProps SymbolFormatFlags = 1 << 4
+	// Skip building an accessible symbol chain
+	/** @internal */
+	SymbolFormatFlagsDoNotIncludeSymbolChain SymbolFormatFlags = 1 << 5
+)
+
 // Ids
 
 type TypeId uint32
@@ -697,6 +728,8 @@ type StructuredType struct {
 	signatures         []*Signature // Signatures (call + construct)
 	callSignatureCount int          // Count of call signatures
 	indexInfos         []*IndexInfo
+
+	objectTypeWithoutAbstractConstructSignatures *Type
 }
 
 func (t *StructuredType) AsStructuredType() *StructuredType { return t }

--- a/internal/printer/singlelinestringwriter.go
+++ b/internal/printer/singlelinestringwriter.go
@@ -8,6 +8,7 @@ import (
 	"github.com/microsoft/typescript-go/internal/stringutil"
 )
 
+// TODO: Definitely not threadsafe - make one per checker instead of one global one (threadlocal storage would be neat)
 var SingleLineStringWriter EmitTextWriter = &singleLineStringWriter{}
 
 type singleLineStringWriter struct {


### PR DESCRIPTION
TODO, annotated with current thoughts on each:
* [ ] Mapped type node creation (Generates tons of custom scopes and symbols, so useless without other in-progress work anyway. Also kinda just lost it among the symbol functions 'til I went back and surveyed what was still missing. Might hop back to this and get it in so at least all the type structures are done.) 
* [ ] JSDoc (mostly in ID related content, but a little bit in js declaration and ts @overload content)
* [ ] JS Declarations more generally (`symbolTableToDeclarationStatements` and friends)
* [ ] Synthetic comments (scattered blocks of functionality throughout the node builder to attach comments to the output - mostly for quickfixes)
* [ ] String quote style preservation (a recent TS feature is preserving single vs double quotes through the emit pipeline, but some API changes precluded initial support)
* [ ] Isolated declarations (`expressionToTypeNode.ts`, plus some wrappers)
  * [ ] Contained node reuse logic also used by non-ID, so also needed for good declaration map support now that sourcemaps are in (but maybe we unwind the extraction to a separate syntactic resolver object to also fix all the bugs the extraction introduced?)
* [ ] Symbol name construction (`symbolToNode` and other flavors - lots of very similar but subtly different functions with little corner cases for services support)
  * [ ] Module specifier generation (`moduleSpecifiers.ts`) <-- current work item, looking at generating this more automatically with our tooling since it's fairly standalone and doesn't interact with many refactored APIs
  * [ ] Entity name accessibility checking and chain generation (`isSymbolAccessible`, `getAccessibleSymbolChain` and the like - these are unimplemented stubs right now, for want of the above, and are a bit unwieldy - also likely candidates for a perf rewrite at some point in the future, as the historically slow part of declaration emit)
 * [ ] Any unported factory/checker/utils that those depend on implicitly that I haven't run into yet (insert mining meme here)
 * [ ] Updates from expandable hover after that merges to strada (notably, lots of scattered approximatelength additions that may not show up as any test failures if not ported)
 * [ ] Make `singlelinetextwriter` usage threadsafe to support concurrent checking (likely one writer per checker instead of a global)
 * [ ] Factor all the node building logic into a subfolder so the growing set of files/loc is less painful on the compile times of checker (probably do this very last)
 * [ ] Allow threading through `EmitContext` to individual factory calls (via symbol tracker?) so the context used by the declaration transform can be correctly used within the node builder, while it still falls back to the checker's internal emit context for diagnostic production or quickfixes and the like that don't need their own emit context
 * [ ] Memoize printer setup per-checker, rather than making a new printer on each builder request to stay threadsafe (maybe the checker should have its' own emit context wrapper to track emit/print related state like this?)
   * [ ] Investigate if `OmitTrailingSemicolon` printer option is redundant with the trailing semicolon eliding wrapper-writer we use in strada - only one of these two may need to be ported
 * [ ] Reintroduce some way to smuggle signature type arguments out of the node builder for quickinfo (previously we patched a `.typeArguments` onto every signature kind)
 * [ ] Actual `declarations.ts` transform once those are all (or mostly) in
   * [ ] TS declarations
   * [ ] JS declarations
   * [ ] Isolated declarations 

I've updated my branch to replace the current `typeToString` implementation with the ported node-builder backed implementation, which is the top-down goal of this PR, ultimately. CI on it should not pass until the node builder is mostly (if not totally) completely ported, due to interdependencies between many of its' subsystems. I'll try to keep this PR in a state where it at least compiles without error, which is usually in between big chunks of functionality, but the tests are going to keep throwing `unimplemented` panics until all the missing functions are either fully ported or at least sufficiently stubbed (which doesn't feel worth it, really).

Structurally, `nodebuilder.go` is the inner contents of `createNodeBuilder`'s closure environment, lifted into members of a struct. All `context` parameters have been removed and replaced with lookups of `context` on the struct itself, since we're OO now, but that's about the only refactor. `nodebuilderapi.go` is the wrapper returned by `createNodeBuilder` which maps all the internal closed over methods to the internal node builder API shape (which is recorded as the `NodeBuilderInterface`... interface)- basically it's the logic that handles setting up `context` objects for each request. Some of that might get renamed to reduce confusion eventually, but the structure seems sound. `nodebuilderscopes.go` may or may not go away - `NodeBuilder.enterNewScope` was pretty big but isolated (used by mapped type and signature construction), so felt like it could stand alone, and it has some utilities only it uses. `symbolaccessibility.go` is for the checker's symbol accessibility functionality - these are also mostly self-contained, though do depend on one-another and some common utilities (though I only have stubs here right now - my previous attempts to optimize them as I ported them have broken them, so we're just gonna port them straight as we can for now).

This is already a bit of a beast to review, size-wise, and I'd say there's still a fair bit left for a full port - but if we add some extra unit tests, some subsystems, like the specifier generation and maybe accessibility, *can* reasonably stand alone as changes. Those things just aren't currently unit tested outside of their integrations into the builder in strada, though, so those tests'd all be additional greenfield work.