### PR TITLE
Remove JSON schema generator in favor of upstream metaModel.ts

### DIFF
--- a/internal/lsp/lsproto/_generate/fetchModel.mjs
+++ b/internal/lsp/lsproto/_generate/fetchModel.mjs
@@ -1,4 +1,3 @@
-import { compile } from "json-schema-to-typescript-lite";
 import fs from "node:fs";
 import path from "node:path";
 import url from "node:url";
@@ -12,17 +11,12 @@ const metaModelSchemaPath = path.join(__dirname, "metaModelSchema.mts");
 const hash = "dadd73f7fc283b4d0adb602adadcf4be16ef3a7b";
 
 const metaModelURL = `https://raw.githubusercontent.com/microsoft/vscode-languageserver-node/${hash}/protocol/metaModel.json`;
-const metaModelSchemaURL = `https://raw.githubusercontent.com/microsoft/vscode-languageserver-node/${hash}/protocol/metaModel.schema.json`;
+const metaModelSchemaURL = `https://raw.githubusercontent.com/microsoft/vscode-languageserver-node/${hash}/tools/src/metaModel.ts`;
 
 const metaModelResponse = await fetch(metaModelURL);
-const metaModel = await metaModelResponse.json();
-fs.writeFileSync(metaModelPath, JSON.stringify(metaModel, undefined, 4));
+const metaModel = await metaModelResponse.text();
+fs.writeFileSync(metaModelPath, metaModel);
 
 const metaModelSchemaResponse = await fetch(metaModelSchemaURL);
-const metaModelSchema = await metaModelSchemaResponse.json();
-
-Object.assign(metaModelSchema, metaModelSchema.definitions.MetaModel);
-delete metaModelSchema.definitions.MetaModel;
-
-const compiled = await compile(metaModelSchema, "MetaModel");
-fs.writeFileSync(metaModelSchemaPath, compiled);
+const metaModelSchema = await metaModelSchemaResponse.text();
+fs.writeFileSync(metaModelSchemaPath, metaModelSchema);

--- a/internal/lsp/lsproto/_generate/metaModelSchema.mts
+++ b/internal/lsp/lsproto/_generate/metaModelSchema.mts
@@ -1,451 +1,609 @@
-export type Type = (BaseType | ReferenceType | ArrayType | MapType | AndType | OrType | TupleType | StructureLiteralType | StringLiteralType | IntegerLiteralType | BooleanLiteralType)
-export type BaseTypes = ("URI" | "DocumentUri" | "integer" | "uinteger" | "decimal" | "RegExp" | "string" | "boolean" | "null")
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+export type BaseTypes = 'URI' | 'DocumentUri' | 'integer' | 'uinteger' | 'decimal' | 'RegExp' | 'string' | 'boolean' | 'null';
+
+export type TypeKind = 'base' | 'reference' | 'array' | 'map' | 'and' | 'or' | 'tuple' | 'literal' | 'stringLiteral' | 'integerLiteral' | 'booleanLiteral';
+
 /**
- * Represents a type that can be used as a key in a map type. If a reference type is used then the type must either resolve to a `string` or `integer` type. (e.g. `type ChangeAnnotationIdentifier === string`).
+ * Indicates in which direction a message is sent in the protocol.
  */
