### PR TITLE
Fix LSP line/pos at start of a line

### DIFF
--- a/internal/ls/converters.go
+++ b/internal/ls/converters.go
@@ -239,8 +239,11 @@ func (c *Converters) PositionToLineAndCharacter(scriptInfo ScriptInfo, position 
 
 	lineMap := scriptInfo.LineMap()
 
-	line, _ := slices.BinarySearch(lineMap.LineStarts, position)
-	line = max(0, line-1)
+	line, isLineStart := slices.BinarySearch(lineMap.LineStarts, position)
+	if !isLineStart {
+		line--
+	}
+	line = max(0, line)
 
 	// The current line ranges from lineMap.LineStarts[line] (or 0) to lineMap.LineStarts[line+1] (or len(text)).
 


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/f9c281b7-6707-4718-a1f4-06b5ca310a91)

After:

![image](https://github.com/user-attachments/assets/24cee406-9da3-44e1-a6f4-77c4153c3169)

We really need tests for this conversion but this should be sufficient to fix this for demo purposes.

Probably fixes the global completions PR?