### PR TITLE
Error early on --build

### DIFF
--- a/internal/execute/tsc.go
+++ b/internal/execute/tsc.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/microsoft/typescript-go/internal/ast"
@@ -21,7 +22,7 @@ type cbType = func(p any) any
 func CommandLine(sys System, cb cbType, commandLineArgs []string) ExitStatus {
 	if len(commandLineArgs) > 0 {
 		// !!! build mode
-		switch commandLineArgs[0] {
+		switch strings.ToLower(commandLineArgs[0]) {
 		case "-b", "--b", "-build", "--build":
 			fmt.Fprint(sys.Writer(), "Build mode is currently unsupported."+sys.NewLine())
 			sys.EndWrite()

--- a/internal/execute/tsc.go
+++ b/internal/execute/tsc.go
@@ -19,6 +19,16 @@ import (
 type cbType = func(p any) any
 
 func CommandLine(sys System, cb cbType, commandLineArgs []string) ExitStatus {
+	if len(commandLineArgs) > 0 {
+		// !!! build mode
+		switch commandLineArgs[0] {
+		case "-b", "--b", "-build", "--build":
+			fmt.Fprint(sys.Writer(), "Build mode is currently unsupported."+sys.NewLine())
+			sys.EndWrite()
+			return ExitStatusNotImplemented
+		}
+	}
+
 	parsedCommandLine := tsoptions.ParseCommandLine(commandLineArgs, sys)
 	e, watcher := executeCommandLineWorker(sys, cb, parsedCommandLine)
 	if watcher == nil {


### PR DESCRIPTION
This is a bit less cryptic than "error TS6369: Option '--build' must be the first command line argument.", which only shows up because we don't yet have build mode code that checks the first arg.