### PR TITLE
Check patterns for validity before putting them into pattern ambient modules

### DIFF
--- a/internal/binder/binder.go
+++ b/internal/binder/binder.go
@@ -806,7 +806,7 @@ func (b *Binder) bindModuleDeclaration(node *ast.Node) {
 				}
 			}
 			symbol := b.declareSymbolAndAddToSymbolTable(node, ast.SymbolFlagsValueModule, ast.SymbolFlagsValueModuleExcludes)
-			if pattern.StarIndex >= 0 {
+			if pattern.IsValid() && pattern.StarIndex >= 0 {
 				b.file.PatternAmbientModules = append(b.file.PatternAmbientModules, &ast.PatternAmbientModule{Pattern: pattern, Symbol: symbol})
 			}
 		}

--- a/internal/core/pattern.go
+++ b/internal/core/pattern.go
@@ -43,9 +43,6 @@ func FindBestPatternMatch[T any](values []T, getPattern func(v T) Pattern, candi
 	longestMatchPrefixLength := -1
 	for _, value := range values {
 		pattern := getPattern(value)
-		if !pattern.IsValid() {
-			continue
-		}
 		if (pattern.StarIndex == -1 || pattern.StarIndex > longestMatchPrefixLength) && pattern.Matches(candidate) {
 			bestPattern = value
 			longestMatchPrefixLength = pattern.StarIndex

--- a/internal/core/pattern.go
+++ b/internal/core/pattern.go
@@ -43,6 +43,9 @@ func FindBestPatternMatch[T any](values []T, getPattern func(v T) Pattern, candi
 	longestMatchPrefixLength := -1
 	for _, value := range values {
 		pattern := getPattern(value)
+		if !pattern.IsValid() {
+			continue
+		}
 		if (pattern.StarIndex == -1 || pattern.StarIndex > longestMatchPrefixLength) && pattern.Matches(candidate) {
 			bestPattern = value
 			longestMatchPrefixLength = pattern.StarIndex

--- a/testdata/baselines/reference/compiler/invalidGlobalAugmentation.errors.txt
+++ b/testdata/baselines/reference/compiler/invalidGlobalAugmentation.errors.txt
@@ -1,0 +1,19 @@
+globals.ts(1,9): error TS2669: Augmentations for the global scope can only be directly nested in external modules or ambient module declarations.
+react-native.ts(2,16): error TS2664: Invalid module name in augmentation, module 'react-native' cannot be found.
+
+
+==== globals.ts (1 errors) ====
+    declare global {
+            ~~~~~~
+!!! error TS2669: Augmentations for the global scope can only be directly nested in external modules or ambient module declarations.
+      const __FOO__: any;
+    }
+    
+==== react-native.ts (1 errors) ====
+    export {}
+    declare module "react-native" {
+                   ~~~~~~~~~~~~~~
+!!! error TS2664: Invalid module name in augmentation, module 'react-native' cannot be found.
+      const __FOO__: any;
+    }
+    

--- a/testdata/tests/cases/compiler/invalidGlobalAugmentation.ts
+++ b/testdata/tests/cases/compiler/invalidGlobalAugmentation.ts
@@ -1,0 +1,13 @@
+// @noTypesAndSymbols: true
+// @noEmit: true
+
+// @Filename: globals.ts
+declare global {
+  const __FOO__: any;
+}
+
+// @Filename: react-native.ts
+export {}
+declare module "react-native" {
+  const __FOO__: any;
+}


### PR DESCRIPTION
Fixes #870

~~Global augmentations are stored as pattern ambient modules with zeroed patterns.~~ Invalid global augmentations were falling through binder cases and getting put into pattern ambient modules, when they should have been skipped.