### PR TITLE
Introduce fast path for program updates in language service

### DIFF
--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -219,25 +219,29 @@ func canReplaceFileInProgram(file1 *ast.SourceFile, file2 *ast.SourceFile) bool 
 		file1.IsDeclarationFile == file2.IsDeclarationFile &&
 		file1.HasNoDefaultLib == file2.HasNoDefaultLib &&
 		file1.UsesUriStyleNodeCoreModules == file2.UsesUriStyleNodeCoreModules &&
-		slices.EqualFunc(file1.Imports, file2.Imports, compareImports) &&
-		slices.EqualFunc(file1.ModuleAugmentations, file2.ModuleAugmentations, compareModuleAugmentations) &&
+		slices.EqualFunc(file1.Imports, file2.Imports, equalModuleSpecifiers) &&
+		slices.EqualFunc(file1.ModuleAugmentations, file2.ModuleAugmentations, equalModuleAugmentationNames) &&
 		slices.Equal(file1.AmbientModuleNames, file2.AmbientModuleNames) &&
-		slices.EqualFunc(file1.ReferencedFiles, file2.ReferencedFiles, compareFileReferences) &&
-		slices.EqualFunc(file1.TypeReferenceDirectives, file2.TypeReferenceDirectives, compareFileReferences) &&
-		slices.EqualFunc(file1.LibReferenceDirectives, file2.LibReferenceDirectives, compareFileReferences) &&
-		file1.CheckJsDirective == file2.CheckJsDirective
+		slices.EqualFunc(file1.ReferencedFiles, file2.ReferencedFiles, equalFileReferences) &&
+		slices.EqualFunc(file1.TypeReferenceDirectives, file2.TypeReferenceDirectives, equalFileReferences) &&
+		slices.EqualFunc(file1.LibReferenceDirectives, file2.LibReferenceDirectives, equalFileReferences) &&
+		equalCheckJSDirectives(file1.CheckJsDirective, file2.CheckJsDirective)
 }
 
