### PR TITLE
Clean up GetElementOrPropertyAccessName

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -3575,7 +3575,7 @@ func (c *Checker) checkTestingKnownTruthyType(condExpr *ast.Node, condType *Type
 	if ast.IsLogicalOrCoalescingBinaryExpression(condExpr) {
 		location = ast.SkipParentheses(condExpr.AsBinaryExpression().Right)
 	}
-	if isModuleExportsAccessExpression(location) {
+	if ast.IsModuleExportsAccessExpression(location) {
 		return
 	}
 	if ast.IsLogicalOrCoalescingBinaryExpression(location) {
@@ -27743,7 +27743,7 @@ func (c *Checker) canGetContextualTypeForAssignmentDeclaration(node *ast.Node) b
 				return false
 			}
 			// and now for one single case of object literal methods
-			name := ast.GetElementOrPropertyAccessArgumentExpressionOrName(left)
+			name := ast.GetElementOrPropertyAccessName(left)
 			if name == nil {
 				return false
 			} else {

--- a/internal/checker/utilities.go
+++ b/internal/checker/utilities.go
@@ -1632,10 +1632,6 @@ func minAndMax[T any](slice []T, getValue func(value T) int) (int, int) {
 	return minValue, maxValue
 }
 
-func isModuleExportsAccessExpression(node *ast.Node) bool {
-	return ast.IsAccessExpression(node) && ast.IsModuleIdentifier(node.Expression()) && ast.GetElementOrPropertyAccessName(node) == "exports"
-}
-
 func getNonModifierTokenRangeOfNode(node *ast.Node) core.TextRange {
 	pos := node.Pos()
 	if node.Modifiers() != nil {

--- a/internal/parser/reparser.go
+++ b/internal/parser/reparser.go
@@ -24,7 +24,7 @@ func (p *Parser) reparseCommonJS(node *ast.Node) {
 		nodes[0].Flags = ast.NodeFlagsReparsed
 		nodes[0].Loc = bin.Loc
 		// TODO: Name can sometimes be a string literal, so downstream code needs to handle this
-		export = p.factory.NewCommonJSExport(p.newModifierList(bin.Loc, nodes), ast.GetElementOrPropertyAccessArgumentExpressionOrName(bin.Left), bin.Right)
+		export = p.factory.NewCommonJSExport(p.newModifierList(bin.Loc, nodes), ast.GetElementOrPropertyAccessName(bin.Left), bin.Right)
 	}
 	if export != nil {
 		export.Flags = ast.NodeFlagsReparsed

--- a/testdata/baselines/reference/conformance/deepElementAccessExpressionInJS.errors.txt
+++ b/testdata/baselines/reference/conformance/deepElementAccessExpressionInJS.errors.txt
@@ -1,0 +1,24 @@
+elementAccessExpressionInJS.js(1,5): error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{ exports: { [key: string]: any; }; }'.
+  No index signature with a parameter of type 'string' was found on type '{ exports: { [key: string]: any; }; }'.
+elementAccessExpressionInJS.js(3,32): error TS7006: Parameter 'index' implicitly has an 'any' type.
+
+
+==== declarations.d.ts (0 errors) ====
+    declare var module: {
+        exports: {
+            [key: string]: any;
+        };
+    }
+==== elementAccessExpressionInJS.js (2 errors) ====
+    if (module[calculatePropertyName(1)]) {
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{ exports: { [key: string]: any; }; }'.
+!!! error TS7053:   No index signature with a parameter of type 'string' was found on type '{ exports: { [key: string]: any; }; }'.
+    }
+    function calculatePropertyName(index) {
+                                   ~~~~~
+!!! error TS7006: Parameter 'index' implicitly has an 'any' type.
+        // this would be some webpack index in real life
+        return `property${index}`;
+    }
+    

--- a/testdata/baselines/reference/conformance/deepElementAccessExpressionInJS.symbols
+++ b/testdata/baselines/reference/conformance/deepElementAccessExpressionInJS.symbols
@@ -1,0 +1,28 @@
+//// [tests/cases/conformance/salsa/deepElementAccessExpressionInJS.ts] ////
+
+=== declarations.d.ts ===
+declare var module: {
+>module : Symbol(module, Decl(declarations.d.ts, 0, 11))
+
+    exports: {
+>exports : Symbol(exports, Decl(declarations.d.ts, 0, 21))
+
+        [key: string]: any;
+>key : Symbol(key, Decl(declarations.d.ts, 2, 9))
+
+    };
+}
+=== elementAccessExpressionInJS.js ===
+if (module[calculatePropertyName(1)]) {
+>module : Symbol(module, Decl(declarations.d.ts, 0, 11))
+>calculatePropertyName : Symbol(calculatePropertyName, Decl(elementAccessExpressionInJS.js, 1, 1))
+}
+function calculatePropertyName(index) {
+>calculatePropertyName : Symbol(calculatePropertyName, Decl(elementAccessExpressionInJS.js, 1, 1))
+>index : Symbol(index, Decl(elementAccessExpressionInJS.js, 2, 31))
+
+    // this would be some webpack index in real life
+    return `property${index}`;
+>index : Symbol(index, Decl(elementAccessExpressionInJS.js, 2, 31))
+}
+

--- a/testdata/baselines/reference/conformance/deepElementAccessExpressionInJS.types
+++ b/testdata/baselines/reference/conformance/deepElementAccessExpressionInJS.types
@@ -1,0 +1,32 @@
+//// [tests/cases/conformance/salsa/deepElementAccessExpressionInJS.ts] ////
+
+=== declarations.d.ts ===
+declare var module: {
+>module : { exports: { [key: string]: any; }; }
+
+    exports: {
+>exports : { [key: string]: any; }
+
+        [key: string]: any;
+>key : string
+
+    };
+}
+=== elementAccessExpressionInJS.js ===
+if (module[calculatePropertyName(1)]) {
+>module[calculatePropertyName(1)] : any
+>module : { exports: { [key: string]: any; }; }
+>calculatePropertyName(1) : string
+>calculatePropertyName : (index: any) => string
+>1 : 1
+}
+function calculatePropertyName(index) {
+>calculatePropertyName : (index: any) => string
+>index : any
+
+    // this would be some webpack index in real life
+    return `property${index}`;
+>`property${index}` : string
+>index : any
+}
+

--- a/testdata/tests/cases/conformance/salsa/deepElementAccessExpressionInJS.ts
+++ b/testdata/tests/cases/conformance/salsa/deepElementAccessExpressionInJS.ts
@@ -1,0 +1,18 @@
+// @allowJs: true
+// @checkJs: true
+// @strict: true
+// @target: es6
+// @outDir: ./out
+// @filename: declarations.d.ts
+declare var module: {
+    exports: {
+        [key: string]: any;
+    };
+}
+// @filename: elementAccessExpressionInJS.js
+if (module[calculatePropertyName(1)]) {
+}
+function calculatePropertyName(index) {
+    // this would be some webpack index in real life
+    return `property${index}`;
+}


### PR DESCRIPTION
Fixes #890

There were two related functions but only one caller needed the .Text() followup. The new code is stricter and therefore less likely to panic downstream.

There was also a duplicate implementation of IsModuleExports in checker. I removed that and cleaned it up as well.

This is also the inauguaral test in cases/conformance/salsa.