### PR TITLE
Concurrent LSP with cancelation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-json-experiment/json v0.0.0-20250223041408-d3c622f1b874
 	github.com/google/go-cmp v0.7.0
 	github.com/pkg/diff v0.0.0-20241224192749-4e6772a4315c
+	golang.org/x/sync v0.11.0
 	golang.org/x/sys v0.31.0
 	gotest.tools/v3 v3.5.2
 )
@@ -14,7 +15,6 @@ require (
 require (
 	github.com/matryer/moq v0.5.3 // indirect
 	golang.org/x/mod v0.23.0 // indirect
-	golang.org/x/sync v0.11.0 // indirect
 	golang.org/x/tools v0.30.0 // indirect
 )
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -2,13 +2,16 @@ package api
 
 import (
 	"bufio"
+	"context"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"io"
+	"strconv"
 	"sync"
 
 	"github.com/microsoft/typescript-go/internal/bundled"
+	"github.com/microsoft/typescript-go/internal/core"
 	"github.com/microsoft/typescript-go/internal/project"
 	"github.com/microsoft/typescript-go/internal/vfs"
 	"github.com/microsoft/typescript-go/internal/vfs/osvfs"
@@ -254,7 +257,7 @@ func (s *Server) handleRequest(method string, payload []byte) ([]byte, error) {
 	case "echo":
 		return payload, nil
 	default:
-		return s.api.HandleRequest(s.requestId, method, payload)
+		return s.api.HandleRequest(core.WithRequestID(context.Background(), strconv.Itoa(s.requestId)), method, payload)
 	}
 }
 

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -39,7 +39,8 @@ foo.bar;`
 	}
 	p := compiler.NewProgram(opts)
 	p.BindSourceFiles()
-	c := p.GetTypeChecker()
+	c, done := p.GetTypeChecker(t.Context())
+	defer done()
 	file := p.GetSourceFile("/foo.ts")
 	interfaceId := file.Statements.Nodes[0].Name()
 	varId := file.Statements.Nodes[1].AsVariableStatement().DeclarationList.AsVariableDeclarationList().Declarations.Nodes[0].Name()

--- a/internal/checker/exports.go
+++ b/internal/checker/exports.go
@@ -48,3 +48,7 @@ func (c *Checker) GetTypeOfPropertyOfContextualType(t *Type, name string) *Type 
 func GetDeclarationModifierFlagsFromSymbol(s *ast.Symbol) ast.ModifierFlags {
 	return getDeclarationModifierFlagsFromSymbol(s)
 }
+
+func (c *Checker) WasCanceled() bool {
+	return c.wasCanceled
+}

--- a/internal/compiler/checkerpool.go
+++ b/internal/compiler/checkerpool.go
@@ -1,0 +1,90 @@
+package compiler
+
+import (
+	"context"
+	"iter"
+	"slices"
+	"sync"
+
+	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/checker"
+	"github.com/microsoft/typescript-go/internal/core"
+)
+
+type CheckerPool interface {
+	GetChecker(ctx context.Context) (*checker.Checker, func())
+	GetCheckerForFile(ctx context.Context, file *ast.SourceFile) (*checker.Checker, func())
+	GetAllCheckers(ctx context.Context) ([]*checker.Checker, func())
+	Files(checker *checker.Checker) iter.Seq[*ast.SourceFile]
+}
+
+type checkerPool struct {
+	checkerCount int
+	program      *Program
+
+	createCheckersOnce sync.Once
+	checkers           []*checker.Checker
+	fileAssociations   map[*ast.SourceFile]*checker.Checker
+}
+
+var _ CheckerPool = (*checkerPool)(nil)
+
+func newCheckerPool(checkerCount int, program *Program) *checkerPool {
+	pool := &checkerPool{
+		program:      program,
+		checkerCount: checkerCount,
+		checkers:     make([]*checker.Checker, checkerCount),
+	}
+
+	return pool
+}
+
+func (p *checkerPool) GetCheckerForFile(ctx context.Context, file *ast.SourceFile) (*checker.Checker, func()) {
+	p.createCheckers()
+	checker := p.fileAssociations[file]
+	return checker, noop
+}
+
+func (p *checkerPool) GetChecker(ctx context.Context) (*checker.Checker, func()) {
+	p.createCheckers()
+	checker := p.checkers[0]
+	return checker, noop
+}
+
+func (p *checkerPool) createCheckers() {
+	p.createCheckersOnce.Do(func() {
+		wg := core.NewWorkGroup(p.program.singleThreaded())
+		for i := range p.checkerCount {
+			wg.Queue(func() {
+				p.checkers[i] = checker.NewChecker(p.program)
+			})
+		}
+
+		wg.RunAndWait()
+
+		p.fileAssociations = make(map[*ast.SourceFile]*checker.Checker, len(p.program.files))
+		for i, file := range p.program.files {
+			p.fileAssociations[file] = p.checkers[i%p.checkerCount]
+		}
+	})
+}
+
+func (p *checkerPool) GetAllCheckers(ctx context.Context) ([]*checker.Checker, func()) {
+	p.createCheckers()
+	return p.checkers, noop
+}
+
+func (p *checkerPool) Files(checker *checker.Checker) iter.Seq[*ast.SourceFile] {
+	checkerIndex := slices.Index(p.checkers, checker)
+	return func(yield func(*ast.SourceFile) bool) {
+		for i, file := range p.program.files {
+			if i%p.checkerCount == checkerIndex {
+				if !yield(file) {
+					return
+				}
+			}
+		}
+	}
+}
+
+func noop() {}

--- a/internal/compiler/emitHost.go
+++ b/internal/compiler/emitHost.go
@@ -34,7 +34,10 @@ func (host *emitHost) WriteFile(fileName string, text string, writeByteOrderMark
 }
 
 func (host *emitHost) GetEmitResolver(file *ast.SourceFile, skipDiagnostics bool) printer.EmitResolver {
-	checker, done := host.program.GetTypeCheckerForFile(context.Background(), file)
+	// The context and done function don't matter in tsc, currently the only caller of this function.
+	// But if this ever gets used by LSP code, we'll need to thread the context properly and pass the
+	// done function to the caller to ensure resources are cleaned up at the end of the request.
+	checker, done := host.program.GetTypeCheckerForFile(context.TODO(), file)
 	defer done()
 	return checker.GetEmitResolver(file, skipDiagnostics)
 }

--- a/internal/compiler/emitHost.go
+++ b/internal/compiler/emitHost.go
@@ -1,6 +1,8 @@
 package compiler
 
 import (
+	"context"
+
 	"github.com/microsoft/typescript-go/internal/ast"
 	"github.com/microsoft/typescript-go/internal/core"
 	"github.com/microsoft/typescript-go/internal/printer"
@@ -32,7 +34,8 @@ func (host *emitHost) WriteFile(fileName string, text string, writeByteOrderMark
 }
 
 func (host *emitHost) GetEmitResolver(file *ast.SourceFile, skipDiagnostics bool) printer.EmitResolver {
-	checker := host.program.GetTypeCheckerForFile(file)
+	checker, done := host.program.GetTypeCheckerForFile(context.Background(), file)
+	defer done()
 	return checker.GetEmitResolver(file, skipDiagnostics)
 }
 

--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -27,6 +27,7 @@ type ProgramOptions struct {
 	SingleThreaded               core.Tristate
 	ProjectReference             []core.ProjectReference
 	ConfigFileParsingDiagnostics []*ast.Diagnostic
+	CheckerPool                  CheckerPool
 }
 
 type Program struct {
@@ -35,9 +36,7 @@ type Program struct {
 	compilerOptions              *core.CompilerOptions
 	configFileName               string
 	nodeModules                  map[string]*ast.SourceFile
-	checkers                     []*checker.Checker
-	checkersOnce                 sync.Once
-	checkersByFile               map[*ast.SourceFile]*checker.Checker
+	checkerPool                  CheckerPool
 	currentDirectory             string
 	configFileParsingDiagnostics []*ast.Diagnostic
 
@@ -78,6 +77,10 @@ func NewProgram(options ProgramOptions) *Program {
 	p.configFileParsingDiagnostics = slices.Clip(options.ConfigFileParsingDiagnostics)
 	if p.compilerOptions == nil {
 		p.compilerOptions = &core.CompilerOptions{}
+	}
+	p.checkerPool = options.CheckerPool
+	if p.checkerPool == nil {
+		p.checkerPool = newCheckerPool(core.IfElse(p.singleThreaded(), 1, 4), p)
 	}
 
 	// p.maxNodeModuleJsDepth = p.options.MaxNodeModuleJsDepth
@@ -212,11 +215,12 @@ func (p *Program) BindSourceFiles() {
 }
 
 func (p *Program) CheckSourceFiles(ctx context.Context) {
-	p.createCheckers()
 	wg := core.NewWorkGroup(p.singleThreaded())
-	for index, checker := range p.checkers {
+	checkers, done := p.checkerPool.GetAllCheckers(ctx)
+	defer done()
+	for index, checker := range checkers {
 		wg.Queue(func() {
-			for i := index; i < len(p.files); i += len(p.checkers) {
+			for i := index; i < len(p.files); i += len(checkers) {
 				checker.CheckSourceFile(ctx, p.files[i])
 			}
 		})
@@ -224,44 +228,21 @@ func (p *Program) CheckSourceFiles(ctx context.Context) {
 	wg.RunAndWait()
 }
 
-func (p *Program) createCheckers() {
-	p.checkersOnce.Do(func() {
-		p.checkers = make([]*checker.Checker, core.IfElse(p.singleThreaded(), 1, 4))
-		wg := core.NewWorkGroup(p.singleThreaded())
-		for i := range p.checkers {
-			wg.Queue(func() {
-				p.checkers[i] = checker.NewChecker(p)
-			})
-		}
-		wg.RunAndWait()
-		p.checkersByFile = make(map[*ast.SourceFile]*checker.Checker)
-		for i, file := range p.files {
-			p.checkersByFile[file] = p.checkers[i%len(p.checkers)]
-		}
-	})
-}
-
 // Return the type checker associated with the program.
-func (p *Program) GetTypeChecker() *checker.Checker {
-	p.createCheckers()
-	// Just use the first (and possibly only) checker for checker requests. Such requests are likely
-	// to obtain types through multiple API calls and we want to ensure that those types are created
-	// by the same checker so they can interoperate.
-	return p.checkers[0]
+func (p *Program) GetTypeChecker(ctx context.Context) (*checker.Checker, func()) {
+	return p.checkerPool.GetChecker(ctx)
 }
 
-func (p *Program) GetTypeCheckers() []*checker.Checker {
-	p.createCheckers()
-	return p.checkers
+func (p *Program) GetTypeCheckers(ctx context.Context) ([]*checker.Checker, func()) {
+	return p.checkerPool.GetAllCheckers(ctx)
 }
 
 // Return a checker for the given file. We may have multiple checkers in concurrent scenarios and this
 // method returns the checker that was tasked with checking the file. Note that it isn't possible to mix
 // types obtained from different checkers, so only non-type data (such as diagnostics or string
 // representations of types) should be obtained from checkers returned by this method.
-func (p *Program) GetTypeCheckerForFile(file *ast.SourceFile) *checker.Checker {
-	p.createCheckers()
-	return p.checkersByFile[file]
+func (p *Program) GetTypeCheckerForFile(ctx context.Context, file *ast.SourceFile) (*checker.Checker, func()) {
+	return p.checkerPool.GetCheckerForFile(ctx, file)
 }
 
 func (p *Program) GetResolvedModule(file *ast.SourceFile, moduleReference string) *ast.SourceFile {
@@ -294,17 +275,19 @@ func (p *Program) GetSemanticDiagnostics(ctx context.Context, sourceFile *ast.So
 	return p.getDiagnosticsHelper(ctx, sourceFile, true /*ensureBound*/, true /*ensureChecked*/, p.getSemanticDiagnosticsForFile)
 }
 
-func (p *Program) GetGlobalDiagnostics() []*ast.Diagnostic {
-	p.createCheckers()
+func (p *Program) GetGlobalDiagnostics(ctx context.Context) []*ast.Diagnostic {
 	var globalDiagnostics []*ast.Diagnostic
-	for _, checker := range p.checkers {
+	checkers, done := p.checkerPool.GetAllCheckers(ctx)
+	defer done()
+	for _, checker := range checkers {
 		globalDiagnostics = append(globalDiagnostics, checker.GetGlobalDiagnostics()...)
 	}
+
 	return SortAndDeduplicateDiagnostics(globalDiagnostics)
 }
 
-func (p *Program) GetOptionsDiagnostics() []*ast.Diagnostic {
-	return SortAndDeduplicateDiagnostics(append(p.GetGlobalDiagnostics(), p.getOptionsDiagnosticsOfConfigFile()...))
+func (p *Program) GetOptionsDiagnostics(ctx context.Context) []*ast.Diagnostic {
+	return SortAndDeduplicateDiagnostics(append(p.GetGlobalDiagnostics(ctx), p.getOptionsDiagnosticsOfConfigFile()...))
 }
 
 func (p *Program) getOptionsDiagnosticsOfConfigFile() []*ast.Diagnostic {
@@ -332,14 +315,20 @@ func (p *Program) getSemanticDiagnosticsForFile(ctx context.Context, sourceFile 
 	if checker.SkipTypeChecking(sourceFile, p.compilerOptions) {
 		return nil
 	}
+
 	var fileChecker *checker.Checker
+	var done func()
 	if sourceFile != nil {
-		fileChecker = p.GetTypeCheckerForFile(sourceFile)
+		fileChecker, done = p.checkerPool.GetCheckerForFile(ctx, sourceFile)
+		defer done()
 	}
 	diags := slices.Clip(sourceFile.BindDiagnostics())
+	checkers, closeCheckers := p.checkerPool.GetAllCheckers(ctx)
+	defer closeCheckers()
+
 	// Ask for diags from all checkers; checking one file may add diagnostics to other files.
 	// These are deduplicated later.
-	for _, checker := range p.checkers {
+	for _, checker := range checkers {
 		if sourceFile == nil || checker == fileChecker {
 			diags = append(diags, checker.GetDiagnostics(ctx, sourceFile)...)
 		} else {
@@ -482,7 +471,9 @@ func (p *Program) SymbolCount() int {
 	for _, file := range p.files {
 		count += file.SymbolCount
 	}
-	for _, checker := range p.checkers {
+	checkers, done := p.checkerPool.GetAllCheckers(context.Background())
+	defer done()
+	for _, checker := range checkers {
 		count += int(checker.SymbolCount)
 	}
 	return count
@@ -490,7 +481,9 @@ func (p *Program) SymbolCount() int {
 
 func (p *Program) TypeCount() int {
 	var count int
-	for _, checker := range p.checkers {
+	checkers, done := p.checkerPool.GetAllCheckers(context.Background())
+	defer done()
+	for _, checker := range checkers {
 		count += int(checker.TypeCount)
 	}
 	return count
@@ -498,7 +491,9 @@ func (p *Program) TypeCount() int {
 
 func (p *Program) InstantiationCount() int {
 	var count int
-	for _, checker := range p.checkers {
+	checkers, done := p.checkerPool.GetAllCheckers(context.Background())
+	defer done()
+	for _, checker := range checkers {
 		count += int(checker.TotalInstantiationCount)
 	}
 	return count

--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -218,10 +218,10 @@ func (p *Program) CheckSourceFiles(ctx context.Context) {
 	wg := core.NewWorkGroup(p.singleThreaded())
 	checkers, done := p.checkerPool.GetAllCheckers(ctx)
 	defer done()
-	for index, checker := range checkers {
+	for _, checker := range checkers {
 		wg.Queue(func() {
-			for i := index; i < len(p.files); i += len(checkers) {
-				checker.CheckSourceFile(ctx, p.files[i])
+			for file := range p.checkerPool.Files(checker) {
+				checker.CheckSourceFile(ctx, file)
 			}
 		})
 	}

--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -27,7 +27,7 @@ type ProgramOptions struct {
 	SingleThreaded               core.Tristate
 	ProjectReference             []core.ProjectReference
 	ConfigFileParsingDiagnostics []*ast.Diagnostic
-	CheckerPool                  CheckerPool
+	CreateCheckerPool            func(*Program) CheckerPool
 }
 
 type Program struct {
@@ -78,8 +78,9 @@ func NewProgram(options ProgramOptions) *Program {
 	if p.compilerOptions == nil {
 		p.compilerOptions = &core.CompilerOptions{}
 	}
-	p.checkerPool = options.CheckerPool
-	if p.checkerPool == nil {
+	if p.programOptions.CreateCheckerPool != nil {
+		p.checkerPool = p.programOptions.CreateCheckerPool(p)
+	} else {
 		p.checkerPool = newCheckerPool(core.IfElse(p.singleThreaded(), 1, 4), p)
 	}
 

--- a/internal/core/context.go
+++ b/internal/core/context.go
@@ -1,0 +1,21 @@
+package core
+
+import "context"
+
+type key int
+
+var requestIDKey key
+
+func WithRequestID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, requestIDKey, id)
+}
+
+func GetRequestID(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if id, ok := ctx.Value(requestIDKey).(string); ok {
+		return id
+	}
+	return ""
+}

--- a/internal/execute/tsc.go
+++ b/internal/execute/tsc.go
@@ -239,25 +239,26 @@ type compileAndEmitResult struct {
 func compileAndEmit(sys System, program *compiler.Program, reportDiagnostic diagnosticReporter) (result compileAndEmitResult) {
 	// todo: check if third return needed after execute is fully implemented
 
+	ctx := context.Background()
 	options := program.Options()
 	allDiagnostics := program.GetConfigFileParsingDiagnostics()
 
 	// todo: early exit logic and append diagnostics
-	diagnostics := program.GetSyntacticDiagnostics(context.Background(), nil)
+	diagnostics := program.GetSyntacticDiagnostics(ctx, nil)
 	if len(diagnostics) == 0 {
 		bindStart := time.Now()
-		_ = program.GetBindDiagnostics(context.Background(), nil)
+		_ = program.GetBindDiagnostics(ctx, nil)
 		result.bindTime = time.Since(bindStart)
 
-		diagnostics = append(diagnostics, program.GetOptionsDiagnostics()...)
+		diagnostics = append(diagnostics, program.GetOptionsDiagnostics(ctx)...)
 		if options.ListFilesOnly.IsFalse() {
 			// program.GetBindDiagnostics(nil)
-			diagnostics = append(diagnostics, program.GetGlobalDiagnostics()...)
+			diagnostics = append(diagnostics, program.GetGlobalDiagnostics(ctx)...)
 		}
 	}
 	if len(diagnostics) == 0 {
 		checkStart := time.Now()
-		diagnostics = append(diagnostics, program.GetSemanticDiagnostics(context.Background(), nil)...)
+		diagnostics = append(diagnostics, program.GetSemanticDiagnostics(ctx, nil)...)
 		result.checkTime = time.Since(checkStart)
 	}
 	// TODO: declaration diagnostics

--- a/internal/ls/api.go
+++ b/internal/ls/api.go
@@ -15,7 +15,7 @@ var (
 )
 
 func (l *LanguageService) GetSymbolAtPosition(fileName string, position int) (*ast.Symbol, error) {
-	program, file := l.tryGetProgramAndFile(fileName)
+	_, file := l.tryGetProgramAndFile(fileName)
 	if file == nil {
 		return nil, fmt.Errorf("%w: %s", ErrNoSourceFile, fileName)
 	}
@@ -23,17 +23,16 @@ func (l *LanguageService) GetSymbolAtPosition(fileName string, position int) (*a
 	if node == nil {
 		return nil, fmt.Errorf("%w: %s:%d", ErrNoTokenAtPosition, fileName, position)
 	}
-	checker := program.GetTypeChecker()
+	checker := l.GetTypeChecker(file)
 	return checker.GetSymbolAtLocation(node), nil
 }
 
 func (l *LanguageService) GetSymbolAtLocation(node *ast.Node) *ast.Symbol {
-	program := l.GetProgram()
-	checker := program.GetTypeChecker()
+	checker := l.GetTypeChecker(ast.GetSourceFileOfNode(node))
 	return checker.GetSymbolAtLocation(node)
 }
 
 func (l *LanguageService) GetTypeOfSymbol(symbol *ast.Symbol) *checker.Type {
-	checker := l.GetProgram().GetTypeChecker()
+	checker := l.GetTypeChecker(nil /*file*/)
 	return checker.GetTypeOfSymbolAtLocation(symbol, nil)
 }

--- a/internal/ls/completions_test.go
+++ b/internal/ls/completions_test.go
@@ -1575,12 +1575,13 @@ func runTest(t *testing.T, files map[string]string, expected map[string]*testCas
 		if !ok {
 			t.Fatalf("No marker found for '%s'", markerName)
 		}
-		completionList := languageService.ProvideCompletion(
-			mainFileName,
-			marker.Position,
+		completionList, err := languageService.ProvideCompletion(
+			ls.FileNameToDocumentURI(mainFileName),
+			marker.LSPosition,
 			context,
 			capabilities,
 			preferences)
+		assert.NilError(t, err)
 		if expectedResult.isIncludes {
 			assertIncludesItem(t, completionList, expectedResult.list)
 		} else {

--- a/internal/ls/completions_test.go
+++ b/internal/ls/completions_test.go
@@ -1,6 +1,7 @@
 package ls_test
 
 import (
+	"context"
 	"slices"
 	"testing"
 
@@ -1551,7 +1552,9 @@ func runTest(t *testing.T, files map[string]string, expected map[string]*testCas
 			parsedFiles[fileName] = content
 		}
 	}
-	languageService := createLanguageService(mainFileName, parsedFiles)
+	ctx := projecttestutil.WithRequestID(t.Context())
+	languageService, done := createLanguageService(ctx, mainFileName, parsedFiles)
+	defer done()
 	context := &lsproto.CompletionContext{
 		TriggerKind: lsproto.CompletionTriggerKindInvoked,
 	}
@@ -1576,6 +1579,7 @@ func runTest(t *testing.T, files map[string]string, expected map[string]*testCas
 			t.Fatalf("No marker found for '%s'", markerName)
 		}
 		completionList, err := languageService.ProvideCompletion(
+			ctx,
 			ls.FileNameToDocumentURI(mainFileName),
 			marker.LSPosition,
 			context,
@@ -1611,11 +1615,11 @@ func assertIncludesItem(t *testing.T, actual *lsproto.CompletionList, expected *
 	return false
 }
 
-func createLanguageService(fileName string, files map[string]string) *ls.LanguageService {
+func createLanguageService(ctx context.Context, fileName string, files map[string]string) (*ls.LanguageService, func()) {
 	projectService, _ := projecttestutil.Setup(files)
 	projectService.OpenFile(fileName, files[fileName], core.ScriptKindTS, "")
 	project := projectService.Projects()[0]
-	return project.LanguageService()
+	return project.GetLanguageServiceForRequest(ctx)
 }
 
 func ptrTo[T any](v T) *T {

--- a/internal/ls/definition.go
+++ b/internal/ls/definition.go
@@ -4,17 +4,19 @@ import (
 	"github.com/microsoft/typescript-go/internal/ast"
 	"github.com/microsoft/typescript-go/internal/astnav"
 	"github.com/microsoft/typescript-go/internal/core"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
 	"github.com/microsoft/typescript-go/internal/scanner"
 )
 
-func (l *LanguageService) ProvideDefinitions(fileName string, position int) []Location {
-	program, file := l.getProgramAndFile(fileName)
-	node := astnav.GetTouchingPropertyName(file, position)
+func (l *LanguageService) ProvideDefinition(documentURI lsproto.DocumentUri, position lsproto.Position) (*lsproto.Definition, error) {
+	file := l.getSourceFile(documentURI)
+	node := astnav.GetTouchingPropertyName(file, int(l.converters.LineAndCharacterToPosition(file, position)))
 	if node.Kind == ast.KindSourceFile {
-		return nil
+		return nil, nil
 	}
 
-	checker := program.GetTypeChecker()
+	checker := l.GetTypeChecker(file)
+
 	if symbol := checker.GetSymbolAtLocation(node); symbol != nil {
 		if symbol.Flags&ast.SymbolFlagsAlias != 0 {
 			if resolved, ok := checker.ResolveAlias(symbol); ok {
@@ -22,18 +24,17 @@ func (l *LanguageService) ProvideDefinitions(fileName string, position int) []Lo
 			}
 		}
 
-		locations := make([]Location, 0, len(symbol.Declarations))
+		locations := make([]lsproto.Location, 0, len(symbol.Declarations))
 		for _, decl := range symbol.Declarations {
 			file := ast.GetSourceFileOfNode(decl)
 			loc := decl.Loc
 			pos := scanner.GetTokenPosOfNode(decl, file, false /*includeJSDoc*/)
-
-			locations = append(locations, Location{
-				FileName: file.FileName(),
-				Range:    core.NewTextRange(pos, loc.End()),
+			locations = append(locations, lsproto.Location{
+				Uri:   FileNameToDocumentURI(file.FileName()),
+				Range: l.converters.ToLSPRange(file, core.NewTextRange(pos, loc.End())),
 			})
 		}
-		return locations
+		return &lsproto.Definition{Locations: &locations}, nil
 	}
-	return nil
+	return nil, nil
 }

--- a/internal/ls/diagnostics.go
+++ b/internal/ls/diagnostics.go
@@ -2,14 +2,71 @@ package ls
 
 import (
 	"context"
-	"slices"
 
 	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/diagnostics"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
 )
 
-func (l *LanguageService) GetDocumentDiagnostics(fileName string) []*ast.Diagnostic {
-	program, file := l.getProgramAndFile(fileName)
+func (l *LanguageService) GetDocumentDiagnostics(documentURI lsproto.DocumentUri) (*lsproto.DocumentDiagnosticReport, error) {
+	program, file := l.getProgramAndFile(documentURI)
 	syntaxDiagnostics := program.GetSyntacticDiagnostics(context.Background(), file)
-	semanticDiagnostics := program.GetSemanticDiagnostics(context.Background(), file)
-	return slices.Concat(syntaxDiagnostics, semanticDiagnostics)
+	var lspDiagnostics []*lsproto.Diagnostic
+	if len(syntaxDiagnostics) != 0 {
+		lspDiagnostics = make([]*lsproto.Diagnostic, len(syntaxDiagnostics))
+		for i, diag := range syntaxDiagnostics {
+			lspDiagnostics[i] = toLSPDiagnostic(diag, l.converters)
+		}
+	} else {
+		checker := l.GetTypeChecker(file)
+		semanticDiagnostics := checker.GetDiagnostics(context.Background(), file)
+		lspDiagnostics = make([]*lsproto.Diagnostic, len(semanticDiagnostics))
+		for i, diag := range semanticDiagnostics {
+			lspDiagnostics[i] = toLSPDiagnostic(diag, l.converters)
+		}
+	}
+	return &lsproto.DocumentDiagnosticReport{
+		RelatedFullDocumentDiagnosticReport: &lsproto.RelatedFullDocumentDiagnosticReport{
+			FullDocumentDiagnosticReport: lsproto.FullDocumentDiagnosticReport{
+				Kind:  lsproto.StringLiteralFull{},
+				Items: lspDiagnostics,
+			},
+		},
+	}, nil
+}
+
+func toLSPDiagnostic(diagnostic *ast.Diagnostic, converters *Converters) *lsproto.Diagnostic {
+	var severity lsproto.DiagnosticSeverity
+	switch diagnostic.Category() {
+	case diagnostics.CategorySuggestion:
+		severity = lsproto.DiagnosticSeverityHint
+	case diagnostics.CategoryMessage:
+		severity = lsproto.DiagnosticSeverityInformation
+	case diagnostics.CategoryWarning:
+		severity = lsproto.DiagnosticSeverityWarning
+	default:
+		severity = lsproto.DiagnosticSeverityError
+	}
+
+	relatedInformation := make([]*lsproto.DiagnosticRelatedInformation, 0, len(diagnostic.RelatedInformation()))
+	for _, related := range diagnostic.RelatedInformation() {
+		relatedInformation = append(relatedInformation, &lsproto.DiagnosticRelatedInformation{
+			Location: lsproto.Location{
+				Uri:   FileNameToDocumentURI(related.File().FileName()),
+				Range: converters.ToLSPRange(related.File(), related.Loc()),
+			},
+			Message: related.Message(),
+		})
+	}
+
+	return &lsproto.Diagnostic{
+		Range: converters.ToLSPRange(diagnostic.File(), diagnostic.Loc()),
+		Code: &lsproto.IntegerOrString{
+			Integer: ptrTo(diagnostic.Code()),
+		},
+		Severity:           &severity,
+		Message:            diagnostic.Message(),
+		Source:             ptrTo("ts"),
+		RelatedInformation: &relatedInformation,
+	}
 }

--- a/internal/ls/host.go
+++ b/internal/ls/host.go
@@ -1,30 +1,12 @@
 package ls
 
 import (
-	"github.com/microsoft/typescript-go/internal/ast"
 	"github.com/microsoft/typescript-go/internal/compiler"
-	"github.com/microsoft/typescript-go/internal/core"
 	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
-	"github.com/microsoft/typescript-go/internal/tspath"
-	"github.com/microsoft/typescript-go/internal/vfs"
 )
 
 type Host interface {
-	FS() vfs.FS
-	DefaultLibraryPath() string
-	GetCurrentDirectory() string
-	NewLine() string
-	Trace(msg string)
-	GetProjectVersion() int
-	// GetRootFileNames was called GetScriptFileNames in the original code.
-	GetRootFileNames() []string
-	// GetCompilerOptions was called GetCompilationSettings in the original code.
-	GetCompilerOptions() *core.CompilerOptions
-	GetSourceFile(fileName string, path tspath.Path, languageVersion core.ScriptTarget) *ast.SourceFile
-	// This responsibility was moved from the language service to the project,
-	// because they were bidirectionally interdependent.
 	GetProgram() *compiler.Program
-	GetDefaultLibraryPath() string
 	GetPositionEncoding() lsproto.PositionEncodingKind
-	GetScriptInfo(fileName string) ScriptInfo
+	GetLineMap(fileName string) *LineMap
 }

--- a/internal/ls/hover.go
+++ b/internal/ls/hover.go
@@ -1,16 +1,53 @@
 package ls
 
 import (
+	"strings"
+
 	"github.com/microsoft/typescript-go/internal/ast"
 	"github.com/microsoft/typescript-go/internal/astnav"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
 )
 
-func (l *LanguageService) ProvideHover(fileName string, position int) string {
-	program, file := l.getProgramAndFile(fileName)
-	node := astnav.GetTouchingPropertyName(file, position)
+func (l *LanguageService) ProvideHover(documentURI lsproto.DocumentUri, position lsproto.Position) (*lsproto.Hover, error) {
+	file := l.getSourceFile(documentURI)
+	node := astnav.GetTouchingPropertyName(file, int(l.converters.LineAndCharacterToPosition(file, position)))
 	if node.Kind == ast.KindSourceFile {
 		// Avoid giving quickInfo for the sourceFile as a whole.
+		return nil, nil
+	}
+	result := l.GetTypeChecker(file).GetQuickInfoAtLocation(node)
+	if result != "" {
+		return &lsproto.Hover{
+			Contents: lsproto.MarkupContentOrMarkedStringOrMarkedStrings{
+				MarkupContent: &lsproto.MarkupContent{
+					Kind:  lsproto.MarkupKindMarkdown,
+					Value: codeFence("typescript", result),
+				},
+			},
+		}, nil
+	}
+	return nil, nil
+}
+
+func codeFence(lang string, code string) string {
+	if code == "" {
 		return ""
 	}
-	return program.GetTypeChecker().GetQuickInfoAtLocation(node)
+	ticks := 3
+	for strings.Contains(code, strings.Repeat("`", ticks)) {
+		ticks++
+	}
+	var result strings.Builder
+	result.Grow(len(code) + len(lang) + 2*ticks + 2)
+	for range ticks {
+		result.WriteByte('`')
+	}
+	result.WriteString(lang)
+	result.WriteByte('\n')
+	result.WriteString(code)
+	result.WriteByte('\n')
+	for range ticks {
+		result.WriteByte('`')
+	}
+	return result.String()
 }

