### PR TITLE
Add option to launch test with pprof profiling enabled

### DIFF
--- a/.vscode/launch.template.json
+++ b/.vscode/launch.template.json
@@ -36,7 +36,7 @@
             "mode": "test",
             "program": "${workspaceFolder}/internal/testrunner",
             "args": [
-                "-cpuprofile",
+                "-test.cpuprofile",
                 "test.prof",
                 "-test.run",
                 "TestSubmodule/${fileBasename}"

--- a/.vscode/launch.template.json
+++ b/.vscode/launch.template.json
@@ -28,6 +28,19 @@
                 "-test.run",
                 "TestSubmodule/${fileBasename}"
             ]
+        },
+        {
+            "name": "Launch submodule test (with profiling)",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "${workspaceFolder}/internal/testrunner",
+            "args": [
+                "-cpuprofile",
+                "test.prof",
+                "-test.run",
+                "TestSubmodule/${fileBasename}"
+            ]
         }
     ]
 }

--- a/.vscode/launch.template.json
+++ b/.vscode/launch.template.json
@@ -37,7 +37,7 @@
             "program": "${workspaceFolder}/internal/testrunner",
             "args": [
                 "-test.cpuprofile",
-                "test.prof",
+                "${workspaceFolder}/test.prof",
                 "-test.run",
                 "TestSubmodule/${fileBasename}"
             ]

--- a/internal/testrunner/compiler_runner.go
+++ b/internal/testrunner/compiler_runner.go
@@ -177,10 +177,6 @@ var cpuprofile = flag.String("cpuprofile", "", "write cpu profile to file")
 func (r *CompilerBaselineRunner) runSingleConfigTest(t *testing.T, testName string, test *compilerFileBasedTest, config *harnessutil.NamedTestConfiguration) {
 	t.Parallel()
 	defer testutil.RecoverAndFail(t, "Panic on compiling test "+test.filename)
-
-	payload := makeUnitsFromTest(test.content, test.filename)
-	compilerTest := newCompilerTest(t, testName, test.filename, &payload, config)
-
 	if *cpuprofile != "" {
 		f, err := os.Create(*cpuprofile)
 		if err != nil {
@@ -189,6 +185,10 @@ func (r *CompilerBaselineRunner) runSingleConfigTest(t *testing.T, testName stri
 		pprof.StartCPUProfile(f)
 		defer pprof.StopCPUProfile()
 	}
+
+	payload := makeUnitsFromTest(test.content, test.filename)
+	compilerTest := newCompilerTest(t, testName, test.filename, &payload, config)
+
 	compilerTest.verifyDiagnostics(t, r.testSuitName, r.isSubmodule)
 	compilerTest.verifyJavaScriptOutput(t, r.testSuitName, r.isSubmodule)
 	compilerTest.verifySourceMapOutput(t, r.testSuitName, r.isSubmodule)

--- a/internal/testrunner/compiler_runner.go
+++ b/internal/testrunner/compiler_runner.go
@@ -1,14 +1,11 @@
 package runner
 
 import (
-	"flag"
 	"fmt"
-	"log"
 	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime/pprof"
 	"slices"
 	"strings"
 	"testing"
@@ -172,19 +169,9 @@ func (r *CompilerBaselineRunner) runTest(t *testing.T, filename string) {
 	}
 }
 
-var cpuprofile = flag.String("cpuprofile", "", "write cpu profile to file")
-
 func (r *CompilerBaselineRunner) runSingleConfigTest(t *testing.T, testName string, test *compilerFileBasedTest, config *harnessutil.NamedTestConfiguration) {
 	t.Parallel()
 	defer testutil.RecoverAndFail(t, "Panic on compiling test "+test.filename)
-	if *cpuprofile != "" {
-		f, err := os.Create(*cpuprofile)
-		if err != nil {
-			log.Fatal(err)
-		}
-		pprof.StartCPUProfile(f)
-		defer pprof.StopCPUProfile()
-	}
 
 	payload := makeUnitsFromTest(test.content, test.filename)
 	compilerTest := newCompilerTest(t, testName, test.filename, &payload, config)


### PR DESCRIPTION
I imagine this is a useful launch task/flag for tracing slow tests - basically just pulled from the `go` docs.