### PR TITLE
feat: display goos & goarch

### DIFF
--- a/internal/execute/outputs.go
+++ b/internal/execute/outputs.go
@@ -95,7 +95,7 @@ func reportStatistics(sys System, program *compiler.Program, result compileAndEm
 }
 
 func printVersion(sys System) {
-	fmt.Fprint(sys.Writer(), diagnostics.Version_0.Format(core.Version)+sys.NewLine())
+	fmt.Fprint(sys.Writer(), diagnostics.Version_0.Format(core.Version)+" "+runtime.GOOS+"/"+runtime.GOARCH+sys.NewLine())
 	sys.EndWrite()
 }
 
@@ -158,7 +158,7 @@ func printEasyHelp(sys System, simpleOptions []*tsoptions.CommandLineOption) {
 		output = append(output, "  ", desc.Format(), sys.NewLine(), sys.NewLine())
 	}
 
-	msg := diagnostics.X_tsc_Colon_The_TypeScript_Compiler.Format() + " - " + diagnostics.Version_0.Format(core.Version)
+	msg := diagnostics.X_tsc_Colon_The_TypeScript_Compiler.Format() + " - " + diagnostics.Version_0.Format(core.Version) + " - " + runtime.GOOS + "/" + runtime.GOARCH
 	output = append(output, getHeader(sys, msg)...)
 
 	output = append(output /*colors.bold(*/, diagnostics.COMMON_COMMANDS.Format() /*)*/, sys.NewLine(), sys.NewLine())


### PR DESCRIPTION
Since the build of TypeScript Go depends on the operating system and CPU architecture, it also outputs `GOOS` and `GOARCH` accordingly.

```
❯ tsc -v
Version 7.0.0-dev darwin/arm64

❯ tsc -h
tsc: The TypeScript Compiler - Version 7.0.0-dev - darwin/arm64
...
```

