### PR TITLE
Ensure LSP server exists on stdin close

### DIFF
--- a/cmd/tsgo/lsp.go
+++ b/cmd/tsgo/lsp.go
@@ -1,10 +1,8 @@
 package main
 
 import (
-	"errors"
 	"flag"
 	"fmt"
-	"io"
 	"os"
 
 	"github.com/microsoft/typescript-go/internal/bundled"
@@ -49,7 +47,7 @@ func runLSP(args []string) int {
 		DefaultLibraryPath: defaultLibraryPath,
 	})
 
-	if err := s.Run(); err != nil && !errors.Is(err, io.EOF) {
+	if err := s.Run(); err != nil {
 		return 1
 	}
 	return 0


### PR DESCRIPTION
Fixes #935

We want the server to exit when stdin closes, but the current code was returning nil, leaving the errgroup running, leaving the process behind.