### PR TITLE
Unconditionally set dirtyFilePath in markAsDirty

### DIFF
--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -387,9 +387,9 @@ func (p *Project) markFileAsDirty(path tspath.Path) {
 func (p *Project) markAsDirty() {
 	p.dirtyStateMu.Lock()
 	defer p.dirtyStateMu.Unlock()
+	p.dirtyFilePath = ""
 	if !p.dirty {
 		p.dirty = true
-		p.dirtyFilePath = ""
 		p.version++
 	}
 }


### PR DESCRIPTION
Fixes a bug caught by @gabritto in https://github.com/microsoft/typescript-go/pull/879/files/a30a84c490a5d49555a8f46b1516836b75c560e8#r2098483287.

I had to make the other changes in order to make the test fail; there was an unnecessary double update on config file changes that was clearing out the dirty state on the second update.