### PR TITLE
Set typescript.native-preview.serverRunning=false on extension startup

### DIFF
--- a/_extension/src/extension.ts
+++ b/_extension/src/extension.ts
@@ -6,6 +6,8 @@ import { setupStatusBar } from "./statusBar";
 import { setupVersionStatusItem } from "./versionStatusItem";
 
 export async function activate(context: vscode.ExtensionContext) {
+    await vscode.commands.executeCommand("setContext", "typescript.native-preview.serverRunning", false);
+
     const output = vscode.window.createOutputChannel("typescript-native-preview", "log");
     const traceOutput = vscode.window.createOutputChannel("typescript-native-preview (LSP)");
     const client = new Client(output, traceOutput);


### PR DESCRIPTION
Disabling via the command restarts the extension host, leaving this context around. Clear it right on initialize back to false so it's always correct.