### PR TITLE
fix: avoid treating await in jsdoc as top-level await

### DIFF
--- a/internal/parser/jsdoc.go
+++ b/internal/parser/jsdoc.go
@@ -129,6 +129,7 @@ func (p *Parser) parseJSDocComment(parent *ast.Node, start int, end int, fullSta
 	saveScannerState := p.scanner.Mark()
 	saveDiagnosticsLength := len(p.diagnostics)
 	saveHasParseError := p.hasParseError
+	saveHasAwaitIdentifier := p.statementHasAwaitIdentifier
 
 	// initial indent is start+4 to account for leading `/** `
 	// + 1 because \n is one character before the first character in the line and,
@@ -158,6 +159,7 @@ func (p *Parser) parseJSDocComment(parent *ast.Node, start int, end int, fullSta
 	p.scanner.Rewind(saveScannerState)
 	p.token = saveToken
 	p.hasParseError = saveHasParseError
+	p.statementHasAwaitIdentifier = saveHasAwaitIdentifier
 
 	return comment
 }

--- a/testdata/baselines/reference/conformance/jsdocParseAwait.errors.txt
+++ b/testdata/baselines/reference/conformance/jsdocParseAwait.errors.txt
@@ -1,0 +1,24 @@
+/a.js(7,7): error TS2322: Type 'number' is not assignable to type 'T'.
+
+
+==== /a.js (1 errors) ====
+    /**
+     * @typedef {object} T
+     * @property {boolean} await
+     */
+    
+    /** @type {T} */
+    const a = 1;
+          ~
+!!! error TS2322: Type 'number' is not assignable to type 'T'.
+    
+    /** @type {T} */
+    const b = {
+        await: false,
+    };
+    
+    /**
+     * @param {boolean} await
+     */
+    function c(await) {}
+    

--- a/testdata/baselines/reference/conformance/jsdocParseAwait.symbols
+++ b/testdata/baselines/reference/conformance/jsdocParseAwait.symbols
@@ -1,0 +1,28 @@
+//// [tests/cases/conformance/jsdoc/jsdocParseAwait.ts] ////
+
+=== /a.js ===
+/**
+ * @typedef {object} T
+ * @property {boolean} await
+ */
+
+/** @type {T} */
+const a = 1;
+>a : Symbol(a, Decl(a.js, 6, 5))
+
+/** @type {T} */
+const b = {
+>b : Symbol(b, Decl(a.js, 9, 5))
+
+    await: false,
+>await : Symbol(await, Decl(a.js, 9, 11))
+
+};
+
+/**
+ * @param {boolean} await
+ */
+function c(await) {}
+>c : Symbol(c, Decl(a.js, 11, 2))
+>await : Symbol(await, Decl(a.js, 16, 11))
+

--- a/testdata/baselines/reference/conformance/jsdocParseAwait.types
+++ b/testdata/baselines/reference/conformance/jsdocParseAwait.types
@@ -1,0 +1,31 @@
+//// [tests/cases/conformance/jsdoc/jsdocParseAwait.ts] ////
+
+=== /a.js ===
+/**
+ * @typedef {object} T
+ * @property {boolean} await
+ */
+
+/** @type {T} */
+const a = 1;
+>a : T
+>1 : 1
+
+/** @type {T} */
+const b = {
+>b : T
+>{    await: false,} : { await: boolean; }
+
+    await: false,
+>await : boolean
+>false : false
+
+};
+
+/**
+ * @param {boolean} await
+ */
+function c(await) {}
+>c : (await: boolean) => void
+>await : boolean
+

--- a/testdata/tests/cases/conformance/jsdoc/jsdocParseAwait.ts
+++ b/testdata/tests/cases/conformance/jsdoc/jsdocParseAwait.ts
@@ -1,0 +1,23 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+
+// @Filename: /a.js
+
+/**
+ * @typedef {object} T
+ * @property {boolean} await
+ */
+
+/** @type {T} */
+const a = 1;
+
+/** @type {T} */
+const b = {
+    await: false,
+};
+
+/**
+ * @param {boolean} await
+ */
+function c(await) {}


### PR DESCRIPTION
Fixes #874

---

`parseJSDocIdentifierName` uses `newIdentifier`, which may flag `await` identifier as a top-level declaration. @sandersn should this be suppressed when parsing JSDoc?

https://github.com/microsoft/typescript-go/blob/cab7a0bf793f3ba0e83619798f2eb191673fe4c7/internal/parser/jsdoc.go#L1253

https://github.com/microsoft/typescript-go/blob/cab7a0bf793f3ba0e83619798f2eb191673fe4c7/internal/parser/parser.go#L2860-L2867