### PR TITLE
Various node builder related performance optimizations

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -14904,7 +14904,7 @@ type ExportCollisionTable = map[string]*ExportCollision
 
 func (c *Checker) getExportsOfModuleWorker(moduleSymbol *ast.Symbol) (exports ast.SymbolTable, typeOnlyExportStarMap map[string]*ast.Node) {
 	var visitedSymbols []*ast.Symbol
-	var nonTypeOnlyNames core.Set[string]
+	nonTypeOnlyNames := core.NewSetWithSizeHint[string](len(moduleSymbol.Exports))
 	// The ES6 spec permits export * declarations in a module to circularly reference the module itself. For example,
 	// module 'a' can 'export * from "b"' and 'b' can 'export * from "a"' without error.
 	var visit func(*ast.Symbol, *ast.Node, bool) ast.SymbolTable

--- a/internal/checker/nodebuilder.go
+++ b/internal/checker/nodebuilder.go
@@ -36,7 +36,6 @@ func (b *NodeBuilder) enterContext(enclosingDeclaration *ast.Node, flags nodebui
 		tracker = NewSymbolTrackerImpl(b.impl.ctx, nil, b.host)
 		b.impl.ctx.tracker = tracker
 	}
-	b.impl.initializeClosures() // recapture ctx
 	b.ctxStack = append(b.ctxStack, b.impl.ctx)
 }
 
