### PR TITLE
add a couple of missing options to be parsed

### DIFF
--- a/internal/tsoptions/parsinghelpers.go
+++ b/internal/tsoptions/parsinghelpers.go
@@ -143,6 +143,8 @@ func ParseCompilerOptions(key string, value any, allOptions *core.CompilerOption
 	switch key {
 	case "allowJs":
 		allOptions.AllowJs = parseTristate(value)
+	case "allowImportingTsExtensions":
+		allOptions.AllowImportingTsExtensions = parseTristate(value)
 	case "allowSyntheticDefaultImports":
 		allOptions.AllowSyntheticDefaultImports = parseTristate(value)
 	case "allowNonTsExtensions":
@@ -309,6 +311,8 @@ func ParseCompilerOptions(key string, value any, allOptions *core.CompilerOption
 		allOptions.ResolvePackageJsonExports = parseTristate(value)
 	case "resolvePackageJsonImports":
 		allOptions.ResolvePackageJsonImports = parseTristate(value)
+	case "rewriteRelativeImportExtensions":
+		allOptions.RewriteRelativeImportExtensions = parseTristate(value)
 	case "reactNamespace":
 		allOptions.ReactNamespace = parseString(value)
 	case "rootDir":


### PR DESCRIPTION
As things are, tsgo basically ignores these fields in a tsconfig, so rewriting imports doesn't work.

Could there be a "default: panic" or similar in this switch? Or some test? That'd presumably help make this kind of bug less easy to come up again.

**EDIT:** This PR is mutually incompatible with my other one, #839. If #839 makes sense, I suggest you merge that one and close #838.