### PR TITLE
Use os.Open for Windows realpath to handle long paths

### DIFF
--- a/internal/vfs/osvfs/realpath_windows.go
+++ b/internal/vfs/osvfs/realpath_windows.go
@@ -19,7 +19,7 @@ func realpath(path string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		defer windows.CloseHandle(h)
+		defer windows.CloseHandle(h) //nolint:errcheck
 	} else {
 		// For long paths, defer to os.Open to run the path through fixLongPath.
 		f, err := os.Open(path)

--- a/internal/vfs/osvfs/realpath_windows.go
+++ b/internal/vfs/osvfs/realpath_windows.go
@@ -12,7 +12,6 @@ import (
 
 func realpath(path string) (string, error) {
 	var h windows.Handle
-
 	if len(path) < 248 {
 		var err error
 		h, err = openMetadata(path)

--- a/internal/vfs/osvfs/realpath_windows.go
+++ b/internal/vfs/osvfs/realpath_windows.go
@@ -11,11 +11,14 @@ import (
 // This implementation is based on what Node's fs.realpath.native does, via libuv: https://github.com/libuv/libuv/blob/ec5a4b54f7da7eeb01679005c615fee9633cdb3b/src/win/fs.c#L2937
 
 func realpath(path string) (string, error) {
-	h, err := openMetadata(path)
+	f, err := os.Open(path)
 	if err != nil {
 		return "", err
 	}
-	defer windows.CloseHandle(h) //nolint:errcheck
+	defer f.Close() //nolint:errcheck
+
+	// Works on directories too since https://go.dev/cl/405275.
+	h := windows.Handle(f.Fd())
 
 	// based on https://github.com/golang/go/blob/f4e3ec3dbe3b8e04a058d266adf8e048bab563f2/src/os/file_windows.go#L389
 
@@ -44,43 +47,4 @@ func realpath(path string) (string, error) {
 	}
 
 	return "", errors.New("GetFinalPathNameByHandle returned unexpected path: " + s)
-}
-
-func openMetadata(path string) (windows.Handle, error) {
-	// based on https://github.com/microsoft/go-winio/blob/3c9576c9346a1892dee136329e7e15309e82fb4f/pkg/fs/resolve.go#L113
-
-	pathUTF16, err := windows.UTF16PtrFromString(path)
-	if err != nil {
-		return windows.InvalidHandle, err
-	}
-
-	const (
-		_FILE_ANY_ACCESS = 0
-
-		_FILE_SHARE_READ   = 0x01
-		_FILE_SHARE_WRITE  = 0x02
-		_FILE_SHARE_DELETE = 0x04
-
-		_OPEN_EXISTING = 0x03
-
-		_FILE_FLAG_BACKUP_SEMANTICS = 0x0200_0000
-	)
-
-	h, err := windows.CreateFile(
-		pathUTF16,
-		_FILE_ANY_ACCESS,
-		_FILE_SHARE_READ|_FILE_SHARE_WRITE|_FILE_SHARE_DELETE,
-		nil,
-		_OPEN_EXISTING,
-		_FILE_FLAG_BACKUP_SEMANTICS,
-		0,
-	)
-	if err != nil {
-		return 0, &os.PathError{
-			Op:   "CreateFile",
-			Path: path,
-			Err:  err,
-		}
-	}
-	return h, nil
 }

--- a/internal/vfs/osvfs/realpath_windows.go
+++ b/internal/vfs/osvfs/realpath_windows.go
@@ -11,7 +11,9 @@ import (
 // This implementation is based on what Node's fs.realpath.native does, via libuv: https://github.com/libuv/libuv/blob/ec5a4b54f7da7eeb01679005c615fee9633cdb3b/src/win/fs.c#L2937
 
 func realpath(path string) (string, error) {
-	f, err := os.Open(path)
+	// flag=3 here prevents OpenFile from requesting any access flags, which makes opening faster.
+	// Other platforms associate a meaning with this flag, so this is safe to use on Windows for this purpose.
+	f, err := os.OpenFile(path, 3, 0)
 	if err != nil {
 		return "", err
 	}

--- a/internal/vfs/osvfs/realpath_windows.go
+++ b/internal/vfs/osvfs/realpath_windows.go
@@ -17,7 +17,7 @@ func realpath(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer f.Close() //nolint:errcheck
+	defer f.Close()
 
 	// Works on directories too since https://go.dev/cl/405275.
 	h := windows.Handle(f.Fd())

--- a/internal/vfs/osvfs/realpath_windows.go
+++ b/internal/vfs/osvfs/realpath_windows.go
@@ -11,16 +11,26 @@ import (
 // This implementation is based on what Node's fs.realpath.native does, via libuv: https://github.com/libuv/libuv/blob/ec5a4b54f7da7eeb01679005c615fee9633cdb3b/src/win/fs.c#L2937
 
 func realpath(path string) (string, error) {
-	// flag=3 here prevents OpenFile from requesting any access flags, which makes opening faster.
-	// Other platforms associate a meaning with this flag, so this is safe to use on Windows for this purpose.
-	f, err := os.OpenFile(path, 3, 0)
-	if err != nil {
-		return "", err
-	}
-	defer f.Close()
+	var h windows.Handle
 
-	// Works on directories too since https://go.dev/cl/405275.
-	h := windows.Handle(f.Fd())
+	if len(path) < 248 {
+		var err error
+		h, err = openMetadata(path)
+		if err != nil {
+			return "", err
+		}
+		defer windows.CloseHandle(h)
+	} else {
+		// For long paths, defer to os.Open to run the path through fixLongPath.
+		f, err := os.Open(path)
+		if err != nil {
+			return "", err
+		}
+		defer f.Close()
+
+		// Works on directories too since https://go.dev/cl/405275.
+		h = windows.Handle(f.Fd())
+	}
 
 	// based on https://github.com/golang/go/blob/f4e3ec3dbe3b8e04a058d266adf8e048bab563f2/src/os/file_windows.go#L389
 
@@ -49,4 +59,43 @@ func realpath(path string) (string, error) {
 	}
 
 	return "", errors.New("GetFinalPathNameByHandle returned unexpected path: " + s)
+}
+
+func openMetadata(path string) (windows.Handle, error) {
+	// based on https://github.com/microsoft/go-winio/blob/3c9576c9346a1892dee136329e7e15309e82fb4f/pkg/fs/resolve.go#L113
+
+	pathUTF16, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return windows.InvalidHandle, err
+	}
+
+	const (
+		_FILE_ANY_ACCESS = 0
+
+		_FILE_SHARE_READ   = 0x01
+		_FILE_SHARE_WRITE  = 0x02
+		_FILE_SHARE_DELETE = 0x04
+
+		_OPEN_EXISTING = 0x03
+
+		_FILE_FLAG_BACKUP_SEMANTICS = 0x0200_0000
+	)
+
+	h, err := windows.CreateFile(
+		pathUTF16,
+		_FILE_ANY_ACCESS,
+		_FILE_SHARE_READ|_FILE_SHARE_WRITE|_FILE_SHARE_DELETE,
+		nil,
+		_OPEN_EXISTING,
+		_FILE_FLAG_BACKUP_SEMANTICS,
+		0,
+	)
+	if err != nil {
+		return 0, &os.PathError{
+			Op:   "CreateFile",
+			Path: path,
+			Err:  err,
+		}
+	}
+	return h, nil
 }


### PR DESCRIPTION
My hand-written `open` function doesn't handle long paths, relying on the SEH bit Go normally sets. But, that bit is undocumented and seemingly isn't approved for using in releases, and isn't set in artifacts built by the Go fork used by Microsoft.

Rather than use `CreateFile` directly, use `os.Open` instead, which will handle long paths. I didn't do this initially because I thought it didn't work on directories, but it actually has worked since https://go.dev/cl/405275 a long time ago.

I don't have a test for this because I can't seem to make a link with long enough paths in the tests... ☹️ 

cc @qmuntal