-export type MapKeyType = ({
-  kind: "base"
-  name: ("URI" | "DocumentUri" | "string" | "integer")
-} | ReferenceType)
+export type MessageDirection = 'clientToServer' | 'serverToClient' | 'both';
+
+/**
+ * Represents a base type like `string` or `DocumentUri`.
+ */
+export type BaseType = {
+	kind: 'base';
+	name: BaseTypes;
+};
+
+/**
+ * Represents a reference to another type (e.g. `TextDocument`).
+ * This is either a `Structure`, a `Enumeration` or a `TypeAlias`
+ * in the same meta model.
+ */
+export type ReferenceType = {
+	kind: 'reference';
+	name: string;
+};
+
+/**
+ * Represents an array type (e.g. `TextDocument[]`).
+ */
+export type ArrayType = {
+	kind: 'array';
+	element: Type;
+};
+
+/**
+ * Represents a type that can be used as a key in a
+ * map type. If a reference type is used then the
+ * type must either resolve to a `string` or `integer`
+ * type. (e.g. `type ChangeAnnotationIdentifier === string`).
+ */
+export type MapKeyType = { kind: 'base'; name: 'URI' | 'DocumentUri' | 'string' | 'integer' } | ReferenceType;
+
+/**
+ * Represents a JSON object map
+ * (e.g. `interface Map<K extends string | integer, V> { [key: K] => V; }`).
+ */
+export type MapType = {
+	kind: 'map';
+	key: MapKeyType;
+	value: Type;
+};
+
+/**
+ * Represents an `and`type
+ * (e.g. TextDocumentParams & WorkDoneProgressParams`).
+ */
+export type AndType = {
+	kind: 'and';
+	items: Type[];
+};
+
+/**
+ * Represents an `or` type
+ * (e.g. `Location | LocationLink`).
+ */
+export type OrType = {
+	kind: 'or';
+	items: Type[];
+};
+
+/**
+ * Represents a `tuple` type
+ * (e.g. `[integer, integer]`).
+ */
+export type TupleType = {
+	kind: 'tuple';
+	items: Type[];
+};
+
+/**
+ * Represents a literal structure
+ * (e.g. `property: { start: uinteger; end: uinteger; }`).
+ */
+export type StructureLiteralType =  {
+	kind: 'literal';
+	value: StructureLiteral;
+};
+
+/**
+ * Represents a string literal type
+ * (e.g. `kind: 'rename'`).
+ */
+export type StringLiteralType = {
+	kind: 'stringLiteral';
+	value: string;
+};
+
+export type IntegerLiteralType = {
+	/**
+	 * Represents an integer literal type
+	 * (e.g. `kind: 1`).
+	 */
+	kind: 'integerLiteral';
+	value: number;
+};
+
+/**
+ * Represents a boolean literal type
+ * (e.g. `kind: true`).
+ */
+export type BooleanLiteralType = {
+	kind: 'booleanLiteral';
+	value: boolean;
+};
+
+export type Type = BaseType | ReferenceType | ArrayType | MapType | AndType | OrType | TupleType | StructureLiteralType | StringLiteralType | IntegerLiteralType | BooleanLiteralType;
+
+/**
+ * Represents a LSP request
+ */
+export type Request = {
+	/**
+	 * The request's method name.
+	 */
+	method: string;
+
+	/**
+	 * The type name of the request if any.
+	 */
+	typeName?: string;
+
+	/**
+	 * The parameter type(s) if any.
+	 */
+	params?: Type | Type[];
+
+	/**
+	 * The result type.
+	 */
+	result: Type;
+
+	/**
+	 * Optional partial result type if the request
+	 * supports partial result reporting.
+	 */
+	partialResult?: Type;
+
+	/**
+	 * An optional error data type.
+	 */
+	errorData?: Type;
+
+	/**
+	 * Optional a dynamic registration method if it
+	 * different from the request's method.
+	 */
+	registrationMethod?: string;
+
+	/**
+	 * Optional registration options if the request
+	 * supports dynamic registration.
+	 */
+	registrationOptions?: Type;
+
+	/**
+	 * The direction in which this request is sent
+	 * in the protocol.
+	 */
+	messageDirection: MessageDirection;
+
+	/**
+	 * An optional documentation;
+	 */
+	documentation?: string;
+
+	/**
+	 * Since when (release number) this request is
+	 * available. Is undefined if not known.
+	 */
+	since?: string;
+
+	/**
+	 * All since tags in case there was more than one tag.
+	 * Is undefined if not known.
+	 */
+	sinceTags?: string[];
+
+	/**
+	 * Whether this is a proposed feature. If omitted
+	 * the feature is final.
+	 */
+	proposed?: boolean;
+
+	/**
+	 * Whether the request is deprecated or not. If deprecated
+	 * the property contains the deprecation message.
+	 */
+	deprecated?: string;
+};
+
+/**
+ * Represents a LSP notification
+ */
+export type Notification = {
+	/**
+	 * The notifications's method name.
+	 */
+	method: string;
+
+	/**
+	 * The type name of the notifications if any.
+	 */
+	typeName?: string;
+
+	/**
+	 * The parameter type(s) if any.
+	 */
+	params?: Type | Type[];
+
+	/**
+	 * Optional a dynamic registration method if it
+	 * different from the notifications's method.
+	 */
+	registrationMethod?: string;
+
+	/**
+	 * Optional registration options if the notification
+	 * supports dynamic registration.
+	 */
+	registrationOptions?: Type;
+
+	/**
+	 * The direction in which this notification is sent
+	 * in the protocol.
+	 */
+	messageDirection: MessageDirection;
+
+	/**
+	 * An optional documentation;
+	 */
+	documentation?: string;
+
+	/**
+	 * Since when (release number) this notification is
+	 * available. Is undefined if not known.
+	 */
+	since?: string;
+
+	/**
+	 * All since tags in case there was more than one tag.
+	 * Is undefined if not known.
+	 */
+	sinceTags?: string[];
+
+	/**
+	 * Whether this is a proposed notification. If omitted
+	 * the notification is final.
+	 */
+	proposed?: boolean;
+
+	/**
+	 * Whether the notification is deprecated or not. If deprecated
+	 * the property contains the deprecation message.
+	 */
+	deprecated?: string;
+};
+
+/**
+ * Represents an object property.
+ */
+export type Property = {
+	/**
+	 * The property name;
+	 */
+	name: string;
+
+	/**
+	 * The type of the property
+	 */
+	type: Type;
+
+	/**
+	 * Whether the property is optional. If
+	 * omitted, the property is mandatory.
+	 */
+	optional?: boolean;
+
+	/**
+	 * An optional documentation.
+	 */
+	documentation?: string;
+
+	/**
+	 * Since when (release number) this property is
+	 * available. Is undefined if not known.
+	 */
+	since?: string;
+
+	/**
+	 * All since tags in case there was more than one tag.
+	 * Is undefined if not known.
+	 */
+	sinceTags?: string[];
+
+	/**
+	 * Whether this is a proposed property. If omitted,
+	 * the structure is final.
+	 */
+	proposed?: boolean;
+
+	/**
+	 * Whether the property is deprecated or not. If deprecated
+	 * the property contains the deprecation message.
+	 */
+	deprecated?: string;
+};
+
+/**
+ * Defines the structure of an object literal.
+ */
+export type Structure = {
+	/**
+	 * The name of the structure.
+	 */
+	name: string;
+
+	/**
+	 * Structures extended from. This structures form
+	 * a polymorphic type hierarchy.
+	 */
+	extends?: Type[];
+
+	/**
+	 * Structures to mix in. The properties of these
+	 * structures are `copied` into this structure.
+	 * Mixins don't form a polymorphic type hierarchy in
+	 * LSP.
+	 */
+	mixins?: Type[];
+
+	/**
+	 * The properties.
+	 */
+	properties: Property[];
+
+	/**
+	 * An optional documentation;
+	 */
+	documentation?: string;
+
+	/**
+	 * Since when (release number) this structure is
+	 * available. Is undefined if not known.
+	 */
+	since?: string;
+
+	/**
+	 * All since tags in case there was more than one tag.
+	 * Is undefined if not known.
+	 */
+	sinceTags?: string[];
+
+	/**
+	 * Whether this is a proposed structure. If omitted,
+	 * the structure is final.
+	 */
+	proposed?: boolean;
+
+	/**
+	 * Whether the structure is deprecated or not. If deprecated
+	 * the property contains the deprecation message.
+	 */
+	deprecated?: string;
+};
+
+/**
+ * Defines an unnamed structure of an object literal.
+ */
+export type StructureLiteral = {
+
+	/**
+	 * The properties.
+	 */
+	properties: Property[];
+
+	/**
+	 * An optional documentation.
+	 */
+	documentation?: string;
+
+	/**
+	 * Since when (release number) this structure is
+	 * available. Is undefined if not known.
+	 */
+	since?: string;
+
+	/**
+	 * All since tags in case there was more than one tag.
+	 * Is undefined if not known.
+	 */
+	sinceTags?: string[];
+
+	/**
+	 * Whether this is a proposed structure. If omitted,
+	 * the structure is final.
+	 */
+	proposed?: boolean;
+
+	/**
+	 * Whether the literal is deprecated or not. If deprecated
+	 * the property contains the deprecation message.
+	 */
+	deprecated?: string;
+};
+
+/**
+ * Defines a type alias.
+ * (e.g. `type Definition = Location | LocationLink`)
+ */
+export type TypeAlias = {
+	/**
+	 * The name of the type alias.
+	 */
+	name: string;
+
+	/**
+	 * The aliased type.
+	 */
+	type: Type;
+
+	/**
+	 * An optional documentation.
+	 */
+	 documentation?: string;
+
+	/**
+	 * Since when (release number) this structure is
+	 * available. Is undefined if not known.
+	 */
+	since?: string;
+
+	/**
+	 * All since tags in case there was more than one tag.
+	 * Is undefined if not known.
+	 */
+	sinceTags?: string[];
+
+	 /**
+	 * Whether this is a proposed type alias. If omitted,
+	 * the type alias is final.
+	 */
+	proposed?: boolean;
+
+	/**
+	 * Whether the type alias is deprecated or not. If deprecated
+	 * the property contains the deprecation message.
+	 */
+	deprecated?: string;
+};
+
+/**
+ * Defines an enumeration entry.
+ */
+export type EnumerationEntry = {
+	/**
+	 * The name of the enum item.
+	 */
+	name: string;
+
+	/**
+	 * The value.
+	 */
+	value: string | number;
+
+	/**
+	 * An optional documentation.
+	 */
+	 documentation?: string;
+
+	/**
+	 * Since when (release number) this enumeration entry is
+	 * available. Is undefined if not known.
+	 */
+	since?: string;
+
+	/**
+	 * All since tags in case there was more than one tag.
+	 * Is undefined if not known.
+	 */
+	sinceTags?: string[];
+
+	 /**
+	 * Whether this is a proposed enumeration entry. If omitted,
+	 * the enumeration entry is final.
+	 */
+	proposed?: boolean;
+
+	/**
+	 * Whether the enum entry is deprecated or not. If deprecated
+	 * the property contains the deprecation message.
+	 */
+	deprecated?: string;
+};
+
+export type EnumerationType = { kind: 'base'; name: 'string' | 'integer' | 'uinteger' };
+
+/**
+ * Defines an enumeration.
+ */
+export type Enumeration = {
+	/**
+	 * The name of the enumeration.
+	 */
+	name: string;
+
+	/**
+	 * The type of the elements.
+	 */
+	type: EnumerationType;
+
+	/**
+	 * The enum values.
+	 */
+	values: EnumerationEntry[];
+
+	/**
+	 * Whether the enumeration supports custom values (e.g. values which are not
+	 * part of the set defined in `values`). If omitted no custom values are
+	 * supported.
+	 */
+	supportsCustomValues?: boolean;
+
+	/**
+	 * An optional documentation.
+	 */
+	 documentation?: string;
+
+	/**
+	 * Since when (release number) this enumeration is
+	 * available. Is undefined if not known.
+	 */
+	since?: string;
+
+	/**
+	 * All since tags in case there was more than one tag.
+	 * Is undefined if not known.
+	 */
+	sinceTags?: string[];
+
+	 /**
+	 * Whether this is a proposed enumeration. If omitted,
+	 * the enumeration is final.
+	 */
+	proposed?: boolean;
+
+	/**
+	 * Whether the enumeration is deprecated or not. If deprecated
+	 * the property contains the deprecation message.
+	 */
+	deprecated?: string;
+};
+
+export type MetaData = {
+	/**
+	 * The protocol version.
+	 */
+	version: string;
+};
 
 /**
  * The actual meta model.
  */
