### PR TITLE
Eliminate ProgramOptions.ConfigFileName

### DIFF
--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -7,10 +7,13 @@ import (
 	"github.com/microsoft/typescript-go/internal/bundled"
 	"github.com/microsoft/typescript-go/internal/checker"
 	"github.com/microsoft/typescript-go/internal/compiler"
+	"github.com/microsoft/typescript-go/internal/core"
 	"github.com/microsoft/typescript-go/internal/repo"
+	"github.com/microsoft/typescript-go/internal/tsoptions"
 	"github.com/microsoft/typescript-go/internal/tspath"
 	"github.com/microsoft/typescript-go/internal/vfs/osvfs"
 	"github.com/microsoft/typescript-go/internal/vfs/vfstest"
+	"gotest.tools/v3/assert"
 )
 
 func TestGetSymbolAtLocation(t *testing.T) {
@@ -25,7 +28,8 @@ foo.bar;`
 		"/foo.ts": content,
 		"/tsconfig.json": `
 				{
-					"compilerOptions": {}
+					"compilerOptions": {},
+					"files": ["foo.ts"]
 				}
 			`,
 	}, false /*useCaseSensitiveFileNames*/)
@@ -33,11 +37,11 @@ foo.bar;`
 
 	cd := "/"
 	host := compiler.NewCompilerHost(nil, cd, fs, bundled.LibPath())
-	opts := compiler.ProgramOptions{
-		Host:           host,
-		ConfigFileName: "/tsconfig.json",
-	}
-	p := compiler.NewProgram(opts)
+
+	parsed, errors := tsoptions.GetParsedCommandLineOfConfigFile("/tsconfig.json", &core.CompilerOptions{}, host, nil)
+	assert.Equal(t, len(errors), 0, "Expected no errors in parsed command line")
+
+	p := compiler.NewProgramFromParsedCommandLine(parsed, host)
 	p.BindSourceFiles()
 	c, done := p.GetTypeChecker(t.Context())
 	defer done()
@@ -64,11 +68,9 @@ func TestCheckSrcCompiler(t *testing.T) {
 	rootPath := tspath.CombinePaths(tspath.NormalizeSlashes(repo.TypeScriptSubmodulePath), "src", "compiler")
 
 	host := compiler.NewCompilerHost(nil, rootPath, fs, bundled.LibPath())
-	opts := compiler.ProgramOptions{
-		Host:           host,
-		ConfigFileName: tspath.CombinePaths(rootPath, "tsconfig.json"),
-	}
-	p := compiler.NewProgram(opts)
+	parsed, errors := tsoptions.GetParsedCommandLineOfConfigFile(tspath.CombinePaths(rootPath, "tsconfig.json"), &core.CompilerOptions{}, host, nil)
+	assert.Equal(t, len(errors), 0, "Expected no errors in parsed command line")
+	p := compiler.NewProgramFromParsedCommandLine(parsed, host)
 	p.CheckSourceFiles(t.Context())
 }
 
@@ -80,11 +82,9 @@ func BenchmarkNewChecker(b *testing.B) {
 	rootPath := tspath.CombinePaths(tspath.NormalizeSlashes(repo.TypeScriptSubmodulePath), "src", "compiler")
 
 	host := compiler.NewCompilerHost(nil, rootPath, fs, bundled.LibPath())
-	opts := compiler.ProgramOptions{
-		Host:           host,
-		ConfigFileName: tspath.CombinePaths(rootPath, "tsconfig.json"),
-	}
-	p := compiler.NewProgram(opts)
+	parsed, errors := tsoptions.GetParsedCommandLineOfConfigFile(tspath.CombinePaths(rootPath, "tsconfig.json"), &core.CompilerOptions{}, host, nil)
+	assert.Equal(b, len(errors), 0, "Expected no errors in parsed command line")
+	p := compiler.NewProgramFromParsedCommandLine(parsed, host)
 
 	b.ReportAllocs()
 

--- a/internal/execute/tsc.go
+++ b/internal/execute/tsc.go
@@ -115,7 +115,7 @@ func executeCommandLineWorker(sys System, cb cbType, commandLine *tsoptions.Pars
 
 	if configFileName != "" {
 		extendedConfigCache := map[tspath.Path]*tsoptions.ExtendedConfigCacheEntry{}
-		configParseResult, errors := getParsedCommandLineOfConfigFile(configFileName, compilerOptionsFromCommandLine, sys, extendedConfigCache)
+		configParseResult, errors := tsoptions.GetParsedCommandLineOfConfigFile(configFileName, compilerOptionsFromCommandLine, sys, extendedConfigCache)
 		if len(errors) != 0 {
 			// these are unrecoverable errors--exit to report them as diagnostics
 			for _, e := range errors {
@@ -170,31 +170,6 @@ func findConfigFile(searchPath string, fileExists func(string) bool, configName 
 		return ""
 	}
 	return result
-}
-
-// Reads the config file and reports errors. Exits if the config file cannot be found
-func getParsedCommandLineOfConfigFile(configFileName string, options *core.CompilerOptions, sys System, extendedConfigCache map[tspath.Path]*tsoptions.ExtendedConfigCacheEntry) (*tsoptions.ParsedCommandLine, []*ast.Diagnostic) {
-	errors := []*ast.Diagnostic{}
-	configFileText, errors := tsoptions.TryReadFile(configFileName, sys.FS().ReadFile, errors)
-	if len(errors) > 0 {
-		// these are unrecoverable errors--exit to report them as diagnostics
-		return nil, errors
-	}
-
-	cwd := sys.GetCurrentDirectory()
-	tsConfigSourceFile := tsoptions.NewTsconfigSourceFileFromFilePath(configFileName, tspath.ToPath(configFileName, cwd, sys.FS().UseCaseSensitiveFileNames()), configFileText)
-	// tsConfigSourceFile.resolvedPath = tsConfigSourceFile.FileName()
-	// tsConfigSourceFile.originalFileName = tsConfigSourceFile.FileName()
-	return tsoptions.ParseJsonSourceFileConfigFileContent(
-		tsConfigSourceFile,
-		sys,
-		tspath.GetNormalizedAbsolutePath(tspath.GetDirectoryPath(configFileName), cwd),
-		options,
-		tspath.GetNormalizedAbsolutePath(configFileName, cwd),
-		nil,
-		nil,
-		extendedConfigCache,
-	), nil
 }
 
 func performCompilation(sys System, cb cbType, config *tsoptions.ParsedCommandLine, reportDiagnostic diagnosticReporter) ExitStatus {

--- a/internal/execute/watcher.go
+++ b/internal/execute/watcher.go
@@ -46,7 +46,7 @@ func (w *watcher) hasErrorsInTsConfig() bool {
 	if w.configFileName != "" {
 		extendedConfigCache := map[tspath.Path]*tsoptions.ExtendedConfigCacheEntry{}
 		// !!! need to check that this merges compileroptions correctly. This differs from non-watch, since we allow overriding of previous options
-		configParseResult, errors := getParsedCommandLineOfConfigFile(w.configFileName, &core.CompilerOptions{}, w.sys, extendedConfigCache)
+		configParseResult, errors := tsoptions.GetParsedCommandLineOfConfigFile(w.configFileName, &core.CompilerOptions{}, w.sys, extendedConfigCache)
 		if len(errors) > 0 {
 			for _, e := range errors {
 				w.reportDiagnostic(e)

--- a/internal/tsoptions/commandlineparser.go
+++ b/internal/tsoptions/commandlineparser.go
@@ -120,7 +120,7 @@ func getInputOptionName(input string) string {
 }
 
 func (p *commandLineParser) parseResponseFile(fileName string) {
-	fileContents, errors := TryReadFile(fileName, func(fileName string) (string, bool) {
+	fileContents, errors := tryReadFile(fileName, func(fileName string) (string, bool) {
 		if p.fs == nil {
 			return "", false
 		}
@@ -166,7 +166,7 @@ func (p *commandLineParser) parseResponseFile(fileName string) {
 	p.parseStrings(args)
 }
 
-func TryReadFile(fileName string, readFile func(string) (string, bool), errors []*ast.Diagnostic) (string, []*ast.Diagnostic) {
+func tryReadFile(fileName string, readFile func(string) (string, bool), errors []*ast.Diagnostic) (string, []*ast.Diagnostic) {
 	// this function adds a compiler diagnostic if the file cannot be read
 	text, e := readFile(fileName)
 

--- a/internal/tsoptions/tsconfigparsing.go
+++ b/internal/tsoptions/tsconfigparsing.go
@@ -864,7 +864,7 @@ func parseOwnConfigOfJson(
 }
 
 func readJsonConfigFile(fileName string, path tspath.Path, readFile func(fileName string) (string, bool)) (*TsConfigSourceFile, []*ast.Diagnostic) {
-	text, diagnostic := TryReadFile(fileName, readFile, []*ast.Diagnostic{})
+	text, diagnostic := tryReadFile(fileName, readFile, []*ast.Diagnostic{})
 	if text != "" {
 		return &TsConfigSourceFile{
 			SourceFile: parser.ParseJSONText(fileName, path, text),

--- a/internal/tsoptions/utilities.go
+++ b/internal/tsoptions/utilities.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/dlclark/regexp2"
+	"github.com/microsoft/typescript-go/internal/ast"
 	"github.com/microsoft/typescript-go/internal/core"
 	"github.com/microsoft/typescript-go/internal/stringutil"
 	"github.com/microsoft/typescript-go/internal/tspath"
@@ -467,4 +468,29 @@ func matchFiles(path string, extensions []string, excludes []string, includes []
 
 func readDirectory(host vfs.FS, currentDir string, path string, extensions []string, excludes []string, includes []string, depth *int) []string {
 	return matchFiles(path, extensions, excludes, includes, host.UseCaseSensitiveFileNames(), currentDir, depth, host)
+}
+
+// Reads the config file and reports errors. Exits if the config file cannot be found
+func GetParsedCommandLineOfConfigFile(configFileName string, options *core.CompilerOptions, sys ParseConfigHost, extendedConfigCache map[tspath.Path]*ExtendedConfigCacheEntry) (*ParsedCommandLine, []*ast.Diagnostic) {
+	errors := []*ast.Diagnostic{}
+	configFileText, errors := TryReadFile(configFileName, sys.FS().ReadFile, errors)
+	if len(errors) > 0 {
+		// these are unrecoverable errors--exit to report them as diagnostics
+		return nil, errors
+	}
+
+	cwd := sys.GetCurrentDirectory()
+	tsConfigSourceFile := NewTsconfigSourceFileFromFilePath(configFileName, tspath.ToPath(configFileName, cwd, sys.FS().UseCaseSensitiveFileNames()), configFileText)
+	// tsConfigSourceFile.resolvedPath = tsConfigSourceFile.FileName()
+	// tsConfigSourceFile.originalFileName = tsConfigSourceFile.FileName()
+	return ParseJsonSourceFileConfigFileContent(
+		tsConfigSourceFile,
+		sys,
+		tspath.GetNormalizedAbsolutePath(tspath.GetDirectoryPath(configFileName), cwd),
+		options,
+		tspath.GetNormalizedAbsolutePath(configFileName, cwd),
+		nil,
+		nil,
+		extendedConfigCache,
+	), nil
 }

--- a/internal/tsoptions/utilities.go
+++ b/internal/tsoptions/utilities.go
@@ -470,10 +470,10 @@ func readDirectory(host vfs.FS, currentDir string, path string, extensions []str
 	return matchFiles(path, extensions, excludes, includes, host.UseCaseSensitiveFileNames(), currentDir, depth, host)
 }
 
-// Reads the config file and reports errors. Exits if the config file cannot be found
+// Reads the config file and reports errors.
 func GetParsedCommandLineOfConfigFile(configFileName string, options *core.CompilerOptions, sys ParseConfigHost, extendedConfigCache map[tspath.Path]*ExtendedConfigCacheEntry) (*ParsedCommandLine, []*ast.Diagnostic) {
 	errors := []*ast.Diagnostic{}
-	configFileText, errors := TryReadFile(configFileName, sys.FS().ReadFile, errors)
+	configFileText, errors := tryReadFile(configFileName, sys.FS().ReadFile, errors)
 	if len(errors) > 0 {
 		// these are unrecoverable errors--exit to report them as diagnostics
 		return nil, errors


### PR DESCRIPTION
This is from back when the CLI was hacked-up. Now there's no reason to have it.