### PR TITLE
[LSP] Fix data races on dirty state and script info version

### DIFF
--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/microsoft/typescript-go/internal/ast"
 	"github.com/microsoft/typescript-go/internal/collections"
@@ -407,6 +408,7 @@ func (p *Project) updateGraph() bool {
 		return false
 	}
 
+	start := time.Now()
 	p.log("Starting updateGraph: Project: " + p.name)
 	var writeFileNames bool
 	oldProgram := p.program
@@ -428,7 +430,6 @@ func (p *Project) updateGraph() bool {
 	oldProgramReused := p.updateProgram()
 	p.dirty = false
 	p.dirtyFilePath = ""
-	p.log(fmt.Sprintf("Finishing updateGraph: Project: %s version: %d", p.name, p.version))
 	if writeFileNames {
 		p.log(p.print(true /*writeFileNames*/, true /*writeFileExplanation*/, false /*writeFileVersionAndText*/))
 	} else if p.program != oldProgram {
@@ -446,6 +447,7 @@ func (p *Project) updateGraph() bool {
 		// but in Strada we throttle, so at least sometimes this should be considered top-level?
 		p.updateWatchers(context.TODO())
 	}
+	p.log(fmt.Sprintf("Finishing updateGraph: Project: %s version: %d in %s", p.name, p.version, time.Since(start)))
 	return true
 }
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -414,7 +414,7 @@ func (p *Project) updateGraph() bool {
 			p.parsedCommandLine = tsoptions.ReloadFileNamesOfParsedCommandLine(p.parsedCommandLine, p.host.FS())
 			writeFileNames = p.setRootFiles(p.parsedCommandLine.FileNames())
 		case PendingReloadFull:
-			if err := p.LoadConfig(); err != nil {
+			if err := p.loadConfig(); err != nil {
 				panic(fmt.Sprintf("failed to reload config: %v", err))
 			}
 		}
@@ -529,6 +529,14 @@ func (p *Project) addRoot(info *ScriptInfo) {
 }
 
 func (p *Project) LoadConfig() error {
+	if err := p.loadConfig(); err != nil {
+		return err
+	}
+	p.markAsDirty()
+	return nil
+}
+
+func (p *Project) loadConfig() error {
 	if p.kind != KindConfigured {
 		panic("loadConfig called on non-configured project")
 	}
@@ -563,8 +571,6 @@ func (p *Project) LoadConfig() error {
 		p.compilerOptions = &core.CompilerOptions{}
 		return fmt.Errorf("could not read file %q", p.configFileName)
 	}
-
-	p.markAsDirty()
 	return nil
 }
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -208,7 +208,7 @@ func (p *Project) GetSourceFile(fileName string, path tspath.Path, languageVersi
 
 // Updates the program if needed.
 func (p *Project) GetProgram() *compiler.Program {
-	p.updateIfDirty()
+	p.updateGraph()
 	return p.program
 }
 
@@ -391,19 +391,14 @@ func (p *Project) markAsDirty() {
 	}
 }
 
-// updateIfDirty returns true if the project was updated.
-func (p *Project) updateIfDirty() bool {
-	// !!! p.invalidateResolutionsOfFailedLookupLocations()
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.dirty && p.updateGraph()
-}
-
 // updateGraph updates the set of files that contribute to the project.
 // Returns true if the set of files in has changed. NOTE: this is the
 // opposite of the return value in Strada, which was frequently inverted,
 // as in `updateProjectIfDirty()`.
 func (p *Project) updateGraph() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	if !p.dirty {
 		return false
 	}

--- a/internal/project/scriptinfo.go
+++ b/internal/project/scriptinfo.go
@@ -110,7 +110,7 @@ func (s *ScriptInfo) setText(newText string) {
 
 func (s *ScriptInfo) markContainingProjectsAsDirty() {
 	for _, project := range s.containingProjects {
-		project.markFileAsDirty(s.path)
+		project.MarkFileAsDirty(s.path)
 	}
 }
 
@@ -175,7 +175,7 @@ func (s *ScriptInfo) detachAllProjects() {
 		// if (isConfiguredProject(p)) {
 		// 	p.getCachedDirectoryStructureHost().addOrDeleteFile(this.fileName, this.path, FileWatcherEventKind.Deleted);
 		// }
-		project.removeFile(s, false /*fileExists*/, false /*detachFromProject*/)
+		project.RemoveFile(s, false /*fileExists*/, false /*detachFromProject*/)
 	}
 	s.containingProjects = nil
 }

--- a/internal/project/scriptinfo.go
+++ b/internal/project/scriptinfo.go
@@ -122,7 +122,6 @@ func (s *ScriptInfo) attachToProject(project *Project) bool {
 		if project.compilerOptions.PreserveSymlinks != core.TSTrue {
 			s.ensureRealpath(project.FS())
 		}
-		project.onFileAddedOrRemoved(s.isSymlink())
 		return true
 	}
 	return false
@@ -130,11 +129,6 @@ func (s *ScriptInfo) attachToProject(project *Project) bool {
 
 func (s *ScriptInfo) isAttached(project *Project) bool {
 	return slices.Contains(s.containingProjects, project)
-}
-
-func (s *ScriptInfo) isSymlink() bool {
-	// !!!
-	return false
 }
 
 func (s *ScriptInfo) isOrphan() bool {
@@ -182,14 +176,12 @@ func (s *ScriptInfo) detachAllProjects() {
 		// 	p.getCachedDirectoryStructureHost().addOrDeleteFile(this.fileName, this.path, FileWatcherEventKind.Deleted);
 		// }
 		project.removeFile(s, false /*fileExists*/, false /*detachFromProject*/)
-		project.onFileAddedOrRemoved(s.isSymlink())
 	}
 	s.containingProjects = nil
 }
 
 func (s *ScriptInfo) detachFromProject(project *Project) {
 	if index := slices.Index(s.containingProjects, project); index != -1 {
-		s.containingProjects[index].onFileAddedOrRemoved(s.isSymlink())
 		s.containingProjects = slices.Delete(s.containingProjects, index, index+1)
 	}
 }

--- a/internal/project/service.go
+++ b/internal/project/service.go
@@ -309,17 +309,17 @@ func (s *Service) onConfigFileChanged(project *Project, changeKind lsproto.FileC
 		project.pendingReload = PendingReloadFull
 		project.markAsDirty()
 	}
-	project.updateIfDirty()
+	project.updateGraph()
 	return nil
 }
 
 func (s *Service) ensureProjectStructureUpToDate() {
 	var hasChanges bool
 	for _, project := range s.configuredProjects {
-		hasChanges = project.updateIfDirty() || hasChanges
+		hasChanges = project.updateGraph() || hasChanges
 	}
 	for _, project := range s.inferredProjects {
-		hasChanges = project.updateIfDirty() || hasChanges
+		hasChanges = project.updateGraph() || hasChanges
 	}
 	if hasChanges {
 		s.ensureProjectForOpenFiles()
@@ -342,7 +342,7 @@ func (s *Service) ensureProjectForOpenFiles() {
 		}
 	}
 	for _, project := range s.inferredProjects {
-		project.updateIfDirty()
+		project.updateGraph()
 	}
 
 	s.Log("After ensureProjectForOpenFiles:")
@@ -570,7 +570,7 @@ func (s *Service) assignProjectToOpenedScriptInfo(info *ScriptInfo) assignProjec
 		// result.configFileErrors = project.getAllProjectErrors()
 	}
 	for _, project := range info.containingProjects {
-		project.updateIfDirty()
+		project.updateGraph()
 	}
 	if info.isOrphan() {
 		// !!!

--- a/internal/project/service.go
+++ b/internal/project/service.go
@@ -211,7 +211,7 @@ func (s *Service) CloseFile(fileName string) {
 		info.close(fileExists)
 		for _, project := range info.containingProjects {
 			if project.kind == KindInferred && project.isRoot(info) {
-				project.removeFile(info, fileExists, true /*detachFromProject*/)
+				project.RemoveFile(info, fileExists, true /*detachFromProject*/)
 			}
 		}
 		delete(s.openFiles, info.path)
@@ -598,7 +598,7 @@ func (s *Service) assignOrphanScriptInfoToInferredProject(info *ScriptInfo, proj
 		project = s.getOrCreateUnrootedInferredProject()
 	}
 
-	project.addRoot(info)
+	project.AddRoot(info)
 	project.updateGraph()
 	// !!! old code ensures that scriptInfo is only part of one project
 }


### PR DESCRIPTION
Changes `project` to operate with a single mutex, and avoids reading `scriptInfo.Version()` multiple times during parsing.