### PR TITLE
Create consistency with vanilla TS on canEmitSimpleArrowHead

### DIFF
--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -1497,8 +1497,9 @@ func canEmitSimpleArrowHead(parentNode *ast.Node, parameters *ast.ParameterList)
 	return parameter.Pos() == greatestEnd(parent.Pos(), parent.Modifiers()) && // may not have parsed tokens between modifiers/start of parent and parameter
 		parent.TypeParameters == nil && // parent may not have type parameters
 		parent.Type == nil && // parent may not have return type annotation
+		parent.Modifiers() == nil && // parent/children may not have decorators or modifiers
+		parameter.Modifiers() == nil &&
 		!parameters.HasTrailingComma() && // parameters may not have a trailing comma
-		parameter.Modifiers() == nil && // parameter may not have decorators or modifiers
 		parameter.DotDotDotToken == nil && // parameter may not be rest
 		parameter.QuestionToken == nil && // parameter may not be optional
 		parameter.Type == nil && // parameter may not have a type annotation


### PR DESCRIPTION
I'm doing some regression testing against Typescript Go for emitted javascript, I'm noticing little nuances that are creating differences in emitted output. This is one of those cases.

The logic for `canEmitSimpleArrowHead` is slightly different where Typescript 5.8 considers whether the parent has modifiers (like `async`) whereas the Go implementation did not

https://github.com/microsoft/TypeScript/blob/83dc0bb2ed91fe0815ab28dc3ff95fae7425e413/src/compiler/emitter.ts#L4597-L4611
```typescript
function canEmitSimpleArrowHead(parentNode: FunctionTypeNode | ConstructorTypeNode | ArrowFunction, parameters: NodeArray<ParameterDeclaration>) {
        const parameter = singleOrUndefined(parameters);
        return parameter
            && parameter.pos === parentNode.pos // may not have parsed tokens between parent and parameter
            && isArrowFunction(parentNode) // only arrow functions may have simple arrow head
            && !parentNode.type // arrow function may not have return type annotation
            && !some(parentNode.modifiers) // parent may not have decorators or modifiers
            && !some(parentNode.typeParameters) // parent may not have type parameters
            && !some(parameter.modifiers) // parameter may not have decorators or modifiers
            && !parameter.dotDotDotToken // parameter may not be rest
            && !parameter.questionToken // parameter may not be optional
            && !parameter.type // parameter may not have a type annotation
            && !parameter.initializer // parameter may not have an initializer
            && isIdentifier(parameter.name); // parameter name must be identifier
    }
```