### PR TITLE
refactor: use slices.Contains and slices.ContainsFunc to simplify code

### DIFF
--- a/internal/checker/mapper.go
+++ b/internal/checker/mapper.go
@@ -1,6 +1,10 @@
 package checker
 
-import "github.com/microsoft/typescript-go/internal/core"
+import (
+	"slices"
+
+	"github.com/microsoft/typescript-go/internal/core"
+)
 
 // TypeMapperKind
 
@@ -158,10 +162,8 @@ func newArrayToSingleTypeMapper(sources []*Type, target *Type) *TypeMapper {
 }
 
 func (m *ArrayToSingleTypeMapper) Map(t *Type) *Type {
-	for _, s := range m.sources {
-		if t == s {
-			return m.target
-		}
+	if slices.Contains(m.sources, t) {
+		return m.target
 	}
 	return t
 }


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.