--- a/internal/ls/languageservice.go
+++ b/internal/ls/languageservice.go
@@ -4,21 +4,18 @@ import (
 	"context"
 
 	"github.com/microsoft/typescript-go/internal/ast"
-	"github.com/microsoft/typescript-go/internal/checker"
 	"github.com/microsoft/typescript-go/internal/compiler"
 	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
 )
 
 type LanguageService struct {
-	ctx         context.Context
-	host        Host
-	converters  *Converters
-	disposables []func()
+	ctx        context.Context
+	host       Host
+	converters *Converters
 }
 
 func NewLanguageService(ctx context.Context, host Host) *LanguageService {
 	return &LanguageService{
-		ctx:        ctx,
 		host:       host,
 		converters: NewConverters(host.GetPositionEncoding(), host.GetLineMap),
 	}
@@ -29,38 +26,10 @@ func (l *LanguageService) GetProgram() *compiler.Program {
 	return l.host.GetProgram()
 }
 
-func (l *LanguageService) GetTypeChecker(file *ast.SourceFile) *checker.Checker {
-	var checker *checker.Checker
-	var done func()
-	if file == nil {
-		checker, done = l.GetProgram().GetTypeChecker(l.ctx)
-	} else {
-		checker, done = l.GetProgram().GetTypeCheckerForFile(l.ctx, file)
-	}
-	l.disposables = append(l.disposables, done)
-	return checker
-}
-
-func (l *LanguageService) Dispose() {
-	for _, dispose := range l.disposables {
-		dispose()
-	}
-	l.disposables = nil
-}
-
 func (l *LanguageService) tryGetProgramAndFile(fileName string) (*compiler.Program, *ast.SourceFile) {
 	program := l.GetProgram()
 	file := program.GetSourceFile(fileName)
 	return program, file
-}
-
-func (l *LanguageService) getSourceFile(documentURI lsproto.DocumentUri) *ast.SourceFile {
-	fileName := DocumentURIToFileName(documentURI)
-	_, file := l.tryGetProgramAndFile(fileName)
-	if file == nil {
-		return nil
-	}
-	return file
 }
 
 func (l *LanguageService) getProgramAndFile(documentURI lsproto.DocumentUri) (*compiler.Program, *ast.SourceFile) {

--- a/internal/ls/utilities.go
+++ b/internal/ls/utilities.go
@@ -268,10 +268,7 @@ func (l *LanguageService) createLspRangeFromNode(node *ast.Node, file *ast.Sourc
 }
 
 func (l *LanguageService) createLspRangeFromBounds(start, end int, file *ast.SourceFile) *lsproto.Range {
-	lspRange, err := l.converters.ToLSPRange(file.FileName(), core.NewTextRange(start, end))
-	if err != nil {
-		panic(err)
-	}
+	lspRange := l.converters.ToLSPRange(file, core.NewTextRange(start, end))
 	return &lspRange
 }
 

--- a/internal/lsp/lsproto/jsonrpc.go
+++ b/internal/lsp/lsproto/jsonrpc.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 )
 
 type JSONRPCVersion struct{}
@@ -37,6 +38,13 @@ func NewID(rawValue IntegerOrString) *ID {
 
 func NewIDString(str string) *ID {
 	return &ID{str: str}
+}
+
+func (id *ID) String() string {
+	if id.str != "" {
+		return id.str
+	}
+	return strconv.Itoa(int(id.int))
 }
 
 func (id *ID) MarshalJSON() ([]byte, error) {

--- a/internal/lsp/lsproto/jsonrpc.go
+++ b/internal/lsp/lsproto/jsonrpc.go
@@ -28,6 +28,13 @@ type ID struct {
 	int int32
 }
 
+func NewID(rawValue IntegerOrString) *ID {
+	if rawValue.String != nil {
+		return &ID{str: *rawValue.String}
+	}
+	return &ID{int: *rawValue.Integer}
+}
+
 func NewIDString(str string) *ID {
 	return &ID{str: str}
 }
@@ -61,13 +68,92 @@ func (id *ID) MustInt() int32 {
 	return id.int
 }
 
-// TODO(jakebailey): NotificationMessage? Use RequestMessage without ID?
+type MessageKind int
+
+const (
+	MessageKindNotification MessageKind = iota
+	MessageKindRequest
+	MessageKindResponse
+)
+
+type Message struct {
+	Kind MessageKind
+	msg  any
+}
+
+func (m *Message) AsRequest() *RequestMessage {
+	return m.msg.(*RequestMessage)
+}
+
+func (m *Message) AsResponse() *ResponseMessage {
+	return m.msg.(*ResponseMessage)
+}
+
+func (m *Message) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		JSONRPC JSONRPCVersion  `json:"jsonrpc"`
+		Method  Method          `json:"method"`
+		ID      *ID             `json:"id,omitempty"`
+		Params  json.RawMessage `json:"params"`
+		Result  any             `json:"result,omitempty"`
+		Error   *ResponseError  `json:"error,omitempty"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidRequest, err)
+	}
+	if raw.ID != nil && raw.Method == "" {
+		m.Kind = MessageKindResponse
+		m.msg = &ResponseMessage{
+			JSONRPC: raw.JSONRPC,
+			ID:      raw.ID,
+			Result:  raw.Result,
+			Error:   raw.Error,
+		}
+		return nil
+	}
+
+	var params any
+	var err error
+	if len(raw.Params) > 0 {
+		params, err = unmarshalParams(raw.Method, raw.Params)
+		if err != nil {
+			return fmt.Errorf("%w: %w", ErrInvalidRequest, err)
+		}
+	}
+
+	if raw.ID == nil {
+		m.Kind = MessageKindNotification
+	} else {
+		m.Kind = MessageKindRequest
+	}
+
+	m.msg = &RequestMessage{
+		JSONRPC: raw.JSONRPC,
+		ID:      raw.ID,
+		Method:  raw.Method,
+		Params:  params,
+	}
+
+	return nil
+}
+
+func (m *Message) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.msg)
+}
+
+func NewNotificationMessage(method Method, params any) *RequestMessage {
+	return &RequestMessage{
+		JSONRPC: JSONRPCVersion{},
+		Method:  method,
+		Params:  params,
+	}
+}
 
 type RequestMessage struct {
 	JSONRPC JSONRPCVersion `json:"jsonrpc"`
 	ID      *ID            `json:"id,omitempty"`
 	Method  Method         `json:"method"`
-	Params  any            `json:"params"`
+	Params  any            `json:"params,omitempty"`
 }
 
 func NewRequestMessage(method Method, id *ID, params any) *RequestMessage {
@@ -75,6 +161,13 @@ func NewRequestMessage(method Method, id *ID, params any) *RequestMessage {
 		ID:     id,
 		Method: method,
 		Params: params,
+	}
+}
+
+func (r *RequestMessage) Message() *Message {
+	return &Message{
+		Kind: MessageKindRequest,
+		msg:  r,
 	}
 }
 
@@ -108,8 +201,26 @@ type ResponseMessage struct {
 	Error   *ResponseError `json:"error,omitempty"`
 }
 
+func (r *ResponseMessage) Message() *Message {
+	return &Message{
+		Kind: MessageKindResponse,
+		msg:  r,
+	}
+}
+
 type ResponseError struct {
 	Code    int32  `json:"code"`
 	Message string `json:"message"`
 	Data    any    `json:"data,omitempty"`
+}
+
+func (r *ResponseError) String() string {
+	if r == nil {
+		return ""
+	}
+	data, err := json.Marshal(r.Data)
+	if err != nil {
+		return fmt.Sprintf("[%d]: %s\n%v", r.Code, r.Message, data)
+	}
+	return fmt.Sprintf("[%d]: %s", r.Code, r.Message)
 }

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -137,7 +137,6 @@ func (s *Server) WatchFiles(ctx context.Context, watchers []*lsproto.FileSystemW
 			},
 		},
 	})
-
 	if err != nil {
 		return "", fmt.Errorf("failed to register file watcher: %w", err)
 	}
@@ -159,7 +158,6 @@ func (s *Server) UnwatchFiles(ctx context.Context, handle project.WatcherHandle)
 				},
 			},
 		})
-
 		if err != nil {
 			return fmt.Errorf("failed to unregister file watcher: %w", err)
 		}
@@ -571,7 +569,6 @@ func (s *Server) handleCompletion(ctx context.Context, req *lsproto.RequestMessa
 		params.Context,
 		s.initializeParams.Capabilities.TextDocument.Completion,
 		&ls.UserPreferences{})
-
 	if err != nil {
 		return err
 	}

--- a/internal/project/checkerpool.go
+++ b/internal/project/checkerpool.go
@@ -1,0 +1,163 @@
+package project
+
+import (
+	"context"
+	"iter"
+	"sync"
+
+	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/checker"
+	"github.com/microsoft/typescript-go/internal/compiler"
+	"github.com/microsoft/typescript-go/internal/core"
+)
+
+type CheckerPool struct {
+	maxCheckers int
+	program     *compiler.Program
+
+	mu                  sync.Mutex
+	cond                *sync.Cond
+	createCheckersOnce  sync.Once
+	checkers            []*checker.Checker
+	inUse               map[*checker.Checker]bool
+	fileAssociations    map[*ast.SourceFile]*checker.Checker
+	requestAssociations map[string]*checker.Checker
+}
+
+var _ compiler.CheckerPool = (*CheckerPool)(nil)
+
+func newCheckerPool(maxCheckers int, program *compiler.Program) *CheckerPool {
+	pool := &CheckerPool{
+		program:             program,
+		maxCheckers:         maxCheckers,
+		checkers:            make([]*checker.Checker, 0, maxCheckers),
+		inUse:               make(map[*checker.Checker]bool),
+		requestAssociations: make(map[string]*checker.Checker),
+	}
+
+	pool.cond = sync.NewCond(&pool.mu)
+	return pool
+}
+
+func (p *CheckerPool) GetCheckerForFile(ctx context.Context, file *ast.SourceFile) (*checker.Checker, func()) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	requestID := core.GetRequestID(ctx)
+	if requestID != "" {
+		if checker, ok := p.requestAssociations[requestID]; ok {
+			if inUse := p.inUse[checker]; !inUse {
+				p.inUse[checker] = true
+				return checker, p.createRelease(requestID, checker)
+			}
+			return checker, noop
+		}
+	}
+
+	if p.fileAssociations == nil {
+		p.fileAssociations = make(map[*ast.SourceFile]*checker.Checker)
+	}
+
+	if checker, ok := p.fileAssociations[file]; ok {
+		if inUse := p.inUse[checker]; !inUse {
+			p.inUse[checker] = true
+			if requestID != "" {
+				p.requestAssociations[requestID] = checker
+			}
+			return checker, p.createRelease(requestID, checker)
+		}
+	}
+
+	checker, release := p.getCheckerLocked(requestID)
+	p.fileAssociations[file] = checker
+	return checker, release
+}
+
+func (p *CheckerPool) GetChecker(ctx context.Context) (*checker.Checker, func()) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.getCheckerLocked(core.GetRequestID(ctx))
+}
+
+func (p *CheckerPool) Files(checker *checker.Checker) iter.Seq[*ast.SourceFile] {
+	panic("unimplemented")
+}
+
+func (p *CheckerPool) GetAllCheckers(ctx context.Context) ([]*checker.Checker, func()) {
+	requestID := core.GetRequestID(ctx)
+	if requestID == "" {
+		panic("cannot call GetAllCheckers on a project.checkerPool without a request ID")
+	}
+
+	// A request can only access one checker
+	c, release := p.GetChecker(ctx)
+	return []*checker.Checker{c}, release
+}
+
+func (p *CheckerPool) getCheckerLocked(requestID string) (*checker.Checker, func()) {
+	if checker := p.getImmediatelyAvailableChecker(); checker != nil {
+		p.inUse[checker] = true
+		if requestID != "" {
+			p.requestAssociations[requestID] = checker
+		}
+		return checker, p.createRelease(requestID, checker)
+	}
+
+	if len(p.checkers) < p.maxCheckers {
+		checker := p.createCheckerLocked()
+		p.inUse[checker] = true
+		if requestID != "" {
+			p.requestAssociations[requestID] = checker
+		}
+		return checker, p.createRelease(requestID, checker)
+	}
+
+	checker := p.waitForAvailableChecker()
+	p.inUse[checker] = true
+	if requestID != "" {
+		p.requestAssociations[requestID] = checker
+	}
+	return checker, p.createRelease(requestID, checker)
+}
+
+func (p *CheckerPool) getImmediatelyAvailableChecker() *checker.Checker {
+	if len(p.checkers) == 0 {
+		return nil
+	}
+
+	for _, checker := range p.checkers {
+		if inUse := p.inUse[checker]; !inUse {
+			return checker
+		}
+	}
+
+	return nil
+}
+
+func (p *CheckerPool) waitForAvailableChecker() *checker.Checker {
+	for {
+		p.cond.Wait()
+		checker := p.getImmediatelyAvailableChecker()
+		if checker != nil {
+			return checker
+		}
+	}
+}
+
+func (p *CheckerPool) createRelease(requestId string, checker *checker.Checker) func() {
+	return func() {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+
+		p.inUse[checker] = false
+		p.cond.Signal()
+	}
+}
+
+func (p *CheckerPool) createCheckerLocked() *checker.Checker {
+	checker := checker.NewChecker(p.program)
+	p.checkers = append(p.checkers, checker)
+	return checker
+}
+
+func noop() {}

--- a/internal/project/checkerpool.go
+++ b/internal/project/checkerpool.go
@@ -20,8 +20,8 @@ type CheckerPool struct {
 	createCheckersOnce  sync.Once
 	checkers            []*checker.Checker
 	inUse               map[*checker.Checker]bool
-	fileAssociations    map[*ast.SourceFile]*checker.Checker
-	requestAssociations map[string]*checker.Checker
+	fileAssociations    map[*ast.SourceFile]int
+	requestAssociations map[string]int
 }
 
 var _ compiler.CheckerPool = (*CheckerPool)(nil)
@@ -30,9 +30,9 @@ func newCheckerPool(maxCheckers int, program *compiler.Program) *CheckerPool {
 	pool := &CheckerPool{
 		program:             program,
 		maxCheckers:         maxCheckers,
-		checkers:            make([]*checker.Checker, 0, maxCheckers),
+		checkers:            make([]*checker.Checker, maxCheckers),
 		inUse:               make(map[*checker.Checker]bool),
-		requestAssociations: make(map[string]*checker.Checker),
+		requestAssociations: make(map[string]int),
 	}
 
 	pool.cond = sync.NewCond(&pool.mu)
@@ -45,38 +45,47 @@ func (p *CheckerPool) GetCheckerForFile(ctx context.Context, file *ast.SourceFil
 
 	requestID := core.GetRequestID(ctx)
 	if requestID != "" {
-		if checker, ok := p.requestAssociations[requestID]; ok {
-			if inUse := p.inUse[checker]; !inUse {
-				p.inUse[checker] = true
-				return checker, p.createRelease(requestID, checker)
+		if index, ok := p.requestAssociations[requestID]; ok {
+			checker := p.checkers[index]
+			if checker != nil {
+				if inUse := p.inUse[checker]; !inUse {
+					p.inUse[checker] = true
+					return checker, p.createRelease(requestID, index, checker)
+				}
+				// Checker is in use, but by the same request - assume it's the
+				// same goroutine or is managing its own synchronization
+				return checker, noop
 			}
-			return checker, noop
 		}
 	}
 
 	if p.fileAssociations == nil {
-		p.fileAssociations = make(map[*ast.SourceFile]*checker.Checker)
+		p.fileAssociations = make(map[*ast.SourceFile]int)
 	}
 
-	if checker, ok := p.fileAssociations[file]; ok {
-		if inUse := p.inUse[checker]; !inUse {
-			p.inUse[checker] = true
-			if requestID != "" {
-				p.requestAssociations[requestID] = checker
+	if index, ok := p.fileAssociations[file]; ok {
+		checker := p.checkers[index]
+		if checker != nil {
+			if inUse := p.inUse[checker]; !inUse {
+				p.inUse[checker] = true
+				if requestID != "" {
+					p.requestAssociations[requestID] = index
+				}
+				return checker, p.createRelease(requestID, index, checker)
 			}
-			return checker, p.createRelease(requestID, checker)
 		}
 	}
 
-	checker, release := p.getCheckerLocked(requestID)
-	p.fileAssociations[file] = checker
-	return checker, release
+	checker, index := p.getCheckerLocked(requestID)
+	p.fileAssociations[file] = index
+	return checker, p.createRelease(requestID, index, checker)
 }
 
 func (p *CheckerPool) GetChecker(ctx context.Context) (*checker.Checker, func()) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	return p.getCheckerLocked(core.GetRequestID(ctx))
+	checker, index := p.getCheckerLocked(core.GetRequestID(ctx))
+	return checker, p.createRelease(core.GetRequestID(ctx), index, checker)
 }
 
 func (p *CheckerPool) Files(checker *checker.Checker) iter.Seq[*ast.SourceFile] {
@@ -94,70 +103,90 @@ func (p *CheckerPool) GetAllCheckers(ctx context.Context) ([]*checker.Checker, f
 	return []*checker.Checker{c}, release
 }
 
-func (p *CheckerPool) getCheckerLocked(requestID string) (*checker.Checker, func()) {
-	if checker := p.getImmediatelyAvailableChecker(); checker != nil {
+func (p *CheckerPool) getCheckerLocked(requestID string) (*checker.Checker, int) {
+	if checker, index := p.getImmediatelyAvailableChecker(); checker != nil {
 		p.inUse[checker] = true
 		if requestID != "" {
-			p.requestAssociations[requestID] = checker
+			p.requestAssociations[requestID] = index
 		}
-		return checker, p.createRelease(requestID, checker)
+		return checker, index
 	}
 
-	if len(p.checkers) < p.maxCheckers {
-		checker := p.createCheckerLocked()
+	if !p.isFullLocked() {
+		checker, index := p.createCheckerLocked()
 		p.inUse[checker] = true
 		if requestID != "" {
-			p.requestAssociations[requestID] = checker
+			p.requestAssociations[requestID] = index
 		}
-		return checker, p.createRelease(requestID, checker)
+		return checker, index
 	}
 
-	checker := p.waitForAvailableChecker()
+	checker, index := p.waitForAvailableChecker()
 	p.inUse[checker] = true
 	if requestID != "" {
-		p.requestAssociations[requestID] = checker
+		p.requestAssociations[requestID] = index
 	}
-	return checker, p.createRelease(requestID, checker)
+	return checker, index
 }
 
-func (p *CheckerPool) getImmediatelyAvailableChecker() *checker.Checker {
-	if len(p.checkers) == 0 {
-		return nil
-	}
-
-	for _, checker := range p.checkers {
+func (p *CheckerPool) getImmediatelyAvailableChecker() (*checker.Checker, int) {
+	for i, checker := range p.checkers {
+		if checker == nil {
+			continue
+		}
 		if inUse := p.inUse[checker]; !inUse {
-			return checker
+			return checker, i
 		}
 	}
 
-	return nil
+	return nil, -1
 }
 
-func (p *CheckerPool) waitForAvailableChecker() *checker.Checker {
+func (p *CheckerPool) waitForAvailableChecker() (*checker.Checker, int) {
 	for {
 		p.cond.Wait()
-		checker := p.getImmediatelyAvailableChecker()
+		checker, index := p.getImmediatelyAvailableChecker()
 		if checker != nil {
-			return checker
+			return checker, index
 		}
 	}
 }
 
-func (p *CheckerPool) createRelease(requestId string, checker *checker.Checker) func() {
+func (p *CheckerPool) createRelease(requestId string, index int, checker *checker.Checker) func() {
 	return func() {
 		p.mu.Lock()
 		defer p.mu.Unlock()
 
-		p.inUse[checker] = false
+		delete(p.requestAssociations, requestId)
+		if checker.WasCanceled() {
+			// Canceled checkers must be disposed
+			p.checkers[index] = nil
+			delete(p.inUse, checker)
+		} else {
+			p.inUse[checker] = false
+		}
 		p.cond.Signal()
 	}
 }
 
-func (p *CheckerPool) createCheckerLocked() *checker.Checker {
-	checker := checker.NewChecker(p.program)
-	p.checkers = append(p.checkers, checker)
-	return checker
+func (p *CheckerPool) isFullLocked() bool {
+	for _, checker := range p.checkers {
+		if checker == nil {
+			return false
+		}
+	}
+	return true
+}
+
+func (p *CheckerPool) createCheckerLocked() (*checker.Checker, int) {
+	for i, existing := range p.checkers {
+		if existing == nil {
+			checker := checker.NewChecker(p.program)
+			p.checkers[i] = checker
+			return checker, i
+		}
+	}
+	panic("called createCheckerLocked when pool is full")
 }
 
 func noop() {}

--- a/internal/project/host.go
+++ b/internal/project/host.go
@@ -1,6 +1,8 @@
 package project
 
 import (
+	"context"
+
 	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
 	"github.com/microsoft/typescript-go/internal/vfs"
 )
@@ -8,9 +10,9 @@ import (
 type WatcherHandle string
 
 type Client interface {
-	WatchFiles(watchers []*lsproto.FileSystemWatcher) (WatcherHandle, error)
-	UnwatchFiles(handle WatcherHandle) error
-	RefreshDiagnostics() error
+	WatchFiles(ctx context.Context, watchers []*lsproto.FileSystemWatcher) (WatcherHandle, error)
+	UnwatchFiles(ctx context.Context, handle WatcherHandle) error
+	RefreshDiagnostics(ctx context.Context) error
 }
 
 type ServiceHost interface {

--- a/internal/project/scriptinfo.go
+++ b/internal/project/scriptinfo.go
@@ -9,7 +9,7 @@ import (
 	"github.com/microsoft/typescript-go/internal/vfs"
 )
 
-var _ ls.ScriptInfo = (*ScriptInfo)(nil)
+var _ ls.Script = (*ScriptInfo)(nil)
 
 type ScriptInfo struct {
 	fileName   string

--- a/internal/project/service.go
+++ b/internal/project/service.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -255,7 +256,7 @@ func (s *Service) SourceFileCount() int {
 	return s.documentRegistry.size()
 }
 
-func (s *Service) OnWatchedFilesChanged(changes []*lsproto.FileEvent) error {
+func (s *Service) OnWatchedFilesChanged(ctx context.Context, changes []*lsproto.FileEvent) error {
 	for _, change := range changes {
 		fileName := ls.DocumentURIToFileName(change.Uri)
 		path := s.toPath(fileName)
@@ -286,7 +287,7 @@ func (s *Service) OnWatchedFilesChanged(changes []*lsproto.FileEvent) error {
 
 	client := s.host.Client()
 	if client != nil {
-		return client.RefreshDiagnostics()
+		return client.RefreshDiagnostics(ctx)
 	}
 
 	return nil

--- a/internal/project/service.go
+++ b/internal/project/service.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -196,7 +197,7 @@ func (s *Service) ChangeFile(document lsproto.VersionedTextDocumentIdentifier, c
 				NewText:   wholeChange.Text,
 			}
 		} else {
-			return fmt.Errorf("invalid change type")
+			return errors.New("invalid change type")
 		}
 	}
 

--- a/internal/project/service_test.go
+++ b/internal/project/service_test.go
@@ -365,7 +365,7 @@ func TestService(t *testing.T) {
 			service.OpenFile("/home/projects/TS/p1/src/index.ts", files["/home/projects/TS/p1/src/index.ts"], core.ScriptKindTS, "")
 			_, project := service.EnsureDefaultProjectForFile("/home/projects/TS/p1/src/index.ts")
 			program := project.GetProgram()
-			assert.Equal(t, len(program.GetSemanticDiagnostics(t.Context(), program.GetSourceFile("/home/projects/TS/p1/src/index.ts"))), 0)
+			assert.Equal(t, len(program.GetSemanticDiagnostics(projecttestutil.WithRequestID(t.Context()), program.GetSourceFile("/home/projects/TS/p1/src/index.ts"))), 0)
 
 			filesCopy := maps.Clone(files)
 			filesCopy["/home/projects/TS/p1/tsconfig.json"] = `{
@@ -383,7 +383,7 @@ func TestService(t *testing.T) {
 			}))
 
 			program = project.GetProgram()
-			assert.Equal(t, len(program.GetSemanticDiagnostics(t.Context(), program.GetSourceFile("/home/projects/TS/p1/src/index.ts"))), 1)
+			assert.Equal(t, len(program.GetSemanticDiagnostics(projecttestutil.WithRequestID(t.Context()), program.GetSourceFile("/home/projects/TS/p1/src/index.ts"))), 1)
 		})
 
 		t.Run("delete explicitly included file", func(t *testing.T) {
@@ -402,7 +402,7 @@ func TestService(t *testing.T) {
 			service.OpenFile("/home/projects/TS/p1/src/index.ts", files["/home/projects/TS/p1/src/index.ts"], core.ScriptKindTS, "")
 			_, project := service.EnsureDefaultProjectForFile("/home/projects/TS/p1/src/index.ts")
 			program := project.GetProgram()
-			assert.Equal(t, len(program.GetSemanticDiagnostics(t.Context(), program.GetSourceFile("/home/projects/TS/p1/src/index.ts"))), 0)
+			assert.Equal(t, len(program.GetSemanticDiagnostics(projecttestutil.WithRequestID(t.Context()), program.GetSourceFile("/home/projects/TS/p1/src/index.ts"))), 0)
 
 			filesCopy := maps.Clone(files)
 			delete(filesCopy, "/home/projects/TS/p1/src/x.ts")
@@ -415,7 +415,7 @@ func TestService(t *testing.T) {
 			}))
 
 			program = project.GetProgram()
-			assert.Equal(t, len(program.GetSemanticDiagnostics(t.Context(), program.GetSourceFile("/home/projects/TS/p1/src/index.ts"))), 1)
+			assert.Equal(t, len(program.GetSemanticDiagnostics(projecttestutil.WithRequestID(t.Context()), program.GetSourceFile("/home/projects/TS/p1/src/index.ts"))), 1)
 			assert.Check(t, program.GetSourceFile("/home/projects/TS/p1/src/x.ts") == nil)
 		})
 