-export interface MetaModel {
-  /**
-   * The enumerations.
-   */
-  enumerations: Enumeration[]
-  metaData: MetaData
-  /**
-   * The notifications.
-   */
-  notifications: Notification[]
-  /**
-   * The requests.
-   */
-  requests: Request[]
-  /**
-   * The structures.
-   */
-  structures: Structure[]
-  /**
-   * The type aliases.
-   */
-  typeAliases: TypeAlias[]
-}
-/**
- * Defines an enumeration.
- */
-export interface Enumeration {
-  /**
-   * Whether the enumeration is deprecated or not. If deprecated the property contains the deprecation message.
-   */
-  deprecated?: string
-  /**
-   * An optional documentation.
-   */
-  documentation?: string
-  /**
-   * The name of the enumeration.
-   */
-  name: string
-  /**
-   * Whether this is a proposed enumeration. If omitted, the enumeration is final.
-   */
-  proposed?: boolean
-  /**
-   * Since when (release number) this enumeration is available. Is undefined if not known.
-   */
-  since?: string
-  /**
-   * All since tags in case there was more than one tag. Is undefined if not known.
-   */
-  sinceTags?: string[]
-  /**
-   * Whether the enumeration supports custom values (e.g. values which are not part of the set defined in `values`). If omitted no custom values are supported.
-   */
-  supportsCustomValues?: boolean
-  type: EnumerationType
-  /**
-   * The enum values.
-   */
-  values: EnumerationEntry[]
-}
-/**
- * The type of the elements.
- */
-export interface EnumerationType {
-  kind: "base"
-  name: ("string" | "integer" | "uinteger")
-}
-/**
- * Defines an enumeration entry.
- */
-export interface EnumerationEntry {
-  /**
-   * Whether the enum entry is deprecated or not. If deprecated the property contains the deprecation message.
-   */
-  deprecated?: string
-  /**
-   * An optional documentation.
-   */
-  documentation?: string
-  /**
-   * The name of the enum item.
-   */
-  name: string
-  /**
-   * Whether this is a proposed enumeration entry. If omitted, the enumeration entry is final.
-   */
-  proposed?: boolean
-  /**
-   * Since when (release number) this enumeration entry is available. Is undefined if not known.
-   */
-  since?: string
-  /**
-   * All since tags in case there was more than one tag. Is undefined if not known.
-   */
-  sinceTags?: string[]
-  /**
-   * The value.
-   */
-  value: (string | number)
-}
-/**
- * Additional meta data.
- */
-export interface MetaData {
-  /**
-   * The protocol version.
-   */
-  version: string
-}
-/**
- * Represents a LSP notification
- */
-export interface Notification {
-  /**
-   * Whether the notification is deprecated or not. If deprecated the property contains the deprecation message.
-   */
-  deprecated?: string
-  /**
-   * An optional documentation;
-   */
-  documentation?: string
-  /**
-   * The direction in which this notification is sent in the protocol.
-   */
-  messageDirection: ("clientToServer" | "serverToClient" | "both")
-  /**
-   * The notifications's method name.
-   */
-  method: string
-  /**
-   * The parameter type(s) if any.
-   */
-  params?: (Type | Type[])
-  /**
-   * Whether this is a proposed notification. If omitted the notification is final.
-   */
-  proposed?: boolean
-  /**
-   * Optional a dynamic registration method if it different from the notifications's method.
-   */
-  registrationMethod?: string
-  /**
-   * Optional registration options if the notification supports dynamic registration.
-   */
-  registrationOptions?: (BaseType | ReferenceType | ArrayType | MapType | AndType | OrType | TupleType | StructureLiteralType | StringLiteralType | IntegerLiteralType | BooleanLiteralType)
-  /**
-   * Since when (release number) this notification is available. Is undefined if not known.
-   */
-  since?: string
-  /**
-   * All since tags in case there was more than one tag. Is undefined if not known.
-   */
-  sinceTags?: string[]
-  /**
-   * The type name of the notifications if any.
-   */
-  typeName?: string
-}
-/**
- * Represents a base type like `string` or `DocumentUri`.
- */
-export interface BaseType {
-  kind: "base"
-  name: BaseTypes
-}
-/**
- * Represents a reference to another type (e.g. `TextDocument`). This is either a `Structure`, a `Enumeration` or a `TypeAlias` in the same meta model.
- */
-export interface ReferenceType {
-  kind: "reference"
-  name: string
-}
-/**
- * Represents an array type (e.g. `TextDocument[]`).
- */
-export interface ArrayType {
-  element: Type
-  kind: "array"
-}
-/**
- * Represents a JSON object map (e.g. `interface Map<K extends string | integer, V> { [key: K] => V; }`).
- */
-export interface MapType {
-  key: MapKeyType
-  kind: "map"
-  value: Type
-}
-/**
- * Represents an `and`type (e.g. TextDocumentParams & WorkDoneProgressParams`).
- */
-export interface AndType {
-  items: Type[]
-  kind: "and"
-}
-/**
- * Represents an `or` type (e.g. `Location | LocationLink`).
- */
-export interface OrType {
-  items: Type[]
-  kind: "or"
-}
-/**
- * Represents a `tuple` type (e.g. `[integer, integer]`).
- */
-export interface TupleType {
-  items: Type[]
-  kind: "tuple"
-}
-/**
- * Represents a literal structure (e.g. `property: { start: uinteger; end: uinteger; }`).
- */
-export interface StructureLiteralType {
-  kind: "literal"
-  value: StructureLiteral
-}
-/**
- * Defines an unnamed structure of an object literal.
- */
-export interface StructureLiteral {
-  /**
-   * Whether the literal is deprecated or not. If deprecated the property contains the deprecation message.
-   */
-  deprecated?: string
-  /**
-   * An optional documentation.
-   */
-  documentation?: string
-  /**
-   * The properties.
-   */
-  properties: Property[]
-  /**
-   * Whether this is a proposed structure. If omitted, the structure is final.
-   */
-  proposed?: boolean
-  /**
-   * Since when (release number) this structure is available. Is undefined if not known.
-   */
-  since?: string
-  /**
-   * All since tags in case there was more than one tag. Is undefined if not known.
-   */
-  sinceTags?: string[]
-}
-/**
- * Represents an object property.
- */
-export interface Property {
-  /**
-   * Whether the property is deprecated or not. If deprecated the property contains the deprecation message.
-   */
-  deprecated?: string
-  /**
-   * An optional documentation.
-   */
-  documentation?: string
-  /**
-   * The property name;
-   */
-  name: string
-  /**
-   * Whether the property is optional. If omitted, the property is mandatory.
-   */
-  optional?: boolean
-  /**
-   * Whether this is a proposed property. If omitted, the structure is final.
-   */
-  proposed?: boolean
-  /**
-   * Since when (release number) this property is available. Is undefined if not known.
-   */
-  since?: string
-  /**
-   * All since tags in case there was more than one tag. Is undefined if not known.
-   */
-  sinceTags?: string[]
-  /**
-   * The type of the property
-   */
-  type: (BaseType | ReferenceType | ArrayType | MapType | AndType | OrType | TupleType | StructureLiteralType | StringLiteralType | IntegerLiteralType | BooleanLiteralType)
-}
-/**
- * Represents a string literal type (e.g. `kind: 'rename'`).
- */
-export interface StringLiteralType {
-  kind: "stringLiteral"
-  value: string
-}
-export interface IntegerLiteralType {
-  /**
-   * Represents an integer literal type (e.g. `kind: 1`).
-   */
-  kind: "integerLiteral"
-  value: number
-}
-/**
- * Represents a boolean literal type (e.g. `kind: true`).
- */
-export interface BooleanLiteralType {
-  kind: "booleanLiteral"
-  value: boolean
-}
-/**
- * Represents a LSP request
- */
-export interface Request {
-  /**
-   * Whether the request is deprecated or not. If deprecated the property contains the deprecation message.
-   */
-  deprecated?: string
-  /**
-   * An optional documentation;
-   */
-  documentation?: string
-  /**
-   * An optional error data type.
-   */
-  errorData?: (BaseType | ReferenceType | ArrayType | MapType | AndType | OrType | TupleType | StructureLiteralType | StringLiteralType | IntegerLiteralType | BooleanLiteralType)
-  /**
-   * The direction in which this request is sent in the protocol.
-   */
-  messageDirection: ("clientToServer" | "serverToClient" | "both")
-  /**
-   * The request's method name.
-   */
-  method: string
-  /**
-   * The parameter type(s) if any.
-   */
-  params?: (Type | Type[])
-  /**
-   * Optional partial result type if the request supports partial result reporting.
-   */
-  partialResult?: (BaseType | ReferenceType | ArrayType | MapType | AndType | OrType | TupleType | StructureLiteralType | StringLiteralType | IntegerLiteralType | BooleanLiteralType)
-  /**
-   * Whether this is a proposed feature. If omitted the feature is final.
-   */
-  proposed?: boolean
-  /**
-   * Optional a dynamic registration method if it different from the request's method.
-   */
-  registrationMethod?: string
-  /**
-   * Optional registration options if the request supports dynamic registration.
-   */
-  registrationOptions?: (BaseType | ReferenceType | ArrayType | MapType | AndType | OrType | TupleType | StructureLiteralType | StringLiteralType | IntegerLiteralType | BooleanLiteralType)
-  /**
-   * The result type.
-   */
-  result: (BaseType | ReferenceType | ArrayType | MapType | AndType | OrType | TupleType | StructureLiteralType | StringLiteralType | IntegerLiteralType | BooleanLiteralType)
-  /**
-   * Since when (release number) this request is available. Is undefined if not known.
-   */
-  since?: string
-  /**
-   * All since tags in case there was more than one tag. Is undefined if not known.
-   */
-  sinceTags?: string[]
-  /**
-   * The type name of the request if any.
-   */
-  typeName?: string
-}
-/**
- * Defines the structure of an object literal.
- */
-export interface Structure {
-  /**
-   * Whether the structure is deprecated or not. If deprecated the property contains the deprecation message.
-   */
-  deprecated?: string
-  /**
-   * An optional documentation;
-   */
-  documentation?: string
-  /**
-   * Structures extended from. This structures form a polymorphic type hierarchy.
-   */
-  extends?: Type[]
-  /**
-   * Structures to mix in. The properties of these structures are `copied` into this structure. Mixins don't form a polymorphic type hierarchy in LSP.
-   */
-  mixins?: Type[]
-  /**
-   * The name of the structure.
-   */
-  name: string
-  /**
-   * The properties.
-   */
-  properties: Property[]
-  /**
-   * Whether this is a proposed structure. If omitted, the structure is final.
-   */
-  proposed?: boolean
-  /**
-   * Since when (release number) this structure is available. Is undefined if not known.
-   */
-  since?: string
-  /**
-   * All since tags in case there was more than one tag. Is undefined if not known.
-   */
-  sinceTags?: string[]
-}
-/**
- * Defines a type alias. (e.g. `type Definition = Location | LocationLink`)
- */
-export interface TypeAlias {
-  /**
-   * Whether the type alias is deprecated or not. If deprecated the property contains the deprecation message.
-   */
-  deprecated?: string
-  /**
-   * An optional documentation.
-   */
-  documentation?: string
-  /**
-   * The name of the type alias.
-   */
-  name: string
-  /**
-   * Whether this is a proposed type alias. If omitted, the type alias is final.
-   */
-  proposed?: boolean
-  /**
-   * Since when (release number) this structure is available. Is undefined if not known.
-   */
-  since?: string
-  /**
-   * All since tags in case there was more than one tag. Is undefined if not known.
-   */
-  sinceTags?: string[]
-  /**
-   * The aliased type.
-   */
-  type: (BaseType | ReferenceType | ArrayType | MapType | AndType | OrType | TupleType | StructureLiteralType | StringLiteralType | IntegerLiteralType | BooleanLiteralType)
-}
+export type MetaModel = {
+	/**
+	 * Additional meta data.
+	 */
+	metaData: MetaData;
+
+	/**
+	 * The requests.
+	 */
+	requests: Request[];
+
+	/**
+	 * The notifications.
+	 */
+	notifications: Notification[];
+
+	/**
+	 * The structures.
+	 */
+	structures: Structure[];
+
+	/**
+	 * The enumerations.
+	 */
+	enumerations: Enumeration[];
+
+	/**
+	 * The type aliases.
+	 */
+	typeAliases: TypeAlias[];
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
                 "execa": "^9.5.1",
                 "glob": "^10.4.5",
                 "hereby": "^1.10.0",
-                "json-schema-to-typescript-lite": "^14.1.0",
                 "picocolors": "^1.1.1",
                 "typescript": "^5.7.3",
                 "which": "^5.0.0"
@@ -54,23 +53,6 @@
         "_packages/ast": {
             "name": "@typescript/ast",
             "version": "1.0.0"
-        },
-        "node_modules/@apidevtools/json-schema-ref-parser": {
-            "version": "11.9.0",
-            "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.0.tgz",
-            "integrity": "sha512-8Q/r5mXLa8Rfyh6r4SgEEFJgISVN5cDNFlcfSWLgFn3odzQhTfHAqzI3hMGdcROViL+8NrDNVVFQtEUrYOksDg==",
-            "dev": true,
-            "dependencies": {
-                "@jsdevtools/ono": "^7.1.3",
-                "@types/json-schema": "^7.0.15",
-                "js-yaml": "^4.1.0"
-            },
-            "engines": {
-                "node": ">= 16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/philsturgeon"
-            }
         },
         "node_modules/@dprint/darwin-arm64": {
             "version": "0.47.6",
@@ -206,12 +188,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/@jsdevtools/ono": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
-            "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
-            "dev": true
-        },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -239,12 +215,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/@types/json-schema": {
-            "version": "7.0.15",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-            "dev": true
         },
         "node_modules/@types/node": {
             "version": "22.10.1",
@@ -298,12 +268,6 @@
             "engines": {
                 "node": ">=4"
             }
-        },
-        "node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
         },
         "node_modules/array-back": {
             "version": "4.0.2",
@@ -705,28 +669,6 @@
             },
             "optionalDependencies": {
                 "@pkgjs/parseargs": "^0.11.0"
-            }
-        },
-        "node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-            "dev": true,
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
-        },
-        "node_modules/json-schema-to-typescript-lite": {
-            "version": "14.1.0",
-            "resolved": "https://registry.npmjs.org/json-schema-to-typescript-lite/-/json-schema-to-typescript-lite-14.1.0.tgz",
-            "integrity": "sha512-b8K6P3aiLgiYKYcHacgZKrwPXPyjekqRPV5vkNfBt0EoohcOSXEbcuGzgi6KQmsAhuy5Mh2KMxofXodRhMxURA==",
-            "dev": true,
-            "dependencies": {
-                "@apidevtools/json-schema-ref-parser": "^11.7.0",
-                "@types/json-schema": "^7.0.15"
             }
         },
         "node_modules/libsyncrpc": {
@@ -1332,17 +1274,6 @@
         }
     },
     "dependencies": {
-        "@apidevtools/json-schema-ref-parser": {
-            "version": "11.9.0",
-            "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.0.tgz",
-            "integrity": "sha512-8Q/r5mXLa8Rfyh6r4SgEEFJgISVN5cDNFlcfSWLgFn3odzQhTfHAqzI3hMGdcROViL+8NrDNVVFQtEUrYOksDg==",
-            "dev": true,
-            "requires": {
-                "@jsdevtools/ono": "^7.1.3",
-                "@types/json-schema": "^7.0.15",
-                "js-yaml": "^4.1.0"
-            }
-        },
         "@dprint/darwin-arm64": {
             "version": "0.47.6",
             "resolved": "https://registry.npmjs.org/@dprint/darwin-arm64/-/darwin-arm64-0.47.6.tgz",
@@ -1420,12 +1351,6 @@
                 "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
             }
         },
