### PR TITLE
Prepare VS Code extension for marketplace preview

### DIFF
--- a/_extension/package.json
+++ b/_extension/package.json
@@ -29,9 +29,9 @@
     "contributes": {
         "configuration": [
             {
-                "title": "TypeScript Go",
+                "title": "TypeScript Native Preview",
                 "properties": {
-                    "typescript-go.trace.server": {
+                    "typescript.native-preview.trace.server": {
                         "type": "string",
                         "enum": [
                             "off",
@@ -39,34 +39,54 @@
                             "verbose"
                         ],
                         "default": "verbose",
-                        "description": "Trace TypeScript Go server communication."
+                        "description": "Trace TypeScript Go server communication.",
+                        "tags": ["experimental"]
                     },
-                    "typescript-go.pprofDir": {
+                    "typescript.native-preview.pprofDir": {
                         "type": "string",
-                        "description": "Directory to write pprof profiles to."
+                        "description": "Directory to write pprof profiles to.",
+                        "tags": ["experimental"]
                     },
-                    "typescript-go.executablePath": {
+                    "typescript.native-preview.tsdk": {
                         "type": "string",
-                        "description": "Path to the tsgo binary. If not specified, the extension will look for it in the default location."
+                        "description": "Path to the @typescript/native-preview package or tsgo binary directory. If not specified, the extension will look for it in the default location.",
+                        "tags": ["experimental"]
                     }
                 }
             }
         ],
         "commands": [
             {
-                "command": "typescript-go.restart",
-                "title": "TypeScript Go: Restart Language Server",
-                "enablement": "typescript-go.serverRunning"
+                "command": "typescript.native-preview.enable",
+                "title": "Enable (Experimental)",
+                "enablement": "!typescript.native-preview.serverRunning",
+                "category": "TypeScript Native Preview"
+            },
+            {
+                "command": "typescript.native-preview.disable",
+                "title": "Disable",
+                "enablement": "typescript.native-preview.serverRunning",
+                "category": "TypeScript Native Preview"
+            },
+            {
+                "command": "typescript.native-preview.restart",
+                "title": "Restart Language Server",
+                "enablement": "typescript.native-preview.serverRunning",
+                "category": "TypeScript Native Preview"
+            },
+            {
+                "command": "typescript.native-preview.output.focus",
+                "title": "Show Output",
+                "enablement": "typescript.native-preview.serverRunning",
+                "category": "TypeScript Native Preview"
+            },
+            {
+                "command": "typescript.native-preview.lsp-trace.focus",
+                "title": "Show LSP Trace",
+                "enablement": "typescript.native-preview.serverRunning",
+                "category": "TypeScript Native Preview"
             }
-        ],
-        "menus": {
-            "commandPalette": [
-                {
-                    "command": "typescript-go.restart",
-                    "when": "typescript-go.serverRunning"
-                }
-            ]
-        }
+        ]
     },
     "main": "./dist/extension.js",
     "files": [

--- a/_extension/src/client.ts
+++ b/_extension/src/client.ts
@@ -1,0 +1,152 @@
+import * as vscode from "vscode";
+import {
+    LanguageClient,
+    LanguageClientOptions,
+    NotebookDocumentFilter,
+    ServerOptions,
+    TextDocumentFilter,
+    TransportKind,
+} from "vscode-languageclient/node";
+import {
+    ExeInfo,
+    getExe,
+    jsTsLanguageModes,
+} from "./util";
+import { getLanguageForUri } from "./util";
+
+export class Client {
+    private outputChannel: vscode.OutputChannel;
+    private traceOutputChannel: vscode.OutputChannel;
+    private client?: LanguageClient;
+    private exe: ExeInfo | undefined;
+    private onStartedCallbacks: Set<() => void> = new Set();
+
+    constructor(outputChannel: vscode.OutputChannel, traceOutputChannel: vscode.OutputChannel) {
+        this.outputChannel = outputChannel;
+        this.traceOutputChannel = traceOutputChannel;
+    }
+
+    async initialize(context: vscode.ExtensionContext): Promise<void> {
+        const config = vscode.workspace.getConfiguration("typescript.native-preview");
+
+        this.exe = await getExe(context);
+
+        this.outputChannel.appendLine(`Resolved to ${this.exe.path}`);
+
+        // Get pprofDir
+        const pprofDir = config.get<string>("pprofDir");
+        const pprofArgs = pprofDir ? ["--pprofDir", pprofDir] : [];
+
+        const serverOptions: ServerOptions = {
+            run: {
+                command: this.exe.path,
+                args: ["--lsp", ...pprofArgs],
+                transport: TransportKind.stdio,
+            },
+            debug: {
+                command: this.exe.path,
+                args: ["--lsp", ...pprofArgs],
+                transport: TransportKind.stdio,
+            },
+        };
+
+        const clientOptions: LanguageClientOptions = {
+            documentSelector: [
+                ...jsTsLanguageModes.map(language => ({ scheme: "file", language })),
+                ...jsTsLanguageModes.map(language => ({ scheme: "untitled", language })),
+            ],
+            outputChannel: this.outputChannel,
+            traceOutputChannel: this.traceOutputChannel,
+            diagnosticPullOptions: {
+                onChange: true,
+                onSave: true,
+                onTabs: true,
+                match(documentSelector, resource) {
+                    // This function is called when diagnostics are requested but
+                    // only the URI itself is known (e.g. open but not yet focused tabs),
+                    // so will not be present in vscode.workspace.textDocuments.
+                    // See if this file matches without consulting vscode.languages.match
+                    // (which requires a TextDocument).
+
+                    const language = getLanguageForUri(resource);
+
+                    for (const selector of documentSelector) {
+                        if (typeof selector === "string") {
+                            if (selector === language) {
+                                return true;
+                            }
+                            continue;
+                        }
+                        if (NotebookDocumentFilter.is(selector)) {
+                            continue;
+                        }
+                        if (TextDocumentFilter.is(selector)) {
+                            if (selector.language !== undefined && selector.language !== language) {
+                                continue;
+                            }
+
+                            if (selector.scheme !== undefined && selector.scheme !== resource.scheme) {
+                                continue;
+                            }
+
+                            if (selector.pattern !== undefined) {
+                                // VS Code's glob matcher is not available via the API;
+                                // see: https://github.com/microsoft/vscode/issues/237304
+                                // But, we're only called on selectors passed above, so just ignore this for now.
+                                throw new Error("Not implemented");
+                            }
+
+                            return true;
+                        }
+                    }
+
+                    return false;
+                },
+            },
+        };
+
+        this.client = new LanguageClient(
+            "typescript.native-preview",
+            "typescript.native-preview-lsp",
+            serverOptions,
+            clientOptions,
+        );
+
+        this.outputChannel.appendLine(`Starting language server...`);
+        this.client.start();
+        vscode.commands.executeCommand("setContext", "typescript.native-preview.serverRunning", true);
+        this.onStartedCallbacks.forEach(callback => callback());
+        context.subscriptions.push(
+            new vscode.Disposable(() => {
+                if (this.client) {
+                    this.client.stop();
+                }
+                vscode.commands.executeCommand("setContext", "typescript.native-preview.serverRunning", false);
+            }),
+        );
+    }
+
+    getCurrentExe(): { path: string; version: string; } | undefined {
+        return this.exe;
+    }
+
+    onStarted(callback: () => void): vscode.Disposable {
+        if (this.exe) {
+            callback();
+            return new vscode.Disposable(() => {});
+        }
+
+        this.onStartedCallbacks.add(callback);
+        return new vscode.Disposable(() => {
+            this.onStartedCallbacks.delete(callback);
+        });
+    }
+
+    restart(): Thenable<void> {
+        if (!this.client) {
+            return Promise.reject(new Error("Language client is not initialized"));
+        }
+        this.outputChannel.appendLine(`Restarting language server...`);
+        return this.client.restart();
+    }
+}

--- a/_extension/src/commands.ts
+++ b/_extension/src/commands.ts
@@ -35,13 +35,15 @@ export function registerCommands(context: vscode.ExtensionContext, client: Clien
  */
 async function updateUseTsgoSetting(enable: boolean): Promise<void> {
     const tsConfig = vscode.workspace.getConfiguration("typescript");
-    const currentValue = tsConfig.get<boolean>("experimental.useTsgo", false);
-    if (currentValue === enable) {
-        return;
+    let target: vscode.ConfigurationTarget | undefined;
+    const useTsgo = tsConfig.inspect("experimental.useTsgo");
+    if (useTsgo) {
+        target = useTsgo.workspaceFolderValue !== undefined ? vscode.ConfigurationTarget.WorkspaceFolder :
+            useTsgo.workspaceValue !== undefined ? vscode.ConfigurationTarget.Workspace :
+            useTsgo.globalValue !== undefined ? vscode.ConfigurationTarget.Global : undefined;
     }
-
     // Update the setting and restart the extension host (needed to change the state of the built-in TS extension)
-    await tsConfig.update("experimental.useTsgo", enable);
+    await tsConfig.update("experimental.useTsgo", enable, target);
     await vscode.commands.executeCommand("workbench.action.restartExtensionHost");
 }
 

--- a/_extension/src/commands.ts
+++ b/_extension/src/commands.ts
@@ -1,9 +1,5 @@
 import * as vscode from "vscode";
 import { Client } from "./client";
-import {
-    builtinTSExtensionId,
-    getBuiltinExePath,
-} from "./util";
 
 export function registerCommands(context: vscode.ExtensionContext, client: Client, outputChannel: vscode.OutputChannel, traceOutputChannel: vscode.OutputChannel): void {
     context.subscriptions.push(vscode.commands.registerCommand("typescript.native-preview.enable", () => {

--- a/_extension/src/commands.ts
+++ b/_extension/src/commands.ts
@@ -1,0 +1,91 @@
+import * as vscode from "vscode";
+import { Client } from "./client";
+import {
+    builtinTSExtensionId,
+    getBuiltinExePath,
+} from "./util";
+
+export function registerCommands(context: vscode.ExtensionContext, client: Client, outputChannel: vscode.OutputChannel, traceOutputChannel: vscode.OutputChannel): void {
+    context.subscriptions.push(vscode.commands.registerCommand("typescript.native-preview.enable", () => {
+        // Fire and forget, because this will restart the extension host and cause an error if we await
+        updateUseTsgoSetting(context, true);
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand("typescript.native-preview.disable", () => {
+        // Fire and forget, because this will restart the extension host and cause an error if we await
+        updateUseTsgoSetting(context, false);
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand("typescript.native-preview.restart", () => {
+        return client.restart();
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand("typescript.native-preview.output.focus", () => {
+        outputChannel.show();
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand("typescript.native-preview.lsp-trace.focus", () => {
+        traceOutputChannel.show();
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand("typescript.native-preview.selectVersion", async () => {
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand("typescript.native-preview.showMenu", showCommands));
+}
+
+/**
+ * Updates the TypeScript Native Preview setting and reloads extension host.
+ */
+async function updateUseTsgoSetting(context: vscode.ExtensionContext, enable: boolean): Promise<void> {
+    const tsConfig = vscode.workspace.getConfiguration("typescript");
+    const currentValue = tsConfig.get<boolean>("experimental.useTsgo", false);
+    if (currentValue === enable) {
+        return;
+    }
+    if (!enable && context.extensionMode === vscode.ExtensionMode.Development) {
+        await vscode.window.showWarningMessage(
+            "TypeScript Native Preview is running in development mode, and will load even when 'typescript.experimental.useTsgo' is false.",
+        );
+    }
+
+    // Update the setting and restart the extension host (needed to change the state of the built-in TS extension)
+    await tsConfig.update("experimental.useTsgo", enable);
+    await vscode.commands.executeCommand("workbench.action.restartExtensionHost");
+}
+
+/**
+ * Shows the quick pick menu for TypeScript Native Preview commands
+ */
+async function showCommands(): Promise<void> {
+    const commands: readonly { label: string; description: string; command: string; }[] = [
+        {
+            label: "$(refresh) Restart Server",
+            description: "Restart the TypeScript Native Preview language server",
+            command: "typescript.native-preview.restart",
+        },
+        {
+            label: "$(output) Show TS Server Log",
+            description: "Show the TypeScript Native Preview server log",
+            command: "typescript.native-preview.output.focus",
+        },
+        {
+            label: "$(debug-console) Show LSP Messages",
+            description: "Show the LSP communication trace",
+            command: "typescript.native-preview.lsp-trace.focus",
+        },
+        {
+            label: "$(stop-circle) Disable TypeScript Native Preview",
+            description: "Switch back to the built-in TypeScript extension",
+            command: "typescript.native-preview.disable",
+        },
+    ];
+
+    const selected = await vscode.window.showQuickPick(commands, {
+        placeHolder: "TypeScript Native Preview Commands",
+    });
+
+    if (selected) {
+        await vscode.commands.executeCommand(selected.command);
+    }
+}

--- a/_extension/src/commands.ts
+++ b/_extension/src/commands.ts
@@ -4,16 +4,16 @@ import { Client } from "./client";
 export function registerCommands(context: vscode.ExtensionContext, client: Client, outputChannel: vscode.OutputChannel, traceOutputChannel: vscode.OutputChannel): void {
     context.subscriptions.push(vscode.commands.registerCommand("typescript.native-preview.enable", () => {
         // Fire and forget, because this will restart the extension host and cause an error if we await
-        updateUseTsgoSetting(context, true);
+        updateUseTsgoSetting(true);
     }));
 
     context.subscriptions.push(vscode.commands.registerCommand("typescript.native-preview.disable", () => {
         // Fire and forget, because this will restart the extension host and cause an error if we await
-        updateUseTsgoSetting(context, false);
+        updateUseTsgoSetting(false);
     }));
 
     context.subscriptions.push(vscode.commands.registerCommand("typescript.native-preview.restart", () => {
-        return client.restart();
+        return client.restart(context);
     }));
 
     context.subscriptions.push(vscode.commands.registerCommand("typescript.native-preview.output.focus", () => {
@@ -33,16 +33,11 @@ export function registerCommands(context: vscode.ExtensionContext, client: Clien
 /**
  * Updates the TypeScript Native Preview setting and reloads extension host.
  */
-async function updateUseTsgoSetting(context: vscode.ExtensionContext, enable: boolean): Promise<void> {
+async function updateUseTsgoSetting(enable: boolean): Promise<void> {
     const tsConfig = vscode.workspace.getConfiguration("typescript");
     const currentValue = tsConfig.get<boolean>("experimental.useTsgo", false);
     if (currentValue === enable) {
         return;
-    }
-    if (!enable && context.extensionMode === vscode.ExtensionMode.Development) {
-        await vscode.window.showWarningMessage(
-            "TypeScript Native Preview is running in development mode, and will load even when 'typescript.experimental.useTsgo' is false.",
-        );
     }
 
     // Update the setting and restart the extension host (needed to change the state of the built-in TS extension)

--- a/_extension/src/extension.ts
+++ b/_extension/src/extension.ts
@@ -1,242 +1,32 @@
-import * as path from "path";
 import * as vscode from "vscode";
 
-import {
-    LanguageClient,
-    LanguageClientOptions,
-    NotebookDocumentFilter,
-    ServerOptions,
-    TextDocumentFilter,
-    TransportKind,
-} from "vscode-languageclient/node";
-
-let client: LanguageClient;
-let statusBarItem: vscode.StatusBarItem;
-
-const BUILTIN_TS_EXTENSION_ID = "vscode.typescript-language-features";
+import { Client } from "./client";
+import { registerCommands } from "./commands";
+import { setupStatusBar } from "./statusBar";
+import { builtinTSExtensionId } from "./util";
+import { setupVersionStatusItem } from "./versionStatusItem";
 
 export async function activate(context: vscode.ExtensionContext) {
-    const tsExtension = vscode.extensions.getExtension(BUILTIN_TS_EXTENSION_ID);
-    if (tsExtension?.isActive && !vscode.workspace.getConfiguration("typescript").get<boolean>("experimental.useTsgo")) {
+    const output = vscode.window.createOutputChannel("typescript-native-preview", "log");
+    const traceOutput = vscode.window.createOutputChannel("typescript-native-preview (LSP)");
+    const client = new Client(output, traceOutput);
+    registerCommands(context, client, output, traceOutput);
+
+    context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(event => {
+        if (event.affectsConfiguration("typescript.experimental.useTsgo")) {
+            vscode.commands.executeCommand("workbench.action.restartExtensionHost");
+        }
+    }));
+
+    if (context.extensionMode !== vscode.ExtensionMode.Development && !vscode.workspace.getConfiguration("typescript").get<boolean>("experimental.useTsgo")) {
+        output.appendLine("TypeScript Native Preview is disabled. Select 'Enable TypeScript Native Preview (Experimental)' in the command palette to enable it.");
         return;
     }
 
-    const output = vscode.window.createOutputChannel("typescript-go", "log");
-    const traceOutput = vscode.window.createOutputChannel("typescript-go (LSP)");
-
+    await client.initialize(context);
     setupStatusBar(context);
-    registerCommands(context, output, traceOutput);
-
-    const config = vscode.workspace.getConfiguration("typescript-go");
-
-    const exe = await getExePath(context);
-
-    output.appendLine(`Resolved to ${exe}`);
-
-    // Get pprofDir
-    const pprofDir = config.get<string>("pprofDir");
-    const pprofArgs = pprofDir ? ["--pprofDir", pprofDir] : [];
-
-    const serverOptions: ServerOptions = {
-        run: {
-            command: exe,
-            args: ["--lsp", ...pprofArgs],
-            transport: TransportKind.stdio,
-        },
-        debug: {
-            command: exe,
-            args: ["--lsp", ...pprofArgs],
-            transport: TransportKind.stdio,
-        },
-    };
-
-    const clientOptions: LanguageClientOptions = {
-        documentSelector: [
-            { scheme: "file", language: "typescript" },
-            { scheme: "file", language: "typescriptreact" },
-            { scheme: "file", language: "javascript" },
-            { scheme: "file", language: "javascriptreact" },
-            { scheme: "untitled", language: "typescript" },
-            { scheme: "untitled", language: "typescriptreact" },
-            { scheme: "untitled", language: "javascript" },
-            { scheme: "untitled", language: "javascriptreact" },
-        ],
-        outputChannel: output,
-        traceOutputChannel: traceOutput,
-        diagnosticPullOptions: {
-            onChange: true,
-            onSave: true,
-            onTabs: true,
-            match(documentSelector, resource) {
-                // This function is called when diagnostics are requested but
-                // only the URI itself is known (e.g. open but not yet focused tabs),
-                // so will not be present in vscode.workspace.textDocuments.
-                // See if this file matches without consulting vscode.languages.match
-                // (which requires a TextDocument).
-
-                const language = getLanguageForUri(resource);
-
-                for (const selector of documentSelector) {
-                    if (typeof selector === "string") {
-                        if (selector === language) {
-                            return true;
-                        }
-                        continue;
-                    }
-                    if (NotebookDocumentFilter.is(selector)) {
-                        continue;
-                    }
-                    if (TextDocumentFilter.is(selector)) {
-                        if (selector.language !== undefined && selector.language !== language) {
-                            continue;
-                        }
-
-                        if (selector.scheme !== undefined && selector.scheme !== resource.scheme) {
-                            continue;
-                        }
-
-                        if (selector.pattern !== undefined) {
-                            // VS Code's glob matcher is not available via the API;
-                            // see: https://github.com/microsoft/vscode/issues/237304
-                            // But, we're only called on selectors passed above, so just ignore this for now.
-                            throw new Error("Not implemented");
-                        }
-
-                        return true;
-                    }
-                }
-
-                return false;
-            },
-        },
-    };
-
-    client = new LanguageClient(
-        "typescript-go",
-        "typescript-go-lsp",
-        serverOptions,
-        clientOptions,
-    );
-
-    output.appendLine(`Starting language server...`);
-    client.start();
-    vscode.commands.executeCommand("setContext", "typescript-go.serverRunning", true);
-}
-
-/**
- * Sets up the status bar item for TypeScript Go
- * @param context Extension context
- */
-function setupStatusBar(context: vscode.ExtensionContext): void {
-    statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
-    statusBarItem.text = "$(beaker) tsgo";
-    statusBarItem.tooltip = "TypeScript Go Language Server";
-    statusBarItem.command = "typescript-go.showMenu";
-    statusBarItem.backgroundColor = new vscode.ThemeColor("statusBarItem.warningBackground");
-    statusBarItem.show();
-    context.subscriptions.push(statusBarItem);
-}
-
-/**
- * Registers all commands for the extension
- * @param context Extension context
- */
-function registerCommands(context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel, traceOutputChannel: vscode.OutputChannel): void {
-    context.subscriptions.push(vscode.commands.registerCommand("typescript-go.restart", async () => {
-        await client.restart();
-    }));
-
-    context.subscriptions.push(vscode.commands.registerCommand("typescript-go.output.focus", () => {
-        outputChannel.show();
-    }));
-
-    context.subscriptions.push(vscode.commands.registerCommand("typescript-go.lsp-trace.focus", () => {
-        traceOutputChannel.show();
-    }));
-
-    context.subscriptions.push(vscode.commands.registerCommand("typescript-go.showMenu", showQuickPickMenu));
-}
-
-/**
- * Shows the quick pick menu for TypeScript Go options
- */
-async function showQuickPickMenu(): Promise<void> {
-    const selected = await vscode.window.showQuickPick([
-        { label: "$(refresh) Restart Server", description: "Restart the TypeScript Go language server" },
-        { label: "$(output) Show TS Server Log", description: "Show the TypeScript Go server log" },
-        { label: "$(debug-console) Show LSP Messages", description: "Show the LSP communication trace" },
-        { label: "$(stop-circle) Disable TypeScript Go", description: "Switch back to the built-in TypeScript extension" },
-    ], {
-        placeHolder: "TypeScript Go Options",
-    });
-
-    if (selected) {
-        if (selected.label.includes("Restart Server")) {
-            await vscode.commands.executeCommand("typescript-go.restart");
-        }
-        else if (selected.label.includes("Show TS Server Log")) {
-            await vscode.commands.executeCommand("typescript-go.output.focus");
-        }
-        else if (selected.label.includes("Show LSP Messages")) {
-            await vscode.commands.executeCommand("typescript-go.lsp-trace.focus");
-        }
-        else if (selected.label.includes("Disable TypeScript Go")) {
-            // Fire and forget, because this command will restart the whole extension host
-            // and awaiting it shows a weird cancellation error.
-            vscode.commands.executeCommand("typescript.experimental.disableTsgo");
-        }
-    }
+    setupVersionStatusItem(context, client);
 }
 
 export async function deactivate(): Promise<void> {
-    // Dispose of status bar item
-    if (statusBarItem) {
-        statusBarItem.dispose();
-    }
-
-    if (!client) {
-        return;
-    }
-
-    await client.stop();
-    return vscode.commands.executeCommand("setContext", "typescript-go.serverRunning", false);
-}
-
-function getLanguageForUri(uri: vscode.Uri): string | undefined {
-    const ext = path.posix.extname(uri.path);
-    switch (ext) {
-        case ".ts":
-        case ".mts":
-        case ".cts":
-            return "typescript";
-        case ".js":
-        case ".mjs":
-        case ".cjs":
-            return "javascript";
-        case ".tsx":
-            return "typescriptreact";
-        case ".jsx":
-            return "javascriptreact";
-        default:
-            return undefined;
-    }
-}
-
-async function getExePath(context: vscode.ExtensionContext): Promise<string> {
-    const config = vscode.workspace.getConfiguration("typescript-go");
-    let exe = config.get<string>("executablePath");
-    if (exe) {
-        return exe;
-    }
-
-    const exeName = `tsgo${process.platform === "win32" ? ".exe" : ""}`;
-
-    exe = context.asAbsolutePath(path.join("../", "built", "local", exeName));
-    try {
-        await vscode.workspace.fs.stat(vscode.Uri.file(exe));
-        return exe;
-    }
-    catch {}
-
-    return context.asAbsolutePath(path.join("./lib", exeName));
 }

--- a/_extension/src/extension.ts
+++ b/_extension/src/extension.ts
@@ -11,12 +11,16 @@ export async function activate(context: vscode.ExtensionContext) {
     const client = new Client(output, traceOutput);
     registerCommands(context, client, output, traceOutput);
 
-    context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(async event => {
+    context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(event => {
         if (event.affectsConfiguration("typescript.experimental.useTsgo")) {
-            const selected = await vscode.window.showInformationMessage("TypeScript Native Preview setting has changed. Restart extensions to apply changes.", "Restart Extensions");
-            if (selected) {
-                vscode.commands.executeCommand("workbench.action.restartExtensionHost");
-            }
+            // Delay because the command to change the config setting will restart
+            // the extension host, so no need to show a message
+            setTimeout(async () => {
+                const selected = await vscode.window.showInformationMessage("TypeScript Native Preview setting has changed. Restart extensions to apply changes.", "Restart Extensions");
+                if (selected) {
+                    vscode.commands.executeCommand("workbench.action.restartExtensionHost");
+                }
+            }, 100);
         }
     }));
 
@@ -24,7 +28,7 @@ export async function activate(context: vscode.ExtensionContext) {
     if (!useTsgo) {
         if (context.extensionMode === vscode.ExtensionMode.Development) {
             if (useTsgo === false) {
-                vscode.window.showWarningMessage(
+                vscode.window.showInformationMessage(
                     'TypeScript Native Preview is running in development mode. Ignoring "typescript.experimental.useTsgo": false.',
                 );
             }

--- a/_extension/src/extension.ts
+++ b/_extension/src/extension.ts
@@ -3,7 +3,6 @@ import * as vscode from "vscode";
 import { Client } from "./client";
 import { registerCommands } from "./commands";
 import { setupStatusBar } from "./statusBar";
-import { builtinTSExtensionId } from "./util";
 import { setupVersionStatusItem } from "./versionStatusItem";
 
 export async function activate(context: vscode.ExtensionContext) {

--- a/_extension/src/statusBar.ts
+++ b/_extension/src/statusBar.ts
@@ -1,0 +1,11 @@
+import * as vscode from "vscode";
+
+export function setupStatusBar(context: vscode.ExtensionContext): void {
+    const statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
+    statusBarItem.text = "$(beaker) tsgo";
+    statusBarItem.tooltip = "TypeScript Native Preview Language Server";
+    statusBarItem.command = "typescript.native-preview.showMenu";
+    statusBarItem.backgroundColor = new vscode.ThemeColor("statusBarItem.warningBackground");
+    statusBarItem.show();
+    context.subscriptions.push(statusBarItem);
+}

--- a/_extension/src/util.ts
+++ b/_extension/src/util.ts
@@ -44,7 +44,7 @@ export async function getExe(context: vscode.ExtensionContext): Promise<ExeInfo>
                 const packagePath = workspaceResolve(exe);
                 const packageJsonPath = vscode.Uri.joinPath(packagePath, "package.json");
                 const packageJson = JSON.parse(await vscode.workspace.fs.readFile(packageJsonPath).then(buffer => buffer.toString()));
-                const getExePath = (await import(path.join(packagePath.fsPath, "lib", "getExePath.js"))).default;
+                const getExePath = (await import(path.join(vscode.Uri.joinPath(packagePath, "lib", "getExePath.js").toString()))).default;
                 return { path: getExePath(), version: packageJson.version };
             }
             catch {}

--- a/_extension/src/util.ts
+++ b/_extension/src/util.ts
@@ -44,17 +44,17 @@ export async function getExe(context: vscode.ExtensionContext): Promise<ExeInfo>
                 const packagePath = workspaceResolve(exe);
                 const packageJsonPath = vscode.Uri.joinPath(packagePath, "package.json");
                 const packageJson = JSON.parse(await vscode.workspace.fs.readFile(packageJsonPath).then(buffer => buffer.toString()));
-                const getExePath = (await import(path.join(vscode.Uri.joinPath(packagePath, "lib", "getExePath.js").toString()))).default;
+                const getExePath = (await import(vscode.Uri.joinPath(packagePath, "lib", "getExePath.js").toString())).default;
                 return { path: getExePath(), version: packageJson.version };
             }
-            catch {}
+            catch { }
         }
         try {
             const exePath = workspaceResolve(path.join(exe, exeName));
             await vscode.workspace.fs.stat(exePath);
             return { path: exePath.fsPath, version: "(local)" };
         }
-        catch {}
+        catch { }
     }
 
     exe = context.asAbsolutePath(path.join("../", "built", "local", exeName));
@@ -62,7 +62,7 @@ export async function getExe(context: vscode.ExtensionContext): Promise<ExeInfo>
         await vscode.workspace.fs.stat(vscode.Uri.file(exe));
         return { path: exe, version: "(local)" };
     }
-    catch {}
+    catch { }
 
     return {
         path: getBuiltinExePath(context),

--- a/_extension/src/util.ts
+++ b/_extension/src/util.ts
@@ -1,0 +1,91 @@
+import * as path from "path";
+import * as vscode from "vscode";
+import packageJson from "../package.json";
+
+const version = packageJson.version;
+
+export const jsTsLanguageModes = [
+    "typescript",
+    "typescriptreact",
+    "javascript",
+    "javascriptreact",
+];
+
+export const builtinTSExtensionId = "vscode.typescript-language-features";
+
+export interface ExeInfo {
+    path: string;
+    version: string;
+}
+
+export function getBuiltinExePath(context: vscode.ExtensionContext): string {
+    return context.asAbsolutePath(path.join("./lib", `tsgo${process.platform === "win32" ? ".exe" : ""}`));
+}
+
+function workspaceResolve(relativePath: string): vscode.Uri {
+    if (path.isAbsolute(relativePath)) {
+        return vscode.Uri.file(relativePath);
+    }
+    if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
+        const workspaceFolder = vscode.workspace.workspaceFolders[0];
+        return vscode.Uri.joinPath(workspaceFolder.uri, relativePath);
+    }
+    return vscode.Uri.file(relativePath);
+}
+
+export async function getExe(context: vscode.ExtensionContext): Promise<ExeInfo> {
+    const config = vscode.workspace.getConfiguration("typescript.native-preview");
+    const exeName = `tsgo${process.platform === "win32" ? ".exe" : ""}`;
+
+    let exe = config.get<string>("tsdk");
+    if (exe) {
+        if (exe.endsWith("/@typescript/native-preview")) {
+            try {
+                const packagePath = workspaceResolve(exe);
+                const packageJsonPath = vscode.Uri.joinPath(packagePath, "package.json");
+                const packageJson = JSON.parse(await vscode.workspace.fs.readFile(packageJsonPath).then(buffer => buffer.toString()));
+                const getExePath = (await import(path.join(packagePath.fsPath, "lib", "getExePath.js"))).default;
+                return { path: getExePath(), version: packageJson.version };
+            }
+            catch {}
+        }
+        try {
+            const exePath = workspaceResolve(path.join(exe, exeName));
+            await vscode.workspace.fs.stat(exePath);
+            return { path: exePath.fsPath, version: "(local)" };
+        }
+        catch {}
+    }
+
+    exe = context.asAbsolutePath(path.join("../", "built", "local", exeName));
+    try {
+        await vscode.workspace.fs.stat(vscode.Uri.file(exe));
+        return { path: exe, version: "(local)" };
+    }
+    catch {}
+
+    return {
+        path: getBuiltinExePath(context),
+        version,
+    };
+}
+
+export function getLanguageForUri(uri: vscode.Uri): string | undefined {
+    const ext = path.posix.extname(uri.path);
+    switch (ext) {
+        case ".ts":
+        case ".mts":
+        case ".cts":
+            return "typescript";
+        case ".js":
+        case ".mjs":
+        case ".cjs":
+            return "javascript";
+        case ".tsx":
+            return "typescriptreact";
+        case ".jsx":
+            return "javascriptreact";
+        default:
+            return undefined;
+    }
+}

--- a/_extension/src/versionStatusItem.ts
+++ b/_extension/src/versionStatusItem.ts
@@ -1,0 +1,16 @@
+import * as vscode from "vscode";
+import { Client } from "./client";
+import { jsTsLanguageModes } from "./util";
+
+export function setupVersionStatusItem(
+    context: vscode.ExtensionContext,
+    client: Client,
+): void {
+    const statusItem = vscode.languages.createLanguageStatusItem("typescript.native-preview.version", jsTsLanguageModes);
+    statusItem.name = "TypeScript Native Preview version";
+    statusItem.detail = "TypeScript Native Preview version";
+    context.subscriptions.push(client.onStarted(() => {
+        statusItem.text = client.getCurrentExe()!.version;
+    }));
+    context.subscriptions.push(statusItem);
+}

--- a/_extension/tsconfig.json
+++ b/_extension/tsconfig.json
@@ -6,7 +6,9 @@
         "outDir": "./dist",
         "esModuleInterop": true,
         "strict": true,
-        "skipLibCheck": true
+        "skipLibCheck": true,
+        "resolveJsonModule": true,
+        "sourceMap": true
     },
     "include": ["./src/**/*"]
 }


### PR DESCRIPTION
This builds on top of #876 to update strings in the extension, allow resolution of the exe from the @typescript/native-preview package, and make minor UX improvements.