-func compareImports(n1 *ast.Node, n2 *ast.Node) bool {
+func equalModuleSpecifiers(n1 *ast.Node, n2 *ast.Node) bool {
 	return n1.Kind == n2.Kind && (!ast.IsStringLiteral(n1) || n1.Text() == n2.Text())
 }
 
-func compareModuleAugmentations(n1 *ast.Node, n2 *ast.Node) bool {
+func equalModuleAugmentationNames(n1 *ast.Node, n2 *ast.Node) bool {
 	return n1.Kind == n2.Kind && n1.Text() == n2.Text()
 }
 
-func compareFileReferences(f1 *ast.FileReference, f2 *ast.FileReference) bool {
+func equalFileReferences(f1 *ast.FileReference, f2 *ast.FileReference) bool {
 	return f1.FileName == f2.FileName && f1.ResolutionMode == f2.ResolutionMode && f1.Preserve == f2.Preserve
+}
+
+func equalCheckJSDirectives(d1 *ast.CheckJsDirective, d2 *ast.CheckJsDirective) bool {
+	return d1 == nil && d2 == nil || d1 != nil && d2 != nil && d1.Enabled == d2.Enabled
 }
 
 func NewProgramFromParsedCommandLine(config *tsoptions.ParsedCommandLine, host CompilerHost) *Program {

--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -210,22 +210,22 @@ func (p *Program) initCheckerPool() {
 	}
 }
 
-func canReplaceFileInProgram(old *ast.SourceFile, new *ast.SourceFile) bool {
-	return old.FileName() == new.FileName() &&
-		old.Path() == new.Path() &&
-		old.LanguageVersion == new.LanguageVersion &&
-		old.LanguageVariant == new.LanguageVariant &&
-		old.ScriptKind == new.ScriptKind &&
-		old.IsDeclarationFile == new.IsDeclarationFile &&
-		old.HasNoDefaultLib == new.HasNoDefaultLib &&
-		old.UsesUriStyleNodeCoreModules == new.UsesUriStyleNodeCoreModules &&
-		slices.EqualFunc(old.Imports, new.Imports, compareImports) &&
-		slices.EqualFunc(old.ModuleAugmentations, new.ModuleAugmentations, compareModuleAugmentations) &&
-		slices.Equal(old.AmbientModuleNames, new.AmbientModuleNames) &&
-		slices.EqualFunc(old.ReferencedFiles, new.ReferencedFiles, compareFileReferences) &&
-		slices.EqualFunc(old.TypeReferenceDirectives, new.TypeReferenceDirectives, compareFileReferences) &&
-		slices.EqualFunc(old.LibReferenceDirectives, new.LibReferenceDirectives, compareFileReferences) &&
-		old.CheckJsDirective == new.CheckJsDirective
+func canReplaceFileInProgram(file1 *ast.SourceFile, file2 *ast.SourceFile) bool {
+	return file1.FileName() == file2.FileName() &&
+		file1.Path() == file2.Path() &&
+		file1.LanguageVersion == file2.LanguageVersion &&
+		file1.LanguageVariant == file2.LanguageVariant &&
+		file1.ScriptKind == file2.ScriptKind &&
+		file1.IsDeclarationFile == file2.IsDeclarationFile &&
+		file1.HasNoDefaultLib == file2.HasNoDefaultLib &&
+		file1.UsesUriStyleNodeCoreModules == file2.UsesUriStyleNodeCoreModules &&
+		slices.EqualFunc(file1.Imports, file2.Imports, compareImports) &&
+		slices.EqualFunc(file1.ModuleAugmentations, file2.ModuleAugmentations, compareModuleAugmentations) &&
+		slices.Equal(file1.AmbientModuleNames, file2.AmbientModuleNames) &&
+		slices.EqualFunc(file1.ReferencedFiles, file2.ReferencedFiles, compareFileReferences) &&
+		slices.EqualFunc(file1.TypeReferenceDirectives, file2.TypeReferenceDirectives, compareFileReferences) &&
+		slices.EqualFunc(file1.LibReferenceDirectives, file2.LibReferenceDirectives, compareFileReferences) &&
+		file1.CheckJsDirective == file2.CheckJsDirective
 }
 
 func compareImports(n1 *ast.Node, n2 *ast.Node) bool {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -440,7 +440,7 @@ func (p *Project) updateGraph() bool {
 
 	p.hasAddedOrRemovedFiles = false
 	p.hasAddedOrRemovedSymlinks = false
-	p.updateProgram()
+	oldProgramReused := p.updateProgram()
 	p.dirty = false
 	p.dirtyFilePath = ""
 	p.log(fmt.Sprintf("Finishing updateGraph: Project: %s version: %d", p.name, p.version))
@@ -449,25 +449,26 @@ func (p *Project) updateGraph() bool {
 	} else if p.program != oldProgram {
 		p.log("Different program with same set of files")
 	}
-
-	if p.program != oldProgram && oldProgram != nil {
-		for _, oldSourceFile := range oldProgram.GetSourceFiles() {
-			if p.program.GetSourceFileByPath(oldSourceFile.Path()) == nil {
-				p.host.DocumentRegistry().ReleaseDocument(oldSourceFile, oldProgram.GetCompilerOptions())
+	if !oldProgramReused {
+		if oldProgram != nil {
+			for _, oldSourceFile := range oldProgram.GetSourceFiles() {
+				if p.program.GetSourceFileByPath(oldSourceFile.Path()) == nil {
+					p.host.DocumentRegistry().ReleaseDocument(oldSourceFile, oldProgram.GetCompilerOptions())
+				}
 			}
 		}
+		// TODO: this is currently always synchronously called by some kind of updating request,
+		// but in Strada we throttle, so at least sometimes this should be considered top-level?
+		p.updateWatchers(context.TODO())
 	}
-
-	// TODO: this is currently always synchronously called by some kind of updating request,
-	// but in Strada we throttle, so at least sometimes this should be considered top-level?
-	p.updateWatchers(context.TODO())
 	return true
 }
 
-func (p *Project) updateProgram() {
+func (p *Project) updateProgram() bool {
 	if p.checkerPool != nil {
 		p.logf("Program %d used %d checker(s)", p.version, p.checkerPool.size())
 	}
+	var oldProgramReused bool
 	if p.program == nil || p.dirtyFilePath == "" {
 		rootFileNames := p.GetRootFileNames()
 		compilerOptions := p.compilerOptions
@@ -483,9 +484,10 @@ func (p *Project) updateProgram() {
 	} else {
 		// The only change in the current program is the contents of the file named by p.dirtyFilePath.
 		// If possible, use data from the old program to create the new program.
-		p.program = compiler.NewProgramWithChangedFile(p.program, p.dirtyFilePath)
+		p.program, oldProgramReused = p.program.UpdateProgram(p.dirtyFilePath)
 	}
 	p.program.BindSourceFiles()
+	return oldProgramReused
 }
 
 func (p *Project) isOrphan() bool {


### PR DESCRIPTION
This PR introduces a fast path for program updates in the language service. When only a single file has been modified and none of the changes impact the program's structure, we create a new program by just cloning the existing program and replacing the single file. This dramatically improves responsiveness in the typical path of typing in a file.