### PR TITLE
Rename _InitializeParams type in LSP

### DIFF
--- a/internal/lsp/lsproto/_generate/fetchModel.mjs
+++ b/internal/lsp/lsproto/_generate/fetchModel.mjs
@@ -14,7 +14,8 @@ const metaModelURL = `https://raw.githubusercontent.com/microsoft/vscode-languag
 const metaModelSchemaURL = `https://raw.githubusercontent.com/microsoft/vscode-languageserver-node/${hash}/tools/src/metaModel.ts`;
 
 const metaModelResponse = await fetch(metaModelURL);
-const metaModel = await metaModelResponse.text();
+let metaModel = await metaModelResponse.text();
+metaModel = metaModel.replaceAll('"_InitializeParams"', '"InitializeParamsBase"');
 fs.writeFileSync(metaModelPath, metaModel);
 
 const metaModelSchemaResponse = await fetch(metaModelSchemaURL);

--- a/internal/lsp/lsproto/lsp_generated.go
+++ b/internal/lsp/lsproto/lsp_generated.go
@@ -958,7 +958,7 @@ type UnregistrationParams struct {
 }
 
 type InitializeParams struct {
-	_InitializeParams
+	InitializeParamsBase
 	WorkspaceFoldersInitializeParams
 }
 
@@ -2748,7 +2748,7 @@ type Unregistration struct {
 }
 
 // The initialize parameters
-type _InitializeParams struct {
+type InitializeParamsBase struct {
 	WorkDoneProgressParams
 
 	// The process Id of the parent process that started


### PR DESCRIPTION
This is the one type that is has an unexported name in the spec.