### PR TITLE
Ensure we don't copy OrderedMaps

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -20072,7 +20072,7 @@ func (c *Checker) createUnionOrIntersectionProperty(containingType *Type, name s
 	if singleProp == nil || isUnion &&
 		(propSet.Size() != 0 || checkFlags&ast.CheckFlagsPartial != 0) &&
 		checkFlags&(ast.CheckFlagsContainsPrivate|ast.CheckFlagsContainsProtected) != 0 &&
-		!(propSet.Size() != 0 && c.hasCommonDeclaration(propSet)) {
+		!(propSet.Size() != 0 && c.hasCommonDeclaration(&propSet)) {
 		// No property was found, or, in a union, a property has a private or protected declaration in one
 		// constituent, but is missing or has a different declaration in another constituent.
 		return nil
@@ -20194,7 +20194,7 @@ func isPrototypeProperty(symbol *ast.Symbol) bool {
 	return symbol.Flags&ast.SymbolFlagsMethod != 0 || symbol.CheckFlags&ast.CheckFlagsSyntheticMethod != 0
 }
 
-func (c *Checker) hasCommonDeclaration(symbols collections.OrderedSet[*ast.Symbol]) bool {
+func (c *Checker) hasCommonDeclaration(symbols *collections.OrderedSet[*ast.Symbol]) bool {
 	var commonDeclarations core.Set[*ast.Node]
 	for symbol := range symbols.Values() {
 		if len(symbol.Declarations) == 0 {

--- a/internal/collections/ordered_map.go
+++ b/internal/collections/ordered_map.go
@@ -18,9 +18,21 @@ import (
 
 // OrderedMap is an insertion ordered map.
 type OrderedMap[K comparable, V any] struct {
+	_    noCopy
 	keys []K
 	mp   map[K]V
 }
+
+// noCopy may be embedded into structs which must not be copied
+// after the first use.
+//
+// See https://golang.org/issues/8005#issuecomment-190753527
+// for details.
+type noCopy struct{}
+
+// Lock is a no-op used by -copylocks checker from `go vet`.
+func (*noCopy) Lock()   {}
+func (*noCopy) Unlock() {}
 
 // NewOrderedMapWithSizeHint creates a new OrderedMap with a hint for the number of elements it will contain.
 func NewOrderedMapWithSizeHint[K comparable, V any](hint int) *OrderedMap[K, V] {
@@ -191,7 +203,7 @@ func (m *OrderedMap[K, V]) clone() OrderedMap[K, V] {
 	}
 }
 
-func (m OrderedMap[K, V]) MarshalJSON() ([]byte, error) {
+func (m *OrderedMap[K, V]) MarshalJSON() ([]byte, error) {
 	if len(m.mp) == 0 {
 		return []byte("{}"), nil
 	}

--- a/internal/tsoptions/tsconfigparsing.go
+++ b/internal/tsoptions/tsconfigparsing.go
@@ -1471,7 +1471,7 @@ func hasFileWithHigherPriorityExtension(file string, extensions [][]string, hasF
 
 // Removes files included via wildcard expansion with a lower extension priority that have already been included.
 // file is the path to the file.
-func removeWildcardFilesWithLowerPriorityExtension(file string, wildcardFiles collections.OrderedMap[string, string], extensions [][]string, keyMapper func(value string) string) {
+func removeWildcardFilesWithLowerPriorityExtension(file string, wildcardFiles *collections.OrderedMap[string, string], extensions [][]string, keyMapper func(value string) string) {
 	var extensionGroup []string
 	for _, group := range extensions {
 		if tspath.FileExtensionIsOneOf(file, group) {
@@ -1575,7 +1575,7 @@ func getFileNamesFromConfigSpecs(
 			// extension due to the user-defined order of entries in the
 			// "include" array. If there is a lower priority extension in the
 			// same directory, we should remove it.
-			removeWildcardFilesWithLowerPriorityExtension(file, wildcardFileMap, supportedExtensions, keyMappper)
+			removeWildcardFilesWithLowerPriorityExtension(file, &wildcardFileMap, supportedExtensions, keyMappper)
 			key := keyMappper(file)
 			if !literalFileMap.Has(key) && !wildcardFileMap.Has(key) {
 				wildcardFileMap.Set(key, file)


### PR DESCRIPTION
Fixes #978

#978 broke because `removeWildcardFilesWithLowerPriorityExtension` passed the map by value and then attempted to delete from it. That will cause the internal `map` to be modified, but the `key` slice to _not_ be modified in the caller. The fix is to pass by pointer.

To prevent this bug from happening in the future, use the `noCopy` pattern to make `go vet` check it. This reveals another place we weren't passing the map by pointer. That one's not a bug, but it could have been.

I don't have a real test for the problem as I think it's self explanatory and `go vet` will catch this, but I could figure out how to test it if required.