-        "@jsdevtools/ono": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
-            "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
-            "dev": true
-        },
         "@pkgjs/parseargs": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1443,12 +1368,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
             "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
-            "dev": true
-        },
-        "@types/json-schema": {
-            "version": "7.0.15",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
             "dev": true
         },
         "@types/node": {
@@ -1497,12 +1416,6 @@
             "requires": {
                 "color-convert": "^1.9.0"
             }
-        },
-        "argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
         },
         "array-back": {
             "version": "4.0.2",
@@ -1788,25 +1701,6 @@
             "requires": {
                 "@isaacs/cliui": "^8.0.2",
                 "@pkgjs/parseargs": "^0.11.0"
-            }
-        },
-        "js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-            "dev": true,
-            "requires": {
-                "argparse": "^2.0.1"
-            }
-        },
-        "json-schema-to-typescript-lite": {
-            "version": "14.1.0",
-            "resolved": "https://registry.npmjs.org/json-schema-to-typescript-lite/-/json-schema-to-typescript-lite-14.1.0.tgz",
-            "integrity": "sha512-b8K6P3aiLgiYKYcHacgZKrwPXPyjekqRPV5vkNfBt0EoohcOSXEbcuGzgi6KQmsAhuy5Mh2KMxofXodRhMxURA==",
-            "dev": true,
-            "requires": {
-                "@apidevtools/json-schema-ref-parser": "^11.7.0",
-                "@types/json-schema": "^7.0.15"
             }
         },
         "libsyncrpc": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
         "execa": "^9.5.1",
         "glob": "^10.4.5",
         "hereby": "^1.10.0",
-        "json-schema-to-typescript-lite": "^14.1.0",
         "picocolors": "^1.1.1",
         "typescript": "^5.7.3",
         "which": "^5.0.0"


### PR DESCRIPTION
When I wrote the code for the LSP code generator, I didn't realize there was already an existing set of type declarations for the meta model. Just pull that instead of using a declaration file generator.