### PR TITLE
Improve logic for choosing value/type meanings in quick info

### DIFF
--- a/internal/checker/printer.go
+++ b/internal/checker/printer.go
@@ -90,9 +90,9 @@ func (c *Checker) GetQuickInfoAtLocation(node *ast.Node) string {
 		return ""
 	}
 	flags := symbol.Flags
-	if flags&ast.SymbolFlagsType != 0 && !ast.IsInExpressionContext(node) {
-		// If the symbol has a type meaning and we're not in an expression context, remove any value meanings
-		flags &^= ast.SymbolFlagsValue
+	if flags&ast.SymbolFlagsType != 0 && (ast.IsPartOfTypeNode(node) || isTypeDeclarationName(node)) {
+		// If the symbol has a type meaning and we're in a type context, remove value-only meanings
+		flags &^= ast.SymbolFlagsVariable | ast.SymbolFlagsFunction
 	}
 	p := c.newPrinter(TypeFormatFlagsNone)
 	if isAlias {


### PR DESCRIPTION
This PR fixes logic for choosing value/type meanings in quick info that wasn't quite working correctly. We now show the right meaning when hovering on each of the identifiers in this code:

```ts
enum E {
    A = 1,
    B = "hello",
    C = Math.sqrt(2)
}

interface Thing {
    bar: number
}
declare const Thing: () => Thing

let t1: typeof Thing = Thing
let t2: Thing = Thing()

Thing().bar

declare function strange<T>(T: T): T;
```