### PR TITLE
Strip glob patterns from include basePath

### DIFF
--- a/internal/vfs/utilities.go
+++ b/internal/vfs/utilities.go
@@ -248,7 +248,7 @@ func getIncludeBasePath(absolute string) string {
 			return tspath.RemoveTrailingDirectorySeparator(tspath.GetDirectoryPath(absolute))
 		}
 	}
-	return absolute[:strings.LastIndex(absolute, string(tspath.DirectorySeparator))]
+	return absolute[:strings.LastIndex(absolute[:wildcardOffset], string(tspath.DirectorySeparator))]
 }
 
 // getBasePaths computes the unique non-wildcard base paths amongst the provided include patterns.

--- a/internal/vfs/utilities.go
+++ b/internal/vfs/utilities.go
@@ -248,7 +248,7 @@ func getIncludeBasePath(absolute string) string {
 			return tspath.RemoveTrailingDirectorySeparator(tspath.GetDirectoryPath(absolute))
 		}
 	}
-	return absolute[:strings.LastIndex(absolute[:wildcardOffset], string(tspath.DirectorySeparator))]
+	return absolute[:max(strings.LastIndex(absolute[:wildcardOffset], string(tspath.DirectorySeparator)), 0)]
 }
 
 // getBasePaths computes the unique non-wildcard base paths amongst the provided include patterns.


### PR DESCRIPTION
quick explanation: 
Absolute paths like "/some/path/glob/**" were getting through when the correct path would be "/some/path/glob"

long: 
An include like `../../ambient-types/**/*` is turned into an absolute path, let's say `/home/dev/project/ambient-types/**/*` and passed here https://github.com/microsoft/typescript-go/blob/e8d352c89b733779275a364d6e5de7df65ac9a42/internal/vfs/utilities.go#L241-L252
That strips the last chunk of the path, so returns `/home/dev/project/ambient-types/**`.  Then `patterns` in https://github.com/microsoft/typescript-go/blob/e8d352c89b733779275a364d6e5de7df65ac9a42/internal/vfs/utilities.go#L425 ends up with one of it's base paths as  `/home/dev/project/ambient-types/**` and that is not a valid path to visit in https://github.com/microsoft/typescript-go/blob/e8d352c89b733779275a364d6e5de7df65ac9a42/internal/vfs/utilities.go#L370-L382 so `systemEntries.Files` and `systemEntries.Directories` are empty and any files represented by that include are not found.

Thing do work with implicit globs, so if that include was `../../ambient-types` the `basePath` ends up as `/home/dev/project/ambient-types` and the files and/or directories are found.  

This is attempting to address #980 