@@ -159,7 +158,7 @@ func (b *NodeBuilder) TypePredicateToTypePredicateNode(predicate *TypePredicate,
 // TypeToTypeNode implements NodeBuilderInterface.
 func (b *NodeBuilder) TypeToTypeNode(typ *Type, enclosingDeclaration *ast.Node, flags nodebuilder.Flags, internalFlags nodebuilder.InternalFlags, tracker nodebuilder.SymbolTracker) *ast.Node {
 	b.enterContext(enclosingDeclaration, flags, internalFlags, tracker)
-	return b.exitContext(b.impl.typeToTypeNodeWorker(typ))
+	return b.exitContext(b.impl.typeToTypeNode(typ))
 }
 
 // var _ NodeBuilderInterface = NewNodeBuilderAPI(nil, nil)

--- a/internal/checker/nodebuilderimpl.go
+++ b/internal/checker/nodebuilderimpl.go
@@ -212,7 +212,7 @@ func (b *nodeBuilderImpl) mapToTypeNodes(list []*Type) *ast.NodeList {
 	if len(list) == 0 {
 		return nil
 	}
-	contents := core.Map(list, b.typeToTypeNode)
+	contents := core.MapMethod(b, list, (*nodeBuilderImpl).typeToTypeNode)
 	return b.f.NewNodeList(contents)
 }
 
@@ -1984,8 +1984,8 @@ func (b *nodeBuilderImpl) isSingleQuotedStringNamed(d *ast.Declaration) bool {
 }
 
 func (b *nodeBuilderImpl) getPropertyNameNodeForSymbol(symbol *ast.Symbol) *ast.Node {
-	stringNamed := len(symbol.Declarations) != 0 && core.Every(symbol.Declarations, b.isStringNamed)
-	singleQuote := len(symbol.Declarations) != 0 && core.Every(symbol.Declarations, b.isSingleQuotedStringNamed)
+	stringNamed := len(symbol.Declarations) != 0 && core.EveryMethod(b, symbol.Declarations, (*nodeBuilderImpl).isStringNamed)
+	singleQuote := len(symbol.Declarations) != 0 && core.EveryMethod(b, symbol.Declarations, (*nodeBuilderImpl).isSingleQuotedStringNamed)
 	isMethod := symbol.Flags&ast.SymbolFlagsMethod != 0
 	fromNameType := b.getPropertyNameNodeForSymbolFromNameType(symbol, singleQuote, stringNamed, isMethod)
 	if fromNameType != nil {

--- a/internal/checker/nodebuilderimpl.go
+++ b/internal/checker/nodebuilderimpl.go
@@ -91,14 +91,6 @@ type nodeBuilderImpl struct {
 	links       core.LinkStore[*ast.Node, NodeBuilderLinks]
 	symbolLinks core.LinkStore[*ast.Symbol, NodeBuilderSymbolLinks]
 
-	// closures
-	typeToTypeNode               func(t *Type) *ast.TypeNode
-	typeReferenceToTypeNode      func(t *Type) *ast.TypeNode
-	conditionalTypeToTypeNode    func(t *Type) *ast.TypeNode
-	createTypeNodeFromObjectType func(t *Type) *ast.TypeNode
-	isStringNamed                func(d *ast.Declaration) bool
-	isSingleQuotedStringNamed    func(d *ast.Declaration) bool
-
 	// state
 	ctx *NodeBuilderContext
 }
@@ -111,18 +103,8 @@ const (
 // Node builder utility functions
 
 func newNodeBuilderImpl(ch *Checker, e *printer.EmitContext) nodeBuilderImpl {
-	result := nodeBuilderImpl{f: e.Factory.AsNodeFactory(), ch: ch, e: e, typeToTypeNode: nil, typeReferenceToTypeNode: nil, conditionalTypeToTypeNode: nil, ctx: nil}
-	result.initializeClosures()
+	result := nodeBuilderImpl{f: e.Factory.AsNodeFactory(), ch: ch, e: e}
 	return result
-}
-
-func (b *nodeBuilderImpl) initializeClosures() {
-	b.typeToTypeNode = b.typeToTypeNodeWorker
-	b.typeReferenceToTypeNode = b.typeReferenceToTypeNodeWorker
-	b.conditionalTypeToTypeNode = b.conditionalTypeToTypeNodeWorker
-	b.createTypeNodeFromObjectType = b.createTypeNodeFromObjectTypeWorker
-	b.isStringNamed = b.isStringNamedWorker
-	b.isSingleQuotedStringNamed = b.isSingleQuotedStringNamedWorker
 }
 
 func (b *nodeBuilderImpl) saveRestoreFlags() func() {
@@ -1978,7 +1960,7 @@ func (b *nodeBuilderImpl) createPropertyNameNodeForIdentifierOrLiteral(name stri
 	return result
 }
 
-func (b *nodeBuilderImpl) isStringNamedWorker(d *ast.Declaration) bool {
+func (b *nodeBuilderImpl) isStringNamed(d *ast.Declaration) bool {
 	name := ast.GetNameOfDeclaration(d)
 	if name == nil {
 		return false
@@ -1994,7 +1976,7 @@ func (b *nodeBuilderImpl) isStringNamedWorker(d *ast.Declaration) bool {
 	return ast.IsStringLiteral(name)
 }
 
-func (b *nodeBuilderImpl) isSingleQuotedStringNamedWorker(d *ast.Declaration) bool {
+func (b *nodeBuilderImpl) isSingleQuotedStringNamed(d *ast.Declaration) bool {
 	return false // !!!
 	// TODO: actually support single-quote-style-maintenance
 	// name := ast.GetNameOfDeclaration(d)
@@ -2218,7 +2200,7 @@ func (b *nodeBuilderImpl) createTypeNodesFromResolvedType(resolvedType *Structur
 	}
 }
 
-func (b *nodeBuilderImpl) createTypeNodeFromObjectTypeWorker(t *Type) *ast.TypeNode {
+func (b *nodeBuilderImpl) createTypeNodeFromObjectType(t *Type) *ast.TypeNode {
 	if b.ch.isGenericMappedType(t) || (t.objectFlags&ObjectFlagsMapped != 0 && t.AsMappedType().containsError) {
 		return b.createMappedTypeNodeFromType(t)
 	}
@@ -2331,7 +2313,7 @@ func (b *nodeBuilderImpl) createAnonymousTypeNode(t *Type) *ast.TypeNode {
 			if _, ok := b.ctx.visitedTypes[typeId]; ok {
 				return b.createElidedInformationPlaceholder()
 			}
-			return b.visitAndTransformType(t, b.createTypeNodeFromObjectType)
+			return b.visitAndTransformType(t, (*nodeBuilderImpl).createTypeNodeFromObjectType)
 		}
 		var isInstanceType ast.SymbolFlags
 		if isClassInstanceSide(b.ch, t) {
@@ -2357,7 +2339,7 @@ func (b *nodeBuilderImpl) createAnonymousTypeNode(t *Type) *ast.TypeNode {
 				return b.createElidedInformationPlaceholder()
 			}
 		} else {
-			return b.visitAndTransformType(t, b.createTypeNodeFromObjectType)
+			return b.visitAndTransformType(t, (*nodeBuilderImpl).createTypeNodeFromObjectType)
 		}
 	} else {
 		// Anonymous types without a symbol are never circular.
@@ -2388,12 +2370,12 @@ func (b *nodeBuilderImpl) typeToTypeNodeOrCircularityElision(t *Type) *ast.TypeN
 			}
 			return b.createElidedInformationPlaceholder()
 		}
-		return b.visitAndTransformType(t, b.typeToTypeNode)
+		return b.visitAndTransformType(t, (*nodeBuilderImpl).typeToTypeNode)
 	}
 	return b.typeToTypeNode(t)
 }
 
-func (b *nodeBuilderImpl) conditionalTypeToTypeNodeWorker(_t *Type) *ast.TypeNode {
+func (b *nodeBuilderImpl) conditionalTypeToTypeNode(_t *Type) *ast.TypeNode {
 	t := _t.AsConditionalType()
 	checkTypeNode := b.typeToTypeNode(t.checkType)
 	b.ctx.approximateLength += 15
@@ -2451,7 +2433,7 @@ func (b *nodeBuilderImpl) getParentSymbolOfTypeParameter(typeParameter *TypePara
 	return b.ch.getSymbolOfNode(host)
 }
 
-func (b *nodeBuilderImpl) typeReferenceToTypeNodeWorker(t *Type) *ast.TypeNode {
+func (b *nodeBuilderImpl) typeReferenceToTypeNode(t *Type) *ast.TypeNode {
 	var typeArguments []*Type = b.ch.getTypeArguments(t)
 	if t.Target() == b.ch.globalArrayType || t.Target() == b.ch.globalReadonlyArrayType {
 		if b.ctx.flags&nodebuilder.FlagsWriteArrayAsGenericType != 0 {
@@ -2585,7 +2567,7 @@ func (b *nodeBuilderImpl) typeReferenceToTypeNodeWorker(t *Type) *ast.TypeNode {
 	}
 }
 
-func (b *nodeBuilderImpl) visitAndTransformType(t *Type, transform func(t *Type) *ast.TypeNode) *ast.TypeNode {
+func (b *nodeBuilderImpl) visitAndTransformType(t *Type, transform func(b *nodeBuilderImpl, t *Type) *ast.TypeNode) *ast.TypeNode {
 	typeId := t.id
 	isConstructorObject := t.objectFlags&ObjectFlagsAnonymous != 0 && t.symbol != nil && t.symbol.Flags&ast.SymbolFlagsClass != 0
 	var id *CompositeSymbolIdentity
@@ -2631,7 +2613,7 @@ func (b *nodeBuilderImpl) visitAndTransformType(t *Type, transform func(t *Type)
 	prevTrackedSymbols := b.ctx.trackedSymbols
 	b.ctx.trackedSymbols = nil
 	startLength := b.ctx.approximateLength
-	result := transform(t)
+	result := transform(b, t)
 	addedLength := b.ctx.approximateLength - startLength
 	if !b.ctx.reportedDiagnostic && !b.ctx.encounteredError {
 		links := b.links.Get(b.ctx.enclosingDeclaration)
@@ -2670,7 +2652,7 @@ func (b *nodeBuilderImpl) visitAndTransformType(t *Type, transform func(t *Type)
 	// }
 }
 
-func (b *nodeBuilderImpl) typeToTypeNodeWorker(t *Type) *ast.TypeNode {
+func (b *nodeBuilderImpl) typeToTypeNode(t *Type) *ast.TypeNode {
 	inTypeAlias := b.ctx.flags & nodebuilder.FlagsInTypeAlias
 	b.ctx.flags &^= nodebuilder.FlagsInTypeAlias
 
@@ -2832,7 +2814,7 @@ func (b *nodeBuilderImpl) typeToTypeNodeWorker(t *Type) *ast.TypeNode {
 	if objectFlags&ObjectFlagsReference != 0 {
 		// Debug.assert(t.flags&TypeFlagsObject != 0) // !!!
 		if t.AsTypeReference().node != nil {
-			return b.visitAndTransformType(t, b.typeReferenceToTypeNode)
+			return b.visitAndTransformType(t, (*nodeBuilderImpl).typeReferenceToTypeNode)
 		} else {
 			return b.typeReferenceToTypeNode(t)
 		}
@@ -2938,7 +2920,7 @@ func (b *nodeBuilderImpl) typeToTypeNodeWorker(t *Type) *ast.TypeNode {
 		return b.f.NewIndexedAccessTypeNode(objectTypeNode, indexTypeNode)
 	}
 	if t.flags&TypeFlagsConditional != 0 {
-		return b.visitAndTransformType(t, b.conditionalTypeToTypeNode)
+		return b.visitAndTransformType(t, (*nodeBuilderImpl).conditionalTypeToTypeNode)
 	}
 	if t.flags&TypeFlagsSubstitution != 0 {
 		typeNode := b.typeToTypeNode(t.AsSubstitutionType().baseType)

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -58,6 +58,17 @@ func Map[T, U any](slice []T, f func(T) U) []U {
 	return result
 }
 
+func MapMethod[R, T, U any](receiver R, slice []T, f func(R, T) U) []U {
+	if slice == nil {
+		return nil
+	}
+	result := make([]U, len(slice))
+	for i, value := range slice {
+		result[i] = f(receiver, value)
+	}
+	return result
+}
+
 func TryMap[T, U any](slice []T, f func(T) (U, error)) ([]U, error) {
 	if len(slice) == 0 {
 		return nil, nil
@@ -146,6 +157,15 @@ func Some[T any](slice []T, f func(T) bool) bool {
 func Every[T any](slice []T, f func(T) bool) bool {
 	for _, value := range slice {
 		if !f(value) {
+			return false
+		}
+	}
+	return true
+}
+
+func EveryMethod[R, T any](receiver R, slice []T, f func(R, T) bool) bool {
+	for _, value := range slice {
+		if !f(receiver, value) {
 			return false
 		}
 	}

--- a/internal/printer/emitcontext.go
+++ b/internal/printer/emitcontext.go
@@ -37,6 +37,12 @@ func NewEmitContext() *EmitContext {
 	return c
 }
 
+func (c *EmitContext) Reset() {
+	*c = EmitContext{
+		Factory: c.Factory,
+	}
+}
+
 func (c *EmitContext) onCreate(node *ast.Node) {
 	node.Flags |= ast.NodeFlagsSynthesized
 }

--- a/internal/printer/emitcontext.go
+++ b/internal/printer/emitcontext.go
@@ -24,10 +24,6 @@ type EmitContext struct {
 	varScopeStack core.Stack[*varScope]
 	letScopeStack core.Stack[*varScope]
 	emitHelpers   collections.OrderedSet[*EmitHelper]
-
-	isCustomPrologue           func(node *ast.Statement) bool
-	isHoistedFunction          func(node *ast.Statement) bool
-	isHoistedVariableStatement func(node *ast.Statement) bool
 }
 
 type varScope struct {
@@ -38,9 +34,6 @@ type varScope struct {
 func NewEmitContext() *EmitContext {
 	c := &EmitContext{}
 	c.Factory = NewNodeFactory(c)
-	c.isCustomPrologue = c.isCustomPrologueWorker
-	c.isHoistedFunction = c.isHoistedFunctionWorker
-	c.isHoistedVariableStatement = c.isHoistedVariableStatementWorker
 	return c
 }
 
@@ -260,14 +253,14 @@ func (c *EmitContext) mergeEnvironment(statements []*ast.Statement, declarations
 
 	// find standard prologues on left in the following order: standard directives, hoisted functions, hoisted variables, other custom
 	leftStandardPrologueEnd := findSpanEnd(statements, ast.IsPrologueDirective, 0)
-	leftHoistedFunctionsEnd := findSpanEnd(statements, c.isHoistedFunction, leftStandardPrologueEnd)
-	leftHoistedVariablesEnd := findSpanEnd(statements, c.isHoistedVariableStatement, leftHoistedFunctionsEnd)
+	leftHoistedFunctionsEnd := findSpanEndWithEmitContext(c, statements, (*EmitContext).isHoistedFunction, leftStandardPrologueEnd)
+	leftHoistedVariablesEnd := findSpanEndWithEmitContext(c, statements, (*EmitContext).isHoistedVariableStatement, leftHoistedFunctionsEnd)
 
 	// find standard prologues on right in the following order: standard directives, hoisted functions, hoisted variables, other custom
 	rightStandardPrologueEnd := findSpanEnd(declarations, ast.IsPrologueDirective, 0)
-	rightHoistedFunctionsEnd := findSpanEnd(declarations, c.isHoistedFunction, rightStandardPrologueEnd)
-	rightHoistedVariablesEnd := findSpanEnd(declarations, c.isHoistedVariableStatement, rightHoistedFunctionsEnd)
-	rightCustomPrologueEnd := findSpanEnd(declarations, c.isCustomPrologue, rightHoistedVariablesEnd)
+	rightHoistedFunctionsEnd := findSpanEndWithEmitContext(c, declarations, (*EmitContext).isHoistedFunction, rightStandardPrologueEnd)
+	rightHoistedVariablesEnd := findSpanEndWithEmitContext(c, declarations, (*EmitContext).isHoistedVariableStatement, rightHoistedFunctionsEnd)
+	rightCustomPrologueEnd := findSpanEndWithEmitContext(c, declarations, (*EmitContext).isCustomPrologue, rightHoistedVariablesEnd)
 	if rightCustomPrologueEnd != len(declarations) {
 		panic("Expected declarations to be valid standard or custom prologues")
 	}
@@ -316,20 +309,20 @@ func (c *EmitContext) mergeEnvironment(statements []*ast.Statement, declarations
 	return left, changed
 }
 
-func (c *EmitContext) isCustomPrologueWorker(node *ast.Statement) bool {
+func (c *EmitContext) isCustomPrologue(node *ast.Statement) bool {
 	return c.EmitFlags(node)&EFCustomPrologue != 0
 }
 
-func (c *EmitContext) isHoistedFunctionWorker(node *ast.Statement) bool {
-	return c.isCustomPrologueWorker(node) && ast.IsFunctionDeclaration(node)
+func (c *EmitContext) isHoistedFunction(node *ast.Statement) bool {
+	return c.isCustomPrologue(node) && ast.IsFunctionDeclaration(node)
 }
 
 func isHoistedVariable(node *ast.VariableDeclarationNode) bool {
 	return ast.IsIdentifier(node.Name()) && node.Initializer() == nil
 }
 
-func (c *EmitContext) isHoistedVariableStatementWorker(node *ast.Statement) bool {
-	return c.isCustomPrologueWorker(node) &&
+func (c *EmitContext) isHoistedVariableStatement(node *ast.Statement) bool {
+	return c.isCustomPrologue(node) &&
 		ast.IsVariableStatement(node) &&
 		core.Every(node.AsVariableStatement().DeclarationList.AsVariableDeclarationList().Declarations.Nodes, isHoistedVariable)
 }

--- a/internal/printer/utilities.go
+++ b/internal/printer/utilities.go
@@ -728,6 +728,14 @@ func makeIdentifierFromModuleName(moduleName string) string {
 	return builder.String()
 }
 
+func findSpanEndWithEmitContext[T any](c *EmitContext, array []T, test func(c *EmitContext, value T) bool, start int) int {
+	i := start
+	for i < len(array) && test(c, array[i]) {
+		i++
+	}
+	return i
+}
+
 func findSpanEnd[T any](array []T, test func(value T) bool, start int) int {
 	i := start
 	for i < len(array) && test(array[i]) {

--- a/internal/testutil/tsbaseline/type_symbol_baseline.go
+++ b/internal/testutil/tsbaseline/type_symbol_baseline.go
@@ -338,6 +338,8 @@ func (walker *typeWriterWalker) writeTypeOrSymbol(node *ast.Node, isSymbolWalk b
 	fileChecker, done := walker.getTypeCheckerForCurrentFile()
 	defer done()
 
+	ctx := printer.NewEmitContext()
+
 	if !isSymbolWalk {
 		// Don't try to get the type of something that's already a type.
 		// Exception for `T` in `type T = something` because that may evaluate to some interesting type.
@@ -374,7 +376,7 @@ func (walker *typeWriterWalker) writeTypeOrSymbol(node *ast.Node, isSymbolWalk b
 			!isIntrinsicJsxTag(node, walker.currentSourceFile) {
 			typeString = t.AsIntrinsicType().IntrinsicName()
 		} else {
-			ctx := printer.NewEmitContext()
+			ctx.Reset()
 			builder := checker.NewNodeBuilder(fileChecker, ctx)
 			typeFormatFlags := checker.TypeFormatFlagsNoTruncation | checker.TypeFormatFlagsAllowUniqueESSymbolType | checker.TypeFormatFlagsGenerateNamesForShadowedTypeParams
 			typeNode := builder.TypeToTypeNode(t, node.Parent, nodebuilder.Flags(typeFormatFlags&checker.TypeFormatFlagsNodeBuilderFlagsMask)|nodebuilder.FlagsIgnoreErrors, nodebuilder.InternalFlagsAllowUnresolvedNames, nil)


### PR DESCRIPTION
- Eliminate the closures; this can be done through the same tricks used in the parser to avoid binding. This reduces some 10%+ allocations.
- Presize `nonTypeOnlyNames`.
- Eliminate the closures from the emit context.
- Reuse emit contexts in type baselines.