### PR TITLE
Fix a couple of Project/ATA bugs

### DIFF
--- a/internal/project/ata.go
+++ b/internal/project/ata.go
@@ -323,6 +323,7 @@ func (ti *TypingsInstaller) invokeRoutineToInstallTypings(
 				if pendingRequestsCount == 1 {
 					ti.pendingRunRequests = nil
 				} else {
+					ti.pendingRunRequests[0] = nil // ensure the request is GC'd
 					ti.pendingRunRequests = ti.pendingRunRequests[1:]
 				}
 			}

--- a/internal/project/discovertypings.go
+++ b/internal/project/discovertypings.go
@@ -69,7 +69,9 @@ func DiscoverTypings(
 	}
 
 	// add typings for unresolved imports
-	modules := slices.Compact(core.Map(typingsInfo.UnresolvedImports, core.NonRelativeModuleNameForTypingCache))
+	modules := core.Map(typingsInfo.UnresolvedImports, core.NonRelativeModuleNameForTypingCache)
+	slices.Sort(modules)
+	modules = slices.Compact(modules)
 	addInferredTypings(fs, log, inferredTypings, modules, "Inferred typings from unresolved imports")
 
 	// Remove typings that the user has added to the exclude list

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -102,8 +102,8 @@ func setIsEqualTo(arr1 []string, arr2 []string) bool {
 	if slices.Equal(arr1, arr2) {
 		return true
 	}
-	compact1 := slices.Compact(arr1)
-	compact2 := slices.Compact(arr2)
+	compact1 := slices.Clone(arr1)
+	compact2 := slices.Clone(arr2)
 	slices.Sort(compact1)
 	slices.Sort(compact2)
 	return slices.Equal(compact1, compact2)


### PR DESCRIPTION
Noticed these while looking at the ATA code.

`Compact` was used in a couple of places where it should have been `Clone` (so ended up modifying input slice later), and one `Compact` call was missing a sort.

Additionally, we could leak memory out of ATA due to the pending requests; it's possible that it would be cleared eventually, but it's best to zero out an element of a slice before slicing it off.