### PR TITLE
Measure config parse / file scan time, actual total time

### DIFF
--- a/cmd/tsgo/sys.go
+++ b/cmd/tsgo/sys.go
@@ -21,6 +21,11 @@ type osSys struct {
 	defaultLibraryPath string
 	newLine            string
 	cwd                string
+	start              time.Time
+}
+
+func (s *osSys) SinceStart() time.Duration {
+	return time.Since(s.start)
 }
 
 func (s *osSys) Now() time.Time {
@@ -65,5 +70,6 @@ func newSystem() *osSys {
 		defaultLibraryPath: bundled.LibPath(),
 		writer:             os.Stdout,
 		newLine:            core.IfElse(runtime.GOOS == "windows", "\r\n", "\n"),
+		start:              time.Now(),
 	}
 }

--- a/internal/execute/outputs.go
+++ b/internal/execute/outputs.go
@@ -79,6 +79,9 @@ func reportStatistics(sys System, program *compiler.Program, result compileAndEm
 	stats.add("Instantiations", program.InstantiationCount())
 	stats.add("Memory used", fmt.Sprintf("%vK", memStats.Alloc/1024))
 	stats.add("Memory allocs", strconv.FormatUint(memStats.Mallocs, 10))
+	if result.configTime != 0 {
+		stats.add("Config time", result.configTime)
+	}
 	stats.add("Parse time", result.parseTime)
 	if result.bindTime != 0 {
 		stats.add("Bind time", result.bindTime)

--- a/internal/execute/system.go
+++ b/internal/execute/system.go
@@ -10,11 +10,13 @@ import (
 type System interface {
 	Writer() io.Writer
 	EndWrite() // needed for testing
-	Now() time.Time
 	FS() vfs.FS
 	DefaultLibraryPath() string
 	GetCurrentDirectory() string
 	NewLine() string // #241 eventually we want to use "\n"
+
+	Now() time.Time
+	SinceStart() time.Duration
 }
 
 type ExitStatus int

--- a/internal/execute/testsys_test.go
+++ b/internal/execute/testsys_test.go
@@ -28,6 +28,7 @@ func newTestSys(fileOrFolderList FileMap, cwd string, args ...string) *testSys {
 		files:              slices.Collect(maps.Keys(fileOrFolderList)),
 		output:             []string{},
 		currentWrite:       &strings.Builder{},
+		start:              time.Now(),
 	}
 }
 
@@ -41,6 +42,8 @@ type testSys struct {
 	defaultLibraryPath string
 	cwd                string
 	files              []string
+
+	start time.Time
 }
 
 func (s *testSys) IsTestDone() bool {
@@ -51,6 +54,10 @@ func (s *testSys) IsTestDone() bool {
 func (s *testSys) Now() time.Time {
 	// todo: make a "test time" structure
 	return time.Now()
+}
+
+func (s *testSys) SinceStart() time.Duration {
+	return time.Since(s.start)
 }
 
 func (s *testSys) FS() vfs.FS {


### PR DESCRIPTION
In Strada, I can't tell if this time was omitted or just a part of the parse time (probably the latter). But we were totally omitting it in this repo, which hides the fact that config loading and file scanning takes a significant amount of time. Collect this number, and then ensure the total time actually includes everything. 

See: https://github.com/microsoft/typescript-go/issues/1062#issuecomment-2944885778

```
Config time:      0.120s
Parse time:       0.513s
Bind time:        0.100s
Check time:       5.719s
Emit time:        0.721s
Total time:       7.176s
```

This is going to make our total time stat longer, but it's more realistic, and we should totally go and optimize file scanning/matching to eliminate the use of `regexp2`.

As part of this, I've refactored `System` such that time fully goes through `System`, which I mistakenly did not do in my original PR moving this functionality into the `execute` pacakge.