### PR TITLE
Don't error on --incremental, just run normally

### DIFF
--- a/internal/execute/system.go
+++ b/internal/execute/system.go
@@ -27,5 +27,4 @@ const (
 	ExitStatusProjectReferenceCycle_OutputsSkipped ExitStatus = 4
 	ExitStatusNotImplemented                       ExitStatus = 5
 	ExitStatusNotImplementedWatch                  ExitStatus = 6
-	ExitStatusNotImplementedIncremental            ExitStatus = 7
 )

--- a/internal/execute/tsc.go
+++ b/internal/execute/tsc.go
@@ -118,9 +118,8 @@ func executeCommandLineWorker(sys System, cb cbType, commandLine *tsoptions.Pars
 		// updateReportDiagnostic
 		if isWatchSet(configParseResult.CompilerOptions()) {
 			return ExitStatusSuccess, createWatcher(sys, configParseResult, reportDiagnostic)
-		} else if isIncrementalCompilation(configParseResult.CompilerOptions()) {
-			return ExitStatusNotImplementedIncremental, nil
 		}
+		// !!! incremental
 		return performCompilation(
 			sys,
 			cb,
@@ -136,9 +135,8 @@ func executeCommandLineWorker(sys System, cb cbType, commandLine *tsoptions.Pars
 		if isWatchSet(compilerOptionsFromCommandLine) {
 			// !!! reportWatchModeWithoutSysSupport
 			return ExitStatusSuccess, createWatcher(sys, commandLine, reportDiagnostic)
-		} else if isIncrementalCompilation(compilerOptionsFromCommandLine) {
-			return ExitStatusNotImplementedIncremental, nil
 		}
+		// !!! incremental
 	}
 	return performCompilation(
 		sys,

--- a/testdata/baselines/reference/tsc/noEmit/when-project-has-strict-true.js
+++ b/testdata/baselines/reference/tsc/noEmit/when-project-has-strict-true.js
@@ -12,13 +12,12 @@ export class class1 {}
 	},
 }
 
-ExitStatus:: 7
+ExitStatus:: 0
 
 CompilerOptions::{
     "noEmit": true
 }
 Output::
-No output
 //// [/home/src/workspaces/project/class1.ts] no change
 //// [/home/src/workspaces/project/tsconfig.json] no change
 


### PR DESCRIPTION
This turns off the early exit and error for `--incremental`; I think it's fine to just let compilation proceed in this case.

Fixes #906