@@ -435,7 +435,7 @@ func TestService(t *testing.T) {
 			service.OpenFile("/home/projects/TS/p1/src/x.ts", files["/home/projects/TS/p1/src/x.ts"], core.ScriptKindTS, "")
 			_, project := service.EnsureDefaultProjectForFile("/home/projects/TS/p1/src/x.ts")
 			program := project.GetProgram()
-			assert.Equal(t, len(program.GetSemanticDiagnostics(t.Context(), program.GetSourceFile("/home/projects/TS/p1/src/x.ts"))), 0)
+			assert.Equal(t, len(program.GetSemanticDiagnostics(projecttestutil.WithRequestID(t.Context()), program.GetSourceFile("/home/projects/TS/p1/src/x.ts"))), 0)
 
 			filesCopy := maps.Clone(files)
 			delete(filesCopy, "/home/projects/TS/p1/src/index.ts")
@@ -448,7 +448,7 @@ func TestService(t *testing.T) {
 			}))
 
 			program = project.GetProgram()
-			assert.Equal(t, len(program.GetSemanticDiagnostics(t.Context(), program.GetSourceFile("/home/projects/TS/p1/src/x.ts"))), 1)
+			assert.Equal(t, len(program.GetSemanticDiagnostics(projecttestutil.WithRequestID(t.Context()), program.GetSourceFile("/home/projects/TS/p1/src/x.ts"))), 1)
 		})
 
 		t.Run("create explicitly included file", func(t *testing.T) {
@@ -468,7 +468,7 @@ func TestService(t *testing.T) {
 			program := project.GetProgram()
 
 			// Initially should have an error because y.ts is missing
-			assert.Equal(t, len(program.GetSemanticDiagnostics(t.Context(), program.GetSourceFile("/home/projects/TS/p1/src/index.ts"))), 1)
+			assert.Equal(t, len(program.GetSemanticDiagnostics(projecttestutil.WithRequestID(t.Context()), program.GetSourceFile("/home/projects/TS/p1/src/index.ts"))), 1)
 
 			// Missing location should be watched
 			assert.DeepEqual(t, host.ClientMock.WatchFilesCalls()[0].Watchers, []*lsproto.FileSystemWatcher{
@@ -505,7 +505,7 @@ func TestService(t *testing.T) {
 
 			// Error should be resolved
 			program = project.GetProgram()
-			assert.Equal(t, len(program.GetSemanticDiagnostics(t.Context(), program.GetSourceFile("/home/projects/TS/p1/src/index.ts"))), 0)
+			assert.Equal(t, len(program.GetSemanticDiagnostics(projecttestutil.WithRequestID(t.Context()), program.GetSourceFile("/home/projects/TS/p1/src/index.ts"))), 0)
 			assert.Check(t, program.GetSourceFile("/home/projects/TS/p1/src/y.ts") != nil)
 		})
 
@@ -526,7 +526,7 @@ func TestService(t *testing.T) {
 			program := project.GetProgram()
 
 			// Initially should have an error because z.ts is missing
-			assert.Equal(t, len(program.GetSemanticDiagnostics(t.Context(), program.GetSourceFile("/home/projects/TS/p1/src/index.ts"))), 1)
+			assert.Equal(t, len(program.GetSemanticDiagnostics(projecttestutil.WithRequestID(t.Context()), program.GetSourceFile("/home/projects/TS/p1/src/index.ts"))), 1)
 
 			// Missing location should be watched
 			assert.Check(t, slices.ContainsFunc(host.ClientMock.WatchFilesCalls()[1].Watchers, func(w *lsproto.FileSystemWatcher) bool {
@@ -546,7 +546,7 @@ func TestService(t *testing.T) {
 
 			// Error should be resolved and the new file should be included in the program
 			program = project.GetProgram()
-			assert.Equal(t, len(program.GetSemanticDiagnostics(t.Context(), program.GetSourceFile("/home/projects/TS/p1/src/index.ts"))), 0)
+			assert.Equal(t, len(program.GetSemanticDiagnostics(projecttestutil.WithRequestID(t.Context()), program.GetSourceFile("/home/projects/TS/p1/src/index.ts"))), 0)
 			assert.Check(t, program.GetSourceFile("/home/projects/TS/p1/src/z.ts") != nil)
 		})
 
@@ -567,7 +567,7 @@ func TestService(t *testing.T) {
 			program := project.GetProgram()
 
 			// Initially should have an error because declaration for 'a' is missing
-			assert.Equal(t, len(program.GetSemanticDiagnostics(t.Context(), program.GetSourceFile("/home/projects/TS/p1/src/index.ts"))), 1)
+			assert.Equal(t, len(program.GetSemanticDiagnostics(projecttestutil.WithRequestID(t.Context()), program.GetSourceFile("/home/projects/TS/p1/src/index.ts"))), 1)
 
 			// Add a new file through wildcard watch
 			filesCopy := maps.Clone(files)
@@ -582,7 +582,7 @@ func TestService(t *testing.T) {
 
 			// Error should be resolved and the new file should be included in the program
 			program = project.GetProgram()
-			assert.Equal(t, len(program.GetSemanticDiagnostics(t.Context(), program.GetSourceFile("/home/projects/TS/p1/src/index.ts"))), 0)
+			assert.Equal(t, len(program.GetSemanticDiagnostics(projecttestutil.WithRequestID(t.Context()), program.GetSourceFile("/home/projects/TS/p1/src/index.ts"))), 0)
 			assert.Check(t, program.GetSourceFile("/home/projects/TS/p1/src/a.ts") != nil)
 		})
 	})

--- a/internal/project/service_test.go
+++ b/internal/project/service_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/microsoft/typescript-go/internal/bundled"
 	"github.com/microsoft/typescript-go/internal/core"
-	"github.com/microsoft/typescript-go/internal/ls"
 	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
 	"github.com/microsoft/typescript-go/internal/project"
 	"github.com/microsoft/typescript-go/internal/testutil/projecttestutil"
@@ -94,7 +93,31 @@ func TestService(t *testing.T) {
 			service.OpenFile("/home/projects/TS/p1/src/x.ts", defaultFiles["/home/projects/TS/p1/src/x.ts"], core.ScriptKindTS, "")
 			info, proj := service.EnsureDefaultProjectForFile("/home/projects/TS/p1/src/x.ts")
 			programBefore := proj.GetProgram()
-			service.ChangeFile("/home/projects/TS/p1/src/x.ts", []ls.TextChange{{TextRange: core.NewTextRange(17, 18), NewText: "2"}})
+			service.ChangeFile(
+				lsproto.VersionedTextDocumentIdentifier{
+					TextDocumentIdentifier: lsproto.TextDocumentIdentifier{
+						Uri: "file:///home/projects/TS/p1/src/x.ts",
+					},
+					Version: 1,
+				},
+				[]lsproto.TextDocumentContentChangeEvent{
+					lsproto.TextDocumentContentChangePartialOrTextDocumentContentChangeWholeDocument{
+						TextDocumentContentChangePartial: ptrTo(lsproto.TextDocumentContentChangePartial{
+							Range: lsproto.Range{
+								Start: lsproto.Position{
+									Line:      0,
+									Character: 17,
+								},
+								End: lsproto.Position{
+									Line:      0,
+									Character: 18,
+								},
+							},
+							Text: "2",
+						}),
+					},
+				},
+			)
 			assert.Equal(t, info.Text(), "export const x = 2;")
 			assert.Equal(t, proj.CurrentProgram(), programBefore)
 			assert.Equal(t, programBefore.GetSourceFile("/home/projects/TS/p1/src/x.ts").Text(), "export const x = 1;")
@@ -108,7 +131,31 @@ func TestService(t *testing.T) {
 			_, proj := service.EnsureDefaultProjectForFile("/home/projects/TS/p1/src/x.ts")
 			programBefore := proj.GetProgram()
 			indexFileBefore := programBefore.GetSourceFile("/home/projects/TS/p1/src/index.ts")
-			service.ChangeFile("/home/projects/TS/p1/src/x.ts", nil)
+			service.ChangeFile(
+				lsproto.VersionedTextDocumentIdentifier{
+					TextDocumentIdentifier: lsproto.TextDocumentIdentifier{
+						Uri: "file:///home/projects/TS/p1/src/x.ts",
+					},
+					Version: 1,
+				},
+				[]lsproto.TextDocumentContentChangeEvent{
+					lsproto.TextDocumentContentChangePartialOrTextDocumentContentChangeWholeDocument{
+						TextDocumentContentChangePartial: ptrTo(lsproto.TextDocumentContentChangePartial{
+							Range: lsproto.Range{
+								Start: lsproto.Position{
+									Line:      0,
+									Character: 0,
+								},
+								End: lsproto.Position{
+									Line:      0,
+									Character: 0,
+								},
+							},
+							Text: ";",
+						}),
+					},
+				},
+			)
 			assert.Equal(t, proj.GetProgram().GetSourceFile("/home/projects/TS/p1/src/index.ts"), indexFileBefore)
 		})
 
@@ -120,7 +167,31 @@ func TestService(t *testing.T) {
 			service.OpenFile("/home/projects/TS/p1/src/index.ts", files["/home/projects/TS/p1/src/index.ts"], core.ScriptKindTS, "")
 			assert.Check(t, service.GetScriptInfo("/home/projects/TS/p1/y.ts") == nil)
 
-			service.ChangeFile("/home/projects/TS/p1/src/index.ts", []ls.TextChange{{TextRange: core.NewTextRange(0, 0), NewText: `import { y } from "../y";\n`}})
+			service.ChangeFile(
+				lsproto.VersionedTextDocumentIdentifier{
+					TextDocumentIdentifier: lsproto.TextDocumentIdentifier{
+						Uri: "file:///home/projects/TS/p1/src/index.ts",
+					},
+					Version: 1,
+				},
+				[]lsproto.TextDocumentContentChangeEvent{
+					lsproto.TextDocumentContentChangePartialOrTextDocumentContentChangeWholeDocument{
+						TextDocumentContentChangePartial: ptrTo(lsproto.TextDocumentContentChangePartial{
+							Range: lsproto.Range{
+								Start: lsproto.Position{
+									Line:      0,
+									Character: 0,
+								},
+								End: lsproto.Position{
+									Line:      0,
+									Character: 0,
+								},
+							},
+							Text: `import { y } from "../y";\n`,
+						}),
+					},
+				},
+			)
 			service.EnsureDefaultProjectForFile("/home/projects/TS/p1/y.ts")
 		})
 	})

--- a/internal/project/service_test.go
+++ b/internal/project/service_test.go
@@ -93,7 +93,7 @@ func TestService(t *testing.T) {
 			service.OpenFile("/home/projects/TS/p1/src/x.ts", defaultFiles["/home/projects/TS/p1/src/x.ts"], core.ScriptKindTS, "")
 			info, proj := service.EnsureDefaultProjectForFile("/home/projects/TS/p1/src/x.ts")
 			programBefore := proj.GetProgram()
-			service.ChangeFile(
+			err := service.ChangeFile(
 				lsproto.VersionedTextDocumentIdentifier{
 					TextDocumentIdentifier: lsproto.TextDocumentIdentifier{
 						Uri: "file:///home/projects/TS/p1/src/x.ts",
@@ -118,6 +118,7 @@ func TestService(t *testing.T) {
 					},
 				},
 			)
+			assert.NilError(t, err)
 			assert.Equal(t, info.Text(), "export const x = 2;")
 			assert.Equal(t, proj.CurrentProgram(), programBefore)
 			assert.Equal(t, programBefore.GetSourceFile("/home/projects/TS/p1/src/x.ts").Text(), "export const x = 1;")
@@ -131,7 +132,7 @@ func TestService(t *testing.T) {
 			_, proj := service.EnsureDefaultProjectForFile("/home/projects/TS/p1/src/x.ts")
 			programBefore := proj.GetProgram()
 			indexFileBefore := programBefore.GetSourceFile("/home/projects/TS/p1/src/index.ts")
-			service.ChangeFile(
+			err := service.ChangeFile(
 				lsproto.VersionedTextDocumentIdentifier{
 					TextDocumentIdentifier: lsproto.TextDocumentIdentifier{
 						Uri: "file:///home/projects/TS/p1/src/x.ts",
@@ -156,6 +157,7 @@ func TestService(t *testing.T) {
 					},
 				},
 			)
+			assert.NilError(t, err)
 			assert.Equal(t, proj.GetProgram().GetSourceFile("/home/projects/TS/p1/src/index.ts"), indexFileBefore)
 		})
 
@@ -167,7 +169,7 @@ func TestService(t *testing.T) {
 			service.OpenFile("/home/projects/TS/p1/src/index.ts", files["/home/projects/TS/p1/src/index.ts"], core.ScriptKindTS, "")
 			assert.Check(t, service.GetScriptInfo("/home/projects/TS/p1/y.ts") == nil)
 
-			service.ChangeFile(
+			err := service.ChangeFile(
 				lsproto.VersionedTextDocumentIdentifier{
 					TextDocumentIdentifier: lsproto.TextDocumentIdentifier{
 						Uri: "file:///home/projects/TS/p1/src/index.ts",
@@ -192,6 +194,7 @@ func TestService(t *testing.T) {
 					},
 				},
 			)
+			assert.NilError(t, err)
 			service.EnsureDefaultProjectForFile("/home/projects/TS/p1/y.ts")
 		})
 	})

--- a/internal/project/service_test.go
+++ b/internal/project/service_test.go
@@ -316,7 +316,7 @@ func TestService(t *testing.T) {
 			files := maps.Clone(defaultFiles)
 			files["/home/projects/TS/p1/src/x.ts"] = `export const x = 2;`
 			host.ReplaceFS(files)
-			assert.NilError(t, service.OnWatchedFilesChanged([]*lsproto.FileEvent{
+			assert.NilError(t, service.OnWatchedFilesChanged(t.Context(), []*lsproto.FileEvent{
 				{
 					Type: lsproto.FileChangeTypeChanged,
 					Uri:  "file:///home/projects/TS/p1/src/x.ts",
@@ -336,7 +336,7 @@ func TestService(t *testing.T) {
 			files := maps.Clone(defaultFiles)
 			files["/home/projects/TS/p1/src/x.ts"] = `export const x = 2;`
 			host.ReplaceFS(files)
-			assert.NilError(t, service.OnWatchedFilesChanged([]*lsproto.FileEvent{
+			assert.NilError(t, service.OnWatchedFilesChanged(t.Context(), []*lsproto.FileEvent{
 				{
 					Type: lsproto.FileChangeTypeChanged,
 					Uri:  "file:///home/projects/TS/p1/src/x.ts",
@@ -375,7 +375,7 @@ func TestService(t *testing.T) {
 				}
 			}`
 			host.ReplaceFS(filesCopy)
-			assert.NilError(t, service.OnWatchedFilesChanged([]*lsproto.FileEvent{
+			assert.NilError(t, service.OnWatchedFilesChanged(t.Context(), []*lsproto.FileEvent{
 				{
 					Type: lsproto.FileChangeTypeChanged,
 					Uri:  "file:///home/projects/TS/p1/tsconfig.json",
@@ -407,7 +407,7 @@ func TestService(t *testing.T) {
 			filesCopy := maps.Clone(files)
 			delete(filesCopy, "/home/projects/TS/p1/src/x.ts")
 			host.ReplaceFS(filesCopy)
-			assert.NilError(t, service.OnWatchedFilesChanged([]*lsproto.FileEvent{
+			assert.NilError(t, service.OnWatchedFilesChanged(t.Context(), []*lsproto.FileEvent{
 				{
 					Type: lsproto.FileChangeTypeDeleted,
 					Uri:  "file:///home/projects/TS/p1/src/x.ts",
@@ -440,7 +440,7 @@ func TestService(t *testing.T) {
 			filesCopy := maps.Clone(files)
 			delete(filesCopy, "/home/projects/TS/p1/src/index.ts")
 			host.ReplaceFS(filesCopy)
-			assert.NilError(t, service.OnWatchedFilesChanged([]*lsproto.FileEvent{
+			assert.NilError(t, service.OnWatchedFilesChanged(t.Context(), []*lsproto.FileEvent{
 				{
 					Type: lsproto.FileChangeTypeDeleted,
 					Uri:  "file:///home/projects/TS/p1/src/index.ts",
@@ -496,7 +496,7 @@ func TestService(t *testing.T) {
 			filesCopy := maps.Clone(files)
 			filesCopy["/home/projects/TS/p1/src/y.ts"] = `export const y = 1;`
 			host.ReplaceFS(filesCopy)
-			assert.NilError(t, service.OnWatchedFilesChanged([]*lsproto.FileEvent{
+			assert.NilError(t, service.OnWatchedFilesChanged(t.Context(), []*lsproto.FileEvent{
 				{
 					Type: lsproto.FileChangeTypeCreated,
 					Uri:  "file:///home/projects/TS/p1/src/y.ts",
@@ -537,7 +537,7 @@ func TestService(t *testing.T) {
 			filesCopy := maps.Clone(files)
 			filesCopy["/home/projects/TS/p1/src/z.ts"] = `export const z = 1;`
 			host.ReplaceFS(filesCopy)
-			assert.NilError(t, service.OnWatchedFilesChanged([]*lsproto.FileEvent{
+			assert.NilError(t, service.OnWatchedFilesChanged(t.Context(), []*lsproto.FileEvent{
 				{
 					Type: lsproto.FileChangeTypeCreated,
 					Uri:  "file:///home/projects/TS/p1/src/z.ts",
@@ -573,7 +573,7 @@ func TestService(t *testing.T) {
 			filesCopy := maps.Clone(files)
 			filesCopy["/home/projects/TS/p1/src/a.ts"] = `const a = 1;`
 			host.ReplaceFS(filesCopy)
-			assert.NilError(t, service.OnWatchedFilesChanged([]*lsproto.FileEvent{
+			assert.NilError(t, service.OnWatchedFilesChanged(t.Context(), []*lsproto.FileEvent{
 				{
 					Type: lsproto.FileChangeTypeCreated,
 					Uri:  "file:///home/projects/TS/p1/src/a.ts",

--- a/internal/project/watch.go
+++ b/internal/project/watch.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"context"
 	"slices"
 
 	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
@@ -29,7 +30,7 @@ func newWatchedFiles[T any](client Client, watchKind lsproto.WatchKind, getGlobs
 	}
 }
 
-func (w *watchedFiles[T]) update(newData T) (updated bool, err error) {
+func (w *watchedFiles[T]) update(ctx context.Context, newData T) (updated bool, err error) {
 	newGlobs := w.getGlobs(newData)
 	w.data = newData
 	if slices.Equal(w.globs, newGlobs) {
@@ -38,7 +39,7 @@ func (w *watchedFiles[T]) update(newData T) (updated bool, err error) {
 
 	w.globs = newGlobs
 	if w.watcherID != "" {
-		if err = w.client.UnwatchFiles(w.watcherID); err != nil {
+		if err = w.client.UnwatchFiles(ctx, w.watcherID); err != nil {
 			return false, err
 		}
 	}
@@ -52,7 +53,7 @@ func (w *watchedFiles[T]) update(newData T) (updated bool, err error) {
 			Kind: &w.watchKind,
 		})
 	}
-	watcherID, err := w.client.WatchFiles(watchers)
+	watcherID, err := w.client.WatchFiles(ctx, watchers)
 	if err != nil {
 		return false, err
 	}

--- a/internal/testrunner/compiler_runner.go
+++ b/internal/testrunner/compiler_runner.go
@@ -455,7 +455,9 @@ func createHarnessTestFile(unit *testUnit, currentDirectory string) *harnessutil
 
 func (c *compilerTest) verifyUnionOrdering(t *testing.T) {
 	t.Run("union ordering", func(t *testing.T) {
-		for _, c := range c.result.Program.GetTypeCheckers() {
+		checkers, done := c.result.Program.GetTypeCheckers(t.Context())
+		defer done()
+		for _, c := range checkers {
 			for union := range c.UnionTypes() {
 				types := union.Types()
 

--- a/internal/testutil/harnessutil/harnessutil.go
+++ b/internal/testutil/harnessutil/harnessutil.go
@@ -537,11 +537,12 @@ func compileFilesWithHost(
 	//         ...ts.filter(longerErrors!, p => !ts.some(shorterErrors, p2 => ts.compareDiagnostics(p, p2) === ts.Comparison.EqualTo)),
 	//     ),
 	// ] : postErrors;
+	ctx := context.Background()
 	program := createProgram(host, options, rootFiles)
 	var diagnostics []*ast.Diagnostic
-	diagnostics = append(diagnostics, program.GetSyntacticDiagnostics(context.Background(), nil)...)
-	diagnostics = append(diagnostics, program.GetSemanticDiagnostics(context.Background(), nil)...)
-	diagnostics = append(diagnostics, program.GetGlobalDiagnostics()...)
+	diagnostics = append(diagnostics, program.GetSyntacticDiagnostics(ctx, nil)...)
+	diagnostics = append(diagnostics, program.GetSemanticDiagnostics(ctx, nil)...)
+	diagnostics = append(diagnostics, program.GetGlobalDiagnostics(ctx)...)
 	emitResult := program.Emit(compiler.EmitOptions{})
 
 	return newCompilationResult(options, program, emitResult, diagnostics, harnessOptions)

--- a/internal/testutil/lstestutil/lstestutil.go
+++ b/internal/testutil/lstestutil/lstestutil.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/microsoft/typescript-go/internal/core"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
 )
 
 type markerRange struct {
@@ -15,9 +16,10 @@ type markerRange struct {
 }
 
 type Marker struct {
-	Filename string
-	Position int
-	Name     string
+	Filename   string
+	Position   int
+	LSPosition lsproto.Position
+	Name       string
 }
 
 type TestData struct {
@@ -174,7 +176,11 @@ func recordMarker(
 	marker := &Marker{
 		Filename: filename,
 		Position: location.position,
-		Name:     name,
+		LSPosition: lsproto.Position{
+			Line:      uint32(location.sourceLine - 1),
+			Character: uint32(location.sourceColumn - 1),
+		},
+		Name: name,
 	}
 	// Verify markers for uniqueness
 	if _, ok := markerMap[name]; ok {

--- a/internal/testutil/projecttestutil/clientmock_generated.go
+++ b/internal/testutil/projecttestutil/clientmock_generated.go
@@ -4,6 +4,7 @@
 package projecttestutil
 
 import (
+	"context"
 	"sync"
 
 	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
@@ -20,13 +21,13 @@ var _ project.Client = &ClientMock{}
 //
 //		// make and configure a mocked project.Client
 //		mockedClient := &ClientMock{
-//			RefreshDiagnosticsFunc: func() error {
+//			RefreshDiagnosticsFunc: func(ctx context.Context) error {
 //				panic("mock out the RefreshDiagnostics method")
 //			},
-//			UnwatchFilesFunc: func(handle project.WatcherHandle) error {
+//			UnwatchFilesFunc: func(ctx context.Context, handle project.WatcherHandle) error {
 //				panic("mock out the UnwatchFiles method")
 //			},
-//			WatchFilesFunc: func(watchers []*lsproto.FileSystemWatcher) (project.WatcherHandle, error) {
+//			WatchFilesFunc: func(ctx context.Context, watchers []*lsproto.FileSystemWatcher) (project.WatcherHandle, error) {
 //				panic("mock out the WatchFiles method")
 //			},
 //		}
@@ -37,26 +38,32 @@ var _ project.Client = &ClientMock{}
 //	}
 type ClientMock struct {
 	// RefreshDiagnosticsFunc mocks the RefreshDiagnostics method.
-	RefreshDiagnosticsFunc func() error
+	RefreshDiagnosticsFunc func(ctx context.Context) error
 
 	// UnwatchFilesFunc mocks the UnwatchFiles method.
-	UnwatchFilesFunc func(handle project.WatcherHandle) error
+	UnwatchFilesFunc func(ctx context.Context, handle project.WatcherHandle) error
 
 	// WatchFilesFunc mocks the WatchFiles method.
-	WatchFilesFunc func(watchers []*lsproto.FileSystemWatcher) (project.WatcherHandle, error)
+	WatchFilesFunc func(ctx context.Context, watchers []*lsproto.FileSystemWatcher) (project.WatcherHandle, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
 		// RefreshDiagnostics holds details about calls to the RefreshDiagnostics method.
 		RefreshDiagnostics []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
 		}
 		// UnwatchFiles holds details about calls to the UnwatchFiles method.
 		UnwatchFiles []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
 			// Handle is the handle argument value.
 			Handle project.WatcherHandle
 		}
 		// WatchFiles holds details about calls to the WatchFiles method.
 		WatchFiles []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
 			// Watchers is the watchers argument value.
 			Watchers []*lsproto.FileSystemWatcher
 		}
@@ -67,9 +74,12 @@ type ClientMock struct {
 }
 
 // RefreshDiagnostics calls RefreshDiagnosticsFunc.
-func (mock *ClientMock) RefreshDiagnostics() error {
+func (mock *ClientMock) RefreshDiagnostics(ctx context.Context) error {
 	callInfo := struct {
-	}{}
+		Ctx context.Context
+	}{
+		Ctx: ctx,
+	}
 	mock.lockRefreshDiagnostics.Lock()
 	mock.calls.RefreshDiagnostics = append(mock.calls.RefreshDiagnostics, callInfo)
 	mock.lockRefreshDiagnostics.Unlock()
@@ -79,7 +89,7 @@ func (mock *ClientMock) RefreshDiagnostics() error {
 		)
 		return errOut
 	}
-	return mock.RefreshDiagnosticsFunc()
+	return mock.RefreshDiagnosticsFunc(ctx)
 }
 
 // RefreshDiagnosticsCalls gets all the calls that were made to RefreshDiagnostics.
@@ -87,8 +97,10 @@ func (mock *ClientMock) RefreshDiagnostics() error {
 //
 //	len(mockedClient.RefreshDiagnosticsCalls())
 func (mock *ClientMock) RefreshDiagnosticsCalls() []struct {
+	Ctx context.Context
 } {
 	var calls []struct {
+		Ctx context.Context
 	}
 	mock.lockRefreshDiagnostics.RLock()
 	calls = mock.calls.RefreshDiagnostics
@@ -97,10 +109,12 @@ func (mock *ClientMock) RefreshDiagnosticsCalls() []struct {
 }
 
 // UnwatchFiles calls UnwatchFilesFunc.
-func (mock *ClientMock) UnwatchFiles(handle project.WatcherHandle) error {
+func (mock *ClientMock) UnwatchFiles(ctx context.Context, handle project.WatcherHandle) error {
 	callInfo := struct {
+		Ctx    context.Context
 		Handle project.WatcherHandle
 	}{
+		Ctx:    ctx,
 		Handle: handle,
 	}
 	mock.lockUnwatchFiles.Lock()
@@ -112,7 +126,7 @@ func (mock *ClientMock) UnwatchFiles(handle project.WatcherHandle) error {
 		)
 		return errOut
 	}
-	return mock.UnwatchFilesFunc(handle)
+	return mock.UnwatchFilesFunc(ctx, handle)
 }
 
 // UnwatchFilesCalls gets all the calls that were made to UnwatchFiles.
@@ -120,9 +134,11 @@ func (mock *ClientMock) UnwatchFiles(handle project.WatcherHandle) error {
 //
 //	len(mockedClient.UnwatchFilesCalls())
 func (mock *ClientMock) UnwatchFilesCalls() []struct {
+	Ctx    context.Context
 	Handle project.WatcherHandle
 } {
 	var calls []struct {
+		Ctx    context.Context
 		Handle project.WatcherHandle
 	}
 	mock.lockUnwatchFiles.RLock()
@@ -132,10 +148,12 @@ func (mock *ClientMock) UnwatchFilesCalls() []struct {
 }
 
 // WatchFiles calls WatchFilesFunc.
-func (mock *ClientMock) WatchFiles(watchers []*lsproto.FileSystemWatcher) (project.WatcherHandle, error) {
+func (mock *ClientMock) WatchFiles(ctx context.Context, watchers []*lsproto.FileSystemWatcher) (project.WatcherHandle, error) {
 	callInfo := struct {
+		Ctx      context.Context
 		Watchers []*lsproto.FileSystemWatcher
 	}{
+		Ctx:      ctx,
 		Watchers: watchers,
 	}
 	mock.lockWatchFiles.Lock()
@@ -148,7 +166,7 @@ func (mock *ClientMock) WatchFiles(watchers []*lsproto.FileSystemWatcher) (proje
 		)
 		return watcherHandleOut, errOut
 	}
-	return mock.WatchFilesFunc(watchers)
+	return mock.WatchFilesFunc(ctx, watchers)
 }
 
 // WatchFilesCalls gets all the calls that were made to WatchFiles.
@@ -156,9 +174,11 @@ func (mock *ClientMock) WatchFiles(watchers []*lsproto.FileSystemWatcher) (proje
 //
 //	len(mockedClient.WatchFilesCalls())
 func (mock *ClientMock) WatchFilesCalls() []struct {
+	Ctx      context.Context
 	Watchers []*lsproto.FileSystemWatcher
 } {
 	var calls []struct {
+		Ctx      context.Context
 		Watchers []*lsproto.FileSystemWatcher
 	}
 	mock.lockWatchFiles.RLock()

--- a/internal/testutil/projecttestutil/projecttestutil.go
+++ b/internal/testutil/projecttestutil/projecttestutil.go
@@ -1,12 +1,14 @@
 package projecttestutil
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
 	"sync"
 
 	"github.com/microsoft/typescript-go/internal/bundled"
+	"github.com/microsoft/typescript-go/internal/core"
 	"github.com/microsoft/typescript-go/internal/project"
 	"github.com/microsoft/typescript-go/internal/vfs"
 	"github.com/microsoft/typescript-go/internal/vfs/vfstest"
@@ -79,4 +81,8 @@ func newProjectServiceHost(files map[string]string) *ProjectServiceHost {
 	}
 	host.logger = project.NewLogger([]io.Writer{&host.output}, "", project.LogLevelVerbose)
 	return host
+}
+
+func WithRequestID(ctx context.Context) context.Context {
+	return core.WithRequestID(ctx, "0")
 }


### PR DESCRIPTION
This PR asyncifies the LSP serve and enables parallel execution of requests.

At the top level, one goroutine reads and parses messages from STDIN and puts them onto a queue to be handled. Another pulls from that queue and dispatches them to the project service, and puts the response objects onto another queue. A third goroutine pulls the response messages and writes them to STDOUT.

The dispatcher categorizes requests into ones that modify state and ones that only query the existing state. The former are handled synchronously within the dispatcher goroutine, while the latter are spun off into their own goroutines so they can execute in parallel.

Executing multiple requests in parallel agains the same program introduces two challenges:

1. Type checkers are not concurrency safe, so each request needs to use a different one. Further, a request must always get the _same_ checker if it asks the Program for one at two different times. For this, I’ve introduced a `CheckerPool` interface whose methods for getting a checker take a `context.Context` and return an available checker, along with a function to return it to the pool when done. The implementation in `compiler` used for `tsc` is just the logic that was already built into Program, while the implementation in `project` creates checkers dynamically and tracks which ones are in use by which requests.
2. The text content of files the request handler inspects must be consistent over the duration of the request. Previously, line/character positions were converted to and from absolute positions in the server layer by looking at the text storage layer owned by the project system, which is mutable over time. With this PR, I’ve made all the LanguageService methods accept and return `lsproto` types (which are exclusively line/character) so all the conversions have to happen in that layer. Then, I removed LanguageService’s ability to access any mutable state (basically). When it asks for the line map of a file, its host attempts to pull the cached one from the text storage layer only if the versions match. Otherwise, the text storage has been updated by another request, and the line map for the old version is computed on demand from the SourceFile text, which is immutable.