### PR TITLE
Fix minor typo

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -1581,7 +1581,7 @@ func (node *NodeDefault) SubtreeFacts() SubtreeFacts {
 }
 
 func (node *NodeDefault) subtreeFactsWorker(self nodeData) SubtreeFacts {
-	// To avoid excessive conditonal checks, the default implementation of subtreeFactsWorker directly invokes
+	// To avoid excessive conditional checks, the default implementation of subtreeFactsWorker directly invokes
 	// computeSubtreeFacts. More complex nodes should implement CompositeNodeBase, which overrides this
 	// method to cache the result. `self` is passed along to ensure we lookup `computeSubtreeFacts` on the
 	// correct type, as `CompositeNodeBase` does not, itself, inherit from `Node`.

--- a/internal/checker/flow.go
+++ b/internal/checker/flow.go
@@ -1419,7 +1419,7 @@ func (c *Checker) getDiscriminantPropertyAccess(f *FlowState, expr *ast.Node, co
 func (c *Checker) getCandidateDiscriminantPropertyAccess(f *FlowState, expr *ast.Node) *ast.Node {
 	switch {
 	case ast.IsBindingPattern(f.reference) || ast.IsFunctionExpressionOrArrowFunction(f.reference) || ast.IsObjectLiteralMethod(f.reference):
-		// When the reference is a binding pattern or function or arrow expression, we are narrowing a pesudo-reference in
+		// When the reference is a binding pattern or function or arrow expression, we are narrowing a pseudo-reference in
 		// getNarrowedTypeOfSymbol. An identifier for a destructuring variable declared in the same binding pattern or
 		// parameter declared in the same parameter list is a candidate.
 		if ast.IsIdentifier(expr) {


### PR DESCRIPTION
Fix typo in comments ("conditonal" → "conditional", "pesudo" → "pseudo")