### PR TITLE
Copy default compiler options for inferred projects from VS Code client

### DIFF
--- a/internal/ls/completions_test.go
+++ b/internal/ls/completions_test.go
@@ -31,6 +31,7 @@ type testCaseResult struct {
 }
 
 const defaultMainFileName = "/index.ts"
+const defaultTsconfigFileName = "/tsconfig.json"
 
 func TestCompletions(t *testing.T) {
 	t.Parallel()
@@ -1542,6 +1543,7 @@ func runTest(t *testing.T, files map[string]string, expected map[string]*testCas
 		mainFileName = defaultMainFileName
 	}
 	parsedFiles := make(map[string]string)
+	parsedFiles[defaultTsconfigFileName] = `{}`
 	var markerPositions map[string]*lstestutil.Marker
 	for fileName, content := range files {
 		if fileName == mainFileName {

--- a/internal/ls/completions_test.go
+++ b/internal/ls/completions_test.go
@@ -30,8 +30,10 @@ type testCaseResult struct {
 	excludes   []string
 }
 
-const defaultMainFileName = "/index.ts"
-const defaultTsconfigFileName = "/tsconfig.json"
+const (
+	defaultMainFileName     = "/index.ts"
+	defaultTsconfigFileName = "/tsconfig.json"
+)
 
 func TestCompletions(t *testing.T) {
 	t.Parallel()

--- a/internal/project/service.go
+++ b/internal/project/service.go
@@ -716,9 +716,19 @@ func (s *Service) getDefaultProjectForScript(scriptInfo *ScriptInfo) *Project {
 }
 
 func (s *Service) createInferredProject(currentDirectory string, projectRootPath tspath.Path) *Project {
-	// !!!
 	compilerOptions := core.CompilerOptions{
-		AllowJs: core.TSTrue,
+		AllowJs:                    core.TSTrue,
+		Module:                     core.ModuleKindESNext,
+		ModuleResolution:           core.ModuleResolutionKindBundler,
+		Target:                     core.ScriptTargetES2022,
+		Jsx:                        core.JsxEmitReactJSX,
+		AllowImportingTsExtensions: core.TSTrue,
+		StrictNullChecks:           core.TSTrue,
+		StrictFunctionTypes:        core.TSTrue,
+		SourceMap:                  core.TSTrue,
+		ESModuleInterop:            core.TSTrue,
+		AllowNonTsExtensions:       core.TSTrue,
+		ResolveJsonModule:          core.TSTrue,
 	}
 	project := NewInferredProject(&compilerOptions, currentDirectory, projectRootPath, s)
 	s.inferredProjects = append(s.inferredProjects, project)

--- a/internal/testutil/lstestutil/lstestutil.go
+++ b/internal/testutil/lstestutil/lstestutil.go
@@ -212,3 +212,35 @@ func recordMarker(
 	}
 	return marker
 }
+
+// type languageServiceHost struct {
+// 	program *compiler.Program
+// 	fs      vfs.FS
+// }
+
+// // GetLineMap implements ls.Host.
+// func (l *languageServiceHost) GetLineMap(fileName string) *ls.LineMap {
+// 	text, ok := l.fs.ReadFile(fileName)
+// 	if !ok {
+// 		panic("file not found")
+// 	}
+// 	return ls.ComputeLineStarts(text)
+// }
+
+// // GetPositionEncoding implements ls.Host.
+// func (l *languageServiceHost) GetPositionEncoding() lsproto.PositionEncodingKind {
+// 	return lsproto.PositionEncodingKindUTF8
+// }
+
+// // GetProgram implements ls.Host.
+// func (l *languageServiceHost) GetProgram() *compiler.Program {
+// 	return l.program
+// }
+
+// var _ ls.Host = (*languageServiceHost)(nil)
+
+// func NewLanguageService(
+// 	files map[string]string,
+// ) *ls.LanguageService {
+// 	fs := vfstest.FromMap(files, true /*useCaseSensitiveFileNames*/)
+// }


### PR DESCRIPTION
Taken from a TSServer config message, replacing `allowSyntheticDefaultImports` with `esModuleInterop`