### PR TITLE
@type tag correctly applies to multiple var decls

### DIFF
--- a/internal/parser/reparser.go
+++ b/internal/parser/reparser.go
@@ -126,6 +126,7 @@ func (p *Parser) reparseTags(parent *ast.Node, jsDoc []*ast.Node) {
 					for _, declaration := range parent.AsVariableStatement().DeclarationList.AsVariableDeclarationList().Declarations.Nodes {
 						if declaration.AsVariableDeclaration().Type == nil {
 							declaration.AsVariableDeclaration().Type = p.makeNewType(tag.AsJSDocTypeTag().TypeExpression, declaration)
+							break
 						}
 					}
 				} else if parent.Kind == ast.KindVariableDeclaration {

--- a/testdata/tests/cases/conformance/typeTagForMultipleVariableDeclarations.ts
+++ b/testdata/tests/cases/conformance/typeTagForMultipleVariableDeclarations.ts
@@ -1,0 +1,9 @@
+// @checkJs: true
+// @filename: typeTagForMultipleVariableDeclarations.js
+// @noTypesAndSymbols: true
+// @allowJs: true
+/** @type {number} */
+var x,y,z;
+x
+y
+z


### PR DESCRIPTION
Specifically, it applies only to the first. This is how it works in Strada, but somehow we have no tests of it.

I don't know how toplevel tests are supposed to work. They don't seem to generate baselines, but in this case all I need is for the test not to panic to see that it's working.