### PR TITLE
Format all generated files

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -50,7 +50,6 @@
         "**/*-lock.json",
         "**/testdata",
         "_submodules/**",
-        "**/*_generated.go",
         "internal/bundled/libs/**",
         "internal/lsp/lsproto/_generate/*.json",
         "internal/lsp/lsproto/_generate/metaModelSchema.mts",

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -18,6 +18,7 @@ import (
 )
 
 //go:generate go tool golang.org/x/tools/cmd/stringer -type=MessageType -output=stringer_generated.go
+//go:generate go tool mvdan.cc/gofumpt -lang=go1.24 -w stringer_generated.go
 
 type MessageType uint8
 

--- a/internal/ast/kind.go
+++ b/internal/ast/kind.go
@@ -1,6 +1,7 @@
 package ast
 
 //go:generate go tool golang.org/x/tools/cmd/stringer -type=Kind -output=kind_stringer_generated.go
+//go:generate go tool mvdan.cc/gofumpt -lang=go1.24 -w kind_stringer_generated.go
 
 type Kind int16
 

--- a/internal/checker/types.go
+++ b/internal/checker/types.go
@@ -10,6 +10,7 @@ import (
 )
 
 //go:generate go tool golang.org/x/tools/cmd/stringer -type=SignatureKind -output=stringer_generated.go
+//go:generate go tool mvdan.cc/gofumpt -lang=go1.24 -w stringer_generated.go
 
 // ParseFlags
 

--- a/internal/core/compileroptions.go
+++ b/internal/core/compileroptions.go
@@ -8,6 +8,7 @@ import (
 )
 
 //go:generate go tool golang.org/x/tools/cmd/stringer -type=ModuleKind,ScriptTarget -output=compileroptions_stringer_generated.go
+//go:generate go tool mvdan.cc/gofumpt -lang=go1.24 -w compileroptions_stringer_generated.go
 
 type CompilerOptions struct {
 	AllowJs                                   Tristate                                  `json:"allowJs,omitzero"`

--- a/internal/core/compileroptions_stringer_generated.go
+++ b/internal/core/compileroptions_stringer_generated.go
@@ -49,6 +49,7 @@ func (i ModuleKind) String() string {
 		return "ModuleKind(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 }
+
 func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.

--- a/internal/core/languagevariant.go
+++ b/internal/core/languagevariant.go
@@ -1,6 +1,7 @@
 package core
 
 //go:generate go tool golang.org/x/tools/cmd/stringer -type=LanguageVariant -output=languagevariant_stringer_generated.go
+//go:generate go tool mvdan.cc/gofumpt -lang=go1.24 -w languagevariant_stringer_generated.go
 
 type LanguageVariant int32
 

--- a/internal/core/scriptkind.go
+++ b/internal/core/scriptkind.go
@@ -1,6 +1,7 @@
 package core
 
 //go:generate go tool golang.org/x/tools/cmd/stringer -type=ScriptKind -output=scriptkind_stringer_generated.go
+//go:generate go tool mvdan.cc/gofumpt -lang=go1.24 -w scriptkind_stringer_generated.go
 
 type ScriptKind int32
 

--- a/internal/core/tristate.go
+++ b/internal/core/tristate.go
@@ -1,6 +1,7 @@
 package core
 
 //go:generate go tool golang.org/x/tools/cmd/stringer -type=Tristate -output=tristate_stringer_generated.go
+//go:generate go tool mvdan.cc/gofumpt -lang=go1.24 -w tristate_stringer_generated.go
 
 // Tristate
 

--- a/internal/diagnostics/diagnostics.go
+++ b/internal/diagnostics/diagnostics.go
@@ -5,6 +5,7 @@ import "github.com/microsoft/typescript-go/internal/stringutil"
 
 //go:generate go run generate.go -output ./diagnostics_generated.go
 //go:generate go tool golang.org/x/tools/cmd/stringer -type=Category -output=stringer_generated.go
+//go:generate go tool mvdan.cc/gofumpt -lang=go1.24 -w diagnostics_generated.go stringer_generated.go
 
 type Category int32
 

--- a/internal/diagnostics/diagnostics_generated.go
+++ b/internal/diagnostics/diagnostics_generated.go
@@ -3,2108 +3,4213 @@
 package diagnostics
 
 var Unterminated_string_literal = &Message{code: 1002, category: CategoryError, key: "Unterminated_string_literal_1002", text: "Unterminated string literal."}
+
 var Identifier_expected = &Message{code: 1003, category: CategoryError, key: "Identifier_expected_1003", text: "Identifier expected."}
+
 var X_0_expected = &Message{code: 1005, category: CategoryError, key: "_0_expected_1005", text: "'{0}' expected."}
+
 var A_file_cannot_have_a_reference_to_itself = &Message{code: 1006, category: CategoryError, key: "A_file_cannot_have_a_reference_to_itself_1006", text: "A file cannot have a reference to itself."}
+
 var The_parser_expected_to_find_a_1_to_match_the_0_token_here = &Message{code: 1007, category: CategoryError, key: "The_parser_expected_to_find_a_1_to_match_the_0_token_here_1007", text: "The parser expected to find a '{1}' to match the '{0}' token here."}
+
 var Trailing_comma_not_allowed = &Message{code: 1009, category: CategoryError, key: "Trailing_comma_not_allowed_1009", text: "Trailing comma not allowed."}
+
 var Asterisk_Slash_expected = &Message{code: 1010, category: CategoryError, key: "Asterisk_Slash_expected_1010", text: "'*/' expected."}
+
 var An_element_access_expression_should_take_an_argument = &Message{code: 1011, category: CategoryError, key: "An_element_access_expression_should_take_an_argument_1011", text: "An element access expression should take an argument."}
+
 var Unexpected_token = &Message{code: 1012, category: CategoryError, key: "Unexpected_token_1012", text: "Unexpected token."}
+
 var A_rest_parameter_or_binding_pattern_may_not_have_a_trailing_comma = &Message{code: 1013, category: CategoryError, key: "A_rest_parameter_or_binding_pattern_may_not_have_a_trailing_comma_1013", text: "A rest parameter or binding pattern may not have a trailing comma."}
+
 var A_rest_parameter_must_be_last_in_a_parameter_list = &Message{code: 1014, category: CategoryError, key: "A_rest_parameter_must_be_last_in_a_parameter_list_1014", text: "A rest parameter must be last in a parameter list."}
+
 var Parameter_cannot_have_question_mark_and_initializer = &Message{code: 1015, category: CategoryError, key: "Parameter_cannot_have_question_mark_and_initializer_1015", text: "Parameter cannot have question mark and initializer."}
+
 var A_required_parameter_cannot_follow_an_optional_parameter = &Message{code: 1016, category: CategoryError, key: "A_required_parameter_cannot_follow_an_optional_parameter_1016", text: "A required parameter cannot follow an optional parameter."}
+
 var An_index_signature_cannot_have_a_rest_parameter = &Message{code: 1017, category: CategoryError, key: "An_index_signature_cannot_have_a_rest_parameter_1017", text: "An index signature cannot have a rest parameter."}
+
 var An_index_signature_parameter_cannot_have_an_accessibility_modifier = &Message{code: 1018, category: CategoryError, key: "An_index_signature_parameter_cannot_have_an_accessibility_modifier_1018", text: "An index signature parameter cannot have an accessibility modifier."}
+
 var An_index_signature_parameter_cannot_have_a_question_mark = &Message{code: 1019, category: CategoryError, key: "An_index_signature_parameter_cannot_have_a_question_mark_1019", text: "An index signature parameter cannot have a question mark."}
+
 var An_index_signature_parameter_cannot_have_an_initializer = &Message{code: 1020, category: CategoryError, key: "An_index_signature_parameter_cannot_have_an_initializer_1020", text: "An index signature parameter cannot have an initializer."}
+
 var An_index_signature_must_have_a_type_annotation = &Message{code: 1021, category: CategoryError, key: "An_index_signature_must_have_a_type_annotation_1021", text: "An index signature must have a type annotation."}
+
 var An_index_signature_parameter_must_have_a_type_annotation = &Message{code: 1022, category: CategoryError, key: "An_index_signature_parameter_must_have_a_type_annotation_1022", text: "An index signature parameter must have a type annotation."}
+
 var X_readonly_modifier_can_only_appear_on_a_property_declaration_or_index_signature = &Message{code: 1024, category: CategoryError, key: "readonly_modifier_can_only_appear_on_a_property_declaration_or_index_signature_1024", text: "'readonly' modifier can only appear on a property declaration or index signature."}
+
 var An_index_signature_cannot_have_a_trailing_comma = &Message{code: 1025, category: CategoryError, key: "An_index_signature_cannot_have_a_trailing_comma_1025", text: "An index signature cannot have a trailing comma."}
+
 var Accessibility_modifier_already_seen = &Message{code: 1028, category: CategoryError, key: "Accessibility_modifier_already_seen_1028", text: "Accessibility modifier already seen."}
+
 var X_0_modifier_must_precede_1_modifier = &Message{code: 1029, category: CategoryError, key: "_0_modifier_must_precede_1_modifier_1029", text: "'{0}' modifier must precede '{1}' modifier."}
+
 var X_0_modifier_already_seen = &Message{code: 1030, category: CategoryError, key: "_0_modifier_already_seen_1030", text: "'{0}' modifier already seen."}
+
 var X_0_modifier_cannot_appear_on_class_elements_of_this_kind = &Message{code: 1031, category: CategoryError, key: "_0_modifier_cannot_appear_on_class_elements_of_this_kind_1031", text: "'{0}' modifier cannot appear on class elements of this kind."}
+
 var X_super_must_be_followed_by_an_argument_list_or_member_access = &Message{code: 1034, category: CategoryError, key: "super_must_be_followed_by_an_argument_list_or_member_access_1034", text: "'super' must be followed by an argument list or member access."}
+
 var Only_ambient_modules_can_use_quoted_names = &Message{code: 1035, category: CategoryError, key: "Only_ambient_modules_can_use_quoted_names_1035", text: "Only ambient modules can use quoted names."}
+
 var Statements_are_not_allowed_in_ambient_contexts = &Message{code: 1036, category: CategoryError, key: "Statements_are_not_allowed_in_ambient_contexts_1036", text: "Statements are not allowed in ambient contexts."}
+
 var A_declare_modifier_cannot_be_used_in_an_already_ambient_context = &Message{code: 1038, category: CategoryError, key: "A_declare_modifier_cannot_be_used_in_an_already_ambient_context_1038", text: "A 'declare' modifier cannot be used in an already ambient context."}
+
 var Initializers_are_not_allowed_in_ambient_contexts = &Message{code: 1039, category: CategoryError, key: "Initializers_are_not_allowed_in_ambient_contexts_1039", text: "Initializers are not allowed in ambient contexts."}
+
 var X_0_modifier_cannot_be_used_in_an_ambient_context = &Message{code: 1040, category: CategoryError, key: "_0_modifier_cannot_be_used_in_an_ambient_context_1040", text: "'{0}' modifier cannot be used in an ambient context."}
+
 var X_0_modifier_cannot_be_used_here = &Message{code: 1042, category: CategoryError, key: "_0_modifier_cannot_be_used_here_1042", text: "'{0}' modifier cannot be used here."}
+
 var X_0_modifier_cannot_appear_on_a_module_or_namespace_element = &Message{code: 1044, category: CategoryError, key: "_0_modifier_cannot_appear_on_a_module_or_namespace_element_1044", text: "'{0}' modifier cannot appear on a module or namespace element."}
+
 var Top_level_declarations_in_d_ts_files_must_start_with_either_a_declare_or_export_modifier = &Message{code: 1046, category: CategoryError, key: "Top_level_declarations_in_d_ts_files_must_start_with_either_a_declare_or_export_modifier_1046", text: "Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier."}
+
 var A_rest_parameter_cannot_be_optional = &Message{code: 1047, category: CategoryError, key: "A_rest_parameter_cannot_be_optional_1047", text: "A rest parameter cannot be optional."}
+
 var A_rest_parameter_cannot_have_an_initializer = &Message{code: 1048, category: CategoryError, key: "A_rest_parameter_cannot_have_an_initializer_1048", text: "A rest parameter cannot have an initializer."}
+
 var A_set_accessor_must_have_exactly_one_parameter = &Message{code: 1049, category: CategoryError, key: "A_set_accessor_must_have_exactly_one_parameter_1049", text: "A 'set' accessor must have exactly one parameter."}
+
 var A_set_accessor_cannot_have_an_optional_parameter = &Message{code: 1051, category: CategoryError, key: "A_set_accessor_cannot_have_an_optional_parameter_1051", text: "A 'set' accessor cannot have an optional parameter."}
+
 var A_set_accessor_parameter_cannot_have_an_initializer = &Message{code: 1052, category: CategoryError, key: "A_set_accessor_parameter_cannot_have_an_initializer_1052", text: "A 'set' accessor parameter cannot have an initializer."}
+
 var A_set_accessor_cannot_have_rest_parameter = &Message{code: 1053, category: CategoryError, key: "A_set_accessor_cannot_have_rest_parameter_1053", text: "A 'set' accessor cannot have rest parameter."}
+
 var A_get_accessor_cannot_have_parameters = &Message{code: 1054, category: CategoryError, key: "A_get_accessor_cannot_have_parameters_1054", text: "A 'get' accessor cannot have parameters."}
+
 var Type_0_is_not_a_valid_async_function_return_type_in_ES5_because_it_does_not_refer_to_a_Promise_compatible_constructor_value = &Message{code: 1055, category: CategoryError, key: "Type_0_is_not_a_valid_async_function_return_type_in_ES5_because_it_does_not_refer_to_a_Promise_compa_1055", text: "Type '{0}' is not a valid async function return type in ES5 because it does not refer to a Promise-compatible constructor value."}
+
 var Accessors_are_only_available_when_targeting_ECMAScript_5_and_higher = &Message{code: 1056, category: CategoryError, key: "Accessors_are_only_available_when_targeting_ECMAScript_5_and_higher_1056", text: "Accessors are only available when targeting ECMAScript 5 and higher."}
+
 var The_return_type_of_an_async_function_must_either_be_a_valid_promise_or_must_not_contain_a_callable_then_member = &Message{code: 1058, category: CategoryError, key: "The_return_type_of_an_async_function_must_either_be_a_valid_promise_or_must_not_contain_a_callable_t_1058", text: "The return type of an async function must either be a valid promise or must not contain a callable 'then' member."}
+
 var A_promise_must_have_a_then_method = &Message{code: 1059, category: CategoryError, key: "A_promise_must_have_a_then_method_1059", text: "A promise must have a 'then' method."}
+
 var The_first_parameter_of_the_then_method_of_a_promise_must_be_a_callback = &Message{code: 1060, category: CategoryError, key: "The_first_parameter_of_the_then_method_of_a_promise_must_be_a_callback_1060", text: "The first parameter of the 'then' method of a promise must be a callback."}
+
 var Enum_member_must_have_initializer = &Message{code: 1061, category: CategoryError, key: "Enum_member_must_have_initializer_1061", text: "Enum member must have initializer."}
+
 var Type_is_referenced_directly_or_indirectly_in_the_fulfillment_callback_of_its_own_then_method = &Message{code: 1062, category: CategoryError, key: "Type_is_referenced_directly_or_indirectly_in_the_fulfillment_callback_of_its_own_then_method_1062", text: "Type is referenced directly or indirectly in the fulfillment callback of its own 'then' method."}
+
 var An_export_assignment_cannot_be_used_in_a_namespace = &Message{code: 1063, category: CategoryError, key: "An_export_assignment_cannot_be_used_in_a_namespace_1063", text: "An export assignment cannot be used in a namespace."}
+
 var The_return_type_of_an_async_function_or_method_must_be_the_global_Promise_T_type_Did_you_mean_to_write_Promise_0 = &Message{code: 1064, category: CategoryError, key: "The_return_type_of_an_async_function_or_method_must_be_the_global_Promise_T_type_Did_you_mean_to_wri_1064", text: "The return type of an async function or method must be the global Promise<T> type. Did you mean to write 'Promise<{0}>'?"}
+
 var The_return_type_of_an_async_function_or_method_must_be_the_global_Promise_T_type = &Message{code: 1065, category: CategoryError, key: "The_return_type_of_an_async_function_or_method_must_be_the_global_Promise_T_type_1065", text: "The return type of an async function or method must be the global Promise<T> type."}
+
 var In_ambient_enum_declarations_member_initializer_must_be_constant_expression = &Message{code: 1066, category: CategoryError, key: "In_ambient_enum_declarations_member_initializer_must_be_constant_expression_1066", text: "In ambient enum declarations member initializer must be constant expression."}
+
 var Unexpected_token_A_constructor_method_accessor_or_property_was_expected = &Message{code: 1068, category: CategoryError, key: "Unexpected_token_A_constructor_method_accessor_or_property_was_expected_1068", text: "Unexpected token. A constructor, method, accessor, or property was expected."}
+
 var Unexpected_token_A_type_parameter_name_was_expected_without_curly_braces = &Message{code: 1069, category: CategoryError, key: "Unexpected_token_A_type_parameter_name_was_expected_without_curly_braces_1069", text: "Unexpected token. A type parameter name was expected without curly braces."}
+
 var X_0_modifier_cannot_appear_on_a_type_member = &Message{code: 1070, category: CategoryError, key: "_0_modifier_cannot_appear_on_a_type_member_1070", text: "'{0}' modifier cannot appear on a type member."}
+
 var X_0_modifier_cannot_appear_on_an_index_signature = &Message{code: 1071, category: CategoryError, key: "_0_modifier_cannot_appear_on_an_index_signature_1071", text: "'{0}' modifier cannot appear on an index signature."}
+
 var A_0_modifier_cannot_be_used_with_an_import_declaration = &Message{code: 1079, category: CategoryError, key: "A_0_modifier_cannot_be_used_with_an_import_declaration_1079", text: "A '{0}' modifier cannot be used with an import declaration."}
+
 var Invalid_reference_directive_syntax = &Message{code: 1084, category: CategoryError, key: "Invalid_reference_directive_syntax_1084", text: "Invalid 'reference' directive syntax."}
+
 var X_0_modifier_cannot_appear_on_a_constructor_declaration = &Message{code: 1089, category: CategoryError, key: "_0_modifier_cannot_appear_on_a_constructor_declaration_1089", text: "'{0}' modifier cannot appear on a constructor declaration."}
+
 var X_0_modifier_cannot_appear_on_a_parameter = &Message{code: 1090, category: CategoryError, key: "_0_modifier_cannot_appear_on_a_parameter_1090", text: "'{0}' modifier cannot appear on a parameter."}
+
 var Only_a_single_variable_declaration_is_allowed_in_a_for_in_statement = &Message{code: 1091, category: CategoryError, key: "Only_a_single_variable_declaration_is_allowed_in_a_for_in_statement_1091", text: "Only a single variable declaration is allowed in a 'for...in' statement."}
+
 var Type_parameters_cannot_appear_on_a_constructor_declaration = &Message{code: 1092, category: CategoryError, key: "Type_parameters_cannot_appear_on_a_constructor_declaration_1092", text: "Type parameters cannot appear on a constructor declaration."}
+
 var Type_annotation_cannot_appear_on_a_constructor_declaration = &Message{code: 1093, category: CategoryError, key: "Type_annotation_cannot_appear_on_a_constructor_declaration_1093", text: "Type annotation cannot appear on a constructor declaration."}
+
 var An_accessor_cannot_have_type_parameters = &Message{code: 1094, category: CategoryError, key: "An_accessor_cannot_have_type_parameters_1094", text: "An accessor cannot have type parameters."}
+
 var A_set_accessor_cannot_have_a_return_type_annotation = &Message{code: 1095, category: CategoryError, key: "A_set_accessor_cannot_have_a_return_type_annotation_1095", text: "A 'set' accessor cannot have a return type annotation."}
+
 var An_index_signature_must_have_exactly_one_parameter = &Message{code: 1096, category: CategoryError, key: "An_index_signature_must_have_exactly_one_parameter_1096", text: "An index signature must have exactly one parameter."}
+
 var X_0_list_cannot_be_empty = &Message{code: 1097, category: CategoryError, key: "_0_list_cannot_be_empty_1097", text: "'{0}' list cannot be empty."}
+
 var Type_parameter_list_cannot_be_empty = &Message{code: 1098, category: CategoryError, key: "Type_parameter_list_cannot_be_empty_1098", text: "Type parameter list cannot be empty."}
+
 var Type_argument_list_cannot_be_empty = &Message{code: 1099, category: CategoryError, key: "Type_argument_list_cannot_be_empty_1099", text: "Type argument list cannot be empty."}
+
 var Invalid_use_of_0_in_strict_mode = &Message{code: 1100, category: CategoryError, key: "Invalid_use_of_0_in_strict_mode_1100", text: "Invalid use of '{0}' in strict mode."}
+
 var X_with_statements_are_not_allowed_in_strict_mode = &Message{code: 1101, category: CategoryError, key: "with_statements_are_not_allowed_in_strict_mode_1101", text: "'with' statements are not allowed in strict mode."}
+
 var X_delete_cannot_be_called_on_an_identifier_in_strict_mode = &Message{code: 1102, category: CategoryError, key: "delete_cannot_be_called_on_an_identifier_in_strict_mode_1102", text: "'delete' cannot be called on an identifier in strict mode."}
+
 var X_for_await_loops_are_only_allowed_within_async_functions_and_at_the_top_levels_of_modules = &Message{code: 1103, category: CategoryError, key: "for_await_loops_are_only_allowed_within_async_functions_and_at_the_top_levels_of_modules_1103", text: "'for await' loops are only allowed within async functions and at the top levels of modules."}
+
 var A_continue_statement_can_only_be_used_within_an_enclosing_iteration_statement = &Message{code: 1104, category: CategoryError, key: "A_continue_statement_can_only_be_used_within_an_enclosing_iteration_statement_1104", text: "A 'continue' statement can only be used within an enclosing iteration statement."}
+
 var A_break_statement_can_only_be_used_within_an_enclosing_iteration_or_switch_statement = &Message{code: 1105, category: CategoryError, key: "A_break_statement_can_only_be_used_within_an_enclosing_iteration_or_switch_statement_1105", text: "A 'break' statement can only be used within an enclosing iteration or switch statement."}
+
 var The_left_hand_side_of_a_for_of_statement_may_not_be_async = &Message{code: 1106, category: CategoryError, key: "The_left_hand_side_of_a_for_of_statement_may_not_be_async_1106", text: "The left-hand side of a 'for...of' statement may not be 'async'."}
+
 var Jump_target_cannot_cross_function_boundary = &Message{code: 1107, category: CategoryError, key: "Jump_target_cannot_cross_function_boundary_1107", text: "Jump target cannot cross function boundary."}
+
 var A_return_statement_can_only_be_used_within_a_function_body = &Message{code: 1108, category: CategoryError, key: "A_return_statement_can_only_be_used_within_a_function_body_1108", text: "A 'return' statement can only be used within a function body."}
+
 var Expression_expected = &Message{code: 1109, category: CategoryError, key: "Expression_expected_1109", text: "Expression expected."}
+
 var Type_expected = &Message{code: 1110, category: CategoryError, key: "Type_expected_1110", text: "Type expected."}
+
 var Private_field_0_must_be_declared_in_an_enclosing_class = &Message{code: 1111, category: CategoryError, key: "Private_field_0_must_be_declared_in_an_enclosing_class_1111", text: "Private field '{0}' must be declared in an enclosing class."}
+
 var A_default_clause_cannot_appear_more_than_once_in_a_switch_statement = &Message{code: 1113, category: CategoryError, key: "A_default_clause_cannot_appear_more_than_once_in_a_switch_statement_1113", text: "A 'default' clause cannot appear more than once in a 'switch' statement."}
+
 var Duplicate_label_0 = &Message{code: 1114, category: CategoryError, key: "Duplicate_label_0_1114", text: "Duplicate label '{0}'."}
+
 var A_continue_statement_can_only_jump_to_a_label_of_an_enclosing_iteration_statement = &Message{code: 1115, category: CategoryError, key: "A_continue_statement_can_only_jump_to_a_label_of_an_enclosing_iteration_statement_1115", text: "A 'continue' statement can only jump to a label of an enclosing iteration statement."}
+
 var A_break_statement_can_only_jump_to_a_label_of_an_enclosing_statement = &Message{code: 1116, category: CategoryError, key: "A_break_statement_can_only_jump_to_a_label_of_an_enclosing_statement_1116", text: "A 'break' statement can only jump to a label of an enclosing statement."}
+
 var An_object_literal_cannot_have_multiple_properties_with_the_same_name = &Message{code: 1117, category: CategoryError, key: "An_object_literal_cannot_have_multiple_properties_with_the_same_name_1117", text: "An object literal cannot have multiple properties with the same name."}
+
 var An_object_literal_cannot_have_multiple_get_Slashset_accessors_with_the_same_name = &Message{code: 1118, category: CategoryError, key: "An_object_literal_cannot_have_multiple_get_Slashset_accessors_with_the_same_name_1118", text: "An object literal cannot have multiple get/set accessors with the same name."}
+
 var An_object_literal_cannot_have_property_and_accessor_with_the_same_name = &Message{code: 1119, category: CategoryError, key: "An_object_literal_cannot_have_property_and_accessor_with_the_same_name_1119", text: "An object literal cannot have property and accessor with the same name."}
+
 var An_export_assignment_cannot_have_modifiers = &Message{code: 1120, category: CategoryError, key: "An_export_assignment_cannot_have_modifiers_1120", text: "An export assignment cannot have modifiers."}
+
 var Octal_literals_are_not_allowed_Use_the_syntax_0 = &Message{code: 1121, category: CategoryError, key: "Octal_literals_are_not_allowed_Use_the_syntax_0_1121", text: "Octal literals are not allowed. Use the syntax '{0}'."}
+
 var Variable_declaration_list_cannot_be_empty = &Message{code: 1123, category: CategoryError, key: "Variable_declaration_list_cannot_be_empty_1123", text: "Variable declaration list cannot be empty."}
+
 var Digit_expected = &Message{code: 1124, category: CategoryError, key: "Digit_expected_1124", text: "Digit expected."}
+
 var Hexadecimal_digit_expected = &Message{code: 1125, category: CategoryError, key: "Hexadecimal_digit_expected_1125", text: "Hexadecimal digit expected."}
+
 var Unexpected_end_of_text = &Message{code: 1126, category: CategoryError, key: "Unexpected_end_of_text_1126", text: "Unexpected end of text."}
+
 var Invalid_character = &Message{code: 1127, category: CategoryError, key: "Invalid_character_1127", text: "Invalid character."}
+
 var Declaration_or_statement_expected = &Message{code: 1128, category: CategoryError, key: "Declaration_or_statement_expected_1128", text: "Declaration or statement expected."}
+
 var Statement_expected = &Message{code: 1129, category: CategoryError, key: "Statement_expected_1129", text: "Statement expected."}
+
 var X_case_or_default_expected = &Message{code: 1130, category: CategoryError, key: "case_or_default_expected_1130", text: "'case' or 'default' expected."}
+
 var Property_or_signature_expected = &Message{code: 1131, category: CategoryError, key: "Property_or_signature_expected_1131", text: "Property or signature expected."}
+
 var Enum_member_expected = &Message{code: 1132, category: CategoryError, key: "Enum_member_expected_1132", text: "Enum member expected."}
+
 var Variable_declaration_expected = &Message{code: 1134, category: CategoryError, key: "Variable_declaration_expected_1134", text: "Variable declaration expected."}
+
 var Argument_expression_expected = &Message{code: 1135, category: CategoryError, key: "Argument_expression_expected_1135", text: "Argument expression expected."}
+
 var Property_assignment_expected = &Message{code: 1136, category: CategoryError, key: "Property_assignment_expected_1136", text: "Property assignment expected."}
+
 var Expression_or_comma_expected = &Message{code: 1137, category: CategoryError, key: "Expression_or_comma_expected_1137", text: "Expression or comma expected."}
+
 var Parameter_declaration_expected = &Message{code: 1138, category: CategoryError, key: "Parameter_declaration_expected_1138", text: "Parameter declaration expected."}
+
 var Type_parameter_declaration_expected = &Message{code: 1139, category: CategoryError, key: "Type_parameter_declaration_expected_1139", text: "Type parameter declaration expected."}
+
 var Type_argument_expected = &Message{code: 1140, category: CategoryError, key: "Type_argument_expected_1140", text: "Type argument expected."}
+
 var String_literal_expected = &Message{code: 1141, category: CategoryError, key: "String_literal_expected_1141", text: "String literal expected."}
+
 var Line_break_not_permitted_here = &Message{code: 1142, category: CategoryError, key: "Line_break_not_permitted_here_1142", text: "Line break not permitted here."}
+
 var X_or_expected = &Message{code: 1144, category: CategoryError, key: "or_expected_1144", text: "'{' or ';' expected."}
+
 var X_or_JSX_element_expected = &Message{code: 1145, category: CategoryError, key: "or_JSX_element_expected_1145", text: "'{' or JSX element expected."}
+
 var Declaration_expected = &Message{code: 1146, category: CategoryError, key: "Declaration_expected_1146", text: "Declaration expected."}
+
 var Import_declarations_in_a_namespace_cannot_reference_a_module = &Message{code: 1147, category: CategoryError, key: "Import_declarations_in_a_namespace_cannot_reference_a_module_1147", text: "Import declarations in a namespace cannot reference a module."}
+
 var Cannot_use_imports_exports_or_module_augmentations_when_module_is_none = &Message{code: 1148, category: CategoryError, key: "Cannot_use_imports_exports_or_module_augmentations_when_module_is_none_1148", text: "Cannot use imports, exports, or module augmentations when '--module' is 'none'."}
+
 var File_name_0_differs_from_already_included_file_name_1_only_in_casing = &Message{code: 1149, category: CategoryError, key: "File_name_0_differs_from_already_included_file_name_1_only_in_casing_1149", text: "File name '{0}' differs from already included file name '{1}' only in casing."}
+
 var X_0_declarations_must_be_initialized = &Message{code: 1155, category: CategoryError, key: "_0_declarations_must_be_initialized_1155", text: "'{0}' declarations must be initialized."}
+
 var X_0_declarations_can_only_be_declared_inside_a_block = &Message{code: 1156, category: CategoryError, key: "_0_declarations_can_only_be_declared_inside_a_block_1156", text: "'{0}' declarations can only be declared inside a block."}
+
 var Unterminated_template_literal = &Message{code: 1160, category: CategoryError, key: "Unterminated_template_literal_1160", text: "Unterminated template literal."}
+
 var Unterminated_regular_expression_literal = &Message{code: 1161, category: CategoryError, key: "Unterminated_regular_expression_literal_1161", text: "Unterminated regular expression literal."}
+
 var An_object_member_cannot_be_declared_optional = &Message{code: 1162, category: CategoryError, key: "An_object_member_cannot_be_declared_optional_1162", text: "An object member cannot be declared optional."}
+
 var A_yield_expression_is_only_allowed_in_a_generator_body = &Message{code: 1163, category: CategoryError, key: "A_yield_expression_is_only_allowed_in_a_generator_body_1163", text: "A 'yield' expression is only allowed in a generator body."}
+
 var Computed_property_names_are_not_allowed_in_enums = &Message{code: 1164, category: CategoryError, key: "Computed_property_names_are_not_allowed_in_enums_1164", text: "Computed property names are not allowed in enums."}
+
 var A_computed_property_name_in_an_ambient_context_must_refer_to_an_expression_whose_type_is_a_literal_type_or_a_unique_symbol_type = &Message{code: 1165, category: CategoryError, key: "A_computed_property_name_in_an_ambient_context_must_refer_to_an_expression_whose_type_is_a_literal_t_1165", text: "A computed property name in an ambient context must refer to an expression whose type is a literal type or a 'unique symbol' type."}
+
 var A_computed_property_name_in_a_class_property_declaration_must_have_a_simple_literal_type_or_a_unique_symbol_type = &Message{code: 1166, category: CategoryError, key: "A_computed_property_name_in_a_class_property_declaration_must_have_a_simple_literal_type_or_a_unique_1166", text: "A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type."}
+
 var A_computed_property_name_in_a_method_overload_must_refer_to_an_expression_whose_type_is_a_literal_type_or_a_unique_symbol_type = &Message{code: 1168, category: CategoryError, key: "A_computed_property_name_in_a_method_overload_must_refer_to_an_expression_whose_type_is_a_literal_ty_1168", text: "A computed property name in a method overload must refer to an expression whose type is a literal type or a 'unique symbol' type."}
+
 var A_computed_property_name_in_an_interface_must_refer_to_an_expression_whose_type_is_a_literal_type_or_a_unique_symbol_type = &Message{code: 1169, category: CategoryError, key: "A_computed_property_name_in_an_interface_must_refer_to_an_expression_whose_type_is_a_literal_type_or_1169", text: "A computed property name in an interface must refer to an expression whose type is a literal type or a 'unique symbol' type."}
+
 var A_computed_property_name_in_a_type_literal_must_refer_to_an_expression_whose_type_is_a_literal_type_or_a_unique_symbol_type = &Message{code: 1170, category: CategoryError, key: "A_computed_property_name_in_a_type_literal_must_refer_to_an_expression_whose_type_is_a_literal_type__1170", text: "A computed property name in a type literal must refer to an expression whose type is a literal type or a 'unique symbol' type."}
+
 var A_comma_expression_is_not_allowed_in_a_computed_property_name = &Message{code: 1171, category: CategoryError, key: "A_comma_expression_is_not_allowed_in_a_computed_property_name_1171", text: "A comma expression is not allowed in a computed property name."}
+
 var X_extends_clause_already_seen = &Message{code: 1172, category: CategoryError, key: "extends_clause_already_seen_1172", text: "'extends' clause already seen."}
+
 var X_extends_clause_must_precede_implements_clause = &Message{code: 1173, category: CategoryError, key: "extends_clause_must_precede_implements_clause_1173", text: "'extends' clause must precede 'implements' clause."}
+
 var Classes_can_only_extend_a_single_class = &Message{code: 1174, category: CategoryError, key: "Classes_can_only_extend_a_single_class_1174", text: "Classes can only extend a single class."}
+
 var X_implements_clause_already_seen = &Message{code: 1175, category: CategoryError, key: "implements_clause_already_seen_1175", text: "'implements' clause already seen."}
+
 var Interface_declaration_cannot_have_implements_clause = &Message{code: 1176, category: CategoryError, key: "Interface_declaration_cannot_have_implements_clause_1176", text: "Interface declaration cannot have 'implements' clause."}
+
 var Binary_digit_expected = &Message{code: 1177, category: CategoryError, key: "Binary_digit_expected_1177", text: "Binary digit expected."}
+
 var Octal_digit_expected = &Message{code: 1178, category: CategoryError, key: "Octal_digit_expected_1178", text: "Octal digit expected."}
+
 var Unexpected_token_expected = &Message{code: 1179, category: CategoryError, key: "Unexpected_token_expected_1179", text: "Unexpected token. '{' expected."}
+
 var Property_destructuring_pattern_expected = &Message{code: 1180, category: CategoryError, key: "Property_destructuring_pattern_expected_1180", text: "Property destructuring pattern expected."}
+
 var Array_element_destructuring_pattern_expected = &Message{code: 1181, category: CategoryError, key: "Array_element_destructuring_pattern_expected_1181", text: "Array element destructuring pattern expected."}
+
 var A_destructuring_declaration_must_have_an_initializer = &Message{code: 1182, category: CategoryError, key: "A_destructuring_declaration_must_have_an_initializer_1182", text: "A destructuring declaration must have an initializer."}
+
 var An_implementation_cannot_be_declared_in_ambient_contexts = &Message{code: 1183, category: CategoryError, key: "An_implementation_cannot_be_declared_in_ambient_contexts_1183", text: "An implementation cannot be declared in ambient contexts."}
+
 var Modifiers_cannot_appear_here = &Message{code: 1184, category: CategoryError, key: "Modifiers_cannot_appear_here_1184", text: "Modifiers cannot appear here."}
+
 var Merge_conflict_marker_encountered = &Message{code: 1185, category: CategoryError, key: "Merge_conflict_marker_encountered_1185", text: "Merge conflict marker encountered."}
+
 var A_rest_element_cannot_have_an_initializer = &Message{code: 1186, category: CategoryError, key: "A_rest_element_cannot_have_an_initializer_1186", text: "A rest element cannot have an initializer."}
+
 var A_parameter_property_may_not_be_declared_using_a_binding_pattern = &Message{code: 1187, category: CategoryError, key: "A_parameter_property_may_not_be_declared_using_a_binding_pattern_1187", text: "A parameter property may not be declared using a binding pattern."}
+
 var Only_a_single_variable_declaration_is_allowed_in_a_for_of_statement = &Message{code: 1188, category: CategoryError, key: "Only_a_single_variable_declaration_is_allowed_in_a_for_of_statement_1188", text: "Only a single variable declaration is allowed in a 'for...of' statement."}
+
 var The_variable_declaration_of_a_for_in_statement_cannot_have_an_initializer = &Message{code: 1189, category: CategoryError, key: "The_variable_declaration_of_a_for_in_statement_cannot_have_an_initializer_1189", text: "The variable declaration of a 'for...in' statement cannot have an initializer."}
+
 var The_variable_declaration_of_a_for_of_statement_cannot_have_an_initializer = &Message{code: 1190, category: CategoryError, key: "The_variable_declaration_of_a_for_of_statement_cannot_have_an_initializer_1190", text: "The variable declaration of a 'for...of' statement cannot have an initializer."}
+
 var An_import_declaration_cannot_have_modifiers = &Message{code: 1191, category: CategoryError, key: "An_import_declaration_cannot_have_modifiers_1191", text: "An import declaration cannot have modifiers."}
+
 var Module_0_has_no_default_export = &Message{code: 1192, category: CategoryError, key: "Module_0_has_no_default_export_1192", text: "Module '{0}' has no default export."}
+
 var An_export_declaration_cannot_have_modifiers = &Message{code: 1193, category: CategoryError, key: "An_export_declaration_cannot_have_modifiers_1193", text: "An export declaration cannot have modifiers."}
+
 var Export_declarations_are_not_permitted_in_a_namespace = &Message{code: 1194, category: CategoryError, key: "Export_declarations_are_not_permitted_in_a_namespace_1194", text: "Export declarations are not permitted in a namespace."}
+
 var X_export_Asterisk_does_not_re_export_a_default = &Message{code: 1195, category: CategoryError, key: "export_Asterisk_does_not_re_export_a_default_1195", text: "'export *' does not re-export a default."}
+
 var Catch_clause_variable_type_annotation_must_be_any_or_unknown_if_specified = &Message{code: 1196, category: CategoryError, key: "Catch_clause_variable_type_annotation_must_be_any_or_unknown_if_specified_1196", text: "Catch clause variable type annotation must be 'any' or 'unknown' if specified."}
+
 var Catch_clause_variable_cannot_have_an_initializer = &Message{code: 1197, category: CategoryError, key: "Catch_clause_variable_cannot_have_an_initializer_1197", text: "Catch clause variable cannot have an initializer."}
+
 var An_extended_Unicode_escape_value_must_be_between_0x0_and_0x10FFFF_inclusive = &Message{code: 1198, category: CategoryError, key: "An_extended_Unicode_escape_value_must_be_between_0x0_and_0x10FFFF_inclusive_1198", text: "An extended Unicode escape value must be between 0x0 and 0x10FFFF inclusive."}
+
 var Unterminated_Unicode_escape_sequence = &Message{code: 1199, category: CategoryError, key: "Unterminated_Unicode_escape_sequence_1199", text: "Unterminated Unicode escape sequence."}
+
 var Line_terminator_not_permitted_before_arrow = &Message{code: 1200, category: CategoryError, key: "Line_terminator_not_permitted_before_arrow_1200", text: "Line terminator not permitted before arrow."}
+
 var Import_assignment_cannot_be_used_when_targeting_ECMAScript_modules_Consider_using_import_Asterisk_as_ns_from_mod_import_a_from_mod_import_d_from_mod_or_another_module_format_instead = &Message{code: 1202, category: CategoryError, key: "Import_assignment_cannot_be_used_when_targeting_ECMAScript_modules_Consider_using_import_Asterisk_as_1202", text: "Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from \"mod\"', 'import {a} from \"mod\"', 'import d from \"mod\"', or another module format instead."}
+
 var Export_assignment_cannot_be_used_when_targeting_ECMAScript_modules_Consider_using_export_default_or_another_module_format_instead = &Message{code: 1203, category: CategoryError, key: "Export_assignment_cannot_be_used_when_targeting_ECMAScript_modules_Consider_using_export_default_or__1203", text: "Export assignment cannot be used when targeting ECMAScript modules. Consider using 'export default' or another module format instead."}
+
 var Re_exporting_a_type_when_0_is_enabled_requires_using_export_type = &Message{code: 1205, category: CategoryError, key: "Re_exporting_a_type_when_0_is_enabled_requires_using_export_type_1205", text: "Re-exporting a type when '{0}' is enabled requires using 'export type'."}
+
 var Decorators_are_not_valid_here = &Message{code: 1206, category: CategoryError, key: "Decorators_are_not_valid_here_1206", text: "Decorators are not valid here."}
+
 var Decorators_cannot_be_applied_to_multiple_get_Slashset_accessors_of_the_same_name = &Message{code: 1207, category: CategoryError, key: "Decorators_cannot_be_applied_to_multiple_get_Slashset_accessors_of_the_same_name_1207", text: "Decorators cannot be applied to multiple get/set accessors of the same name."}
+
 var Invalid_optional_chain_from_new_expression_Did_you_mean_to_call_0 = &Message{code: 1209, category: CategoryError, key: "Invalid_optional_chain_from_new_expression_Did_you_mean_to_call_0_1209", text: "Invalid optional chain from new expression. Did you mean to call '{0}()'?"}
+
 var Code_contained_in_a_class_is_evaluated_in_JavaScript_s_strict_mode_which_does_not_allow_this_use_of_0_For_more_information_see_https_Colon_Slash_Slashdeveloper_mozilla_org_Slashen_US_Slashdocs_SlashWeb_SlashJavaScript_SlashReference_SlashStrict_mode = &Message{code: 1210, category: CategoryError, key: "Code_contained_in_a_class_is_evaluated_in_JavaScript_s_strict_mode_which_does_not_allow_this_use_of__1210", text: "Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of '{0}'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode."}
+
 var A_class_declaration_without_the_default_modifier_must_have_a_name = &Message{code: 1211, category: CategoryError, key: "A_class_declaration_without_the_default_modifier_must_have_a_name_1211", text: "A class declaration without the 'default' modifier must have a name."}
+
 var Identifier_expected_0_is_a_reserved_word_in_strict_mode = &Message{code: 1212, category: CategoryError, key: "Identifier_expected_0_is_a_reserved_word_in_strict_mode_1212", text: "Identifier expected. '{0}' is a reserved word in strict mode."}
+
 var Identifier_expected_0_is_a_reserved_word_in_strict_mode_Class_definitions_are_automatically_in_strict_mode = &Message{code: 1213, category: CategoryError, key: "Identifier_expected_0_is_a_reserved_word_in_strict_mode_Class_definitions_are_automatically_in_stric_1213", text: "Identifier expected. '{0}' is a reserved word in strict mode. Class definitions are automatically in strict mode."}
+
 var Identifier_expected_0_is_a_reserved_word_in_strict_mode_Modules_are_automatically_in_strict_mode = &Message{code: 1214, category: CategoryError, key: "Identifier_expected_0_is_a_reserved_word_in_strict_mode_Modules_are_automatically_in_strict_mode_1214", text: "Identifier expected. '{0}' is a reserved word in strict mode. Modules are automatically in strict mode."}
+
 var Invalid_use_of_0_Modules_are_automatically_in_strict_mode = &Message{code: 1215, category: CategoryError, key: "Invalid_use_of_0_Modules_are_automatically_in_strict_mode_1215", text: "Invalid use of '{0}'. Modules are automatically in strict mode."}
+
 var Identifier_expected_esModule_is_reserved_as_an_exported_marker_when_transforming_ECMAScript_modules = &Message{code: 1216, category: CategoryError, key: "Identifier_expected_esModule_is_reserved_as_an_exported_marker_when_transforming_ECMAScript_modules_1216", text: "Identifier expected. '__esModule' is reserved as an exported marker when transforming ECMAScript modules."}
+
 var Export_assignment_is_not_supported_when_module_flag_is_system = &Message{code: 1218, category: CategoryError, key: "Export_assignment_is_not_supported_when_module_flag_is_system_1218", text: "Export assignment is not supported when '--module' flag is 'system'."}
+
 var Generators_are_not_allowed_in_an_ambient_context = &Message{code: 1221, category: CategoryError, key: "Generators_are_not_allowed_in_an_ambient_context_1221", text: "Generators are not allowed in an ambient context."}
+
 var An_overload_signature_cannot_be_declared_as_a_generator = &Message{code: 1222, category: CategoryError, key: "An_overload_signature_cannot_be_declared_as_a_generator_1222", text: "An overload signature cannot be declared as a generator."}
+
 var X_0_tag_already_specified = &Message{code: 1223, category: CategoryError, key: "_0_tag_already_specified_1223", text: "'{0}' tag already specified."}
+
 var Signature_0_must_be_a_type_predicate = &Message{code: 1224, category: CategoryError, key: "Signature_0_must_be_a_type_predicate_1224", text: "Signature '{0}' must be a type predicate."}
+
 var Cannot_find_parameter_0 = &Message{code: 1225, category: CategoryError, key: "Cannot_find_parameter_0_1225", text: "Cannot find parameter '{0}'."}
+
 var Type_predicate_0_is_not_assignable_to_1 = &Message{code: 1226, category: CategoryError, key: "Type_predicate_0_is_not_assignable_to_1_1226", text: "Type predicate '{0}' is not assignable to '{1}'."}
+
 var Parameter_0_is_not_in_the_same_position_as_parameter_1 = &Message{code: 1227, category: CategoryError, key: "Parameter_0_is_not_in_the_same_position_as_parameter_1_1227", text: "Parameter '{0}' is not in the same position as parameter '{1}'."}
+
 var A_type_predicate_is_only_allowed_in_return_type_position_for_functions_and_methods = &Message{code: 1228, category: CategoryError, key: "A_type_predicate_is_only_allowed_in_return_type_position_for_functions_and_methods_1228", text: "A type predicate is only allowed in return type position for functions and methods."}
+
 var A_type_predicate_cannot_reference_a_rest_parameter = &Message{code: 1229, category: CategoryError, key: "A_type_predicate_cannot_reference_a_rest_parameter_1229", text: "A type predicate cannot reference a rest parameter."}
+
 var A_type_predicate_cannot_reference_element_0_in_a_binding_pattern = &Message{code: 1230, category: CategoryError, key: "A_type_predicate_cannot_reference_element_0_in_a_binding_pattern_1230", text: "A type predicate cannot reference element '{0}' in a binding pattern."}
+
 var An_export_assignment_must_be_at_the_top_level_of_a_file_or_module_declaration = &Message{code: 1231, category: CategoryError, key: "An_export_assignment_must_be_at_the_top_level_of_a_file_or_module_declaration_1231", text: "An export assignment must be at the top level of a file or module declaration."}
+
 var An_import_declaration_can_only_be_used_at_the_top_level_of_a_namespace_or_module = &Message{code: 1232, category: CategoryError, key: "An_import_declaration_can_only_be_used_at_the_top_level_of_a_namespace_or_module_1232", text: "An import declaration can only be used at the top level of a namespace or module."}
+
 var An_export_declaration_can_only_be_used_at_the_top_level_of_a_namespace_or_module = &Message{code: 1233, category: CategoryError, key: "An_export_declaration_can_only_be_used_at_the_top_level_of_a_namespace_or_module_1233", text: "An export declaration can only be used at the top level of a namespace or module."}
+
 var An_ambient_module_declaration_is_only_allowed_at_the_top_level_in_a_file = &Message{code: 1234, category: CategoryError, key: "An_ambient_module_declaration_is_only_allowed_at_the_top_level_in_a_file_1234", text: "An ambient module declaration is only allowed at the top level in a file."}
+
 var A_namespace_declaration_is_only_allowed_at_the_top_level_of_a_namespace_or_module = &Message{code: 1235, category: CategoryError, key: "A_namespace_declaration_is_only_allowed_at_the_top_level_of_a_namespace_or_module_1235", text: "A namespace declaration is only allowed at the top level of a namespace or module."}
+
 var The_return_type_of_a_property_decorator_function_must_be_either_void_or_any = &Message{code: 1236, category: CategoryError, key: "The_return_type_of_a_property_decorator_function_must_be_either_void_or_any_1236", text: "The return type of a property decorator function must be either 'void' or 'any'."}
+
 var The_return_type_of_a_parameter_decorator_function_must_be_either_void_or_any = &Message{code: 1237, category: CategoryError, key: "The_return_type_of_a_parameter_decorator_function_must_be_either_void_or_any_1237", text: "The return type of a parameter decorator function must be either 'void' or 'any'."}
+
 var Unable_to_resolve_signature_of_class_decorator_when_called_as_an_expression = &Message{code: 1238, category: CategoryError, key: "Unable_to_resolve_signature_of_class_decorator_when_called_as_an_expression_1238", text: "Unable to resolve signature of class decorator when called as an expression."}
+
 var Unable_to_resolve_signature_of_parameter_decorator_when_called_as_an_expression = &Message{code: 1239, category: CategoryError, key: "Unable_to_resolve_signature_of_parameter_decorator_when_called_as_an_expression_1239", text: "Unable to resolve signature of parameter decorator when called as an expression."}
+
 var Unable_to_resolve_signature_of_property_decorator_when_called_as_an_expression = &Message{code: 1240, category: CategoryError, key: "Unable_to_resolve_signature_of_property_decorator_when_called_as_an_expression_1240", text: "Unable to resolve signature of property decorator when called as an expression."}
+
 var Unable_to_resolve_signature_of_method_decorator_when_called_as_an_expression = &Message{code: 1241, category: CategoryError, key: "Unable_to_resolve_signature_of_method_decorator_when_called_as_an_expression_1241", text: "Unable to resolve signature of method decorator when called as an expression."}
+
 var X_abstract_modifier_can_only_appear_on_a_class_method_or_property_declaration = &Message{code: 1242, category: CategoryError, key: "abstract_modifier_can_only_appear_on_a_class_method_or_property_declaration_1242", text: "'abstract' modifier can only appear on a class, method, or property declaration."}
+
 var X_0_modifier_cannot_be_used_with_1_modifier = &Message{code: 1243, category: CategoryError, key: "_0_modifier_cannot_be_used_with_1_modifier_1243", text: "'{0}' modifier cannot be used with '{1}' modifier."}
+
 var Abstract_methods_can_only_appear_within_an_abstract_class = &Message{code: 1244, category: CategoryError, key: "Abstract_methods_can_only_appear_within_an_abstract_class_1244", text: "Abstract methods can only appear within an abstract class."}
+
 var Method_0_cannot_have_an_implementation_because_it_is_marked_abstract = &Message{code: 1245, category: CategoryError, key: "Method_0_cannot_have_an_implementation_because_it_is_marked_abstract_1245", text: "Method '{0}' cannot have an implementation because it is marked abstract."}
+
 var An_interface_property_cannot_have_an_initializer = &Message{code: 1246, category: CategoryError, key: "An_interface_property_cannot_have_an_initializer_1246", text: "An interface property cannot have an initializer."}
+
 var A_type_literal_property_cannot_have_an_initializer = &Message{code: 1247, category: CategoryError, key: "A_type_literal_property_cannot_have_an_initializer_1247", text: "A type literal property cannot have an initializer."}
+
 var A_class_member_cannot_have_the_0_keyword = &Message{code: 1248, category: CategoryError, key: "A_class_member_cannot_have_the_0_keyword_1248", text: "A class member cannot have the '{0}' keyword."}
+
 var A_decorator_can_only_decorate_a_method_implementation_not_an_overload = &Message{code: 1249, category: CategoryError, key: "A_decorator_can_only_decorate_a_method_implementation_not_an_overload_1249", text: "A decorator can only decorate a method implementation, not an overload."}
+
 var Function_declarations_are_not_allowed_inside_blocks_in_strict_mode_when_targeting_ES5 = &Message{code: 1250, category: CategoryError, key: "Function_declarations_are_not_allowed_inside_blocks_in_strict_mode_when_targeting_ES5_1250", text: "Function declarations are not allowed inside blocks in strict mode when targeting 'ES5'."}
+
 var Function_declarations_are_not_allowed_inside_blocks_in_strict_mode_when_targeting_ES5_Class_definitions_are_automatically_in_strict_mode = &Message{code: 1251, category: CategoryError, key: "Function_declarations_are_not_allowed_inside_blocks_in_strict_mode_when_targeting_ES5_Class_definiti_1251", text: "Function declarations are not allowed inside blocks in strict mode when targeting 'ES5'. Class definitions are automatically in strict mode."}
+
 var Function_declarations_are_not_allowed_inside_blocks_in_strict_mode_when_targeting_ES5_Modules_are_automatically_in_strict_mode = &Message{code: 1252, category: CategoryError, key: "Function_declarations_are_not_allowed_inside_blocks_in_strict_mode_when_targeting_ES5_Modules_are_au_1252", text: "Function declarations are not allowed inside blocks in strict mode when targeting 'ES5'. Modules are automatically in strict mode."}
+
 var Abstract_properties_can_only_appear_within_an_abstract_class = &Message{code: 1253, category: CategoryError, key: "Abstract_properties_can_only_appear_within_an_abstract_class_1253", text: "Abstract properties can only appear within an abstract class."}
+
 var A_const_initializer_in_an_ambient_context_must_be_a_string_or_numeric_literal_or_literal_enum_reference = &Message{code: 1254, category: CategoryError, key: "A_const_initializer_in_an_ambient_context_must_be_a_string_or_numeric_literal_or_literal_enum_refere_1254", text: "A 'const' initializer in an ambient context must be a string or numeric literal or literal enum reference."}
+
 var A_definite_assignment_assertion_is_not_permitted_in_this_context = &Message{code: 1255, category: CategoryError, key: "A_definite_assignment_assertion_is_not_permitted_in_this_context_1255", text: "A definite assignment assertion '!' is not permitted in this context."}
+
 var A_required_element_cannot_follow_an_optional_element = &Message{code: 1257, category: CategoryError, key: "A_required_element_cannot_follow_an_optional_element_1257", text: "A required element cannot follow an optional element."}
+
 var A_default_export_must_be_at_the_top_level_of_a_file_or_module_declaration = &Message{code: 1258, category: CategoryError, key: "A_default_export_must_be_at_the_top_level_of_a_file_or_module_declaration_1258", text: "A default export must be at the top level of a file or module declaration."}
+
 var Module_0_can_only_be_default_imported_using_the_1_flag = &Message{code: 1259, category: CategoryError, key: "Module_0_can_only_be_default_imported_using_the_1_flag_1259", text: "Module '{0}' can only be default-imported using the '{1}' flag"}
+
 var Keywords_cannot_contain_escape_characters = &Message{code: 1260, category: CategoryError, key: "Keywords_cannot_contain_escape_characters_1260", text: "Keywords cannot contain escape characters."}
+
 var Already_included_file_name_0_differs_from_file_name_1_only_in_casing = &Message{code: 1261, category: CategoryError, key: "Already_included_file_name_0_differs_from_file_name_1_only_in_casing_1261", text: "Already included file name '{0}' differs from file name '{1}' only in casing."}
+
 var Identifier_expected_0_is_a_reserved_word_at_the_top_level_of_a_module = &Message{code: 1262, category: CategoryError, key: "Identifier_expected_0_is_a_reserved_word_at_the_top_level_of_a_module_1262", text: "Identifier expected. '{0}' is a reserved word at the top-level of a module."}
+
 var Declarations_with_initializers_cannot_also_have_definite_assignment_assertions = &Message{code: 1263, category: CategoryError, key: "Declarations_with_initializers_cannot_also_have_definite_assignment_assertions_1263", text: "Declarations with initializers cannot also have definite assignment assertions."}
+
 var Declarations_with_definite_assignment_assertions_must_also_have_type_annotations = &Message{code: 1264, category: CategoryError, key: "Declarations_with_definite_assignment_assertions_must_also_have_type_annotations_1264", text: "Declarations with definite assignment assertions must also have type annotations."}
+
 var A_rest_element_cannot_follow_another_rest_element = &Message{code: 1265, category: CategoryError, key: "A_rest_element_cannot_follow_another_rest_element_1265", text: "A rest element cannot follow another rest element."}
+
 var An_optional_element_cannot_follow_a_rest_element = &Message{code: 1266, category: CategoryError, key: "An_optional_element_cannot_follow_a_rest_element_1266", text: "An optional element cannot follow a rest element."}
+
 var Property_0_cannot_have_an_initializer_because_it_is_marked_abstract = &Message{code: 1267, category: CategoryError, key: "Property_0_cannot_have_an_initializer_because_it_is_marked_abstract_1267", text: "Property '{0}' cannot have an initializer because it is marked abstract."}
+
 var An_index_signature_parameter_type_must_be_string_number_symbol_or_a_template_literal_type = &Message{code: 1268, category: CategoryError, key: "An_index_signature_parameter_type_must_be_string_number_symbol_or_a_template_literal_type_1268", text: "An index signature parameter type must be 'string', 'number', 'symbol', or a template literal type."}
+
 var Cannot_use_export_import_on_a_type_or_type_only_namespace_when_0_is_enabled = &Message{code: 1269, category: CategoryError, key: "Cannot_use_export_import_on_a_type_or_type_only_namespace_when_0_is_enabled_1269", text: "Cannot use 'export import' on a type or type-only namespace when '{0}' is enabled."}
+
 var Decorator_function_return_type_0_is_not_assignable_to_type_1 = &Message{code: 1270, category: CategoryError, key: "Decorator_function_return_type_0_is_not_assignable_to_type_1_1270", text: "Decorator function return type '{0}' is not assignable to type '{1}'."}
+
 var Decorator_function_return_type_is_0_but_is_expected_to_be_void_or_any = &Message{code: 1271, category: CategoryError, key: "Decorator_function_return_type_is_0_but_is_expected_to_be_void_or_any_1271", text: "Decorator function return type is '{0}' but is expected to be 'void' or 'any'."}
+
 var A_type_referenced_in_a_decorated_signature_must_be_imported_with_import_type_or_a_namespace_import_when_isolatedModules_and_emitDecoratorMetadata_are_enabled = &Message{code: 1272, category: CategoryError, key: "A_type_referenced_in_a_decorated_signature_must_be_imported_with_import_type_or_a_namespace_import_w_1272", text: "A type referenced in a decorated signature must be imported with 'import type' or a namespace import when 'isolatedModules' and 'emitDecoratorMetadata' are enabled."}
+
 var X_0_modifier_cannot_appear_on_a_type_parameter = &Message{code: 1273, category: CategoryError, key: "_0_modifier_cannot_appear_on_a_type_parameter_1273", text: "'{0}' modifier cannot appear on a type parameter"}
+
 var X_0_modifier_can_only_appear_on_a_type_parameter_of_a_class_interface_or_type_alias = &Message{code: 1274, category: CategoryError, key: "_0_modifier_can_only_appear_on_a_type_parameter_of_a_class_interface_or_type_alias_1274", text: "'{0}' modifier can only appear on a type parameter of a class, interface or type alias"}
+
 var X_accessor_modifier_can_only_appear_on_a_property_declaration = &Message{code: 1275, category: CategoryError, key: "accessor_modifier_can_only_appear_on_a_property_declaration_1275", text: "'accessor' modifier can only appear on a property declaration."}
+
 var An_accessor_property_cannot_be_declared_optional = &Message{code: 1276, category: CategoryError, key: "An_accessor_property_cannot_be_declared_optional_1276", text: "An 'accessor' property cannot be declared optional."}
+
 var X_0_modifier_can_only_appear_on_a_type_parameter_of_a_function_method_or_class = &Message{code: 1277, category: CategoryError, key: "_0_modifier_can_only_appear_on_a_type_parameter_of_a_function_method_or_class_1277", text: "'{0}' modifier can only appear on a type parameter of a function, method or class"}
+
 var The_runtime_will_invoke_the_decorator_with_1_arguments_but_the_decorator_expects_0 = &Message{code: 1278, category: CategoryError, key: "The_runtime_will_invoke_the_decorator_with_1_arguments_but_the_decorator_expects_0_1278", text: "The runtime will invoke the decorator with {1} arguments, but the decorator expects {0}."}
+
 var The_runtime_will_invoke_the_decorator_with_1_arguments_but_the_decorator_expects_at_least_0 = &Message{code: 1279, category: CategoryError, key: "The_runtime_will_invoke_the_decorator_with_1_arguments_but_the_decorator_expects_at_least_0_1279", text: "The runtime will invoke the decorator with {1} arguments, but the decorator expects at least {0}."}
+
 var Namespaces_are_not_allowed_in_global_script_files_when_0_is_enabled_If_this_file_is_not_intended_to_be_a_global_script_set_moduleDetection_to_force_or_add_an_empty_export_statement = &Message{code: 1280, category: CategoryError, key: "Namespaces_are_not_allowed_in_global_script_files_when_0_is_enabled_If_this_file_is_not_intended_to__1280", text: "Namespaces are not allowed in global script files when '{0}' is enabled. If this file is not intended to be a global script, set 'moduleDetection' to 'force' or add an empty 'export {}' statement."}
+
 var Cannot_access_0_from_another_file_without_qualification_when_1_is_enabled_Use_2_instead = &Message{code: 1281, category: CategoryError, key: "Cannot_access_0_from_another_file_without_qualification_when_1_is_enabled_Use_2_instead_1281", text: "Cannot access '{0}' from another file without qualification when '{1}' is enabled. Use '{2}' instead."}
+
 var An_export_declaration_must_reference_a_value_when_verbatimModuleSyntax_is_enabled_but_0_only_refers_to_a_type = &Message{code: 1282, category: CategoryError, key: "An_export_declaration_must_reference_a_value_when_verbatimModuleSyntax_is_enabled_but_0_only_refers__1282", text: "An 'export =' declaration must reference a value when 'verbatimModuleSyntax' is enabled, but '{0}' only refers to a type."}
+
 var An_export_declaration_must_reference_a_real_value_when_verbatimModuleSyntax_is_enabled_but_0_resolves_to_a_type_only_declaration = &Message{code: 1283, category: CategoryError, key: "An_export_declaration_must_reference_a_real_value_when_verbatimModuleSyntax_is_enabled_but_0_resolve_1283", text: "An 'export =' declaration must reference a real value when 'verbatimModuleSyntax' is enabled, but '{0}' resolves to a type-only declaration."}
+
 var An_export_default_must_reference_a_value_when_verbatimModuleSyntax_is_enabled_but_0_only_refers_to_a_type = &Message{code: 1284, category: CategoryError, key: "An_export_default_must_reference_a_value_when_verbatimModuleSyntax_is_enabled_but_0_only_refers_to_a_1284", text: "An 'export default' must reference a value when 'verbatimModuleSyntax' is enabled, but '{0}' only refers to a type."}
+
 var An_export_default_must_reference_a_real_value_when_verbatimModuleSyntax_is_enabled_but_0_resolves_to_a_type_only_declaration = &Message{code: 1285, category: CategoryError, key: "An_export_default_must_reference_a_real_value_when_verbatimModuleSyntax_is_enabled_but_0_resolves_to_1285", text: "An 'export default' must reference a real value when 'verbatimModuleSyntax' is enabled, but '{0}' resolves to a type-only declaration."}
+
 var ESM_syntax_is_not_allowed_in_a_CommonJS_module_when_verbatimModuleSyntax_is_enabled = &Message{code: 1286, category: CategoryError, key: "ESM_syntax_is_not_allowed_in_a_CommonJS_module_when_verbatimModuleSyntax_is_enabled_1286", text: "ESM syntax is not allowed in a CommonJS module when 'verbatimModuleSyntax' is enabled."}
+
 var A_top_level_export_modifier_cannot_be_used_on_value_declarations_in_a_CommonJS_module_when_verbatimModuleSyntax_is_enabled = &Message{code: 1287, category: CategoryError, key: "A_top_level_export_modifier_cannot_be_used_on_value_declarations_in_a_CommonJS_module_when_verbatimM_1287", text: "A top-level 'export' modifier cannot be used on value declarations in a CommonJS module when 'verbatimModuleSyntax' is enabled."}
+
 var An_import_alias_cannot_resolve_to_a_type_or_type_only_declaration_when_verbatimModuleSyntax_is_enabled = &Message{code: 1288, category: CategoryError, key: "An_import_alias_cannot_resolve_to_a_type_or_type_only_declaration_when_verbatimModuleSyntax_is_enabl_1288", text: "An import alias cannot resolve to a type or type-only declaration when 'verbatimModuleSyntax' is enabled."}
+
 var X_0_resolves_to_a_type_only_declaration_and_must_be_marked_type_only_in_this_file_before_re_exporting_when_1_is_enabled_Consider_using_import_type_where_0_is_imported = &Message{code: 1289, category: CategoryError, key: "_0_resolves_to_a_type_only_declaration_and_must_be_marked_type_only_in_this_file_before_re_exporting_1289", text: "'{0}' resolves to a type-only declaration and must be marked type-only in this file before re-exporting when '{1}' is enabled. Consider using 'import type' where '{0}' is imported."}
+
 var X_0_resolves_to_a_type_only_declaration_and_must_be_marked_type_only_in_this_file_before_re_exporting_when_1_is_enabled_Consider_using_export_type_0_as_default = &Message{code: 1290, category: CategoryError, key: "_0_resolves_to_a_type_only_declaration_and_must_be_marked_type_only_in_this_file_before_re_exporting_1290", text: "'{0}' resolves to a type-only declaration and must be marked type-only in this file before re-exporting when '{1}' is enabled. Consider using 'export type { {0} as default }'."}
+
 var X_0_resolves_to_a_type_and_must_be_marked_type_only_in_this_file_before_re_exporting_when_1_is_enabled_Consider_using_import_type_where_0_is_imported = &Message{code: 1291, category: CategoryError, key: "_0_resolves_to_a_type_and_must_be_marked_type_only_in_this_file_before_re_exporting_when_1_is_enable_1291", text: "'{0}' resolves to a type and must be marked type-only in this file before re-exporting when '{1}' is enabled. Consider using 'import type' where '{0}' is imported."}
+
 var X_0_resolves_to_a_type_and_must_be_marked_type_only_in_this_file_before_re_exporting_when_1_is_enabled_Consider_using_export_type_0_as_default = &Message{code: 1292, category: CategoryError, key: "_0_resolves_to_a_type_and_must_be_marked_type_only_in_this_file_before_re_exporting_when_1_is_enable_1292", text: "'{0}' resolves to a type and must be marked type-only in this file before re-exporting when '{1}' is enabled. Consider using 'export type { {0} as default }'."}
+
 var ESM_syntax_is_not_allowed_in_a_CommonJS_module_when_module_is_set_to_preserve = &Message{code: 1293, category: CategoryError, key: "ESM_syntax_is_not_allowed_in_a_CommonJS_module_when_module_is_set_to_preserve_1293", text: "ESM syntax is not allowed in a CommonJS module when 'module' is set to 'preserve'."}
+
 var This_syntax_is_not_allowed_when_erasableSyntaxOnly_is_enabled = &Message{code: 1294, category: CategoryError, key: "This_syntax_is_not_allowed_when_erasableSyntaxOnly_is_enabled_1294", text: "This syntax is not allowed when 'erasableSyntaxOnly' is enabled."}
+
 var X_with_statements_are_not_allowed_in_an_async_function_block = &Message{code: 1300, category: CategoryError, key: "with_statements_are_not_allowed_in_an_async_function_block_1300", text: "'with' statements are not allowed in an async function block."}
+
 var X_await_expressions_are_only_allowed_within_async_functions_and_at_the_top_levels_of_modules = &Message{code: 1308, category: CategoryError, key: "await_expressions_are_only_allowed_within_async_functions_and_at_the_top_levels_of_modules_1308", text: "'await' expressions are only allowed within async functions and at the top levels of modules."}
+
 var The_current_file_is_a_CommonJS_module_and_cannot_use_await_at_the_top_level = &Message{code: 1309, category: CategoryError, key: "The_current_file_is_a_CommonJS_module_and_cannot_use_await_at_the_top_level_1309", text: "The current file is a CommonJS module and cannot use 'await' at the top level."}
+
 var Did_you_mean_to_use_a_Colon_An_can_only_follow_a_property_name_when_the_containing_object_literal_is_part_of_a_destructuring_pattern = &Message{code: 1312, category: CategoryError, key: "Did_you_mean_to_use_a_Colon_An_can_only_follow_a_property_name_when_the_containing_object_literal_is_1312", text: "Did you mean to use a ':'? An '=' can only follow a property name when the containing object literal is part of a destructuring pattern."}
+
 var The_body_of_an_if_statement_cannot_be_the_empty_statement = &Message{code: 1313, category: CategoryError, key: "The_body_of_an_if_statement_cannot_be_the_empty_statement_1313", text: "The body of an 'if' statement cannot be the empty statement."}
+
 var Global_module_exports_may_only_appear_in_module_files = &Message{code: 1314, category: CategoryError, key: "Global_module_exports_may_only_appear_in_module_files_1314", text: "Global module exports may only appear in module files."}
+
 var Global_module_exports_may_only_appear_in_declaration_files = &Message{code: 1315, category: CategoryError, key: "Global_module_exports_may_only_appear_in_declaration_files_1315", text: "Global module exports may only appear in declaration files."}
+
 var Global_module_exports_may_only_appear_at_top_level = &Message{code: 1316, category: CategoryError, key: "Global_module_exports_may_only_appear_at_top_level_1316", text: "Global module exports may only appear at top level."}
+
 var A_parameter_property_cannot_be_declared_using_a_rest_parameter = &Message{code: 1317, category: CategoryError, key: "A_parameter_property_cannot_be_declared_using_a_rest_parameter_1317", text: "A parameter property cannot be declared using a rest parameter."}
+
 var An_abstract_accessor_cannot_have_an_implementation = &Message{code: 1318, category: CategoryError, key: "An_abstract_accessor_cannot_have_an_implementation_1318", text: "An abstract accessor cannot have an implementation."}
+
 var A_default_export_can_only_be_used_in_an_ECMAScript_style_module = &Message{code: 1319, category: CategoryError, key: "A_default_export_can_only_be_used_in_an_ECMAScript_style_module_1319", text: "A default export can only be used in an ECMAScript-style module."}
+
 var Type_of_await_operand_must_either_be_a_valid_promise_or_must_not_contain_a_callable_then_member = &Message{code: 1320, category: CategoryError, key: "Type_of_await_operand_must_either_be_a_valid_promise_or_must_not_contain_a_callable_then_member_1320", text: "Type of 'await' operand must either be a valid promise or must not contain a callable 'then' member."}
+
 var Type_of_yield_operand_in_an_async_generator_must_either_be_a_valid_promise_or_must_not_contain_a_callable_then_member = &Message{code: 1321, category: CategoryError, key: "Type_of_yield_operand_in_an_async_generator_must_either_be_a_valid_promise_or_must_not_contain_a_cal_1321", text: "Type of 'yield' operand in an async generator must either be a valid promise or must not contain a callable 'then' member."}
+
 var Type_of_iterated_elements_of_a_yield_Asterisk_operand_must_either_be_a_valid_promise_or_must_not_contain_a_callable_then_member = &Message{code: 1322, category: CategoryError, key: "Type_of_iterated_elements_of_a_yield_Asterisk_operand_must_either_be_a_valid_promise_or_must_not_con_1322", text: "Type of iterated elements of a 'yield*' operand must either be a valid promise or must not contain a callable 'then' member."}
+
 var Dynamic_imports_are_only_supported_when_the_module_flag_is_set_to_es2020_es2022_esnext_commonjs_amd_system_umd_node16_node18_or_nodenext = &Message{code: 1323, category: CategoryError, key: "Dynamic_imports_are_only_supported_when_the_module_flag_is_set_to_es2020_es2022_esnext_commonjs_amd__1323", text: "Dynamic imports are only supported when the '--module' flag is set to 'es2020', 'es2022', 'esnext', 'commonjs', 'amd', 'system', 'umd', 'node16', 'node18', or 'nodenext'."}
+
 var Dynamic_imports_only_support_a_second_argument_when_the_module_option_is_set_to_esnext_node16_node18_nodenext_or_preserve = &Message{code: 1324, category: CategoryError, key: "Dynamic_imports_only_support_a_second_argument_when_the_module_option_is_set_to_esnext_node16_node18_1324", text: "Dynamic imports only support a second argument when the '--module' option is set to 'esnext', 'node16', 'node18', 'nodenext', or 'preserve'."}
+
 var Argument_of_dynamic_import_cannot_be_spread_element = &Message{code: 1325, category: CategoryError, key: "Argument_of_dynamic_import_cannot_be_spread_element_1325", text: "Argument of dynamic import cannot be spread element."}
+
 var This_use_of_import_is_invalid_import_calls_can_be_written_but_they_must_have_parentheses_and_cannot_have_type_arguments = &Message{code: 1326, category: CategoryError, key: "This_use_of_import_is_invalid_import_calls_can_be_written_but_they_must_have_parentheses_and_cannot__1326", text: "This use of 'import' is invalid. 'import()' calls can be written, but they must have parentheses and cannot have type arguments."}
+
 var String_literal_with_double_quotes_expected = &Message{code: 1327, category: CategoryError, key: "String_literal_with_double_quotes_expected_1327", text: "String literal with double quotes expected."}
+
 var Property_value_can_only_be_string_literal_numeric_literal_true_false_null_object_literal_or_array_literal = &Message{code: 1328, category: CategoryError, key: "Property_value_can_only_be_string_literal_numeric_literal_true_false_null_object_literal_or_array_li_1328", text: "Property value can only be string literal, numeric literal, 'true', 'false', 'null', object literal or array literal."}
+
 var X_0_accepts_too_few_arguments_to_be_used_as_a_decorator_here_Did_you_mean_to_call_it_first_and_write_0 = &Message{code: 1329, category: CategoryError, key: "_0_accepts_too_few_arguments_to_be_used_as_a_decorator_here_Did_you_mean_to_call_it_first_and_write__1329", text: "'{0}' accepts too few arguments to be used as a decorator here. Did you mean to call it first and write '@{0}()'?"}
+
 var A_property_of_an_interface_or_type_literal_whose_type_is_a_unique_symbol_type_must_be_readonly = &Message{code: 1330, category: CategoryError, key: "A_property_of_an_interface_or_type_literal_whose_type_is_a_unique_symbol_type_must_be_readonly_1330", text: "A property of an interface or type literal whose type is a 'unique symbol' type must be 'readonly'."}
+
 var A_property_of_a_class_whose_type_is_a_unique_symbol_type_must_be_both_static_and_readonly = &Message{code: 1331, category: CategoryError, key: "A_property_of_a_class_whose_type_is_a_unique_symbol_type_must_be_both_static_and_readonly_1331", text: "A property of a class whose type is a 'unique symbol' type must be both 'static' and 'readonly'."}
+
 var A_variable_whose_type_is_a_unique_symbol_type_must_be_const = &Message{code: 1332, category: CategoryError, key: "A_variable_whose_type_is_a_unique_symbol_type_must_be_const_1332", text: "A variable whose type is a 'unique symbol' type must be 'const'."}
+
 var X_unique_symbol_types_may_not_be_used_on_a_variable_declaration_with_a_binding_name = &Message{code: 1333, category: CategoryError, key: "unique_symbol_types_may_not_be_used_on_a_variable_declaration_with_a_binding_name_1333", text: "'unique symbol' types may not be used on a variable declaration with a binding name."}
+
 var X_unique_symbol_types_are_only_allowed_on_variables_in_a_variable_statement = &Message{code: 1334, category: CategoryError, key: "unique_symbol_types_are_only_allowed_on_variables_in_a_variable_statement_1334", text: "'unique symbol' types are only allowed on variables in a variable statement."}
+
 var X_unique_symbol_types_are_not_allowed_here = &Message{code: 1335, category: CategoryError, key: "unique_symbol_types_are_not_allowed_here_1335", text: "'unique symbol' types are not allowed here."}
+
 var An_index_signature_parameter_type_cannot_be_a_literal_type_or_generic_type_Consider_using_a_mapped_object_type_instead = &Message{code: 1337, category: CategoryError, key: "An_index_signature_parameter_type_cannot_be_a_literal_type_or_generic_type_Consider_using_a_mapped_o_1337", text: "An index signature parameter type cannot be a literal type or generic type. Consider using a mapped object type instead."}
+
 var X_infer_declarations_are_only_permitted_in_the_extends_clause_of_a_conditional_type = &Message{code: 1338, category: CategoryError, key: "infer_declarations_are_only_permitted_in_the_extends_clause_of_a_conditional_type_1338", text: "'infer' declarations are only permitted in the 'extends' clause of a conditional type."}
+
 var Module_0_does_not_refer_to_a_value_but_is_used_as_a_value_here = &Message{code: 1339, category: CategoryError, key: "Module_0_does_not_refer_to_a_value_but_is_used_as_a_value_here_1339", text: "Module '{0}' does not refer to a value, but is used as a value here."}
+
 var Module_0_does_not_refer_to_a_type_but_is_used_as_a_type_here_Did_you_mean_typeof_import_0 = &Message{code: 1340, category: CategoryError, key: "Module_0_does_not_refer_to_a_type_but_is_used_as_a_type_here_Did_you_mean_typeof_import_0_1340", text: "Module '{0}' does not refer to a type, but is used as a type here. Did you mean 'typeof import('{0}')'?"}
+
 var Class_constructor_may_not_be_an_accessor = &Message{code: 1341, category: CategoryError, key: "Class_constructor_may_not_be_an_accessor_1341", text: "Class constructor may not be an accessor."}
+
 var The_import_meta_meta_property_is_only_allowed_when_the_module_option_is_es2020_es2022_esnext_system_node16_node18_or_nodenext = &Message{code: 1343, category: CategoryError, key: "The_import_meta_meta_property_is_only_allowed_when_the_module_option_is_es2020_es2022_esnext_system__1343", text: "The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', 'node18', or 'nodenext'."}
+
 var A_label_is_not_allowed_here = &Message{code: 1344, category: CategoryError, key: "A_label_is_not_allowed_here_1344", text: "'A label is not allowed here."}
+
 var An_expression_of_type_void_cannot_be_tested_for_truthiness = &Message{code: 1345, category: CategoryError, key: "An_expression_of_type_void_cannot_be_tested_for_truthiness_1345", text: "An expression of type 'void' cannot be tested for truthiness."}
+
 var This_parameter_is_not_allowed_with_use_strict_directive = &Message{code: 1346, category: CategoryError, key: "This_parameter_is_not_allowed_with_use_strict_directive_1346", text: "This parameter is not allowed with 'use strict' directive."}
+
 var X_use_strict_directive_cannot_be_used_with_non_simple_parameter_list = &Message{code: 1347, category: CategoryError, key: "use_strict_directive_cannot_be_used_with_non_simple_parameter_list_1347", text: "'use strict' directive cannot be used with non-simple parameter list."}
+
 var Non_simple_parameter_declared_here = &Message{code: 1348, category: CategoryError, key: "Non_simple_parameter_declared_here_1348", text: "Non-simple parameter declared here."}
+
 var X_use_strict_directive_used_here = &Message{code: 1349, category: CategoryError, key: "use_strict_directive_used_here_1349", text: "'use strict' directive used here."}
+
 var Print_the_final_configuration_instead_of_building = &Message{code: 1350, category: CategoryMessage, key: "Print_the_final_configuration_instead_of_building_1350", text: "Print the final configuration instead of building."}
+
 var An_identifier_or_keyword_cannot_immediately_follow_a_numeric_literal = &Message{code: 1351, category: CategoryError, key: "An_identifier_or_keyword_cannot_immediately_follow_a_numeric_literal_1351", text: "An identifier or keyword cannot immediately follow a numeric literal."}
+
 var A_bigint_literal_cannot_use_exponential_notation = &Message{code: 1352, category: CategoryError, key: "A_bigint_literal_cannot_use_exponential_notation_1352", text: "A bigint literal cannot use exponential notation."}
+
 var A_bigint_literal_must_be_an_integer = &Message{code: 1353, category: CategoryError, key: "A_bigint_literal_must_be_an_integer_1353", text: "A bigint literal must be an integer."}
+
 var X_readonly_type_modifier_is_only_permitted_on_array_and_tuple_literal_types = &Message{code: 1354, category: CategoryError, key: "readonly_type_modifier_is_only_permitted_on_array_and_tuple_literal_types_1354", text: "'readonly' type modifier is only permitted on array and tuple literal types."}
+
 var A_const_assertions_can_only_be_applied_to_references_to_enum_members_or_string_number_boolean_array_or_object_literals = &Message{code: 1355, category: CategoryError, key: "A_const_assertions_can_only_be_applied_to_references_to_enum_members_or_string_number_boolean_array__1355", text: "A 'const' assertions can only be applied to references to enum members, or string, number, boolean, array, or object literals."}
+
 var Did_you_mean_to_mark_this_function_as_async = &Message{code: 1356, category: CategoryError, key: "Did_you_mean_to_mark_this_function_as_async_1356", text: "Did you mean to mark this function as 'async'?"}
+
 var An_enum_member_name_must_be_followed_by_a_or = &Message{code: 1357, category: CategoryError, key: "An_enum_member_name_must_be_followed_by_a_or_1357", text: "An enum member name must be followed by a ',', '=', or '}'."}
+
 var Tagged_template_expressions_are_not_permitted_in_an_optional_chain = &Message{code: 1358, category: CategoryError, key: "Tagged_template_expressions_are_not_permitted_in_an_optional_chain_1358", text: "Tagged template expressions are not permitted in an optional chain."}
+
 var Identifier_expected_0_is_a_reserved_word_that_cannot_be_used_here = &Message{code: 1359, category: CategoryError, key: "Identifier_expected_0_is_a_reserved_word_that_cannot_be_used_here_1359", text: "Identifier expected. '{0}' is a reserved word that cannot be used here."}
+
 var Type_0_does_not_satisfy_the_expected_type_1 = &Message{code: 1360, category: CategoryError, key: "Type_0_does_not_satisfy_the_expected_type_1_1360", text: "Type '{0}' does not satisfy the expected type '{1}'."}
+
 var X_0_cannot_be_used_as_a_value_because_it_was_imported_using_import_type = &Message{code: 1361, category: CategoryError, key: "_0_cannot_be_used_as_a_value_because_it_was_imported_using_import_type_1361", text: "'{0}' cannot be used as a value because it was imported using 'import type'."}
+
 var X_0_cannot_be_used_as_a_value_because_it_was_exported_using_export_type = &Message{code: 1362, category: CategoryError, key: "_0_cannot_be_used_as_a_value_because_it_was_exported_using_export_type_1362", text: "'{0}' cannot be used as a value because it was exported using 'export type'."}
+
 var A_type_only_import_can_specify_a_default_import_or_named_bindings_but_not_both = &Message{code: 1363, category: CategoryError, key: "A_type_only_import_can_specify_a_default_import_or_named_bindings_but_not_both_1363", text: "A type-only import can specify a default import or named bindings, but not both."}
+
 var Convert_to_type_only_export = &Message{code: 1364, category: CategoryMessage, key: "Convert_to_type_only_export_1364", text: "Convert to type-only export"}
+
 var Convert_all_re_exported_types_to_type_only_exports = &Message{code: 1365, category: CategoryMessage, key: "Convert_all_re_exported_types_to_type_only_exports_1365", text: "Convert all re-exported types to type-only exports"}
+
 var Split_into_two_separate_import_declarations = &Message{code: 1366, category: CategoryMessage, key: "Split_into_two_separate_import_declarations_1366", text: "Split into two separate import declarations"}
+
 var Split_all_invalid_type_only_imports = &Message{code: 1367, category: CategoryMessage, key: "Split_all_invalid_type_only_imports_1367", text: "Split all invalid type-only imports"}
+
 var Class_constructor_may_not_be_a_generator = &Message{code: 1368, category: CategoryError, key: "Class_constructor_may_not_be_a_generator_1368", text: "Class constructor may not be a generator."}
+
 var Did_you_mean_0 = &Message{code: 1369, category: CategoryMessage, key: "Did_you_mean_0_1369", text: "Did you mean '{0}'?"}
+
 var X_await_expressions_are_only_allowed_at_the_top_level_of_a_file_when_that_file_is_a_module_but_this_file_has_no_imports_or_exports_Consider_adding_an_empty_export_to_make_this_file_a_module = &Message{code: 1375, category: CategoryError, key: "await_expressions_are_only_allowed_at_the_top_level_of_a_file_when_that_file_is_a_module_but_this_fi_1375", text: "'await' expressions are only allowed at the top level of a file when that file is a module, but this file has no imports or exports. Consider adding an empty 'export {}' to make this file a module."}
+
 var X_0_was_imported_here = &Message{code: 1376, category: CategoryMessage, key: "_0_was_imported_here_1376", text: "'{0}' was imported here."}
+
 var X_0_was_exported_here = &Message{code: 1377, category: CategoryMessage, key: "_0_was_exported_here_1377", text: "'{0}' was exported here."}
+
 var Top_level_await_expressions_are_only_allowed_when_the_module_option_is_set_to_es2022_esnext_system_node16_node18_nodenext_or_preserve_and_the_target_option_is_set_to_es2017_or_higher = &Message{code: 1378, category: CategoryError, key: "Top_level_await_expressions_are_only_allowed_when_the_module_option_is_set_to_es2022_esnext_system_n_1378", text: "Top-level 'await' expressions are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher."}
+
 var An_import_alias_cannot_reference_a_declaration_that_was_exported_using_export_type = &Message{code: 1379, category: CategoryError, key: "An_import_alias_cannot_reference_a_declaration_that_was_exported_using_export_type_1379", text: "An import alias cannot reference a declaration that was exported using 'export type'."}
+
 var An_import_alias_cannot_reference_a_declaration_that_was_imported_using_import_type = &Message{code: 1380, category: CategoryError, key: "An_import_alias_cannot_reference_a_declaration_that_was_imported_using_import_type_1380", text: "An import alias cannot reference a declaration that was imported using 'import type'."}
+
 var Unexpected_token_Did_you_mean_or_rbrace = &Message{code: 1381, category: CategoryError, key: "Unexpected_token_Did_you_mean_or_rbrace_1381", text: "Unexpected token. Did you mean `{'}'}` or `&rbrace;`?"}
+
 var Unexpected_token_Did_you_mean_or_gt = &Message{code: 1382, category: CategoryError, key: "Unexpected_token_Did_you_mean_or_gt_1382", text: "Unexpected token. Did you mean `{'>'}` or `&gt;`?"}
+
 var Function_type_notation_must_be_parenthesized_when_used_in_a_union_type = &Message{code: 1385, category: CategoryError, key: "Function_type_notation_must_be_parenthesized_when_used_in_a_union_type_1385", text: "Function type notation must be parenthesized when used in a union type."}
+
 var Constructor_type_notation_must_be_parenthesized_when_used_in_a_union_type = &Message{code: 1386, category: CategoryError, key: "Constructor_type_notation_must_be_parenthesized_when_used_in_a_union_type_1386", text: "Constructor type notation must be parenthesized when used in a union type."}
+
 var Function_type_notation_must_be_parenthesized_when_used_in_an_intersection_type = &Message{code: 1387, category: CategoryError, key: "Function_type_notation_must_be_parenthesized_when_used_in_an_intersection_type_1387", text: "Function type notation must be parenthesized when used in an intersection type."}
+
 var Constructor_type_notation_must_be_parenthesized_when_used_in_an_intersection_type = &Message{code: 1388, category: CategoryError, key: "Constructor_type_notation_must_be_parenthesized_when_used_in_an_intersection_type_1388", text: "Constructor type notation must be parenthesized when used in an intersection type."}
+
 var X_0_is_not_allowed_as_a_variable_declaration_name = &Message{code: 1389, category: CategoryError, key: "_0_is_not_allowed_as_a_variable_declaration_name_1389", text: "'{0}' is not allowed as a variable declaration name."}
+
 var X_0_is_not_allowed_as_a_parameter_name = &Message{code: 1390, category: CategoryError, key: "_0_is_not_allowed_as_a_parameter_name_1390", text: "'{0}' is not allowed as a parameter name."}
+
 var An_import_alias_cannot_use_import_type = &Message{code: 1392, category: CategoryError, key: "An_import_alias_cannot_use_import_type_1392", text: "An import alias cannot use 'import type'"}
+
 var Imported_via_0_from_file_1 = &Message{code: 1393, category: CategoryMessage, key: "Imported_via_0_from_file_1_1393", text: "Imported via {0} from file '{1}'"}
+
 var Imported_via_0_from_file_1_with_packageId_2 = &Message{code: 1394, category: CategoryMessage, key: "Imported_via_0_from_file_1_with_packageId_2_1394", text: "Imported via {0} from file '{1}' with packageId '{2}'"}
+
 var Imported_via_0_from_file_1_to_import_importHelpers_as_specified_in_compilerOptions = &Message{code: 1395, category: CategoryMessage, key: "Imported_via_0_from_file_1_to_import_importHelpers_as_specified_in_compilerOptions_1395", text: "Imported via {0} from file '{1}' to import 'importHelpers' as specified in compilerOptions"}
+
 var Imported_via_0_from_file_1_with_packageId_2_to_import_importHelpers_as_specified_in_compilerOptions = &Message{code: 1396, category: CategoryMessage, key: "Imported_via_0_from_file_1_with_packageId_2_to_import_importHelpers_as_specified_in_compilerOptions_1396", text: "Imported via {0} from file '{1}' with packageId '{2}' to import 'importHelpers' as specified in compilerOptions"}
+
 var Imported_via_0_from_file_1_to_import_jsx_and_jsxs_factory_functions = &Message{code: 1397, category: CategoryMessage, key: "Imported_via_0_from_file_1_to_import_jsx_and_jsxs_factory_functions_1397", text: "Imported via {0} from file '{1}' to import 'jsx' and 'jsxs' factory functions"}
+
 var Imported_via_0_from_file_1_with_packageId_2_to_import_jsx_and_jsxs_factory_functions = &Message{code: 1398, category: CategoryMessage, key: "Imported_via_0_from_file_1_with_packageId_2_to_import_jsx_and_jsxs_factory_functions_1398", text: "Imported via {0} from file '{1}' with packageId '{2}' to import 'jsx' and 'jsxs' factory functions"}
+
 var File_is_included_via_import_here = &Message{code: 1399, category: CategoryMessage, key: "File_is_included_via_import_here_1399", text: "File is included via import here."}
+
 var Referenced_via_0_from_file_1 = &Message{code: 1400, category: CategoryMessage, key: "Referenced_via_0_from_file_1_1400", text: "Referenced via '{0}' from file '{1}'"}
+
 var File_is_included_via_reference_here = &Message{code: 1401, category: CategoryMessage, key: "File_is_included_via_reference_here_1401", text: "File is included via reference here."}
+
 var Type_library_referenced_via_0_from_file_1 = &Message{code: 1402, category: CategoryMessage, key: "Type_library_referenced_via_0_from_file_1_1402", text: "Type library referenced via '{0}' from file '{1}'"}
+
 var Type_library_referenced_via_0_from_file_1_with_packageId_2 = &Message{code: 1403, category: CategoryMessage, key: "Type_library_referenced_via_0_from_file_1_with_packageId_2_1403", text: "Type library referenced via '{0}' from file '{1}' with packageId '{2}'"}
+
 var File_is_included_via_type_library_reference_here = &Message{code: 1404, category: CategoryMessage, key: "File_is_included_via_type_library_reference_here_1404", text: "File is included via type library reference here."}
+
 var Library_referenced_via_0_from_file_1 = &Message{code: 1405, category: CategoryMessage, key: "Library_referenced_via_0_from_file_1_1405", text: "Library referenced via '{0}' from file '{1}'"}
+
 var File_is_included_via_library_reference_here = &Message{code: 1406, category: CategoryMessage, key: "File_is_included_via_library_reference_here_1406", text: "File is included via library reference here."}
+
 var Matched_by_include_pattern_0_in_1 = &Message{code: 1407, category: CategoryMessage, key: "Matched_by_include_pattern_0_in_1_1407", text: "Matched by include pattern '{0}' in '{1}'"}
+
 var File_is_matched_by_include_pattern_specified_here = &Message{code: 1408, category: CategoryMessage, key: "File_is_matched_by_include_pattern_specified_here_1408", text: "File is matched by include pattern specified here."}
+
 var Part_of_files_list_in_tsconfig_json = &Message{code: 1409, category: CategoryMessage, key: "Part_of_files_list_in_tsconfig_json_1409", text: "Part of 'files' list in tsconfig.json"}
+
 var File_is_matched_by_files_list_specified_here = &Message{code: 1410, category: CategoryMessage, key: "File_is_matched_by_files_list_specified_here_1410", text: "File is matched by 'files' list specified here."}
+
 var Output_from_referenced_project_0_included_because_1_specified = &Message{code: 1411, category: CategoryMessage, key: "Output_from_referenced_project_0_included_because_1_specified_1411", text: "Output from referenced project '{0}' included because '{1}' specified"}
+
 var Output_from_referenced_project_0_included_because_module_is_specified_as_none = &Message{code: 1412, category: CategoryMessage, key: "Output_from_referenced_project_0_included_because_module_is_specified_as_none_1412", text: "Output from referenced project '{0}' included because '--module' is specified as 'none'"}
+
 var File_is_output_from_referenced_project_specified_here = &Message{code: 1413, category: CategoryMessage, key: "File_is_output_from_referenced_project_specified_here_1413", text: "File is output from referenced project specified here."}
+
 var Source_from_referenced_project_0_included_because_1_specified = &Message{code: 1414, category: CategoryMessage, key: "Source_from_referenced_project_0_included_because_1_specified_1414", text: "Source from referenced project '{0}' included because '{1}' specified"}
+
 var Source_from_referenced_project_0_included_because_module_is_specified_as_none = &Message{code: 1415, category: CategoryMessage, key: "Source_from_referenced_project_0_included_because_module_is_specified_as_none_1415", text: "Source from referenced project '{0}' included because '--module' is specified as 'none'"}
+
 var File_is_source_from_referenced_project_specified_here = &Message{code: 1416, category: CategoryMessage, key: "File_is_source_from_referenced_project_specified_here_1416", text: "File is source from referenced project specified here."}
+
 var Entry_point_of_type_library_0_specified_in_compilerOptions = &Message{code: 1417, category: CategoryMessage, key: "Entry_point_of_type_library_0_specified_in_compilerOptions_1417", text: "Entry point of type library '{0}' specified in compilerOptions"}
+
 var Entry_point_of_type_library_0_specified_in_compilerOptions_with_packageId_1 = &Message{code: 1418, category: CategoryMessage, key: "Entry_point_of_type_library_0_specified_in_compilerOptions_with_packageId_1_1418", text: "Entry point of type library '{0}' specified in compilerOptions with packageId '{1}'"}
+
 var File_is_entry_point_of_type_library_specified_here = &Message{code: 1419, category: CategoryMessage, key: "File_is_entry_point_of_type_library_specified_here_1419", text: "File is entry point of type library specified here."}
+
 var Entry_point_for_implicit_type_library_0 = &Message{code: 1420, category: CategoryMessage, key: "Entry_point_for_implicit_type_library_0_1420", text: "Entry point for implicit type library '{0}'"}
+
 var Entry_point_for_implicit_type_library_0_with_packageId_1 = &Message{code: 1421, category: CategoryMessage, key: "Entry_point_for_implicit_type_library_0_with_packageId_1_1421", text: "Entry point for implicit type library '{0}' with packageId '{1}'"}
+
 var Library_0_specified_in_compilerOptions = &Message{code: 1422, category: CategoryMessage, key: "Library_0_specified_in_compilerOptions_1422", text: "Library '{0}' specified in compilerOptions"}
+
 var File_is_library_specified_here = &Message{code: 1423, category: CategoryMessage, key: "File_is_library_specified_here_1423", text: "File is library specified here."}
+
 var Default_library = &Message{code: 1424, category: CategoryMessage, key: "Default_library_1424", text: "Default library"}
+
 var Default_library_for_target_0 = &Message{code: 1425, category: CategoryMessage, key: "Default_library_for_target_0_1425", text: "Default library for target '{0}'"}
+
 var File_is_default_library_for_target_specified_here = &Message{code: 1426, category: CategoryMessage, key: "File_is_default_library_for_target_specified_here_1426", text: "File is default library for target specified here."}
+
 var Root_file_specified_for_compilation = &Message{code: 1427, category: CategoryMessage, key: "Root_file_specified_for_compilation_1427", text: "Root file specified for compilation"}
+
 var File_is_output_of_project_reference_source_0 = &Message{code: 1428, category: CategoryMessage, key: "File_is_output_of_project_reference_source_0_1428", text: "File is output of project reference source '{0}'"}
+
 var File_redirects_to_file_0 = &Message{code: 1429, category: CategoryMessage, key: "File_redirects_to_file_0_1429", text: "File redirects to file '{0}'"}
+
 var The_file_is_in_the_program_because_Colon = &Message{code: 1430, category: CategoryMessage, key: "The_file_is_in_the_program_because_Colon_1430", text: "The file is in the program because:"}
+
 var X_for_await_loops_are_only_allowed_at_the_top_level_of_a_file_when_that_file_is_a_module_but_this_file_has_no_imports_or_exports_Consider_adding_an_empty_export_to_make_this_file_a_module = &Message{code: 1431, category: CategoryError, key: "for_await_loops_are_only_allowed_at_the_top_level_of_a_file_when_that_file_is_a_module_but_this_file_1431", text: "'for await' loops are only allowed at the top level of a file when that file is a module, but this file has no imports or exports. Consider adding an empty 'export {}' to make this file a module."}
+
 var Top_level_for_await_loops_are_only_allowed_when_the_module_option_is_set_to_es2022_esnext_system_node16_node18_nodenext_or_preserve_and_the_target_option_is_set_to_es2017_or_higher = &Message{code: 1432, category: CategoryError, key: "Top_level_for_await_loops_are_only_allowed_when_the_module_option_is_set_to_es2022_esnext_system_nod_1432", text: "Top-level 'for await' loops are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher."}
+
 var Neither_decorators_nor_modifiers_may_be_applied_to_this_parameters = &Message{code: 1433, category: CategoryError, key: "Neither_decorators_nor_modifiers_may_be_applied_to_this_parameters_1433", text: "Neither decorators nor modifiers may be applied to 'this' parameters."}
+
 var Unexpected_keyword_or_identifier = &Message{code: 1434, category: CategoryError, key: "Unexpected_keyword_or_identifier_1434", text: "Unexpected keyword or identifier."}
+
 var Unknown_keyword_or_identifier_Did_you_mean_0 = &Message{code: 1435, category: CategoryError, key: "Unknown_keyword_or_identifier_Did_you_mean_0_1435", text: "Unknown keyword or identifier. Did you mean '{0}'?"}
+
 var Decorators_must_precede_the_name_and_all_keywords_of_property_declarations = &Message{code: 1436, category: CategoryError, key: "Decorators_must_precede_the_name_and_all_keywords_of_property_declarations_1436", text: "Decorators must precede the name and all keywords of property declarations."}
+
 var Namespace_must_be_given_a_name = &Message{code: 1437, category: CategoryError, key: "Namespace_must_be_given_a_name_1437", text: "Namespace must be given a name."}
+
 var Interface_must_be_given_a_name = &Message{code: 1438, category: CategoryError, key: "Interface_must_be_given_a_name_1438", text: "Interface must be given a name."}
+
 var Type_alias_must_be_given_a_name = &Message{code: 1439, category: CategoryError, key: "Type_alias_must_be_given_a_name_1439", text: "Type alias must be given a name."}
+
 var Variable_declaration_not_allowed_at_this_location = &Message{code: 1440, category: CategoryError, key: "Variable_declaration_not_allowed_at_this_location_1440", text: "Variable declaration not allowed at this location."}
+
 var Cannot_start_a_function_call_in_a_type_annotation = &Message{code: 1441, category: CategoryError, key: "Cannot_start_a_function_call_in_a_type_annotation_1441", text: "Cannot start a function call in a type annotation."}
+
 var Expected_for_property_initializer = &Message{code: 1442, category: CategoryError, key: "Expected_for_property_initializer_1442", text: "Expected '=' for property initializer."}
+
 var Module_declaration_names_may_only_use_or_quoted_strings = &Message{code: 1443, category: CategoryError, key: "Module_declaration_names_may_only_use_or_quoted_strings_1443", text: "Module declaration names may only use ' or \" quoted strings."}
+
 var X_0_resolves_to_a_type_only_declaration_and_must_be_re_exported_using_a_type_only_re_export_when_1_is_enabled = &Message{code: 1448, category: CategoryError, key: "_0_resolves_to_a_type_only_declaration_and_must_be_re_exported_using_a_type_only_re_export_when_1_is_1448", text: "'{0}' resolves to a type-only declaration and must be re-exported using a type-only re-export when '{1}' is enabled."}
+
 var Preserve_unused_imported_values_in_the_JavaScript_output_that_would_otherwise_be_removed = &Message{code: 1449, category: CategoryMessage, key: "Preserve_unused_imported_values_in_the_JavaScript_output_that_would_otherwise_be_removed_1449", text: "Preserve unused imported values in the JavaScript output that would otherwise be removed."}
+
 var Dynamic_imports_can_only_accept_a_module_specifier_and_an_optional_set_of_attributes_as_arguments = &Message{code: 1450, category: CategoryMessage, key: "Dynamic_imports_can_only_accept_a_module_specifier_and_an_optional_set_of_attributes_as_arguments_1450", text: "Dynamic imports can only accept a module specifier and an optional set of attributes as arguments"}
+
 var Private_identifiers_are_only_allowed_in_class_bodies_and_may_only_be_used_as_part_of_a_class_member_declaration_property_access_or_on_the_left_hand_side_of_an_in_expression = &Message{code: 1451, category: CategoryError, key: "Private_identifiers_are_only_allowed_in_class_bodies_and_may_only_be_used_as_part_of_a_class_member__1451", text: "Private identifiers are only allowed in class bodies and may only be used as part of a class member declaration, property access, or on the left-hand-side of an 'in' expression"}
+
 var X_resolution_mode_should_be_either_require_or_import = &Message{code: 1453, category: CategoryError, key: "resolution_mode_should_be_either_require_or_import_1453", text: "`resolution-mode` should be either `require` or `import`."}
+
 var X_resolution_mode_can_only_be_set_for_type_only_imports = &Message{code: 1454, category: CategoryError, key: "resolution_mode_can_only_be_set_for_type_only_imports_1454", text: "`resolution-mode` can only be set for type-only imports."}
+
 var X_resolution_mode_is_the_only_valid_key_for_type_import_assertions = &Message{code: 1455, category: CategoryError, key: "resolution_mode_is_the_only_valid_key_for_type_import_assertions_1455", text: "`resolution-mode` is the only valid key for type import assertions."}
+
 var Type_import_assertions_should_have_exactly_one_key_resolution_mode_with_value_import_or_require = &Message{code: 1456, category: CategoryError, key: "Type_import_assertions_should_have_exactly_one_key_resolution_mode_with_value_import_or_require_1456", text: "Type import assertions should have exactly one key - `resolution-mode` - with value `import` or `require`."}
+
 var Matched_by_default_include_pattern_Asterisk_Asterisk_Slash_Asterisk = &Message{code: 1457, category: CategoryMessage, key: "Matched_by_default_include_pattern_Asterisk_Asterisk_Slash_Asterisk_1457", text: "Matched by default include pattern '**/*'"}
+
 var File_is_ECMAScript_module_because_0_has_field_type_with_value_module = &Message{code: 1458, category: CategoryMessage, key: "File_is_ECMAScript_module_because_0_has_field_type_with_value_module_1458", text: "File is ECMAScript module because '{0}' has field \"type\" with value \"module\""}
+
 var File_is_CommonJS_module_because_0_has_field_type_whose_value_is_not_module = &Message{code: 1459, category: CategoryMessage, key: "File_is_CommonJS_module_because_0_has_field_type_whose_value_is_not_module_1459", text: "File is CommonJS module because '{0}' has field \"type\" whose value is not \"module\""}
+
 var File_is_CommonJS_module_because_0_does_not_have_field_type = &Message{code: 1460, category: CategoryMessage, key: "File_is_CommonJS_module_because_0_does_not_have_field_type_1460", text: "File is CommonJS module because '{0}' does not have field \"type\""}
+
 var File_is_CommonJS_module_because_package_json_was_not_found = &Message{code: 1461, category: CategoryMessage, key: "File_is_CommonJS_module_because_package_json_was_not_found_1461", text: "File is CommonJS module because 'package.json' was not found"}
+
 var X_resolution_mode_is_the_only_valid_key_for_type_import_attributes = &Message{code: 1463, category: CategoryError, key: "resolution_mode_is_the_only_valid_key_for_type_import_attributes_1463", text: "'resolution-mode' is the only valid key for type import attributes."}
+
 var Type_import_attributes_should_have_exactly_one_key_resolution_mode_with_value_import_or_require = &Message{code: 1464, category: CategoryError, key: "Type_import_attributes_should_have_exactly_one_key_resolution_mode_with_value_import_or_require_1464", text: "Type import attributes should have exactly one key - 'resolution-mode' - with value 'import' or 'require'."}
+
 var The_import_meta_meta_property_is_not_allowed_in_files_which_will_build_into_CommonJS_output = &Message{code: 1470, category: CategoryError, key: "The_import_meta_meta_property_is_not_allowed_in_files_which_will_build_into_CommonJS_output_1470", text: "The 'import.meta' meta-property is not allowed in files which will build into CommonJS output."}
+
 var Module_0_cannot_be_imported_using_this_construct_The_specifier_only_resolves_to_an_ES_module_which_cannot_be_imported_with_require_Use_an_ECMAScript_import_instead = &Message{code: 1471, category: CategoryError, key: "Module_0_cannot_be_imported_using_this_construct_The_specifier_only_resolves_to_an_ES_module_which_c_1471", text: "Module '{0}' cannot be imported using this construct. The specifier only resolves to an ES module, which cannot be imported with 'require'. Use an ECMAScript import instead."}
+
 var X_catch_or_finally_expected = &Message{code: 1472, category: CategoryError, key: "catch_or_finally_expected_1472", text: "'catch' or 'finally' expected."}
+
 var An_import_declaration_can_only_be_used_at_the_top_level_of_a_module = &Message{code: 1473, category: CategoryError, key: "An_import_declaration_can_only_be_used_at_the_top_level_of_a_module_1473", text: "An import declaration can only be used at the top level of a module."}
+
 var An_export_declaration_can_only_be_used_at_the_top_level_of_a_module = &Message{code: 1474, category: CategoryError, key: "An_export_declaration_can_only_be_used_at_the_top_level_of_a_module_1474", text: "An export declaration can only be used at the top level of a module."}
+
 var Control_what_method_is_used_to_detect_module_format_JS_files = &Message{code: 1475, category: CategoryMessage, key: "Control_what_method_is_used_to_detect_module_format_JS_files_1475", text: "Control what method is used to detect module-format JS files."}
+
 var X_auto_Colon_Treat_files_with_imports_exports_import_meta_jsx_with_jsx_Colon_react_jsx_or_esm_format_with_module_Colon_node16_as_modules = &Message{code: 1476, category: CategoryMessage, key: "auto_Colon_Treat_files_with_imports_exports_import_meta_jsx_with_jsx_Colon_react_jsx_or_esm_format_w_1476", text: "\"auto\": Treat files with imports, exports, import.meta, jsx (with jsx: react-jsx), or esm format (with module: node16+) as modules."}
+
 var An_instantiation_expression_cannot_be_followed_by_a_property_access = &Message{code: 1477, category: CategoryError, key: "An_instantiation_expression_cannot_be_followed_by_a_property_access_1477", text: "An instantiation expression cannot be followed by a property access."}
+
 var Identifier_or_string_literal_expected = &Message{code: 1478, category: CategoryError, key: "Identifier_or_string_literal_expected_1478", text: "Identifier or string literal expected."}
+
 var The_current_file_is_a_CommonJS_module_whose_imports_will_produce_require_calls_however_the_referenced_file_is_an_ECMAScript_module_and_cannot_be_imported_with_require_Consider_writing_a_dynamic_import_0_call_instead = &Message{code: 1479, category: CategoryError, key: "The_current_file_is_a_CommonJS_module_whose_imports_will_produce_require_calls_however_the_reference_1479", text: "The current file is a CommonJS module whose imports will produce 'require' calls; however, the referenced file is an ECMAScript module and cannot be imported with 'require'. Consider writing a dynamic 'import(\"{0}\")' call instead."}
+
 var To_convert_this_file_to_an_ECMAScript_module_change_its_file_extension_to_0_or_create_a_local_package_json_file_with_type_Colon_module = &Message{code: 1480, category: CategoryMessage, key: "To_convert_this_file_to_an_ECMAScript_module_change_its_file_extension_to_0_or_create_a_local_packag_1480", text: "To convert this file to an ECMAScript module, change its file extension to '{0}' or create a local package.json file with `{ \"type\": \"module\" }`."}
+
 var To_convert_this_file_to_an_ECMAScript_module_change_its_file_extension_to_0_or_add_the_field_type_Colon_module_to_1 = &Message{code: 1481, category: CategoryMessage, key: "To_convert_this_file_to_an_ECMAScript_module_change_its_file_extension_to_0_or_add_the_field_type_Co_1481", text: "To convert this file to an ECMAScript module, change its file extension to '{0}', or add the field `\"type\": \"module\"` to '{1}'."}
+
 var To_convert_this_file_to_an_ECMAScript_module_add_the_field_type_Colon_module_to_0 = &Message{code: 1482, category: CategoryMessage, key: "To_convert_this_file_to_an_ECMAScript_module_add_the_field_type_Colon_module_to_0_1482", text: "To convert this file to an ECMAScript module, add the field `\"type\": \"module\"` to '{0}'."}
+
 var To_convert_this_file_to_an_ECMAScript_module_create_a_local_package_json_file_with_type_Colon_module = &Message{code: 1483, category: CategoryMessage, key: "To_convert_this_file_to_an_ECMAScript_module_create_a_local_package_json_file_with_type_Colon_module_1483", text: "To convert this file to an ECMAScript module, create a local package.json file with `{ \"type\": \"module\" }`."}
+
 var X_0_is_a_type_and_must_be_imported_using_a_type_only_import_when_verbatimModuleSyntax_is_enabled = &Message{code: 1484, category: CategoryError, key: "_0_is_a_type_and_must_be_imported_using_a_type_only_import_when_verbatimModuleSyntax_is_enabled_1484", text: "'{0}' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled."}
+
 var X_0_resolves_to_a_type_only_declaration_and_must_be_imported_using_a_type_only_import_when_verbatimModuleSyntax_is_enabled = &Message{code: 1485, category: CategoryError, key: "_0_resolves_to_a_type_only_declaration_and_must_be_imported_using_a_type_only_import_when_verbatimMo_1485", text: "'{0}' resolves to a type-only declaration and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled."}
+
 var Decorator_used_before_export_here = &Message{code: 1486, category: CategoryError, key: "Decorator_used_before_export_here_1486", text: "Decorator used before 'export' here."}
+
 var Octal_escape_sequences_are_not_allowed_Use_the_syntax_0 = &Message{code: 1487, category: CategoryError, key: "Octal_escape_sequences_are_not_allowed_Use_the_syntax_0_1487", text: "Octal escape sequences are not allowed. Use the syntax '{0}'."}
+
 var Escape_sequence_0_is_not_allowed = &Message{code: 1488, category: CategoryError, key: "Escape_sequence_0_is_not_allowed_1488", text: "Escape sequence '{0}' is not allowed."}
+
 var Decimals_with_leading_zeros_are_not_allowed = &Message{code: 1489, category: CategoryError, key: "Decimals_with_leading_zeros_are_not_allowed_1489", text: "Decimals with leading zeros are not allowed."}
+
 var File_appears_to_be_binary = &Message{code: 1490, category: CategoryError, key: "File_appears_to_be_binary_1490", text: "File appears to be binary."}
+
 var X_0_modifier_cannot_appear_on_a_using_declaration = &Message{code: 1491, category: CategoryError, key: "_0_modifier_cannot_appear_on_a_using_declaration_1491", text: "'{0}' modifier cannot appear on a 'using' declaration."}
+
 var X_0_declarations_may_not_have_binding_patterns = &Message{code: 1492, category: CategoryError, key: "_0_declarations_may_not_have_binding_patterns_1492", text: "'{0}' declarations may not have binding patterns."}
+
 var The_left_hand_side_of_a_for_in_statement_cannot_be_a_using_declaration = &Message{code: 1493, category: CategoryError, key: "The_left_hand_side_of_a_for_in_statement_cannot_be_a_using_declaration_1493", text: "The left-hand side of a 'for...in' statement cannot be a 'using' declaration."}
+
 var The_left_hand_side_of_a_for_in_statement_cannot_be_an_await_using_declaration = &Message{code: 1494, category: CategoryError, key: "The_left_hand_side_of_a_for_in_statement_cannot_be_an_await_using_declaration_1494", text: "The left-hand side of a 'for...in' statement cannot be an 'await using' declaration."}
+
 var X_0_modifier_cannot_appear_on_an_await_using_declaration = &Message{code: 1495, category: CategoryError, key: "_0_modifier_cannot_appear_on_an_await_using_declaration_1495", text: "'{0}' modifier cannot appear on an 'await using' declaration."}
+
 var Identifier_string_literal_or_number_literal_expected = &Message{code: 1496, category: CategoryError, key: "Identifier_string_literal_or_number_literal_expected_1496", text: "Identifier, string literal, or number literal expected."}
+
 var Expression_must_be_enclosed_in_parentheses_to_be_used_as_a_decorator = &Message{code: 1497, category: CategoryError, key: "Expression_must_be_enclosed_in_parentheses_to_be_used_as_a_decorator_1497", text: "Expression must be enclosed in parentheses to be used as a decorator."}
+
 var Invalid_syntax_in_decorator = &Message{code: 1498, category: CategoryError, key: "Invalid_syntax_in_decorator_1498", text: "Invalid syntax in decorator."}
+
 var Unknown_regular_expression_flag = &Message{code: 1499, category: CategoryError, key: "Unknown_regular_expression_flag_1499", text: "Unknown regular expression flag."}
+
 var Duplicate_regular_expression_flag = &Message{code: 1500, category: CategoryError, key: "Duplicate_regular_expression_flag_1500", text: "Duplicate regular expression flag."}
+
 var This_regular_expression_flag_is_only_available_when_targeting_0_or_later = &Message{code: 1501, category: CategoryError, key: "This_regular_expression_flag_is_only_available_when_targeting_0_or_later_1501", text: "This regular expression flag is only available when targeting '{0}' or later."}
+
 var The_Unicode_u_flag_and_the_Unicode_Sets_v_flag_cannot_be_set_simultaneously = &Message{code: 1502, category: CategoryError, key: "The_Unicode_u_flag_and_the_Unicode_Sets_v_flag_cannot_be_set_simultaneously_1502", text: "The Unicode (u) flag and the Unicode Sets (v) flag cannot be set simultaneously."}
+
 var Named_capturing_groups_are_only_available_when_targeting_ES2018_or_later = &Message{code: 1503, category: CategoryError, key: "Named_capturing_groups_are_only_available_when_targeting_ES2018_or_later_1503", text: "Named capturing groups are only available when targeting 'ES2018' or later."}
+
 var Subpattern_flags_must_be_present_when_there_is_a_minus_sign = &Message{code: 1504, category: CategoryError, key: "Subpattern_flags_must_be_present_when_there_is_a_minus_sign_1504", text: "Subpattern flags must be present when there is a minus sign."}
+
 var Incomplete_quantifier_Digit_expected = &Message{code: 1505, category: CategoryError, key: "Incomplete_quantifier_Digit_expected_1505", text: "Incomplete quantifier. Digit expected."}
+
 var Numbers_out_of_order_in_quantifier = &Message{code: 1506, category: CategoryError, key: "Numbers_out_of_order_in_quantifier_1506", text: "Numbers out of order in quantifier."}
+
 var There_is_nothing_available_for_repetition = &Message{code: 1507, category: CategoryError, key: "There_is_nothing_available_for_repetition_1507", text: "There is nothing available for repetition."}
+
 var Unexpected_0_Did_you_mean_to_escape_it_with_backslash = &Message{code: 1508, category: CategoryError, key: "Unexpected_0_Did_you_mean_to_escape_it_with_backslash_1508", text: "Unexpected '{0}'. Did you mean to escape it with backslash?"}
+
 var This_regular_expression_flag_cannot_be_toggled_within_a_subpattern = &Message{code: 1509, category: CategoryError, key: "This_regular_expression_flag_cannot_be_toggled_within_a_subpattern_1509", text: "This regular expression flag cannot be toggled within a subpattern."}
+
 var X_k_must_be_followed_by_a_capturing_group_name_enclosed_in_angle_brackets = &Message{code: 1510, category: CategoryError, key: "k_must_be_followed_by_a_capturing_group_name_enclosed_in_angle_brackets_1510", text: "'\\k' must be followed by a capturing group name enclosed in angle brackets."}
+
 var X_q_is_only_available_inside_character_class = &Message{code: 1511, category: CategoryError, key: "q_is_only_available_inside_character_class_1511", text: "'\\q' is only available inside character class."}
+
 var X_c_must_be_followed_by_an_ASCII_letter = &Message{code: 1512, category: CategoryError, key: "c_must_be_followed_by_an_ASCII_letter_1512", text: "'\\c' must be followed by an ASCII letter."}
+
 var Undetermined_character_escape = &Message{code: 1513, category: CategoryError, key: "Undetermined_character_escape_1513", text: "Undetermined character escape."}
+
 var Expected_a_capturing_group_name = &Message{code: 1514, category: CategoryError, key: "Expected_a_capturing_group_name_1514", text: "Expected a capturing group name."}
+
 var Named_capturing_groups_with_the_same_name_must_be_mutually_exclusive_to_each_other = &Message{code: 1515, category: CategoryError, key: "Named_capturing_groups_with_the_same_name_must_be_mutually_exclusive_to_each_other_1515", text: "Named capturing groups with the same name must be mutually exclusive to each other."}
+
 var A_character_class_range_must_not_be_bounded_by_another_character_class = &Message{code: 1516, category: CategoryError, key: "A_character_class_range_must_not_be_bounded_by_another_character_class_1516", text: "A character class range must not be bounded by another character class."}
+
 var Range_out_of_order_in_character_class = &Message{code: 1517, category: CategoryError, key: "Range_out_of_order_in_character_class_1517", text: "Range out of order in character class."}
+
 var Anything_that_would_possibly_match_more_than_a_single_character_is_invalid_inside_a_negated_character_class = &Message{code: 1518, category: CategoryError, key: "Anything_that_would_possibly_match_more_than_a_single_character_is_invalid_inside_a_negated_characte_1518", text: "Anything that would possibly match more than a single character is invalid inside a negated character class."}
+
 var Operators_must_not_be_mixed_within_a_character_class_Wrap_it_in_a_nested_class_instead = &Message{code: 1519, category: CategoryError, key: "Operators_must_not_be_mixed_within_a_character_class_Wrap_it_in_a_nested_class_instead_1519", text: "Operators must not be mixed within a character class. Wrap it in a nested class instead."}
+
 var Expected_a_class_set_operand = &Message{code: 1520, category: CategoryError, key: "Expected_a_class_set_operand_1520", text: "Expected a class set operand."}
+
 var X_q_must_be_followed_by_string_alternatives_enclosed_in_braces = &Message{code: 1521, category: CategoryError, key: "q_must_be_followed_by_string_alternatives_enclosed_in_braces_1521", text: "'\\q' must be followed by string alternatives enclosed in braces."}
+
 var A_character_class_must_not_contain_a_reserved_double_punctuator_Did_you_mean_to_escape_it_with_backslash = &Message{code: 1522, category: CategoryError, key: "A_character_class_must_not_contain_a_reserved_double_punctuator_Did_you_mean_to_escape_it_with_backs_1522", text: "A character class must not contain a reserved double punctuator. Did you mean to escape it with backslash?"}
+
 var Expected_a_Unicode_property_name = &Message{code: 1523, category: CategoryError, key: "Expected_a_Unicode_property_name_1523", text: "Expected a Unicode property name."}
+
 var Unknown_Unicode_property_name = &Message{code: 1524, category: CategoryError, key: "Unknown_Unicode_property_name_1524", text: "Unknown Unicode property name."}
+
 var Expected_a_Unicode_property_value = &Message{code: 1525, category: CategoryError, key: "Expected_a_Unicode_property_value_1525", text: "Expected a Unicode property value."}
+
 var Unknown_Unicode_property_value = &Message{code: 1526, category: CategoryError, key: "Unknown_Unicode_property_value_1526", text: "Unknown Unicode property value."}
+
 var Expected_a_Unicode_property_name_or_value = &Message{code: 1527, category: CategoryError, key: "Expected_a_Unicode_property_name_or_value_1527", text: "Expected a Unicode property name or value."}
+
 var Any_Unicode_property_that_would_possibly_match_more_than_a_single_character_is_only_available_when_the_Unicode_Sets_v_flag_is_set = &Message{code: 1528, category: CategoryError, key: "Any_Unicode_property_that_would_possibly_match_more_than_a_single_character_is_only_available_when_t_1528", text: "Any Unicode property that would possibly match more than a single character is only available when the Unicode Sets (v) flag is set."}
+
 var Unknown_Unicode_property_name_or_value = &Message{code: 1529, category: CategoryError, key: "Unknown_Unicode_property_name_or_value_1529", text: "Unknown Unicode property name or value."}
+
 var Unicode_property_value_expressions_are_only_available_when_the_Unicode_u_flag_or_the_Unicode_Sets_v_flag_is_set = &Message{code: 1530, category: CategoryError, key: "Unicode_property_value_expressions_are_only_available_when_the_Unicode_u_flag_or_the_Unicode_Sets_v__1530", text: "Unicode property value expressions are only available when the Unicode (u) flag or the Unicode Sets (v) flag is set."}
+
 var X_0_must_be_followed_by_a_Unicode_property_value_expression_enclosed_in_braces = &Message{code: 1531, category: CategoryError, key: "_0_must_be_followed_by_a_Unicode_property_value_expression_enclosed_in_braces_1531", text: "'\\{0}' must be followed by a Unicode property value expression enclosed in braces."}
+
 var There_is_no_capturing_group_named_0_in_this_regular_expression = &Message{code: 1532, category: CategoryError, key: "There_is_no_capturing_group_named_0_in_this_regular_expression_1532", text: "There is no capturing group named '{0}' in this regular expression."}
+
 var This_backreference_refers_to_a_group_that_does_not_exist_There_are_only_0_capturing_groups_in_this_regular_expression = &Message{code: 1533, category: CategoryError, key: "This_backreference_refers_to_a_group_that_does_not_exist_There_are_only_0_capturing_groups_in_this_r_1533", text: "This backreference refers to a group that does not exist. There are only {0} capturing groups in this regular expression."}
+
 var This_backreference_refers_to_a_group_that_does_not_exist_There_are_no_capturing_groups_in_this_regular_expression = &Message{code: 1534, category: CategoryError, key: "This_backreference_refers_to_a_group_that_does_not_exist_There_are_no_capturing_groups_in_this_regul_1534", text: "This backreference refers to a group that does not exist. There are no capturing groups in this regular expression."}
+
 var This_character_cannot_be_escaped_in_a_regular_expression = &Message{code: 1535, category: CategoryError, key: "This_character_cannot_be_escaped_in_a_regular_expression_1535", text: "This character cannot be escaped in a regular expression."}
+
 var Octal_escape_sequences_and_backreferences_are_not_allowed_in_a_character_class_If_this_was_intended_as_an_escape_sequence_use_the_syntax_0_instead = &Message{code: 1536, category: CategoryError, key: "Octal_escape_sequences_and_backreferences_are_not_allowed_in_a_character_class_If_this_was_intended__1536", text: "Octal escape sequences and backreferences are not allowed in a character class. If this was intended as an escape sequence, use the syntax '{0}' instead."}
+
 var Decimal_escape_sequences_and_backreferences_are_not_allowed_in_a_character_class = &Message{code: 1537, category: CategoryError, key: "Decimal_escape_sequences_and_backreferences_are_not_allowed_in_a_character_class_1537", text: "Decimal escape sequences and backreferences are not allowed in a character class."}
+
 var Unicode_escape_sequences_are_only_available_when_the_Unicode_u_flag_or_the_Unicode_Sets_v_flag_is_set = &Message{code: 1538, category: CategoryError, key: "Unicode_escape_sequences_are_only_available_when_the_Unicode_u_flag_or_the_Unicode_Sets_v_flag_is_se_1538", text: "Unicode escape sequences are only available when the Unicode (u) flag or the Unicode Sets (v) flag is set."}
+
 var A_bigint_literal_cannot_be_used_as_a_property_name = &Message{code: 1539, category: CategoryError, key: "A_bigint_literal_cannot_be_used_as_a_property_name_1539", text: "A 'bigint' literal cannot be used as a property name."}
+
 var A_namespace_declaration_should_not_be_declared_using_the_module_keyword_Please_use_the_namespace_keyword_instead = &Message{code: 1540, category: CategorySuggestion, key: "A_namespace_declaration_should_not_be_declared_using_the_module_keyword_Please_use_the_namespace_key_1540", text: "A 'namespace' declaration should not be declared using the 'module' keyword. Please use the 'namespace' keyword instead.", reportsDeprecated: true}
+
 var Type_only_import_of_an_ECMAScript_module_from_a_CommonJS_module_must_have_a_resolution_mode_attribute = &Message{code: 1541, category: CategoryError, key: "Type_only_import_of_an_ECMAScript_module_from_a_CommonJS_module_must_have_a_resolution_mode_attribut_1541", text: "Type-only import of an ECMAScript module from a CommonJS module must have a 'resolution-mode' attribute."}
+
 var Type_import_of_an_ECMAScript_module_from_a_CommonJS_module_must_have_a_resolution_mode_attribute = &Message{code: 1542, category: CategoryError, key: "Type_import_of_an_ECMAScript_module_from_a_CommonJS_module_must_have_a_resolution_mode_attribute_1542", text: "Type import of an ECMAScript module from a CommonJS module must have a 'resolution-mode' attribute."}
+
 var Importing_a_JSON_file_into_an_ECMAScript_module_requires_a_type_Colon_json_import_attribute_when_module_is_set_to_0 = &Message{code: 1543, category: CategoryError, key: "Importing_a_JSON_file_into_an_ECMAScript_module_requires_a_type_Colon_json_import_attribute_when_mod_1543", text: "Importing a JSON file into an ECMAScript module requires a 'type: \"json\"' import attribute when 'module' is set to '{0}'."}
+
 var Named_imports_from_a_JSON_file_into_an_ECMAScript_module_are_not_allowed_when_module_is_set_to_0 = &Message{code: 1544, category: CategoryError, key: "Named_imports_from_a_JSON_file_into_an_ECMAScript_module_are_not_allowed_when_module_is_set_to_0_1544", text: "Named imports from a JSON file into an ECMAScript module are not allowed when 'module' is set to '{0}'."}
+
 var The_types_of_0_are_incompatible_between_these_types = &Message{code: 2200, category: CategoryError, key: "The_types_of_0_are_incompatible_between_these_types_2200", text: "The types of '{0}' are incompatible between these types."}
+
 var The_types_returned_by_0_are_incompatible_between_these_types = &Message{code: 2201, category: CategoryError, key: "The_types_returned_by_0_are_incompatible_between_these_types_2201", text: "The types returned by '{0}' are incompatible between these types."}
+
 var Call_signature_return_types_0_and_1_are_incompatible = &Message{code: 2202, category: CategoryError, key: "Call_signature_return_types_0_and_1_are_incompatible_2202", text: "Call signature return types '{0}' and '{1}' are incompatible.", elidedInCompatibilityPyramid: true}
+
 var Construct_signature_return_types_0_and_1_are_incompatible = &Message{code: 2203, category: CategoryError, key: "Construct_signature_return_types_0_and_1_are_incompatible_2203", text: "Construct signature return types '{0}' and '{1}' are incompatible.", elidedInCompatibilityPyramid: true}
+
 var Call_signatures_with_no_arguments_have_incompatible_return_types_0_and_1 = &Message{code: 2204, category: CategoryError, key: "Call_signatures_with_no_arguments_have_incompatible_return_types_0_and_1_2204", text: "Call signatures with no arguments have incompatible return types '{0}' and '{1}'.", elidedInCompatibilityPyramid: true}
+
 var Construct_signatures_with_no_arguments_have_incompatible_return_types_0_and_1 = &Message{code: 2205, category: CategoryError, key: "Construct_signatures_with_no_arguments_have_incompatible_return_types_0_and_1_2205", text: "Construct signatures with no arguments have incompatible return types '{0}' and '{1}'.", elidedInCompatibilityPyramid: true}
+
 var The_type_modifier_cannot_be_used_on_a_named_import_when_import_type_is_used_on_its_import_statement = &Message{code: 2206, category: CategoryError, key: "The_type_modifier_cannot_be_used_on_a_named_import_when_import_type_is_used_on_its_import_statement_2206", text: "The 'type' modifier cannot be used on a named import when 'import type' is used on its import statement."}
+
 var The_type_modifier_cannot_be_used_on_a_named_export_when_export_type_is_used_on_its_export_statement = &Message{code: 2207, category: CategoryError, key: "The_type_modifier_cannot_be_used_on_a_named_export_when_export_type_is_used_on_its_export_statement_2207", text: "The 'type' modifier cannot be used on a named export when 'export type' is used on its export statement."}
+
 var This_type_parameter_might_need_an_extends_0_constraint = &Message{code: 2208, category: CategoryError, key: "This_type_parameter_might_need_an_extends_0_constraint_2208", text: "This type parameter might need an `extends {0}` constraint."}
+
 var The_project_root_is_ambiguous_but_is_required_to_resolve_export_map_entry_0_in_file_1_Supply_the_rootDir_compiler_option_to_disambiguate = &Message{code: 2209, category: CategoryError, key: "The_project_root_is_ambiguous_but_is_required_to_resolve_export_map_entry_0_in_file_1_Supply_the_roo_2209", text: "The project root is ambiguous, but is required to resolve export map entry '{0}' in file '{1}'. Supply the `rootDir` compiler option to disambiguate."}
+
 var The_project_root_is_ambiguous_but_is_required_to_resolve_import_map_entry_0_in_file_1_Supply_the_rootDir_compiler_option_to_disambiguate = &Message{code: 2210, category: CategoryError, key: "The_project_root_is_ambiguous_but_is_required_to_resolve_import_map_entry_0_in_file_1_Supply_the_roo_2210", text: "The project root is ambiguous, but is required to resolve import map entry '{0}' in file '{1}'. Supply the `rootDir` compiler option to disambiguate."}
+
 var Add_extends_constraint = &Message{code: 2211, category: CategoryMessage, key: "Add_extends_constraint_2211", text: "Add `extends` constraint."}
+
 var Add_extends_constraint_to_all_type_parameters = &Message{code: 2212, category: CategoryMessage, key: "Add_extends_constraint_to_all_type_parameters_2212", text: "Add `extends` constraint to all type parameters"}
+
 var Duplicate_identifier_0 = &Message{code: 2300, category: CategoryError, key: "Duplicate_identifier_0_2300", text: "Duplicate identifier '{0}'."}
+
 var Initializer_of_instance_member_variable_0_cannot_reference_identifier_1_declared_in_the_constructor = &Message{code: 2301, category: CategoryError, key: "Initializer_of_instance_member_variable_0_cannot_reference_identifier_1_declared_in_the_constructor_2301", text: "Initializer of instance member variable '{0}' cannot reference identifier '{1}' declared in the constructor."}
+
 var Static_members_cannot_reference_class_type_parameters = &Message{code: 2302, category: CategoryError, key: "Static_members_cannot_reference_class_type_parameters_2302", text: "Static members cannot reference class type parameters."}
+
 var Circular_definition_of_import_alias_0 = &Message{code: 2303, category: CategoryError, key: "Circular_definition_of_import_alias_0_2303", text: "Circular definition of import alias '{0}'."}
+
 var Cannot_find_name_0 = &Message{code: 2304, category: CategoryError, key: "Cannot_find_name_0_2304", text: "Cannot find name '{0}'."}
+
 var Module_0_has_no_exported_member_1 = &Message{code: 2305, category: CategoryError, key: "Module_0_has_no_exported_member_1_2305", text: "Module '{0}' has no exported member '{1}'."}
+
 var File_0_is_not_a_module = &Message{code: 2306, category: CategoryError, key: "File_0_is_not_a_module_2306", text: "File '{0}' is not a module."}
+
 var Cannot_find_module_0_or_its_corresponding_type_declarations = &Message{code: 2307, category: CategoryError, key: "Cannot_find_module_0_or_its_corresponding_type_declarations_2307", text: "Cannot find module '{0}' or its corresponding type declarations."}
+
 var Module_0_has_already_exported_a_member_named_1_Consider_explicitly_re_exporting_to_resolve_the_ambiguity = &Message{code: 2308, category: CategoryError, key: "Module_0_has_already_exported_a_member_named_1_Consider_explicitly_re_exporting_to_resolve_the_ambig_2308", text: "Module {0} has already exported a member named '{1}'. Consider explicitly re-exporting to resolve the ambiguity."}
+
 var An_export_assignment_cannot_be_used_in_a_module_with_other_exported_elements = &Message{code: 2309, category: CategoryError, key: "An_export_assignment_cannot_be_used_in_a_module_with_other_exported_elements_2309", text: "An export assignment cannot be used in a module with other exported elements."}
+
 var Type_0_recursively_references_itself_as_a_base_type = &Message{code: 2310, category: CategoryError, key: "Type_0_recursively_references_itself_as_a_base_type_2310", text: "Type '{0}' recursively references itself as a base type."}
+
 var Cannot_find_name_0_Did_you_mean_to_write_this_in_an_async_function = &Message{code: 2311, category: CategoryError, key: "Cannot_find_name_0_Did_you_mean_to_write_this_in_an_async_function_2311", text: "Cannot find name '{0}'. Did you mean to write this in an async function?"}
+
 var An_interface_can_only_extend_an_object_type_or_intersection_of_object_types_with_statically_known_members = &Message{code: 2312, category: CategoryError, key: "An_interface_can_only_extend_an_object_type_or_intersection_of_object_types_with_statically_known_me_2312", text: "An interface can only extend an object type or intersection of object types with statically known members."}
+
 var Type_parameter_0_has_a_circular_constraint = &Message{code: 2313, category: CategoryError, key: "Type_parameter_0_has_a_circular_constraint_2313", text: "Type parameter '{0}' has a circular constraint."}
+
 var Generic_type_0_requires_1_type_argument_s = &Message{code: 2314, category: CategoryError, key: "Generic_type_0_requires_1_type_argument_s_2314", text: "Generic type '{0}' requires {1} type argument(s)."}
+
 var Type_0_is_not_generic = &Message{code: 2315, category: CategoryError, key: "Type_0_is_not_generic_2315", text: "Type '{0}' is not generic."}
+
 var Global_type_0_must_be_a_class_or_interface_type = &Message{code: 2316, category: CategoryError, key: "Global_type_0_must_be_a_class_or_interface_type_2316", text: "Global type '{0}' must be a class or interface type."}
+
 var Global_type_0_must_have_1_type_parameter_s = &Message{code: 2317, category: CategoryError, key: "Global_type_0_must_have_1_type_parameter_s_2317", text: "Global type '{0}' must have {1} type parameter(s)."}
+
 var Cannot_find_global_type_0 = &Message{code: 2318, category: CategoryError, key: "Cannot_find_global_type_0_2318", text: "Cannot find global type '{0}'."}
+
 var Named_property_0_of_types_1_and_2_are_not_identical = &Message{code: 2319, category: CategoryError, key: "Named_property_0_of_types_1_and_2_are_not_identical_2319", text: "Named property '{0}' of types '{1}' and '{2}' are not identical."}
+
 var Interface_0_cannot_simultaneously_extend_types_1_and_2 = &Message{code: 2320, category: CategoryError, key: "Interface_0_cannot_simultaneously_extend_types_1_and_2_2320", text: "Interface '{0}' cannot simultaneously extend types '{1}' and '{2}'."}
+
 var Excessive_stack_depth_comparing_types_0_and_1 = &Message{code: 2321, category: CategoryError, key: "Excessive_stack_depth_comparing_types_0_and_1_2321", text: "Excessive stack depth comparing types '{0}' and '{1}'."}
+
 var Type_0_is_not_assignable_to_type_1 = &Message{code: 2322, category: CategoryError, key: "Type_0_is_not_assignable_to_type_1_2322", text: "Type '{0}' is not assignable to type '{1}'."}
+
 var Cannot_redeclare_exported_variable_0 = &Message{code: 2323, category: CategoryError, key: "Cannot_redeclare_exported_variable_0_2323", text: "Cannot redeclare exported variable '{0}'."}
+
 var Property_0_is_missing_in_type_1 = &Message{code: 2324, category: CategoryError, key: "Property_0_is_missing_in_type_1_2324", text: "Property '{0}' is missing in type '{1}'."}
+
 var Property_0_is_private_in_type_1_but_not_in_type_2 = &Message{code: 2325, category: CategoryError, key: "Property_0_is_private_in_type_1_but_not_in_type_2_2325", text: "Property '{0}' is private in type '{1}' but not in type '{2}'."}
+
 var Types_of_property_0_are_incompatible = &Message{code: 2326, category: CategoryError, key: "Types_of_property_0_are_incompatible_2326", text: "Types of property '{0}' are incompatible."}
+
 var Property_0_is_optional_in_type_1_but_required_in_type_2 = &Message{code: 2327, category: CategoryError, key: "Property_0_is_optional_in_type_1_but_required_in_type_2_2327", text: "Property '{0}' is optional in type '{1}' but required in type '{2}'."}
+
 var Types_of_parameters_0_and_1_are_incompatible = &Message{code: 2328, category: CategoryError, key: "Types_of_parameters_0_and_1_are_incompatible_2328", text: "Types of parameters '{0}' and '{1}' are incompatible."}
+
 var Index_signature_for_type_0_is_missing_in_type_1 = &Message{code: 2329, category: CategoryError, key: "Index_signature_for_type_0_is_missing_in_type_1_2329", text: "Index signature for type '{0}' is missing in type '{1}'."}
+
 var X_0_and_1_index_signatures_are_incompatible = &Message{code: 2330, category: CategoryError, key: "_0_and_1_index_signatures_are_incompatible_2330", text: "'{0}' and '{1}' index signatures are incompatible."}
+
 var X_this_cannot_be_referenced_in_a_module_or_namespace_body = &Message{code: 2331, category: CategoryError, key: "this_cannot_be_referenced_in_a_module_or_namespace_body_2331", text: "'this' cannot be referenced in a module or namespace body."}
+
 var X_this_cannot_be_referenced_in_current_location = &Message{code: 2332, category: CategoryError, key: "this_cannot_be_referenced_in_current_location_2332", text: "'this' cannot be referenced in current location."}
+
 var X_this_cannot_be_referenced_in_a_static_property_initializer = &Message{code: 2334, category: CategoryError, key: "this_cannot_be_referenced_in_a_static_property_initializer_2334", text: "'this' cannot be referenced in a static property initializer."}
+
 var X_super_can_only_be_referenced_in_a_derived_class = &Message{code: 2335, category: CategoryError, key: "super_can_only_be_referenced_in_a_derived_class_2335", text: "'super' can only be referenced in a derived class."}
+
 var X_super_cannot_be_referenced_in_constructor_arguments = &Message{code: 2336, category: CategoryError, key: "super_cannot_be_referenced_in_constructor_arguments_2336", text: "'super' cannot be referenced in constructor arguments."}
+
 var Super_calls_are_not_permitted_outside_constructors_or_in_nested_functions_inside_constructors = &Message{code: 2337, category: CategoryError, key: "Super_calls_are_not_permitted_outside_constructors_or_in_nested_functions_inside_constructors_2337", text: "Super calls are not permitted outside constructors or in nested functions inside constructors."}
+
 var X_super_property_access_is_permitted_only_in_a_constructor_member_function_or_member_accessor_of_a_derived_class = &Message{code: 2338, category: CategoryError, key: "super_property_access_is_permitted_only_in_a_constructor_member_function_or_member_accessor_of_a_der_2338", text: "'super' property access is permitted only in a constructor, member function, or member accessor of a derived class."}
+
 var Property_0_does_not_exist_on_type_1 = &Message{code: 2339, category: CategoryError, key: "Property_0_does_not_exist_on_type_1_2339", text: "Property '{0}' does not exist on type '{1}'."}
+
 var Only_public_and_protected_methods_of_the_base_class_are_accessible_via_the_super_keyword = &Message{code: 2340, category: CategoryError, key: "Only_public_and_protected_methods_of_the_base_class_are_accessible_via_the_super_keyword_2340", text: "Only public and protected methods of the base class are accessible via the 'super' keyword."}
+
 var Property_0_is_private_and_only_accessible_within_class_1 = &Message{code: 2341, category: CategoryError, key: "Property_0_is_private_and_only_accessible_within_class_1_2341", text: "Property '{0}' is private and only accessible within class '{1}'."}
+
 var This_syntax_requires_an_imported_helper_named_1_which_does_not_exist_in_0_Consider_upgrading_your_version_of_0 = &Message{code: 2343, category: CategoryError, key: "This_syntax_requires_an_imported_helper_named_1_which_does_not_exist_in_0_Consider_upgrading_your_ve_2343", text: "This syntax requires an imported helper named '{1}' which does not exist in '{0}'. Consider upgrading your version of '{0}'."}
+
 var Type_0_does_not_satisfy_the_constraint_1 = &Message{code: 2344, category: CategoryError, key: "Type_0_does_not_satisfy_the_constraint_1_2344", text: "Type '{0}' does not satisfy the constraint '{1}'."}
+
 var Argument_of_type_0_is_not_assignable_to_parameter_of_type_1 = &Message{code: 2345, category: CategoryError, key: "Argument_of_type_0_is_not_assignable_to_parameter_of_type_1_2345", text: "Argument of type '{0}' is not assignable to parameter of type '{1}'."}
+
 var Untyped_function_calls_may_not_accept_type_arguments = &Message{code: 2347, category: CategoryError, key: "Untyped_function_calls_may_not_accept_type_arguments_2347", text: "Untyped function calls may not accept type arguments."}
+
 var Value_of_type_0_is_not_callable_Did_you_mean_to_include_new = &Message{code: 2348, category: CategoryError, key: "Value_of_type_0_is_not_callable_Did_you_mean_to_include_new_2348", text: "Value of type '{0}' is not callable. Did you mean to include 'new'?"}
+
 var This_expression_is_not_callable = &Message{code: 2349, category: CategoryError, key: "This_expression_is_not_callable_2349", text: "This expression is not callable."}
+
 var Only_a_void_function_can_be_called_with_the_new_keyword = &Message{code: 2350, category: CategoryError, key: "Only_a_void_function_can_be_called_with_the_new_keyword_2350", text: "Only a void function can be called with the 'new' keyword."}
+
 var This_expression_is_not_constructable = &Message{code: 2351, category: CategoryError, key: "This_expression_is_not_constructable_2351", text: "This expression is not constructable."}
+
 var Conversion_of_type_0_to_type_1_may_be_a_mistake_because_neither_type_sufficiently_overlaps_with_the_other_If_this_was_intentional_convert_the_expression_to_unknown_first = &Message{code: 2352, category: CategoryError, key: "Conversion_of_type_0_to_type_1_may_be_a_mistake_because_neither_type_sufficiently_overlaps_with_the__2352", text: "Conversion of type '{0}' to type '{1}' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first."}
+
 var Object_literal_may_only_specify_known_properties_and_0_does_not_exist_in_type_1 = &Message{code: 2353, category: CategoryError, key: "Object_literal_may_only_specify_known_properties_and_0_does_not_exist_in_type_1_2353", text: "Object literal may only specify known properties, and '{0}' does not exist in type '{1}'."}
+
 var This_syntax_requires_an_imported_helper_but_module_0_cannot_be_found = &Message{code: 2354, category: CategoryError, key: "This_syntax_requires_an_imported_helper_but_module_0_cannot_be_found_2354", text: "This syntax requires an imported helper but module '{0}' cannot be found."}
+
 var A_function_whose_declared_type_is_neither_undefined_void_nor_any_must_return_a_value = &Message{code: 2355, category: CategoryError, key: "A_function_whose_declared_type_is_neither_undefined_void_nor_any_must_return_a_value_2355", text: "A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value."}
+
 var An_arithmetic_operand_must_be_of_type_any_number_bigint_or_an_enum_type = &Message{code: 2356, category: CategoryError, key: "An_arithmetic_operand_must_be_of_type_any_number_bigint_or_an_enum_type_2356", text: "An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type."}
+
 var The_operand_of_an_increment_or_decrement_operator_must_be_a_variable_or_a_property_access = &Message{code: 2357, category: CategoryError, key: "The_operand_of_an_increment_or_decrement_operator_must_be_a_variable_or_a_property_access_2357", text: "The operand of an increment or decrement operator must be a variable or a property access."}
+
 var The_left_hand_side_of_an_instanceof_expression_must_be_of_type_any_an_object_type_or_a_type_parameter = &Message{code: 2358, category: CategoryError, key: "The_left_hand_side_of_an_instanceof_expression_must_be_of_type_any_an_object_type_or_a_type_paramete_2358", text: "The left-hand side of an 'instanceof' expression must be of type 'any', an object type or a type parameter."}
+
 var The_right_hand_side_of_an_instanceof_expression_must_be_either_of_type_any_a_class_function_or_other_type_assignable_to_the_Function_interface_type_or_an_object_type_with_a_Symbol_hasInstance_method = &Message{code: 2359, category: CategoryError, key: "The_right_hand_side_of_an_instanceof_expression_must_be_either_of_type_any_a_class_function_or_other_2359", text: "The right-hand side of an 'instanceof' expression must be either of type 'any', a class, function, or other type assignable to the 'Function' interface type, or an object type with a 'Symbol.hasInstance' method."}
+
 var The_left_hand_side_of_an_arithmetic_operation_must_be_of_type_any_number_bigint_or_an_enum_type = &Message{code: 2362, category: CategoryError, key: "The_left_hand_side_of_an_arithmetic_operation_must_be_of_type_any_number_bigint_or_an_enum_type_2362", text: "The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type."}
+
 var The_right_hand_side_of_an_arithmetic_operation_must_be_of_type_any_number_bigint_or_an_enum_type = &Message{code: 2363, category: CategoryError, key: "The_right_hand_side_of_an_arithmetic_operation_must_be_of_type_any_number_bigint_or_an_enum_type_2363", text: "The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type."}
+
 var The_left_hand_side_of_an_assignment_expression_must_be_a_variable_or_a_property_access = &Message{code: 2364, category: CategoryError, key: "The_left_hand_side_of_an_assignment_expression_must_be_a_variable_or_a_property_access_2364", text: "The left-hand side of an assignment expression must be a variable or a property access."}
+
 var Operator_0_cannot_be_applied_to_types_1_and_2 = &Message{code: 2365, category: CategoryError, key: "Operator_0_cannot_be_applied_to_types_1_and_2_2365", text: "Operator '{0}' cannot be applied to types '{1}' and '{2}'."}
+
 var Function_lacks_ending_return_statement_and_return_type_does_not_include_undefined = &Message{code: 2366, category: CategoryError, key: "Function_lacks_ending_return_statement_and_return_type_does_not_include_undefined_2366", text: "Function lacks ending return statement and return type does not include 'undefined'."}
+
 var This_comparison_appears_to_be_unintentional_because_the_types_0_and_1_have_no_overlap = &Message{code: 2367, category: CategoryError, key: "This_comparison_appears_to_be_unintentional_because_the_types_0_and_1_have_no_overlap_2367", text: "This comparison appears to be unintentional because the types '{0}' and '{1}' have no overlap."}
+
 var Type_parameter_name_cannot_be_0 = &Message{code: 2368, category: CategoryError, key: "Type_parameter_name_cannot_be_0_2368", text: "Type parameter name cannot be '{0}'."}
+
 var A_parameter_property_is_only_allowed_in_a_constructor_implementation = &Message{code: 2369, category: CategoryError, key: "A_parameter_property_is_only_allowed_in_a_constructor_implementation_2369", text: "A parameter property is only allowed in a constructor implementation."}
+
 var A_rest_parameter_must_be_of_an_array_type = &Message{code: 2370, category: CategoryError, key: "A_rest_parameter_must_be_of_an_array_type_2370", text: "A rest parameter must be of an array type."}
+
 var A_parameter_initializer_is_only_allowed_in_a_function_or_constructor_implementation = &Message{code: 2371, category: CategoryError, key: "A_parameter_initializer_is_only_allowed_in_a_function_or_constructor_implementation_2371", text: "A parameter initializer is only allowed in a function or constructor implementation."}
+
 var Parameter_0_cannot_reference_itself = &Message{code: 2372, category: CategoryError, key: "Parameter_0_cannot_reference_itself_2372", text: "Parameter '{0}' cannot reference itself."}
+
 var Parameter_0_cannot_reference_identifier_1_declared_after_it = &Message{code: 2373, category: CategoryError, key: "Parameter_0_cannot_reference_identifier_1_declared_after_it_2373", text: "Parameter '{0}' cannot reference identifier '{1}' declared after it."}
+
 var Duplicate_index_signature_for_type_0 = &Message{code: 2374, category: CategoryError, key: "Duplicate_index_signature_for_type_0_2374", text: "Duplicate index signature for type '{0}'."}
+
 var Type_0_is_not_assignable_to_type_1_with_exactOptionalPropertyTypes_Colon_true_Consider_adding_undefined_to_the_types_of_the_target_s_properties = &Message{code: 2375, category: CategoryError, key: "Type_0_is_not_assignable_to_type_1_with_exactOptionalPropertyTypes_Colon_true_Consider_adding_undefi_2375", text: "Type '{0}' is not assignable to type '{1}' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties."}
+
 var A_super_call_must_be_the_first_statement_in_the_constructor_to_refer_to_super_or_this_when_a_derived_class_contains_initialized_properties_parameter_properties_or_private_identifiers = &Message{code: 2376, category: CategoryError, key: "A_super_call_must_be_the_first_statement_in_the_constructor_to_refer_to_super_or_this_when_a_derived_2376", text: "A 'super' call must be the first statement in the constructor to refer to 'super' or 'this' when a derived class contains initialized properties, parameter properties, or private identifiers."}
+
 var Constructors_for_derived_classes_must_contain_a_super_call = &Message{code: 2377, category: CategoryError, key: "Constructors_for_derived_classes_must_contain_a_super_call_2377", text: "Constructors for derived classes must contain a 'super' call."}
+
 var A_get_accessor_must_return_a_value = &Message{code: 2378, category: CategoryError, key: "A_get_accessor_must_return_a_value_2378", text: "A 'get' accessor must return a value."}
+
 var Argument_of_type_0_is_not_assignable_to_parameter_of_type_1_with_exactOptionalPropertyTypes_Colon_true_Consider_adding_undefined_to_the_types_of_the_target_s_properties = &Message{code: 2379, category: CategoryError, key: "Argument_of_type_0_is_not_assignable_to_parameter_of_type_1_with_exactOptionalPropertyTypes_Colon_tr_2379", text: "Argument of type '{0}' is not assignable to parameter of type '{1}' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties."}
+
 var Overload_signatures_must_all_be_exported_or_non_exported = &Message{code: 2383, category: CategoryError, key: "Overload_signatures_must_all_be_exported_or_non_exported_2383", text: "Overload signatures must all be exported or non-exported."}
+
 var Overload_signatures_must_all_be_ambient_or_non_ambient = &Message{code: 2384, category: CategoryError, key: "Overload_signatures_must_all_be_ambient_or_non_ambient_2384", text: "Overload signatures must all be ambient or non-ambient."}
+
 var Overload_signatures_must_all_be_public_private_or_protected = &Message{code: 2385, category: CategoryError, key: "Overload_signatures_must_all_be_public_private_or_protected_2385", text: "Overload signatures must all be public, private or protected."}
+
 var Overload_signatures_must_all_be_optional_or_required = &Message{code: 2386, category: CategoryError, key: "Overload_signatures_must_all_be_optional_or_required_2386", text: "Overload signatures must all be optional or required."}
+
 var Function_overload_must_be_static = &Message{code: 2387, category: CategoryError, key: "Function_overload_must_be_static_2387", text: "Function overload must be static."}
+
 var Function_overload_must_not_be_static = &Message{code: 2388, category: CategoryError, key: "Function_overload_must_not_be_static_2388", text: "Function overload must not be static."}
+
 var Function_implementation_name_must_be_0 = &Message{code: 2389, category: CategoryError, key: "Function_implementation_name_must_be_0_2389", text: "Function implementation name must be '{0}'."}
+
 var Constructor_implementation_is_missing = &Message{code: 2390, category: CategoryError, key: "Constructor_implementation_is_missing_2390", text: "Constructor implementation is missing."}
+
 var Function_implementation_is_missing_or_not_immediately_following_the_declaration = &Message{code: 2391, category: CategoryError, key: "Function_implementation_is_missing_or_not_immediately_following_the_declaration_2391", text: "Function implementation is missing or not immediately following the declaration."}
+
 var Multiple_constructor_implementations_are_not_allowed = &Message{code: 2392, category: CategoryError, key: "Multiple_constructor_implementations_are_not_allowed_2392", text: "Multiple constructor implementations are not allowed."}
+
 var Duplicate_function_implementation = &Message{code: 2393, category: CategoryError, key: "Duplicate_function_implementation_2393", text: "Duplicate function implementation."}
+
 var This_overload_signature_is_not_compatible_with_its_implementation_signature = &Message{code: 2394, category: CategoryError, key: "This_overload_signature_is_not_compatible_with_its_implementation_signature_2394", text: "This overload signature is not compatible with its implementation signature."}
+
 var Individual_declarations_in_merged_declaration_0_must_be_all_exported_or_all_local = &Message{code: 2395, category: CategoryError, key: "Individual_declarations_in_merged_declaration_0_must_be_all_exported_or_all_local_2395", text: "Individual declarations in merged declaration '{0}' must be all exported or all local."}
+
 var Duplicate_identifier_arguments_Compiler_uses_arguments_to_initialize_rest_parameters = &Message{code: 2396, category: CategoryError, key: "Duplicate_identifier_arguments_Compiler_uses_arguments_to_initialize_rest_parameters_2396", text: "Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters."}
+
 var Declaration_name_conflicts_with_built_in_global_identifier_0 = &Message{code: 2397, category: CategoryError, key: "Declaration_name_conflicts_with_built_in_global_identifier_0_2397", text: "Declaration name conflicts with built-in global identifier '{0}'."}
+
 var X_constructor_cannot_be_used_as_a_parameter_property_name = &Message{code: 2398, category: CategoryError, key: "constructor_cannot_be_used_as_a_parameter_property_name_2398", text: "'constructor' cannot be used as a parameter property name."}
+
 var Duplicate_identifier_this_Compiler_uses_variable_declaration_this_to_capture_this_reference = &Message{code: 2399, category: CategoryError, key: "Duplicate_identifier_this_Compiler_uses_variable_declaration_this_to_capture_this_reference_2399", text: "Duplicate identifier '_this'. Compiler uses variable declaration '_this' to capture 'this' reference."}
+
 var Expression_resolves_to_variable_declaration_this_that_compiler_uses_to_capture_this_reference = &Message{code: 2400, category: CategoryError, key: "Expression_resolves_to_variable_declaration_this_that_compiler_uses_to_capture_this_reference_2400", text: "Expression resolves to variable declaration '_this' that compiler uses to capture 'this' reference."}
+
 var A_super_call_must_be_a_root_level_statement_within_a_constructor_of_a_derived_class_that_contains_initialized_properties_parameter_properties_or_private_identifiers = &Message{code: 2401, category: CategoryError, key: "A_super_call_must_be_a_root_level_statement_within_a_constructor_of_a_derived_class_that_contains_in_2401", text: "A 'super' call must be a root-level statement within a constructor of a derived class that contains initialized properties, parameter properties, or private identifiers."}
+
 var Expression_resolves_to_super_that_compiler_uses_to_capture_base_class_reference = &Message{code: 2402, category: CategoryError, key: "Expression_resolves_to_super_that_compiler_uses_to_capture_base_class_reference_2402", text: "Expression resolves to '_super' that compiler uses to capture base class reference."}
+
 var Subsequent_variable_declarations_must_have_the_same_type_Variable_0_must_be_of_type_1_but_here_has_type_2 = &Message{code: 2403, category: CategoryError, key: "Subsequent_variable_declarations_must_have_the_same_type_Variable_0_must_be_of_type_1_but_here_has_t_2403", text: "Subsequent variable declarations must have the same type.  Variable '{0}' must be of type '{1}', but here has type '{2}'."}
+
 var The_left_hand_side_of_a_for_in_statement_cannot_use_a_type_annotation = &Message{code: 2404, category: CategoryError, key: "The_left_hand_side_of_a_for_in_statement_cannot_use_a_type_annotation_2404", text: "The left-hand side of a 'for...in' statement cannot use a type annotation."}
+
 var The_left_hand_side_of_a_for_in_statement_must_be_of_type_string_or_any = &Message{code: 2405, category: CategoryError, key: "The_left_hand_side_of_a_for_in_statement_must_be_of_type_string_or_any_2405", text: "The left-hand side of a 'for...in' statement must be of type 'string' or 'any'."}
+
 var The_left_hand_side_of_a_for_in_statement_must_be_a_variable_or_a_property_access = &Message{code: 2406, category: CategoryError, key: "The_left_hand_side_of_a_for_in_statement_must_be_a_variable_or_a_property_access_2406", text: "The left-hand side of a 'for...in' statement must be a variable or a property access."}
+
 var The_right_hand_side_of_a_for_in_statement_must_be_of_type_any_an_object_type_or_a_type_parameter_but_here_has_type_0 = &Message{code: 2407, category: CategoryError, key: "The_right_hand_side_of_a_for_in_statement_must_be_of_type_any_an_object_type_or_a_type_parameter_but_2407", text: "The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type '{0}'."}
+
 var Setters_cannot_return_a_value = &Message{code: 2408, category: CategoryError, key: "Setters_cannot_return_a_value_2408", text: "Setters cannot return a value."}
+
 var Return_type_of_constructor_signature_must_be_assignable_to_the_instance_type_of_the_class = &Message{code: 2409, category: CategoryError, key: "Return_type_of_constructor_signature_must_be_assignable_to_the_instance_type_of_the_class_2409", text: "Return type of constructor signature must be assignable to the instance type of the class."}
+
 var The_with_statement_is_not_supported_All_symbols_in_a_with_block_will_have_type_any = &Message{code: 2410, category: CategoryError, key: "The_with_statement_is_not_supported_All_symbols_in_a_with_block_will_have_type_any_2410", text: "The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'."}
+
 var Property_0_of_type_1_is_not_assignable_to_2_index_type_3 = &Message{code: 2411, category: CategoryError, key: "Property_0_of_type_1_is_not_assignable_to_2_index_type_3_2411", text: "Property '{0}' of type '{1}' is not assignable to '{2}' index type '{3}'."}
+
 var Type_0_is_not_assignable_to_type_1_with_exactOptionalPropertyTypes_Colon_true_Consider_adding_undefined_to_the_type_of_the_target = &Message{code: 2412, category: CategoryError, key: "Type_0_is_not_assignable_to_type_1_with_exactOptionalPropertyTypes_Colon_true_Consider_adding_undefi_2412", text: "Type '{0}' is not assignable to type '{1}' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the type of the target."}
+
 var X_0_index_type_1_is_not_assignable_to_2_index_type_3 = &Message{code: 2413, category: CategoryError, key: "_0_index_type_1_is_not_assignable_to_2_index_type_3_2413", text: "'{0}' index type '{1}' is not assignable to '{2}' index type '{3}'."}
+
 var Class_name_cannot_be_0 = &Message{code: 2414, category: CategoryError, key: "Class_name_cannot_be_0_2414", text: "Class name cannot be '{0}'."}
+
 var Class_0_incorrectly_extends_base_class_1 = &Message{code: 2415, category: CategoryError, key: "Class_0_incorrectly_extends_base_class_1_2415", text: "Class '{0}' incorrectly extends base class '{1}'."}
+
 var Property_0_in_type_1_is_not_assignable_to_the_same_property_in_base_type_2 = &Message{code: 2416, category: CategoryError, key: "Property_0_in_type_1_is_not_assignable_to_the_same_property_in_base_type_2_2416", text: "Property '{0}' in type '{1}' is not assignable to the same property in base type '{2}'."}
+
 var Class_static_side_0_incorrectly_extends_base_class_static_side_1 = &Message{code: 2417, category: CategoryError, key: "Class_static_side_0_incorrectly_extends_base_class_static_side_1_2417", text: "Class static side '{0}' incorrectly extends base class static side '{1}'."}
+
 var Type_of_computed_property_s_value_is_0_which_is_not_assignable_to_type_1 = &Message{code: 2418, category: CategoryError, key: "Type_of_computed_property_s_value_is_0_which_is_not_assignable_to_type_1_2418", text: "Type of computed property's value is '{0}', which is not assignable to type '{1}'."}
+
 var Types_of_construct_signatures_are_incompatible = &Message{code: 2419, category: CategoryError, key: "Types_of_construct_signatures_are_incompatible_2419", text: "Types of construct signatures are incompatible."}
+
 var Class_0_incorrectly_implements_interface_1 = &Message{code: 2420, category: CategoryError, key: "Class_0_incorrectly_implements_interface_1_2420", text: "Class '{0}' incorrectly implements interface '{1}'."}
+
 var A_class_can_only_implement_an_object_type_or_intersection_of_object_types_with_statically_known_members = &Message{code: 2422, category: CategoryError, key: "A_class_can_only_implement_an_object_type_or_intersection_of_object_types_with_statically_known_memb_2422", text: "A class can only implement an object type or intersection of object types with statically known members."}
+
 var Class_0_defines_instance_member_function_1_but_extended_class_2_defines_it_as_instance_member_accessor = &Message{code: 2423, category: CategoryError, key: "Class_0_defines_instance_member_function_1_but_extended_class_2_defines_it_as_instance_member_access_2423", text: "Class '{0}' defines instance member function '{1}', but extended class '{2}' defines it as instance member accessor."}
+
 var Class_0_defines_instance_member_property_1_but_extended_class_2_defines_it_as_instance_member_function = &Message{code: 2425, category: CategoryError, key: "Class_0_defines_instance_member_property_1_but_extended_class_2_defines_it_as_instance_member_functi_2425", text: "Class '{0}' defines instance member property '{1}', but extended class '{2}' defines it as instance member function."}
+
 var Class_0_defines_instance_member_accessor_1_but_extended_class_2_defines_it_as_instance_member_function = &Message{code: 2426, category: CategoryError, key: "Class_0_defines_instance_member_accessor_1_but_extended_class_2_defines_it_as_instance_member_functi_2426", text: "Class '{0}' defines instance member accessor '{1}', but extended class '{2}' defines it as instance member function."}
+
 var Interface_name_cannot_be_0 = &Message{code: 2427, category: CategoryError, key: "Interface_name_cannot_be_0_2427", text: "Interface name cannot be '{0}'."}
+
 var All_declarations_of_0_must_have_identical_type_parameters = &Message{code: 2428, category: CategoryError, key: "All_declarations_of_0_must_have_identical_type_parameters_2428", text: "All declarations of '{0}' must have identical type parameters."}
+
 var Interface_0_incorrectly_extends_interface_1 = &Message{code: 2430, category: CategoryError, key: "Interface_0_incorrectly_extends_interface_1_2430", text: "Interface '{0}' incorrectly extends interface '{1}'."}
+
 var Enum_name_cannot_be_0 = &Message{code: 2431, category: CategoryError, key: "Enum_name_cannot_be_0_2431", text: "Enum name cannot be '{0}'."}
+
 var In_an_enum_with_multiple_declarations_only_one_declaration_can_omit_an_initializer_for_its_first_enum_element = &Message{code: 2432, category: CategoryError, key: "In_an_enum_with_multiple_declarations_only_one_declaration_can_omit_an_initializer_for_its_first_enu_2432", text: "In an enum with multiple declarations, only one declaration can omit an initializer for its first enum element."}
+
 var A_namespace_declaration_cannot_be_in_a_different_file_from_a_class_or_function_with_which_it_is_merged = &Message{code: 2433, category: CategoryError, key: "A_namespace_declaration_cannot_be_in_a_different_file_from_a_class_or_function_with_which_it_is_merg_2433", text: "A namespace declaration cannot be in a different file from a class or function with which it is merged."}
+
 var A_namespace_declaration_cannot_be_located_prior_to_a_class_or_function_with_which_it_is_merged = &Message{code: 2434, category: CategoryError, key: "A_namespace_declaration_cannot_be_located_prior_to_a_class_or_function_with_which_it_is_merged_2434", text: "A namespace declaration cannot be located prior to a class or function with which it is merged."}
+
 var Ambient_modules_cannot_be_nested_in_other_modules_or_namespaces = &Message{code: 2435, category: CategoryError, key: "Ambient_modules_cannot_be_nested_in_other_modules_or_namespaces_2435", text: "Ambient modules cannot be nested in other modules or namespaces."}
+
 var Ambient_module_declaration_cannot_specify_relative_module_name = &Message{code: 2436, category: CategoryError, key: "Ambient_module_declaration_cannot_specify_relative_module_name_2436", text: "Ambient module declaration cannot specify relative module name."}
+
 var Module_0_is_hidden_by_a_local_declaration_with_the_same_name = &Message{code: 2437, category: CategoryError, key: "Module_0_is_hidden_by_a_local_declaration_with_the_same_name_2437", text: "Module '{0}' is hidden by a local declaration with the same name."}
+
 var Import_name_cannot_be_0 = &Message{code: 2438, category: CategoryError, key: "Import_name_cannot_be_0_2438", text: "Import name cannot be '{0}'."}
+
 var Import_or_export_declaration_in_an_ambient_module_declaration_cannot_reference_module_through_relative_module_name = &Message{code: 2439, category: CategoryError, key: "Import_or_export_declaration_in_an_ambient_module_declaration_cannot_reference_module_through_relati_2439", text: "Import or export declaration in an ambient module declaration cannot reference module through relative module name."}
+
 var Import_declaration_conflicts_with_local_declaration_of_0 = &Message{code: 2440, category: CategoryError, key: "Import_declaration_conflicts_with_local_declaration_of_0_2440", text: "Import declaration conflicts with local declaration of '{0}'."}
+
 var Duplicate_identifier_0_Compiler_reserves_name_1_in_top_level_scope_of_a_module = &Message{code: 2441, category: CategoryError, key: "Duplicate_identifier_0_Compiler_reserves_name_1_in_top_level_scope_of_a_module_2441", text: "Duplicate identifier '{0}'. Compiler reserves name '{1}' in top level scope of a module."}
+
 var Types_have_separate_declarations_of_a_private_property_0 = &Message{code: 2442, category: CategoryError, key: "Types_have_separate_declarations_of_a_private_property_0_2442", text: "Types have separate declarations of a private property '{0}'."}
+
 var Property_0_is_protected_but_type_1_is_not_a_class_derived_from_2 = &Message{code: 2443, category: CategoryError, key: "Property_0_is_protected_but_type_1_is_not_a_class_derived_from_2_2443", text: "Property '{0}' is protected but type '{1}' is not a class derived from '{2}'."}
+
 var Property_0_is_protected_in_type_1_but_public_in_type_2 = &Message{code: 2444, category: CategoryError, key: "Property_0_is_protected_in_type_1_but_public_in_type_2_2444", text: "Property '{0}' is protected in type '{1}' but public in type '{2}'."}
+
 var Property_0_is_protected_and_only_accessible_within_class_1_and_its_subclasses = &Message{code: 2445, category: CategoryError, key: "Property_0_is_protected_and_only_accessible_within_class_1_and_its_subclasses_2445", text: "Property '{0}' is protected and only accessible within class '{1}' and its subclasses."}
+
 var Property_0_is_protected_and_only_accessible_through_an_instance_of_class_1_This_is_an_instance_of_class_2 = &Message{code: 2446, category: CategoryError, key: "Property_0_is_protected_and_only_accessible_through_an_instance_of_class_1_This_is_an_instance_of_cl_2446", text: "Property '{0}' is protected and only accessible through an instance of class '{1}'. This is an instance of class '{2}'."}
+
 var The_0_operator_is_not_allowed_for_boolean_types_Consider_using_1_instead = &Message{code: 2447, category: CategoryError, key: "The_0_operator_is_not_allowed_for_boolean_types_Consider_using_1_instead_2447", text: "The '{0}' operator is not allowed for boolean types. Consider using '{1}' instead."}
+
 var Block_scoped_variable_0_used_before_its_declaration = &Message{code: 2448, category: CategoryError, key: "Block_scoped_variable_0_used_before_its_declaration_2448", text: "Block-scoped variable '{0}' used before its declaration."}
+
 var Class_0_used_before_its_declaration = &Message{code: 2449, category: CategoryError, key: "Class_0_used_before_its_declaration_2449", text: "Class '{0}' used before its declaration."}
+
 var Enum_0_used_before_its_declaration = &Message{code: 2450, category: CategoryError, key: "Enum_0_used_before_its_declaration_2450", text: "Enum '{0}' used before its declaration."}
+
 var Cannot_redeclare_block_scoped_variable_0 = &Message{code: 2451, category: CategoryError, key: "Cannot_redeclare_block_scoped_variable_0_2451", text: "Cannot redeclare block-scoped variable '{0}'."}
+
 var An_enum_member_cannot_have_a_numeric_name = &Message{code: 2452, category: CategoryError, key: "An_enum_member_cannot_have_a_numeric_name_2452", text: "An enum member cannot have a numeric name."}
+
 var Variable_0_is_used_before_being_assigned = &Message{code: 2454, category: CategoryError, key: "Variable_0_is_used_before_being_assigned_2454", text: "Variable '{0}' is used before being assigned."}
+
 var Type_alias_0_circularly_references_itself = &Message{code: 2456, category: CategoryError, key: "Type_alias_0_circularly_references_itself_2456", text: "Type alias '{0}' circularly references itself."}
+
 var Type_alias_name_cannot_be_0 = &Message{code: 2457, category: CategoryError, key: "Type_alias_name_cannot_be_0_2457", text: "Type alias name cannot be '{0}'."}
+
 var An_AMD_module_cannot_have_multiple_name_assignments = &Message{code: 2458, category: CategoryError, key: "An_AMD_module_cannot_have_multiple_name_assignments_2458", text: "An AMD module cannot have multiple name assignments."}
+
 var Module_0_declares_1_locally_but_it_is_not_exported = &Message{code: 2459, category: CategoryError, key: "Module_0_declares_1_locally_but_it_is_not_exported_2459", text: "Module '{0}' declares '{1}' locally, but it is not exported."}
+
 var Module_0_declares_1_locally_but_it_is_exported_as_2 = &Message{code: 2460, category: CategoryError, key: "Module_0_declares_1_locally_but_it_is_exported_as_2_2460", text: "Module '{0}' declares '{1}' locally, but it is exported as '{2}'."}
+
 var Type_0_is_not_an_array_type = &Message{code: 2461, category: CategoryError, key: "Type_0_is_not_an_array_type_2461", text: "Type '{0}' is not an array type."}
+
 var A_rest_element_must_be_last_in_a_destructuring_pattern = &Message{code: 2462, category: CategoryError, key: "A_rest_element_must_be_last_in_a_destructuring_pattern_2462", text: "A rest element must be last in a destructuring pattern."}
+
 var A_binding_pattern_parameter_cannot_be_optional_in_an_implementation_signature = &Message{code: 2463, category: CategoryError, key: "A_binding_pattern_parameter_cannot_be_optional_in_an_implementation_signature_2463", text: "A binding pattern parameter cannot be optional in an implementation signature."}
+
 var A_computed_property_name_must_be_of_type_string_number_symbol_or_any = &Message{code: 2464, category: CategoryError, key: "A_computed_property_name_must_be_of_type_string_number_symbol_or_any_2464", text: "A computed property name must be of type 'string', 'number', 'symbol', or 'any'."}
+
 var X_this_cannot_be_referenced_in_a_computed_property_name = &Message{code: 2465, category: CategoryError, key: "this_cannot_be_referenced_in_a_computed_property_name_2465", text: "'this' cannot be referenced in a computed property name."}
+
 var X_super_cannot_be_referenced_in_a_computed_property_name = &Message{code: 2466, category: CategoryError, key: "super_cannot_be_referenced_in_a_computed_property_name_2466", text: "'super' cannot be referenced in a computed property name."}
+
 var A_computed_property_name_cannot_reference_a_type_parameter_from_its_containing_type = &Message{code: 2467, category: CategoryError, key: "A_computed_property_name_cannot_reference_a_type_parameter_from_its_containing_type_2467", text: "A computed property name cannot reference a type parameter from its containing type."}
+
 var Cannot_find_global_value_0 = &Message{code: 2468, category: CategoryError, key: "Cannot_find_global_value_0_2468", text: "Cannot find global value '{0}'."}
+
 var The_0_operator_cannot_be_applied_to_type_symbol = &Message{code: 2469, category: CategoryError, key: "The_0_operator_cannot_be_applied_to_type_symbol_2469", text: "The '{0}' operator cannot be applied to type 'symbol'."}
+
 var Spread_operator_in_new_expressions_is_only_available_when_targeting_ECMAScript_5_and_higher = &Message{code: 2472, category: CategoryError, key: "Spread_operator_in_new_expressions_is_only_available_when_targeting_ECMAScript_5_and_higher_2472", text: "Spread operator in 'new' expressions is only available when targeting ECMAScript 5 and higher."}
+
 var Enum_declarations_must_all_be_const_or_non_const = &Message{code: 2473, category: CategoryError, key: "Enum_declarations_must_all_be_const_or_non_const_2473", text: "Enum declarations must all be const or non-const."}
+
 var X_const_enum_member_initializers_must_be_constant_expressions = &Message{code: 2474, category: CategoryError, key: "const_enum_member_initializers_must_be_constant_expressions_2474", text: "const enum member initializers must be constant expressions."}
+
 var X_const_enums_can_only_be_used_in_property_or_index_access_expressions_or_the_right_hand_side_of_an_import_declaration_or_export_assignment_or_type_query = &Message{code: 2475, category: CategoryError, key: "const_enums_can_only_be_used_in_property_or_index_access_expressions_or_the_right_hand_side_of_an_im_2475", text: "'const' enums can only be used in property or index access expressions or the right hand side of an import declaration or export assignment or type query."}
+
 var A_const_enum_member_can_only_be_accessed_using_a_string_literal = &Message{code: 2476, category: CategoryError, key: "A_const_enum_member_can_only_be_accessed_using_a_string_literal_2476", text: "A const enum member can only be accessed using a string literal."}
+
 var X_const_enum_member_initializer_was_evaluated_to_a_non_finite_value = &Message{code: 2477, category: CategoryError, key: "const_enum_member_initializer_was_evaluated_to_a_non_finite_value_2477", text: "'const' enum member initializer was evaluated to a non-finite value."}
+
 var X_const_enum_member_initializer_was_evaluated_to_disallowed_value_NaN = &Message{code: 2478, category: CategoryError, key: "const_enum_member_initializer_was_evaluated_to_disallowed_value_NaN_2478", text: "'const' enum member initializer was evaluated to disallowed value 'NaN'."}
+
 var X_let_is_not_allowed_to_be_used_as_a_name_in_let_or_const_declarations = &Message{code: 2480, category: CategoryError, key: "let_is_not_allowed_to_be_used_as_a_name_in_let_or_const_declarations_2480", text: "'let' is not allowed to be used as a name in 'let' or 'const' declarations."}
+
 var Cannot_initialize_outer_scoped_variable_0_in_the_same_scope_as_block_scoped_declaration_1 = &Message{code: 2481, category: CategoryError, key: "Cannot_initialize_outer_scoped_variable_0_in_the_same_scope_as_block_scoped_declaration_1_2481", text: "Cannot initialize outer scoped variable '{0}' in the same scope as block scoped declaration '{1}'."}
+
 var The_left_hand_side_of_a_for_of_statement_cannot_use_a_type_annotation = &Message{code: 2483, category: CategoryError, key: "The_left_hand_side_of_a_for_of_statement_cannot_use_a_type_annotation_2483", text: "The left-hand side of a 'for...of' statement cannot use a type annotation."}
+
 var Export_declaration_conflicts_with_exported_declaration_of_0 = &Message{code: 2484, category: CategoryError, key: "Export_declaration_conflicts_with_exported_declaration_of_0_2484", text: "Export declaration conflicts with exported declaration of '{0}'."}
+
 var The_left_hand_side_of_a_for_of_statement_must_be_a_variable_or_a_property_access = &Message{code: 2487, category: CategoryError, key: "The_left_hand_side_of_a_for_of_statement_must_be_a_variable_or_a_property_access_2487", text: "The left-hand side of a 'for...of' statement must be a variable or a property access."}
+
 var Type_0_must_have_a_Symbol_iterator_method_that_returns_an_iterator = &Message{code: 2488, category: CategoryError, key: "Type_0_must_have_a_Symbol_iterator_method_that_returns_an_iterator_2488", text: "Type '{0}' must have a '[Symbol.iterator]()' method that returns an iterator."}
+
 var An_iterator_must_have_a_next_method = &Message{code: 2489, category: CategoryError, key: "An_iterator_must_have_a_next_method_2489", text: "An iterator must have a 'next()' method."}
+
 var The_type_returned_by_the_0_method_of_an_iterator_must_have_a_value_property = &Message{code: 2490, category: CategoryError, key: "The_type_returned_by_the_0_method_of_an_iterator_must_have_a_value_property_2490", text: "The type returned by the '{0}()' method of an iterator must have a 'value' property."}
+
 var The_left_hand_side_of_a_for_in_statement_cannot_be_a_destructuring_pattern = &Message{code: 2491, category: CategoryError, key: "The_left_hand_side_of_a_for_in_statement_cannot_be_a_destructuring_pattern_2491", text: "The left-hand side of a 'for...in' statement cannot be a destructuring pattern."}
+
 var Cannot_redeclare_identifier_0_in_catch_clause = &Message{code: 2492, category: CategoryError, key: "Cannot_redeclare_identifier_0_in_catch_clause_2492", text: "Cannot redeclare identifier '{0}' in catch clause."}
+
 var Tuple_type_0_of_length_1_has_no_element_at_index_2 = &Message{code: 2493, category: CategoryError, key: "Tuple_type_0_of_length_1_has_no_element_at_index_2_2493", text: "Tuple type '{0}' of length '{1}' has no element at index '{2}'."}
+
 var Using_a_string_in_a_for_of_statement_is_only_supported_in_ECMAScript_5_and_higher = &Message{code: 2494, category: CategoryError, key: "Using_a_string_in_a_for_of_statement_is_only_supported_in_ECMAScript_5_and_higher_2494", text: "Using a string in a 'for...of' statement is only supported in ECMAScript 5 and higher."}
+
 var Type_0_is_not_an_array_type_or_a_string_type = &Message{code: 2495, category: CategoryError, key: "Type_0_is_not_an_array_type_or_a_string_type_2495", text: "Type '{0}' is not an array type or a string type."}
+
 var The_arguments_object_cannot_be_referenced_in_an_arrow_function_in_ES5_Consider_using_a_standard_function_expression = &Message{code: 2496, category: CategoryError, key: "The_arguments_object_cannot_be_referenced_in_an_arrow_function_in_ES5_Consider_using_a_standard_func_2496", text: "The 'arguments' object cannot be referenced in an arrow function in ES5. Consider using a standard function expression."}
+
 var This_module_can_only_be_referenced_with_ECMAScript_imports_Slashexports_by_turning_on_the_0_flag_and_referencing_its_default_export = &Message{code: 2497, category: CategoryError, key: "This_module_can_only_be_referenced_with_ECMAScript_imports_Slashexports_by_turning_on_the_0_flag_and_2497", text: "This module can only be referenced with ECMAScript imports/exports by turning on the '{0}' flag and referencing its default export."}
+
 var Module_0_uses_export_and_cannot_be_used_with_export_Asterisk = &Message{code: 2498, category: CategoryError, key: "Module_0_uses_export_and_cannot_be_used_with_export_Asterisk_2498", text: "Module '{0}' uses 'export =' and cannot be used with 'export *'."}
+
 var An_interface_can_only_extend_an_identifier_Slashqualified_name_with_optional_type_arguments = &Message{code: 2499, category: CategoryError, key: "An_interface_can_only_extend_an_identifier_Slashqualified_name_with_optional_type_arguments_2499", text: "An interface can only extend an identifier/qualified-name with optional type arguments."}
+
 var A_class_can_only_implement_an_identifier_Slashqualified_name_with_optional_type_arguments = &Message{code: 2500, category: CategoryError, key: "A_class_can_only_implement_an_identifier_Slashqualified_name_with_optional_type_arguments_2500", text: "A class can only implement an identifier/qualified-name with optional type arguments."}
+
 var A_rest_element_cannot_contain_a_binding_pattern = &Message{code: 2501, category: CategoryError, key: "A_rest_element_cannot_contain_a_binding_pattern_2501", text: "A rest element cannot contain a binding pattern."}
+
 var X_0_is_referenced_directly_or_indirectly_in_its_own_type_annotation = &Message{code: 2502, category: CategoryError, key: "_0_is_referenced_directly_or_indirectly_in_its_own_type_annotation_2502", text: "'{0}' is referenced directly or indirectly in its own type annotation."}
+
 var Cannot_find_namespace_0 = &Message{code: 2503, category: CategoryError, key: "Cannot_find_namespace_0_2503", text: "Cannot find namespace '{0}'."}
+
 var Type_0_must_have_a_Symbol_asyncIterator_method_that_returns_an_async_iterator = &Message{code: 2504, category: CategoryError, key: "Type_0_must_have_a_Symbol_asyncIterator_method_that_returns_an_async_iterator_2504", text: "Type '{0}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator."}
+
 var A_generator_cannot_have_a_void_type_annotation = &Message{code: 2505, category: CategoryError, key: "A_generator_cannot_have_a_void_type_annotation_2505", text: "A generator cannot have a 'void' type annotation."}
+
 var X_0_is_referenced_directly_or_indirectly_in_its_own_base_expression = &Message{code: 2506, category: CategoryError, key: "_0_is_referenced_directly_or_indirectly_in_its_own_base_expression_2506", text: "'{0}' is referenced directly or indirectly in its own base expression."}
+
 var Type_0_is_not_a_constructor_function_type = &Message{code: 2507, category: CategoryError, key: "Type_0_is_not_a_constructor_function_type_2507", text: "Type '{0}' is not a constructor function type."}
+
 var No_base_constructor_has_the_specified_number_of_type_arguments = &Message{code: 2508, category: CategoryError, key: "No_base_constructor_has_the_specified_number_of_type_arguments_2508", text: "No base constructor has the specified number of type arguments."}
+
 var Base_constructor_return_type_0_is_not_an_object_type_or_intersection_of_object_types_with_statically_known_members = &Message{code: 2509, category: CategoryError, key: "Base_constructor_return_type_0_is_not_an_object_type_or_intersection_of_object_types_with_statically_2509", text: "Base constructor return type '{0}' is not an object type or intersection of object types with statically known members."}
+
 var Base_constructors_must_all_have_the_same_return_type = &Message{code: 2510, category: CategoryError, key: "Base_constructors_must_all_have_the_same_return_type_2510", text: "Base constructors must all have the same return type."}
+
 var Cannot_create_an_instance_of_an_abstract_class = &Message{code: 2511, category: CategoryError, key: "Cannot_create_an_instance_of_an_abstract_class_2511", text: "Cannot create an instance of an abstract class."}
+
 var Overload_signatures_must_all_be_abstract_or_non_abstract = &Message{code: 2512, category: CategoryError, key: "Overload_signatures_must_all_be_abstract_or_non_abstract_2512", text: "Overload signatures must all be abstract or non-abstract."}
+
 var Abstract_method_0_in_class_1_cannot_be_accessed_via_super_expression = &Message{code: 2513, category: CategoryError, key: "Abstract_method_0_in_class_1_cannot_be_accessed_via_super_expression_2513", text: "Abstract method '{0}' in class '{1}' cannot be accessed via super expression."}
+
 var A_tuple_type_cannot_be_indexed_with_a_negative_value = &Message{code: 2514, category: CategoryError, key: "A_tuple_type_cannot_be_indexed_with_a_negative_value_2514", text: "A tuple type cannot be indexed with a negative value."}
+
 var Non_abstract_class_0_does_not_implement_inherited_abstract_member_1_from_class_2 = &Message{code: 2515, category: CategoryError, key: "Non_abstract_class_0_does_not_implement_inherited_abstract_member_1_from_class_2_2515", text: "Non-abstract class '{0}' does not implement inherited abstract member {1} from class '{2}'."}
+
 var All_declarations_of_an_abstract_method_must_be_consecutive = &Message{code: 2516, category: CategoryError, key: "All_declarations_of_an_abstract_method_must_be_consecutive_2516", text: "All declarations of an abstract method must be consecutive."}
+
 var Cannot_assign_an_abstract_constructor_type_to_a_non_abstract_constructor_type = &Message{code: 2517, category: CategoryError, key: "Cannot_assign_an_abstract_constructor_type_to_a_non_abstract_constructor_type_2517", text: "Cannot assign an abstract constructor type to a non-abstract constructor type."}
+
 var A_this_based_type_guard_is_not_compatible_with_a_parameter_based_type_guard = &Message{code: 2518, category: CategoryError, key: "A_this_based_type_guard_is_not_compatible_with_a_parameter_based_type_guard_2518", text: "A 'this'-based type guard is not compatible with a parameter-based type guard."}
+
 var An_async_iterator_must_have_a_next_method = &Message{code: 2519, category: CategoryError, key: "An_async_iterator_must_have_a_next_method_2519", text: "An async iterator must have a 'next()' method."}
+
 var Duplicate_identifier_0_Compiler_uses_declaration_1_to_support_async_functions = &Message{code: 2520, category: CategoryError, key: "Duplicate_identifier_0_Compiler_uses_declaration_1_to_support_async_functions_2520", text: "Duplicate identifier '{0}'. Compiler uses declaration '{1}' to support async functions."}
+
 var The_arguments_object_cannot_be_referenced_in_an_async_function_or_method_in_ES5_Consider_using_a_standard_function_or_method = &Message{code: 2522, category: CategoryError, key: "The_arguments_object_cannot_be_referenced_in_an_async_function_or_method_in_ES5_Consider_using_a_sta_2522", text: "The 'arguments' object cannot be referenced in an async function or method in ES5. Consider using a standard function or method."}
+
 var X_yield_expressions_cannot_be_used_in_a_parameter_initializer = &Message{code: 2523, category: CategoryError, key: "yield_expressions_cannot_be_used_in_a_parameter_initializer_2523", text: "'yield' expressions cannot be used in a parameter initializer."}
+
 var X_await_expressions_cannot_be_used_in_a_parameter_initializer = &Message{code: 2524, category: CategoryError, key: "await_expressions_cannot_be_used_in_a_parameter_initializer_2524", text: "'await' expressions cannot be used in a parameter initializer."}
+
 var A_this_type_is_available_only_in_a_non_static_member_of_a_class_or_interface = &Message{code: 2526, category: CategoryError, key: "A_this_type_is_available_only_in_a_non_static_member_of_a_class_or_interface_2526", text: "A 'this' type is available only in a non-static member of a class or interface."}
+
 var The_inferred_type_of_0_references_an_inaccessible_1_type_A_type_annotation_is_necessary = &Message{code: 2527, category: CategoryError, key: "The_inferred_type_of_0_references_an_inaccessible_1_type_A_type_annotation_is_necessary_2527", text: "The inferred type of '{0}' references an inaccessible '{1}' type. A type annotation is necessary."}
+
 var A_module_cannot_have_multiple_default_exports = &Message{code: 2528, category: CategoryError, key: "A_module_cannot_have_multiple_default_exports_2528", text: "A module cannot have multiple default exports."}
+
 var Duplicate_identifier_0_Compiler_reserves_name_1_in_top_level_scope_of_a_module_containing_async_functions = &Message{code: 2529, category: CategoryError, key: "Duplicate_identifier_0_Compiler_reserves_name_1_in_top_level_scope_of_a_module_containing_async_func_2529", text: "Duplicate identifier '{0}'. Compiler reserves name '{1}' in top level scope of a module containing async functions."}
+
 var Property_0_is_incompatible_with_index_signature = &Message{code: 2530, category: CategoryError, key: "Property_0_is_incompatible_with_index_signature_2530", text: "Property '{0}' is incompatible with index signature."}
+
 var Object_is_possibly_null = &Message{code: 2531, category: CategoryError, key: "Object_is_possibly_null_2531", text: "Object is possibly 'null'."}
+
 var Object_is_possibly_undefined = &Message{code: 2532, category: CategoryError, key: "Object_is_possibly_undefined_2532", text: "Object is possibly 'undefined'."}
+
 var Object_is_possibly_null_or_undefined = &Message{code: 2533, category: CategoryError, key: "Object_is_possibly_null_or_undefined_2533", text: "Object is possibly 'null' or 'undefined'."}
+
 var A_function_returning_never_cannot_have_a_reachable_end_point = &Message{code: 2534, category: CategoryError, key: "A_function_returning_never_cannot_have_a_reachable_end_point_2534", text: "A function returning 'never' cannot have a reachable end point."}
+
 var Type_0_cannot_be_used_to_index_type_1 = &Message{code: 2536, category: CategoryError, key: "Type_0_cannot_be_used_to_index_type_1_2536", text: "Type '{0}' cannot be used to index type '{1}'."}
+
 var Type_0_has_no_matching_index_signature_for_type_1 = &Message{code: 2537, category: CategoryError, key: "Type_0_has_no_matching_index_signature_for_type_1_2537", text: "Type '{0}' has no matching index signature for type '{1}'."}
+
 var Type_0_cannot_be_used_as_an_index_type = &Message{code: 2538, category: CategoryError, key: "Type_0_cannot_be_used_as_an_index_type_2538", text: "Type '{0}' cannot be used as an index type."}
+
 var Cannot_assign_to_0_because_it_is_not_a_variable = &Message{code: 2539, category: CategoryError, key: "Cannot_assign_to_0_because_it_is_not_a_variable_2539", text: "Cannot assign to '{0}' because it is not a variable."}
+
 var Cannot_assign_to_0_because_it_is_a_read_only_property = &Message{code: 2540, category: CategoryError, key: "Cannot_assign_to_0_because_it_is_a_read_only_property_2540", text: "Cannot assign to '{0}' because it is a read-only property."}
+
 var Index_signature_in_type_0_only_permits_reading = &Message{code: 2542, category: CategoryError, key: "Index_signature_in_type_0_only_permits_reading_2542", text: "Index signature in type '{0}' only permits reading."}
+
 var Duplicate_identifier_newTarget_Compiler_uses_variable_declaration_newTarget_to_capture_new_target_meta_property_reference = &Message{code: 2543, category: CategoryError, key: "Duplicate_identifier_newTarget_Compiler_uses_variable_declaration_newTarget_to_capture_new_target_me_2543", text: "Duplicate identifier '_newTarget'. Compiler uses variable declaration '_newTarget' to capture 'new.target' meta-property reference."}
+
 var Expression_resolves_to_variable_declaration_newTarget_that_compiler_uses_to_capture_new_target_meta_property_reference = &Message{code: 2544, category: CategoryError, key: "Expression_resolves_to_variable_declaration_newTarget_that_compiler_uses_to_capture_new_target_meta__2544", text: "Expression resolves to variable declaration '_newTarget' that compiler uses to capture 'new.target' meta-property reference."}
+
 var A_mixin_class_must_have_a_constructor_with_a_single_rest_parameter_of_type_any = &Message{code: 2545, category: CategoryError, key: "A_mixin_class_must_have_a_constructor_with_a_single_rest_parameter_of_type_any_2545", text: "A mixin class must have a constructor with a single rest parameter of type 'any[]'."}
+
 var The_type_returned_by_the_0_method_of_an_async_iterator_must_be_a_promise_for_a_type_with_a_value_property = &Message{code: 2547, category: CategoryError, key: "The_type_returned_by_the_0_method_of_an_async_iterator_must_be_a_promise_for_a_type_with_a_value_pro_2547", text: "The type returned by the '{0}()' method of an async iterator must be a promise for a type with a 'value' property."}
+
 var Type_0_is_not_an_array_type_or_does_not_have_a_Symbol_iterator_method_that_returns_an_iterator = &Message{code: 2548, category: CategoryError, key: "Type_0_is_not_an_array_type_or_does_not_have_a_Symbol_iterator_method_that_returns_an_iterator_2548", text: "Type '{0}' is not an array type or does not have a '[Symbol.iterator]()' method that returns an iterator."}
+
 var Type_0_is_not_an_array_type_or_a_string_type_or_does_not_have_a_Symbol_iterator_method_that_returns_an_iterator = &Message{code: 2549, category: CategoryError, key: "Type_0_is_not_an_array_type_or_a_string_type_or_does_not_have_a_Symbol_iterator_method_that_returns__2549", text: "Type '{0}' is not an array type or a string type or does not have a '[Symbol.iterator]()' method that returns an iterator."}
+
 var Property_0_does_not_exist_on_type_1_Do_you_need_to_change_your_target_library_Try_changing_the_lib_compiler_option_to_2_or_later = &Message{code: 2550, category: CategoryError, key: "Property_0_does_not_exist_on_type_1_Do_you_need_to_change_your_target_library_Try_changing_the_lib_c_2550", text: "Property '{0}' does not exist on type '{1}'. Do you need to change your target library? Try changing the 'lib' compiler option to '{2}' or later."}
+
 var Property_0_does_not_exist_on_type_1_Did_you_mean_2 = &Message{code: 2551, category: CategoryError, key: "Property_0_does_not_exist_on_type_1_Did_you_mean_2_2551", text: "Property '{0}' does not exist on type '{1}'. Did you mean '{2}'?"}
+
 var Cannot_find_name_0_Did_you_mean_1 = &Message{code: 2552, category: CategoryError, key: "Cannot_find_name_0_Did_you_mean_1_2552", text: "Cannot find name '{0}'. Did you mean '{1}'?"}
+
 var Computed_values_are_not_permitted_in_an_enum_with_string_valued_members = &Message{code: 2553, category: CategoryError, key: "Computed_values_are_not_permitted_in_an_enum_with_string_valued_members_2553", text: "Computed values are not permitted in an enum with string valued members."}
+
 var Expected_0_arguments_but_got_1 = &Message{code: 2554, category: CategoryError, key: "Expected_0_arguments_but_got_1_2554", text: "Expected {0} arguments, but got {1}."}
+
 var Expected_at_least_0_arguments_but_got_1 = &Message{code: 2555, category: CategoryError, key: "Expected_at_least_0_arguments_but_got_1_2555", text: "Expected at least {0} arguments, but got {1}."}
+
 var A_spread_argument_must_either_have_a_tuple_type_or_be_passed_to_a_rest_parameter = &Message{code: 2556, category: CategoryError, key: "A_spread_argument_must_either_have_a_tuple_type_or_be_passed_to_a_rest_parameter_2556", text: "A spread argument must either have a tuple type or be passed to a rest parameter."}
+
 var Expected_0_type_arguments_but_got_1 = &Message{code: 2558, category: CategoryError, key: "Expected_0_type_arguments_but_got_1_2558", text: "Expected {0} type arguments, but got {1}."}
+
 var Type_0_has_no_properties_in_common_with_type_1 = &Message{code: 2559, category: CategoryError, key: "Type_0_has_no_properties_in_common_with_type_1_2559", text: "Type '{0}' has no properties in common with type '{1}'."}
+
 var Value_of_type_0_has_no_properties_in_common_with_type_1_Did_you_mean_to_call_it = &Message{code: 2560, category: CategoryError, key: "Value_of_type_0_has_no_properties_in_common_with_type_1_Did_you_mean_to_call_it_2560", text: "Value of type '{0}' has no properties in common with type '{1}'. Did you mean to call it?"}
+
 var Object_literal_may_only_specify_known_properties_but_0_does_not_exist_in_type_1_Did_you_mean_to_write_2 = &Message{code: 2561, category: CategoryError, key: "Object_literal_may_only_specify_known_properties_but_0_does_not_exist_in_type_1_Did_you_mean_to_writ_2561", text: "Object literal may only specify known properties, but '{0}' does not exist in type '{1}'. Did you mean to write '{2}'?"}
+
 var Base_class_expressions_cannot_reference_class_type_parameters = &Message{code: 2562, category: CategoryError, key: "Base_class_expressions_cannot_reference_class_type_parameters_2562", text: "Base class expressions cannot reference class type parameters."}
+
 var The_containing_function_or_module_body_is_too_large_for_control_flow_analysis = &Message{code: 2563, category: CategoryError, key: "The_containing_function_or_module_body_is_too_large_for_control_flow_analysis_2563", text: "The containing function or module body is too large for control flow analysis."}
+
 var Property_0_has_no_initializer_and_is_not_definitely_assigned_in_the_constructor = &Message{code: 2564, category: CategoryError, key: "Property_0_has_no_initializer_and_is_not_definitely_assigned_in_the_constructor_2564", text: "Property '{0}' has no initializer and is not definitely assigned in the constructor."}
+
 var Property_0_is_used_before_being_assigned = &Message{code: 2565, category: CategoryError, key: "Property_0_is_used_before_being_assigned_2565", text: "Property '{0}' is used before being assigned."}
+
 var A_rest_element_cannot_have_a_property_name = &Message{code: 2566, category: CategoryError, key: "A_rest_element_cannot_have_a_property_name_2566", text: "A rest element cannot have a property name."}
+
 var Enum_declarations_can_only_merge_with_namespace_or_other_enum_declarations = &Message{code: 2567, category: CategoryError, key: "Enum_declarations_can_only_merge_with_namespace_or_other_enum_declarations_2567", text: "Enum declarations can only merge with namespace or other enum declarations."}
+
 var Property_0_may_not_exist_on_type_1_Did_you_mean_2 = &Message{code: 2568, category: CategoryError, key: "Property_0_may_not_exist_on_type_1_Did_you_mean_2_2568", text: "Property '{0}' may not exist on type '{1}'. Did you mean '{2}'?"}
+
 var Could_not_find_name_0_Did_you_mean_1 = &Message{code: 2570, category: CategoryError, key: "Could_not_find_name_0_Did_you_mean_1_2570", text: "Could not find name '{0}'. Did you mean '{1}'?"}
+
 var Object_is_of_type_unknown = &Message{code: 2571, category: CategoryError, key: "Object_is_of_type_unknown_2571", text: "Object is of type 'unknown'."}
+
 var A_rest_element_type_must_be_an_array_type = &Message{code: 2574, category: CategoryError, key: "A_rest_element_type_must_be_an_array_type_2574", text: "A rest element type must be an array type."}
+
 var No_overload_expects_0_arguments_but_overloads_do_exist_that_expect_either_1_or_2_arguments = &Message{code: 2575, category: CategoryError, key: "No_overload_expects_0_arguments_but_overloads_do_exist_that_expect_either_1_or_2_arguments_2575", text: "No overload expects {0} arguments, but overloads do exist that expect either {1} or {2} arguments."}
+
 var Property_0_does_not_exist_on_type_1_Did_you_mean_to_access_the_static_member_2_instead = &Message{code: 2576, category: CategoryError, key: "Property_0_does_not_exist_on_type_1_Did_you_mean_to_access_the_static_member_2_instead_2576", text: "Property '{0}' does not exist on type '{1}'. Did you mean to access the static member '{2}' instead?"}
+
 var Return_type_annotation_circularly_references_itself = &Message{code: 2577, category: CategoryError, key: "Return_type_annotation_circularly_references_itself_2577", text: "Return type annotation circularly references itself."}
+
 var Unused_ts_expect_error_directive = &Message{code: 2578, category: CategoryError, key: "Unused_ts_expect_error_directive_2578", text: "Unused '@ts-expect-error' directive."}
+
 var Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_node_Try_npm_i_save_dev_types_Slashnode = &Message{code: 2580, category: CategoryError, key: "Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_node_Try_npm_i_save_dev_types_Slashno_2580", text: "Cannot find name '{0}'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`."}
+
 var Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_jQuery_Try_npm_i_save_dev_types_Slashjquery = &Message{code: 2581, category: CategoryError, key: "Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_jQuery_Try_npm_i_save_dev_types_Slash_2581", text: "Cannot find name '{0}'. Do you need to install type definitions for jQuery? Try `npm i --save-dev @types/jquery`."}
+
 var Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_a_test_runner_Try_npm_i_save_dev_types_Slashjest_or_npm_i_save_dev_types_Slashmocha = &Message{code: 2582, category: CategoryError, key: "Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_a_test_runner_Try_npm_i_save_dev_type_2582", text: "Cannot find name '{0}'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha`."}
+
 var Cannot_find_name_0_Do_you_need_to_change_your_target_library_Try_changing_the_lib_compiler_option_to_1_or_later = &Message{code: 2583, category: CategoryError, key: "Cannot_find_name_0_Do_you_need_to_change_your_target_library_Try_changing_the_lib_compiler_option_to_2583", text: "Cannot find name '{0}'. Do you need to change your target library? Try changing the 'lib' compiler option to '{1}' or later."}
+
 var Cannot_find_name_0_Do_you_need_to_change_your_target_library_Try_changing_the_lib_compiler_option_to_include_dom = &Message{code: 2584, category: CategoryError, key: "Cannot_find_name_0_Do_you_need_to_change_your_target_library_Try_changing_the_lib_compiler_option_to_2584", text: "Cannot find name '{0}'. Do you need to change your target library? Try changing the 'lib' compiler option to include 'dom'."}
+
 var X_0_only_refers_to_a_type_but_is_being_used_as_a_value_here_Do_you_need_to_change_your_target_library_Try_changing_the_lib_compiler_option_to_es2015_or_later = &Message{code: 2585, category: CategoryError, key: "_0_only_refers_to_a_type_but_is_being_used_as_a_value_here_Do_you_need_to_change_your_target_library_2585", text: "'{0}' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later."}
+
 var Cannot_assign_to_0_because_it_is_a_constant = &Message{code: 2588, category: CategoryError, key: "Cannot_assign_to_0_because_it_is_a_constant_2588", text: "Cannot assign to '{0}' because it is a constant."}
+
 var Type_instantiation_is_excessively_deep_and_possibly_infinite = &Message{code: 2589, category: CategoryError, key: "Type_instantiation_is_excessively_deep_and_possibly_infinite_2589", text: "Type instantiation is excessively deep and possibly infinite."}
+
 var Expression_produces_a_union_type_that_is_too_complex_to_represent = &Message{code: 2590, category: CategoryError, key: "Expression_produces_a_union_type_that_is_too_complex_to_represent_2590", text: "Expression produces a union type that is too complex to represent."}
+
 var Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_node_Try_npm_i_save_dev_types_Slashnode_and_then_add_node_to_the_types_field_in_your_tsconfig = &Message{code: 2591, category: CategoryError, key: "Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_node_Try_npm_i_save_dev_types_Slashno_2591", text: "Cannot find name '{0}'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig."}
+
 var Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_jQuery_Try_npm_i_save_dev_types_Slashjquery_and_then_add_jquery_to_the_types_field_in_your_tsconfig = &Message{code: 2592, category: CategoryError, key: "Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_jQuery_Try_npm_i_save_dev_types_Slash_2592", text: "Cannot find name '{0}'. Do you need to install type definitions for jQuery? Try `npm i --save-dev @types/jquery` and then add 'jquery' to the types field in your tsconfig."}
+
 var Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_a_test_runner_Try_npm_i_save_dev_types_Slashjest_or_npm_i_save_dev_types_Slashmocha_and_then_add_jest_or_mocha_to_the_types_field_in_your_tsconfig = &Message{code: 2593, category: CategoryError, key: "Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_a_test_runner_Try_npm_i_save_dev_type_2593", text: "Cannot find name '{0}'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig."}
+
 var This_module_is_declared_with_export_and_can_only_be_used_with_a_default_import_when_using_the_0_flag = &Message{code: 2594, category: CategoryError, key: "This_module_is_declared_with_export_and_can_only_be_used_with_a_default_import_when_using_the_0_flag_2594", text: "This module is declared with 'export =', and can only be used with a default import when using the '{0}' flag."}
+
 var X_0_can_only_be_imported_by_using_a_default_import = &Message{code: 2595, category: CategoryError, key: "_0_can_only_be_imported_by_using_a_default_import_2595", text: "'{0}' can only be imported by using a default import."}
+
 var X_0_can_only_be_imported_by_turning_on_the_esModuleInterop_flag_and_using_a_default_import = &Message{code: 2596, category: CategoryError, key: "_0_can_only_be_imported_by_turning_on_the_esModuleInterop_flag_and_using_a_default_import_2596", text: "'{0}' can only be imported by turning on the 'esModuleInterop' flag and using a default import."}
+
 var X_0_can_only_be_imported_by_using_a_require_call_or_by_using_a_default_import = &Message{code: 2597, category: CategoryError, key: "_0_can_only_be_imported_by_using_a_require_call_or_by_using_a_default_import_2597", text: "'{0}' can only be imported by using a 'require' call or by using a default import."}
+
 var X_0_can_only_be_imported_by_using_a_require_call_or_by_turning_on_the_esModuleInterop_flag_and_using_a_default_import = &Message{code: 2598, category: CategoryError, key: "_0_can_only_be_imported_by_using_a_require_call_or_by_turning_on_the_esModuleInterop_flag_and_using__2598", text: "'{0}' can only be imported by using a 'require' call or by turning on the 'esModuleInterop' flag and using a default import."}
+
 var JSX_element_implicitly_has_type_any_because_the_global_type_JSX_Element_does_not_exist = &Message{code: 2602, category: CategoryError, key: "JSX_element_implicitly_has_type_any_because_the_global_type_JSX_Element_does_not_exist_2602", text: "JSX element implicitly has type 'any' because the global type 'JSX.Element' does not exist."}
+
 var Property_0_in_type_1_is_not_assignable_to_type_2 = &Message{code: 2603, category: CategoryError, key: "Property_0_in_type_1_is_not_assignable_to_type_2_2603", text: "Property '{0}' in type '{1}' is not assignable to type '{2}'."}
+
 var JSX_element_type_0_does_not_have_any_construct_or_call_signatures = &Message{code: 2604, category: CategoryError, key: "JSX_element_type_0_does_not_have_any_construct_or_call_signatures_2604", text: "JSX element type '{0}' does not have any construct or call signatures."}
+
 var Property_0_of_JSX_spread_attribute_is_not_assignable_to_target_property = &Message{code: 2606, category: CategoryError, key: "Property_0_of_JSX_spread_attribute_is_not_assignable_to_target_property_2606", text: "Property '{0}' of JSX spread attribute is not assignable to target property."}
+
 var JSX_element_class_does_not_support_attributes_because_it_does_not_have_a_0_property = &Message{code: 2607, category: CategoryError, key: "JSX_element_class_does_not_support_attributes_because_it_does_not_have_a_0_property_2607", text: "JSX element class does not support attributes because it does not have a '{0}' property."}
+
 var The_global_type_JSX_0_may_not_have_more_than_one_property = &Message{code: 2608, category: CategoryError, key: "The_global_type_JSX_0_may_not_have_more_than_one_property_2608", text: "The global type 'JSX.{0}' may not have more than one property."}
+
 var JSX_spread_child_must_be_an_array_type = &Message{code: 2609, category: CategoryError, key: "JSX_spread_child_must_be_an_array_type_2609", text: "JSX spread child must be an array type."}
+
 var X_0_is_defined_as_an_accessor_in_class_1_but_is_overridden_here_in_2_as_an_instance_property = &Message{code: 2610, category: CategoryError, key: "_0_is_defined_as_an_accessor_in_class_1_but_is_overridden_here_in_2_as_an_instance_property_2610", text: "'{0}' is defined as an accessor in class '{1}', but is overridden here in '{2}' as an instance property."}
+
 var X_0_is_defined_as_a_property_in_class_1_but_is_overridden_here_in_2_as_an_accessor = &Message{code: 2611, category: CategoryError, key: "_0_is_defined_as_a_property_in_class_1_but_is_overridden_here_in_2_as_an_accessor_2611", text: "'{0}' is defined as a property in class '{1}', but is overridden here in '{2}' as an accessor."}
+
 var Property_0_will_overwrite_the_base_property_in_1_If_this_is_intentional_add_an_initializer_Otherwise_add_a_declare_modifier_or_remove_the_redundant_declaration = &Message{code: 2612, category: CategoryError, key: "Property_0_will_overwrite_the_base_property_in_1_If_this_is_intentional_add_an_initializer_Otherwise_2612", text: "Property '{0}' will overwrite the base property in '{1}'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration."}
+
 var Module_0_has_no_default_export_Did_you_mean_to_use_import_1_from_0_instead = &Message{code: 2613, category: CategoryError, key: "Module_0_has_no_default_export_Did_you_mean_to_use_import_1_from_0_instead_2613", text: "Module '{0}' has no default export. Did you mean to use 'import { {1} } from {0}' instead?"}
+
 var Module_0_has_no_exported_member_1_Did_you_mean_to_use_import_1_from_0_instead = &Message{code: 2614, category: CategoryError, key: "Module_0_has_no_exported_member_1_Did_you_mean_to_use_import_1_from_0_instead_2614", text: "Module '{0}' has no exported member '{1}'. Did you mean to use 'import {1} from {0}' instead?"}
+
 var Type_of_property_0_circularly_references_itself_in_mapped_type_1 = &Message{code: 2615, category: CategoryError, key: "Type_of_property_0_circularly_references_itself_in_mapped_type_1_2615", text: "Type of property '{0}' circularly references itself in mapped type '{1}'."}
+
 var X_0_can_only_be_imported_by_using_import_1_require_2_or_a_default_import = &Message{code: 2616, category: CategoryError, key: "_0_can_only_be_imported_by_using_import_1_require_2_or_a_default_import_2616", text: "'{0}' can only be imported by using 'import {1} = require({2})' or a default import."}
+
 var X_0_can_only_be_imported_by_using_import_1_require_2_or_by_turning_on_the_esModuleInterop_flag_and_using_a_default_import = &Message{code: 2617, category: CategoryError, key: "_0_can_only_be_imported_by_using_import_1_require_2_or_by_turning_on_the_esModuleInterop_flag_and_us_2617", text: "'{0}' can only be imported by using 'import {1} = require({2})' or by turning on the 'esModuleInterop' flag and using a default import."}
+
 var Source_has_0_element_s_but_target_requires_1 = &Message{code: 2618, category: CategoryError, key: "Source_has_0_element_s_but_target_requires_1_2618", text: "Source has {0} element(s) but target requires {1}."}
+
 var Source_has_0_element_s_but_target_allows_only_1 = &Message{code: 2619, category: CategoryError, key: "Source_has_0_element_s_but_target_allows_only_1_2619", text: "Source has {0} element(s) but target allows only {1}."}
+
 var Target_requires_0_element_s_but_source_may_have_fewer = &Message{code: 2620, category: CategoryError, key: "Target_requires_0_element_s_but_source_may_have_fewer_2620", text: "Target requires {0} element(s) but source may have fewer."}
+
 var Target_allows_only_0_element_s_but_source_may_have_more = &Message{code: 2621, category: CategoryError, key: "Target_allows_only_0_element_s_but_source_may_have_more_2621", text: "Target allows only {0} element(s) but source may have more."}
+
 var Source_provides_no_match_for_required_element_at_position_0_in_target = &Message{code: 2623, category: CategoryError, key: "Source_provides_no_match_for_required_element_at_position_0_in_target_2623", text: "Source provides no match for required element at position {0} in target."}
+
 var Source_provides_no_match_for_variadic_element_at_position_0_in_target = &Message{code: 2624, category: CategoryError, key: "Source_provides_no_match_for_variadic_element_at_position_0_in_target_2624", text: "Source provides no match for variadic element at position {0} in target."}
+
 var Variadic_element_at_position_0_in_source_does_not_match_element_at_position_1_in_target = &Message{code: 2625, category: CategoryError, key: "Variadic_element_at_position_0_in_source_does_not_match_element_at_position_1_in_target_2625", text: "Variadic element at position {0} in source does not match element at position {1} in target."}
+
 var Type_at_position_0_in_source_is_not_compatible_with_type_at_position_1_in_target = &Message{code: 2626, category: CategoryError, key: "Type_at_position_0_in_source_is_not_compatible_with_type_at_position_1_in_target_2626", text: "Type at position {0} in source is not compatible with type at position {1} in target."}
+
 var Type_at_positions_0_through_1_in_source_is_not_compatible_with_type_at_position_2_in_target = &Message{code: 2627, category: CategoryError, key: "Type_at_positions_0_through_1_in_source_is_not_compatible_with_type_at_position_2_in_target_2627", text: "Type at positions {0} through {1} in source is not compatible with type at position {2} in target."}
+
 var Cannot_assign_to_0_because_it_is_an_enum = &Message{code: 2628, category: CategoryError, key: "Cannot_assign_to_0_because_it_is_an_enum_2628", text: "Cannot assign to '{0}' because it is an enum."}
+
 var Cannot_assign_to_0_because_it_is_a_class = &Message{code: 2629, category: CategoryError, key: "Cannot_assign_to_0_because_it_is_a_class_2629", text: "Cannot assign to '{0}' because it is a class."}
+
 var Cannot_assign_to_0_because_it_is_a_function = &Message{code: 2630, category: CategoryError, key: "Cannot_assign_to_0_because_it_is_a_function_2630", text: "Cannot assign to '{0}' because it is a function."}
+
 var Cannot_assign_to_0_because_it_is_a_namespace = &Message{code: 2631, category: CategoryError, key: "Cannot_assign_to_0_because_it_is_a_namespace_2631", text: "Cannot assign to '{0}' because it is a namespace."}
+
 var Cannot_assign_to_0_because_it_is_an_import = &Message{code: 2632, category: CategoryError, key: "Cannot_assign_to_0_because_it_is_an_import_2632", text: "Cannot assign to '{0}' because it is an import."}
+
 var JSX_property_access_expressions_cannot_include_JSX_namespace_names = &Message{code: 2633, category: CategoryError, key: "JSX_property_access_expressions_cannot_include_JSX_namespace_names_2633", text: "JSX property access expressions cannot include JSX namespace names"}
+
 var X_0_index_signatures_are_incompatible = &Message{code: 2634, category: CategoryError, key: "_0_index_signatures_are_incompatible_2634", text: "'{0}' index signatures are incompatible."}
+
 var Type_0_has_no_signatures_for_which_the_type_argument_list_is_applicable = &Message{code: 2635, category: CategoryError, key: "Type_0_has_no_signatures_for_which_the_type_argument_list_is_applicable_2635", text: "Type '{0}' has no signatures for which the type argument list is applicable."}
+
 var Type_0_is_not_assignable_to_type_1_as_implied_by_variance_annotation = &Message{code: 2636, category: CategoryError, key: "Type_0_is_not_assignable_to_type_1_as_implied_by_variance_annotation_2636", text: "Type '{0}' is not assignable to type '{1}' as implied by variance annotation."}
+
 var Variance_annotations_are_only_supported_in_type_aliases_for_object_function_constructor_and_mapped_types = &Message{code: 2637, category: CategoryError, key: "Variance_annotations_are_only_supported_in_type_aliases_for_object_function_constructor_and_mapped_t_2637", text: "Variance annotations are only supported in type aliases for object, function, constructor, and mapped types."}
+
 var Type_0_may_represent_a_primitive_value_which_is_not_permitted_as_the_right_operand_of_the_in_operator = &Message{code: 2638, category: CategoryError, key: "Type_0_may_represent_a_primitive_value_which_is_not_permitted_as_the_right_operand_of_the_in_operato_2638", text: "Type '{0}' may represent a primitive value, which is not permitted as the right operand of the 'in' operator."}
+
 var React_components_cannot_include_JSX_namespace_names = &Message{code: 2639, category: CategoryError, key: "React_components_cannot_include_JSX_namespace_names_2639", text: "React components cannot include JSX namespace names"}
+
 var Cannot_augment_module_0_with_value_exports_because_it_resolves_to_a_non_module_entity = &Message{code: 2649, category: CategoryError, key: "Cannot_augment_module_0_with_value_exports_because_it_resolves_to_a_non_module_entity_2649", text: "Cannot augment module '{0}' with value exports because it resolves to a non-module entity."}
+
 var Non_abstract_class_expression_is_missing_implementations_for_the_following_members_of_0_Colon_1_and_2_more = &Message{code: 2650, category: CategoryError, key: "Non_abstract_class_expression_is_missing_implementations_for_the_following_members_of_0_Colon_1_and__2650", text: "Non-abstract class expression is missing implementations for the following members of '{0}': {1} and {2} more."}
+
 var A_member_initializer_in_a_enum_declaration_cannot_reference_members_declared_after_it_including_members_defined_in_other_enums = &Message{code: 2651, category: CategoryError, key: "A_member_initializer_in_a_enum_declaration_cannot_reference_members_declared_after_it_including_memb_2651", text: "A member initializer in a enum declaration cannot reference members declared after it, including members defined in other enums."}
+
 var Merged_declaration_0_cannot_include_a_default_export_declaration_Consider_adding_a_separate_export_default_0_declaration_instead = &Message{code: 2652, category: CategoryError, key: "Merged_declaration_0_cannot_include_a_default_export_declaration_Consider_adding_a_separate_export_d_2652", text: "Merged declaration '{0}' cannot include a default export declaration. Consider adding a separate 'export default {0}' declaration instead."}
+
 var Non_abstract_class_expression_does_not_implement_inherited_abstract_member_0_from_class_1 = &Message{code: 2653, category: CategoryError, key: "Non_abstract_class_expression_does_not_implement_inherited_abstract_member_0_from_class_1_2653", text: "Non-abstract class expression does not implement inherited abstract member '{0}' from class '{1}'."}
+
 var Non_abstract_class_0_is_missing_implementations_for_the_following_members_of_1_Colon_2 = &Message{code: 2654, category: CategoryError, key: "Non_abstract_class_0_is_missing_implementations_for_the_following_members_of_1_Colon_2_2654", text: "Non-abstract class '{0}' is missing implementations for the following members of '{1}': {2}."}
+
 var Non_abstract_class_0_is_missing_implementations_for_the_following_members_of_1_Colon_2_and_3_more = &Message{code: 2655, category: CategoryError, key: "Non_abstract_class_0_is_missing_implementations_for_the_following_members_of_1_Colon_2_and_3_more_2655", text: "Non-abstract class '{0}' is missing implementations for the following members of '{1}': {2} and {3} more."}
+
 var Non_abstract_class_expression_is_missing_implementations_for_the_following_members_of_0_Colon_1 = &Message{code: 2656, category: CategoryError, key: "Non_abstract_class_expression_is_missing_implementations_for_the_following_members_of_0_Colon_1_2656", text: "Non-abstract class expression is missing implementations for the following members of '{0}': {1}."}
+
 var JSX_expressions_must_have_one_parent_element = &Message{code: 2657, category: CategoryError, key: "JSX_expressions_must_have_one_parent_element_2657", text: "JSX expressions must have one parent element."}
+
 var Type_0_provides_no_match_for_the_signature_1 = &Message{code: 2658, category: CategoryError, key: "Type_0_provides_no_match_for_the_signature_1_2658", text: "Type '{0}' provides no match for the signature '{1}'."}
+
 var X_super_is_only_allowed_in_members_of_object_literal_expressions_when_option_target_is_ES2015_or_higher = &Message{code: 2659, category: CategoryError, key: "super_is_only_allowed_in_members_of_object_literal_expressions_when_option_target_is_ES2015_or_highe_2659", text: "'super' is only allowed in members of object literal expressions when option 'target' is 'ES2015' or higher."}
+
 var X_super_can_only_be_referenced_in_members_of_derived_classes_or_object_literal_expressions = &Message{code: 2660, category: CategoryError, key: "super_can_only_be_referenced_in_members_of_derived_classes_or_object_literal_expressions_2660", text: "'super' can only be referenced in members of derived classes or object literal expressions."}
+
 var Cannot_export_0_Only_local_declarations_can_be_exported_from_a_module = &Message{code: 2661, category: CategoryError, key: "Cannot_export_0_Only_local_declarations_can_be_exported_from_a_module_2661", text: "Cannot export '{0}'. Only local declarations can be exported from a module."}
+
 var Cannot_find_name_0_Did_you_mean_the_static_member_1_0 = &Message{code: 2662, category: CategoryError, key: "Cannot_find_name_0_Did_you_mean_the_static_member_1_0_2662", text: "Cannot find name '{0}'. Did you mean the static member '{1}.{0}'?"}
+
 var Cannot_find_name_0_Did_you_mean_the_instance_member_this_0 = &Message{code: 2663, category: CategoryError, key: "Cannot_find_name_0_Did_you_mean_the_instance_member_this_0_2663", text: "Cannot find name '{0}'. Did you mean the instance member 'this.{0}'?"}
+
 var Invalid_module_name_in_augmentation_module_0_cannot_be_found = &Message{code: 2664, category: CategoryError, key: "Invalid_module_name_in_augmentation_module_0_cannot_be_found_2664", text: "Invalid module name in augmentation, module '{0}' cannot be found."}
+
 var Invalid_module_name_in_augmentation_Module_0_resolves_to_an_untyped_module_at_1_which_cannot_be_augmented = &Message{code: 2665, category: CategoryError, key: "Invalid_module_name_in_augmentation_Module_0_resolves_to_an_untyped_module_at_1_which_cannot_be_augm_2665", text: "Invalid module name in augmentation. Module '{0}' resolves to an untyped module at '{1}', which cannot be augmented."}
+
 var Exports_and_export_assignments_are_not_permitted_in_module_augmentations = &Message{code: 2666, category: CategoryError, key: "Exports_and_export_assignments_are_not_permitted_in_module_augmentations_2666", text: "Exports and export assignments are not permitted in module augmentations."}
+
 var Imports_are_not_permitted_in_module_augmentations_Consider_moving_them_to_the_enclosing_external_module = &Message{code: 2667, category: CategoryError, key: "Imports_are_not_permitted_in_module_augmentations_Consider_moving_them_to_the_enclosing_external_mod_2667", text: "Imports are not permitted in module augmentations. Consider moving them to the enclosing external module."}
+
 var X_export_modifier_cannot_be_applied_to_ambient_modules_and_module_augmentations_since_they_are_always_visible = &Message{code: 2668, category: CategoryError, key: "export_modifier_cannot_be_applied_to_ambient_modules_and_module_augmentations_since_they_are_always__2668", text: "'export' modifier cannot be applied to ambient modules and module augmentations since they are always visible."}
+
 var Augmentations_for_the_global_scope_can_only_be_directly_nested_in_external_modules_or_ambient_module_declarations = &Message{code: 2669, category: CategoryError, key: "Augmentations_for_the_global_scope_can_only_be_directly_nested_in_external_modules_or_ambient_module_2669", text: "Augmentations for the global scope can only be directly nested in external modules or ambient module declarations."}
+
 var Augmentations_for_the_global_scope_should_have_declare_modifier_unless_they_appear_in_already_ambient_context = &Message{code: 2670, category: CategoryError, key: "Augmentations_for_the_global_scope_should_have_declare_modifier_unless_they_appear_in_already_ambien_2670", text: "Augmentations for the global scope should have 'declare' modifier unless they appear in already ambient context."}
+
 var Cannot_augment_module_0_because_it_resolves_to_a_non_module_entity = &Message{code: 2671, category: CategoryError, key: "Cannot_augment_module_0_because_it_resolves_to_a_non_module_entity_2671", text: "Cannot augment module '{0}' because it resolves to a non-module entity."}
+
 var Cannot_assign_a_0_constructor_type_to_a_1_constructor_type = &Message{code: 2672, category: CategoryError, key: "Cannot_assign_a_0_constructor_type_to_a_1_constructor_type_2672", text: "Cannot assign a '{0}' constructor type to a '{1}' constructor type."}
+
 var Constructor_of_class_0_is_private_and_only_accessible_within_the_class_declaration = &Message{code: 2673, category: CategoryError, key: "Constructor_of_class_0_is_private_and_only_accessible_within_the_class_declaration_2673", text: "Constructor of class '{0}' is private and only accessible within the class declaration."}
+
 var Constructor_of_class_0_is_protected_and_only_accessible_within_the_class_declaration = &Message{code: 2674, category: CategoryError, key: "Constructor_of_class_0_is_protected_and_only_accessible_within_the_class_declaration_2674", text: "Constructor of class '{0}' is protected and only accessible within the class declaration."}
+
 var Cannot_extend_a_class_0_Class_constructor_is_marked_as_private = &Message{code: 2675, category: CategoryError, key: "Cannot_extend_a_class_0_Class_constructor_is_marked_as_private_2675", text: "Cannot extend a class '{0}'. Class constructor is marked as private."}
+
 var Accessors_must_both_be_abstract_or_non_abstract = &Message{code: 2676, category: CategoryError, key: "Accessors_must_both_be_abstract_or_non_abstract_2676", text: "Accessors must both be abstract or non-abstract."}
+
 var A_type_predicate_s_type_must_be_assignable_to_its_parameter_s_type = &Message{code: 2677, category: CategoryError, key: "A_type_predicate_s_type_must_be_assignable_to_its_parameter_s_type_2677", text: "A type predicate's type must be assignable to its parameter's type."}
+
 var Type_0_is_not_comparable_to_type_1 = &Message{code: 2678, category: CategoryError, key: "Type_0_is_not_comparable_to_type_1_2678", text: "Type '{0}' is not comparable to type '{1}'."}
+
 var A_function_that_is_called_with_the_new_keyword_cannot_have_a_this_type_that_is_void = &Message{code: 2679, category: CategoryError, key: "A_function_that_is_called_with_the_new_keyword_cannot_have_a_this_type_that_is_void_2679", text: "A function that is called with the 'new' keyword cannot have a 'this' type that is 'void'."}
+
 var A_0_parameter_must_be_the_first_parameter = &Message{code: 2680, category: CategoryError, key: "A_0_parameter_must_be_the_first_parameter_2680", text: "A '{0}' parameter must be the first parameter."}
+
 var A_constructor_cannot_have_a_this_parameter = &Message{code: 2681, category: CategoryError, key: "A_constructor_cannot_have_a_this_parameter_2681", text: "A constructor cannot have a 'this' parameter."}
+
 var X_this_implicitly_has_type_any_because_it_does_not_have_a_type_annotation = &Message{code: 2683, category: CategoryError, key: "this_implicitly_has_type_any_because_it_does_not_have_a_type_annotation_2683", text: "'this' implicitly has type 'any' because it does not have a type annotation."}
+
 var The_this_context_of_type_0_is_not_assignable_to_method_s_this_of_type_1 = &Message{code: 2684, category: CategoryError, key: "The_this_context_of_type_0_is_not_assignable_to_method_s_this_of_type_1_2684", text: "The 'this' context of type '{0}' is not assignable to method's 'this' of type '{1}'."}
+
 var The_this_types_of_each_signature_are_incompatible = &Message{code: 2685, category: CategoryError, key: "The_this_types_of_each_signature_are_incompatible_2685", text: "The 'this' types of each signature are incompatible."}
+
 var X_0_refers_to_a_UMD_global_but_the_current_file_is_a_module_Consider_adding_an_import_instead = &Message{code: 2686, category: CategoryError, key: "_0_refers_to_a_UMD_global_but_the_current_file_is_a_module_Consider_adding_an_import_instead_2686", text: "'{0}' refers to a UMD global, but the current file is a module. Consider adding an import instead."}
+
 var All_declarations_of_0_must_have_identical_modifiers = &Message{code: 2687, category: CategoryError, key: "All_declarations_of_0_must_have_identical_modifiers_2687", text: "All declarations of '{0}' must have identical modifiers."}
+
 var Cannot_find_type_definition_file_for_0 = &Message{code: 2688, category: CategoryError, key: "Cannot_find_type_definition_file_for_0_2688", text: "Cannot find type definition file for '{0}'."}
+
 var Cannot_extend_an_interface_0_Did_you_mean_implements = &Message{code: 2689, category: CategoryError, key: "Cannot_extend_an_interface_0_Did_you_mean_implements_2689", text: "Cannot extend an interface '{0}'. Did you mean 'implements'?"}
+
 var X_0_only_refers_to_a_type_but_is_being_used_as_a_value_here_Did_you_mean_to_use_1_in_0 = &Message{code: 2690, category: CategoryError, key: "_0_only_refers_to_a_type_but_is_being_used_as_a_value_here_Did_you_mean_to_use_1_in_0_2690", text: "'{0}' only refers to a type, but is being used as a value here. Did you mean to use '{1} in {0}'?"}
+
 var X_0_is_a_primitive_but_1_is_a_wrapper_object_Prefer_using_0_when_possible = &Message{code: 2692, category: CategoryError, key: "_0_is_a_primitive_but_1_is_a_wrapper_object_Prefer_using_0_when_possible_2692", text: "'{0}' is a primitive, but '{1}' is a wrapper object. Prefer using '{0}' when possible."}
+
 var X_0_only_refers_to_a_type_but_is_being_used_as_a_value_here = &Message{code: 2693, category: CategoryError, key: "_0_only_refers_to_a_type_but_is_being_used_as_a_value_here_2693", text: "'{0}' only refers to a type, but is being used as a value here."}
+
 var Namespace_0_has_no_exported_member_1 = &Message{code: 2694, category: CategoryError, key: "Namespace_0_has_no_exported_member_1_2694", text: "Namespace '{0}' has no exported member '{1}'."}
+
 var Left_side_of_comma_operator_is_unused_and_has_no_side_effects = &Message{code: 2695, category: CategoryError, key: "Left_side_of_comma_operator_is_unused_and_has_no_side_effects_2695", text: "Left side of comma operator is unused and has no side effects.", reportsUnnecessary: true}
+
 var The_Object_type_is_assignable_to_very_few_other_types_Did_you_mean_to_use_the_any_type_instead = &Message{code: 2696, category: CategoryError, key: "The_Object_type_is_assignable_to_very_few_other_types_Did_you_mean_to_use_the_any_type_instead_2696", text: "The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?"}
+
 var An_async_function_or_method_must_return_a_Promise_Make_sure_you_have_a_declaration_for_Promise_or_include_ES2015_in_your_lib_option = &Message{code: 2697, category: CategoryError, key: "An_async_function_or_method_must_return_a_Promise_Make_sure_you_have_a_declaration_for_Promise_or_in_2697", text: "An async function or method must return a 'Promise'. Make sure you have a declaration for 'Promise' or include 'ES2015' in your '--lib' option."}
+
 var Spread_types_may_only_be_created_from_object_types = &Message{code: 2698, category: CategoryError, key: "Spread_types_may_only_be_created_from_object_types_2698", text: "Spread types may only be created from object types."}
+
 var Static_property_0_conflicts_with_built_in_property_Function_0_of_constructor_function_1 = &Message{code: 2699, category: CategoryError, key: "Static_property_0_conflicts_with_built_in_property_Function_0_of_constructor_function_1_2699", text: "Static property '{0}' conflicts with built-in property 'Function.{0}' of constructor function '{1}'."}
+
 var Rest_types_may_only_be_created_from_object_types = &Message{code: 2700, category: CategoryError, key: "Rest_types_may_only_be_created_from_object_types_2700", text: "Rest types may only be created from object types."}
+
 var The_target_of_an_object_rest_assignment_must_be_a_variable_or_a_property_access = &Message{code: 2701, category: CategoryError, key: "The_target_of_an_object_rest_assignment_must_be_a_variable_or_a_property_access_2701", text: "The target of an object rest assignment must be a variable or a property access."}
+
 var X_0_only_refers_to_a_type_but_is_being_used_as_a_namespace_here = &Message{code: 2702, category: CategoryError, key: "_0_only_refers_to_a_type_but_is_being_used_as_a_namespace_here_2702", text: "'{0}' only refers to a type, but is being used as a namespace here."}
+
 var The_operand_of_a_delete_operator_must_be_a_property_reference = &Message{code: 2703, category: CategoryError, key: "The_operand_of_a_delete_operator_must_be_a_property_reference_2703", text: "The operand of a 'delete' operator must be a property reference."}
+
 var The_operand_of_a_delete_operator_cannot_be_a_read_only_property = &Message{code: 2704, category: CategoryError, key: "The_operand_of_a_delete_operator_cannot_be_a_read_only_property_2704", text: "The operand of a 'delete' operator cannot be a read-only property."}
+
 var An_async_function_or_method_in_ES5_requires_the_Promise_constructor_Make_sure_you_have_a_declaration_for_the_Promise_constructor_or_include_ES2015_in_your_lib_option = &Message{code: 2705, category: CategoryError, key: "An_async_function_or_method_in_ES5_requires_the_Promise_constructor_Make_sure_you_have_a_declaration_2705", text: "An async function or method in ES5 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option."}
+
 var Required_type_parameters_may_not_follow_optional_type_parameters = &Message{code: 2706, category: CategoryError, key: "Required_type_parameters_may_not_follow_optional_type_parameters_2706", text: "Required type parameters may not follow optional type parameters."}
+
 var Generic_type_0_requires_between_1_and_2_type_arguments = &Message{code: 2707, category: CategoryError, key: "Generic_type_0_requires_between_1_and_2_type_arguments_2707", text: "Generic type '{0}' requires between {1} and {2} type arguments."}
+
 var Cannot_use_namespace_0_as_a_value = &Message{code: 2708, category: CategoryError, key: "Cannot_use_namespace_0_as_a_value_2708", text: "Cannot use namespace '{0}' as a value."}
+
 var Cannot_use_namespace_0_as_a_type = &Message{code: 2709, category: CategoryError, key: "Cannot_use_namespace_0_as_a_type_2709", text: "Cannot use namespace '{0}' as a type."}
+
 var X_0_are_specified_twice_The_attribute_named_0_will_be_overwritten = &Message{code: 2710, category: CategoryError, key: "_0_are_specified_twice_The_attribute_named_0_will_be_overwritten_2710", text: "'{0}' are specified twice. The attribute named '{0}' will be overwritten."}
+
 var A_dynamic_import_call_returns_a_Promise_Make_sure_you_have_a_declaration_for_Promise_or_include_ES2015_in_your_lib_option = &Message{code: 2711, category: CategoryError, key: "A_dynamic_import_call_returns_a_Promise_Make_sure_you_have_a_declaration_for_Promise_or_include_ES20_2711", text: "A dynamic import call returns a 'Promise'. Make sure you have a declaration for 'Promise' or include 'ES2015' in your '--lib' option."}
+
 var A_dynamic_import_call_in_ES5_requires_the_Promise_constructor_Make_sure_you_have_a_declaration_for_the_Promise_constructor_or_include_ES2015_in_your_lib_option = &Message{code: 2712, category: CategoryError, key: "A_dynamic_import_call_in_ES5_requires_the_Promise_constructor_Make_sure_you_have_a_declaration_for_t_2712", text: "A dynamic import call in ES5 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option."}
+
 var Cannot_access_0_1_because_0_is_a_type_but_not_a_namespace_Did_you_mean_to_retrieve_the_type_of_the_property_1_in_0_with_0_1 = &Message{code: 2713, category: CategoryError, key: "Cannot_access_0_1_because_0_is_a_type_but_not_a_namespace_Did_you_mean_to_retrieve_the_type_of_the_p_2713", text: "Cannot access '{0}.{1}' because '{0}' is a type, but not a namespace. Did you mean to retrieve the type of the property '{1}' in '{0}' with '{0}[\"{1}\"]'?"}
+
 var The_expression_of_an_export_assignment_must_be_an_identifier_or_qualified_name_in_an_ambient_context = &Message{code: 2714, category: CategoryError, key: "The_expression_of_an_export_assignment_must_be_an_identifier_or_qualified_name_in_an_ambient_context_2714", text: "The expression of an export assignment must be an identifier or qualified name in an ambient context."}
+
 var Abstract_property_0_in_class_1_cannot_be_accessed_in_the_constructor = &Message{code: 2715, category: CategoryError, key: "Abstract_property_0_in_class_1_cannot_be_accessed_in_the_constructor_2715", text: "Abstract property '{0}' in class '{1}' cannot be accessed in the constructor."}
+
 var Type_parameter_0_has_a_circular_default = &Message{code: 2716, category: CategoryError, key: "Type_parameter_0_has_a_circular_default_2716", text: "Type parameter '{0}' has a circular default."}
+
 var Subsequent_property_declarations_must_have_the_same_type_Property_0_must_be_of_type_1_but_here_has_type_2 = &Message{code: 2717, category: CategoryError, key: "Subsequent_property_declarations_must_have_the_same_type_Property_0_must_be_of_type_1_but_here_has_t_2717", text: "Subsequent property declarations must have the same type.  Property '{0}' must be of type '{1}', but here has type '{2}'."}
+
 var Duplicate_property_0 = &Message{code: 2718, category: CategoryError, key: "Duplicate_property_0_2718", text: "Duplicate property '{0}'."}
+
 var Type_0_is_not_assignable_to_type_1_Two_different_types_with_this_name_exist_but_they_are_unrelated = &Message{code: 2719, category: CategoryError, key: "Type_0_is_not_assignable_to_type_1_Two_different_types_with_this_name_exist_but_they_are_unrelated_2719", text: "Type '{0}' is not assignable to type '{1}'. Two different types with this name exist, but they are unrelated."}
+
 var Class_0_incorrectly_implements_class_1_Did_you_mean_to_extend_1_and_inherit_its_members_as_a_subclass = &Message{code: 2720, category: CategoryError, key: "Class_0_incorrectly_implements_class_1_Did_you_mean_to_extend_1_and_inherit_its_members_as_a_subclas_2720", text: "Class '{0}' incorrectly implements class '{1}'. Did you mean to extend '{1}' and inherit its members as a subclass?"}
+
 var Cannot_invoke_an_object_which_is_possibly_null = &Message{code: 2721, category: CategoryError, key: "Cannot_invoke_an_object_which_is_possibly_null_2721", text: "Cannot invoke an object which is possibly 'null'."}
+
 var Cannot_invoke_an_object_which_is_possibly_undefined = &Message{code: 2722, category: CategoryError, key: "Cannot_invoke_an_object_which_is_possibly_undefined_2722", text: "Cannot invoke an object which is possibly 'undefined'."}
+
 var Cannot_invoke_an_object_which_is_possibly_null_or_undefined = &Message{code: 2723, category: CategoryError, key: "Cannot_invoke_an_object_which_is_possibly_null_or_undefined_2723", text: "Cannot invoke an object which is possibly 'null' or 'undefined'."}
+
 var X_0_has_no_exported_member_named_1_Did_you_mean_2 = &Message{code: 2724, category: CategoryError, key: "_0_has_no_exported_member_named_1_Did_you_mean_2_2724", text: "'{0}' has no exported member named '{1}'. Did you mean '{2}'?"}
+
 var Class_name_cannot_be_Object_when_targeting_ES5_with_module_0 = &Message{code: 2725, category: CategoryError, key: "Class_name_cannot_be_Object_when_targeting_ES5_with_module_0_2725", text: "Class name cannot be 'Object' when targeting ES5 with module {0}."}
+
 var Cannot_find_lib_definition_for_0 = &Message{code: 2726, category: CategoryError, key: "Cannot_find_lib_definition_for_0_2726", text: "Cannot find lib definition for '{0}'."}
+
 var Cannot_find_lib_definition_for_0_Did_you_mean_1 = &Message{code: 2727, category: CategoryError, key: "Cannot_find_lib_definition_for_0_Did_you_mean_1_2727", text: "Cannot find lib definition for '{0}'. Did you mean '{1}'?"}
+
 var X_0_is_declared_here = &Message{code: 2728, category: CategoryMessage, key: "_0_is_declared_here_2728", text: "'{0}' is declared here."}
+
 var Property_0_is_used_before_its_initialization = &Message{code: 2729, category: CategoryError, key: "Property_0_is_used_before_its_initialization_2729", text: "Property '{0}' is used before its initialization."}
+
 var An_arrow_function_cannot_have_a_this_parameter = &Message{code: 2730, category: CategoryError, key: "An_arrow_function_cannot_have_a_this_parameter_2730", text: "An arrow function cannot have a 'this' parameter."}
+
 var Implicit_conversion_of_a_symbol_to_a_string_will_fail_at_runtime_Consider_wrapping_this_expression_in_String = &Message{code: 2731, category: CategoryError, key: "Implicit_conversion_of_a_symbol_to_a_string_will_fail_at_runtime_Consider_wrapping_this_expression_i_2731", text: "Implicit conversion of a 'symbol' to a 'string' will fail at runtime. Consider wrapping this expression in 'String(...)'."}
+
 var Cannot_find_module_0_Consider_using_resolveJsonModule_to_import_module_with_json_extension = &Message{code: 2732, category: CategoryError, key: "Cannot_find_module_0_Consider_using_resolveJsonModule_to_import_module_with_json_extension_2732", text: "Cannot find module '{0}'. Consider using '--resolveJsonModule' to import module with '.json' extension."}
+
 var Property_0_was_also_declared_here = &Message{code: 2733, category: CategoryError, key: "Property_0_was_also_declared_here_2733", text: "Property '{0}' was also declared here."}
+
 var Are_you_missing_a_semicolon = &Message{code: 2734, category: CategoryError, key: "Are_you_missing_a_semicolon_2734", text: "Are you missing a semicolon?"}
+
 var Did_you_mean_for_0_to_be_constrained_to_type_new_args_Colon_any_1 = &Message{code: 2735, category: CategoryError, key: "Did_you_mean_for_0_to_be_constrained_to_type_new_args_Colon_any_1_2735", text: "Did you mean for '{0}' to be constrained to type 'new (...args: any[]) => {1}'?"}
+
 var Operator_0_cannot_be_applied_to_type_1 = &Message{code: 2736, category: CategoryError, key: "Operator_0_cannot_be_applied_to_type_1_2736", text: "Operator '{0}' cannot be applied to type '{1}'."}
+
 var BigInt_literals_are_not_available_when_targeting_lower_than_ES2020 = &Message{code: 2737, category: CategoryError, key: "BigInt_literals_are_not_available_when_targeting_lower_than_ES2020_2737", text: "BigInt literals are not available when targeting lower than ES2020."}
+
 var An_outer_value_of_this_is_shadowed_by_this_container = &Message{code: 2738, category: CategoryMessage, key: "An_outer_value_of_this_is_shadowed_by_this_container_2738", text: "An outer value of 'this' is shadowed by this container."}
+
 var Type_0_is_missing_the_following_properties_from_type_1_Colon_2 = &Message{code: 2739, category: CategoryError, key: "Type_0_is_missing_the_following_properties_from_type_1_Colon_2_2739", text: "Type '{0}' is missing the following properties from type '{1}': {2}"}
+
 var Type_0_is_missing_the_following_properties_from_type_1_Colon_2_and_3_more = &Message{code: 2740, category: CategoryError, key: "Type_0_is_missing_the_following_properties_from_type_1_Colon_2_and_3_more_2740", text: "Type '{0}' is missing the following properties from type '{1}': {2}, and {3} more."}
+
 var Property_0_is_missing_in_type_1_but_required_in_type_2 = &Message{code: 2741, category: CategoryError, key: "Property_0_is_missing_in_type_1_but_required_in_type_2_2741", text: "Property '{0}' is missing in type '{1}' but required in type '{2}'."}
+
 var The_inferred_type_of_0_cannot_be_named_without_a_reference_to_1_This_is_likely_not_portable_A_type_annotation_is_necessary = &Message{code: 2742, category: CategoryError, key: "The_inferred_type_of_0_cannot_be_named_without_a_reference_to_1_This_is_likely_not_portable_A_type_a_2742", text: "The inferred type of '{0}' cannot be named without a reference to '{1}'. This is likely not portable. A type annotation is necessary."}
+
 var No_overload_expects_0_type_arguments_but_overloads_do_exist_that_expect_either_1_or_2_type_arguments = &Message{code: 2743, category: CategoryError, key: "No_overload_expects_0_type_arguments_but_overloads_do_exist_that_expect_either_1_or_2_type_arguments_2743", text: "No overload expects {0} type arguments, but overloads do exist that expect either {1} or {2} type arguments."}
+
 var Type_parameter_defaults_can_only_reference_previously_declared_type_parameters = &Message{code: 2744, category: CategoryError, key: "Type_parameter_defaults_can_only_reference_previously_declared_type_parameters_2744", text: "Type parameter defaults can only reference previously declared type parameters."}
+
 var This_JSX_tag_s_0_prop_expects_type_1_which_requires_multiple_children_but_only_a_single_child_was_provided = &Message{code: 2745, category: CategoryError, key: "This_JSX_tag_s_0_prop_expects_type_1_which_requires_multiple_children_but_only_a_single_child_was_pr_2745", text: "This JSX tag's '{0}' prop expects type '{1}' which requires multiple children, but only a single child was provided."}
+
 var This_JSX_tag_s_0_prop_expects_a_single_child_of_type_1_but_multiple_children_were_provided = &Message{code: 2746, category: CategoryError, key: "This_JSX_tag_s_0_prop_expects_a_single_child_of_type_1_but_multiple_children_were_provided_2746", text: "This JSX tag's '{0}' prop expects a single child of type '{1}', but multiple children were provided."}
+
 var X_0_components_don_t_accept_text_as_child_elements_Text_in_JSX_has_the_type_string_but_the_expected_type_of_1_is_2 = &Message{code: 2747, category: CategoryError, key: "_0_components_don_t_accept_text_as_child_elements_Text_in_JSX_has_the_type_string_but_the_expected_t_2747", text: "'{0}' components don't accept text as child elements. Text in JSX has the type 'string', but the expected type of '{1}' is '{2}'."}
+
 var Cannot_access_ambient_const_enums_when_0_is_enabled = &Message{code: 2748, category: CategoryError, key: "Cannot_access_ambient_const_enums_when_0_is_enabled_2748", text: "Cannot access ambient const enums when '{0}' is enabled."}
+
 var X_0_refers_to_a_value_but_is_being_used_as_a_type_here_Did_you_mean_typeof_0 = &Message{code: 2749, category: CategoryError, key: "_0_refers_to_a_value_but_is_being_used_as_a_type_here_Did_you_mean_typeof_0_2749", text: "'{0}' refers to a value, but is being used as a type here. Did you mean 'typeof {0}'?"}
+
 var The_implementation_signature_is_declared_here = &Message{code: 2750, category: CategoryError, key: "The_implementation_signature_is_declared_here_2750", text: "The implementation signature is declared here."}
+
 var Circularity_originates_in_type_at_this_location = &Message{code: 2751, category: CategoryError, key: "Circularity_originates_in_type_at_this_location_2751", text: "Circularity originates in type at this location."}
+
 var The_first_export_default_is_here = &Message{code: 2752, category: CategoryError, key: "The_first_export_default_is_here_2752", text: "The first export default is here."}
+
 var Another_export_default_is_here = &Message{code: 2753, category: CategoryError, key: "Another_export_default_is_here_2753", text: "Another export default is here."}
+
 var X_super_may_not_use_type_arguments = &Message{code: 2754, category: CategoryError, key: "super_may_not_use_type_arguments_2754", text: "'super' may not use type arguments."}
+
 var No_constituent_of_type_0_is_callable = &Message{code: 2755, category: CategoryError, key: "No_constituent_of_type_0_is_callable_2755", text: "No constituent of type '{0}' is callable."}
+
 var Not_all_constituents_of_type_0_are_callable = &Message{code: 2756, category: CategoryError, key: "Not_all_constituents_of_type_0_are_callable_2756", text: "Not all constituents of type '{0}' are callable."}
+
 var Type_0_has_no_call_signatures = &Message{code: 2757, category: CategoryError, key: "Type_0_has_no_call_signatures_2757", text: "Type '{0}' has no call signatures."}
+
 var Each_member_of_the_union_type_0_has_signatures_but_none_of_those_signatures_are_compatible_with_each_other = &Message{code: 2758, category: CategoryError, key: "Each_member_of_the_union_type_0_has_signatures_but_none_of_those_signatures_are_compatible_with_each_2758", text: "Each member of the union type '{0}' has signatures, but none of those signatures are compatible with each other."}
+
 var No_constituent_of_type_0_is_constructable = &Message{code: 2759, category: CategoryError, key: "No_constituent_of_type_0_is_constructable_2759", text: "No constituent of type '{0}' is constructable."}
+
 var Not_all_constituents_of_type_0_are_constructable = &Message{code: 2760, category: CategoryError, key: "Not_all_constituents_of_type_0_are_constructable_2760", text: "Not all constituents of type '{0}' are constructable."}
+
 var Type_0_has_no_construct_signatures = &Message{code: 2761, category: CategoryError, key: "Type_0_has_no_construct_signatures_2761", text: "Type '{0}' has no construct signatures."}
+
 var Each_member_of_the_union_type_0_has_construct_signatures_but_none_of_those_signatures_are_compatible_with_each_other = &Message{code: 2762, category: CategoryError, key: "Each_member_of_the_union_type_0_has_construct_signatures_but_none_of_those_signatures_are_compatible_2762", text: "Each member of the union type '{0}' has construct signatures, but none of those signatures are compatible with each other."}
+
 var Cannot_iterate_value_because_the_next_method_of_its_iterator_expects_type_1_but_for_of_will_always_send_0 = &Message{code: 2763, category: CategoryError, key: "Cannot_iterate_value_because_the_next_method_of_its_iterator_expects_type_1_but_for_of_will_always_s_2763", text: "Cannot iterate value because the 'next' method of its iterator expects type '{1}', but for-of will always send '{0}'."}
+
 var Cannot_iterate_value_because_the_next_method_of_its_iterator_expects_type_1_but_array_spread_will_always_send_0 = &Message{code: 2764, category: CategoryError, key: "Cannot_iterate_value_because_the_next_method_of_its_iterator_expects_type_1_but_array_spread_will_al_2764", text: "Cannot iterate value because the 'next' method of its iterator expects type '{1}', but array spread will always send '{0}'."}
+
 var Cannot_iterate_value_because_the_next_method_of_its_iterator_expects_type_1_but_array_destructuring_will_always_send_0 = &Message{code: 2765, category: CategoryError, key: "Cannot_iterate_value_because_the_next_method_of_its_iterator_expects_type_1_but_array_destructuring__2765", text: "Cannot iterate value because the 'next' method of its iterator expects type '{1}', but array destructuring will always send '{0}'."}
+
 var Cannot_delegate_iteration_to_value_because_the_next_method_of_its_iterator_expects_type_1_but_the_containing_generator_will_always_send_0 = &Message{code: 2766, category: CategoryError, key: "Cannot_delegate_iteration_to_value_because_the_next_method_of_its_iterator_expects_type_1_but_the_co_2766", text: "Cannot delegate iteration to value because the 'next' method of its iterator expects type '{1}', but the containing generator will always send '{0}'."}
+
 var The_0_property_of_an_iterator_must_be_a_method = &Message{code: 2767, category: CategoryError, key: "The_0_property_of_an_iterator_must_be_a_method_2767", text: "The '{0}' property of an iterator must be a method."}
+
 var The_0_property_of_an_async_iterator_must_be_a_method = &Message{code: 2768, category: CategoryError, key: "The_0_property_of_an_async_iterator_must_be_a_method_2768", text: "The '{0}' property of an async iterator must be a method."}
+
 var No_overload_matches_this_call = &Message{code: 2769, category: CategoryError, key: "No_overload_matches_this_call_2769", text: "No overload matches this call."}
+
 var The_last_overload_gave_the_following_error = &Message{code: 2770, category: CategoryError, key: "The_last_overload_gave_the_following_error_2770", text: "The last overload gave the following error."}
+
 var The_last_overload_is_declared_here = &Message{code: 2771, category: CategoryError, key: "The_last_overload_is_declared_here_2771", text: "The last overload is declared here."}
+
 var Overload_0_of_1_2_gave_the_following_error = &Message{code: 2772, category: CategoryError, key: "Overload_0_of_1_2_gave_the_following_error_2772", text: "Overload {0} of {1}, '{2}', gave the following error."}
+
 var Did_you_forget_to_use_await = &Message{code: 2773, category: CategoryError, key: "Did_you_forget_to_use_await_2773", text: "Did you forget to use 'await'?"}
+
 var This_condition_will_always_return_true_since_this_function_is_always_defined_Did_you_mean_to_call_it_instead = &Message{code: 2774, category: CategoryError, key: "This_condition_will_always_return_true_since_this_function_is_always_defined_Did_you_mean_to_call_it_2774", text: "This condition will always return true since this function is always defined. Did you mean to call it instead?"}
+
 var Assertions_require_every_name_in_the_call_target_to_be_declared_with_an_explicit_type_annotation = &Message{code: 2775, category: CategoryError, key: "Assertions_require_every_name_in_the_call_target_to_be_declared_with_an_explicit_type_annotation_2775", text: "Assertions require every name in the call target to be declared with an explicit type annotation."}
+
 var Assertions_require_the_call_target_to_be_an_identifier_or_qualified_name = &Message{code: 2776, category: CategoryError, key: "Assertions_require_the_call_target_to_be_an_identifier_or_qualified_name_2776", text: "Assertions require the call target to be an identifier or qualified name."}
+
 var The_operand_of_an_increment_or_decrement_operator_may_not_be_an_optional_property_access = &Message{code: 2777, category: CategoryError, key: "The_operand_of_an_increment_or_decrement_operator_may_not_be_an_optional_property_access_2777", text: "The operand of an increment or decrement operator may not be an optional property access."}
+
 var The_target_of_an_object_rest_assignment_may_not_be_an_optional_property_access = &Message{code: 2778, category: CategoryError, key: "The_target_of_an_object_rest_assignment_may_not_be_an_optional_property_access_2778", text: "The target of an object rest assignment may not be an optional property access."}
+
 var The_left_hand_side_of_an_assignment_expression_may_not_be_an_optional_property_access = &Message{code: 2779, category: CategoryError, key: "The_left_hand_side_of_an_assignment_expression_may_not_be_an_optional_property_access_2779", text: "The left-hand side of an assignment expression may not be an optional property access."}
+
 var The_left_hand_side_of_a_for_in_statement_may_not_be_an_optional_property_access = &Message{code: 2780, category: CategoryError, key: "The_left_hand_side_of_a_for_in_statement_may_not_be_an_optional_property_access_2780", text: "The left-hand side of a 'for...in' statement may not be an optional property access."}
+
 var The_left_hand_side_of_a_for_of_statement_may_not_be_an_optional_property_access = &Message{code: 2781, category: CategoryError, key: "The_left_hand_side_of_a_for_of_statement_may_not_be_an_optional_property_access_2781", text: "The left-hand side of a 'for...of' statement may not be an optional property access."}
+
 var X_0_needs_an_explicit_type_annotation = &Message{code: 2782, category: CategoryMessage, key: "_0_needs_an_explicit_type_annotation_2782", text: "'{0}' needs an explicit type annotation."}
+
 var X_0_is_specified_more_than_once_so_this_usage_will_be_overwritten = &Message{code: 2783, category: CategoryError, key: "_0_is_specified_more_than_once_so_this_usage_will_be_overwritten_2783", text: "'{0}' is specified more than once, so this usage will be overwritten."}
+
 var X_get_and_set_accessors_cannot_declare_this_parameters = &Message{code: 2784, category: CategoryError, key: "get_and_set_accessors_cannot_declare_this_parameters_2784", text: "'get' and 'set' accessors cannot declare 'this' parameters."}
+
 var This_spread_always_overwrites_this_property = &Message{code: 2785, category: CategoryError, key: "This_spread_always_overwrites_this_property_2785", text: "This spread always overwrites this property."}
+
 var X_0_cannot_be_used_as_a_JSX_component = &Message{code: 2786, category: CategoryError, key: "_0_cannot_be_used_as_a_JSX_component_2786", text: "'{0}' cannot be used as a JSX component."}
+
 var Its_return_type_0_is_not_a_valid_JSX_element = &Message{code: 2787, category: CategoryError, key: "Its_return_type_0_is_not_a_valid_JSX_element_2787", text: "Its return type '{0}' is not a valid JSX element."}
+
 var Its_instance_type_0_is_not_a_valid_JSX_element = &Message{code: 2788, category: CategoryError, key: "Its_instance_type_0_is_not_a_valid_JSX_element_2788", text: "Its instance type '{0}' is not a valid JSX element."}
+
 var Its_element_type_0_is_not_a_valid_JSX_element = &Message{code: 2789, category: CategoryError, key: "Its_element_type_0_is_not_a_valid_JSX_element_2789", text: "Its element type '{0}' is not a valid JSX element."}
+
 var The_operand_of_a_delete_operator_must_be_optional = &Message{code: 2790, category: CategoryError, key: "The_operand_of_a_delete_operator_must_be_optional_2790", text: "The operand of a 'delete' operator must be optional."}
+
 var Exponentiation_cannot_be_performed_on_bigint_values_unless_the_target_option_is_set_to_es2016_or_later = &Message{code: 2791, category: CategoryError, key: "Exponentiation_cannot_be_performed_on_bigint_values_unless_the_target_option_is_set_to_es2016_or_lat_2791", text: "Exponentiation cannot be performed on 'bigint' values unless the 'target' option is set to 'es2016' or later."}
+
 var Cannot_find_module_0_Did_you_mean_to_set_the_moduleResolution_option_to_nodenext_or_to_add_aliases_to_the_paths_option = &Message{code: 2792, category: CategoryError, key: "Cannot_find_module_0_Did_you_mean_to_set_the_moduleResolution_option_to_nodenext_or_to_add_aliases_t_2792", text: "Cannot find module '{0}'. Did you mean to set the 'moduleResolution' option to 'nodenext', or to add aliases to the 'paths' option?"}
+
 var The_call_would_have_succeeded_against_this_implementation_but_implementation_signatures_of_overloads_are_not_externally_visible = &Message{code: 2793, category: CategoryError, key: "The_call_would_have_succeeded_against_this_implementation_but_implementation_signatures_of_overloads_2793", text: "The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible."}
+
 var Expected_0_arguments_but_got_1_Did_you_forget_to_include_void_in_your_type_argument_to_Promise = &Message{code: 2794, category: CategoryError, key: "Expected_0_arguments_but_got_1_Did_you_forget_to_include_void_in_your_type_argument_to_Promise_2794", text: "Expected {0} arguments, but got {1}. Did you forget to include 'void' in your type argument to 'Promise'?"}
+
 var The_intrinsic_keyword_can_only_be_used_to_declare_compiler_provided_intrinsic_types = &Message{code: 2795, category: CategoryError, key: "The_intrinsic_keyword_can_only_be_used_to_declare_compiler_provided_intrinsic_types_2795", text: "The 'intrinsic' keyword can only be used to declare compiler provided intrinsic types."}
+
 var It_is_likely_that_you_are_missing_a_comma_to_separate_these_two_template_expressions_They_form_a_tagged_template_expression_which_cannot_be_invoked = &Message{code: 2796, category: CategoryError, key: "It_is_likely_that_you_are_missing_a_comma_to_separate_these_two_template_expressions_They_form_a_tag_2796", text: "It is likely that you are missing a comma to separate these two template expressions. They form a tagged template expression which cannot be invoked."}
+
 var A_mixin_class_that_extends_from_a_type_variable_containing_an_abstract_construct_signature_must_also_be_declared_abstract = &Message{code: 2797, category: CategoryError, key: "A_mixin_class_that_extends_from_a_type_variable_containing_an_abstract_construct_signature_must_also_2797", text: "A mixin class that extends from a type variable containing an abstract construct signature must also be declared 'abstract'."}
+
 var The_declaration_was_marked_as_deprecated_here = &Message{code: 2798, category: CategoryError, key: "The_declaration_was_marked_as_deprecated_here_2798", text: "The declaration was marked as deprecated here."}
+
 var Type_produces_a_tuple_type_that_is_too_large_to_represent = &Message{code: 2799, category: CategoryError, key: "Type_produces_a_tuple_type_that_is_too_large_to_represent_2799", text: "Type produces a tuple type that is too large to represent."}
+
 var Expression_produces_a_tuple_type_that_is_too_large_to_represent = &Message{code: 2800, category: CategoryError, key: "Expression_produces_a_tuple_type_that_is_too_large_to_represent_2800", text: "Expression produces a tuple type that is too large to represent."}
+
 var This_condition_will_always_return_true_since_this_0_is_always_defined = &Message{code: 2801, category: CategoryError, key: "This_condition_will_always_return_true_since_this_0_is_always_defined_2801", text: "This condition will always return true since this '{0}' is always defined."}
+
 var Type_0_can_only_be_iterated_through_when_using_the_downlevelIteration_flag_or_with_a_target_of_es2015_or_higher = &Message{code: 2802, category: CategoryError, key: "Type_0_can_only_be_iterated_through_when_using_the_downlevelIteration_flag_or_with_a_target_of_es201_2802", text: "Type '{0}' can only be iterated through when using the '--downlevelIteration' flag or with a '--target' of 'es2015' or higher."}
+
 var Cannot_assign_to_private_method_0_Private_methods_are_not_writable = &Message{code: 2803, category: CategoryError, key: "Cannot_assign_to_private_method_0_Private_methods_are_not_writable_2803", text: "Cannot assign to private method '{0}'. Private methods are not writable."}
+
 var Duplicate_identifier_0_Static_and_instance_elements_cannot_share_the_same_private_name = &Message{code: 2804, category: CategoryError, key: "Duplicate_identifier_0_Static_and_instance_elements_cannot_share_the_same_private_name_2804", text: "Duplicate identifier '{0}'. Static and instance elements cannot share the same private name."}
+
 var Private_accessor_was_defined_without_a_getter = &Message{code: 2806, category: CategoryError, key: "Private_accessor_was_defined_without_a_getter_2806", text: "Private accessor was defined without a getter."}
+
 var This_syntax_requires_an_imported_helper_named_1_with_2_parameters_which_is_not_compatible_with_the_one_in_0_Consider_upgrading_your_version_of_0 = &Message{code: 2807, category: CategoryError, key: "This_syntax_requires_an_imported_helper_named_1_with_2_parameters_which_is_not_compatible_with_the_o_2807", text: "This syntax requires an imported helper named '{1}' with {2} parameters, which is not compatible with the one in '{0}'. Consider upgrading your version of '{0}'."}
+
 var A_get_accessor_must_be_at_least_as_accessible_as_the_setter = &Message{code: 2808, category: CategoryError, key: "A_get_accessor_must_be_at_least_as_accessible_as_the_setter_2808", text: "A get accessor must be at least as accessible as the setter"}
+
 var Declaration_or_statement_expected_This_follows_a_block_of_statements_so_if_you_intended_to_write_a_destructuring_assignment_you_might_need_to_wrap_the_whole_assignment_in_parentheses = &Message{code: 2809, category: CategoryError, key: "Declaration_or_statement_expected_This_follows_a_block_of_statements_so_if_you_intended_to_write_a_d_2809", text: "Declaration or statement expected. This '=' follows a block of statements, so if you intended to write a destructuring assignment, you might need to wrap the whole assignment in parentheses."}
+
 var Expected_1_argument_but_got_0_new_Promise_needs_a_JSDoc_hint_to_produce_a_resolve_that_can_be_called_without_arguments = &Message{code: 2810, category: CategoryError, key: "Expected_1_argument_but_got_0_new_Promise_needs_a_JSDoc_hint_to_produce_a_resolve_that_can_be_called_2810", text: "Expected 1 argument, but got 0. 'new Promise()' needs a JSDoc hint to produce a 'resolve' that can be called without arguments."}
+
 var Initializer_for_property_0 = &Message{code: 2811, category: CategoryError, key: "Initializer_for_property_0_2811", text: "Initializer for property '{0}'"}
+
 var Property_0_does_not_exist_on_type_1_Try_changing_the_lib_compiler_option_to_include_dom = &Message{code: 2812, category: CategoryError, key: "Property_0_does_not_exist_on_type_1_Try_changing_the_lib_compiler_option_to_include_dom_2812", text: "Property '{0}' does not exist on type '{1}'. Try changing the 'lib' compiler option to include 'dom'."}
+
 var Class_declaration_cannot_implement_overload_list_for_0 = &Message{code: 2813, category: CategoryError, key: "Class_declaration_cannot_implement_overload_list_for_0_2813", text: "Class declaration cannot implement overload list for '{0}'."}
+
 var Function_with_bodies_can_only_merge_with_classes_that_are_ambient = &Message{code: 2814, category: CategoryError, key: "Function_with_bodies_can_only_merge_with_classes_that_are_ambient_2814", text: "Function with bodies can only merge with classes that are ambient."}
+
 var X_arguments_cannot_be_referenced_in_property_initializers = &Message{code: 2815, category: CategoryError, key: "arguments_cannot_be_referenced_in_property_initializers_2815", text: "'arguments' cannot be referenced in property initializers."}
+
 var Cannot_use_this_in_a_static_property_initializer_of_a_decorated_class = &Message{code: 2816, category: CategoryError, key: "Cannot_use_this_in_a_static_property_initializer_of_a_decorated_class_2816", text: "Cannot use 'this' in a static property initializer of a decorated class."}
+
 var Property_0_has_no_initializer_and_is_not_definitely_assigned_in_a_class_static_block = &Message{code: 2817, category: CategoryError, key: "Property_0_has_no_initializer_and_is_not_definitely_assigned_in_a_class_static_block_2817", text: "Property '{0}' has no initializer and is not definitely assigned in a class static block."}
+
 var Duplicate_identifier_0_Compiler_reserves_name_1_when_emitting_super_references_in_static_initializers = &Message{code: 2818, category: CategoryError, key: "Duplicate_identifier_0_Compiler_reserves_name_1_when_emitting_super_references_in_static_initializer_2818", text: "Duplicate identifier '{0}'. Compiler reserves name '{1}' when emitting 'super' references in static initializers."}
+
 var Namespace_name_cannot_be_0 = &Message{code: 2819, category: CategoryError, key: "Namespace_name_cannot_be_0_2819", text: "Namespace name cannot be '{0}'."}
+
 var Type_0_is_not_assignable_to_type_1_Did_you_mean_2 = &Message{code: 2820, category: CategoryError, key: "Type_0_is_not_assignable_to_type_1_Did_you_mean_2_2820", text: "Type '{0}' is not assignable to type '{1}'. Did you mean '{2}'?"}
+
 var Import_assertions_are_only_supported_when_the_module_option_is_set_to_esnext_node18_nodenext_or_preserve = &Message{code: 2821, category: CategoryError, key: "Import_assertions_are_only_supported_when_the_module_option_is_set_to_esnext_node18_nodenext_or_pres_2821", text: "Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'nodenext', or 'preserve'."}
+
 var Import_assertions_cannot_be_used_with_type_only_imports_or_exports = &Message{code: 2822, category: CategoryError, key: "Import_assertions_cannot_be_used_with_type_only_imports_or_exports_2822", text: "Import assertions cannot be used with type-only imports or exports."}
+
 var Import_attributes_are_only_supported_when_the_module_option_is_set_to_esnext_node18_nodenext_or_preserve = &Message{code: 2823, category: CategoryError, key: "Import_attributes_are_only_supported_when_the_module_option_is_set_to_esnext_node18_nodenext_or_pres_2823", text: "Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'nodenext', or 'preserve'."}
+
 var Cannot_find_namespace_0_Did_you_mean_1 = &Message{code: 2833, category: CategoryError, key: "Cannot_find_namespace_0_Did_you_mean_1_2833", text: "Cannot find namespace '{0}'. Did you mean '{1}'?"}
+
 var Relative_import_paths_need_explicit_file_extensions_in_ECMAScript_imports_when_moduleResolution_is_node16_or_nodenext_Consider_adding_an_extension_to_the_import_path = &Message{code: 2834, category: CategoryError, key: "Relative_import_paths_need_explicit_file_extensions_in_ECMAScript_imports_when_moduleResolution_is_n_2834", text: "Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Consider adding an extension to the import path."}
+
 var Relative_import_paths_need_explicit_file_extensions_in_ECMAScript_imports_when_moduleResolution_is_node16_or_nodenext_Did_you_mean_0 = &Message{code: 2835, category: CategoryError, key: "Relative_import_paths_need_explicit_file_extensions_in_ECMAScript_imports_when_moduleResolution_is_n_2835", text: "Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean '{0}'?"}
+
 var Import_assertions_are_not_allowed_on_statements_that_compile_to_CommonJS_require_calls = &Message{code: 2836, category: CategoryError, key: "Import_assertions_are_not_allowed_on_statements_that_compile_to_CommonJS_require_calls_2836", text: "Import assertions are not allowed on statements that compile to CommonJS 'require' calls."}
+
 var Import_assertion_values_must_be_string_literal_expressions = &Message{code: 2837, category: CategoryError, key: "Import_assertion_values_must_be_string_literal_expressions_2837", text: "Import assertion values must be string literal expressions."}
+
 var All_declarations_of_0_must_have_identical_constraints = &Message{code: 2838, category: CategoryError, key: "All_declarations_of_0_must_have_identical_constraints_2838", text: "All declarations of '{0}' must have identical constraints."}
+
 var This_condition_will_always_return_0_since_JavaScript_compares_objects_by_reference_not_value = &Message{code: 2839, category: CategoryError, key: "This_condition_will_always_return_0_since_JavaScript_compares_objects_by_reference_not_value_2839", text: "This condition will always return '{0}' since JavaScript compares objects by reference, not value."}
+
 var An_interface_cannot_extend_a_primitive_type_like_0_It_can_only_extend_other_named_object_types = &Message{code: 2840, category: CategoryError, key: "An_interface_cannot_extend_a_primitive_type_like_0_It_can_only_extend_other_named_object_types_2840", text: "An interface cannot extend a primitive type like '{0}'. It can only extend other named object types."}
+
 var X_0_is_an_unused_renaming_of_1_Did_you_intend_to_use_it_as_a_type_annotation = &Message{code: 2842, category: CategoryError, key: "_0_is_an_unused_renaming_of_1_Did_you_intend_to_use_it_as_a_type_annotation_2842", text: "'{0}' is an unused renaming of '{1}'. Did you intend to use it as a type annotation?"}
+
 var We_can_only_write_a_type_for_0_by_adding_a_type_for_the_entire_parameter_here = &Message{code: 2843, category: CategoryError, key: "We_can_only_write_a_type_for_0_by_adding_a_type_for_the_entire_parameter_here_2843", text: "We can only write a type for '{0}' by adding a type for the entire parameter here."}
+
 var Type_of_instance_member_variable_0_cannot_reference_identifier_1_declared_in_the_constructor = &Message{code: 2844, category: CategoryError, key: "Type_of_instance_member_variable_0_cannot_reference_identifier_1_declared_in_the_constructor_2844", text: "Type of instance member variable '{0}' cannot reference identifier '{1}' declared in the constructor."}
+
 var This_condition_will_always_return_0 = &Message{code: 2845, category: CategoryError, key: "This_condition_will_always_return_0_2845", text: "This condition will always return '{0}'."}
+
 var A_declaration_file_cannot_be_imported_without_import_type_Did_you_mean_to_import_an_implementation_file_0_instead = &Message{code: 2846, category: CategoryError, key: "A_declaration_file_cannot_be_imported_without_import_type_Did_you_mean_to_import_an_implementation_f_2846", text: "A declaration file cannot be imported without 'import type'. Did you mean to import an implementation file '{0}' instead?"}
+
 var The_right_hand_side_of_an_instanceof_expression_must_not_be_an_instantiation_expression = &Message{code: 2848, category: CategoryError, key: "The_right_hand_side_of_an_instanceof_expression_must_not_be_an_instantiation_expression_2848", text: "The right-hand side of an 'instanceof' expression must not be an instantiation expression."}
+
 var Target_signature_provides_too_few_arguments_Expected_0_or_more_but_got_1 = &Message{code: 2849, category: CategoryError, key: "Target_signature_provides_too_few_arguments_Expected_0_or_more_but_got_1_2849", text: "Target signature provides too few arguments. Expected {0} or more, but got {1}."}
+
 var The_initializer_of_a_using_declaration_must_be_either_an_object_with_a_Symbol_dispose_method_or_be_null_or_undefined = &Message{code: 2850, category: CategoryError, key: "The_initializer_of_a_using_declaration_must_be_either_an_object_with_a_Symbol_dispose_method_or_be_n_2850", text: "The initializer of a 'using' declaration must be either an object with a '[Symbol.dispose]()' method, or be 'null' or 'undefined'."}
+
 var The_initializer_of_an_await_using_declaration_must_be_either_an_object_with_a_Symbol_asyncDispose_or_Symbol_dispose_method_or_be_null_or_undefined = &Message{code: 2851, category: CategoryError, key: "The_initializer_of_an_await_using_declaration_must_be_either_an_object_with_a_Symbol_asyncDispose_or_2851", text: "The initializer of an 'await using' declaration must be either an object with a '[Symbol.asyncDispose]()' or '[Symbol.dispose]()' method, or be 'null' or 'undefined'."}
+
 var X_await_using_statements_are_only_allowed_within_async_functions_and_at_the_top_levels_of_modules = &Message{code: 2852, category: CategoryError, key: "await_using_statements_are_only_allowed_within_async_functions_and_at_the_top_levels_of_modules_2852", text: "'await using' statements are only allowed within async functions and at the top levels of modules."}
+
 var X_await_using_statements_are_only_allowed_at_the_top_level_of_a_file_when_that_file_is_a_module_but_this_file_has_no_imports_or_exports_Consider_adding_an_empty_export_to_make_this_file_a_module = &Message{code: 2853, category: CategoryError, key: "await_using_statements_are_only_allowed_at_the_top_level_of_a_file_when_that_file_is_a_module_but_th_2853", text: "'await using' statements are only allowed at the top level of a file when that file is a module, but this file has no imports or exports. Consider adding an empty 'export {}' to make this file a module."}
+
 var Top_level_await_using_statements_are_only_allowed_when_the_module_option_is_set_to_es2022_esnext_system_node16_node18_nodenext_or_preserve_and_the_target_option_is_set_to_es2017_or_higher = &Message{code: 2854, category: CategoryError, key: "Top_level_await_using_statements_are_only_allowed_when_the_module_option_is_set_to_es2022_esnext_sys_2854", text: "Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher."}
+
 var Class_field_0_defined_by_the_parent_class_is_not_accessible_in_the_child_class_via_super = &Message{code: 2855, category: CategoryError, key: "Class_field_0_defined_by_the_parent_class_is_not_accessible_in_the_child_class_via_super_2855", text: "Class field '{0}' defined by the parent class is not accessible in the child class via super."}
+
 var Import_attributes_are_not_allowed_on_statements_that_compile_to_CommonJS_require_calls = &Message{code: 2856, category: CategoryError, key: "Import_attributes_are_not_allowed_on_statements_that_compile_to_CommonJS_require_calls_2856", text: "Import attributes are not allowed on statements that compile to CommonJS 'require' calls."}
+
 var Import_attributes_cannot_be_used_with_type_only_imports_or_exports = &Message{code: 2857, category: CategoryError, key: "Import_attributes_cannot_be_used_with_type_only_imports_or_exports_2857", text: "Import attributes cannot be used with type-only imports or exports."}
+
 var Import_attribute_values_must_be_string_literal_expressions = &Message{code: 2858, category: CategoryError, key: "Import_attribute_values_must_be_string_literal_expressions_2858", text: "Import attribute values must be string literal expressions."}
+
 var Excessive_complexity_comparing_types_0_and_1 = &Message{code: 2859, category: CategoryError, key: "Excessive_complexity_comparing_types_0_and_1_2859", text: "Excessive complexity comparing types '{0}' and '{1}'."}
+
 var The_left_hand_side_of_an_instanceof_expression_must_be_assignable_to_the_first_argument_of_the_right_hand_side_s_Symbol_hasInstance_method = &Message{code: 2860, category: CategoryError, key: "The_left_hand_side_of_an_instanceof_expression_must_be_assignable_to_the_first_argument_of_the_right_2860", text: "The left-hand side of an 'instanceof' expression must be assignable to the first argument of the right-hand side's '[Symbol.hasInstance]' method."}
+
 var An_object_s_Symbol_hasInstance_method_must_return_a_boolean_value_for_it_to_be_used_on_the_right_hand_side_of_an_instanceof_expression = &Message{code: 2861, category: CategoryError, key: "An_object_s_Symbol_hasInstance_method_must_return_a_boolean_value_for_it_to_be_used_on_the_right_han_2861", text: "An object's '[Symbol.hasInstance]' method must return a boolean value for it to be used on the right-hand side of an 'instanceof' expression."}
+
 var Type_0_is_generic_and_can_only_be_indexed_for_reading = &Message{code: 2862, category: CategoryError, key: "Type_0_is_generic_and_can_only_be_indexed_for_reading_2862", text: "Type '{0}' is generic and can only be indexed for reading."}
+
 var A_class_cannot_extend_a_primitive_type_like_0_Classes_can_only_extend_constructable_values = &Message{code: 2863, category: CategoryError, key: "A_class_cannot_extend_a_primitive_type_like_0_Classes_can_only_extend_constructable_values_2863", text: "A class cannot extend a primitive type like '{0}'. Classes can only extend constructable values."}
+
 var A_class_cannot_implement_a_primitive_type_like_0_It_can_only_implement_other_named_object_types = &Message{code: 2864, category: CategoryError, key: "A_class_cannot_implement_a_primitive_type_like_0_It_can_only_implement_other_named_object_types_2864", text: "A class cannot implement a primitive type like '{0}'. It can only implement other named object types."}
+
 var Import_0_conflicts_with_local_value_so_must_be_declared_with_a_type_only_import_when_isolatedModules_is_enabled = &Message{code: 2865, category: CategoryError, key: "Import_0_conflicts_with_local_value_so_must_be_declared_with_a_type_only_import_when_isolatedModules_2865", text: "Import '{0}' conflicts with local value, so must be declared with a type-only import when 'isolatedModules' is enabled."}
+
 var Import_0_conflicts_with_global_value_used_in_this_file_so_must_be_declared_with_a_type_only_import_when_isolatedModules_is_enabled = &Message{code: 2866, category: CategoryError, key: "Import_0_conflicts_with_global_value_used_in_this_file_so_must_be_declared_with_a_type_only_import_w_2866", text: "Import '{0}' conflicts with global value used in this file, so must be declared with a type-only import when 'isolatedModules' is enabled."}
+
 var Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_Bun_Try_npm_i_save_dev_types_Slashbun = &Message{code: 2867, category: CategoryError, key: "Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_Bun_Try_npm_i_save_dev_types_Slashbun_2867", text: "Cannot find name '{0}'. Do you need to install type definitions for Bun? Try `npm i --save-dev @types/bun`."}
+
 var Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_Bun_Try_npm_i_save_dev_types_Slashbun_and_then_add_bun_to_the_types_field_in_your_tsconfig = &Message{code: 2868, category: CategoryError, key: "Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_Bun_Try_npm_i_save_dev_types_Slashbun_2868", text: "Cannot find name '{0}'. Do you need to install type definitions for Bun? Try `npm i --save-dev @types/bun` and then add 'bun' to the types field in your tsconfig."}
+
 var Right_operand_of_is_unreachable_because_the_left_operand_is_never_nullish = &Message{code: 2869, category: CategoryError, key: "Right_operand_of_is_unreachable_because_the_left_operand_is_never_nullish_2869", text: "Right operand of ?? is unreachable because the left operand is never nullish."}
+
 var This_binary_expression_is_never_nullish_Are_you_missing_parentheses = &Message{code: 2870, category: CategoryError, key: "This_binary_expression_is_never_nullish_Are_you_missing_parentheses_2870", text: "This binary expression is never nullish. Are you missing parentheses?"}
+
 var This_expression_is_always_nullish = &Message{code: 2871, category: CategoryError, key: "This_expression_is_always_nullish_2871", text: "This expression is always nullish."}
+
 var This_kind_of_expression_is_always_truthy = &Message{code: 2872, category: CategoryError, key: "This_kind_of_expression_is_always_truthy_2872", text: "This kind of expression is always truthy."}
+
 var This_kind_of_expression_is_always_falsy = &Message{code: 2873, category: CategoryError, key: "This_kind_of_expression_is_always_falsy_2873", text: "This kind of expression is always falsy."}
+
 var This_JSX_tag_requires_0_to_be_in_scope_but_it_could_not_be_found = &Message{code: 2874, category: CategoryError, key: "This_JSX_tag_requires_0_to_be_in_scope_but_it_could_not_be_found_2874", text: "This JSX tag requires '{0}' to be in scope, but it could not be found."}
+
 var This_JSX_tag_requires_the_module_path_0_to_exist_but_none_could_be_found_Make_sure_you_have_types_for_the_appropriate_package_installed = &Message{code: 2875, category: CategoryError, key: "This_JSX_tag_requires_the_module_path_0_to_exist_but_none_could_be_found_Make_sure_you_have_types_fo_2875", text: "This JSX tag requires the module path '{0}' to exist, but none could be found. Make sure you have types for the appropriate package installed."}
+
 var This_relative_import_path_is_unsafe_to_rewrite_because_it_looks_like_a_file_name_but_actually_resolves_to_0 = &Message{code: 2876, category: CategoryError, key: "This_relative_import_path_is_unsafe_to_rewrite_because_it_looks_like_a_file_name_but_actually_resolv_2876", text: "This relative import path is unsafe to rewrite because it looks like a file name, but actually resolves to \"{0}\"."}
+
 var This_import_uses_a_0_extension_to_resolve_to_an_input_TypeScript_file_but_will_not_be_rewritten_during_emit_because_it_is_not_a_relative_path = &Message{code: 2877, category: CategoryError, key: "This_import_uses_a_0_extension_to_resolve_to_an_input_TypeScript_file_but_will_not_be_rewritten_duri_2877", text: "This import uses a '{0}' extension to resolve to an input TypeScript file, but will not be rewritten during emit because it is not a relative path."}
+
 var This_import_path_is_unsafe_to_rewrite_because_it_resolves_to_another_project_and_the_relative_path_between_the_projects_output_files_is_not_the_same_as_the_relative_path_between_its_input_files = &Message{code: 2878, category: CategoryError, key: "This_import_path_is_unsafe_to_rewrite_because_it_resolves_to_another_project_and_the_relative_path_b_2878", text: "This import path is unsafe to rewrite because it resolves to another project, and the relative path between the projects' output files is not the same as the relative path between its input files."}
+
 var Using_JSX_fragments_requires_fragment_factory_0_to_be_in_scope_but_it_could_not_be_found = &Message{code: 2879, category: CategoryError, key: "Using_JSX_fragments_requires_fragment_factory_0_to_be_in_scope_but_it_could_not_be_found_2879", text: "Using JSX fragments requires fragment factory '{0}' to be in scope, but it could not be found."}
+
 var Import_assertions_have_been_replaced_by_import_attributes_Use_with_instead_of_assert = &Message{code: 2880, category: CategoryError, key: "Import_assertions_have_been_replaced_by_import_attributes_Use_with_instead_of_assert_2880", text: "Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'."}
+
 var Import_declaration_0_is_using_private_name_1 = &Message{code: 4000, category: CategoryError, key: "Import_declaration_0_is_using_private_name_1_4000", text: "Import declaration '{0}' is using private name '{1}'."}
+
 var Type_parameter_0_of_exported_class_has_or_is_using_private_name_1 = &Message{code: 4002, category: CategoryError, key: "Type_parameter_0_of_exported_class_has_or_is_using_private_name_1_4002", text: "Type parameter '{0}' of exported class has or is using private name '{1}'."}
+
 var Type_parameter_0_of_exported_interface_has_or_is_using_private_name_1 = &Message{code: 4004, category: CategoryError, key: "Type_parameter_0_of_exported_interface_has_or_is_using_private_name_1_4004", text: "Type parameter '{0}' of exported interface has or is using private name '{1}'."}
+
 var Type_parameter_0_of_constructor_signature_from_exported_interface_has_or_is_using_private_name_1 = &Message{code: 4006, category: CategoryError, key: "Type_parameter_0_of_constructor_signature_from_exported_interface_has_or_is_using_private_name_1_4006", text: "Type parameter '{0}' of constructor signature from exported interface has or is using private name '{1}'."}
+
 var Type_parameter_0_of_call_signature_from_exported_interface_has_or_is_using_private_name_1 = &Message{code: 4008, category: CategoryError, key: "Type_parameter_0_of_call_signature_from_exported_interface_has_or_is_using_private_name_1_4008", text: "Type parameter '{0}' of call signature from exported interface has or is using private name '{1}'."}
+
 var Type_parameter_0_of_public_static_method_from_exported_class_has_or_is_using_private_name_1 = &Message{code: 4010, category: CategoryError, key: "Type_parameter_0_of_public_static_method_from_exported_class_has_or_is_using_private_name_1_4010", text: "Type parameter '{0}' of public static method from exported class has or is using private name '{1}'."}
+
 var Type_parameter_0_of_public_method_from_exported_class_has_or_is_using_private_name_1 = &Message{code: 4012, category: CategoryError, key: "Type_parameter_0_of_public_method_from_exported_class_has_or_is_using_private_name_1_4012", text: "Type parameter '{0}' of public method from exported class has or is using private name '{1}'."}
+
 var Type_parameter_0_of_method_from_exported_interface_has_or_is_using_private_name_1 = &Message{code: 4014, category: CategoryError, key: "Type_parameter_0_of_method_from_exported_interface_has_or_is_using_private_name_1_4014", text: "Type parameter '{0}' of method from exported interface has or is using private name '{1}'."}
+
 var Type_parameter_0_of_exported_function_has_or_is_using_private_name_1 = &Message{code: 4016, category: CategoryError, key: "Type_parameter_0_of_exported_function_has_or_is_using_private_name_1_4016", text: "Type parameter '{0}' of exported function has or is using private name '{1}'."}
+
 var Implements_clause_of_exported_class_0_has_or_is_using_private_name_1 = &Message{code: 4019, category: CategoryError, key: "Implements_clause_of_exported_class_0_has_or_is_using_private_name_1_4019", text: "Implements clause of exported class '{0}' has or is using private name '{1}'."}
+
 var X_extends_clause_of_exported_class_0_has_or_is_using_private_name_1 = &Message{code: 4020, category: CategoryError, key: "extends_clause_of_exported_class_0_has_or_is_using_private_name_1_4020", text: "'extends' clause of exported class '{0}' has or is using private name '{1}'."}
+
 var X_extends_clause_of_exported_class_has_or_is_using_private_name_0 = &Message{code: 4021, category: CategoryError, key: "extends_clause_of_exported_class_has_or_is_using_private_name_0_4021", text: "'extends' clause of exported class has or is using private name '{0}'."}
+
 var X_extends_clause_of_exported_interface_0_has_or_is_using_private_name_1 = &Message{code: 4022, category: CategoryError, key: "extends_clause_of_exported_interface_0_has_or_is_using_private_name_1_4022", text: "'extends' clause of exported interface '{0}' has or is using private name '{1}'."}
+
 var Exported_variable_0_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named = &Message{code: 4023, category: CategoryError, key: "Exported_variable_0_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named_4023", text: "Exported variable '{0}' has or is using name '{1}' from external module {2} but cannot be named."}
+
 var Exported_variable_0_has_or_is_using_name_1_from_private_module_2 = &Message{code: 4024, category: CategoryError, key: "Exported_variable_0_has_or_is_using_name_1_from_private_module_2_4024", text: "Exported variable '{0}' has or is using name '{1}' from private module '{2}'."}
+
 var Exported_variable_0_has_or_is_using_private_name_1 = &Message{code: 4025, category: CategoryError, key: "Exported_variable_0_has_or_is_using_private_name_1_4025", text: "Exported variable '{0}' has or is using private name '{1}'."}
+
 var Public_static_property_0_of_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named = &Message{code: 4026, category: CategoryError, key: "Public_static_property_0_of_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot__4026", text: "Public static property '{0}' of exported class has or is using name '{1}' from external module {2} but cannot be named."}
+
 var Public_static_property_0_of_exported_class_has_or_is_using_name_1_from_private_module_2 = &Message{code: 4027, category: CategoryError, key: "Public_static_property_0_of_exported_class_has_or_is_using_name_1_from_private_module_2_4027", text: "Public static property '{0}' of exported class has or is using name '{1}' from private module '{2}'."}
+
 var Public_static_property_0_of_exported_class_has_or_is_using_private_name_1 = &Message{code: 4028, category: CategoryError, key: "Public_static_property_0_of_exported_class_has_or_is_using_private_name_1_4028", text: "Public static property '{0}' of exported class has or is using private name '{1}'."}
+
 var Public_property_0_of_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named = &Message{code: 4029, category: CategoryError, key: "Public_property_0_of_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_name_4029", text: "Public property '{0}' of exported class has or is using name '{1}' from external module {2} but cannot be named."}
+
 var Public_property_0_of_exported_class_has_or_is_using_name_1_from_private_module_2 = &Message{code: 4030, category: CategoryError, key: "Public_property_0_of_exported_class_has_or_is_using_name_1_from_private_module_2_4030", text: "Public property '{0}' of exported class has or is using name '{1}' from private module '{2}'."}
+
 var Public_property_0_of_exported_class_has_or_is_using_private_name_1 = &Message{code: 4031, category: CategoryError, key: "Public_property_0_of_exported_class_has_or_is_using_private_name_1_4031", text: "Public property '{0}' of exported class has or is using private name '{1}'."}
+
 var Property_0_of_exported_interface_has_or_is_using_name_1_from_private_module_2 = &Message{code: 4032, category: CategoryError, key: "Property_0_of_exported_interface_has_or_is_using_name_1_from_private_module_2_4032", text: "Property '{0}' of exported interface has or is using name '{1}' from private module '{2}'."}
+
 var Property_0_of_exported_interface_has_or_is_using_private_name_1 = &Message{code: 4033, category: CategoryError, key: "Property_0_of_exported_interface_has_or_is_using_private_name_1_4033", text: "Property '{0}' of exported interface has or is using private name '{1}'."}
+
 var Parameter_type_of_public_static_setter_0_from_exported_class_has_or_is_using_name_1_from_private_module_2 = &Message{code: 4034, category: CategoryError, key: "Parameter_type_of_public_static_setter_0_from_exported_class_has_or_is_using_name_1_from_private_mod_4034", text: "Parameter type of public static setter '{0}' from exported class has or is using name '{1}' from private module '{2}'."}
+
 var Parameter_type_of_public_static_setter_0_from_exported_class_has_or_is_using_private_name_1 = &Message{code: 4035, category: CategoryError, key: "Parameter_type_of_public_static_setter_0_from_exported_class_has_or_is_using_private_name_1_4035", text: "Parameter type of public static setter '{0}' from exported class has or is using private name '{1}'."}
+
 var Parameter_type_of_public_setter_0_from_exported_class_has_or_is_using_name_1_from_private_module_2 = &Message{code: 4036, category: CategoryError, key: "Parameter_type_of_public_setter_0_from_exported_class_has_or_is_using_name_1_from_private_module_2_4036", text: "Parameter type of public setter '{0}' from exported class has or is using name '{1}' from private module '{2}'."}
+
 var Parameter_type_of_public_setter_0_from_exported_class_has_or_is_using_private_name_1 = &Message{code: 4037, category: CategoryError, key: "Parameter_type_of_public_setter_0_from_exported_class_has_or_is_using_private_name_1_4037", text: "Parameter type of public setter '{0}' from exported class has or is using private name '{1}'."}
+
 var Return_type_of_public_static_getter_0_from_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named = &Message{code: 4038, category: CategoryError, key: "Return_type_of_public_static_getter_0_from_exported_class_has_or_is_using_name_1_from_external_modul_4038", text: "Return type of public static getter '{0}' from exported class has or is using name '{1}' from external module {2} but cannot be named."}
+
 var Return_type_of_public_static_getter_0_from_exported_class_has_or_is_using_name_1_from_private_module_2 = &Message{code: 4039, category: CategoryError, key: "Return_type_of_public_static_getter_0_from_exported_class_has_or_is_using_name_1_from_private_module_4039", text: "Return type of public static getter '{0}' from exported class has or is using name '{1}' from private module '{2}'."}
+
 var Return_type_of_public_static_getter_0_from_exported_class_has_or_is_using_private_name_1 = &Message{code: 4040, category: CategoryError, key: "Return_type_of_public_static_getter_0_from_exported_class_has_or_is_using_private_name_1_4040", text: "Return type of public static getter '{0}' from exported class has or is using private name '{1}'."}
+
 var Return_type_of_public_getter_0_from_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named = &Message{code: 4041, category: CategoryError, key: "Return_type_of_public_getter_0_from_exported_class_has_or_is_using_name_1_from_external_module_2_but_4041", text: "Return type of public getter '{0}' from exported class has or is using name '{1}' from external module {2} but cannot be named."}
+
 var Return_type_of_public_getter_0_from_exported_class_has_or_is_using_name_1_from_private_module_2 = &Message{code: 4042, category: CategoryError, key: "Return_type_of_public_getter_0_from_exported_class_has_or_is_using_name_1_from_private_module_2_4042", text: "Return type of public getter '{0}' from exported class has or is using name '{1}' from private module '{2}'."}
+
 var Return_type_of_public_getter_0_from_exported_class_has_or_is_using_private_name_1 = &Message{code: 4043, category: CategoryError, key: "Return_type_of_public_getter_0_from_exported_class_has_or_is_using_private_name_1_4043", text: "Return type of public getter '{0}' from exported class has or is using private name '{1}'."}
+
 var Return_type_of_constructor_signature_from_exported_interface_has_or_is_using_name_0_from_private_module_1 = &Message{code: 4044, category: CategoryError, key: "Return_type_of_constructor_signature_from_exported_interface_has_or_is_using_name_0_from_private_mod_4044", text: "Return type of constructor signature from exported interface has or is using name '{0}' from private module '{1}'."}
+
 var Return_type_of_constructor_signature_from_exported_interface_has_or_is_using_private_name_0 = &Message{code: 4045, category: CategoryError, key: "Return_type_of_constructor_signature_from_exported_interface_has_or_is_using_private_name_0_4045", text: "Return type of constructor signature from exported interface has or is using private name '{0}'."}
+
 var Return_type_of_call_signature_from_exported_interface_has_or_is_using_name_0_from_private_module_1 = &Message{code: 4046, category: CategoryError, key: "Return_type_of_call_signature_from_exported_interface_has_or_is_using_name_0_from_private_module_1_4046", text: "Return type of call signature from exported interface has or is using name '{0}' from private module '{1}'."}
+
 var Return_type_of_call_signature_from_exported_interface_has_or_is_using_private_name_0 = &Message{code: 4047, category: CategoryError, key: "Return_type_of_call_signature_from_exported_interface_has_or_is_using_private_name_0_4047", text: "Return type of call signature from exported interface has or is using private name '{0}'."}
+
 var Return_type_of_index_signature_from_exported_interface_has_or_is_using_name_0_from_private_module_1 = &Message{code: 4048, category: CategoryError, key: "Return_type_of_index_signature_from_exported_interface_has_or_is_using_name_0_from_private_module_1_4048", text: "Return type of index signature from exported interface has or is using name '{0}' from private module '{1}'."}
+
 var Return_type_of_index_signature_from_exported_interface_has_or_is_using_private_name_0 = &Message{code: 4049, category: CategoryError, key: "Return_type_of_index_signature_from_exported_interface_has_or_is_using_private_name_0_4049", text: "Return type of index signature from exported interface has or is using private name '{0}'."}
+
 var Return_type_of_public_static_method_from_exported_class_has_or_is_using_name_0_from_external_module_1_but_cannot_be_named = &Message{code: 4050, category: CategoryError, key: "Return_type_of_public_static_method_from_exported_class_has_or_is_using_name_0_from_external_module__4050", text: "Return type of public static method from exported class has or is using name '{0}' from external module {1} but cannot be named."}
+
 var Return_type_of_public_static_method_from_exported_class_has_or_is_using_name_0_from_private_module_1 = &Message{code: 4051, category: CategoryError, key: "Return_type_of_public_static_method_from_exported_class_has_or_is_using_name_0_from_private_module_1_4051", text: "Return type of public static method from exported class has or is using name '{0}' from private module '{1}'."}
+
 var Return_type_of_public_static_method_from_exported_class_has_or_is_using_private_name_0 = &Message{code: 4052, category: CategoryError, key: "Return_type_of_public_static_method_from_exported_class_has_or_is_using_private_name_0_4052", text: "Return type of public static method from exported class has or is using private name '{0}'."}
+
 var Return_type_of_public_method_from_exported_class_has_or_is_using_name_0_from_external_module_1_but_cannot_be_named = &Message{code: 4053, category: CategoryError, key: "Return_type_of_public_method_from_exported_class_has_or_is_using_name_0_from_external_module_1_but_c_4053", text: "Return type of public method from exported class has or is using name '{0}' from external module {1} but cannot be named."}
+
 var Return_type_of_public_method_from_exported_class_has_or_is_using_name_0_from_private_module_1 = &Message{code: 4054, category: CategoryError, key: "Return_type_of_public_method_from_exported_class_has_or_is_using_name_0_from_private_module_1_4054", text: "Return type of public method from exported class has or is using name '{0}' from private module '{1}'."}
+
 var Return_type_of_public_method_from_exported_class_has_or_is_using_private_name_0 = &Message{code: 4055, category: CategoryError, key: "Return_type_of_public_method_from_exported_class_has_or_is_using_private_name_0_4055", text: "Return type of public method from exported class has or is using private name '{0}'."}
+
 var Return_type_of_method_from_exported_interface_has_or_is_using_name_0_from_private_module_1 = &Message{code: 4056, category: CategoryError, key: "Return_type_of_method_from_exported_interface_has_or_is_using_name_0_from_private_module_1_4056", text: "Return type of method from exported interface has or is using name '{0}' from private module '{1}'."}
+
 var Return_type_of_method_from_exported_interface_has_or_is_using_private_name_0 = &Message{code: 4057, category: CategoryError, key: "Return_type_of_method_from_exported_interface_has_or_is_using_private_name_0_4057", text: "Return type of method from exported interface has or is using private name '{0}'."}
+
 var Return_type_of_exported_function_has_or_is_using_name_0_from_external_module_1_but_cannot_be_named = &Message{code: 4058, category: CategoryError, key: "Return_type_of_exported_function_has_or_is_using_name_0_from_external_module_1_but_cannot_be_named_4058", text: "Return type of exported function has or is using name '{0}' from external module {1} but cannot be named."}
+
 var Return_type_of_exported_function_has_or_is_using_name_0_from_private_module_1 = &Message{code: 4059, category: CategoryError, key: "Return_type_of_exported_function_has_or_is_using_name_0_from_private_module_1_4059", text: "Return type of exported function has or is using name '{0}' from private module '{1}'."}
+
 var Return_type_of_exported_function_has_or_is_using_private_name_0 = &Message{code: 4060, category: CategoryError, key: "Return_type_of_exported_function_has_or_is_using_private_name_0_4060", text: "Return type of exported function has or is using private name '{0}'."}
+
 var Parameter_0_of_constructor_from_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named = &Message{code: 4061, category: CategoryError, key: "Parameter_0_of_constructor_from_exported_class_has_or_is_using_name_1_from_external_module_2_but_can_4061", text: "Parameter '{0}' of constructor from exported class has or is using name '{1}' from external module {2} but cannot be named."}
+
 var Parameter_0_of_constructor_from_exported_class_has_or_is_using_name_1_from_private_module_2 = &Message{code: 4062, category: CategoryError, key: "Parameter_0_of_constructor_from_exported_class_has_or_is_using_name_1_from_private_module_2_4062", text: "Parameter '{0}' of constructor from exported class has or is using name '{1}' from private module '{2}'."}
+
 var Parameter_0_of_constructor_from_exported_class_has_or_is_using_private_name_1 = &Message{code: 4063, category: CategoryError, key: "Parameter_0_of_constructor_from_exported_class_has_or_is_using_private_name_1_4063", text: "Parameter '{0}' of constructor from exported class has or is using private name '{1}'."}
+
 var Parameter_0_of_constructor_signature_from_exported_interface_has_or_is_using_name_1_from_private_module_2 = &Message{code: 4064, category: CategoryError, key: "Parameter_0_of_constructor_signature_from_exported_interface_has_or_is_using_name_1_from_private_mod_4064", text: "Parameter '{0}' of constructor signature from exported interface has or is using name '{1}' from private module '{2}'."}
+
 var Parameter_0_of_constructor_signature_from_exported_interface_has_or_is_using_private_name_1 = &Message{code: 4065, category: CategoryError, key: "Parameter_0_of_constructor_signature_from_exported_interface_has_or_is_using_private_name_1_4065", text: "Parameter '{0}' of constructor signature from exported interface has or is using private name '{1}'."}
+
 var Parameter_0_of_call_signature_from_exported_interface_has_or_is_using_name_1_from_private_module_2 = &Message{code: 4066, category: CategoryError, key: "Parameter_0_of_call_signature_from_exported_interface_has_or_is_using_name_1_from_private_module_2_4066", text: "Parameter '{0}' of call signature from exported interface has or is using name '{1}' from private module '{2}'."}
+
 var Parameter_0_of_call_signature_from_exported_interface_has_or_is_using_private_name_1 = &Message{code: 4067, category: CategoryError, key: "Parameter_0_of_call_signature_from_exported_interface_has_or_is_using_private_name_1_4067", text: "Parameter '{0}' of call signature from exported interface has or is using private name '{1}'."}
+
 var Parameter_0_of_public_static_method_from_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named = &Message{code: 4068, category: CategoryError, key: "Parameter_0_of_public_static_method_from_exported_class_has_or_is_using_name_1_from_external_module__4068", text: "Parameter '{0}' of public static method from exported class has or is using name '{1}' from external module {2} but cannot be named."}
+
 var Parameter_0_of_public_static_method_from_exported_class_has_or_is_using_name_1_from_private_module_2 = &Message{code: 4069, category: CategoryError, key: "Parameter_0_of_public_static_method_from_exported_class_has_or_is_using_name_1_from_private_module_2_4069", text: "Parameter '{0}' of public static method from exported class has or is using name '{1}' from private module '{2}'."}
+
 var Parameter_0_of_public_static_method_from_exported_class_has_or_is_using_private_name_1 = &Message{code: 4070, category: CategoryError, key: "Parameter_0_of_public_static_method_from_exported_class_has_or_is_using_private_name_1_4070", text: "Parameter '{0}' of public static method from exported class has or is using private name '{1}'."}
+
 var Parameter_0_of_public_method_from_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named = &Message{code: 4071, category: CategoryError, key: "Parameter_0_of_public_method_from_exported_class_has_or_is_using_name_1_from_external_module_2_but_c_4071", text: "Parameter '{0}' of public method from exported class has or is using name '{1}' from external module {2} but cannot be named."}
+
 var Parameter_0_of_public_method_from_exported_class_has_or_is_using_name_1_from_private_module_2 = &Message{code: 4072, category: CategoryError, key: "Parameter_0_of_public_method_from_exported_class_has_or_is_using_name_1_from_private_module_2_4072", text: "Parameter '{0}' of public method from exported class has or is using name '{1}' from private module '{2}'."}
+
 var Parameter_0_of_public_method_from_exported_class_has_or_is_using_private_name_1 = &Message{code: 4073, category: CategoryError, key: "Parameter_0_of_public_method_from_exported_class_has_or_is_using_private_name_1_4073", text: "Parameter '{0}' of public method from exported class has or is using private name '{1}'."}
+
 var Parameter_0_of_method_from_exported_interface_has_or_is_using_name_1_from_private_module_2 = &Message{code: 4074, category: CategoryError, key: "Parameter_0_of_method_from_exported_interface_has_or_is_using_name_1_from_private_module_2_4074", text: "Parameter '{0}' of method from exported interface has or is using name '{1}' from private module '{2}'."}
+
 var Parameter_0_of_method_from_exported_interface_has_or_is_using_private_name_1 = &Message{code: 4075, category: CategoryError, key: "Parameter_0_of_method_from_exported_interface_has_or_is_using_private_name_1_4075", text: "Parameter '{0}' of method from exported interface has or is using private name '{1}'."}
+
 var Parameter_0_of_exported_function_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named = &Message{code: 4076, category: CategoryError, key: "Parameter_0_of_exported_function_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named_4076", text: "Parameter '{0}' of exported function has or is using name '{1}' from external module {2} but cannot be named."}
+
 var Parameter_0_of_exported_function_has_or_is_using_name_1_from_private_module_2 = &Message{code: 4077, category: CategoryError, key: "Parameter_0_of_exported_function_has_or_is_using_name_1_from_private_module_2_4077", text: "Parameter '{0}' of exported function has or is using name '{1}' from private module '{2}'."}
+
 var Parameter_0_of_exported_function_has_or_is_using_private_name_1 = &Message{code: 4078, category: CategoryError, key: "Parameter_0_of_exported_function_has_or_is_using_private_name_1_4078", text: "Parameter '{0}' of exported function has or is using private name '{1}'."}
+
 var Exported_type_alias_0_has_or_is_using_private_name_1 = &Message{code: 4081, category: CategoryError, key: "Exported_type_alias_0_has_or_is_using_private_name_1_4081", text: "Exported type alias '{0}' has or is using private name '{1}'."}
+
 var Default_export_of_the_module_has_or_is_using_private_name_0 = &Message{code: 4082, category: CategoryError, key: "Default_export_of_the_module_has_or_is_using_private_name_0_4082", text: "Default export of the module has or is using private name '{0}'."}
+
 var Type_parameter_0_of_exported_type_alias_has_or_is_using_private_name_1 = &Message{code: 4083, category: CategoryError, key: "Type_parameter_0_of_exported_type_alias_has_or_is_using_private_name_1_4083", text: "Type parameter '{0}' of exported type alias has or is using private name '{1}'."}
+
 var Exported_type_alias_0_has_or_is_using_private_name_1_from_module_2 = &Message{code: 4084, category: CategoryError, key: "Exported_type_alias_0_has_or_is_using_private_name_1_from_module_2_4084", text: "Exported type alias '{0}' has or is using private name '{1}' from module {2}."}
+
 var Extends_clause_for_inferred_type_0_has_or_is_using_private_name_1 = &Message{code: 4085, category: CategoryError, key: "Extends_clause_for_inferred_type_0_has_or_is_using_private_name_1_4085", text: "Extends clause for inferred type '{0}' has or is using private name '{1}'."}
+
 var Parameter_0_of_index_signature_from_exported_interface_has_or_is_using_name_1_from_private_module_2 = &Message{code: 4091, category: CategoryError, key: "Parameter_0_of_index_signature_from_exported_interface_has_or_is_using_name_1_from_private_module_2_4091", text: "Parameter '{0}' of index signature from exported interface has or is using name '{1}' from private module '{2}'."}
+
 var Parameter_0_of_index_signature_from_exported_interface_has_or_is_using_private_name_1 = &Message{code: 4092, category: CategoryError, key: "Parameter_0_of_index_signature_from_exported_interface_has_or_is_using_private_name_1_4092", text: "Parameter '{0}' of index signature from exported interface has or is using private name '{1}'."}
+
 var Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected = &Message{code: 4094, category: CategoryError, key: "Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094", text: "Property '{0}' of exported anonymous class type may not be private or protected."}
+
 var Public_static_method_0_of_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named = &Message{code: 4095, category: CategoryError, key: "Public_static_method_0_of_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_4095", text: "Public static method '{0}' of exported class has or is using name '{1}' from external module {2} but cannot be named."}
+
 var Public_static_method_0_of_exported_class_has_or_is_using_name_1_from_private_module_2 = &Message{code: 4096, category: CategoryError, key: "Public_static_method_0_of_exported_class_has_or_is_using_name_1_from_private_module_2_4096", text: "Public static method '{0}' of exported class has or is using name '{1}' from private module '{2}'."}
+
 var Public_static_method_0_of_exported_class_has_or_is_using_private_name_1 = &Message{code: 4097, category: CategoryError, key: "Public_static_method_0_of_exported_class_has_or_is_using_private_name_1_4097", text: "Public static method '{0}' of exported class has or is using private name '{1}'."}
+
 var Public_method_0_of_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named = &Message{code: 4098, category: CategoryError, key: "Public_method_0_of_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named_4098", text: "Public method '{0}' of exported class has or is using name '{1}' from external module {2} but cannot be named."}
+
 var Public_method_0_of_exported_class_has_or_is_using_name_1_from_private_module_2 = &Message{code: 4099, category: CategoryError, key: "Public_method_0_of_exported_class_has_or_is_using_name_1_from_private_module_2_4099", text: "Public method '{0}' of exported class has or is using name '{1}' from private module '{2}'."}
+
 var Public_method_0_of_exported_class_has_or_is_using_private_name_1 = &Message{code: 4100, category: CategoryError, key: "Public_method_0_of_exported_class_has_or_is_using_private_name_1_4100", text: "Public method '{0}' of exported class has or is using private name '{1}'."}
+
 var Method_0_of_exported_interface_has_or_is_using_name_1_from_private_module_2 = &Message{code: 4101, category: CategoryError, key: "Method_0_of_exported_interface_has_or_is_using_name_1_from_private_module_2_4101", text: "Method '{0}' of exported interface has or is using name '{1}' from private module '{2}'."}
+
 var Method_0_of_exported_interface_has_or_is_using_private_name_1 = &Message{code: 4102, category: CategoryError, key: "Method_0_of_exported_interface_has_or_is_using_private_name_1_4102", text: "Method '{0}' of exported interface has or is using private name '{1}'."}
+
 var Type_parameter_0_of_exported_mapped_object_type_is_using_private_name_1 = &Message{code: 4103, category: CategoryError, key: "Type_parameter_0_of_exported_mapped_object_type_is_using_private_name_1_4103", text: "Type parameter '{0}' of exported mapped object type is using private name '{1}'."}
+
 var The_type_0_is_readonly_and_cannot_be_assigned_to_the_mutable_type_1 = &Message{code: 4104, category: CategoryError, key: "The_type_0_is_readonly_and_cannot_be_assigned_to_the_mutable_type_1_4104", text: "The type '{0}' is 'readonly' and cannot be assigned to the mutable type '{1}'."}
+
 var Private_or_protected_member_0_cannot_be_accessed_on_a_type_parameter = &Message{code: 4105, category: CategoryError, key: "Private_or_protected_member_0_cannot_be_accessed_on_a_type_parameter_4105", text: "Private or protected member '{0}' cannot be accessed on a type parameter."}
+
 var Parameter_0_of_accessor_has_or_is_using_private_name_1 = &Message{code: 4106, category: CategoryError, key: "Parameter_0_of_accessor_has_or_is_using_private_name_1_4106", text: "Parameter '{0}' of accessor has or is using private name '{1}'."}
+
 var Parameter_0_of_accessor_has_or_is_using_name_1_from_private_module_2 = &Message{code: 4107, category: CategoryError, key: "Parameter_0_of_accessor_has_or_is_using_name_1_from_private_module_2_4107", text: "Parameter '{0}' of accessor has or is using name '{1}' from private module '{2}'."}
+
 var Parameter_0_of_accessor_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named = &Message{code: 4108, category: CategoryError, key: "Parameter_0_of_accessor_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named_4108", text: "Parameter '{0}' of accessor has or is using name '{1}' from external module '{2}' but cannot be named."}
+
 var Type_arguments_for_0_circularly_reference_themselves = &Message{code: 4109, category: CategoryError, key: "Type_arguments_for_0_circularly_reference_themselves_4109", text: "Type arguments for '{0}' circularly reference themselves."}
+
 var Tuple_type_arguments_circularly_reference_themselves = &Message{code: 4110, category: CategoryError, key: "Tuple_type_arguments_circularly_reference_themselves_4110", text: "Tuple type arguments circularly reference themselves."}
+
 var Property_0_comes_from_an_index_signature_so_it_must_be_accessed_with_0 = &Message{code: 4111, category: CategoryError, key: "Property_0_comes_from_an_index_signature_so_it_must_be_accessed_with_0_4111", text: "Property '{0}' comes from an index signature, so it must be accessed with ['{0}']."}
+
 var This_member_cannot_have_an_override_modifier_because_its_containing_class_0_does_not_extend_another_class = &Message{code: 4112, category: CategoryError, key: "This_member_cannot_have_an_override_modifier_because_its_containing_class_0_does_not_extend_another__4112", text: "This member cannot have an 'override' modifier because its containing class '{0}' does not extend another class."}
+
 var This_member_cannot_have_an_override_modifier_because_it_is_not_declared_in_the_base_class_0 = &Message{code: 4113, category: CategoryError, key: "This_member_cannot_have_an_override_modifier_because_it_is_not_declared_in_the_base_class_0_4113", text: "This member cannot have an 'override' modifier because it is not declared in the base class '{0}'."}
+
 var This_member_must_have_an_override_modifier_because_it_overrides_a_member_in_the_base_class_0 = &Message{code: 4114, category: CategoryError, key: "This_member_must_have_an_override_modifier_because_it_overrides_a_member_in_the_base_class_0_4114", text: "This member must have an 'override' modifier because it overrides a member in the base class '{0}'."}
+
 var This_parameter_property_must_have_an_override_modifier_because_it_overrides_a_member_in_base_class_0 = &Message{code: 4115, category: CategoryError, key: "This_parameter_property_must_have_an_override_modifier_because_it_overrides_a_member_in_base_class_0_4115", text: "This parameter property must have an 'override' modifier because it overrides a member in base class '{0}'."}
+
 var This_member_must_have_an_override_modifier_because_it_overrides_an_abstract_method_that_is_declared_in_the_base_class_0 = &Message{code: 4116, category: CategoryError, key: "This_member_must_have_an_override_modifier_because_it_overrides_an_abstract_method_that_is_declared__4116", text: "This member must have an 'override' modifier because it overrides an abstract method that is declared in the base class '{0}'."}
+
 var This_member_cannot_have_an_override_modifier_because_it_is_not_declared_in_the_base_class_0_Did_you_mean_1 = &Message{code: 4117, category: CategoryError, key: "This_member_cannot_have_an_override_modifier_because_it_is_not_declared_in_the_base_class_0_Did_you__4117", text: "This member cannot have an 'override' modifier because it is not declared in the base class '{0}'. Did you mean '{1}'?"}
+
 var The_type_of_this_node_cannot_be_serialized_because_its_property_0_cannot_be_serialized = &Message{code: 4118, category: CategoryError, key: "The_type_of_this_node_cannot_be_serialized_because_its_property_0_cannot_be_serialized_4118", text: "The type of this node cannot be serialized because its property '{0}' cannot be serialized."}
+
 var This_member_must_have_a_JSDoc_comment_with_an_override_tag_because_it_overrides_a_member_in_the_base_class_0 = &Message{code: 4119, category: CategoryError, key: "This_member_must_have_a_JSDoc_comment_with_an_override_tag_because_it_overrides_a_member_in_the_base_4119", text: "This member must have a JSDoc comment with an '@override' tag because it overrides a member in the base class '{0}'."}
+
 var This_parameter_property_must_have_a_JSDoc_comment_with_an_override_tag_because_it_overrides_a_member_in_the_base_class_0 = &Message{code: 4120, category: CategoryError, key: "This_parameter_property_must_have_a_JSDoc_comment_with_an_override_tag_because_it_overrides_a_member_4120", text: "This parameter property must have a JSDoc comment with an '@override' tag because it overrides a member in the base class '{0}'."}
+
 var This_member_cannot_have_a_JSDoc_comment_with_an_override_tag_because_its_containing_class_0_does_not_extend_another_class = &Message{code: 4121, category: CategoryError, key: "This_member_cannot_have_a_JSDoc_comment_with_an_override_tag_because_its_containing_class_0_does_not_4121", text: "This member cannot have a JSDoc comment with an '@override' tag because its containing class '{0}' does not extend another class."}
+
 var This_member_cannot_have_a_JSDoc_comment_with_an_override_tag_because_it_is_not_declared_in_the_base_class_0 = &Message{code: 4122, category: CategoryError, key: "This_member_cannot_have_a_JSDoc_comment_with_an_override_tag_because_it_is_not_declared_in_the_base__4122", text: "This member cannot have a JSDoc comment with an '@override' tag because it is not declared in the base class '{0}'."}
+
 var This_member_cannot_have_a_JSDoc_comment_with_an_override_tag_because_it_is_not_declared_in_the_base_class_0_Did_you_mean_1 = &Message{code: 4123, category: CategoryError, key: "This_member_cannot_have_a_JSDoc_comment_with_an_override_tag_because_it_is_not_declared_in_the_base__4123", text: "This member cannot have a JSDoc comment with an 'override' tag because it is not declared in the base class '{0}'. Did you mean '{1}'?"}
+
 var Compiler_option_0_of_value_1_is_unstable_Use_nightly_TypeScript_to_silence_this_error_Try_updating_with_npm_install_D_typescript_next = &Message{code: 4124, category: CategoryError, key: "Compiler_option_0_of_value_1_is_unstable_Use_nightly_TypeScript_to_silence_this_error_Try_updating_w_4124", text: "Compiler option '{0}' of value '{1}' is unstable. Use nightly TypeScript to silence this error. Try updating with 'npm install -D typescript@next'."}
+
 var Each_declaration_of_0_1_differs_in_its_value_where_2_was_expected_but_3_was_given = &Message{code: 4125, category: CategoryError, key: "Each_declaration_of_0_1_differs_in_its_value_where_2_was_expected_but_3_was_given_4125", text: "Each declaration of '{0}.{1}' differs in its value, where '{2}' was expected but '{3}' was given."}
+
 var One_value_of_0_1_is_the_string_2_and_the_other_is_assumed_to_be_an_unknown_numeric_value = &Message{code: 4126, category: CategoryError, key: "One_value_of_0_1_is_the_string_2_and_the_other_is_assumed_to_be_an_unknown_numeric_value_4126", text: "One value of '{0}.{1}' is the string '{2}', and the other is assumed to be an unknown numeric value."}
+
 var This_member_cannot_have_an_override_modifier_because_its_name_is_dynamic = &Message{code: 4127, category: CategoryError, key: "This_member_cannot_have_an_override_modifier_because_its_name_is_dynamic_4127", text: "This member cannot have an 'override' modifier because its name is dynamic."}
+
 var This_member_cannot_have_a_JSDoc_comment_with_an_override_tag_because_its_name_is_dynamic = &Message{code: 4128, category: CategoryError, key: "This_member_cannot_have_a_JSDoc_comment_with_an_override_tag_because_its_name_is_dynamic_4128", text: "This member cannot have a JSDoc comment with an '@override' tag because its name is dynamic."}
+
 var The_current_host_does_not_support_the_0_option = &Message{code: 5001, category: CategoryError, key: "The_current_host_does_not_support_the_0_option_5001", text: "The current host does not support the '{0}' option."}
+
 var Cannot_find_the_common_subdirectory_path_for_the_input_files = &Message{code: 5009, category: CategoryError, key: "Cannot_find_the_common_subdirectory_path_for_the_input_files_5009", text: "Cannot find the common subdirectory path for the input files."}
+
 var File_specification_cannot_end_in_a_recursive_directory_wildcard_Asterisk_Asterisk_Colon_0 = &Message{code: 5010, category: CategoryError, key: "File_specification_cannot_end_in_a_recursive_directory_wildcard_Asterisk_Asterisk_Colon_0_5010", text: "File specification cannot end in a recursive directory wildcard ('**'): '{0}'."}
+
 var Cannot_read_file_0_Colon_1 = &Message{code: 5012, category: CategoryError, key: "Cannot_read_file_0_Colon_1_5012", text: "Cannot read file '{0}': {1}."}
+
 var Unknown_compiler_option_0 = &Message{code: 5023, category: CategoryError, key: "Unknown_compiler_option_0_5023", text: "Unknown compiler option '{0}'."}
+
 var Compiler_option_0_requires_a_value_of_type_1 = &Message{code: 5024, category: CategoryError, key: "Compiler_option_0_requires_a_value_of_type_1_5024", text: "Compiler option '{0}' requires a value of type {1}."}
+
 var Unknown_compiler_option_0_Did_you_mean_1 = &Message{code: 5025, category: CategoryError, key: "Unknown_compiler_option_0_Did_you_mean_1_5025", text: "Unknown compiler option '{0}'. Did you mean '{1}'?"}
+
 var Could_not_write_file_0_Colon_1 = &Message{code: 5033, category: CategoryError, key: "Could_not_write_file_0_Colon_1_5033", text: "Could not write file '{0}': {1}."}
+
 var Option_project_cannot_be_mixed_with_source_files_on_a_command_line = &Message{code: 5042, category: CategoryError, key: "Option_project_cannot_be_mixed_with_source_files_on_a_command_line_5042", text: "Option 'project' cannot be mixed with source files on a command line."}
+
 var Option_isolatedModules_can_only_be_used_when_either_option_module_is_provided_or_option_target_is_ES2015_or_higher = &Message{code: 5047, category: CategoryError, key: "Option_isolatedModules_can_only_be_used_when_either_option_module_is_provided_or_option_target_is_ES_5047", text: "Option 'isolatedModules' can only be used when either option '--module' is provided or option 'target' is 'ES2015' or higher."}
+
 var Option_0_can_only_be_used_when_either_option_inlineSourceMap_or_option_sourceMap_is_provided = &Message{code: 5051, category: CategoryError, key: "Option_0_can_only_be_used_when_either_option_inlineSourceMap_or_option_sourceMap_is_provided_5051", text: "Option '{0} can only be used when either option '--inlineSourceMap' or option '--sourceMap' is provided."}
+
 var Option_0_cannot_be_specified_without_specifying_option_1 = &Message{code: 5052, category: CategoryError, key: "Option_0_cannot_be_specified_without_specifying_option_1_5052", text: "Option '{0}' cannot be specified without specifying option '{1}'."}
+
 var Option_0_cannot_be_specified_with_option_1 = &Message{code: 5053, category: CategoryError, key: "Option_0_cannot_be_specified_with_option_1_5053", text: "Option '{0}' cannot be specified with option '{1}'."}
+
 var A_tsconfig_json_file_is_already_defined_at_Colon_0 = &Message{code: 5054, category: CategoryError, key: "A_tsconfig_json_file_is_already_defined_at_Colon_0_5054", text: "A 'tsconfig.json' file is already defined at: '{0}'."}
+
 var Cannot_write_file_0_because_it_would_overwrite_input_file = &Message{code: 5055, category: CategoryError, key: "Cannot_write_file_0_because_it_would_overwrite_input_file_5055", text: "Cannot write file '{0}' because it would overwrite input file."}
+
 var Cannot_write_file_0_because_it_would_be_overwritten_by_multiple_input_files = &Message{code: 5056, category: CategoryError, key: "Cannot_write_file_0_because_it_would_be_overwritten_by_multiple_input_files_5056", text: "Cannot write file '{0}' because it would be overwritten by multiple input files."}
+
 var Cannot_find_a_tsconfig_json_file_at_the_specified_directory_Colon_0 = &Message{code: 5057, category: CategoryError, key: "Cannot_find_a_tsconfig_json_file_at_the_specified_directory_Colon_0_5057", text: "Cannot find a tsconfig.json file at the specified directory: '{0}'."}
+
 var The_specified_path_does_not_exist_Colon_0 = &Message{code: 5058, category: CategoryError, key: "The_specified_path_does_not_exist_Colon_0_5058", text: "The specified path does not exist: '{0}'."}
+
 var Invalid_value_for_reactNamespace_0_is_not_a_valid_identifier = &Message{code: 5059, category: CategoryError, key: "Invalid_value_for_reactNamespace_0_is_not_a_valid_identifier_5059", text: "Invalid value for '--reactNamespace'. '{0}' is not a valid identifier."}
+
 var Pattern_0_can_have_at_most_one_Asterisk_character = &Message{code: 5061, category: CategoryError, key: "Pattern_0_can_have_at_most_one_Asterisk_character_5061", text: "Pattern '{0}' can have at most one '*' character."}
+
 var Substitution_0_in_pattern_1_can_have_at_most_one_Asterisk_character = &Message{code: 5062, category: CategoryError, key: "Substitution_0_in_pattern_1_can_have_at_most_one_Asterisk_character_5062", text: "Substitution '{0}' in pattern '{1}' can have at most one '*' character."}
+
 var Substitutions_for_pattern_0_should_be_an_array = &Message{code: 5063, category: CategoryError, key: "Substitutions_for_pattern_0_should_be_an_array_5063", text: "Substitutions for pattern '{0}' should be an array."}
+
 var Substitution_0_for_pattern_1_has_incorrect_type_expected_string_got_2 = &Message{code: 5064, category: CategoryError, key: "Substitution_0_for_pattern_1_has_incorrect_type_expected_string_got_2_5064", text: "Substitution '{0}' for pattern '{1}' has incorrect type, expected 'string', got '{2}'."}
+
 var File_specification_cannot_contain_a_parent_directory_that_appears_after_a_recursive_directory_wildcard_Asterisk_Asterisk_Colon_0 = &Message{code: 5065, category: CategoryError, key: "File_specification_cannot_contain_a_parent_directory_that_appears_after_a_recursive_directory_wildca_5065", text: "File specification cannot contain a parent directory ('..') that appears after a recursive directory wildcard ('**'): '{0}'."}
+
 var Substitutions_for_pattern_0_shouldn_t_be_an_empty_array = &Message{code: 5066, category: CategoryError, key: "Substitutions_for_pattern_0_shouldn_t_be_an_empty_array_5066", text: "Substitutions for pattern '{0}' shouldn't be an empty array."}
+
 var Invalid_value_for_jsxFactory_0_is_not_a_valid_identifier_or_qualified_name = &Message{code: 5067, category: CategoryError, key: "Invalid_value_for_jsxFactory_0_is_not_a_valid_identifier_or_qualified_name_5067", text: "Invalid value for 'jsxFactory'. '{0}' is not a valid identifier or qualified-name."}
+
 var Adding_a_tsconfig_json_file_will_help_organize_projects_that_contain_both_TypeScript_and_JavaScript_files_Learn_more_at_https_Colon_Slash_Slashaka_ms_Slashtsconfig = &Message{code: 5068, category: CategoryError, key: "Adding_a_tsconfig_json_file_will_help_organize_projects_that_contain_both_TypeScript_and_JavaScript__5068", text: "Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig."}
+
 var Option_0_cannot_be_specified_without_specifying_option_1_or_option_2 = &Message{code: 5069, category: CategoryError, key: "Option_0_cannot_be_specified_without_specifying_option_1_or_option_2_5069", text: "Option '{0}' cannot be specified without specifying option '{1}' or option '{2}'."}
+
 var Option_resolveJsonModule_cannot_be_specified_when_moduleResolution_is_set_to_classic = &Message{code: 5070, category: CategoryError, key: "Option_resolveJsonModule_cannot_be_specified_when_moduleResolution_is_set_to_classic_5070", text: "Option '--resolveJsonModule' cannot be specified when 'moduleResolution' is set to 'classic'."}
+
 var Option_resolveJsonModule_cannot_be_specified_when_module_is_set_to_none_system_or_umd = &Message{code: 5071, category: CategoryError, key: "Option_resolveJsonModule_cannot_be_specified_when_module_is_set_to_none_system_or_umd_5071", text: "Option '--resolveJsonModule' cannot be specified when 'module' is set to 'none', 'system', or 'umd'."}
+
 var Unknown_build_option_0 = &Message{code: 5072, category: CategoryError, key: "Unknown_build_option_0_5072", text: "Unknown build option '{0}'."}
+
 var Build_option_0_requires_a_value_of_type_1 = &Message{code: 5073, category: CategoryError, key: "Build_option_0_requires_a_value_of_type_1_5073", text: "Build option '{0}' requires a value of type {1}."}
+
 var Option_incremental_can_only_be_specified_using_tsconfig_emitting_to_single_file_or_when_option_tsBuildInfoFile_is_specified = &Message{code: 5074, category: CategoryError, key: "Option_incremental_can_only_be_specified_using_tsconfig_emitting_to_single_file_or_when_option_tsBui_5074", text: "Option '--incremental' can only be specified using tsconfig, emitting to single file or when option '--tsBuildInfoFile' is specified."}
+
 var X_0_is_assignable_to_the_constraint_of_type_1_but_1_could_be_instantiated_with_a_different_subtype_of_constraint_2 = &Message{code: 5075, category: CategoryError, key: "_0_is_assignable_to_the_constraint_of_type_1_but_1_could_be_instantiated_with_a_different_subtype_of_5075", text: "'{0}' is assignable to the constraint of type '{1}', but '{1}' could be instantiated with a different subtype of constraint '{2}'."}
+
 var X_0_and_1_operations_cannot_be_mixed_without_parentheses = &Message{code: 5076, category: CategoryError, key: "_0_and_1_operations_cannot_be_mixed_without_parentheses_5076", text: "'{0}' and '{1}' operations cannot be mixed without parentheses."}
+
 var Unknown_build_option_0_Did_you_mean_1 = &Message{code: 5077, category: CategoryError, key: "Unknown_build_option_0_Did_you_mean_1_5077", text: "Unknown build option '{0}'. Did you mean '{1}'?"}
+
 var Unknown_watch_option_0 = &Message{code: 5078, category: CategoryError, key: "Unknown_watch_option_0_5078", text: "Unknown watch option '{0}'."}
+
 var Unknown_watch_option_0_Did_you_mean_1 = &Message{code: 5079, category: CategoryError, key: "Unknown_watch_option_0_Did_you_mean_1_5079", text: "Unknown watch option '{0}'. Did you mean '{1}'?"}
+
 var Watch_option_0_requires_a_value_of_type_1 = &Message{code: 5080, category: CategoryError, key: "Watch_option_0_requires_a_value_of_type_1_5080", text: "Watch option '{0}' requires a value of type {1}."}
+
 var Cannot_find_a_tsconfig_json_file_at_the_current_directory_Colon_0 = &Message{code: 5081, category: CategoryError, key: "Cannot_find_a_tsconfig_json_file_at_the_current_directory_Colon_0_5081", text: "Cannot find a tsconfig.json file at the current directory: {0}."}
+
 var X_0_could_be_instantiated_with_an_arbitrary_type_which_could_be_unrelated_to_1 = &Message{code: 5082, category: CategoryError, key: "_0_could_be_instantiated_with_an_arbitrary_type_which_could_be_unrelated_to_1_5082", text: "'{0}' could be instantiated with an arbitrary type which could be unrelated to '{1}'."}
+
 var Cannot_read_file_0 = &Message{code: 5083, category: CategoryError, key: "Cannot_read_file_0_5083", text: "Cannot read file '{0}'."}
+
 var A_tuple_member_cannot_be_both_optional_and_rest = &Message{code: 5085, category: CategoryError, key: "A_tuple_member_cannot_be_both_optional_and_rest_5085", text: "A tuple member cannot be both optional and rest."}
+
 var A_labeled_tuple_element_is_declared_as_optional_with_a_question_mark_after_the_name_and_before_the_colon_rather_than_after_the_type = &Message{code: 5086, category: CategoryError, key: "A_labeled_tuple_element_is_declared_as_optional_with_a_question_mark_after_the_name_and_before_the_c_5086", text: "A labeled tuple element is declared as optional with a question mark after the name and before the colon, rather than after the type."}
+
 var A_labeled_tuple_element_is_declared_as_rest_with_a_before_the_name_rather_than_before_the_type = &Message{code: 5087, category: CategoryError, key: "A_labeled_tuple_element_is_declared_as_rest_with_a_before_the_name_rather_than_before_the_type_5087", text: "A labeled tuple element is declared as rest with a '...' before the name, rather than before the type."}
+
 var The_inferred_type_of_0_references_a_type_with_a_cyclic_structure_which_cannot_be_trivially_serialized_A_type_annotation_is_necessary = &Message{code: 5088, category: CategoryError, key: "The_inferred_type_of_0_references_a_type_with_a_cyclic_structure_which_cannot_be_trivially_serialize_5088", text: "The inferred type of '{0}' references a type with a cyclic structure which cannot be trivially serialized. A type annotation is necessary."}
+
 var Option_0_cannot_be_specified_when_option_jsx_is_1 = &Message{code: 5089, category: CategoryError, key: "Option_0_cannot_be_specified_when_option_jsx_is_1_5089", text: "Option '{0}' cannot be specified when option 'jsx' is '{1}'."}
+
 var Non_relative_paths_are_not_allowed_when_baseUrl_is_not_set_Did_you_forget_a_leading_Slash = &Message{code: 5090, category: CategoryError, key: "Non_relative_paths_are_not_allowed_when_baseUrl_is_not_set_Did_you_forget_a_leading_Slash_5090", text: "Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?"}
+
 var Option_preserveConstEnums_cannot_be_disabled_when_0_is_enabled = &Message{code: 5091, category: CategoryError, key: "Option_preserveConstEnums_cannot_be_disabled_when_0_is_enabled_5091", text: "Option 'preserveConstEnums' cannot be disabled when '{0}' is enabled."}
+
 var The_root_value_of_a_0_file_must_be_an_object = &Message{code: 5092, category: CategoryError, key: "The_root_value_of_a_0_file_must_be_an_object_5092", text: "The root value of a '{0}' file must be an object."}
+
 var Compiler_option_0_may_only_be_used_with_build = &Message{code: 5093, category: CategoryError, key: "Compiler_option_0_may_only_be_used_with_build_5093", text: "Compiler option '--{0}' may only be used with '--build'."}
+
 var Compiler_option_0_may_not_be_used_with_build = &Message{code: 5094, category: CategoryError, key: "Compiler_option_0_may_not_be_used_with_build_5094", text: "Compiler option '--{0}' may not be used with '--build'."}
+
 var Option_0_can_only_be_used_when_module_is_set_to_preserve_or_to_es2015_or_later = &Message{code: 5095, category: CategoryError, key: "Option_0_can_only_be_used_when_module_is_set_to_preserve_or_to_es2015_or_later_5095", text: "Option '{0}' can only be used when 'module' is set to 'preserve' or to 'es2015' or later."}
+
 var Option_allowImportingTsExtensions_can_only_be_used_when_either_noEmit_or_emitDeclarationOnly_is_set = &Message{code: 5096, category: CategoryError, key: "Option_allowImportingTsExtensions_can_only_be_used_when_either_noEmit_or_emitDeclarationOnly_is_set_5096", text: "Option 'allowImportingTsExtensions' can only be used when either 'noEmit' or 'emitDeclarationOnly' is set."}
+
 var An_import_path_can_only_end_with_a_0_extension_when_allowImportingTsExtensions_is_enabled = &Message{code: 5097, category: CategoryError, key: "An_import_path_can_only_end_with_a_0_extension_when_allowImportingTsExtensions_is_enabled_5097", text: "An import path can only end with a '{0}' extension when 'allowImportingTsExtensions' is enabled."}
+
 var Option_0_can_only_be_used_when_moduleResolution_is_set_to_node16_nodenext_or_bundler = &Message{code: 5098, category: CategoryError, key: "Option_0_can_only_be_used_when_moduleResolution_is_set_to_node16_nodenext_or_bundler_5098", text: "Option '{0}' can only be used when 'moduleResolution' is set to 'node16', 'nodenext', or 'bundler'."}
+
 var Option_0_is_deprecated_and_will_stop_functioning_in_TypeScript_1_Specify_compilerOption_ignoreDeprecations_Colon_2_to_silence_this_error = &Message{code: 5101, category: CategoryError, key: "Option_0_is_deprecated_and_will_stop_functioning_in_TypeScript_1_Specify_compilerOption_ignoreDeprec_5101", text: "Option '{0}' is deprecated and will stop functioning in TypeScript {1}. Specify compilerOption '\"ignoreDeprecations\": \"{2}\"' to silence this error."}
+
 var Option_0_has_been_removed_Please_remove_it_from_your_configuration = &Message{code: 5102, category: CategoryError, key: "Option_0_has_been_removed_Please_remove_it_from_your_configuration_5102", text: "Option '{0}' has been removed. Please remove it from your configuration."}
+
 var Invalid_value_for_ignoreDeprecations = &Message{code: 5103, category: CategoryError, key: "Invalid_value_for_ignoreDeprecations_5103", text: "Invalid value for '--ignoreDeprecations'."}
+
 var Option_0_is_redundant_and_cannot_be_specified_with_option_1 = &Message{code: 5104, category: CategoryError, key: "Option_0_is_redundant_and_cannot_be_specified_with_option_1_5104", text: "Option '{0}' is redundant and cannot be specified with option '{1}'."}
+
 var Option_verbatimModuleSyntax_cannot_be_used_when_module_is_set_to_UMD_AMD_or_System = &Message{code: 5105, category: CategoryError, key: "Option_verbatimModuleSyntax_cannot_be_used_when_module_is_set_to_UMD_AMD_or_System_5105", text: "Option 'verbatimModuleSyntax' cannot be used when 'module' is set to 'UMD', 'AMD', or 'System'."}
+
 var Use_0_instead = &Message{code: 5106, category: CategoryMessage, key: "Use_0_instead_5106", text: "Use '{0}' instead."}
+
 var Option_0_1_is_deprecated_and_will_stop_functioning_in_TypeScript_2_Specify_compilerOption_ignoreDeprecations_Colon_3_to_silence_this_error = &Message{code: 5107, category: CategoryError, key: "Option_0_1_is_deprecated_and_will_stop_functioning_in_TypeScript_2_Specify_compilerOption_ignoreDepr_5107", text: "Option '{0}={1}' is deprecated and will stop functioning in TypeScript {2}. Specify compilerOption '\"ignoreDeprecations\": \"{3}\"' to silence this error."}
+
 var Option_0_1_has_been_removed_Please_remove_it_from_your_configuration = &Message{code: 5108, category: CategoryError, key: "Option_0_1_has_been_removed_Please_remove_it_from_your_configuration_5108", text: "Option '{0}={1}' has been removed. Please remove it from your configuration."}
+
 var Option_moduleResolution_must_be_set_to_0_or_left_unspecified_when_option_module_is_set_to_1 = &Message{code: 5109, category: CategoryError, key: "Option_moduleResolution_must_be_set_to_0_or_left_unspecified_when_option_module_is_set_to_1_5109", text: "Option 'moduleResolution' must be set to '{0}' (or left unspecified) when option 'module' is set to '{1}'."}
+
 var Option_module_must_be_set_to_0_when_option_moduleResolution_is_set_to_1 = &Message{code: 5110, category: CategoryError, key: "Option_module_must_be_set_to_0_when_option_moduleResolution_is_set_to_1_5110", text: "Option 'module' must be set to '{0}' when option 'moduleResolution' is set to '{1}'."}
+
 var Generates_a_sourcemap_for_each_corresponding_d_ts_file = &Message{code: 6000, category: CategoryMessage, key: "Generates_a_sourcemap_for_each_corresponding_d_ts_file_6000", text: "Generates a sourcemap for each corresponding '.d.ts' file."}
+
 var Concatenate_and_emit_output_to_single_file = &Message{code: 6001, category: CategoryMessage, key: "Concatenate_and_emit_output_to_single_file_6001", text: "Concatenate and emit output to single file."}
+
 var Generates_corresponding_d_ts_file = &Message{code: 6002, category: CategoryMessage, key: "Generates_corresponding_d_ts_file_6002", text: "Generates corresponding '.d.ts' file."}
+
 var Specify_the_location_where_debugger_should_locate_TypeScript_files_instead_of_source_locations = &Message{code: 6004, category: CategoryMessage, key: "Specify_the_location_where_debugger_should_locate_TypeScript_files_instead_of_source_locations_6004", text: "Specify the location where debugger should locate TypeScript files instead of source locations."}
+
 var Watch_input_files = &Message{code: 6005, category: CategoryMessage, key: "Watch_input_files_6005", text: "Watch input files."}
+
 var Redirect_output_structure_to_the_directory = &Message{code: 6006, category: CategoryMessage, key: "Redirect_output_structure_to_the_directory_6006", text: "Redirect output structure to the directory."}
+
 var Do_not_erase_const_enum_declarations_in_generated_code = &Message{code: 6007, category: CategoryMessage, key: "Do_not_erase_const_enum_declarations_in_generated_code_6007", text: "Do not erase const enum declarations in generated code."}
+
 var Do_not_emit_outputs_if_any_errors_were_reported = &Message{code: 6008, category: CategoryMessage, key: "Do_not_emit_outputs_if_any_errors_were_reported_6008", text: "Do not emit outputs if any errors were reported."}
+
 var Do_not_emit_comments_to_output = &Message{code: 6009, category: CategoryMessage, key: "Do_not_emit_comments_to_output_6009", text: "Do not emit comments to output."}
+
 var Do_not_emit_outputs = &Message{code: 6010, category: CategoryMessage, key: "Do_not_emit_outputs_6010", text: "Do not emit outputs."}
+
 var Allow_default_imports_from_modules_with_no_default_export_This_does_not_affect_code_emit_just_typechecking = &Message{code: 6011, category: CategoryMessage, key: "Allow_default_imports_from_modules_with_no_default_export_This_does_not_affect_code_emit_just_typech_6011", text: "Allow default imports from modules with no default export. This does not affect code emit, just typechecking."}
+
 var Skip_type_checking_of_declaration_files = &Message{code: 6012, category: CategoryMessage, key: "Skip_type_checking_of_declaration_files_6012", text: "Skip type checking of declaration files."}
+
 var Do_not_resolve_the_real_path_of_symlinks = &Message{code: 6013, category: CategoryMessage, key: "Do_not_resolve_the_real_path_of_symlinks_6013", text: "Do not resolve the real path of symlinks."}
+
 var Only_emit_d_ts_declaration_files = &Message{code: 6014, category: CategoryMessage, key: "Only_emit_d_ts_declaration_files_6014", text: "Only emit '.d.ts' declaration files."}
+
 var Specify_ECMAScript_target_version = &Message{code: 6015, category: CategoryMessage, key: "Specify_ECMAScript_target_version_6015", text: "Specify ECMAScript target version."}
+
 var Specify_module_code_generation = &Message{code: 6016, category: CategoryMessage, key: "Specify_module_code_generation_6016", text: "Specify module code generation."}
+
 var Print_this_message = &Message{code: 6017, category: CategoryMessage, key: "Print_this_message_6017", text: "Print this message."}
+
 var Print_the_compiler_s_version = &Message{code: 6019, category: CategoryMessage, key: "Print_the_compiler_s_version_6019", text: "Print the compiler's version."}
+
 var Compile_the_project_given_the_path_to_its_configuration_file_or_to_a_folder_with_a_tsconfig_json = &Message{code: 6020, category: CategoryMessage, key: "Compile_the_project_given_the_path_to_its_configuration_file_or_to_a_folder_with_a_tsconfig_json_6020", text: "Compile the project given the path to its configuration file, or to a folder with a 'tsconfig.json'."}
+
 var Syntax_Colon_0 = &Message{code: 6023, category: CategoryMessage, key: "Syntax_Colon_0_6023", text: "Syntax: {0}"}
+
 var X_options = &Message{code: 6024, category: CategoryMessage, key: "options_6024", text: "options"}
+
 var X_file = &Message{code: 6025, category: CategoryMessage, key: "file_6025", text: "file"}
+
 var Examples_Colon_0 = &Message{code: 6026, category: CategoryMessage, key: "Examples_Colon_0_6026", text: "Examples: {0}"}
+
 var Options_Colon = &Message{code: 6027, category: CategoryMessage, key: "Options_Colon_6027", text: "Options:"}
+
 var Version_0 = &Message{code: 6029, category: CategoryMessage, key: "Version_0_6029", text: "Version {0}"}
+
 var Insert_command_line_options_and_files_from_a_file = &Message{code: 6030, category: CategoryMessage, key: "Insert_command_line_options_and_files_from_a_file_6030", text: "Insert command line options and files from a file."}
+
 var Starting_compilation_in_watch_mode = &Message{code: 6031, category: CategoryMessage, key: "Starting_compilation_in_watch_mode_6031", text: "Starting compilation in watch mode..."}
+
 var File_change_detected_Starting_incremental_compilation = &Message{code: 6032, category: CategoryMessage, key: "File_change_detected_Starting_incremental_compilation_6032", text: "File change detected. Starting incremental compilation..."}
+
 var KIND = &Message{code: 6034, category: CategoryMessage, key: "KIND_6034", text: "KIND"}
+
 var FILE = &Message{code: 6035, category: CategoryMessage, key: "FILE_6035", text: "FILE"}
+
 var VERSION = &Message{code: 6036, category: CategoryMessage, key: "VERSION_6036", text: "VERSION"}
+
 var LOCATION = &Message{code: 6037, category: CategoryMessage, key: "LOCATION_6037", text: "LOCATION"}
+
 var DIRECTORY = &Message{code: 6038, category: CategoryMessage, key: "DIRECTORY_6038", text: "DIRECTORY"}
+
 var STRATEGY = &Message{code: 6039, category: CategoryMessage, key: "STRATEGY_6039", text: "STRATEGY"}
+
 var FILE_OR_DIRECTORY = &Message{code: 6040, category: CategoryMessage, key: "FILE_OR_DIRECTORY_6040", text: "FILE OR DIRECTORY"}
+
 var Errors_Files = &Message{code: 6041, category: CategoryMessage, key: "Errors_Files_6041", text: "Errors  Files"}
+
 var Generates_corresponding_map_file = &Message{code: 6043, category: CategoryMessage, key: "Generates_corresponding_map_file_6043", text: "Generates corresponding '.map' file."}
+
 var Compiler_option_0_expects_an_argument = &Message{code: 6044, category: CategoryError, key: "Compiler_option_0_expects_an_argument_6044", text: "Compiler option '{0}' expects an argument."}
+
 var Unterminated_quoted_string_in_response_file_0 = &Message{code: 6045, category: CategoryError, key: "Unterminated_quoted_string_in_response_file_0_6045", text: "Unterminated quoted string in response file '{0}'."}
+
 var Argument_for_0_option_must_be_Colon_1 = &Message{code: 6046, category: CategoryError, key: "Argument_for_0_option_must_be_Colon_1_6046", text: "Argument for '{0}' option must be: {1}."}
+
 var Locale_must_be_of_the_form_language_or_language_territory_For_example_0_or_1 = &Message{code: 6048, category: CategoryError, key: "Locale_must_be_of_the_form_language_or_language_territory_For_example_0_or_1_6048", text: "Locale must be of the form <language> or <language>-<territory>. For example '{0}' or '{1}'."}
+
 var Unable_to_open_file_0 = &Message{code: 6050, category: CategoryError, key: "Unable_to_open_file_0_6050", text: "Unable to open file '{0}'."}
+
 var Corrupted_locale_file_0 = &Message{code: 6051, category: CategoryError, key: "Corrupted_locale_file_0_6051", text: "Corrupted locale file {0}."}
+
 var Raise_error_on_expressions_and_declarations_with_an_implied_any_type = &Message{code: 6052, category: CategoryMessage, key: "Raise_error_on_expressions_and_declarations_with_an_implied_any_type_6052", text: "Raise error on expressions and declarations with an implied 'any' type."}
+
 var File_0_not_found = &Message{code: 6053, category: CategoryError, key: "File_0_not_found_6053", text: "File '{0}' not found."}
+
 var File_0_has_an_unsupported_extension_The_only_supported_extensions_are_1 = &Message{code: 6054, category: CategoryError, key: "File_0_has_an_unsupported_extension_The_only_supported_extensions_are_1_6054", text: "File '{0}' has an unsupported extension. The only supported extensions are {1}."}
+
 var Suppress_noImplicitAny_errors_for_indexing_objects_lacking_index_signatures = &Message{code: 6055, category: CategoryMessage, key: "Suppress_noImplicitAny_errors_for_indexing_objects_lacking_index_signatures_6055", text: "Suppress noImplicitAny errors for indexing objects lacking index signatures."}
+
 var Do_not_emit_declarations_for_code_that_has_an_internal_annotation = &Message{code: 6056, category: CategoryMessage, key: "Do_not_emit_declarations_for_code_that_has_an_internal_annotation_6056", text: "Do not emit declarations for code that has an '@internal' annotation."}
+
 var Specify_the_root_directory_of_input_files_Use_to_control_the_output_directory_structure_with_outDir = &Message{code: 6058, category: CategoryMessage, key: "Specify_the_root_directory_of_input_files_Use_to_control_the_output_directory_structure_with_outDir_6058", text: "Specify the root directory of input files. Use to control the output directory structure with --outDir."}
+
 var File_0_is_not_under_rootDir_1_rootDir_is_expected_to_contain_all_source_files = &Message{code: 6059, category: CategoryError, key: "File_0_is_not_under_rootDir_1_rootDir_is_expected_to_contain_all_source_files_6059", text: "File '{0}' is not under 'rootDir' '{1}'. 'rootDir' is expected to contain all source files."}
+
 var Specify_the_end_of_line_sequence_to_be_used_when_emitting_files_Colon_CRLF_dos_or_LF_unix = &Message{code: 6060, category: CategoryMessage, key: "Specify_the_end_of_line_sequence_to_be_used_when_emitting_files_Colon_CRLF_dos_or_LF_unix_6060", text: "Specify the end of line sequence to be used when emitting files: 'CRLF' (dos) or 'LF' (unix)."}
+
 var NEWLINE = &Message{code: 6061, category: CategoryMessage, key: "NEWLINE_6061", text: "NEWLINE"}
+
 var Option_0_can_only_be_specified_in_tsconfig_json_file_or_set_to_null_on_command_line = &Message{code: 6064, category: CategoryError, key: "Option_0_can_only_be_specified_in_tsconfig_json_file_or_set_to_null_on_command_line_6064", text: "Option '{0}' can only be specified in 'tsconfig.json' file or set to 'null' on command line."}
+
 var Enables_experimental_support_for_ES7_decorators = &Message{code: 6065, category: CategoryMessage, key: "Enables_experimental_support_for_ES7_decorators_6065", text: "Enables experimental support for ES7 decorators."}
+
 var Enables_experimental_support_for_emitting_type_metadata_for_decorators = &Message{code: 6066, category: CategoryMessage, key: "Enables_experimental_support_for_emitting_type_metadata_for_decorators_6066", text: "Enables experimental support for emitting type metadata for decorators."}
+
 var Initializes_a_TypeScript_project_and_creates_a_tsconfig_json_file = &Message{code: 6070, category: CategoryMessage, key: "Initializes_a_TypeScript_project_and_creates_a_tsconfig_json_file_6070", text: "Initializes a TypeScript project and creates a tsconfig.json file."}
+
 var Successfully_created_a_tsconfig_json_file = &Message{code: 6071, category: CategoryMessage, key: "Successfully_created_a_tsconfig_json_file_6071", text: "Successfully created a tsconfig.json file."}
+
 var Suppress_excess_property_checks_for_object_literals = &Message{code: 6072, category: CategoryMessage, key: "Suppress_excess_property_checks_for_object_literals_6072", text: "Suppress excess property checks for object literals."}
+
 var Stylize_errors_and_messages_using_color_and_context_experimental = &Message{code: 6073, category: CategoryMessage, key: "Stylize_errors_and_messages_using_color_and_context_experimental_6073", text: "Stylize errors and messages using color and context (experimental)."}
+
 var Do_not_report_errors_on_unused_labels = &Message{code: 6074, category: CategoryMessage, key: "Do_not_report_errors_on_unused_labels_6074", text: "Do not report errors on unused labels."}
+
 var Report_error_when_not_all_code_paths_in_function_return_a_value = &Message{code: 6075, category: CategoryMessage, key: "Report_error_when_not_all_code_paths_in_function_return_a_value_6075", text: "Report error when not all code paths in function return a value."}
+
 var Report_errors_for_fallthrough_cases_in_switch_statement = &Message{code: 6076, category: CategoryMessage, key: "Report_errors_for_fallthrough_cases_in_switch_statement_6076", text: "Report errors for fallthrough cases in switch statement."}
+
 var Do_not_report_errors_on_unreachable_code = &Message{code: 6077, category: CategoryMessage, key: "Do_not_report_errors_on_unreachable_code_6077", text: "Do not report errors on unreachable code."}
+
 var Disallow_inconsistently_cased_references_to_the_same_file = &Message{code: 6078, category: CategoryMessage, key: "Disallow_inconsistently_cased_references_to_the_same_file_6078", text: "Disallow inconsistently-cased references to the same file."}
+
 var Specify_library_files_to_be_included_in_the_compilation = &Message{code: 6079, category: CategoryMessage, key: "Specify_library_files_to_be_included_in_the_compilation_6079", text: "Specify library files to be included in the compilation."}
+
 var Specify_JSX_code_generation = &Message{code: 6080, category: CategoryMessage, key: "Specify_JSX_code_generation_6080", text: "Specify JSX code generation."}
+
 var Only_amd_and_system_modules_are_supported_alongside_0 = &Message{code: 6082, category: CategoryError, key: "Only_amd_and_system_modules_are_supported_alongside_0_6082", text: "Only 'amd' and 'system' modules are supported alongside --{0}."}
+
 var Base_directory_to_resolve_non_absolute_module_names = &Message{code: 6083, category: CategoryMessage, key: "Base_directory_to_resolve_non_absolute_module_names_6083", text: "Base directory to resolve non-absolute module names."}
+
 var Deprecated_Use_jsxFactory_instead_Specify_the_object_invoked_for_createElement_when_targeting_react_JSX_emit = &Message{code: 6084, category: CategoryMessage, key: "Deprecated_Use_jsxFactory_instead_Specify_the_object_invoked_for_createElement_when_targeting_react__6084", text: "[Deprecated] Use '--jsxFactory' instead. Specify the object invoked for createElement when targeting 'react' JSX emit"}
+
 var Enable_tracing_of_the_name_resolution_process = &Message{code: 6085, category: CategoryMessage, key: "Enable_tracing_of_the_name_resolution_process_6085", text: "Enable tracing of the name resolution process."}
+
 var Resolving_module_0_from_1 = &Message{code: 6086, category: CategoryMessage, key: "Resolving_module_0_from_1_6086", text: "======== Resolving module '{0}' from '{1}'. ========"}
+
 var Explicitly_specified_module_resolution_kind_Colon_0 = &Message{code: 6087, category: CategoryMessage, key: "Explicitly_specified_module_resolution_kind_Colon_0_6087", text: "Explicitly specified module resolution kind: '{0}'."}
+
 var Module_resolution_kind_is_not_specified_using_0 = &Message{code: 6088, category: CategoryMessage, key: "Module_resolution_kind_is_not_specified_using_0_6088", text: "Module resolution kind is not specified, using '{0}'."}
+
 var Module_name_0_was_successfully_resolved_to_1 = &Message{code: 6089, category: CategoryMessage, key: "Module_name_0_was_successfully_resolved_to_1_6089", text: "======== Module name '{0}' was successfully resolved to '{1}'. ========"}
+
 var Module_name_0_was_not_resolved = &Message{code: 6090, category: CategoryMessage, key: "Module_name_0_was_not_resolved_6090", text: "======== Module name '{0}' was not resolved. ========"}
+
 var X_paths_option_is_specified_looking_for_a_pattern_to_match_module_name_0 = &Message{code: 6091, category: CategoryMessage, key: "paths_option_is_specified_looking_for_a_pattern_to_match_module_name_0_6091", text: "'paths' option is specified, looking for a pattern to match module name '{0}'."}
+
 var Module_name_0_matched_pattern_1 = &Message{code: 6092, category: CategoryMessage, key: "Module_name_0_matched_pattern_1_6092", text: "Module name '{0}', matched pattern '{1}'."}
+
 var Trying_substitution_0_candidate_module_location_Colon_1 = &Message{code: 6093, category: CategoryMessage, key: "Trying_substitution_0_candidate_module_location_Colon_1_6093", text: "Trying substitution '{0}', candidate module location: '{1}'."}
+
 var Resolving_module_name_0_relative_to_base_url_1_2 = &Message{code: 6094, category: CategoryMessage, key: "Resolving_module_name_0_relative_to_base_url_1_2_6094", text: "Resolving module name '{0}' relative to base url '{1}' - '{2}'."}
+
 var Loading_module_as_file_Slash_folder_candidate_module_location_0_target_file_types_Colon_1 = &Message{code: 6095, category: CategoryMessage, key: "Loading_module_as_file_Slash_folder_candidate_module_location_0_target_file_types_Colon_1_6095", text: "Loading module as file / folder, candidate module location '{0}', target file types: {1}."}
+
 var File_0_does_not_exist = &Message{code: 6096, category: CategoryMessage, key: "File_0_does_not_exist_6096", text: "File '{0}' does not exist."}
+
 var File_0_exists_use_it_as_a_name_resolution_result = &Message{code: 6097, category: CategoryMessage, key: "File_0_exists_use_it_as_a_name_resolution_result_6097", text: "File '{0}' exists - use it as a name resolution result."}
+
 var Loading_module_0_from_node_modules_folder_target_file_types_Colon_1 = &Message{code: 6098, category: CategoryMessage, key: "Loading_module_0_from_node_modules_folder_target_file_types_Colon_1_6098", text: "Loading module '{0}' from 'node_modules' folder, target file types: {1}."}
+
 var Found_package_json_at_0 = &Message{code: 6099, category: CategoryMessage, key: "Found_package_json_at_0_6099", text: "Found 'package.json' at '{0}'."}
+
 var X_package_json_does_not_have_a_0_field = &Message{code: 6100, category: CategoryMessage, key: "package_json_does_not_have_a_0_field_6100", text: "'package.json' does not have a '{0}' field."}
+
 var X_package_json_has_0_field_1_that_references_2 = &Message{code: 6101, category: CategoryMessage, key: "package_json_has_0_field_1_that_references_2_6101", text: "'package.json' has '{0}' field '{1}' that references '{2}'."}
+
 var Allow_javascript_files_to_be_compiled = &Message{code: 6102, category: CategoryMessage, key: "Allow_javascript_files_to_be_compiled_6102", text: "Allow javascript files to be compiled."}
+
 var Checking_if_0_is_the_longest_matching_prefix_for_1_2 = &Message{code: 6104, category: CategoryMessage, key: "Checking_if_0_is_the_longest_matching_prefix_for_1_2_6104", text: "Checking if '{0}' is the longest matching prefix for '{1}' - '{2}'."}
+
 var Expected_type_of_0_field_in_package_json_to_be_1_got_2 = &Message{code: 6105, category: CategoryMessage, key: "Expected_type_of_0_field_in_package_json_to_be_1_got_2_6105", text: "Expected type of '{0}' field in 'package.json' to be '{1}', got '{2}'."}
+
 var X_baseUrl_option_is_set_to_0_using_this_value_to_resolve_non_relative_module_name_1 = &Message{code: 6106, category: CategoryMessage, key: "baseUrl_option_is_set_to_0_using_this_value_to_resolve_non_relative_module_name_1_6106", text: "'baseUrl' option is set to '{0}', using this value to resolve non-relative module name '{1}'."}
+
 var X_rootDirs_option_is_set_using_it_to_resolve_relative_module_name_0 = &Message{code: 6107, category: CategoryMessage, key: "rootDirs_option_is_set_using_it_to_resolve_relative_module_name_0_6107", text: "'rootDirs' option is set, using it to resolve relative module name '{0}'."}
+
 var Longest_matching_prefix_for_0_is_1 = &Message{code: 6108, category: CategoryMessage, key: "Longest_matching_prefix_for_0_is_1_6108", text: "Longest matching prefix for '{0}' is '{1}'."}
+
 var Loading_0_from_the_root_dir_1_candidate_location_2 = &Message{code: 6109, category: CategoryMessage, key: "Loading_0_from_the_root_dir_1_candidate_location_2_6109", text: "Loading '{0}' from the root dir '{1}', candidate location '{2}'."}
+
 var Trying_other_entries_in_rootDirs = &Message{code: 6110, category: CategoryMessage, key: "Trying_other_entries_in_rootDirs_6110", text: "Trying other entries in 'rootDirs'."}
+
 var Module_resolution_using_rootDirs_has_failed = &Message{code: 6111, category: CategoryMessage, key: "Module_resolution_using_rootDirs_has_failed_6111", text: "Module resolution using 'rootDirs' has failed."}
+
 var Do_not_emit_use_strict_directives_in_module_output = &Message{code: 6112, category: CategoryMessage, key: "Do_not_emit_use_strict_directives_in_module_output_6112", text: "Do not emit 'use strict' directives in module output."}
+
 var Enable_strict_null_checks = &Message{code: 6113, category: CategoryMessage, key: "Enable_strict_null_checks_6113", text: "Enable strict null checks."}
+
 var Unknown_option_excludes_Did_you_mean_exclude = &Message{code: 6114, category: CategoryError, key: "Unknown_option_excludes_Did_you_mean_exclude_6114", text: "Unknown option 'excludes'. Did you mean 'exclude'?"}
+
 var Raise_error_on_this_expressions_with_an_implied_any_type = &Message{code: 6115, category: CategoryMessage, key: "Raise_error_on_this_expressions_with_an_implied_any_type_6115", text: "Raise error on 'this' expressions with an implied 'any' type."}
+
 var Resolving_type_reference_directive_0_containing_file_1_root_directory_2 = &Message{code: 6116, category: CategoryMessage, key: "Resolving_type_reference_directive_0_containing_file_1_root_directory_2_6116", text: "======== Resolving type reference directive '{0}', containing file '{1}', root directory '{2}'. ========"}
+
 var Type_reference_directive_0_was_successfully_resolved_to_1_primary_Colon_2 = &Message{code: 6119, category: CategoryMessage, key: "Type_reference_directive_0_was_successfully_resolved_to_1_primary_Colon_2_6119", text: "======== Type reference directive '{0}' was successfully resolved to '{1}', primary: {2}. ========"}
+
 var Type_reference_directive_0_was_not_resolved = &Message{code: 6120, category: CategoryMessage, key: "Type_reference_directive_0_was_not_resolved_6120", text: "======== Type reference directive '{0}' was not resolved. ========"}
+
 var Resolving_with_primary_search_path_0 = &Message{code: 6121, category: CategoryMessage, key: "Resolving_with_primary_search_path_0_6121", text: "Resolving with primary search path '{0}'."}
+
 var Root_directory_cannot_be_determined_skipping_primary_search_paths = &Message{code: 6122, category: CategoryMessage, key: "Root_directory_cannot_be_determined_skipping_primary_search_paths_6122", text: "Root directory cannot be determined, skipping primary search paths."}
+
 var Resolving_type_reference_directive_0_containing_file_1_root_directory_not_set = &Message{code: 6123, category: CategoryMessage, key: "Resolving_type_reference_directive_0_containing_file_1_root_directory_not_set_6123", text: "======== Resolving type reference directive '{0}', containing file '{1}', root directory not set. ========"}
+
 var Type_declaration_files_to_be_included_in_compilation = &Message{code: 6124, category: CategoryMessage, key: "Type_declaration_files_to_be_included_in_compilation_6124", text: "Type declaration files to be included in compilation."}
+
 var Looking_up_in_node_modules_folder_initial_location_0 = &Message{code: 6125, category: CategoryMessage, key: "Looking_up_in_node_modules_folder_initial_location_0_6125", text: "Looking up in 'node_modules' folder, initial location '{0}'."}
+
 var Containing_file_is_not_specified_and_root_directory_cannot_be_determined_skipping_lookup_in_node_modules_folder = &Message{code: 6126, category: CategoryMessage, key: "Containing_file_is_not_specified_and_root_directory_cannot_be_determined_skipping_lookup_in_node_mod_6126", text: "Containing file is not specified and root directory cannot be determined, skipping lookup in 'node_modules' folder."}
+
 var Resolving_type_reference_directive_0_containing_file_not_set_root_directory_1 = &Message{code: 6127, category: CategoryMessage, key: "Resolving_type_reference_directive_0_containing_file_not_set_root_directory_1_6127", text: "======== Resolving type reference directive '{0}', containing file not set, root directory '{1}'. ========"}
+
 var Resolving_type_reference_directive_0_containing_file_not_set_root_directory_not_set = &Message{code: 6128, category: CategoryMessage, key: "Resolving_type_reference_directive_0_containing_file_not_set_root_directory_not_set_6128", text: "======== Resolving type reference directive '{0}', containing file not set, root directory not set. ========"}
+
 var Resolving_real_path_for_0_result_1 = &Message{code: 6130, category: CategoryMessage, key: "Resolving_real_path_for_0_result_1_6130", text: "Resolving real path for '{0}', result '{1}'."}
+
 var Cannot_compile_modules_using_option_0_unless_the_module_flag_is_amd_or_system = &Message{code: 6131, category: CategoryError, key: "Cannot_compile_modules_using_option_0_unless_the_module_flag_is_amd_or_system_6131", text: "Cannot compile modules using option '{0}' unless the '--module' flag is 'amd' or 'system'."}
+
 var File_name_0_has_a_1_extension_stripping_it = &Message{code: 6132, category: CategoryMessage, key: "File_name_0_has_a_1_extension_stripping_it_6132", text: "File name '{0}' has a '{1}' extension - stripping it."}
+
 var X_0_is_declared_but_its_value_is_never_read = &Message{code: 6133, category: CategoryError, key: "_0_is_declared_but_its_value_is_never_read_6133", text: "'{0}' is declared but its value is never read.", reportsUnnecessary: true}
+
 var Report_errors_on_unused_locals = &Message{code: 6134, category: CategoryMessage, key: "Report_errors_on_unused_locals_6134", text: "Report errors on unused locals."}
+
 var Report_errors_on_unused_parameters = &Message{code: 6135, category: CategoryMessage, key: "Report_errors_on_unused_parameters_6135", text: "Report errors on unused parameters."}
+
 var The_maximum_dependency_depth_to_search_under_node_modules_and_load_JavaScript_files = &Message{code: 6136, category: CategoryMessage, key: "The_maximum_dependency_depth_to_search_under_node_modules_and_load_JavaScript_files_6136", text: "The maximum dependency depth to search under node_modules and load JavaScript files."}
+
 var Cannot_import_type_declaration_files_Consider_importing_0_instead_of_1 = &Message{code: 6137, category: CategoryError, key: "Cannot_import_type_declaration_files_Consider_importing_0_instead_of_1_6137", text: "Cannot import type declaration files. Consider importing '{0}' instead of '{1}'."}
+
 var Property_0_is_declared_but_its_value_is_never_read = &Message{code: 6138, category: CategoryError, key: "Property_0_is_declared_but_its_value_is_never_read_6138", text: "Property '{0}' is declared but its value is never read.", reportsUnnecessary: true}
+
 var Import_emit_helpers_from_tslib = &Message{code: 6139, category: CategoryMessage, key: "Import_emit_helpers_from_tslib_6139", text: "Import emit helpers from 'tslib'."}
+
 var Auto_discovery_for_typings_is_enabled_in_project_0_Running_extra_resolution_pass_for_module_1_using_cache_location_2 = &Message{code: 6140, category: CategoryError, key: "Auto_discovery_for_typings_is_enabled_in_project_0_Running_extra_resolution_pass_for_module_1_using__6140", text: "Auto discovery for typings is enabled in project '{0}'. Running extra resolution pass for module '{1}' using cache location '{2}'."}
+
 var Parse_in_strict_mode_and_emit_use_strict_for_each_source_file = &Message{code: 6141, category: CategoryMessage, key: "Parse_in_strict_mode_and_emit_use_strict_for_each_source_file_6141", text: "Parse in strict mode and emit \"use strict\" for each source file."}
+
 var Module_0_was_resolved_to_1_but_jsx_is_not_set = &Message{code: 6142, category: CategoryError, key: "Module_0_was_resolved_to_1_but_jsx_is_not_set_6142", text: "Module '{0}' was resolved to '{1}', but '--jsx' is not set."}
+
 var Module_0_was_resolved_as_locally_declared_ambient_module_in_file_1 = &Message{code: 6144, category: CategoryMessage, key: "Module_0_was_resolved_as_locally_declared_ambient_module_in_file_1_6144", text: "Module '{0}' was resolved as locally declared ambient module in file '{1}'."}
+
 var Specify_the_JSX_factory_function_to_use_when_targeting_react_JSX_emit_e_g_React_createElement_or_h = &Message{code: 6146, category: CategoryMessage, key: "Specify_the_JSX_factory_function_to_use_when_targeting_react_JSX_emit_e_g_React_createElement_or_h_6146", text: "Specify the JSX factory function to use when targeting 'react' JSX emit, e.g. 'React.createElement' or 'h'."}
+
 var Resolution_for_module_0_was_found_in_cache_from_location_1 = &Message{code: 6147, category: CategoryMessage, key: "Resolution_for_module_0_was_found_in_cache_from_location_1_6147", text: "Resolution for module '{0}' was found in cache from location '{1}'."}
+
 var Directory_0_does_not_exist_skipping_all_lookups_in_it = &Message{code: 6148, category: CategoryMessage, key: "Directory_0_does_not_exist_skipping_all_lookups_in_it_6148", text: "Directory '{0}' does not exist, skipping all lookups in it."}
+
 var Show_diagnostic_information = &Message{code: 6149, category: CategoryMessage, key: "Show_diagnostic_information_6149", text: "Show diagnostic information."}
+
 var Show_verbose_diagnostic_information = &Message{code: 6150, category: CategoryMessage, key: "Show_verbose_diagnostic_information_6150", text: "Show verbose diagnostic information."}
+
 var Emit_a_single_file_with_source_maps_instead_of_having_a_separate_file = &Message{code: 6151, category: CategoryMessage, key: "Emit_a_single_file_with_source_maps_instead_of_having_a_separate_file_6151", text: "Emit a single file with source maps instead of having a separate file."}
+
 var Emit_the_source_alongside_the_sourcemaps_within_a_single_file_requires_inlineSourceMap_or_sourceMap_to_be_set = &Message{code: 6152, category: CategoryMessage, key: "Emit_the_source_alongside_the_sourcemaps_within_a_single_file_requires_inlineSourceMap_or_sourceMap__6152", text: "Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set."}
+
 var Transpile_each_file_as_a_separate_module_similar_to_ts_transpileModule = &Message{code: 6153, category: CategoryMessage, key: "Transpile_each_file_as_a_separate_module_similar_to_ts_transpileModule_6153", text: "Transpile each file as a separate module (similar to 'ts.transpileModule')."}
+
 var Print_names_of_generated_files_part_of_the_compilation = &Message{code: 6154, category: CategoryMessage, key: "Print_names_of_generated_files_part_of_the_compilation_6154", text: "Print names of generated files part of the compilation."}
+
 var Print_names_of_files_part_of_the_compilation = &Message{code: 6155, category: CategoryMessage, key: "Print_names_of_files_part_of_the_compilation_6155", text: "Print names of files part of the compilation."}
+
 var The_locale_used_when_displaying_messages_to_the_user_e_g_en_us = &Message{code: 6156, category: CategoryMessage, key: "The_locale_used_when_displaying_messages_to_the_user_e_g_en_us_6156", text: "The locale used when displaying messages to the user (e.g. 'en-us')"}
+
 var Do_not_generate_custom_helper_functions_like_extends_in_compiled_output = &Message{code: 6157, category: CategoryMessage, key: "Do_not_generate_custom_helper_functions_like_extends_in_compiled_output_6157", text: "Do not generate custom helper functions like '__extends' in compiled output."}
+
 var Do_not_include_the_default_library_file_lib_d_ts = &Message{code: 6158, category: CategoryMessage, key: "Do_not_include_the_default_library_file_lib_d_ts_6158", text: "Do not include the default library file (lib.d.ts)."}
+
 var Do_not_add_triple_slash_references_or_imported_modules_to_the_list_of_compiled_files = &Message{code: 6159, category: CategoryMessage, key: "Do_not_add_triple_slash_references_or_imported_modules_to_the_list_of_compiled_files_6159", text: "Do not add triple-slash references or imported modules to the list of compiled files."}
+
 var Deprecated_Use_skipLibCheck_instead_Skip_type_checking_of_default_library_declaration_files = &Message{code: 6160, category: CategoryMessage, key: "Deprecated_Use_skipLibCheck_instead_Skip_type_checking_of_default_library_declaration_files_6160", text: "[Deprecated] Use '--skipLibCheck' instead. Skip type checking of default library declaration files."}
+
 var List_of_folders_to_include_type_definitions_from = &Message{code: 6161, category: CategoryMessage, key: "List_of_folders_to_include_type_definitions_from_6161", text: "List of folders to include type definitions from."}
+
 var Disable_size_limitations_on_JavaScript_projects = &Message{code: 6162, category: CategoryMessage, key: "Disable_size_limitations_on_JavaScript_projects_6162", text: "Disable size limitations on JavaScript projects."}
+
 var The_character_set_of_the_input_files = &Message{code: 6163, category: CategoryMessage, key: "The_character_set_of_the_input_files_6163", text: "The character set of the input files."}
+
 var Skipping_module_0_that_looks_like_an_absolute_URI_target_file_types_Colon_1 = &Message{code: 6164, category: CategoryMessage, key: "Skipping_module_0_that_looks_like_an_absolute_URI_target_file_types_Colon_1_6164", text: "Skipping module '{0}' that looks like an absolute URI, target file types: {1}."}
+
 var Do_not_truncate_error_messages = &Message{code: 6165, category: CategoryMessage, key: "Do_not_truncate_error_messages_6165", text: "Do not truncate error messages."}
+
 var Output_directory_for_generated_declaration_files = &Message{code: 6166, category: CategoryMessage, key: "Output_directory_for_generated_declaration_files_6166", text: "Output directory for generated declaration files."}
+
 var A_series_of_entries_which_re_map_imports_to_lookup_locations_relative_to_the_baseUrl = &Message{code: 6167, category: CategoryMessage, key: "A_series_of_entries_which_re_map_imports_to_lookup_locations_relative_to_the_baseUrl_6167", text: "A series of entries which re-map imports to lookup locations relative to the 'baseUrl'."}
+
 var List_of_root_folders_whose_combined_content_represents_the_structure_of_the_project_at_runtime = &Message{code: 6168, category: CategoryMessage, key: "List_of_root_folders_whose_combined_content_represents_the_structure_of_the_project_at_runtime_6168", text: "List of root folders whose combined content represents the structure of the project at runtime."}
+
 var Show_all_compiler_options = &Message{code: 6169, category: CategoryMessage, key: "Show_all_compiler_options_6169", text: "Show all compiler options."}
+
 var Deprecated_Use_outFile_instead_Concatenate_and_emit_output_to_single_file = &Message{code: 6170, category: CategoryMessage, key: "Deprecated_Use_outFile_instead_Concatenate_and_emit_output_to_single_file_6170", text: "[Deprecated] Use '--outFile' instead. Concatenate and emit output to single file"}
+
 var Command_line_Options = &Message{code: 6171, category: CategoryMessage, key: "Command_line_Options_6171", text: "Command-line Options"}
+
 var Provide_full_support_for_iterables_in_for_of_spread_and_destructuring_when_targeting_ES5 = &Message{code: 6179, category: CategoryMessage, key: "Provide_full_support_for_iterables_in_for_of_spread_and_destructuring_when_targeting_ES5_6179", text: "Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5'."}
+
 var Enable_all_strict_type_checking_options = &Message{code: 6180, category: CategoryMessage, key: "Enable_all_strict_type_checking_options_6180", text: "Enable all strict type-checking options."}
+
 var Scoped_package_detected_looking_in_0 = &Message{code: 6182, category: CategoryMessage, key: "Scoped_package_detected_looking_in_0_6182", text: "Scoped package detected, looking in '{0}'"}
+
 var Reusing_resolution_of_module_0_from_1_of_old_program_it_was_successfully_resolved_to_2 = &Message{code: 6183, category: CategoryMessage, key: "Reusing_resolution_of_module_0_from_1_of_old_program_it_was_successfully_resolved_to_2_6183", text: "Reusing resolution of module '{0}' from '{1}' of old program, it was successfully resolved to '{2}'."}
+
 var Reusing_resolution_of_module_0_from_1_of_old_program_it_was_successfully_resolved_to_2_with_Package_ID_3 = &Message{code: 6184, category: CategoryMessage, key: "Reusing_resolution_of_module_0_from_1_of_old_program_it_was_successfully_resolved_to_2_with_Package__6184", text: "Reusing resolution of module '{0}' from '{1}' of old program, it was successfully resolved to '{2}' with Package ID '{3}'."}
+
 var Enable_strict_checking_of_function_types = &Message{code: 6186, category: CategoryMessage, key: "Enable_strict_checking_of_function_types_6186", text: "Enable strict checking of function types."}
+
 var Enable_strict_checking_of_property_initialization_in_classes = &Message{code: 6187, category: CategoryMessage, key: "Enable_strict_checking_of_property_initialization_in_classes_6187", text: "Enable strict checking of property initialization in classes."}
+
 var Numeric_separators_are_not_allowed_here = &Message{code: 6188, category: CategoryError, key: "Numeric_separators_are_not_allowed_here_6188", text: "Numeric separators are not allowed here."}
+
 var Multiple_consecutive_numeric_separators_are_not_permitted = &Message{code: 6189, category: CategoryError, key: "Multiple_consecutive_numeric_separators_are_not_permitted_6189", text: "Multiple consecutive numeric separators are not permitted."}
+
 var Whether_to_keep_outdated_console_output_in_watch_mode_instead_of_clearing_the_screen = &Message{code: 6191, category: CategoryMessage, key: "Whether_to_keep_outdated_console_output_in_watch_mode_instead_of_clearing_the_screen_6191", text: "Whether to keep outdated console output in watch mode instead of clearing the screen."}
+
 var All_imports_in_import_declaration_are_unused = &Message{code: 6192, category: CategoryError, key: "All_imports_in_import_declaration_are_unused_6192", text: "All imports in import declaration are unused.", reportsUnnecessary: true}
+
 var Found_1_error_Watching_for_file_changes = &Message{code: 6193, category: CategoryMessage, key: "Found_1_error_Watching_for_file_changes_6193", text: "Found 1 error. Watching for file changes."}
+
 var Found_0_errors_Watching_for_file_changes = &Message{code: 6194, category: CategoryMessage, key: "Found_0_errors_Watching_for_file_changes_6194", text: "Found {0} errors. Watching for file changes."}
+
 var Resolve_keyof_to_string_valued_property_names_only_no_numbers_or_symbols = &Message{code: 6195, category: CategoryMessage, key: "Resolve_keyof_to_string_valued_property_names_only_no_numbers_or_symbols_6195", text: "Resolve 'keyof' to string valued property names only (no numbers or symbols)."}
+
 var X_0_is_declared_but_never_used = &Message{code: 6196, category: CategoryError, key: "_0_is_declared_but_never_used_6196", text: "'{0}' is declared but never used.", reportsUnnecessary: true}
+
 var Include_modules_imported_with_json_extension = &Message{code: 6197, category: CategoryMessage, key: "Include_modules_imported_with_json_extension_6197", text: "Include modules imported with '.json' extension"}
+
 var All_destructured_elements_are_unused = &Message{code: 6198, category: CategoryError, key: "All_destructured_elements_are_unused_6198", text: "All destructured elements are unused.", reportsUnnecessary: true}
+
 var All_variables_are_unused = &Message{code: 6199, category: CategoryError, key: "All_variables_are_unused_6199", text: "All variables are unused.", reportsUnnecessary: true}
+
 var Definitions_of_the_following_identifiers_conflict_with_those_in_another_file_Colon_0 = &Message{code: 6200, category: CategoryError, key: "Definitions_of_the_following_identifiers_conflict_with_those_in_another_file_Colon_0_6200", text: "Definitions of the following identifiers conflict with those in another file: {0}"}
+
 var Conflicts_are_in_this_file = &Message{code: 6201, category: CategoryMessage, key: "Conflicts_are_in_this_file_6201", text: "Conflicts are in this file."}
+
 var Project_references_may_not_form_a_circular_graph_Cycle_detected_Colon_0 = &Message{code: 6202, category: CategoryError, key: "Project_references_may_not_form_a_circular_graph_Cycle_detected_Colon_0_6202", text: "Project references may not form a circular graph. Cycle detected: {0}"}
+
 var X_0_was_also_declared_here = &Message{code: 6203, category: CategoryMessage, key: "_0_was_also_declared_here_6203", text: "'{0}' was also declared here."}
+
 var X_and_here = &Message{code: 6204, category: CategoryMessage, key: "and_here_6204", text: "and here."}
+
 var All_type_parameters_are_unused = &Message{code: 6205, category: CategoryError, key: "All_type_parameters_are_unused_6205", text: "All type parameters are unused."}
+
 var X_package_json_has_a_typesVersions_field_with_version_specific_path_mappings = &Message{code: 6206, category: CategoryMessage, key: "package_json_has_a_typesVersions_field_with_version_specific_path_mappings_6206", text: "'package.json' has a 'typesVersions' field with version-specific path mappings."}
+
 var X_package_json_does_not_have_a_typesVersions_entry_that_matches_version_0 = &Message{code: 6207, category: CategoryMessage, key: "package_json_does_not_have_a_typesVersions_entry_that_matches_version_0_6207", text: "'package.json' does not have a 'typesVersions' entry that matches version '{0}'."}
+
 var X_package_json_has_a_typesVersions_entry_0_that_matches_compiler_version_1_looking_for_a_pattern_to_match_module_name_2 = &Message{code: 6208, category: CategoryMessage, key: "package_json_has_a_typesVersions_entry_0_that_matches_compiler_version_1_looking_for_a_pattern_to_ma_6208", text: "'package.json' has a 'typesVersions' entry '{0}' that matches compiler version '{1}', looking for a pattern to match module name '{2}'."}
+
 var X_package_json_has_a_typesVersions_entry_0_that_is_not_a_valid_semver_range = &Message{code: 6209, category: CategoryMessage, key: "package_json_has_a_typesVersions_entry_0_that_is_not_a_valid_semver_range_6209", text: "'package.json' has a 'typesVersions' entry '{0}' that is not a valid semver range."}
+
 var An_argument_for_0_was_not_provided = &Message{code: 6210, category: CategoryMessage, key: "An_argument_for_0_was_not_provided_6210", text: "An argument for '{0}' was not provided."}
+
 var An_argument_matching_this_binding_pattern_was_not_provided = &Message{code: 6211, category: CategoryMessage, key: "An_argument_matching_this_binding_pattern_was_not_provided_6211", text: "An argument matching this binding pattern was not provided."}
+
 var Did_you_mean_to_call_this_expression = &Message{code: 6212, category: CategoryMessage, key: "Did_you_mean_to_call_this_expression_6212", text: "Did you mean to call this expression?"}
+
 var Did_you_mean_to_use_new_with_this_expression = &Message{code: 6213, category: CategoryMessage, key: "Did_you_mean_to_use_new_with_this_expression_6213", text: "Did you mean to use 'new' with this expression?"}
+
 var Enable_strict_bind_call_and_apply_methods_on_functions = &Message{code: 6214, category: CategoryMessage, key: "Enable_strict_bind_call_and_apply_methods_on_functions_6214", text: "Enable strict 'bind', 'call', and 'apply' methods on functions."}
+
 var Using_compiler_options_of_project_reference_redirect_0 = &Message{code: 6215, category: CategoryMessage, key: "Using_compiler_options_of_project_reference_redirect_0_6215", text: "Using compiler options of project reference redirect '{0}'."}
+
 var Found_1_error = &Message{code: 6216, category: CategoryMessage, key: "Found_1_error_6216", text: "Found 1 error."}
+
 var Found_0_errors = &Message{code: 6217, category: CategoryMessage, key: "Found_0_errors_6217", text: "Found {0} errors."}
+
 var Module_name_0_was_successfully_resolved_to_1_with_Package_ID_2 = &Message{code: 6218, category: CategoryMessage, key: "Module_name_0_was_successfully_resolved_to_1_with_Package_ID_2_6218", text: "======== Module name '{0}' was successfully resolved to '{1}' with Package ID '{2}'. ========"}
+
 var Type_reference_directive_0_was_successfully_resolved_to_1_with_Package_ID_2_primary_Colon_3 = &Message{code: 6219, category: CategoryMessage, key: "Type_reference_directive_0_was_successfully_resolved_to_1_with_Package_ID_2_primary_Colon_3_6219", text: "======== Type reference directive '{0}' was successfully resolved to '{1}' with Package ID '{2}', primary: {3}. ========"}
+
 var X_package_json_had_a_falsy_0_field = &Message{code: 6220, category: CategoryMessage, key: "package_json_had_a_falsy_0_field_6220", text: "'package.json' had a falsy '{0}' field."}
+
 var Disable_use_of_source_files_instead_of_declaration_files_from_referenced_projects = &Message{code: 6221, category: CategoryMessage, key: "Disable_use_of_source_files_instead_of_declaration_files_from_referenced_projects_6221", text: "Disable use of source files instead of declaration files from referenced projects."}
+
 var Emit_class_fields_with_Define_instead_of_Set = &Message{code: 6222, category: CategoryMessage, key: "Emit_class_fields_with_Define_instead_of_Set_6222", text: "Emit class fields with Define instead of Set."}
+
 var Generates_a_CPU_profile = &Message{code: 6223, category: CategoryMessage, key: "Generates_a_CPU_profile_6223", text: "Generates a CPU profile."}
+
 var Disable_solution_searching_for_this_project = &Message{code: 6224, category: CategoryMessage, key: "Disable_solution_searching_for_this_project_6224", text: "Disable solution searching for this project."}
+
 var Specify_strategy_for_watching_file_Colon_FixedPollingInterval_default_PriorityPollingInterval_DynamicPriorityPolling_FixedChunkSizePolling_UseFsEvents_UseFsEventsOnParentDirectory = &Message{code: 6225, category: CategoryMessage, key: "Specify_strategy_for_watching_file_Colon_FixedPollingInterval_default_PriorityPollingInterval_Dynami_6225", text: "Specify strategy for watching file: 'FixedPollingInterval' (default), 'PriorityPollingInterval', 'DynamicPriorityPolling', 'FixedChunkSizePolling', 'UseFsEvents', 'UseFsEventsOnParentDirectory'."}
+
 var Specify_strategy_for_watching_directory_on_platforms_that_don_t_support_recursive_watching_natively_Colon_UseFsEvents_default_FixedPollingInterval_DynamicPriorityPolling_FixedChunkSizePolling = &Message{code: 6226, category: CategoryMessage, key: "Specify_strategy_for_watching_directory_on_platforms_that_don_t_support_recursive_watching_natively__6226", text: "Specify strategy for watching directory on platforms that don't support recursive watching natively: 'UseFsEvents' (default), 'FixedPollingInterval', 'DynamicPriorityPolling', 'FixedChunkSizePolling'."}
+
 var Specify_strategy_for_creating_a_polling_watch_when_it_fails_to_create_using_file_system_events_Colon_FixedInterval_default_PriorityInterval_DynamicPriority_FixedChunkSize = &Message{code: 6227, category: CategoryMessage, key: "Specify_strategy_for_creating_a_polling_watch_when_it_fails_to_create_using_file_system_events_Colon_6227", text: "Specify strategy for creating a polling watch when it fails to create using file system events: 'FixedInterval' (default), 'PriorityInterval', 'DynamicPriority', 'FixedChunkSize'."}
+
 var Tag_0_expects_at_least_1_arguments_but_the_JSX_factory_2_provides_at_most_3 = &Message{code: 6229, category: CategoryError, key: "Tag_0_expects_at_least_1_arguments_but_the_JSX_factory_2_provides_at_most_3_6229", text: "Tag '{0}' expects at least '{1}' arguments, but the JSX factory '{2}' provides at most '{3}'."}
+
 var Option_0_can_only_be_specified_in_tsconfig_json_file_or_set_to_false_or_null_on_command_line = &Message{code: 6230, category: CategoryError, key: "Option_0_can_only_be_specified_in_tsconfig_json_file_or_set_to_false_or_null_on_command_line_6230", text: "Option '{0}' can only be specified in 'tsconfig.json' file or set to 'false' or 'null' on command line."}
+
 var Could_not_resolve_the_path_0_with_the_extensions_Colon_1 = &Message{code: 6231, category: CategoryError, key: "Could_not_resolve_the_path_0_with_the_extensions_Colon_1_6231", text: "Could not resolve the path '{0}' with the extensions: {1}."}
+
 var Declaration_augments_declaration_in_another_file_This_cannot_be_serialized = &Message{code: 6232, category: CategoryError, key: "Declaration_augments_declaration_in_another_file_This_cannot_be_serialized_6232", text: "Declaration augments declaration in another file. This cannot be serialized."}
+
 var This_is_the_declaration_being_augmented_Consider_moving_the_augmenting_declaration_into_the_same_file = &Message{code: 6233, category: CategoryError, key: "This_is_the_declaration_being_augmented_Consider_moving_the_augmenting_declaration_into_the_same_fil_6233", text: "This is the declaration being augmented. Consider moving the augmenting declaration into the same file."}
+
 var This_expression_is_not_callable_because_it_is_a_get_accessor_Did_you_mean_to_use_it_without = &Message{code: 6234, category: CategoryError, key: "This_expression_is_not_callable_because_it_is_a_get_accessor_Did_you_mean_to_use_it_without_6234", text: "This expression is not callable because it is a 'get' accessor. Did you mean to use it without '()'?"}
+
 var Disable_loading_referenced_projects = &Message{code: 6235, category: CategoryMessage, key: "Disable_loading_referenced_projects_6235", text: "Disable loading referenced projects."}
+
 var Arguments_for_the_rest_parameter_0_were_not_provided = &Message{code: 6236, category: CategoryError, key: "Arguments_for_the_rest_parameter_0_were_not_provided_6236", text: "Arguments for the rest parameter '{0}' were not provided."}
+
 var Generates_an_event_trace_and_a_list_of_types = &Message{code: 6237, category: CategoryMessage, key: "Generates_an_event_trace_and_a_list_of_types_6237", text: "Generates an event trace and a list of types."}
+
 var Specify_the_module_specifier_to_be_used_to_import_the_jsx_and_jsxs_factory_functions_from_eg_react = &Message{code: 6238, category: CategoryError, key: "Specify_the_module_specifier_to_be_used_to_import_the_jsx_and_jsxs_factory_functions_from_eg_react_6238", text: "Specify the module specifier to be used to import the 'jsx' and 'jsxs' factory functions from. eg, react"}
+
 var File_0_exists_according_to_earlier_cached_lookups = &Message{code: 6239, category: CategoryMessage, key: "File_0_exists_according_to_earlier_cached_lookups_6239", text: "File '{0}' exists according to earlier cached lookups."}
+
 var File_0_does_not_exist_according_to_earlier_cached_lookups = &Message{code: 6240, category: CategoryMessage, key: "File_0_does_not_exist_according_to_earlier_cached_lookups_6240", text: "File '{0}' does not exist according to earlier cached lookups."}
+
 var Resolution_for_type_reference_directive_0_was_found_in_cache_from_location_1 = &Message{code: 6241, category: CategoryMessage, key: "Resolution_for_type_reference_directive_0_was_found_in_cache_from_location_1_6241", text: "Resolution for type reference directive '{0}' was found in cache from location '{1}'."}
+
 var Resolving_type_reference_directive_0_containing_file_1 = &Message{code: 6242, category: CategoryMessage, key: "Resolving_type_reference_directive_0_containing_file_1_6242", text: "======== Resolving type reference directive '{0}', containing file '{1}'. ========"}
+
 var Interpret_optional_property_types_as_written_rather_than_adding_undefined = &Message{code: 6243, category: CategoryMessage, key: "Interpret_optional_property_types_as_written_rather_than_adding_undefined_6243", text: "Interpret optional property types as written, rather than adding 'undefined'."}
+
 var Modules = &Message{code: 6244, category: CategoryMessage, key: "Modules_6244", text: "Modules"}
+
 var File_Management = &Message{code: 6245, category: CategoryMessage, key: "File_Management_6245", text: "File Management"}
+
 var Emit = &Message{code: 6246, category: CategoryMessage, key: "Emit_6246", text: "Emit"}
+
 var JavaScript_Support = &Message{code: 6247, category: CategoryMessage, key: "JavaScript_Support_6247", text: "JavaScript Support"}
+
 var Type_Checking = &Message{code: 6248, category: CategoryMessage, key: "Type_Checking_6248", text: "Type Checking"}
+
 var Editor_Support = &Message{code: 6249, category: CategoryMessage, key: "Editor_Support_6249", text: "Editor Support"}
+
 var Watch_and_Build_Modes = &Message{code: 6250, category: CategoryMessage, key: "Watch_and_Build_Modes_6250", text: "Watch and Build Modes"}
+
 var Compiler_Diagnostics = &Message{code: 6251, category: CategoryMessage, key: "Compiler_Diagnostics_6251", text: "Compiler Diagnostics"}
+
 var Interop_Constraints = &Message{code: 6252, category: CategoryMessage, key: "Interop_Constraints_6252", text: "Interop Constraints"}
+
 var Backwards_Compatibility = &Message{code: 6253, category: CategoryMessage, key: "Backwards_Compatibility_6253", text: "Backwards Compatibility"}
+
 var Language_and_Environment = &Message{code: 6254, category: CategoryMessage, key: "Language_and_Environment_6254", text: "Language and Environment"}
+
 var Projects = &Message{code: 6255, category: CategoryMessage, key: "Projects_6255", text: "Projects"}
+
 var Output_Formatting = &Message{code: 6256, category: CategoryMessage, key: "Output_Formatting_6256", text: "Output Formatting"}
+
 var Completeness = &Message{code: 6257, category: CategoryMessage, key: "Completeness_6257", text: "Completeness"}
+
 var X_0_should_be_set_inside_the_compilerOptions_object_of_the_config_json_file = &Message{code: 6258, category: CategoryError, key: "_0_should_be_set_inside_the_compilerOptions_object_of_the_config_json_file_6258", text: "'{0}' should be set inside the 'compilerOptions' object of the config json file"}
+
 var Found_1_error_in_0 = &Message{code: 6259, category: CategoryMessage, key: "Found_1_error_in_0_6259", text: "Found 1 error in {0}"}
+
 var Found_0_errors_in_the_same_file_starting_at_Colon_1 = &Message{code: 6260, category: CategoryMessage, key: "Found_0_errors_in_the_same_file_starting_at_Colon_1_6260", text: "Found {0} errors in the same file, starting at: {1}"}
+
 var Found_0_errors_in_1_files = &Message{code: 6261, category: CategoryMessage, key: "Found_0_errors_in_1_files_6261", text: "Found {0} errors in {1} files."}
+
 var File_name_0_has_a_1_extension_looking_up_2_instead = &Message{code: 6262, category: CategoryMessage, key: "File_name_0_has_a_1_extension_looking_up_2_instead_6262", text: "File name '{0}' has a '{1}' extension - looking up '{2}' instead."}
+
 var Module_0_was_resolved_to_1_but_allowArbitraryExtensions_is_not_set = &Message{code: 6263, category: CategoryError, key: "Module_0_was_resolved_to_1_but_allowArbitraryExtensions_is_not_set_6263", text: "Module '{0}' was resolved to '{1}', but '--allowArbitraryExtensions' is not set."}
+
 var Enable_importing_files_with_any_extension_provided_a_declaration_file_is_present = &Message{code: 6264, category: CategoryMessage, key: "Enable_importing_files_with_any_extension_provided_a_declaration_file_is_present_6264", text: "Enable importing files with any extension, provided a declaration file is present."}
+
 var Resolving_type_reference_directive_for_program_that_specifies_custom_typeRoots_skipping_lookup_in_node_modules_folder = &Message{code: 6265, category: CategoryMessage, key: "Resolving_type_reference_directive_for_program_that_specifies_custom_typeRoots_skipping_lookup_in_no_6265", text: "Resolving type reference directive for program that specifies custom typeRoots, skipping lookup in 'node_modules' folder."}
+
 var Option_0_can_only_be_specified_on_command_line = &Message{code: 6266, category: CategoryError, key: "Option_0_can_only_be_specified_on_command_line_6266", text: "Option '{0}' can only be specified on command line."}
+
 var Directory_0_has_no_containing_package_json_scope_Imports_will_not_resolve = &Message{code: 6270, category: CategoryMessage, key: "Directory_0_has_no_containing_package_json_scope_Imports_will_not_resolve_6270", text: "Directory '{0}' has no containing package.json scope. Imports will not resolve."}
+
 var Import_specifier_0_does_not_exist_in_package_json_scope_at_path_1 = &Message{code: 6271, category: CategoryMessage, key: "Import_specifier_0_does_not_exist_in_package_json_scope_at_path_1_6271", text: "Import specifier '{0}' does not exist in package.json scope at path '{1}'."}
+
 var Invalid_import_specifier_0_has_no_possible_resolutions = &Message{code: 6272, category: CategoryMessage, key: "Invalid_import_specifier_0_has_no_possible_resolutions_6272", text: "Invalid import specifier '{0}' has no possible resolutions."}
+
 var X_package_json_scope_0_has_no_imports_defined = &Message{code: 6273, category: CategoryMessage, key: "package_json_scope_0_has_no_imports_defined_6273", text: "package.json scope '{0}' has no imports defined."}
+
 var X_package_json_scope_0_explicitly_maps_specifier_1_to_null = &Message{code: 6274, category: CategoryMessage, key: "package_json_scope_0_explicitly_maps_specifier_1_to_null_6274", text: "package.json scope '{0}' explicitly maps specifier '{1}' to null."}
+
 var X_package_json_scope_0_has_invalid_type_for_target_of_specifier_1 = &Message{code: 6275, category: CategoryMessage, key: "package_json_scope_0_has_invalid_type_for_target_of_specifier_1_6275", text: "package.json scope '{0}' has invalid type for target of specifier '{1}'"}
+
 var Export_specifier_0_does_not_exist_in_package_json_scope_at_path_1 = &Message{code: 6276, category: CategoryMessage, key: "Export_specifier_0_does_not_exist_in_package_json_scope_at_path_1_6276", text: "Export specifier '{0}' does not exist in package.json scope at path '{1}'."}
+
 var Resolution_of_non_relative_name_failed_trying_with_modern_Node_resolution_features_disabled_to_see_if_npm_library_needs_configuration_update = &Message{code: 6277, category: CategoryMessage, key: "Resolution_of_non_relative_name_failed_trying_with_modern_Node_resolution_features_disabled_to_see_i_6277", text: "Resolution of non-relative name failed; trying with modern Node resolution features disabled to see if npm library needs configuration update."}
+
 var There_are_types_at_0_but_this_result_could_not_be_resolved_when_respecting_package_json_exports_The_1_library_may_need_to_update_its_package_json_or_typings = &Message{code: 6278, category: CategoryMessage, key: "There_are_types_at_0_but_this_result_could_not_be_resolved_when_respecting_package_json_exports_The__6278", text: "There are types at '{0}', but this result could not be resolved when respecting package.json \"exports\". The '{1}' library may need to update its package.json or typings."}
+
 var Resolution_of_non_relative_name_failed_trying_with_moduleResolution_bundler_to_see_if_project_may_need_configuration_update = &Message{code: 6279, category: CategoryMessage, key: "Resolution_of_non_relative_name_failed_trying_with_moduleResolution_bundler_to_see_if_project_may_ne_6279", text: "Resolution of non-relative name failed; trying with '--moduleResolution bundler' to see if project may need configuration update."}
+
 var There_are_types_at_0_but_this_result_could_not_be_resolved_under_your_current_moduleResolution_setting_Consider_updating_to_node16_nodenext_or_bundler = &Message{code: 6280, category: CategoryMessage, key: "There_are_types_at_0_but_this_result_could_not_be_resolved_under_your_current_moduleResolution_setti_6280", text: "There are types at '{0}', but this result could not be resolved under your current 'moduleResolution' setting. Consider updating to 'node16', 'nodenext', or 'bundler'."}
+
 var X_package_json_has_a_peerDependencies_field = &Message{code: 6281, category: CategoryMessage, key: "package_json_has_a_peerDependencies_field_6281", text: "'package.json' has a 'peerDependencies' field."}
+
 var Found_peerDependency_0_with_1_version = &Message{code: 6282, category: CategoryMessage, key: "Found_peerDependency_0_with_1_version_6282", text: "Found peerDependency '{0}' with '{1}' version."}
+
 var Failed_to_find_peerDependency_0 = &Message{code: 6283, category: CategoryMessage, key: "Failed_to_find_peerDependency_0_6283", text: "Failed to find peerDependency '{0}'."}
+
 var Enable_project_compilation = &Message{code: 6302, category: CategoryMessage, key: "Enable_project_compilation_6302", text: "Enable project compilation"}
+
 var Composite_projects_may_not_disable_declaration_emit = &Message{code: 6304, category: CategoryError, key: "Composite_projects_may_not_disable_declaration_emit_6304", text: "Composite projects may not disable declaration emit."}
+
 var Output_file_0_has_not_been_built_from_source_file_1 = &Message{code: 6305, category: CategoryError, key: "Output_file_0_has_not_been_built_from_source_file_1_6305", text: "Output file '{0}' has not been built from source file '{1}'."}
+
 var Referenced_project_0_must_have_setting_composite_Colon_true = &Message{code: 6306, category: CategoryError, key: "Referenced_project_0_must_have_setting_composite_Colon_true_6306", text: "Referenced project '{0}' must have setting \"composite\": true."}
+
 var File_0_is_not_listed_within_the_file_list_of_project_1_Projects_must_list_all_files_or_use_an_include_pattern = &Message{code: 6307, category: CategoryError, key: "File_0_is_not_listed_within_the_file_list_of_project_1_Projects_must_list_all_files_or_use_an_includ_6307", text: "File '{0}' is not listed within the file list of project '{1}'. Projects must list all files or use an 'include' pattern."}
+
 var Referenced_project_0_may_not_disable_emit = &Message{code: 6310, category: CategoryError, key: "Referenced_project_0_may_not_disable_emit_6310", text: "Referenced project '{0}' may not disable emit."}
+
 var Project_0_is_out_of_date_because_output_1_is_older_than_input_2 = &Message{code: 6350, category: CategoryMessage, key: "Project_0_is_out_of_date_because_output_1_is_older_than_input_2_6350", text: "Project '{0}' is out of date because output '{1}' is older than input '{2}'"}
+
 var Project_0_is_up_to_date_because_newest_input_1_is_older_than_output_2 = &Message{code: 6351, category: CategoryMessage, key: "Project_0_is_up_to_date_because_newest_input_1_is_older_than_output_2_6351", text: "Project '{0}' is up to date because newest input '{1}' is older than output '{2}'"}
+
 var Project_0_is_out_of_date_because_output_file_1_does_not_exist = &Message{code: 6352, category: CategoryMessage, key: "Project_0_is_out_of_date_because_output_file_1_does_not_exist_6352", text: "Project '{0}' is out of date because output file '{1}' does not exist"}
+
 var Project_0_is_out_of_date_because_its_dependency_1_is_out_of_date = &Message{code: 6353, category: CategoryMessage, key: "Project_0_is_out_of_date_because_its_dependency_1_is_out_of_date_6353", text: "Project '{0}' is out of date because its dependency '{1}' is out of date"}
+
 var Project_0_is_up_to_date_with_d_ts_files_from_its_dependencies = &Message{code: 6354, category: CategoryMessage, key: "Project_0_is_up_to_date_with_d_ts_files_from_its_dependencies_6354", text: "Project '{0}' is up to date with .d.ts files from its dependencies"}
+
 var Projects_in_this_build_Colon_0 = &Message{code: 6355, category: CategoryMessage, key: "Projects_in_this_build_Colon_0_6355", text: "Projects in this build: {0}"}
+
 var A_non_dry_build_would_delete_the_following_files_Colon_0 = &Message{code: 6356, category: CategoryMessage, key: "A_non_dry_build_would_delete_the_following_files_Colon_0_6356", text: "A non-dry build would delete the following files: {0}"}
+
 var A_non_dry_build_would_build_project_0 = &Message{code: 6357, category: CategoryMessage, key: "A_non_dry_build_would_build_project_0_6357", text: "A non-dry build would build project '{0}'"}
+
 var Building_project_0 = &Message{code: 6358, category: CategoryMessage, key: "Building_project_0_6358", text: "Building project '{0}'..."}
+
 var Updating_output_timestamps_of_project_0 = &Message{code: 6359, category: CategoryMessage, key: "Updating_output_timestamps_of_project_0_6359", text: "Updating output timestamps of project '{0}'..."}
+
 var Project_0_is_up_to_date = &Message{code: 6361, category: CategoryMessage, key: "Project_0_is_up_to_date_6361", text: "Project '{0}' is up to date"}
+
 var Skipping_build_of_project_0_because_its_dependency_1_has_errors = &Message{code: 6362, category: CategoryMessage, key: "Skipping_build_of_project_0_because_its_dependency_1_has_errors_6362", text: "Skipping build of project '{0}' because its dependency '{1}' has errors"}
+
 var Project_0_can_t_be_built_because_its_dependency_1_has_errors = &Message{code: 6363, category: CategoryMessage, key: "Project_0_can_t_be_built_because_its_dependency_1_has_errors_6363", text: "Project '{0}' can't be built because its dependency '{1}' has errors"}
+
 var Build_one_or_more_projects_and_their_dependencies_if_out_of_date = &Message{code: 6364, category: CategoryMessage, key: "Build_one_or_more_projects_and_their_dependencies_if_out_of_date_6364", text: "Build one or more projects and their dependencies, if out of date"}
+
 var Delete_the_outputs_of_all_projects = &Message{code: 6365, category: CategoryMessage, key: "Delete_the_outputs_of_all_projects_6365", text: "Delete the outputs of all projects."}
+
 var Show_what_would_be_built_or_deleted_if_specified_with_clean = &Message{code: 6367, category: CategoryMessage, key: "Show_what_would_be_built_or_deleted_if_specified_with_clean_6367", text: "Show what would be built (or deleted, if specified with '--clean')"}
+
 var Option_build_must_be_the_first_command_line_argument = &Message{code: 6369, category: CategoryError, key: "Option_build_must_be_the_first_command_line_argument_6369", text: "Option '--build' must be the first command line argument."}
+
 var Options_0_and_1_cannot_be_combined = &Message{code: 6370, category: CategoryError, key: "Options_0_and_1_cannot_be_combined_6370", text: "Options '{0}' and '{1}' cannot be combined."}
+
 var Updating_unchanged_output_timestamps_of_project_0 = &Message{code: 6371, category: CategoryMessage, key: "Updating_unchanged_output_timestamps_of_project_0_6371", text: "Updating unchanged output timestamps of project '{0}'..."}
+
 var A_non_dry_build_would_update_timestamps_for_output_of_project_0 = &Message{code: 6374, category: CategoryMessage, key: "A_non_dry_build_would_update_timestamps_for_output_of_project_0_6374", text: "A non-dry build would update timestamps for output of project '{0}'"}
+
 var Cannot_write_file_0_because_it_will_overwrite_tsbuildinfo_file_generated_by_referenced_project_1 = &Message{code: 6377, category: CategoryError, key: "Cannot_write_file_0_because_it_will_overwrite_tsbuildinfo_file_generated_by_referenced_project_1_6377", text: "Cannot write file '{0}' because it will overwrite '.tsbuildinfo' file generated by referenced project '{1}'"}
+
 var Composite_projects_may_not_disable_incremental_compilation = &Message{code: 6379, category: CategoryError, key: "Composite_projects_may_not_disable_incremental_compilation_6379", text: "Composite projects may not disable incremental compilation."}
+
 var Specify_file_to_store_incremental_compilation_information = &Message{code: 6380, category: CategoryMessage, key: "Specify_file_to_store_incremental_compilation_information_6380", text: "Specify file to store incremental compilation information"}
+
 var Project_0_is_out_of_date_because_output_for_it_was_generated_with_version_1_that_differs_with_current_version_2 = &Message{code: 6381, category: CategoryMessage, key: "Project_0_is_out_of_date_because_output_for_it_was_generated_with_version_1_that_differs_with_curren_6381", text: "Project '{0}' is out of date because output for it was generated with version '{1}' that differs with current version '{2}'"}
+
 var Skipping_build_of_project_0_because_its_dependency_1_was_not_built = &Message{code: 6382, category: CategoryMessage, key: "Skipping_build_of_project_0_because_its_dependency_1_was_not_built_6382", text: "Skipping build of project '{0}' because its dependency '{1}' was not built"}
+
 var Project_0_can_t_be_built_because_its_dependency_1_was_not_built = &Message{code: 6383, category: CategoryMessage, key: "Project_0_can_t_be_built_because_its_dependency_1_was_not_built_6383", text: "Project '{0}' can't be built because its dependency '{1}' was not built"}
+
 var Have_recompiles_in_incremental_and_watch_assume_that_changes_within_a_file_will_only_affect_files_directly_depending_on_it = &Message{code: 6384, category: CategoryMessage, key: "Have_recompiles_in_incremental_and_watch_assume_that_changes_within_a_file_will_only_affect_files_di_6384", text: "Have recompiles in '--incremental' and '--watch' assume that changes within a file will only affect files directly depending on it."}
+
 var X_0_is_deprecated = &Message{code: 6385, category: CategorySuggestion, key: "_0_is_deprecated_6385", text: "'{0}' is deprecated.", reportsDeprecated: true}
+
 var Performance_timings_for_diagnostics_or_extendedDiagnostics_are_not_available_in_this_session_A_native_implementation_of_the_Web_Performance_API_could_not_be_found = &Message{code: 6386, category: CategoryMessage, key: "Performance_timings_for_diagnostics_or_extendedDiagnostics_are_not_available_in_this_session_A_nativ_6386", text: "Performance timings for '--diagnostics' or '--extendedDiagnostics' are not available in this session. A native implementation of the Web Performance API could not be found."}
+
 var The_signature_0_of_1_is_deprecated = &Message{code: 6387, category: CategorySuggestion, key: "The_signature_0_of_1_is_deprecated_6387", text: "The signature '{0}' of '{1}' is deprecated.", reportsDeprecated: true}
+
 var Project_0_is_being_forcibly_rebuilt = &Message{code: 6388, category: CategoryMessage, key: "Project_0_is_being_forcibly_rebuilt_6388", text: "Project '{0}' is being forcibly rebuilt"}
+
 var Reusing_resolution_of_module_0_from_1_of_old_program_it_was_not_resolved = &Message{code: 6389, category: CategoryMessage, key: "Reusing_resolution_of_module_0_from_1_of_old_program_it_was_not_resolved_6389", text: "Reusing resolution of module '{0}' from '{1}' of old program, it was not resolved."}
+
 var Reusing_resolution_of_type_reference_directive_0_from_1_of_old_program_it_was_successfully_resolved_to_2 = &Message{code: 6390, category: CategoryMessage, key: "Reusing_resolution_of_type_reference_directive_0_from_1_of_old_program_it_was_successfully_resolved__6390", text: "Reusing resolution of type reference directive '{0}' from '{1}' of old program, it was successfully resolved to '{2}'."}
+
 var Reusing_resolution_of_type_reference_directive_0_from_1_of_old_program_it_was_successfully_resolved_to_2_with_Package_ID_3 = &Message{code: 6391, category: CategoryMessage, key: "Reusing_resolution_of_type_reference_directive_0_from_1_of_old_program_it_was_successfully_resolved__6391", text: "Reusing resolution of type reference directive '{0}' from '{1}' of old program, it was successfully resolved to '{2}' with Package ID '{3}'."}
+
 var Reusing_resolution_of_type_reference_directive_0_from_1_of_old_program_it_was_not_resolved = &Message{code: 6392, category: CategoryMessage, key: "Reusing_resolution_of_type_reference_directive_0_from_1_of_old_program_it_was_not_resolved_6392", text: "Reusing resolution of type reference directive '{0}' from '{1}' of old program, it was not resolved."}
+
 var Reusing_resolution_of_module_0_from_1_found_in_cache_from_location_2_it_was_successfully_resolved_to_3 = &Message{code: 6393, category: CategoryMessage, key: "Reusing_resolution_of_module_0_from_1_found_in_cache_from_location_2_it_was_successfully_resolved_to_6393", text: "Reusing resolution of module '{0}' from '{1}' found in cache from location '{2}', it was successfully resolved to '{3}'."}
+
 var Reusing_resolution_of_module_0_from_1_found_in_cache_from_location_2_it_was_successfully_resolved_to_3_with_Package_ID_4 = &Message{code: 6394, category: CategoryMessage, key: "Reusing_resolution_of_module_0_from_1_found_in_cache_from_location_2_it_was_successfully_resolved_to_6394", text: "Reusing resolution of module '{0}' from '{1}' found in cache from location '{2}', it was successfully resolved to '{3}' with Package ID '{4}'."}
+
 var Reusing_resolution_of_module_0_from_1_found_in_cache_from_location_2_it_was_not_resolved = &Message{code: 6395, category: CategoryMessage, key: "Reusing_resolution_of_module_0_from_1_found_in_cache_from_location_2_it_was_not_resolved_6395", text: "Reusing resolution of module '{0}' from '{1}' found in cache from location '{2}', it was not resolved."}
+
 var Reusing_resolution_of_type_reference_directive_0_from_1_found_in_cache_from_location_2_it_was_successfully_resolved_to_3 = &Message{code: 6396, category: CategoryMessage, key: "Reusing_resolution_of_type_reference_directive_0_from_1_found_in_cache_from_location_2_it_was_succes_6396", text: "Reusing resolution of type reference directive '{0}' from '{1}' found in cache from location '{2}', it was successfully resolved to '{3}'."}
+
 var Reusing_resolution_of_type_reference_directive_0_from_1_found_in_cache_from_location_2_it_was_successfully_resolved_to_3_with_Package_ID_4 = &Message{code: 6397, category: CategoryMessage, key: "Reusing_resolution_of_type_reference_directive_0_from_1_found_in_cache_from_location_2_it_was_succes_6397", text: "Reusing resolution of type reference directive '{0}' from '{1}' found in cache from location '{2}', it was successfully resolved to '{3}' with Package ID '{4}'."}
+
 var Reusing_resolution_of_type_reference_directive_0_from_1_found_in_cache_from_location_2_it_was_not_resolved = &Message{code: 6398, category: CategoryMessage, key: "Reusing_resolution_of_type_reference_directive_0_from_1_found_in_cache_from_location_2_it_was_not_re_6398", text: "Reusing resolution of type reference directive '{0}' from '{1}' found in cache from location '{2}', it was not resolved."}
+
 var Project_0_is_out_of_date_because_buildinfo_file_1_indicates_that_some_of_the_changes_were_not_emitted = &Message{code: 6399, category: CategoryMessage, key: "Project_0_is_out_of_date_because_buildinfo_file_1_indicates_that_some_of_the_changes_were_not_emitte_6399", text: "Project '{0}' is out of date because buildinfo file '{1}' indicates that some of the changes were not emitted"}
+
 var Project_0_is_up_to_date_but_needs_to_update_timestamps_of_output_files_that_are_older_than_input_files = &Message{code: 6400, category: CategoryMessage, key: "Project_0_is_up_to_date_but_needs_to_update_timestamps_of_output_files_that_are_older_than_input_fil_6400", text: "Project '{0}' is up to date but needs to update timestamps of output files that are older than input files"}
+
 var Project_0_is_out_of_date_because_there_was_error_reading_file_1 = &Message{code: 6401, category: CategoryMessage, key: "Project_0_is_out_of_date_because_there_was_error_reading_file_1_6401", text: "Project '{0}' is out of date because there was error reading file '{1}'"}
+
 var Resolving_in_0_mode_with_conditions_1 = &Message{code: 6402, category: CategoryMessage, key: "Resolving_in_0_mode_with_conditions_1_6402", text: "Resolving in {0} mode with conditions {1}."}
+
 var Matched_0_condition_1 = &Message{code: 6403, category: CategoryMessage, key: "Matched_0_condition_1_6403", text: "Matched '{0}' condition '{1}'."}
+
 var Using_0_subpath_1_with_target_2 = &Message{code: 6404, category: CategoryMessage, key: "Using_0_subpath_1_with_target_2_6404", text: "Using '{0}' subpath '{1}' with target '{2}'."}
+
 var Saw_non_matching_condition_0 = &Message{code: 6405, category: CategoryMessage, key: "Saw_non_matching_condition_0_6405", text: "Saw non-matching condition '{0}'."}
+
 var Project_0_is_out_of_date_because_buildinfo_file_1_indicates_there_is_change_in_compilerOptions = &Message{code: 6406, category: CategoryMessage, key: "Project_0_is_out_of_date_because_buildinfo_file_1_indicates_there_is_change_in_compilerOptions_6406", text: "Project '{0}' is out of date because buildinfo file '{1}' indicates there is change in compilerOptions"}
+
 var Allow_imports_to_include_TypeScript_file_extensions_Requires_moduleResolution_bundler_and_either_noEmit_or_emitDeclarationOnly_to_be_set = &Message{code: 6407, category: CategoryMessage, key: "Allow_imports_to_include_TypeScript_file_extensions_Requires_moduleResolution_bundler_and_either_noE_6407", text: "Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set."}
+
 var Use_the_package_json_exports_field_when_resolving_package_imports = &Message{code: 6408, category: CategoryMessage, key: "Use_the_package_json_exports_field_when_resolving_package_imports_6408", text: "Use the package.json 'exports' field when resolving package imports."}
+
 var Use_the_package_json_imports_field_when_resolving_imports = &Message{code: 6409, category: CategoryMessage, key: "Use_the_package_json_imports_field_when_resolving_imports_6409", text: "Use the package.json 'imports' field when resolving imports."}
+
 var Conditions_to_set_in_addition_to_the_resolver_specific_defaults_when_resolving_imports = &Message{code: 6410, category: CategoryMessage, key: "Conditions_to_set_in_addition_to_the_resolver_specific_defaults_when_resolving_imports_6410", text: "Conditions to set in addition to the resolver-specific defaults when resolving imports."}
+
 var X_true_when_moduleResolution_is_node16_nodenext_or_bundler_otherwise_false = &Message{code: 6411, category: CategoryMessage, key: "true_when_moduleResolution_is_node16_nodenext_or_bundler_otherwise_false_6411", text: "`true` when 'moduleResolution' is 'node16', 'nodenext', or 'bundler'; otherwise `false`."}
+
 var Project_0_is_out_of_date_because_buildinfo_file_1_indicates_that_file_2_was_root_file_of_compilation_but_not_any_more = &Message{code: 6412, category: CategoryMessage, key: "Project_0_is_out_of_date_because_buildinfo_file_1_indicates_that_file_2_was_root_file_of_compilation_6412", text: "Project '{0}' is out of date because buildinfo file '{1}' indicates that file '{2}' was root file of compilation but not any more."}
+
 var Entering_conditional_exports = &Message{code: 6413, category: CategoryMessage, key: "Entering_conditional_exports_6413", text: "Entering conditional exports."}
+
 var Resolved_under_condition_0 = &Message{code: 6414, category: CategoryMessage, key: "Resolved_under_condition_0_6414", text: "Resolved under condition '{0}'."}
+
 var Failed_to_resolve_under_condition_0 = &Message{code: 6415, category: CategoryMessage, key: "Failed_to_resolve_under_condition_0_6415", text: "Failed to resolve under condition '{0}'."}
+
 var Exiting_conditional_exports = &Message{code: 6416, category: CategoryMessage, key: "Exiting_conditional_exports_6416", text: "Exiting conditional exports."}
+
 var Searching_all_ancestor_node_modules_directories_for_preferred_extensions_Colon_0 = &Message{code: 6417, category: CategoryMessage, key: "Searching_all_ancestor_node_modules_directories_for_preferred_extensions_Colon_0_6417", text: "Searching all ancestor node_modules directories for preferred extensions: {0}."}
+
 var Searching_all_ancestor_node_modules_directories_for_fallback_extensions_Colon_0 = &Message{code: 6418, category: CategoryMessage, key: "Searching_all_ancestor_node_modules_directories_for_fallback_extensions_Colon_0_6418", text: "Searching all ancestor node_modules directories for fallback extensions: {0}."}
+
 var Project_0_is_out_of_date_because_buildinfo_file_1_indicates_that_program_needs_to_report_errors = &Message{code: 6419, category: CategoryMessage, key: "Project_0_is_out_of_date_because_buildinfo_file_1_indicates_that_program_needs_to_report_errors_6419", text: "Project '{0}' is out of date because buildinfo file '{1}' indicates that program needs to report errors."}
+
 var Project_0_is_out_of_date_because_1 = &Message{code: 6420, category: CategoryMessage, key: "Project_0_is_out_of_date_because_1_6420", text: "Project '{0}' is out of date because {1}."}
+
 var Rewrite_ts_tsx_mts_and_cts_file_extensions_in_relative_import_paths_to_their_JavaScript_equivalent_in_output_files = &Message{code: 6421, category: CategoryMessage, key: "Rewrite_ts_tsx_mts_and_cts_file_extensions_in_relative_import_paths_to_their_JavaScript_equivalent_i_6421", text: "Rewrite '.ts', '.tsx', '.mts', and '.cts' file extensions in relative import paths to their JavaScript equivalent in output files."}
+
 var The_expected_type_comes_from_property_0_which_is_declared_here_on_type_1 = &Message{code: 6500, category: CategoryMessage, key: "The_expected_type_comes_from_property_0_which_is_declared_here_on_type_1_6500", text: "The expected type comes from property '{0}' which is declared here on type '{1}'"}
+
 var The_expected_type_comes_from_this_index_signature = &Message{code: 6501, category: CategoryMessage, key: "The_expected_type_comes_from_this_index_signature_6501", text: "The expected type comes from this index signature."}
+
 var The_expected_type_comes_from_the_return_type_of_this_signature = &Message{code: 6502, category: CategoryMessage, key: "The_expected_type_comes_from_the_return_type_of_this_signature_6502", text: "The expected type comes from the return type of this signature."}
+
 var Print_names_of_files_that_are_part_of_the_compilation_and_then_stop_processing = &Message{code: 6503, category: CategoryMessage, key: "Print_names_of_files_that_are_part_of_the_compilation_and_then_stop_processing_6503", text: "Print names of files that are part of the compilation and then stop processing."}
+
 var File_0_is_a_JavaScript_file_Did_you_mean_to_enable_the_allowJs_option = &Message{code: 6504, category: CategoryError, key: "File_0_is_a_JavaScript_file_Did_you_mean_to_enable_the_allowJs_option_6504", text: "File '{0}' is a JavaScript file. Did you mean to enable the 'allowJs' option?"}
+
 var Print_names_of_files_and_the_reason_they_are_part_of_the_compilation = &Message{code: 6505, category: CategoryMessage, key: "Print_names_of_files_and_the_reason_they_are_part_of_the_compilation_6505", text: "Print names of files and the reason they are part of the compilation."}
+
 var Consider_adding_a_declare_modifier_to_this_class = &Message{code: 6506, category: CategoryMessage, key: "Consider_adding_a_declare_modifier_to_this_class_6506", text: "Consider adding a 'declare' modifier to this class."}
+
 var Allow_JavaScript_files_to_be_a_part_of_your_program_Use_the_checkJS_option_to_get_errors_from_these_files = &Message{code: 6600, category: CategoryMessage, key: "Allow_JavaScript_files_to_be_a_part_of_your_program_Use_the_checkJS_option_to_get_errors_from_these__6600", text: "Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files."}
+
 var Allow_import_x_from_y_when_a_module_doesn_t_have_a_default_export = &Message{code: 6601, category: CategoryMessage, key: "Allow_import_x_from_y_when_a_module_doesn_t_have_a_default_export_6601", text: "Allow 'import x from y' when a module doesn't have a default export."}
+
 var Allow_accessing_UMD_globals_from_modules = &Message{code: 6602, category: CategoryMessage, key: "Allow_accessing_UMD_globals_from_modules_6602", text: "Allow accessing UMD globals from modules."}
+
 var Disable_error_reporting_for_unreachable_code = &Message{code: 6603, category: CategoryMessage, key: "Disable_error_reporting_for_unreachable_code_6603", text: "Disable error reporting for unreachable code."}
+
 var Disable_error_reporting_for_unused_labels = &Message{code: 6604, category: CategoryMessage, key: "Disable_error_reporting_for_unused_labels_6604", text: "Disable error reporting for unused labels."}
+
 var Ensure_use_strict_is_always_emitted = &Message{code: 6605, category: CategoryMessage, key: "Ensure_use_strict_is_always_emitted_6605", text: "Ensure 'use strict' is always emitted."}
+
 var Have_recompiles_in_projects_that_use_incremental_and_watch_mode_assume_that_changes_within_a_file_will_only_affect_files_directly_depending_on_it = &Message{code: 6606, category: CategoryMessage, key: "Have_recompiles_in_projects_that_use_incremental_and_watch_mode_assume_that_changes_within_a_file_wi_6606", text: "Have recompiles in projects that use 'incremental' and 'watch' mode assume that changes within a file will only affect files directly depending on it."}
+
 var Specify_the_base_directory_to_resolve_non_relative_module_names = &Message{code: 6607, category: CategoryMessage, key: "Specify_the_base_directory_to_resolve_non_relative_module_names_6607", text: "Specify the base directory to resolve non-relative module names."}
+
 var No_longer_supported_In_early_versions_manually_set_the_text_encoding_for_reading_files = &Message{code: 6608, category: CategoryMessage, key: "No_longer_supported_In_early_versions_manually_set_the_text_encoding_for_reading_files_6608", text: "No longer supported. In early versions, manually set the text encoding for reading files."}
+
 var Enable_error_reporting_in_type_checked_JavaScript_files = &Message{code: 6609, category: CategoryMessage, key: "Enable_error_reporting_in_type_checked_JavaScript_files_6609", text: "Enable error reporting in type-checked JavaScript files."}
+
 var Enable_constraints_that_allow_a_TypeScript_project_to_be_used_with_project_references = &Message{code: 6611, category: CategoryMessage, key: "Enable_constraints_that_allow_a_TypeScript_project_to_be_used_with_project_references_6611", text: "Enable constraints that allow a TypeScript project to be used with project references."}
+
 var Generate_d_ts_files_from_TypeScript_and_JavaScript_files_in_your_project = &Message{code: 6612, category: CategoryMessage, key: "Generate_d_ts_files_from_TypeScript_and_JavaScript_files_in_your_project_6612", text: "Generate .d.ts files from TypeScript and JavaScript files in your project."}
+
 var Specify_the_output_directory_for_generated_declaration_files = &Message{code: 6613, category: CategoryMessage, key: "Specify_the_output_directory_for_generated_declaration_files_6613", text: "Specify the output directory for generated declaration files."}
+
 var Create_sourcemaps_for_d_ts_files = &Message{code: 6614, category: CategoryMessage, key: "Create_sourcemaps_for_d_ts_files_6614", text: "Create sourcemaps for d.ts files."}
+
 var Output_compiler_performance_information_after_building = &Message{code: 6615, category: CategoryMessage, key: "Output_compiler_performance_information_after_building_6615", text: "Output compiler performance information after building."}
+
 var Disables_inference_for_type_acquisition_by_looking_at_filenames_in_a_project = &Message{code: 6616, category: CategoryMessage, key: "Disables_inference_for_type_acquisition_by_looking_at_filenames_in_a_project_6616", text: "Disables inference for type acquisition by looking at filenames in a project."}
+
 var Reduce_the_number_of_projects_loaded_automatically_by_TypeScript = &Message{code: 6617, category: CategoryMessage, key: "Reduce_the_number_of_projects_loaded_automatically_by_TypeScript_6617", text: "Reduce the number of projects loaded automatically by TypeScript."}
+
 var Remove_the_20mb_cap_on_total_source_code_size_for_JavaScript_files_in_the_TypeScript_language_server = &Message{code: 6618, category: CategoryMessage, key: "Remove_the_20mb_cap_on_total_source_code_size_for_JavaScript_files_in_the_TypeScript_language_server_6618", text: "Remove the 20mb cap on total source code size for JavaScript files in the TypeScript language server."}
+
 var Opt_a_project_out_of_multi_project_reference_checking_when_editing = &Message{code: 6619, category: CategoryMessage, key: "Opt_a_project_out_of_multi_project_reference_checking_when_editing_6619", text: "Opt a project out of multi-project reference checking when editing."}
+
 var Disable_preferring_source_files_instead_of_declaration_files_when_referencing_composite_projects = &Message{code: 6620, category: CategoryMessage, key: "Disable_preferring_source_files_instead_of_declaration_files_when_referencing_composite_projects_6620", text: "Disable preferring source files instead of declaration files when referencing composite projects."}
+
 var Emit_more_compliant_but_verbose_and_less_performant_JavaScript_for_iteration = &Message{code: 6621, category: CategoryMessage, key: "Emit_more_compliant_but_verbose_and_less_performant_JavaScript_for_iteration_6621", text: "Emit more compliant, but verbose and less performant JavaScript for iteration."}
+
 var Emit_a_UTF_8_Byte_Order_Mark_BOM_in_the_beginning_of_output_files = &Message{code: 6622, category: CategoryMessage, key: "Emit_a_UTF_8_Byte_Order_Mark_BOM_in_the_beginning_of_output_files_6622", text: "Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files."}
+
 var Only_output_d_ts_files_and_not_JavaScript_files = &Message{code: 6623, category: CategoryMessage, key: "Only_output_d_ts_files_and_not_JavaScript_files_6623", text: "Only output d.ts files and not JavaScript files."}
+
 var Emit_design_type_metadata_for_decorated_declarations_in_source_files = &Message{code: 6624, category: CategoryMessage, key: "Emit_design_type_metadata_for_decorated_declarations_in_source_files_6624", text: "Emit design-type metadata for decorated declarations in source files."}
+
 var Disable_the_type_acquisition_for_JavaScript_projects = &Message{code: 6625, category: CategoryMessage, key: "Disable_the_type_acquisition_for_JavaScript_projects_6625", text: "Disable the type acquisition for JavaScript projects"}
+
 var Emit_additional_JavaScript_to_ease_support_for_importing_CommonJS_modules_This_enables_allowSyntheticDefaultImports_for_type_compatibility = &Message{code: 6626, category: CategoryMessage, key: "Emit_additional_JavaScript_to_ease_support_for_importing_CommonJS_modules_This_enables_allowSyntheti_6626", text: "Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility."}
+
 var Filters_results_from_the_include_option = &Message{code: 6627, category: CategoryMessage, key: "Filters_results_from_the_include_option_6627", text: "Filters results from the `include` option."}
+
 var Remove_a_list_of_directories_from_the_watch_process = &Message{code: 6628, category: CategoryMessage, key: "Remove_a_list_of_directories_from_the_watch_process_6628", text: "Remove a list of directories from the watch process."}
+
 var Remove_a_list_of_files_from_the_watch_mode_s_processing = &Message{code: 6629, category: CategoryMessage, key: "Remove_a_list_of_files_from_the_watch_mode_s_processing_6629", text: "Remove a list of files from the watch mode's processing."}
+
 var Enable_experimental_support_for_legacy_experimental_decorators = &Message{code: 6630, category: CategoryMessage, key: "Enable_experimental_support_for_legacy_experimental_decorators_6630", text: "Enable experimental support for legacy experimental decorators."}
+
 var Print_files_read_during_the_compilation_including_why_it_was_included = &Message{code: 6631, category: CategoryMessage, key: "Print_files_read_during_the_compilation_including_why_it_was_included_6631", text: "Print files read during the compilation including why it was included."}
+
 var Output_more_detailed_compiler_performance_information_after_building = &Message{code: 6632, category: CategoryMessage, key: "Output_more_detailed_compiler_performance_information_after_building_6632", text: "Output more detailed compiler performance information after building."}
+
 var Specify_one_or_more_path_or_node_module_references_to_base_configuration_files_from_which_settings_are_inherited = &Message{code: 6633, category: CategoryMessage, key: "Specify_one_or_more_path_or_node_module_references_to_base_configuration_files_from_which_settings_a_6633", text: "Specify one or more path or node module references to base configuration files from which settings are inherited."}
+
 var Specify_what_approach_the_watcher_should_use_if_the_system_runs_out_of_native_file_watchers = &Message{code: 6634, category: CategoryMessage, key: "Specify_what_approach_the_watcher_should_use_if_the_system_runs_out_of_native_file_watchers_6634", text: "Specify what approach the watcher should use if the system runs out of native file watchers."}
+
 var Include_a_list_of_files_This_does_not_support_glob_patterns_as_opposed_to_include = &Message{code: 6635, category: CategoryMessage, key: "Include_a_list_of_files_This_does_not_support_glob_patterns_as_opposed_to_include_6635", text: "Include a list of files. This does not support glob patterns, as opposed to `include`."}
+
 var Build_all_projects_including_those_that_appear_to_be_up_to_date = &Message{code: 6636, category: CategoryMessage, key: "Build_all_projects_including_those_that_appear_to_be_up_to_date_6636", text: "Build all projects, including those that appear to be up to date."}
+
 var Ensure_that_casing_is_correct_in_imports = &Message{code: 6637, category: CategoryMessage, key: "Ensure_that_casing_is_correct_in_imports_6637", text: "Ensure that casing is correct in imports."}
+
 var Emit_a_v8_CPU_profile_of_the_compiler_run_for_debugging = &Message{code: 6638, category: CategoryMessage, key: "Emit_a_v8_CPU_profile_of_the_compiler_run_for_debugging_6638", text: "Emit a v8 CPU profile of the compiler run for debugging."}
+
 var Allow_importing_helper_functions_from_tslib_once_per_project_instead_of_including_them_per_file = &Message{code: 6639, category: CategoryMessage, key: "Allow_importing_helper_functions_from_tslib_once_per_project_instead_of_including_them_per_file_6639", text: "Allow importing helper functions from tslib once per project, instead of including them per-file."}
+
 var Skip_building_downstream_projects_on_error_in_upstream_project = &Message{code: 6640, category: CategoryMessage, key: "Skip_building_downstream_projects_on_error_in_upstream_project_6640", text: "Skip building downstream projects on error in upstream project."}
+
 var Specify_a_list_of_glob_patterns_that_match_files_to_be_included_in_compilation = &Message{code: 6641, category: CategoryMessage, key: "Specify_a_list_of_glob_patterns_that_match_files_to_be_included_in_compilation_6641", text: "Specify a list of glob patterns that match files to be included in compilation."}
+
 var Save_tsbuildinfo_files_to_allow_for_incremental_compilation_of_projects = &Message{code: 6642, category: CategoryMessage, key: "Save_tsbuildinfo_files_to_allow_for_incremental_compilation_of_projects_6642", text: "Save .tsbuildinfo files to allow for incremental compilation of projects."}
+
 var Include_sourcemap_files_inside_the_emitted_JavaScript = &Message{code: 6643, category: CategoryMessage, key: "Include_sourcemap_files_inside_the_emitted_JavaScript_6643", text: "Include sourcemap files inside the emitted JavaScript."}
+
 var Include_source_code_in_the_sourcemaps_inside_the_emitted_JavaScript = &Message{code: 6644, category: CategoryMessage, key: "Include_source_code_in_the_sourcemaps_inside_the_emitted_JavaScript_6644", text: "Include source code in the sourcemaps inside the emitted JavaScript."}
+
 var Ensure_that_each_file_can_be_safely_transpiled_without_relying_on_other_imports = &Message{code: 6645, category: CategoryMessage, key: "Ensure_that_each_file_can_be_safely_transpiled_without_relying_on_other_imports_6645", text: "Ensure that each file can be safely transpiled without relying on other imports."}
+
 var Specify_what_JSX_code_is_generated = &Message{code: 6646, category: CategoryMessage, key: "Specify_what_JSX_code_is_generated_6646", text: "Specify what JSX code is generated."}
+
 var Specify_the_JSX_factory_function_used_when_targeting_React_JSX_emit_e_g_React_createElement_or_h = &Message{code: 6647, category: CategoryMessage, key: "Specify_the_JSX_factory_function_used_when_targeting_React_JSX_emit_e_g_React_createElement_or_h_6647", text: "Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'."}
+
 var Specify_the_JSX_Fragment_reference_used_for_fragments_when_targeting_React_JSX_emit_e_g_React_Fragment_or_Fragment = &Message{code: 6648, category: CategoryMessage, key: "Specify_the_JSX_Fragment_reference_used_for_fragments_when_targeting_React_JSX_emit_e_g_React_Fragme_6648", text: "Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'."}
+
 var Specify_module_specifier_used_to_import_the_JSX_factory_functions_when_using_jsx_Colon_react_jsx_Asterisk = &Message{code: 6649, category: CategoryMessage, key: "Specify_module_specifier_used_to_import_the_JSX_factory_functions_when_using_jsx_Colon_react_jsx_Ast_6649", text: "Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'."}
+
 var Make_keyof_only_return_strings_instead_of_string_numbers_or_symbols_Legacy_option = &Message{code: 6650, category: CategoryMessage, key: "Make_keyof_only_return_strings_instead_of_string_numbers_or_symbols_Legacy_option_6650", text: "Make keyof only return strings instead of string, numbers or symbols. Legacy option."}
+
 var Specify_a_set_of_bundled_library_declaration_files_that_describe_the_target_runtime_environment = &Message{code: 6651, category: CategoryMessage, key: "Specify_a_set_of_bundled_library_declaration_files_that_describe_the_target_runtime_environment_6651", text: "Specify a set of bundled library declaration files that describe the target runtime environment."}
+
 var Print_the_names_of_emitted_files_after_a_compilation = &Message{code: 6652, category: CategoryMessage, key: "Print_the_names_of_emitted_files_after_a_compilation_6652", text: "Print the names of emitted files after a compilation."}
+
 var Print_all_of_the_files_read_during_the_compilation = &Message{code: 6653, category: CategoryMessage, key: "Print_all_of_the_files_read_during_the_compilation_6653", text: "Print all of the files read during the compilation."}
+
 var Set_the_language_of_the_messaging_from_TypeScript_This_does_not_affect_emit = &Message{code: 6654, category: CategoryMessage, key: "Set_the_language_of_the_messaging_from_TypeScript_This_does_not_affect_emit_6654", text: "Set the language of the messaging from TypeScript. This does not affect emit."}
+
 var Specify_the_location_where_debugger_should_locate_map_files_instead_of_generated_locations = &Message{code: 6655, category: CategoryMessage, key: "Specify_the_location_where_debugger_should_locate_map_files_instead_of_generated_locations_6655", text: "Specify the location where debugger should locate map files instead of generated locations."}
+
 var Specify_the_maximum_folder_depth_used_for_checking_JavaScript_files_from_node_modules_Only_applicable_with_allowJs = &Message{code: 6656, category: CategoryMessage, key: "Specify_the_maximum_folder_depth_used_for_checking_JavaScript_files_from_node_modules_Only_applicabl_6656", text: "Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'."}
+
 var Specify_what_module_code_is_generated = &Message{code: 6657, category: CategoryMessage, key: "Specify_what_module_code_is_generated_6657", text: "Specify what module code is generated."}
+
 var Specify_how_TypeScript_looks_up_a_file_from_a_given_module_specifier = &Message{code: 6658, category: CategoryMessage, key: "Specify_how_TypeScript_looks_up_a_file_from_a_given_module_specifier_6658", text: "Specify how TypeScript looks up a file from a given module specifier."}
+
 var Set_the_newline_character_for_emitting_files = &Message{code: 6659, category: CategoryMessage, key: "Set_the_newline_character_for_emitting_files_6659", text: "Set the newline character for emitting files."}
+
 var Disable_emitting_files_from_a_compilation = &Message{code: 6660, category: CategoryMessage, key: "Disable_emitting_files_from_a_compilation_6660", text: "Disable emitting files from a compilation."}
+
 var Disable_generating_custom_helper_functions_like_extends_in_compiled_output = &Message{code: 6661, category: CategoryMessage, key: "Disable_generating_custom_helper_functions_like_extends_in_compiled_output_6661", text: "Disable generating custom helper functions like '__extends' in compiled output."}
+
 var Disable_emitting_files_if_any_type_checking_errors_are_reported = &Message{code: 6662, category: CategoryMessage, key: "Disable_emitting_files_if_any_type_checking_errors_are_reported_6662", text: "Disable emitting files if any type checking errors are reported."}
+
 var Disable_truncating_types_in_error_messages = &Message{code: 6663, category: CategoryMessage, key: "Disable_truncating_types_in_error_messages_6663", text: "Disable truncating types in error messages."}
+
 var Enable_error_reporting_for_fallthrough_cases_in_switch_statements = &Message{code: 6664, category: CategoryMessage, key: "Enable_error_reporting_for_fallthrough_cases_in_switch_statements_6664", text: "Enable error reporting for fallthrough cases in switch statements."}
+
 var Enable_error_reporting_for_expressions_and_declarations_with_an_implied_any_type = &Message{code: 6665, category: CategoryMessage, key: "Enable_error_reporting_for_expressions_and_declarations_with_an_implied_any_type_6665", text: "Enable error reporting for expressions and declarations with an implied 'any' type."}
+
 var Ensure_overriding_members_in_derived_classes_are_marked_with_an_override_modifier = &Message{code: 6666, category: CategoryMessage, key: "Ensure_overriding_members_in_derived_classes_are_marked_with_an_override_modifier_6666", text: "Ensure overriding members in derived classes are marked with an override modifier."}
+
 var Enable_error_reporting_for_codepaths_that_do_not_explicitly_return_in_a_function = &Message{code: 6667, category: CategoryMessage, key: "Enable_error_reporting_for_codepaths_that_do_not_explicitly_return_in_a_function_6667", text: "Enable error reporting for codepaths that do not explicitly return in a function."}
+
 var Enable_error_reporting_when_this_is_given_the_type_any = &Message{code: 6668, category: CategoryMessage, key: "Enable_error_reporting_when_this_is_given_the_type_any_6668", text: "Enable error reporting when 'this' is given the type 'any'."}
+
 var Disable_adding_use_strict_directives_in_emitted_JavaScript_files = &Message{code: 6669, category: CategoryMessage, key: "Disable_adding_use_strict_directives_in_emitted_JavaScript_files_6669", text: "Disable adding 'use strict' directives in emitted JavaScript files."}
+
 var Disable_including_any_library_files_including_the_default_lib_d_ts = &Message{code: 6670, category: CategoryMessage, key: "Disable_including_any_library_files_including_the_default_lib_d_ts_6670", text: "Disable including any library files, including the default lib.d.ts."}
+
 var Enforces_using_indexed_accessors_for_keys_declared_using_an_indexed_type = &Message{code: 6671, category: CategoryMessage, key: "Enforces_using_indexed_accessors_for_keys_declared_using_an_indexed_type_6671", text: "Enforces using indexed accessors for keys declared using an indexed type."}
+
 var Disallow_import_s_require_s_or_reference_s_from_expanding_the_number_of_files_TypeScript_should_add_to_a_project = &Message{code: 6672, category: CategoryMessage, key: "Disallow_import_s_require_s_or_reference_s_from_expanding_the_number_of_files_TypeScript_should_add__6672", text: "Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project."}
+
 var Disable_strict_checking_of_generic_signatures_in_function_types = &Message{code: 6673, category: CategoryMessage, key: "Disable_strict_checking_of_generic_signatures_in_function_types_6673", text: "Disable strict checking of generic signatures in function types."}
+
 var Add_undefined_to_a_type_when_accessed_using_an_index = &Message{code: 6674, category: CategoryMessage, key: "Add_undefined_to_a_type_when_accessed_using_an_index_6674", text: "Add 'undefined' to a type when accessed using an index."}
+
 var Enable_error_reporting_when_local_variables_aren_t_read = &Message{code: 6675, category: CategoryMessage, key: "Enable_error_reporting_when_local_variables_aren_t_read_6675", text: "Enable error reporting when local variables aren't read."}
+
 var Raise_an_error_when_a_function_parameter_isn_t_read = &Message{code: 6676, category: CategoryMessage, key: "Raise_an_error_when_a_function_parameter_isn_t_read_6676", text: "Raise an error when a function parameter isn't read."}
+
 var Deprecated_setting_Use_outFile_instead = &Message{code: 6677, category: CategoryMessage, key: "Deprecated_setting_Use_outFile_instead_6677", text: "Deprecated setting. Use 'outFile' instead."}
+
 var Specify_an_output_folder_for_all_emitted_files = &Message{code: 6678, category: CategoryMessage, key: "Specify_an_output_folder_for_all_emitted_files_6678", text: "Specify an output folder for all emitted files."}
+
 var Specify_a_file_that_bundles_all_outputs_into_one_JavaScript_file_If_declaration_is_true_also_designates_a_file_that_bundles_all_d_ts_output = &Message{code: 6679, category: CategoryMessage, key: "Specify_a_file_that_bundles_all_outputs_into_one_JavaScript_file_If_declaration_is_true_also_designa_6679", text: "Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output."}
+
 var Specify_a_set_of_entries_that_re_map_imports_to_additional_lookup_locations = &Message{code: 6680, category: CategoryMessage, key: "Specify_a_set_of_entries_that_re_map_imports_to_additional_lookup_locations_6680", text: "Specify a set of entries that re-map imports to additional lookup locations."}
+
 var Specify_a_list_of_language_service_plugins_to_include = &Message{code: 6681, category: CategoryMessage, key: "Specify_a_list_of_language_service_plugins_to_include_6681", text: "Specify a list of language service plugins to include."}
+
 var Disable_erasing_const_enum_declarations_in_generated_code = &Message{code: 6682, category: CategoryMessage, key: "Disable_erasing_const_enum_declarations_in_generated_code_6682", text: "Disable erasing 'const enum' declarations in generated code."}
+
 var Disable_resolving_symlinks_to_their_realpath_This_correlates_to_the_same_flag_in_node = &Message{code: 6683, category: CategoryMessage, key: "Disable_resolving_symlinks_to_their_realpath_This_correlates_to_the_same_flag_in_node_6683", text: "Disable resolving symlinks to their realpath. This correlates to the same flag in node."}
+
 var Disable_wiping_the_console_in_watch_mode = &Message{code: 6684, category: CategoryMessage, key: "Disable_wiping_the_console_in_watch_mode_6684", text: "Disable wiping the console in watch mode."}
+
 var Enable_color_and_formatting_in_TypeScript_s_output_to_make_compiler_errors_easier_to_read = &Message{code: 6685, category: CategoryMessage, key: "Enable_color_and_formatting_in_TypeScript_s_output_to_make_compiler_errors_easier_to_read_6685", text: "Enable color and formatting in TypeScript's output to make compiler errors easier to read."}
+
 var Specify_the_object_invoked_for_createElement_This_only_applies_when_targeting_react_JSX_emit = &Message{code: 6686, category: CategoryMessage, key: "Specify_the_object_invoked_for_createElement_This_only_applies_when_targeting_react_JSX_emit_6686", text: "Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit."}
+
 var Specify_an_array_of_objects_that_specify_paths_for_projects_Used_in_project_references = &Message{code: 6687, category: CategoryMessage, key: "Specify_an_array_of_objects_that_specify_paths_for_projects_Used_in_project_references_6687", text: "Specify an array of objects that specify paths for projects. Used in project references."}
+
 var Disable_emitting_comments = &Message{code: 6688, category: CategoryMessage, key: "Disable_emitting_comments_6688", text: "Disable emitting comments."}
+
 var Enable_importing_json_files = &Message{code: 6689, category: CategoryMessage, key: "Enable_importing_json_files_6689", text: "Enable importing .json files."}
+
 var Specify_the_root_folder_within_your_source_files = &Message{code: 6690, category: CategoryMessage, key: "Specify_the_root_folder_within_your_source_files_6690", text: "Specify the root folder within your source files."}
+
 var Allow_multiple_folders_to_be_treated_as_one_when_resolving_modules = &Message{code: 6691, category: CategoryMessage, key: "Allow_multiple_folders_to_be_treated_as_one_when_resolving_modules_6691", text: "Allow multiple folders to be treated as one when resolving modules."}
+
 var Skip_type_checking_d_ts_files_that_are_included_with_TypeScript = &Message{code: 6692, category: CategoryMessage, key: "Skip_type_checking_d_ts_files_that_are_included_with_TypeScript_6692", text: "Skip type checking .d.ts files that are included with TypeScript."}
+
 var Skip_type_checking_all_d_ts_files = &Message{code: 6693, category: CategoryMessage, key: "Skip_type_checking_all_d_ts_files_6693", text: "Skip type checking all .d.ts files."}
+
 var Create_source_map_files_for_emitted_JavaScript_files = &Message{code: 6694, category: CategoryMessage, key: "Create_source_map_files_for_emitted_JavaScript_files_6694", text: "Create source map files for emitted JavaScript files."}
+
 var Specify_the_root_path_for_debuggers_to_find_the_reference_source_code = &Message{code: 6695, category: CategoryMessage, key: "Specify_the_root_path_for_debuggers_to_find_the_reference_source_code_6695", text: "Specify the root path for debuggers to find the reference source code."}
+
 var Check_that_the_arguments_for_bind_call_and_apply_methods_match_the_original_function = &Message{code: 6697, category: CategoryMessage, key: "Check_that_the_arguments_for_bind_call_and_apply_methods_match_the_original_function_6697", text: "Check that the arguments for 'bind', 'call', and 'apply' methods match the original function."}
+
 var When_assigning_functions_check_to_ensure_parameters_and_the_return_values_are_subtype_compatible = &Message{code: 6698, category: CategoryMessage, key: "When_assigning_functions_check_to_ensure_parameters_and_the_return_values_are_subtype_compatible_6698", text: "When assigning functions, check to ensure parameters and the return values are subtype-compatible."}
+
 var When_type_checking_take_into_account_null_and_undefined = &Message{code: 6699, category: CategoryMessage, key: "When_type_checking_take_into_account_null_and_undefined_6699", text: "When type checking, take into account 'null' and 'undefined'."}
+
 var Check_for_class_properties_that_are_declared_but_not_set_in_the_constructor = &Message{code: 6700, category: CategoryMessage, key: "Check_for_class_properties_that_are_declared_but_not_set_in_the_constructor_6700", text: "Check for class properties that are declared but not set in the constructor."}
+
 var Disable_emitting_declarations_that_have_internal_in_their_JSDoc_comments = &Message{code: 6701, category: CategoryMessage, key: "Disable_emitting_declarations_that_have_internal_in_their_JSDoc_comments_6701", text: "Disable emitting declarations that have '@internal' in their JSDoc comments."}
+
 var Disable_reporting_of_excess_property_errors_during_the_creation_of_object_literals = &Message{code: 6702, category: CategoryMessage, key: "Disable_reporting_of_excess_property_errors_during_the_creation_of_object_literals_6702", text: "Disable reporting of excess property errors during the creation of object literals."}
+
 var Suppress_noImplicitAny_errors_when_indexing_objects_that_lack_index_signatures = &Message{code: 6703, category: CategoryMessage, key: "Suppress_noImplicitAny_errors_when_indexing_objects_that_lack_index_signatures_6703", text: "Suppress 'noImplicitAny' errors when indexing objects that lack index signatures."}
+
 var Synchronously_call_callbacks_and_update_the_state_of_directory_watchers_on_platforms_that_don_t_support_recursive_watching_natively = &Message{code: 6704, category: CategoryMessage, key: "Synchronously_call_callbacks_and_update_the_state_of_directory_watchers_on_platforms_that_don_t_supp_6704", text: "Synchronously call callbacks and update the state of directory watchers on platforms that don`t support recursive watching natively."}
+
 var Set_the_JavaScript_language_version_for_emitted_JavaScript_and_include_compatible_library_declarations = &Message{code: 6705, category: CategoryMessage, key: "Set_the_JavaScript_language_version_for_emitted_JavaScript_and_include_compatible_library_declaratio_6705", text: "Set the JavaScript language version for emitted JavaScript and include compatible library declarations."}
+
 var Log_paths_used_during_the_moduleResolution_process = &Message{code: 6706, category: CategoryMessage, key: "Log_paths_used_during_the_moduleResolution_process_6706", text: "Log paths used during the 'moduleResolution' process."}
+
 var Specify_the_path_to_tsbuildinfo_incremental_compilation_file = &Message{code: 6707, category: CategoryMessage, key: "Specify_the_path_to_tsbuildinfo_incremental_compilation_file_6707", text: "Specify the path to .tsbuildinfo incremental compilation file."}
+
 var Specify_options_for_automatic_acquisition_of_declaration_files = &Message{code: 6709, category: CategoryMessage, key: "Specify_options_for_automatic_acquisition_of_declaration_files_6709", text: "Specify options for automatic acquisition of declaration files."}
+
 var Specify_multiple_folders_that_act_like_Slashnode_modules_Slash_types = &Message{code: 6710, category: CategoryMessage, key: "Specify_multiple_folders_that_act_like_Slashnode_modules_Slash_types_6710", text: "Specify multiple folders that act like './node_modules/@types'."}
+
 var Specify_type_package_names_to_be_included_without_being_referenced_in_a_source_file = &Message{code: 6711, category: CategoryMessage, key: "Specify_type_package_names_to_be_included_without_being_referenced_in_a_source_file_6711", text: "Specify type package names to be included without being referenced in a source file."}
+
 var Emit_ECMAScript_standard_compliant_class_fields = &Message{code: 6712, category: CategoryMessage, key: "Emit_ECMAScript_standard_compliant_class_fields_6712", text: "Emit ECMAScript-standard-compliant class fields."}
+
 var Enable_verbose_logging = &Message{code: 6713, category: CategoryMessage, key: "Enable_verbose_logging_6713", text: "Enable verbose logging."}
+
 var Specify_how_directories_are_watched_on_systems_that_lack_recursive_file_watching_functionality = &Message{code: 6714, category: CategoryMessage, key: "Specify_how_directories_are_watched_on_systems_that_lack_recursive_file_watching_functionality_6714", text: "Specify how directories are watched on systems that lack recursive file-watching functionality."}
+
 var Specify_how_the_TypeScript_watch_mode_works = &Message{code: 6715, category: CategoryMessage, key: "Specify_how_the_TypeScript_watch_mode_works_6715", text: "Specify how the TypeScript watch mode works."}
+
 var Require_undeclared_properties_from_index_signatures_to_use_element_accesses = &Message{code: 6717, category: CategoryMessage, key: "Require_undeclared_properties_from_index_signatures_to_use_element_accesses_6717", text: "Require undeclared properties from index signatures to use element accesses."}
+
 var Specify_emit_Slashchecking_behavior_for_imports_that_are_only_used_for_types = &Message{code: 6718, category: CategoryMessage, key: "Specify_emit_Slashchecking_behavior_for_imports_that_are_only_used_for_types_6718", text: "Specify emit/checking behavior for imports that are only used for types."}
+
 var Require_sufficient_annotation_on_exports_so_other_tools_can_trivially_generate_declaration_files = &Message{code: 6719, category: CategoryMessage, key: "Require_sufficient_annotation_on_exports_so_other_tools_can_trivially_generate_declaration_files_6719", text: "Require sufficient annotation on exports so other tools can trivially generate declaration files."}
+
 var Built_in_iterators_are_instantiated_with_a_TReturn_type_of_undefined_instead_of_any = &Message{code: 6720, category: CategoryMessage, key: "Built_in_iterators_are_instantiated_with_a_TReturn_type_of_undefined_instead_of_any_6720", text: "Built-in iterators are instantiated with a 'TReturn' type of 'undefined' instead of 'any'."}
+
 var Do_not_allow_runtime_constructs_that_are_not_part_of_ECMAScript = &Message{code: 6721, category: CategoryMessage, key: "Do_not_allow_runtime_constructs_that_are_not_part_of_ECMAScript_6721", text: "Do not allow runtime constructs that are not part of ECMAScript."}
+
 var Default_catch_clause_variables_as_unknown_instead_of_any = &Message{code: 6803, category: CategoryMessage, key: "Default_catch_clause_variables_as_unknown_instead_of_any_6803", text: "Default catch clause variables as 'unknown' instead of 'any'."}
+
 var Do_not_transform_or_elide_any_imports_or_exports_not_marked_as_type_only_ensuring_they_are_written_in_the_output_file_s_format_based_on_the_module_setting = &Message{code: 6804, category: CategoryMessage, key: "Do_not_transform_or_elide_any_imports_or_exports_not_marked_as_type_only_ensuring_they_are_written_i_6804", text: "Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting."}
+
 var Disable_full_type_checking_only_critical_parse_and_emit_errors_will_be_reported = &Message{code: 6805, category: CategoryMessage, key: "Disable_full_type_checking_only_critical_parse_and_emit_errors_will_be_reported_6805", text: "Disable full type checking (only critical parse and emit errors will be reported)."}
+
 var Check_side_effect_imports = &Message{code: 6806, category: CategoryMessage, key: "Check_side_effect_imports_6806", text: "Check side effect imports."}
+
 var This_operation_can_be_simplified_This_shift_is_identical_to_0_1_2 = &Message{code: 6807, category: CategoryError, key: "This_operation_can_be_simplified_This_shift_is_identical_to_0_1_2_6807", text: "This operation can be simplified. This shift is identical to `{0} {1} {2}`."}
+
 var Enable_lib_replacement = &Message{code: 6808, category: CategoryMessage, key: "Enable_lib_replacement_6808", text: "Enable lib replacement."}
+
 var X_one_of_Colon = &Message{code: 6900, category: CategoryMessage, key: "one_of_Colon_6900", text: "one of:"}
+
 var X_one_or_more_Colon = &Message{code: 6901, category: CategoryMessage, key: "one_or_more_Colon_6901", text: "one or more:"}
+
 var X_type_Colon = &Message{code: 6902, category: CategoryMessage, key: "type_Colon_6902", text: "type:"}
+
 var X_default_Colon = &Message{code: 6903, category: CategoryMessage, key: "default_Colon_6903", text: "default:"}
+
 var X_module_system_or_esModuleInterop = &Message{code: 6904, category: CategoryMessage, key: "module_system_or_esModuleInterop_6904", text: "module === \"system\" or esModuleInterop"}
+
 var X_false_unless_strict_is_set = &Message{code: 6905, category: CategoryMessage, key: "false_unless_strict_is_set_6905", text: "`false`, unless `strict` is set"}
+
 var X_false_unless_composite_is_set = &Message{code: 6906, category: CategoryMessage, key: "false_unless_composite_is_set_6906", text: "`false`, unless `composite` is set"}
+
 var X_node_modules_bower_components_jspm_packages_plus_the_value_of_outDir_if_one_is_specified = &Message{code: 6907, category: CategoryMessage, key: "node_modules_bower_components_jspm_packages_plus_the_value_of_outDir_if_one_is_specified_6907", text: "`[\"node_modules\", \"bower_components\", \"jspm_packages\"]`, plus the value of `outDir` if one is specified."}
+
 var X_if_files_is_specified_otherwise_Asterisk_Asterisk_Slash_Asterisk = &Message{code: 6908, category: CategoryMessage, key: "if_files_is_specified_otherwise_Asterisk_Asterisk_Slash_Asterisk_6908", text: "`[]` if `files` is specified, otherwise `[\"**/*\"]`"}
+
 var X_true_if_composite_false_otherwise = &Message{code: 6909, category: CategoryMessage, key: "true_if_composite_false_otherwise_6909", text: "`true` if `composite`, `false` otherwise"}
+
 var Computed_from_the_list_of_input_files = &Message{code: 6911, category: CategoryMessage, key: "Computed_from_the_list_of_input_files_6911", text: "Computed from the list of input files"}
+
 var Platform_specific = &Message{code: 6912, category: CategoryMessage, key: "Platform_specific_6912", text: "Platform specific"}
+
 var You_can_learn_about_all_of_the_compiler_options_at_0 = &Message{code: 6913, category: CategoryMessage, key: "You_can_learn_about_all_of_the_compiler_options_at_0_6913", text: "You can learn about all of the compiler options at {0}"}
+
 var Including_watch_w_will_start_watching_the_current_project_for_the_file_changes_Once_set_you_can_config_watch_mode_with_Colon = &Message{code: 6914, category: CategoryMessage, key: "Including_watch_w_will_start_watching_the_current_project_for_the_file_changes_Once_set_you_can_conf_6914", text: "Including --watch, -w will start watching the current project for the file changes. Once set, you can config watch mode with:"}
+
 var Using_build_b_will_make_tsc_behave_more_like_a_build_orchestrator_than_a_compiler_This_is_used_to_trigger_building_composite_projects_which_you_can_learn_more_about_at_0 = &Message{code: 6915, category: CategoryMessage, key: "Using_build_b_will_make_tsc_behave_more_like_a_build_orchestrator_than_a_compiler_This_is_used_to_tr_6915", text: "Using --build, -b will make tsc behave more like a build orchestrator than a compiler. This is used to trigger building composite projects which you can learn more about at {0}"}
+
 var COMMON_COMMANDS = &Message{code: 6916, category: CategoryMessage, key: "COMMON_COMMANDS_6916", text: "COMMON COMMANDS"}
+
 var ALL_COMPILER_OPTIONS = &Message{code: 6917, category: CategoryMessage, key: "ALL_COMPILER_OPTIONS_6917", text: "ALL COMPILER OPTIONS"}
+
 var WATCH_OPTIONS = &Message{code: 6918, category: CategoryMessage, key: "WATCH_OPTIONS_6918", text: "WATCH OPTIONS"}
+
 var BUILD_OPTIONS = &Message{code: 6919, category: CategoryMessage, key: "BUILD_OPTIONS_6919", text: "BUILD OPTIONS"}
+
 var COMMON_COMPILER_OPTIONS = &Message{code: 6920, category: CategoryMessage, key: "COMMON_COMPILER_OPTIONS_6920", text: "COMMON COMPILER OPTIONS"}
+
 var COMMAND_LINE_FLAGS = &Message{code: 6921, category: CategoryMessage, key: "COMMAND_LINE_FLAGS_6921", text: "COMMAND LINE FLAGS"}
+
 var X_tsc_Colon_The_TypeScript_Compiler = &Message{code: 6922, category: CategoryMessage, key: "tsc_Colon_The_TypeScript_Compiler_6922", text: "tsc: The TypeScript Compiler"}
+
 var Compiles_the_current_project_tsconfig_json_in_the_working_directory = &Message{code: 6923, category: CategoryMessage, key: "Compiles_the_current_project_tsconfig_json_in_the_working_directory_6923", text: "Compiles the current project (tsconfig.json in the working directory.)"}
+
 var Ignoring_tsconfig_json_compiles_the_specified_files_with_default_compiler_options = &Message{code: 6924, category: CategoryMessage, key: "Ignoring_tsconfig_json_compiles_the_specified_files_with_default_compiler_options_6924", text: "Ignoring tsconfig.json, compiles the specified files with default compiler options."}
+
 var Build_a_composite_project_in_the_working_directory = &Message{code: 6925, category: CategoryMessage, key: "Build_a_composite_project_in_the_working_directory_6925", text: "Build a composite project in the working directory."}
+
 var Creates_a_tsconfig_json_with_the_recommended_settings_in_the_working_directory = &Message{code: 6926, category: CategoryMessage, key: "Creates_a_tsconfig_json_with_the_recommended_settings_in_the_working_directory_6926", text: "Creates a tsconfig.json with the recommended settings in the working directory."}
+
 var Compiles_the_TypeScript_project_located_at_the_specified_path = &Message{code: 6927, category: CategoryMessage, key: "Compiles_the_TypeScript_project_located_at_the_specified_path_6927", text: "Compiles the TypeScript project located at the specified path."}
+
 var An_expanded_version_of_this_information_showing_all_possible_compiler_options = &Message{code: 6928, category: CategoryMessage, key: "An_expanded_version_of_this_information_showing_all_possible_compiler_options_6928", text: "An expanded version of this information, showing all possible compiler options"}
+
 var Compiles_the_current_project_with_additional_settings = &Message{code: 6929, category: CategoryMessage, key: "Compiles_the_current_project_with_additional_settings_6929", text: "Compiles the current project, with additional settings."}
+
 var X_true_for_ES2022_and_above_including_ESNext = &Message{code: 6930, category: CategoryMessage, key: "true_for_ES2022_and_above_including_ESNext_6930", text: "`true` for ES2022 and above, including ESNext."}
+
 var List_of_file_name_suffixes_to_search_when_resolving_a_module = &Message{code: 6931, category: CategoryError, key: "List_of_file_name_suffixes_to_search_when_resolving_a_module_6931", text: "List of file name suffixes to search when resolving a module."}
+
 var Variable_0_implicitly_has_an_1_type = &Message{code: 7005, category: CategoryError, key: "Variable_0_implicitly_has_an_1_type_7005", text: "Variable '{0}' implicitly has an '{1}' type."}
+
 var Parameter_0_implicitly_has_an_1_type = &Message{code: 7006, category: CategoryError, key: "Parameter_0_implicitly_has_an_1_type_7006", text: "Parameter '{0}' implicitly has an '{1}' type."}
+
 var Member_0_implicitly_has_an_1_type = &Message{code: 7008, category: CategoryError, key: "Member_0_implicitly_has_an_1_type_7008", text: "Member '{0}' implicitly has an '{1}' type."}
+
 var X_new_expression_whose_target_lacks_a_construct_signature_implicitly_has_an_any_type = &Message{code: 7009, category: CategoryError, key: "new_expression_whose_target_lacks_a_construct_signature_implicitly_has_an_any_type_7009", text: "'new' expression, whose target lacks a construct signature, implicitly has an 'any' type."}
+
 var X_0_which_lacks_return_type_annotation_implicitly_has_an_1_return_type = &Message{code: 7010, category: CategoryError, key: "_0_which_lacks_return_type_annotation_implicitly_has_an_1_return_type_7010", text: "'{0}', which lacks return-type annotation, implicitly has an '{1}' return type."}
+
 var Function_expression_which_lacks_return_type_annotation_implicitly_has_an_0_return_type = &Message{code: 7011, category: CategoryError, key: "Function_expression_which_lacks_return_type_annotation_implicitly_has_an_0_return_type_7011", text: "Function expression, which lacks return-type annotation, implicitly has an '{0}' return type."}
+
 var This_overload_implicitly_returns_the_type_0_because_it_lacks_a_return_type_annotation = &Message{code: 7012, category: CategoryError, key: "This_overload_implicitly_returns_the_type_0_because_it_lacks_a_return_type_annotation_7012", text: "This overload implicitly returns the type '{0}' because it lacks a return type annotation."}
+
 var Construct_signature_which_lacks_return_type_annotation_implicitly_has_an_any_return_type = &Message{code: 7013, category: CategoryError, key: "Construct_signature_which_lacks_return_type_annotation_implicitly_has_an_any_return_type_7013", text: "Construct signature, which lacks return-type annotation, implicitly has an 'any' return type."}
+
 var Function_type_which_lacks_return_type_annotation_implicitly_has_an_0_return_type = &Message{code: 7014, category: CategoryError, key: "Function_type_which_lacks_return_type_annotation_implicitly_has_an_0_return_type_7014", text: "Function type, which lacks return-type annotation, implicitly has an '{0}' return type."}
+
 var Element_implicitly_has_an_any_type_because_index_expression_is_not_of_type_number = &Message{code: 7015, category: CategoryError, key: "Element_implicitly_has_an_any_type_because_index_expression_is_not_of_type_number_7015", text: "Element implicitly has an 'any' type because index expression is not of type 'number'."}
+
 var Could_not_find_a_declaration_file_for_module_0_1_implicitly_has_an_any_type = &Message{code: 7016, category: CategoryError, key: "Could_not_find_a_declaration_file_for_module_0_1_implicitly_has_an_any_type_7016", text: "Could not find a declaration file for module '{0}'. '{1}' implicitly has an 'any' type."}
+
 var Element_implicitly_has_an_any_type_because_type_0_has_no_index_signature = &Message{code: 7017, category: CategoryError, key: "Element_implicitly_has_an_any_type_because_type_0_has_no_index_signature_7017", text: "Element implicitly has an 'any' type because type '{0}' has no index signature."}
+
 var Object_literal_s_property_0_implicitly_has_an_1_type = &Message{code: 7018, category: CategoryError, key: "Object_literal_s_property_0_implicitly_has_an_1_type_7018", text: "Object literal's property '{0}' implicitly has an '{1}' type."}
+
 var Rest_parameter_0_implicitly_has_an_any_type = &Message{code: 7019, category: CategoryError, key: "Rest_parameter_0_implicitly_has_an_any_type_7019", text: "Rest parameter '{0}' implicitly has an 'any[]' type."}
+
 var Call_signature_which_lacks_return_type_annotation_implicitly_has_an_any_return_type = &Message{code: 7020, category: CategoryError, key: "Call_signature_which_lacks_return_type_annotation_implicitly_has_an_any_return_type_7020", text: "Call signature, which lacks return-type annotation, implicitly has an 'any' return type."}
+
 var X_0_implicitly_has_type_any_because_it_does_not_have_a_type_annotation_and_is_referenced_directly_or_indirectly_in_its_own_initializer = &Message{code: 7022, category: CategoryError, key: "_0_implicitly_has_type_any_because_it_does_not_have_a_type_annotation_and_is_referenced_directly_or__7022", text: "'{0}' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer."}
+
 var X_0_implicitly_has_return_type_any_because_it_does_not_have_a_return_type_annotation_and_is_referenced_directly_or_indirectly_in_one_of_its_return_expressions = &Message{code: 7023, category: CategoryError, key: "_0_implicitly_has_return_type_any_because_it_does_not_have_a_return_type_annotation_and_is_reference_7023", text: "'{0}' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions."}
+
 var Function_implicitly_has_return_type_any_because_it_does_not_have_a_return_type_annotation_and_is_referenced_directly_or_indirectly_in_one_of_its_return_expressions = &Message{code: 7024, category: CategoryError, key: "Function_implicitly_has_return_type_any_because_it_does_not_have_a_return_type_annotation_and_is_ref_7024", text: "Function implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions."}
+
 var Generator_implicitly_has_yield_type_0_Consider_supplying_a_return_type_annotation = &Message{code: 7025, category: CategoryError, key: "Generator_implicitly_has_yield_type_0_Consider_supplying_a_return_type_annotation_7025", text: "Generator implicitly has yield type '{0}'. Consider supplying a return type annotation."}
+
 var JSX_element_implicitly_has_type_any_because_no_interface_JSX_0_exists = &Message{code: 7026, category: CategoryError, key: "JSX_element_implicitly_has_type_any_because_no_interface_JSX_0_exists_7026", text: "JSX element implicitly has type 'any' because no interface 'JSX.{0}' exists."}
+
 var Unreachable_code_detected = &Message{code: 7027, category: CategoryError, key: "Unreachable_code_detected_7027", text: "Unreachable code detected.", reportsUnnecessary: true}
+
 var Unused_label = &Message{code: 7028, category: CategoryError, key: "Unused_label_7028", text: "Unused label.", reportsUnnecessary: true}
+
 var Fallthrough_case_in_switch = &Message{code: 7029, category: CategoryError, key: "Fallthrough_case_in_switch_7029", text: "Fallthrough case in switch."}
+
 var Not_all_code_paths_return_a_value = &Message{code: 7030, category: CategoryError, key: "Not_all_code_paths_return_a_value_7030", text: "Not all code paths return a value."}
+
 var Binding_element_0_implicitly_has_an_1_type = &Message{code: 7031, category: CategoryError, key: "Binding_element_0_implicitly_has_an_1_type_7031", text: "Binding element '{0}' implicitly has an '{1}' type."}
+
 var Property_0_implicitly_has_type_any_because_its_set_accessor_lacks_a_parameter_type_annotation = &Message{code: 7032, category: CategoryError, key: "Property_0_implicitly_has_type_any_because_its_set_accessor_lacks_a_parameter_type_annotation_7032", text: "Property '{0}' implicitly has type 'any', because its set accessor lacks a parameter type annotation."}
+
 var Property_0_implicitly_has_type_any_because_its_get_accessor_lacks_a_return_type_annotation = &Message{code: 7033, category: CategoryError, key: "Property_0_implicitly_has_type_any_because_its_get_accessor_lacks_a_return_type_annotation_7033", text: "Property '{0}' implicitly has type 'any', because its get accessor lacks a return type annotation."}
+
 var Variable_0_implicitly_has_type_1_in_some_locations_where_its_type_cannot_be_determined = &Message{code: 7034, category: CategoryError, key: "Variable_0_implicitly_has_type_1_in_some_locations_where_its_type_cannot_be_determined_7034", text: "Variable '{0}' implicitly has type '{1}' in some locations where its type cannot be determined."}
+
 var Try_npm_i_save_dev_types_Slash_1_if_it_exists_or_add_a_new_declaration_d_ts_file_containing_declare_module_0 = &Message{code: 7035, category: CategoryError, key: "Try_npm_i_save_dev_types_Slash_1_if_it_exists_or_add_a_new_declaration_d_ts_file_containing_declare__7035", text: "Try `npm i --save-dev @types/{1}` if it exists or add a new declaration (.d.ts) file containing `declare module '{0}';`"}
+
 var Dynamic_import_s_specifier_must_be_of_type_string_but_here_has_type_0 = &Message{code: 7036, category: CategoryError, key: "Dynamic_import_s_specifier_must_be_of_type_string_but_here_has_type_0_7036", text: "Dynamic import's specifier must be of type 'string', but here has type '{0}'."}
+
 var Enables_emit_interoperability_between_CommonJS_and_ES_Modules_via_creation_of_namespace_objects_for_all_imports_Implies_allowSyntheticDefaultImports = &Message{code: 7037, category: CategoryMessage, key: "Enables_emit_interoperability_between_CommonJS_and_ES_Modules_via_creation_of_namespace_objects_for__7037", text: "Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'."}
+
 var Type_originates_at_this_import_A_namespace_style_import_cannot_be_called_or_constructed_and_will_cause_a_failure_at_runtime_Consider_using_a_default_import_or_import_require_here_instead = &Message{code: 7038, category: CategoryMessage, key: "Type_originates_at_this_import_A_namespace_style_import_cannot_be_called_or_constructed_and_will_cau_7038", text: "Type originates at this import. A namespace-style import cannot be called or constructed, and will cause a failure at runtime. Consider using a default import or import require here instead."}
+
 var Mapped_object_type_implicitly_has_an_any_template_type = &Message{code: 7039, category: CategoryError, key: "Mapped_object_type_implicitly_has_an_any_template_type_7039", text: "Mapped object type implicitly has an 'any' template type."}
+
 var If_the_0_package_actually_exposes_this_module_consider_sending_a_pull_request_to_amend_https_Colon_Slash_Slashgithub_com_SlashDefinitelyTyped_SlashDefinitelyTyped_Slashtree_Slashmaster_Slashtypes_Slash_1 = &Message{code: 7040, category: CategoryError, key: "If_the_0_package_actually_exposes_this_module_consider_sending_a_pull_request_to_amend_https_Colon_S_7040", text: "If the '{0}' package actually exposes this module, consider sending a pull request to amend 'https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/{1}'"}
+
 var The_containing_arrow_function_captures_the_global_value_of_this = &Message{code: 7041, category: CategoryError, key: "The_containing_arrow_function_captures_the_global_value_of_this_7041", text: "The containing arrow function captures the global value of 'this'."}
+
 var Module_0_was_resolved_to_1_but_resolveJsonModule_is_not_used = &Message{code: 7042, category: CategoryError, key: "Module_0_was_resolved_to_1_but_resolveJsonModule_is_not_used_7042", text: "Module '{0}' was resolved to '{1}', but '--resolveJsonModule' is not used."}
+
 var Variable_0_implicitly_has_an_1_type_but_a_better_type_may_be_inferred_from_usage = &Message{code: 7043, category: CategorySuggestion, key: "Variable_0_implicitly_has_an_1_type_but_a_better_type_may_be_inferred_from_usage_7043", text: "Variable '{0}' implicitly has an '{1}' type, but a better type may be inferred from usage."}
+
 var Parameter_0_implicitly_has_an_1_type_but_a_better_type_may_be_inferred_from_usage = &Message{code: 7044, category: CategorySuggestion, key: "Parameter_0_implicitly_has_an_1_type_but_a_better_type_may_be_inferred_from_usage_7044", text: "Parameter '{0}' implicitly has an '{1}' type, but a better type may be inferred from usage."}
+
 var Member_0_implicitly_has_an_1_type_but_a_better_type_may_be_inferred_from_usage = &Message{code: 7045, category: CategorySuggestion, key: "Member_0_implicitly_has_an_1_type_but_a_better_type_may_be_inferred_from_usage_7045", text: "Member '{0}' implicitly has an '{1}' type, but a better type may be inferred from usage."}
+
 var Variable_0_implicitly_has_type_1_in_some_locations_but_a_better_type_may_be_inferred_from_usage = &Message{code: 7046, category: CategorySuggestion, key: "Variable_0_implicitly_has_type_1_in_some_locations_but_a_better_type_may_be_inferred_from_usage_7046", text: "Variable '{0}' implicitly has type '{1}' in some locations, but a better type may be inferred from usage."}
+
 var Rest_parameter_0_implicitly_has_an_any_type_but_a_better_type_may_be_inferred_from_usage = &Message{code: 7047, category: CategorySuggestion, key: "Rest_parameter_0_implicitly_has_an_any_type_but_a_better_type_may_be_inferred_from_usage_7047", text: "Rest parameter '{0}' implicitly has an 'any[]' type, but a better type may be inferred from usage."}
+
 var Property_0_implicitly_has_type_any_but_a_better_type_for_its_get_accessor_may_be_inferred_from_usage = &Message{code: 7048, category: CategorySuggestion, key: "Property_0_implicitly_has_type_any_but_a_better_type_for_its_get_accessor_may_be_inferred_from_usage_7048", text: "Property '{0}' implicitly has type 'any', but a better type for its get accessor may be inferred from usage."}
+
 var Property_0_implicitly_has_type_any_but_a_better_type_for_its_set_accessor_may_be_inferred_from_usage = &Message{code: 7049, category: CategorySuggestion, key: "Property_0_implicitly_has_type_any_but_a_better_type_for_its_set_accessor_may_be_inferred_from_usage_7049", text: "Property '{0}' implicitly has type 'any', but a better type for its set accessor may be inferred from usage."}
+
 var X_0_implicitly_has_an_1_return_type_but_a_better_type_may_be_inferred_from_usage = &Message{code: 7050, category: CategorySuggestion, key: "_0_implicitly_has_an_1_return_type_but_a_better_type_may_be_inferred_from_usage_7050", text: "'{0}' implicitly has an '{1}' return type, but a better type may be inferred from usage."}
+
 var Parameter_has_a_name_but_no_type_Did_you_mean_0_Colon_1 = &Message{code: 7051, category: CategoryError, key: "Parameter_has_a_name_but_no_type_Did_you_mean_0_Colon_1_7051", text: "Parameter has a name but no type. Did you mean '{0}: {1}'?"}
+
 var Element_implicitly_has_an_any_type_because_type_0_has_no_index_signature_Did_you_mean_to_call_1 = &Message{code: 7052, category: CategoryError, key: "Element_implicitly_has_an_any_type_because_type_0_has_no_index_signature_Did_you_mean_to_call_1_7052", text: "Element implicitly has an 'any' type because type '{0}' has no index signature. Did you mean to call '{1}'?"}
+
 var Element_implicitly_has_an_any_type_because_expression_of_type_0_can_t_be_used_to_index_type_1 = &Message{code: 7053, category: CategoryError, key: "Element_implicitly_has_an_any_type_because_expression_of_type_0_can_t_be_used_to_index_type_1_7053", text: "Element implicitly has an 'any' type because expression of type '{0}' can't be used to index type '{1}'."}
+
 var No_index_signature_with_a_parameter_of_type_0_was_found_on_type_1 = &Message{code: 7054, category: CategoryError, key: "No_index_signature_with_a_parameter_of_type_0_was_found_on_type_1_7054", text: "No index signature with a parameter of type '{0}' was found on type '{1}'."}
+
 var X_0_which_lacks_return_type_annotation_implicitly_has_an_1_yield_type = &Message{code: 7055, category: CategoryError, key: "_0_which_lacks_return_type_annotation_implicitly_has_an_1_yield_type_7055", text: "'{0}', which lacks return-type annotation, implicitly has an '{1}' yield type."}
+
 var The_inferred_type_of_this_node_exceeds_the_maximum_length_the_compiler_will_serialize_An_explicit_type_annotation_is_needed = &Message{code: 7056, category: CategoryError, key: "The_inferred_type_of_this_node_exceeds_the_maximum_length_the_compiler_will_serialize_An_explicit_ty_7056", text: "The inferred type of this node exceeds the maximum length the compiler will serialize. An explicit type annotation is needed."}
+
 var X_yield_expression_implicitly_results_in_an_any_type_because_its_containing_generator_lacks_a_return_type_annotation = &Message{code: 7057, category: CategoryError, key: "yield_expression_implicitly_results_in_an_any_type_because_its_containing_generator_lacks_a_return_t_7057", text: "'yield' expression implicitly results in an 'any' type because its containing generator lacks a return-type annotation."}
+
 var If_the_0_package_actually_exposes_this_module_try_adding_a_new_declaration_d_ts_file_containing_declare_module_1 = &Message{code: 7058, category: CategoryError, key: "If_the_0_package_actually_exposes_this_module_try_adding_a_new_declaration_d_ts_file_containing_decl_7058", text: "If the '{0}' package actually exposes this module, try adding a new declaration (.d.ts) file containing `declare module '{1}';`"}
+
 var This_syntax_is_reserved_in_files_with_the_mts_or_cts_extension_Use_an_as_expression_instead = &Message{code: 7059, category: CategoryError, key: "This_syntax_is_reserved_in_files_with_the_mts_or_cts_extension_Use_an_as_expression_instead_7059", text: "This syntax is reserved in files with the .mts or .cts extension. Use an `as` expression instead."}
+
 var This_syntax_is_reserved_in_files_with_the_mts_or_cts_extension_Add_a_trailing_comma_or_explicit_constraint = &Message{code: 7060, category: CategoryError, key: "This_syntax_is_reserved_in_files_with_the_mts_or_cts_extension_Add_a_trailing_comma_or_explicit_cons_7060", text: "This syntax is reserved in files with the .mts or .cts extension. Add a trailing comma or explicit constraint."}
+
 var A_mapped_type_may_not_declare_properties_or_methods = &Message{code: 7061, category: CategoryError, key: "A_mapped_type_may_not_declare_properties_or_methods_7061", text: "A mapped type may not declare properties or methods."}
+
 var You_cannot_rename_this_element = &Message{code: 8000, category: CategoryError, key: "You_cannot_rename_this_element_8000", text: "You cannot rename this element."}
+
 var You_cannot_rename_elements_that_are_defined_in_the_standard_TypeScript_library = &Message{code: 8001, category: CategoryError, key: "You_cannot_rename_elements_that_are_defined_in_the_standard_TypeScript_library_8001", text: "You cannot rename elements that are defined in the standard TypeScript library."}
+
 var X_import_can_only_be_used_in_TypeScript_files = &Message{code: 8002, category: CategoryError, key: "import_can_only_be_used_in_TypeScript_files_8002", text: "'import ... =' can only be used in TypeScript files."}
+
 var X_export_can_only_be_used_in_TypeScript_files = &Message{code: 8003, category: CategoryError, key: "export_can_only_be_used_in_TypeScript_files_8003", text: "'export =' can only be used in TypeScript files."}
+
 var Type_parameter_declarations_can_only_be_used_in_TypeScript_files = &Message{code: 8004, category: CategoryError, key: "Type_parameter_declarations_can_only_be_used_in_TypeScript_files_8004", text: "Type parameter declarations can only be used in TypeScript files."}
+
 var X_implements_clauses_can_only_be_used_in_TypeScript_files = &Message{code: 8005, category: CategoryError, key: "implements_clauses_can_only_be_used_in_TypeScript_files_8005", text: "'implements' clauses can only be used in TypeScript files."}
+
 var X_0_declarations_can_only_be_used_in_TypeScript_files = &Message{code: 8006, category: CategoryError, key: "_0_declarations_can_only_be_used_in_TypeScript_files_8006", text: "'{0}' declarations can only be used in TypeScript files."}
+
 var Type_aliases_can_only_be_used_in_TypeScript_files = &Message{code: 8008, category: CategoryError, key: "Type_aliases_can_only_be_used_in_TypeScript_files_8008", text: "Type aliases can only be used in TypeScript files."}
+
 var The_0_modifier_can_only_be_used_in_TypeScript_files = &Message{code: 8009, category: CategoryError, key: "The_0_modifier_can_only_be_used_in_TypeScript_files_8009", text: "The '{0}' modifier can only be used in TypeScript files."}
+
 var Type_annotations_can_only_be_used_in_TypeScript_files = &Message{code: 8010, category: CategoryError, key: "Type_annotations_can_only_be_used_in_TypeScript_files_8010", text: "Type annotations can only be used in TypeScript files."}
+
 var Type_arguments_can_only_be_used_in_TypeScript_files = &Message{code: 8011, category: CategoryError, key: "Type_arguments_can_only_be_used_in_TypeScript_files_8011", text: "Type arguments can only be used in TypeScript files."}
+
 var Parameter_modifiers_can_only_be_used_in_TypeScript_files = &Message{code: 8012, category: CategoryError, key: "Parameter_modifiers_can_only_be_used_in_TypeScript_files_8012", text: "Parameter modifiers can only be used in TypeScript files."}
+
 var Non_null_assertions_can_only_be_used_in_TypeScript_files = &Message{code: 8013, category: CategoryError, key: "Non_null_assertions_can_only_be_used_in_TypeScript_files_8013", text: "Non-null assertions can only be used in TypeScript files."}
+
 var Type_assertion_expressions_can_only_be_used_in_TypeScript_files = &Message{code: 8016, category: CategoryError, key: "Type_assertion_expressions_can_only_be_used_in_TypeScript_files_8016", text: "Type assertion expressions can only be used in TypeScript files."}
+
 var Signature_declarations_can_only_be_used_in_TypeScript_files = &Message{code: 8017, category: CategoryError, key: "Signature_declarations_can_only_be_used_in_TypeScript_files_8017", text: "Signature declarations can only be used in TypeScript files."}
+
 var Report_errors_in_js_files = &Message{code: 8019, category: CategoryMessage, key: "Report_errors_in_js_files_8019", text: "Report errors in .js files."}
+
 var JSDoc_types_can_only_be_used_inside_documentation_comments = &Message{code: 8020, category: CategoryError, key: "JSDoc_types_can_only_be_used_inside_documentation_comments_8020", text: "JSDoc types can only be used inside documentation comments."}
+
 var JSDoc_typedef_tag_should_either_have_a_type_annotation_or_be_followed_by_property_or_member_tags = &Message{code: 8021, category: CategoryError, key: "JSDoc_typedef_tag_should_either_have_a_type_annotation_or_be_followed_by_property_or_member_tags_8021", text: "JSDoc '@typedef' tag should either have a type annotation or be followed by '@property' or '@member' tags."}
+
 var JSDoc_0_is_not_attached_to_a_class = &Message{code: 8022, category: CategoryError, key: "JSDoc_0_is_not_attached_to_a_class_8022", text: "JSDoc '@{0}' is not attached to a class."}
+
 var JSDoc_0_1_does_not_match_the_extends_2_clause = &Message{code: 8023, category: CategoryError, key: "JSDoc_0_1_does_not_match_the_extends_2_clause_8023", text: "JSDoc '@{0} {1}' does not match the 'extends {2}' clause."}
+
 var JSDoc_param_tag_has_name_0_but_there_is_no_parameter_with_that_name = &Message{code: 8024, category: CategoryError, key: "JSDoc_param_tag_has_name_0_but_there_is_no_parameter_with_that_name_8024", text: "JSDoc '@param' tag has name '{0}', but there is no parameter with that name."}
+
 var Class_declarations_cannot_have_more_than_one_augments_or_extends_tag = &Message{code: 8025, category: CategoryError, key: "Class_declarations_cannot_have_more_than_one_augments_or_extends_tag_8025", text: "Class declarations cannot have more than one '@augments' or '@extends' tag."}
+
 var Expected_0_type_arguments_provide_these_with_an_extends_tag = &Message{code: 8026, category: CategoryError, key: "Expected_0_type_arguments_provide_these_with_an_extends_tag_8026", text: "Expected {0} type arguments; provide these with an '@extends' tag."}
+
 var Expected_0_1_type_arguments_provide_these_with_an_extends_tag = &Message{code: 8027, category: CategoryError, key: "Expected_0_1_type_arguments_provide_these_with_an_extends_tag_8027", text: "Expected {0}-{1} type arguments; provide these with an '@extends' tag."}
+
 var JSDoc_may_only_appear_in_the_last_parameter_of_a_signature = &Message{code: 8028, category: CategoryError, key: "JSDoc_may_only_appear_in_the_last_parameter_of_a_signature_8028", text: "JSDoc '...' may only appear in the last parameter of a signature."}
+
 var JSDoc_param_tag_has_name_0_but_there_is_no_parameter_with_that_name_It_would_match_arguments_if_it_had_an_array_type = &Message{code: 8029, category: CategoryError, key: "JSDoc_param_tag_has_name_0_but_there_is_no_parameter_with_that_name_It_would_match_arguments_if_it_h_8029", text: "JSDoc '@param' tag has name '{0}', but there is no parameter with that name. It would match 'arguments' if it had an array type."}
+
 var The_type_of_a_function_declaration_must_match_the_function_s_signature = &Message{code: 8030, category: CategoryError, key: "The_type_of_a_function_declaration_must_match_the_function_s_signature_8030", text: "The type of a function declaration must match the function's signature."}
+
 var You_cannot_rename_a_module_via_a_global_import = &Message{code: 8031, category: CategoryError, key: "You_cannot_rename_a_module_via_a_global_import_8031", text: "You cannot rename a module via a global import."}
+
 var Qualified_name_0_is_not_allowed_without_a_leading_param_object_1 = &Message{code: 8032, category: CategoryError, key: "Qualified_name_0_is_not_allowed_without_a_leading_param_object_1_8032", text: "Qualified name '{0}' is not allowed without a leading '@param {object} {1}'."}
+
 var A_JSDoc_typedef_comment_may_not_contain_multiple_type_tags = &Message{code: 8033, category: CategoryError, key: "A_JSDoc_typedef_comment_may_not_contain_multiple_type_tags_8033", text: "A JSDoc '@typedef' comment may not contain multiple '@type' tags."}
+
 var The_tag_was_first_specified_here = &Message{code: 8034, category: CategoryError, key: "The_tag_was_first_specified_here_8034", text: "The tag was first specified here."}
+
 var You_cannot_rename_elements_that_are_defined_in_a_node_modules_folder = &Message{code: 8035, category: CategoryError, key: "You_cannot_rename_elements_that_are_defined_in_a_node_modules_folder_8035", text: "You cannot rename elements that are defined in a 'node_modules' folder."}
+
 var You_cannot_rename_elements_that_are_defined_in_another_node_modules_folder = &Message{code: 8036, category: CategoryError, key: "You_cannot_rename_elements_that_are_defined_in_another_node_modules_folder_8036", text: "You cannot rename elements that are defined in another 'node_modules' folder."}
+
 var Type_satisfaction_expressions_can_only_be_used_in_TypeScript_files = &Message{code: 8037, category: CategoryError, key: "Type_satisfaction_expressions_can_only_be_used_in_TypeScript_files_8037", text: "Type satisfaction expressions can only be used in TypeScript files."}
+
 var Decorators_may_not_appear_after_export_or_export_default_if_they_also_appear_before_export = &Message{code: 8038, category: CategoryError, key: "Decorators_may_not_appear_after_export_or_export_default_if_they_also_appear_before_export_8038", text: "Decorators may not appear after 'export' or 'export default' if they also appear before 'export'."}
+
 var A_JSDoc_template_tag_may_not_follow_a_typedef_callback_or_overload_tag = &Message{code: 8039, category: CategoryError, key: "A_JSDoc_template_tag_may_not_follow_a_typedef_callback_or_overload_tag_8039", text: "A JSDoc '@template' tag may not follow a '@typedef', '@callback', or '@overload' tag"}
+
 var Declaration_emit_for_this_file_requires_using_private_name_0_An_explicit_type_annotation_may_unblock_declaration_emit = &Message{code: 9005, category: CategoryError, key: "Declaration_emit_for_this_file_requires_using_private_name_0_An_explicit_type_annotation_may_unblock_9005", text: "Declaration emit for this file requires using private name '{0}'. An explicit type annotation may unblock declaration emit."}
+
 var Declaration_emit_for_this_file_requires_using_private_name_0_from_module_1_An_explicit_type_annotation_may_unblock_declaration_emit = &Message{code: 9006, category: CategoryError, key: "Declaration_emit_for_this_file_requires_using_private_name_0_from_module_1_An_explicit_type_annotati_9006", text: "Declaration emit for this file requires using private name '{0}' from module '{1}'. An explicit type annotation may unblock declaration emit."}
+
 var Function_must_have_an_explicit_return_type_annotation_with_isolatedDeclarations = &Message{code: 9007, category: CategoryError, key: "Function_must_have_an_explicit_return_type_annotation_with_isolatedDeclarations_9007", text: "Function must have an explicit return type annotation with --isolatedDeclarations."}
+
 var Method_must_have_an_explicit_return_type_annotation_with_isolatedDeclarations = &Message{code: 9008, category: CategoryError, key: "Method_must_have_an_explicit_return_type_annotation_with_isolatedDeclarations_9008", text: "Method must have an explicit return type annotation with --isolatedDeclarations."}
+
 var At_least_one_accessor_must_have_an_explicit_type_annotation_with_isolatedDeclarations = &Message{code: 9009, category: CategoryError, key: "At_least_one_accessor_must_have_an_explicit_type_annotation_with_isolatedDeclarations_9009", text: "At least one accessor must have an explicit type annotation with --isolatedDeclarations."}
+
 var Variable_must_have_an_explicit_type_annotation_with_isolatedDeclarations = &Message{code: 9010, category: CategoryError, key: "Variable_must_have_an_explicit_type_annotation_with_isolatedDeclarations_9010", text: "Variable must have an explicit type annotation with --isolatedDeclarations."}
+
 var Parameter_must_have_an_explicit_type_annotation_with_isolatedDeclarations = &Message{code: 9011, category: CategoryError, key: "Parameter_must_have_an_explicit_type_annotation_with_isolatedDeclarations_9011", text: "Parameter must have an explicit type annotation with --isolatedDeclarations."}
+
 var Property_must_have_an_explicit_type_annotation_with_isolatedDeclarations = &Message{code: 9012, category: CategoryError, key: "Property_must_have_an_explicit_type_annotation_with_isolatedDeclarations_9012", text: "Property must have an explicit type annotation with --isolatedDeclarations."}
+
 var Expression_type_can_t_be_inferred_with_isolatedDeclarations = &Message{code: 9013, category: CategoryError, key: "Expression_type_can_t_be_inferred_with_isolatedDeclarations_9013", text: "Expression type can't be inferred with --isolatedDeclarations."}
+
 var Computed_properties_must_be_number_or_string_literals_variables_or_dotted_expressions_with_isolatedDeclarations = &Message{code: 9014, category: CategoryError, key: "Computed_properties_must_be_number_or_string_literals_variables_or_dotted_expressions_with_isolatedD_9014", text: "Computed properties must be number or string literals, variables or dotted expressions with --isolatedDeclarations."}
+
 var Objects_that_contain_spread_assignments_can_t_be_inferred_with_isolatedDeclarations = &Message{code: 9015, category: CategoryError, key: "Objects_that_contain_spread_assignments_can_t_be_inferred_with_isolatedDeclarations_9015", text: "Objects that contain spread assignments can't be inferred with --isolatedDeclarations."}
+
 var Objects_that_contain_shorthand_properties_can_t_be_inferred_with_isolatedDeclarations = &Message{code: 9016, category: CategoryError, key: "Objects_that_contain_shorthand_properties_can_t_be_inferred_with_isolatedDeclarations_9016", text: "Objects that contain shorthand properties can't be inferred with --isolatedDeclarations."}
+
 var Only_const_arrays_can_be_inferred_with_isolatedDeclarations = &Message{code: 9017, category: CategoryError, key: "Only_const_arrays_can_be_inferred_with_isolatedDeclarations_9017", text: "Only const arrays can be inferred with --isolatedDeclarations."}
+
 var Arrays_with_spread_elements_can_t_inferred_with_isolatedDeclarations = &Message{code: 9018, category: CategoryError, key: "Arrays_with_spread_elements_can_t_inferred_with_isolatedDeclarations_9018", text: "Arrays with spread elements can't inferred with --isolatedDeclarations."}
+
 var Binding_elements_can_t_be_exported_directly_with_isolatedDeclarations = &Message{code: 9019, category: CategoryError, key: "Binding_elements_can_t_be_exported_directly_with_isolatedDeclarations_9019", text: "Binding elements can't be exported directly with --isolatedDeclarations."}
+
 var Enum_member_initializers_must_be_computable_without_references_to_external_symbols_with_isolatedDeclarations = &Message{code: 9020, category: CategoryError, key: "Enum_member_initializers_must_be_computable_without_references_to_external_symbols_with_isolatedDecl_9020", text: "Enum member initializers must be computable without references to external symbols with --isolatedDeclarations."}
+
 var Extends_clause_can_t_contain_an_expression_with_isolatedDeclarations = &Message{code: 9021, category: CategoryError, key: "Extends_clause_can_t_contain_an_expression_with_isolatedDeclarations_9021", text: "Extends clause can't contain an expression with --isolatedDeclarations."}
+
 var Inference_from_class_expressions_is_not_supported_with_isolatedDeclarations = &Message{code: 9022, category: CategoryError, key: "Inference_from_class_expressions_is_not_supported_with_isolatedDeclarations_9022", text: "Inference from class expressions is not supported with --isolatedDeclarations."}
+
 var Assigning_properties_to_functions_without_declaring_them_is_not_supported_with_isolatedDeclarations_Add_an_explicit_declaration_for_the_properties_assigned_to_this_function = &Message{code: 9023, category: CategoryError, key: "Assigning_properties_to_functions_without_declaring_them_is_not_supported_with_isolatedDeclarations__9023", text: "Assigning properties to functions without declaring them is not supported with --isolatedDeclarations. Add an explicit declaration for the properties assigned to this function."}
+
 var Declaration_emit_for_this_parameter_requires_implicitly_adding_undefined_to_its_type_This_is_not_supported_with_isolatedDeclarations = &Message{code: 9025, category: CategoryError, key: "Declaration_emit_for_this_parameter_requires_implicitly_adding_undefined_to_its_type_This_is_not_sup_9025", text: "Declaration emit for this parameter requires implicitly adding undefined to its type. This is not supported with --isolatedDeclarations."}
+
 var Declaration_emit_for_this_file_requires_preserving_this_import_for_augmentations_This_is_not_supported_with_isolatedDeclarations = &Message{code: 9026, category: CategoryError, key: "Declaration_emit_for_this_file_requires_preserving_this_import_for_augmentations_This_is_not_support_9026", text: "Declaration emit for this file requires preserving this import for augmentations. This is not supported with --isolatedDeclarations."}
+
 var Add_a_type_annotation_to_the_variable_0 = &Message{code: 9027, category: CategoryError, key: "Add_a_type_annotation_to_the_variable_0_9027", text: "Add a type annotation to the variable {0}."}
+
 var Add_a_type_annotation_to_the_parameter_0 = &Message{code: 9028, category: CategoryError, key: "Add_a_type_annotation_to_the_parameter_0_9028", text: "Add a type annotation to the parameter {0}."}
+
 var Add_a_type_annotation_to_the_property_0 = &Message{code: 9029, category: CategoryError, key: "Add_a_type_annotation_to_the_property_0_9029", text: "Add a type annotation to the property {0}."}
+
 var Add_a_return_type_to_the_function_expression = &Message{code: 9030, category: CategoryError, key: "Add_a_return_type_to_the_function_expression_9030", text: "Add a return type to the function expression."}
+
 var Add_a_return_type_to_the_function_declaration = &Message{code: 9031, category: CategoryError, key: "Add_a_return_type_to_the_function_declaration_9031", text: "Add a return type to the function declaration."}
+
 var Add_a_return_type_to_the_get_accessor_declaration = &Message{code: 9032, category: CategoryError, key: "Add_a_return_type_to_the_get_accessor_declaration_9032", text: "Add a return type to the get accessor declaration."}
+
 var Add_a_type_to_parameter_of_the_set_accessor_declaration = &Message{code: 9033, category: CategoryError, key: "Add_a_type_to_parameter_of_the_set_accessor_declaration_9033", text: "Add a type to parameter of the set accessor declaration."}
+
 var Add_a_return_type_to_the_method = &Message{code: 9034, category: CategoryError, key: "Add_a_return_type_to_the_method_9034", text: "Add a return type to the method"}
+
 var Add_satisfies_and_a_type_assertion_to_this_expression_satisfies_T_as_T_to_make_the_type_explicit = &Message{code: 9035, category: CategoryError, key: "Add_satisfies_and_a_type_assertion_to_this_expression_satisfies_T_as_T_to_make_the_type_explicit_9035", text: "Add satisfies and a type assertion to this expression (satisfies T as T) to make the type explicit."}
+
 var Move_the_expression_in_default_export_to_a_variable_and_add_a_type_annotation_to_it = &Message{code: 9036, category: CategoryError, key: "Move_the_expression_in_default_export_to_a_variable_and_add_a_type_annotation_to_it_9036", text: "Move the expression in default export to a variable and add a type annotation to it."}
+
 var Default_exports_can_t_be_inferred_with_isolatedDeclarations = &Message{code: 9037, category: CategoryError, key: "Default_exports_can_t_be_inferred_with_isolatedDeclarations_9037", text: "Default exports can't be inferred with --isolatedDeclarations."}
+
 var Computed_property_names_on_class_or_object_literals_cannot_be_inferred_with_isolatedDeclarations = &Message{code: 9038, category: CategoryError, key: "Computed_property_names_on_class_or_object_literals_cannot_be_inferred_with_isolatedDeclarations_9038", text: "Computed property names on class or object literals cannot be inferred with --isolatedDeclarations."}
+
 var Type_containing_private_name_0_can_t_be_used_with_isolatedDeclarations = &Message{code: 9039, category: CategoryError, key: "Type_containing_private_name_0_can_t_be_used_with_isolatedDeclarations_9039", text: "Type containing private name '{0}' can't be used with --isolatedDeclarations."}
+
 var JSX_attributes_must_only_be_assigned_a_non_empty_expression = &Message{code: 17000, category: CategoryError, key: "JSX_attributes_must_only_be_assigned_a_non_empty_expression_17000", text: "JSX attributes must only be assigned a non-empty 'expression'."}
+
 var JSX_elements_cannot_have_multiple_attributes_with_the_same_name = &Message{code: 17001, category: CategoryError, key: "JSX_elements_cannot_have_multiple_attributes_with_the_same_name_17001", text: "JSX elements cannot have multiple attributes with the same name."}
+
 var Expected_corresponding_JSX_closing_tag_for_0 = &Message{code: 17002, category: CategoryError, key: "Expected_corresponding_JSX_closing_tag_for_0_17002", text: "Expected corresponding JSX closing tag for '{0}'."}
+
 var Cannot_use_JSX_unless_the_jsx_flag_is_provided = &Message{code: 17004, category: CategoryError, key: "Cannot_use_JSX_unless_the_jsx_flag_is_provided_17004", text: "Cannot use JSX unless the '--jsx' flag is provided."}
+
 var A_constructor_cannot_contain_a_super_call_when_its_class_extends_null = &Message{code: 17005, category: CategoryError, key: "A_constructor_cannot_contain_a_super_call_when_its_class_extends_null_17005", text: "A constructor cannot contain a 'super' call when its class extends 'null'."}
+
 var An_unary_expression_with_the_0_operator_is_not_allowed_in_the_left_hand_side_of_an_exponentiation_expression_Consider_enclosing_the_expression_in_parentheses = &Message{code: 17006, category: CategoryError, key: "An_unary_expression_with_the_0_operator_is_not_allowed_in_the_left_hand_side_of_an_exponentiation_ex_17006", text: "An unary expression with the '{0}' operator is not allowed in the left-hand side of an exponentiation expression. Consider enclosing the expression in parentheses."}
+
 var A_type_assertion_expression_is_not_allowed_in_the_left_hand_side_of_an_exponentiation_expression_Consider_enclosing_the_expression_in_parentheses = &Message{code: 17007, category: CategoryError, key: "A_type_assertion_expression_is_not_allowed_in_the_left_hand_side_of_an_exponentiation_expression_Con_17007", text: "A type assertion expression is not allowed in the left-hand side of an exponentiation expression. Consider enclosing the expression in parentheses."}
+
 var JSX_element_0_has_no_corresponding_closing_tag = &Message{code: 17008, category: CategoryError, key: "JSX_element_0_has_no_corresponding_closing_tag_17008", text: "JSX element '{0}' has no corresponding closing tag."}
+
 var X_super_must_be_called_before_accessing_this_in_the_constructor_of_a_derived_class = &Message{code: 17009, category: CategoryError, key: "super_must_be_called_before_accessing_this_in_the_constructor_of_a_derived_class_17009", text: "'super' must be called before accessing 'this' in the constructor of a derived class."}
+
 var Unknown_type_acquisition_option_0 = &Message{code: 17010, category: CategoryError, key: "Unknown_type_acquisition_option_0_17010", text: "Unknown type acquisition option '{0}'."}
+
 var X_super_must_be_called_before_accessing_a_property_of_super_in_the_constructor_of_a_derived_class = &Message{code: 17011, category: CategoryError, key: "super_must_be_called_before_accessing_a_property_of_super_in_the_constructor_of_a_derived_class_17011", text: "'super' must be called before accessing a property of 'super' in the constructor of a derived class."}
+
 var X_0_is_not_a_valid_meta_property_for_keyword_1_Did_you_mean_2 = &Message{code: 17012, category: CategoryError, key: "_0_is_not_a_valid_meta_property_for_keyword_1_Did_you_mean_2_17012", text: "'{0}' is not a valid meta-property for keyword '{1}'. Did you mean '{2}'?"}
+
 var Meta_property_0_is_only_allowed_in_the_body_of_a_function_declaration_function_expression_or_constructor = &Message{code: 17013, category: CategoryError, key: "Meta_property_0_is_only_allowed_in_the_body_of_a_function_declaration_function_expression_or_constru_17013", text: "Meta-property '{0}' is only allowed in the body of a function declaration, function expression, or constructor."}
+
 var JSX_fragment_has_no_corresponding_closing_tag = &Message{code: 17014, category: CategoryError, key: "JSX_fragment_has_no_corresponding_closing_tag_17014", text: "JSX fragment has no corresponding closing tag."}
+
 var Expected_corresponding_closing_tag_for_JSX_fragment = &Message{code: 17015, category: CategoryError, key: "Expected_corresponding_closing_tag_for_JSX_fragment_17015", text: "Expected corresponding closing tag for JSX fragment."}
+
 var The_jsxFragmentFactory_compiler_option_must_be_provided_to_use_JSX_fragments_with_the_jsxFactory_compiler_option = &Message{code: 17016, category: CategoryError, key: "The_jsxFragmentFactory_compiler_option_must_be_provided_to_use_JSX_fragments_with_the_jsxFactory_com_17016", text: "The 'jsxFragmentFactory' compiler option must be provided to use JSX fragments with the 'jsxFactory' compiler option."}
+
 var An_jsxFrag_pragma_is_required_when_using_an_jsx_pragma_with_JSX_fragments = &Message{code: 17017, category: CategoryError, key: "An_jsxFrag_pragma_is_required_when_using_an_jsx_pragma_with_JSX_fragments_17017", text: "An @jsxFrag pragma is required when using an @jsx pragma with JSX fragments."}
+
 var Unknown_type_acquisition_option_0_Did_you_mean_1 = &Message{code: 17018, category: CategoryError, key: "Unknown_type_acquisition_option_0_Did_you_mean_1_17018", text: "Unknown type acquisition option '{0}'. Did you mean '{1}'?"}
+
 var X_0_at_the_end_of_a_type_is_not_valid_TypeScript_syntax_Did_you_mean_to_write_1 = &Message{code: 17019, category: CategoryError, key: "_0_at_the_end_of_a_type_is_not_valid_TypeScript_syntax_Did_you_mean_to_write_1_17019", text: "'{0}' at the end of a type is not valid TypeScript syntax. Did you mean to write '{1}'?"}
+
 var X_0_at_the_start_of_a_type_is_not_valid_TypeScript_syntax_Did_you_mean_to_write_1 = &Message{code: 17020, category: CategoryError, key: "_0_at_the_start_of_a_type_is_not_valid_TypeScript_syntax_Did_you_mean_to_write_1_17020", text: "'{0}' at the start of a type is not valid TypeScript syntax. Did you mean to write '{1}'?"}
+
 var Unicode_escape_sequence_cannot_appear_here = &Message{code: 17021, category: CategoryError, key: "Unicode_escape_sequence_cannot_appear_here_17021", text: "Unicode escape sequence cannot appear here."}
+
 var Circularity_detected_while_resolving_configuration_Colon_0 = &Message{code: 18000, category: CategoryError, key: "Circularity_detected_while_resolving_configuration_Colon_0_18000", text: "Circularity detected while resolving configuration: {0}"}
+
 var The_files_list_in_config_file_0_is_empty = &Message{code: 18002, category: CategoryError, key: "The_files_list_in_config_file_0_is_empty_18002", text: "The 'files' list in config file '{0}' is empty."}
+
 var No_inputs_were_found_in_config_file_0_Specified_include_paths_were_1_and_exclude_paths_were_2 = &Message{code: 18003, category: CategoryError, key: "No_inputs_were_found_in_config_file_0_Specified_include_paths_were_1_and_exclude_paths_were_2_18003", text: "No inputs were found in config file '{0}'. Specified 'include' paths were '{1}' and 'exclude' paths were '{2}'."}
+
 var No_value_exists_in_scope_for_the_shorthand_property_0_Either_declare_one_or_provide_an_initializer = &Message{code: 18004, category: CategoryError, key: "No_value_exists_in_scope_for_the_shorthand_property_0_Either_declare_one_or_provide_an_initializer_18004", text: "No value exists in scope for the shorthand property '{0}'. Either declare one or provide an initializer."}
+
 var Classes_may_not_have_a_field_named_constructor = &Message{code: 18006, category: CategoryError, key: "Classes_may_not_have_a_field_named_constructor_18006", text: "Classes may not have a field named 'constructor'."}
+
 var JSX_expressions_may_not_use_the_comma_operator_Did_you_mean_to_write_an_array = &Message{code: 18007, category: CategoryError, key: "JSX_expressions_may_not_use_the_comma_operator_Did_you_mean_to_write_an_array_18007", text: "JSX expressions may not use the comma operator. Did you mean to write an array?"}
+
 var Private_identifiers_cannot_be_used_as_parameters = &Message{code: 18009, category: CategoryError, key: "Private_identifiers_cannot_be_used_as_parameters_18009", text: "Private identifiers cannot be used as parameters."}
+
 var An_accessibility_modifier_cannot_be_used_with_a_private_identifier = &Message{code: 18010, category: CategoryError, key: "An_accessibility_modifier_cannot_be_used_with_a_private_identifier_18010", text: "An accessibility modifier cannot be used with a private identifier."}
+
 var The_operand_of_a_delete_operator_cannot_be_a_private_identifier = &Message{code: 18011, category: CategoryError, key: "The_operand_of_a_delete_operator_cannot_be_a_private_identifier_18011", text: "The operand of a 'delete' operator cannot be a private identifier."}
+
 var X_constructor_is_a_reserved_word = &Message{code: 18012, category: CategoryError, key: "constructor_is_a_reserved_word_18012", text: "'#constructor' is a reserved word."}
+
 var Property_0_is_not_accessible_outside_class_1_because_it_has_a_private_identifier = &Message{code: 18013, category: CategoryError, key: "Property_0_is_not_accessible_outside_class_1_because_it_has_a_private_identifier_18013", text: "Property '{0}' is not accessible outside class '{1}' because it has a private identifier."}
+
 var The_property_0_cannot_be_accessed_on_type_1_within_this_class_because_it_is_shadowed_by_another_private_identifier_with_the_same_spelling = &Message{code: 18014, category: CategoryError, key: "The_property_0_cannot_be_accessed_on_type_1_within_this_class_because_it_is_shadowed_by_another_priv_18014", text: "The property '{0}' cannot be accessed on type '{1}' within this class because it is shadowed by another private identifier with the same spelling."}
+
 var Property_0_in_type_1_refers_to_a_different_member_that_cannot_be_accessed_from_within_type_2 = &Message{code: 18015, category: CategoryError, key: "Property_0_in_type_1_refers_to_a_different_member_that_cannot_be_accessed_from_within_type_2_18015", text: "Property '{0}' in type '{1}' refers to a different member that cannot be accessed from within type '{2}'."}
+
 var Private_identifiers_are_not_allowed_outside_class_bodies = &Message{code: 18016, category: CategoryError, key: "Private_identifiers_are_not_allowed_outside_class_bodies_18016", text: "Private identifiers are not allowed outside class bodies."}
+
 var The_shadowing_declaration_of_0_is_defined_here = &Message{code: 18017, category: CategoryError, key: "The_shadowing_declaration_of_0_is_defined_here_18017", text: "The shadowing declaration of '{0}' is defined here"}
+
 var The_declaration_of_0_that_you_probably_intended_to_use_is_defined_here = &Message{code: 18018, category: CategoryError, key: "The_declaration_of_0_that_you_probably_intended_to_use_is_defined_here_18018", text: "The declaration of '{0}' that you probably intended to use is defined here"}
+
 var X_0_modifier_cannot_be_used_with_a_private_identifier = &Message{code: 18019, category: CategoryError, key: "_0_modifier_cannot_be_used_with_a_private_identifier_18019", text: "'{0}' modifier cannot be used with a private identifier."}
+
 var An_enum_member_cannot_be_named_with_a_private_identifier = &Message{code: 18024, category: CategoryError, key: "An_enum_member_cannot_be_named_with_a_private_identifier_18024", text: "An enum member cannot be named with a private identifier."}
+
 var X_can_only_be_used_at_the_start_of_a_file = &Message{code: 18026, category: CategoryError, key: "can_only_be_used_at_the_start_of_a_file_18026", text: "'#!' can only be used at the start of a file."}
+
 var Compiler_reserves_name_0_when_emitting_private_identifier_downlevel = &Message{code: 18027, category: CategoryError, key: "Compiler_reserves_name_0_when_emitting_private_identifier_downlevel_18027", text: "Compiler reserves name '{0}' when emitting private identifier downlevel."}
+
 var Private_identifiers_are_only_available_when_targeting_ECMAScript_2015_and_higher = &Message{code: 18028, category: CategoryError, key: "Private_identifiers_are_only_available_when_targeting_ECMAScript_2015_and_higher_18028", text: "Private identifiers are only available when targeting ECMAScript 2015 and higher."}
+
 var Private_identifiers_are_not_allowed_in_variable_declarations = &Message{code: 18029, category: CategoryError, key: "Private_identifiers_are_not_allowed_in_variable_declarations_18029", text: "Private identifiers are not allowed in variable declarations."}
+
 var An_optional_chain_cannot_contain_private_identifiers = &Message{code: 18030, category: CategoryError, key: "An_optional_chain_cannot_contain_private_identifiers_18030", text: "An optional chain cannot contain private identifiers."}
+
 var The_intersection_0_was_reduced_to_never_because_property_1_has_conflicting_types_in_some_constituents = &Message{code: 18031, category: CategoryError, key: "The_intersection_0_was_reduced_to_never_because_property_1_has_conflicting_types_in_some_constituent_18031", text: "The intersection '{0}' was reduced to 'never' because property '{1}' has conflicting types in some constituents."}
+
 var The_intersection_0_was_reduced_to_never_because_property_1_exists_in_multiple_constituents_and_is_private_in_some = &Message{code: 18032, category: CategoryError, key: "The_intersection_0_was_reduced_to_never_because_property_1_exists_in_multiple_constituents_and_is_pr_18032", text: "The intersection '{0}' was reduced to 'never' because property '{1}' exists in multiple constituents and is private in some."}
+
 var Type_0_is_not_assignable_to_type_1_as_required_for_computed_enum_member_values = &Message{code: 18033, category: CategoryError, key: "Type_0_is_not_assignable_to_type_1_as_required_for_computed_enum_member_values_18033", text: "Type '{0}' is not assignable to type '{1}' as required for computed enum member values."}
+
 var Specify_the_JSX_fragment_factory_function_to_use_when_targeting_react_JSX_emit_with_jsxFactory_compiler_option_is_specified_e_g_Fragment = &Message{code: 18034, category: CategoryMessage, key: "Specify_the_JSX_fragment_factory_function_to_use_when_targeting_react_JSX_emit_with_jsxFactory_compi_18034", text: "Specify the JSX fragment factory function to use when targeting 'react' JSX emit with 'jsxFactory' compiler option is specified, e.g. 'Fragment'."}
+
 var Invalid_value_for_jsxFragmentFactory_0_is_not_a_valid_identifier_or_qualified_name = &Message{code: 18035, category: CategoryError, key: "Invalid_value_for_jsxFragmentFactory_0_is_not_a_valid_identifier_or_qualified_name_18035", text: "Invalid value for 'jsxFragmentFactory'. '{0}' is not a valid identifier or qualified-name."}
+
 var Class_decorators_can_t_be_used_with_static_private_identifier_Consider_removing_the_experimental_decorator = &Message{code: 18036, category: CategoryError, key: "Class_decorators_can_t_be_used_with_static_private_identifier_Consider_removing_the_experimental_dec_18036", text: "Class decorators can't be used with static private identifier. Consider removing the experimental decorator."}
+
 var X_await_expression_cannot_be_used_inside_a_class_static_block = &Message{code: 18037, category: CategoryError, key: "await_expression_cannot_be_used_inside_a_class_static_block_18037", text: "'await' expression cannot be used inside a class static block."}
+
 var X_for_await_loops_cannot_be_used_inside_a_class_static_block = &Message{code: 18038, category: CategoryError, key: "for_await_loops_cannot_be_used_inside_a_class_static_block_18038", text: "'for await' loops cannot be used inside a class static block."}
+
 var Invalid_use_of_0_It_cannot_be_used_inside_a_class_static_block = &Message{code: 18039, category: CategoryError, key: "Invalid_use_of_0_It_cannot_be_used_inside_a_class_static_block_18039", text: "Invalid use of '{0}'. It cannot be used inside a class static block."}
+
 var A_return_statement_cannot_be_used_inside_a_class_static_block = &Message{code: 18041, category: CategoryError, key: "A_return_statement_cannot_be_used_inside_a_class_static_block_18041", text: "A 'return' statement cannot be used inside a class static block."}
+
 var X_0_is_a_type_and_cannot_be_imported_in_JavaScript_files_Use_1_in_a_JSDoc_type_annotation = &Message{code: 18042, category: CategoryError, key: "_0_is_a_type_and_cannot_be_imported_in_JavaScript_files_Use_1_in_a_JSDoc_type_annotation_18042", text: "'{0}' is a type and cannot be imported in JavaScript files. Use '{1}' in a JSDoc type annotation."}
+
 var Types_cannot_appear_in_export_declarations_in_JavaScript_files = &Message{code: 18043, category: CategoryError, key: "Types_cannot_appear_in_export_declarations_in_JavaScript_files_18043", text: "Types cannot appear in export declarations in JavaScript files."}
+
 var X_0_is_automatically_exported_here = &Message{code: 18044, category: CategoryMessage, key: "_0_is_automatically_exported_here_18044", text: "'{0}' is automatically exported here."}
+
 var Properties_with_the_accessor_modifier_are_only_available_when_targeting_ECMAScript_2015_and_higher = &Message{code: 18045, category: CategoryError, key: "Properties_with_the_accessor_modifier_are_only_available_when_targeting_ECMAScript_2015_and_higher_18045", text: "Properties with the 'accessor' modifier are only available when targeting ECMAScript 2015 and higher."}
+
 var X_0_is_of_type_unknown = &Message{code: 18046, category: CategoryError, key: "_0_is_of_type_unknown_18046", text: "'{0}' is of type 'unknown'."}
+
 var X_0_is_possibly_null = &Message{code: 18047, category: CategoryError, key: "_0_is_possibly_null_18047", text: "'{0}' is possibly 'null'."}
+
 var X_0_is_possibly_undefined = &Message{code: 18048, category: CategoryError, key: "_0_is_possibly_undefined_18048", text: "'{0}' is possibly 'undefined'."}
+
 var X_0_is_possibly_null_or_undefined = &Message{code: 18049, category: CategoryError, key: "_0_is_possibly_null_or_undefined_18049", text: "'{0}' is possibly 'null' or 'undefined'."}
+
 var The_value_0_cannot_be_used_here = &Message{code: 18050, category: CategoryError, key: "The_value_0_cannot_be_used_here_18050", text: "The value '{0}' cannot be used here."}
+
 var Compiler_option_0_cannot_be_given_an_empty_string = &Message{code: 18051, category: CategoryError, key: "Compiler_option_0_cannot_be_given_an_empty_string_18051", text: "Compiler option '{0}' cannot be given an empty string."}
+
 var Its_type_0_is_not_a_valid_JSX_element_type = &Message{code: 18053, category: CategoryError, key: "Its_type_0_is_not_a_valid_JSX_element_type_18053", text: "Its type '{0}' is not a valid JSX element type."}
+
 var X_await_using_statements_cannot_be_used_inside_a_class_static_block = &Message{code: 18054, category: CategoryError, key: "await_using_statements_cannot_be_used_inside_a_class_static_block_18054", text: "'await using' statements cannot be used inside a class static block."}
+
 var X_0_has_a_string_type_but_must_have_syntactically_recognizable_string_syntax_when_isolatedModules_is_enabled = &Message{code: 18055, category: CategoryError, key: "_0_has_a_string_type_but_must_have_syntactically_recognizable_string_syntax_when_isolatedModules_is__18055", text: "'{0}' has a string type, but must have syntactically recognizable string syntax when 'isolatedModules' is enabled."}
+
 var Enum_member_following_a_non_literal_numeric_member_must_have_an_initializer_when_isolatedModules_is_enabled = &Message{code: 18056, category: CategoryError, key: "Enum_member_following_a_non_literal_numeric_member_must_have_an_initializer_when_isolatedModules_is__18056", text: "Enum member following a non-literal numeric member must have an initializer when 'isolatedModules' is enabled."}
+
 var String_literal_import_and_export_names_are_not_supported_when_the_module_flag_is_set_to_es2015_or_es2020 = &Message{code: 18057, category: CategoryError, key: "String_literal_import_and_export_names_are_not_supported_when_the_module_flag_is_set_to_es2015_or_es_18057", text: "String literal import and export names are not supported when the '--module' flag is set to 'es2015' or 'es2020'."}
+
 var X_module_AMD_or_UMD_or_System_or_ES6_then_Classic_Otherwise_Node = &Message{code: 69010, category: CategoryMessage, key: "module_AMD_or_UMD_or_System_or_ES6_then_Classic_Otherwise_Node_69010", text: "module === `AMD` or `UMD` or `System` or `ES6`, then `Classic`, Otherwise `Node`"}
+
 var File_is_a_CommonJS_module_it_may_be_converted_to_an_ES_module = &Message{code: 80001, category: CategorySuggestion, key: "File_is_a_CommonJS_module_it_may_be_converted_to_an_ES_module_80001", text: "File is a CommonJS module; it may be converted to an ES module."}
+
 var This_constructor_function_may_be_converted_to_a_class_declaration = &Message{code: 80002, category: CategorySuggestion, key: "This_constructor_function_may_be_converted_to_a_class_declaration_80002", text: "This constructor function may be converted to a class declaration."}
+
 var Import_may_be_converted_to_a_default_import = &Message{code: 80003, category: CategorySuggestion, key: "Import_may_be_converted_to_a_default_import_80003", text: "Import may be converted to a default import."}
+
 var JSDoc_types_may_be_moved_to_TypeScript_types = &Message{code: 80004, category: CategorySuggestion, key: "JSDoc_types_may_be_moved_to_TypeScript_types_80004", text: "JSDoc types may be moved to TypeScript types."}
+
 var X_require_call_may_be_converted_to_an_import = &Message{code: 80005, category: CategorySuggestion, key: "require_call_may_be_converted_to_an_import_80005", text: "'require' call may be converted to an import."}
+
 var This_may_be_converted_to_an_async_function = &Message{code: 80006, category: CategorySuggestion, key: "This_may_be_converted_to_an_async_function_80006", text: "This may be converted to an async function."}
+
 var X_await_has_no_effect_on_the_type_of_this_expression = &Message{code: 80007, category: CategorySuggestion, key: "await_has_no_effect_on_the_type_of_this_expression_80007", text: "'await' has no effect on the type of this expression."}
+
 var Numeric_literals_with_absolute_values_equal_to_2_53_or_greater_are_too_large_to_be_represented_accurately_as_integers = &Message{code: 80008, category: CategorySuggestion, key: "Numeric_literals_with_absolute_values_equal_to_2_53_or_greater_are_too_large_to_be_represented_accur_80008", text: "Numeric literals with absolute values equal to 2^53 or greater are too large to be represented accurately as integers."}
+
 var JSDoc_typedef_may_be_converted_to_TypeScript_type = &Message{code: 80009, category: CategorySuggestion, key: "JSDoc_typedef_may_be_converted_to_TypeScript_type_80009", text: "JSDoc typedef may be converted to TypeScript type."}
+
 var JSDoc_typedefs_may_be_converted_to_TypeScript_types = &Message{code: 80010, category: CategorySuggestion, key: "JSDoc_typedefs_may_be_converted_to_TypeScript_types_80010", text: "JSDoc typedefs may be converted to TypeScript types."}
+
 var Add_missing_super_call = &Message{code: 90001, category: CategoryMessage, key: "Add_missing_super_call_90001", text: "Add missing 'super()' call"}
+
 var Make_super_call_the_first_statement_in_the_constructor = &Message{code: 90002, category: CategoryMessage, key: "Make_super_call_the_first_statement_in_the_constructor_90002", text: "Make 'super()' call the first statement in the constructor"}
+
 var Change_extends_to_implements = &Message{code: 90003, category: CategoryMessage, key: "Change_extends_to_implements_90003", text: "Change 'extends' to 'implements'"}
+
 var Remove_unused_declaration_for_Colon_0 = &Message{code: 90004, category: CategoryMessage, key: "Remove_unused_declaration_for_Colon_0_90004", text: "Remove unused declaration for: '{0}'"}
+
 var Remove_import_from_0 = &Message{code: 90005, category: CategoryMessage, key: "Remove_import_from_0_90005", text: "Remove import from '{0}'"}
+
 var Implement_interface_0 = &Message{code: 90006, category: CategoryMessage, key: "Implement_interface_0_90006", text: "Implement interface '{0}'"}
+
 var Implement_inherited_abstract_class = &Message{code: 90007, category: CategoryMessage, key: "Implement_inherited_abstract_class_90007", text: "Implement inherited abstract class"}
+
 var Add_0_to_unresolved_variable = &Message{code: 90008, category: CategoryMessage, key: "Add_0_to_unresolved_variable_90008", text: "Add '{0}.' to unresolved variable"}
+
 var Remove_variable_statement = &Message{code: 90010, category: CategoryMessage, key: "Remove_variable_statement_90010", text: "Remove variable statement"}
+
 var Remove_template_tag = &Message{code: 90011, category: CategoryMessage, key: "Remove_template_tag_90011", text: "Remove template tag"}
+
 var Remove_type_parameters = &Message{code: 90012, category: CategoryMessage, key: "Remove_type_parameters_90012", text: "Remove type parameters"}
+
 var Import_0_from_1 = &Message{code: 90013, category: CategoryMessage, key: "Import_0_from_1_90013", text: "Import '{0}' from \"{1}\""}
+
 var Change_0_to_1 = &Message{code: 90014, category: CategoryMessage, key: "Change_0_to_1_90014", text: "Change '{0}' to '{1}'"}
+
 var Declare_property_0 = &Message{code: 90016, category: CategoryMessage, key: "Declare_property_0_90016", text: "Declare property '{0}'"}
+
 var Add_index_signature_for_property_0 = &Message{code: 90017, category: CategoryMessage, key: "Add_index_signature_for_property_0_90017", text: "Add index signature for property '{0}'"}
+
 var Disable_checking_for_this_file = &Message{code: 90018, category: CategoryMessage, key: "Disable_checking_for_this_file_90018", text: "Disable checking for this file"}
+
 var Ignore_this_error_message = &Message{code: 90019, category: CategoryMessage, key: "Ignore_this_error_message_90019", text: "Ignore this error message"}
+
 var Initialize_property_0_in_the_constructor = &Message{code: 90020, category: CategoryMessage, key: "Initialize_property_0_in_the_constructor_90020", text: "Initialize property '{0}' in the constructor"}
+
 var Initialize_static_property_0 = &Message{code: 90021, category: CategoryMessage, key: "Initialize_static_property_0_90021", text: "Initialize static property '{0}'"}
+
 var Change_spelling_to_0 = &Message{code: 90022, category: CategoryMessage, key: "Change_spelling_to_0_90022", text: "Change spelling to '{0}'"}
+
 var Declare_method_0 = &Message{code: 90023, category: CategoryMessage, key: "Declare_method_0_90023", text: "Declare method '{0}'"}
+
 var Declare_static_method_0 = &Message{code: 90024, category: CategoryMessage, key: "Declare_static_method_0_90024", text: "Declare static method '{0}'"}
+
 var Prefix_0_with_an_underscore = &Message{code: 90025, category: CategoryMessage, key: "Prefix_0_with_an_underscore_90025", text: "Prefix '{0}' with an underscore"}
+
 var Rewrite_as_the_indexed_access_type_0 = &Message{code: 90026, category: CategoryMessage, key: "Rewrite_as_the_indexed_access_type_0_90026", text: "Rewrite as the indexed access type '{0}'"}
+
 var Declare_static_property_0 = &Message{code: 90027, category: CategoryMessage, key: "Declare_static_property_0_90027", text: "Declare static property '{0}'"}
+
 var Call_decorator_expression = &Message{code: 90028, category: CategoryMessage, key: "Call_decorator_expression_90028", text: "Call decorator expression"}
+
 var Add_async_modifier_to_containing_function = &Message{code: 90029, category: CategoryMessage, key: "Add_async_modifier_to_containing_function_90029", text: "Add async modifier to containing function"}
+
 var Replace_infer_0_with_unknown = &Message{code: 90030, category: CategoryMessage, key: "Replace_infer_0_with_unknown_90030", text: "Replace 'infer {0}' with 'unknown'"}
+
 var Replace_all_unused_infer_with_unknown = &Message{code: 90031, category: CategoryMessage, key: "Replace_all_unused_infer_with_unknown_90031", text: "Replace all unused 'infer' with 'unknown'"}
+
 var Add_parameter_name = &Message{code: 90034, category: CategoryMessage, key: "Add_parameter_name_90034", text: "Add parameter name"}
+
 var Declare_private_property_0 = &Message{code: 90035, category: CategoryMessage, key: "Declare_private_property_0_90035", text: "Declare private property '{0}'"}
+
 var Replace_0_with_Promise_1 = &Message{code: 90036, category: CategoryMessage, key: "Replace_0_with_Promise_1_90036", text: "Replace '{0}' with 'Promise<{1}>'"}
+
 var Fix_all_incorrect_return_type_of_an_async_functions = &Message{code: 90037, category: CategoryMessage, key: "Fix_all_incorrect_return_type_of_an_async_functions_90037", text: "Fix all incorrect return type of an async functions"}
+
 var Declare_private_method_0 = &Message{code: 90038, category: CategoryMessage, key: "Declare_private_method_0_90038", text: "Declare private method '{0}'"}
+
 var Remove_unused_destructuring_declaration = &Message{code: 90039, category: CategoryMessage, key: "Remove_unused_destructuring_declaration_90039", text: "Remove unused destructuring declaration"}
+
 var Remove_unused_declarations_for_Colon_0 = &Message{code: 90041, category: CategoryMessage, key: "Remove_unused_declarations_for_Colon_0_90041", text: "Remove unused declarations for: '{0}'"}
+
 var Declare_a_private_field_named_0 = &Message{code: 90053, category: CategoryMessage, key: "Declare_a_private_field_named_0_90053", text: "Declare a private field named '{0}'."}
+
 var Includes_imports_of_types_referenced_by_0 = &Message{code: 90054, category: CategoryMessage, key: "Includes_imports_of_types_referenced_by_0_90054", text: "Includes imports of types referenced by '{0}'"}
+
 var Remove_type_from_import_declaration_from_0 = &Message{code: 90055, category: CategoryMessage, key: "Remove_type_from_import_declaration_from_0_90055", text: "Remove 'type' from import declaration from \"{0}\""}
+
 var Remove_type_from_import_of_0_from_1 = &Message{code: 90056, category: CategoryMessage, key: "Remove_type_from_import_of_0_from_1_90056", text: "Remove 'type' from import of '{0}' from \"{1}\""}
+
 var Add_import_from_0 = &Message{code: 90057, category: CategoryMessage, key: "Add_import_from_0_90057", text: "Add import from \"{0}\""}
+
 var Update_import_from_0 = &Message{code: 90058, category: CategoryMessage, key: "Update_import_from_0_90058", text: "Update import from \"{0}\""}
+
 var Export_0_from_module_1 = &Message{code: 90059, category: CategoryMessage, key: "Export_0_from_module_1_90059", text: "Export '{0}' from module '{1}'"}
+
 var Export_all_referenced_locals = &Message{code: 90060, category: CategoryMessage, key: "Export_all_referenced_locals_90060", text: "Export all referenced locals"}
+
 var Update_modifiers_of_0 = &Message{code: 90061, category: CategoryMessage, key: "Update_modifiers_of_0_90061", text: "Update modifiers of '{0}'"}
+
 var Add_annotation_of_type_0 = &Message{code: 90062, category: CategoryMessage, key: "Add_annotation_of_type_0_90062", text: "Add annotation of type '{0}'"}
+
 var Add_return_type_0 = &Message{code: 90063, category: CategoryMessage, key: "Add_return_type_0_90063", text: "Add return type '{0}'"}
+
 var Extract_base_class_to_variable = &Message{code: 90064, category: CategoryMessage, key: "Extract_base_class_to_variable_90064", text: "Extract base class to variable"}
+
 var Extract_default_export_to_variable = &Message{code: 90065, category: CategoryMessage, key: "Extract_default_export_to_variable_90065", text: "Extract default export to variable"}
+
 var Extract_binding_expressions_to_variable = &Message{code: 90066, category: CategoryMessage, key: "Extract_binding_expressions_to_variable_90066", text: "Extract binding expressions to variable"}
+
 var Add_all_missing_type_annotations = &Message{code: 90067, category: CategoryMessage, key: "Add_all_missing_type_annotations_90067", text: "Add all missing type annotations"}
+
 var Add_satisfies_and_an_inline_type_assertion_with_0 = &Message{code: 90068, category: CategoryMessage, key: "Add_satisfies_and_an_inline_type_assertion_with_0_90068", text: "Add satisfies and an inline type assertion with '{0}'"}
+
 var Extract_to_variable_and_replace_with_0_as_typeof_0 = &Message{code: 90069, category: CategoryMessage, key: "Extract_to_variable_and_replace_with_0_as_typeof_0_90069", text: "Extract to variable and replace with '{0} as typeof {0}'"}
+
 var Mark_array_literal_as_const = &Message{code: 90070, category: CategoryMessage, key: "Mark_array_literal_as_const_90070", text: "Mark array literal as const"}
+
 var Annotate_types_of_properties_expando_function_in_a_namespace = &Message{code: 90071, category: CategoryMessage, key: "Annotate_types_of_properties_expando_function_in_a_namespace_90071", text: "Annotate types of properties expando function in a namespace"}
+
 var Convert_function_to_an_ES2015_class = &Message{code: 95001, category: CategoryMessage, key: "Convert_function_to_an_ES2015_class_95001", text: "Convert function to an ES2015 class"}
+
 var Convert_0_to_1_in_0 = &Message{code: 95003, category: CategoryMessage, key: "Convert_0_to_1_in_0_95003", text: "Convert '{0}' to '{1} in {0}'"}
+
 var Extract_to_0_in_1 = &Message{code: 95004, category: CategoryMessage, key: "Extract_to_0_in_1_95004", text: "Extract to {0} in {1}"}
+
 var Extract_function = &Message{code: 95005, category: CategoryMessage, key: "Extract_function_95005", text: "Extract function"}
+
 var Extract_constant = &Message{code: 95006, category: CategoryMessage, key: "Extract_constant_95006", text: "Extract constant"}
+
 var Extract_to_0_in_enclosing_scope = &Message{code: 95007, category: CategoryMessage, key: "Extract_to_0_in_enclosing_scope_95007", text: "Extract to {0} in enclosing scope"}
+
 var Extract_to_0_in_1_scope = &Message{code: 95008, category: CategoryMessage, key: "Extract_to_0_in_1_scope_95008", text: "Extract to {0} in {1} scope"}
+
 var Annotate_with_type_from_JSDoc = &Message{code: 95009, category: CategoryMessage, key: "Annotate_with_type_from_JSDoc_95009", text: "Annotate with type from JSDoc"}
+
 var Infer_type_of_0_from_usage = &Message{code: 95011, category: CategoryMessage, key: "Infer_type_of_0_from_usage_95011", text: "Infer type of '{0}' from usage"}
+
 var Infer_parameter_types_from_usage = &Message{code: 95012, category: CategoryMessage, key: "Infer_parameter_types_from_usage_95012", text: "Infer parameter types from usage"}
+
 var Convert_to_default_import = &Message{code: 95013, category: CategoryMessage, key: "Convert_to_default_import_95013", text: "Convert to default import"}
+
 var Install_0 = &Message{code: 95014, category: CategoryMessage, key: "Install_0_95014", text: "Install '{0}'"}
+
 var Replace_import_with_0 = &Message{code: 95015, category: CategoryMessage, key: "Replace_import_with_0_95015", text: "Replace import with '{0}'."}
+
 var Use_synthetic_default_member = &Message{code: 95016, category: CategoryMessage, key: "Use_synthetic_default_member_95016", text: "Use synthetic 'default' member."}
+
 var Convert_to_ES_module = &Message{code: 95017, category: CategoryMessage, key: "Convert_to_ES_module_95017", text: "Convert to ES module"}
+
 var Add_undefined_type_to_property_0 = &Message{code: 95018, category: CategoryMessage, key: "Add_undefined_type_to_property_0_95018", text: "Add 'undefined' type to property '{0}'"}
+
 var Add_initializer_to_property_0 = &Message{code: 95019, category: CategoryMessage, key: "Add_initializer_to_property_0_95019", text: "Add initializer to property '{0}'"}
+
 var Add_definite_assignment_assertion_to_property_0 = &Message{code: 95020, category: CategoryMessage, key: "Add_definite_assignment_assertion_to_property_0_95020", text: "Add definite assignment assertion to property '{0}'"}
+
 var Convert_all_type_literals_to_mapped_type = &Message{code: 95021, category: CategoryMessage, key: "Convert_all_type_literals_to_mapped_type_95021", text: "Convert all type literals to mapped type"}
+
 var Add_all_missing_members = &Message{code: 95022, category: CategoryMessage, key: "Add_all_missing_members_95022", text: "Add all missing members"}
+
 var Infer_all_types_from_usage = &Message{code: 95023, category: CategoryMessage, key: "Infer_all_types_from_usage_95023", text: "Infer all types from usage"}
+
 var Delete_all_unused_declarations = &Message{code: 95024, category: CategoryMessage, key: "Delete_all_unused_declarations_95024", text: "Delete all unused declarations"}
+
 var Prefix_all_unused_declarations_with_where_possible = &Message{code: 95025, category: CategoryMessage, key: "Prefix_all_unused_declarations_with_where_possible_95025", text: "Prefix all unused declarations with '_' where possible"}
+
 var Fix_all_detected_spelling_errors = &Message{code: 95026, category: CategoryMessage, key: "Fix_all_detected_spelling_errors_95026", text: "Fix all detected spelling errors"}
+
 var Add_initializers_to_all_uninitialized_properties = &Message{code: 95027, category: CategoryMessage, key: "Add_initializers_to_all_uninitialized_properties_95027", text: "Add initializers to all uninitialized properties"}
+
 var Add_definite_assignment_assertions_to_all_uninitialized_properties = &Message{code: 95028, category: CategoryMessage, key: "Add_definite_assignment_assertions_to_all_uninitialized_properties_95028", text: "Add definite assignment assertions to all uninitialized properties"}
+
 var Add_undefined_type_to_all_uninitialized_properties = &Message{code: 95029, category: CategoryMessage, key: "Add_undefined_type_to_all_uninitialized_properties_95029", text: "Add undefined type to all uninitialized properties"}
+
 var Change_all_jsdoc_style_types_to_TypeScript = &Message{code: 95030, category: CategoryMessage, key: "Change_all_jsdoc_style_types_to_TypeScript_95030", text: "Change all jsdoc-style types to TypeScript"}
+
 var Change_all_jsdoc_style_types_to_TypeScript_and_add_undefined_to_nullable_types = &Message{code: 95031, category: CategoryMessage, key: "Change_all_jsdoc_style_types_to_TypeScript_and_add_undefined_to_nullable_types_95031", text: "Change all jsdoc-style types to TypeScript (and add '| undefined' to nullable types)"}
+
 var Implement_all_unimplemented_interfaces = &Message{code: 95032, category: CategoryMessage, key: "Implement_all_unimplemented_interfaces_95032", text: "Implement all unimplemented interfaces"}
+
 var Install_all_missing_types_packages = &Message{code: 95033, category: CategoryMessage, key: "Install_all_missing_types_packages_95033", text: "Install all missing types packages"}
+
 var Rewrite_all_as_indexed_access_types = &Message{code: 95034, category: CategoryMessage, key: "Rewrite_all_as_indexed_access_types_95034", text: "Rewrite all as indexed access types"}
+
 var Convert_all_to_default_imports = &Message{code: 95035, category: CategoryMessage, key: "Convert_all_to_default_imports_95035", text: "Convert all to default imports"}
+
 var Make_all_super_calls_the_first_statement_in_their_constructor = &Message{code: 95036, category: CategoryMessage, key: "Make_all_super_calls_the_first_statement_in_their_constructor_95036", text: "Make all 'super()' calls the first statement in their constructor"}
+
 var Add_qualifier_to_all_unresolved_variables_matching_a_member_name = &Message{code: 95037, category: CategoryMessage, key: "Add_qualifier_to_all_unresolved_variables_matching_a_member_name_95037", text: "Add qualifier to all unresolved variables matching a member name"}
+
 var Change_all_extended_interfaces_to_implements = &Message{code: 95038, category: CategoryMessage, key: "Change_all_extended_interfaces_to_implements_95038", text: "Change all extended interfaces to 'implements'"}
+
 var Add_all_missing_super_calls = &Message{code: 95039, category: CategoryMessage, key: "Add_all_missing_super_calls_95039", text: "Add all missing super calls"}
+
 var Implement_all_inherited_abstract_classes = &Message{code: 95040, category: CategoryMessage, key: "Implement_all_inherited_abstract_classes_95040", text: "Implement all inherited abstract classes"}
+
 var Add_all_missing_async_modifiers = &Message{code: 95041, category: CategoryMessage, key: "Add_all_missing_async_modifiers_95041", text: "Add all missing 'async' modifiers"}
+
 var Add_ts_ignore_to_all_error_messages = &Message{code: 95042, category: CategoryMessage, key: "Add_ts_ignore_to_all_error_messages_95042", text: "Add '@ts-ignore' to all error messages"}
+
 var Annotate_everything_with_types_from_JSDoc = &Message{code: 95043, category: CategoryMessage, key: "Annotate_everything_with_types_from_JSDoc_95043", text: "Annotate everything with types from JSDoc"}
+
 var Add_to_all_uncalled_decorators = &Message{code: 95044, category: CategoryMessage, key: "Add_to_all_uncalled_decorators_95044", text: "Add '()' to all uncalled decorators"}
+
 var Convert_all_constructor_functions_to_classes = &Message{code: 95045, category: CategoryMessage, key: "Convert_all_constructor_functions_to_classes_95045", text: "Convert all constructor functions to classes"}
+
 var Generate_get_and_set_accessors = &Message{code: 95046, category: CategoryMessage, key: "Generate_get_and_set_accessors_95046", text: "Generate 'get' and 'set' accessors"}
+
 var Convert_require_to_import = &Message{code: 95047, category: CategoryMessage, key: "Convert_require_to_import_95047", text: "Convert 'require' to 'import'"}
+
 var Convert_all_require_to_import = &Message{code: 95048, category: CategoryMessage, key: "Convert_all_require_to_import_95048", text: "Convert all 'require' to 'import'"}
+
 var Move_to_a_new_file = &Message{code: 95049, category: CategoryMessage, key: "Move_to_a_new_file_95049", text: "Move to a new file"}
+
 var Remove_unreachable_code = &Message{code: 95050, category: CategoryMessage, key: "Remove_unreachable_code_95050", text: "Remove unreachable code"}
+
 var Remove_all_unreachable_code = &Message{code: 95051, category: CategoryMessage, key: "Remove_all_unreachable_code_95051", text: "Remove all unreachable code"}
+
 var Add_missing_typeof = &Message{code: 95052, category: CategoryMessage, key: "Add_missing_typeof_95052", text: "Add missing 'typeof'"}
+
 var Remove_unused_label = &Message{code: 95053, category: CategoryMessage, key: "Remove_unused_label_95053", text: "Remove unused label"}
+
 var Remove_all_unused_labels = &Message{code: 95054, category: CategoryMessage, key: "Remove_all_unused_labels_95054", text: "Remove all unused labels"}
+
 var Convert_0_to_mapped_object_type = &Message{code: 95055, category: CategoryMessage, key: "Convert_0_to_mapped_object_type_95055", text: "Convert '{0}' to mapped object type"}
+
 var Convert_namespace_import_to_named_imports = &Message{code: 95056, category: CategoryMessage, key: "Convert_namespace_import_to_named_imports_95056", text: "Convert namespace import to named imports"}
+
 var Convert_named_imports_to_namespace_import = &Message{code: 95057, category: CategoryMessage, key: "Convert_named_imports_to_namespace_import_95057", text: "Convert named imports to namespace import"}
+
 var Add_or_remove_braces_in_an_arrow_function = &Message{code: 95058, category: CategoryMessage, key: "Add_or_remove_braces_in_an_arrow_function_95058", text: "Add or remove braces in an arrow function"}
+
 var Add_braces_to_arrow_function = &Message{code: 95059, category: CategoryMessage, key: "Add_braces_to_arrow_function_95059", text: "Add braces to arrow function"}
+
 var Remove_braces_from_arrow_function = &Message{code: 95060, category: CategoryMessage, key: "Remove_braces_from_arrow_function_95060", text: "Remove braces from arrow function"}
+
 var Convert_default_export_to_named_export = &Message{code: 95061, category: CategoryMessage, key: "Convert_default_export_to_named_export_95061", text: "Convert default export to named export"}
+
 var Convert_named_export_to_default_export = &Message{code: 95062, category: CategoryMessage, key: "Convert_named_export_to_default_export_95062", text: "Convert named export to default export"}
+
 var Add_missing_enum_member_0 = &Message{code: 95063, category: CategoryMessage, key: "Add_missing_enum_member_0_95063", text: "Add missing enum member '{0}'"}
+
 var Add_all_missing_imports = &Message{code: 95064, category: CategoryMessage, key: "Add_all_missing_imports_95064", text: "Add all missing imports"}
+
 var Convert_to_async_function = &Message{code: 95065, category: CategoryMessage, key: "Convert_to_async_function_95065", text: "Convert to async function"}
+
 var Convert_all_to_async_functions = &Message{code: 95066, category: CategoryMessage, key: "Convert_all_to_async_functions_95066", text: "Convert all to async functions"}
+
 var Add_missing_call_parentheses = &Message{code: 95067, category: CategoryMessage, key: "Add_missing_call_parentheses_95067", text: "Add missing call parentheses"}
+
 var Add_all_missing_call_parentheses = &Message{code: 95068, category: CategoryMessage, key: "Add_all_missing_call_parentheses_95068", text: "Add all missing call parentheses"}
+
 var Add_unknown_conversion_for_non_overlapping_types = &Message{code: 95069, category: CategoryMessage, key: "Add_unknown_conversion_for_non_overlapping_types_95069", text: "Add 'unknown' conversion for non-overlapping types"}
+
 var Add_unknown_to_all_conversions_of_non_overlapping_types = &Message{code: 95070, category: CategoryMessage, key: "Add_unknown_to_all_conversions_of_non_overlapping_types_95070", text: "Add 'unknown' to all conversions of non-overlapping types"}
+
 var Add_missing_new_operator_to_call = &Message{code: 95071, category: CategoryMessage, key: "Add_missing_new_operator_to_call_95071", text: "Add missing 'new' operator to call"}
+
 var Add_missing_new_operator_to_all_calls = &Message{code: 95072, category: CategoryMessage, key: "Add_missing_new_operator_to_all_calls_95072", text: "Add missing 'new' operator to all calls"}
+
 var Add_names_to_all_parameters_without_names = &Message{code: 95073, category: CategoryMessage, key: "Add_names_to_all_parameters_without_names_95073", text: "Add names to all parameters without names"}
+
 var Enable_the_experimentalDecorators_option_in_your_configuration_file = &Message{code: 95074, category: CategoryMessage, key: "Enable_the_experimentalDecorators_option_in_your_configuration_file_95074", text: "Enable the 'experimentalDecorators' option in your configuration file"}
+
 var Convert_parameters_to_destructured_object = &Message{code: 95075, category: CategoryMessage, key: "Convert_parameters_to_destructured_object_95075", text: "Convert parameters to destructured object"}
+
 var Extract_type = &Message{code: 95077, category: CategoryMessage, key: "Extract_type_95077", text: "Extract type"}
+
 var Extract_to_type_alias = &Message{code: 95078, category: CategoryMessage, key: "Extract_to_type_alias_95078", text: "Extract to type alias"}
+
 var Extract_to_typedef = &Message{code: 95079, category: CategoryMessage, key: "Extract_to_typedef_95079", text: "Extract to typedef"}
+
 var Infer_this_type_of_0_from_usage = &Message{code: 95080, category: CategoryMessage, key: "Infer_this_type_of_0_from_usage_95080", text: "Infer 'this' type of '{0}' from usage"}
+
 var Add_const_to_unresolved_variable = &Message{code: 95081, category: CategoryMessage, key: "Add_const_to_unresolved_variable_95081", text: "Add 'const' to unresolved variable"}
+
 var Add_const_to_all_unresolved_variables = &Message{code: 95082, category: CategoryMessage, key: "Add_const_to_all_unresolved_variables_95082", text: "Add 'const' to all unresolved variables"}
+
 var Add_await = &Message{code: 95083, category: CategoryMessage, key: "Add_await_95083", text: "Add 'await'"}
+
 var Add_await_to_initializer_for_0 = &Message{code: 95084, category: CategoryMessage, key: "Add_await_to_initializer_for_0_95084", text: "Add 'await' to initializer for '{0}'"}
+
 var Fix_all_expressions_possibly_missing_await = &Message{code: 95085, category: CategoryMessage, key: "Fix_all_expressions_possibly_missing_await_95085", text: "Fix all expressions possibly missing 'await'"}
+
 var Remove_unnecessary_await = &Message{code: 95086, category: CategoryMessage, key: "Remove_unnecessary_await_95086", text: "Remove unnecessary 'await'"}
+
 var Remove_all_unnecessary_uses_of_await = &Message{code: 95087, category: CategoryMessage, key: "Remove_all_unnecessary_uses_of_await_95087", text: "Remove all unnecessary uses of 'await'"}
+
 var Enable_the_jsx_flag_in_your_configuration_file = &Message{code: 95088, category: CategoryMessage, key: "Enable_the_jsx_flag_in_your_configuration_file_95088", text: "Enable the '--jsx' flag in your configuration file"}
+
 var Add_await_to_initializers = &Message{code: 95089, category: CategoryMessage, key: "Add_await_to_initializers_95089", text: "Add 'await' to initializers"}
+
 var Extract_to_interface = &Message{code: 95090, category: CategoryMessage, key: "Extract_to_interface_95090", text: "Extract to interface"}
+
 var Convert_to_a_bigint_numeric_literal = &Message{code: 95091, category: CategoryMessage, key: "Convert_to_a_bigint_numeric_literal_95091", text: "Convert to a bigint numeric literal"}
+
 var Convert_all_to_bigint_numeric_literals = &Message{code: 95092, category: CategoryMessage, key: "Convert_all_to_bigint_numeric_literals_95092", text: "Convert all to bigint numeric literals"}
+
 var Convert_const_to_let = &Message{code: 95093, category: CategoryMessage, key: "Convert_const_to_let_95093", text: "Convert 'const' to 'let'"}
+
 var Prefix_with_declare = &Message{code: 95094, category: CategoryMessage, key: "Prefix_with_declare_95094", text: "Prefix with 'declare'"}
+
 var Prefix_all_incorrect_property_declarations_with_declare = &Message{code: 95095, category: CategoryMessage, key: "Prefix_all_incorrect_property_declarations_with_declare_95095", text: "Prefix all incorrect property declarations with 'declare'"}
+
 var Convert_to_template_string = &Message{code: 95096, category: CategoryMessage, key: "Convert_to_template_string_95096", text: "Convert to template string"}
+
 var Add_export_to_make_this_file_into_a_module = &Message{code: 95097, category: CategoryMessage, key: "Add_export_to_make_this_file_into_a_module_95097", text: "Add 'export {}' to make this file into a module"}
+
 var Set_the_target_option_in_your_configuration_file_to_0 = &Message{code: 95098, category: CategoryMessage, key: "Set_the_target_option_in_your_configuration_file_to_0_95098", text: "Set the 'target' option in your configuration file to '{0}'"}
+
 var Set_the_module_option_in_your_configuration_file_to_0 = &Message{code: 95099, category: CategoryMessage, key: "Set_the_module_option_in_your_configuration_file_to_0_95099", text: "Set the 'module' option in your configuration file to '{0}'"}
+
 var Convert_invalid_character_to_its_html_entity_code = &Message{code: 95100, category: CategoryMessage, key: "Convert_invalid_character_to_its_html_entity_code_95100", text: "Convert invalid character to its html entity code"}
+
 var Convert_all_invalid_characters_to_HTML_entity_code = &Message{code: 95101, category: CategoryMessage, key: "Convert_all_invalid_characters_to_HTML_entity_code_95101", text: "Convert all invalid characters to HTML entity code"}
+
 var Convert_all_const_to_let = &Message{code: 95102, category: CategoryMessage, key: "Convert_all_const_to_let_95102", text: "Convert all 'const' to 'let'"}
+
 var Convert_function_expression_0_to_arrow_function = &Message{code: 95105, category: CategoryMessage, key: "Convert_function_expression_0_to_arrow_function_95105", text: "Convert function expression '{0}' to arrow function"}
+
 var Convert_function_declaration_0_to_arrow_function = &Message{code: 95106, category: CategoryMessage, key: "Convert_function_declaration_0_to_arrow_function_95106", text: "Convert function declaration '{0}' to arrow function"}
+
 var Fix_all_implicit_this_errors = &Message{code: 95107, category: CategoryMessage, key: "Fix_all_implicit_this_errors_95107", text: "Fix all implicit-'this' errors"}
+
 var Wrap_invalid_character_in_an_expression_container = &Message{code: 95108, category: CategoryMessage, key: "Wrap_invalid_character_in_an_expression_container_95108", text: "Wrap invalid character in an expression container"}
+
 var Wrap_all_invalid_characters_in_an_expression_container = &Message{code: 95109, category: CategoryMessage, key: "Wrap_all_invalid_characters_in_an_expression_container_95109", text: "Wrap all invalid characters in an expression container"}
+
 var Visit_https_Colon_Slash_Slashaka_ms_Slashtsconfig_to_read_more_about_this_file = &Message{code: 95110, category: CategoryMessage, key: "Visit_https_Colon_Slash_Slashaka_ms_Slashtsconfig_to_read_more_about_this_file_95110", text: "Visit https://aka.ms/tsconfig to read more about this file"}
+
 var Add_a_return_statement = &Message{code: 95111, category: CategoryMessage, key: "Add_a_return_statement_95111", text: "Add a return statement"}
+
 var Remove_braces_from_arrow_function_body = &Message{code: 95112, category: CategoryMessage, key: "Remove_braces_from_arrow_function_body_95112", text: "Remove braces from arrow function body"}
+
 var Wrap_the_following_body_with_parentheses_which_should_be_an_object_literal = &Message{code: 95113, category: CategoryMessage, key: "Wrap_the_following_body_with_parentheses_which_should_be_an_object_literal_95113", text: "Wrap the following body with parentheses which should be an object literal"}
+
 var Add_all_missing_return_statement = &Message{code: 95114, category: CategoryMessage, key: "Add_all_missing_return_statement_95114", text: "Add all missing return statement"}
+
 var Remove_braces_from_all_arrow_function_bodies_with_relevant_issues = &Message{code: 95115, category: CategoryMessage, key: "Remove_braces_from_all_arrow_function_bodies_with_relevant_issues_95115", text: "Remove braces from all arrow function bodies with relevant issues"}
+
 var Wrap_all_object_literal_with_parentheses = &Message{code: 95116, category: CategoryMessage, key: "Wrap_all_object_literal_with_parentheses_95116", text: "Wrap all object literal with parentheses"}
+
 var Move_labeled_tuple_element_modifiers_to_labels = &Message{code: 95117, category: CategoryMessage, key: "Move_labeled_tuple_element_modifiers_to_labels_95117", text: "Move labeled tuple element modifiers to labels"}
+
 var Convert_overload_list_to_single_signature = &Message{code: 95118, category: CategoryMessage, key: "Convert_overload_list_to_single_signature_95118", text: "Convert overload list to single signature"}
+
 var Generate_get_and_set_accessors_for_all_overriding_properties = &Message{code: 95119, category: CategoryMessage, key: "Generate_get_and_set_accessors_for_all_overriding_properties_95119", text: "Generate 'get' and 'set' accessors for all overriding properties"}
+
 var Wrap_in_JSX_fragment = &Message{code: 95120, category: CategoryMessage, key: "Wrap_in_JSX_fragment_95120", text: "Wrap in JSX fragment"}
+
 var Wrap_all_unparented_JSX_in_JSX_fragment = &Message{code: 95121, category: CategoryMessage, key: "Wrap_all_unparented_JSX_in_JSX_fragment_95121", text: "Wrap all unparented JSX in JSX fragment"}
+
 var Convert_arrow_function_or_function_expression = &Message{code: 95122, category: CategoryMessage, key: "Convert_arrow_function_or_function_expression_95122", text: "Convert arrow function or function expression"}
+
 var Convert_to_anonymous_function = &Message{code: 95123, category: CategoryMessage, key: "Convert_to_anonymous_function_95123", text: "Convert to anonymous function"}
+
 var Convert_to_named_function = &Message{code: 95124, category: CategoryMessage, key: "Convert_to_named_function_95124", text: "Convert to named function"}
+
 var Convert_to_arrow_function = &Message{code: 95125, category: CategoryMessage, key: "Convert_to_arrow_function_95125", text: "Convert to arrow function"}
+
 var Remove_parentheses = &Message{code: 95126, category: CategoryMessage, key: "Remove_parentheses_95126", text: "Remove parentheses"}
+
 var Could_not_find_a_containing_arrow_function = &Message{code: 95127, category: CategoryMessage, key: "Could_not_find_a_containing_arrow_function_95127", text: "Could not find a containing arrow function"}
+
 var Containing_function_is_not_an_arrow_function = &Message{code: 95128, category: CategoryMessage, key: "Containing_function_is_not_an_arrow_function_95128", text: "Containing function is not an arrow function"}
+
 var Could_not_find_export_statement = &Message{code: 95129, category: CategoryMessage, key: "Could_not_find_export_statement_95129", text: "Could not find export statement"}
+
 var This_file_already_has_a_default_export = &Message{code: 95130, category: CategoryMessage, key: "This_file_already_has_a_default_export_95130", text: "This file already has a default export"}
+
 var Could_not_find_import_clause = &Message{code: 95131, category: CategoryMessage, key: "Could_not_find_import_clause_95131", text: "Could not find import clause"}
+
 var Could_not_find_namespace_import_or_named_imports = &Message{code: 95132, category: CategoryMessage, key: "Could_not_find_namespace_import_or_named_imports_95132", text: "Could not find namespace import or named imports"}
+
 var Selection_is_not_a_valid_type_node = &Message{code: 95133, category: CategoryMessage, key: "Selection_is_not_a_valid_type_node_95133", text: "Selection is not a valid type node"}
+
 var No_type_could_be_extracted_from_this_type_node = &Message{code: 95134, category: CategoryMessage, key: "No_type_could_be_extracted_from_this_type_node_95134", text: "No type could be extracted from this type node"}
+
 var Could_not_find_property_for_which_to_generate_accessor = &Message{code: 95135, category: CategoryMessage, key: "Could_not_find_property_for_which_to_generate_accessor_95135", text: "Could not find property for which to generate accessor"}
+
 var Name_is_not_valid = &Message{code: 95136, category: CategoryMessage, key: "Name_is_not_valid_95136", text: "Name is not valid"}
+
 var Can_only_convert_property_with_modifier = &Message{code: 95137, category: CategoryMessage, key: "Can_only_convert_property_with_modifier_95137", text: "Can only convert property with modifier"}
+
 var Switch_each_misused_0_to_1 = &Message{code: 95138, category: CategoryMessage, key: "Switch_each_misused_0_to_1_95138", text: "Switch each misused '{0}' to '{1}'"}
+
 var Convert_to_optional_chain_expression = &Message{code: 95139, category: CategoryMessage, key: "Convert_to_optional_chain_expression_95139", text: "Convert to optional chain expression"}
+
 var Could_not_find_convertible_access_expression = &Message{code: 95140, category: CategoryMessage, key: "Could_not_find_convertible_access_expression_95140", text: "Could not find convertible access expression"}
+
 var Could_not_find_matching_access_expressions = &Message{code: 95141, category: CategoryMessage, key: "Could_not_find_matching_access_expressions_95141", text: "Could not find matching access expressions"}
+
 var Can_only_convert_logical_AND_access_chains = &Message{code: 95142, category: CategoryMessage, key: "Can_only_convert_logical_AND_access_chains_95142", text: "Can only convert logical AND access chains"}
+
 var Add_void_to_Promise_resolved_without_a_value = &Message{code: 95143, category: CategoryMessage, key: "Add_void_to_Promise_resolved_without_a_value_95143", text: "Add 'void' to Promise resolved without a value"}
+
 var Add_void_to_all_Promises_resolved_without_a_value = &Message{code: 95144, category: CategoryMessage, key: "Add_void_to_all_Promises_resolved_without_a_value_95144", text: "Add 'void' to all Promises resolved without a value"}
+
 var Use_element_access_for_0 = &Message{code: 95145, category: CategoryMessage, key: "Use_element_access_for_0_95145", text: "Use element access for '{0}'"}
+
 var Use_element_access_for_all_undeclared_properties = &Message{code: 95146, category: CategoryMessage, key: "Use_element_access_for_all_undeclared_properties_95146", text: "Use element access for all undeclared properties."}
+
 var Delete_all_unused_imports = &Message{code: 95147, category: CategoryMessage, key: "Delete_all_unused_imports_95147", text: "Delete all unused imports"}
+
 var Infer_function_return_type = &Message{code: 95148, category: CategoryMessage, key: "Infer_function_return_type_95148", text: "Infer function return type"}
+
 var Return_type_must_be_inferred_from_a_function = &Message{code: 95149, category: CategoryMessage, key: "Return_type_must_be_inferred_from_a_function_95149", text: "Return type must be inferred from a function"}
+
 var Could_not_determine_function_return_type = &Message{code: 95150, category: CategoryMessage, key: "Could_not_determine_function_return_type_95150", text: "Could not determine function return type"}
+
 var Could_not_convert_to_arrow_function = &Message{code: 95151, category: CategoryMessage, key: "Could_not_convert_to_arrow_function_95151", text: "Could not convert to arrow function"}
+
 var Could_not_convert_to_named_function = &Message{code: 95152, category: CategoryMessage, key: "Could_not_convert_to_named_function_95152", text: "Could not convert to named function"}
+
 var Could_not_convert_to_anonymous_function = &Message{code: 95153, category: CategoryMessage, key: "Could_not_convert_to_anonymous_function_95153", text: "Could not convert to anonymous function"}
+
 var Can_only_convert_string_concatenations_and_string_literals = &Message{code: 95154, category: CategoryMessage, key: "Can_only_convert_string_concatenations_and_string_literals_95154", text: "Can only convert string concatenations and string literals"}
+
 var Selection_is_not_a_valid_statement_or_statements = &Message{code: 95155, category: CategoryMessage, key: "Selection_is_not_a_valid_statement_or_statements_95155", text: "Selection is not a valid statement or statements"}
+
 var Add_missing_function_declaration_0 = &Message{code: 95156, category: CategoryMessage, key: "Add_missing_function_declaration_0_95156", text: "Add missing function declaration '{0}'"}
+
 var Add_all_missing_function_declarations = &Message{code: 95157, category: CategoryMessage, key: "Add_all_missing_function_declarations_95157", text: "Add all missing function declarations"}
+
 var Method_not_implemented = &Message{code: 95158, category: CategoryMessage, key: "Method_not_implemented_95158", text: "Method not implemented."}
+
 var Function_not_implemented = &Message{code: 95159, category: CategoryMessage, key: "Function_not_implemented_95159", text: "Function not implemented."}
+
 var Add_override_modifier = &Message{code: 95160, category: CategoryMessage, key: "Add_override_modifier_95160", text: "Add 'override' modifier"}
+
 var Remove_override_modifier = &Message{code: 95161, category: CategoryMessage, key: "Remove_override_modifier_95161", text: "Remove 'override' modifier"}
+
 var Add_all_missing_override_modifiers = &Message{code: 95162, category: CategoryMessage, key: "Add_all_missing_override_modifiers_95162", text: "Add all missing 'override' modifiers"}
+
 var Remove_all_unnecessary_override_modifiers = &Message{code: 95163, category: CategoryMessage, key: "Remove_all_unnecessary_override_modifiers_95163", text: "Remove all unnecessary 'override' modifiers"}
+
 var Can_only_convert_named_export = &Message{code: 95164, category: CategoryMessage, key: "Can_only_convert_named_export_95164", text: "Can only convert named export"}
+
 var Add_missing_properties = &Message{code: 95165, category: CategoryMessage, key: "Add_missing_properties_95165", text: "Add missing properties"}
+
 var Add_all_missing_properties = &Message{code: 95166, category: CategoryMessage, key: "Add_all_missing_properties_95166", text: "Add all missing properties"}
+
 var Add_missing_attributes = &Message{code: 95167, category: CategoryMessage, key: "Add_missing_attributes_95167", text: "Add missing attributes"}
+
 var Add_all_missing_attributes = &Message{code: 95168, category: CategoryMessage, key: "Add_all_missing_attributes_95168", text: "Add all missing attributes"}
+
 var Add_undefined_to_optional_property_type = &Message{code: 95169, category: CategoryMessage, key: "Add_undefined_to_optional_property_type_95169", text: "Add 'undefined' to optional property type"}
+
 var Convert_named_imports_to_default_import = &Message{code: 95170, category: CategoryMessage, key: "Convert_named_imports_to_default_import_95170", text: "Convert named imports to default import"}
+
 var Delete_unused_param_tag_0 = &Message{code: 95171, category: CategoryMessage, key: "Delete_unused_param_tag_0_95171", text: "Delete unused '@param' tag '{0}'"}
+
 var Delete_all_unused_param_tags = &Message{code: 95172, category: CategoryMessage, key: "Delete_all_unused_param_tags_95172", text: "Delete all unused '@param' tags"}
+
 var Rename_param_tag_name_0_to_1 = &Message{code: 95173, category: CategoryMessage, key: "Rename_param_tag_name_0_to_1_95173", text: "Rename '@param' tag name '{0}' to '{1}'"}
+
 var Use_0 = &Message{code: 95174, category: CategoryMessage, key: "Use_0_95174", text: "Use `{0}`."}
+
 var Use_Number_isNaN_in_all_conditions = &Message{code: 95175, category: CategoryMessage, key: "Use_Number_isNaN_in_all_conditions_95175", text: "Use `Number.isNaN` in all conditions."}
+
 var Convert_typedef_to_TypeScript_type = &Message{code: 95176, category: CategoryMessage, key: "Convert_typedef_to_TypeScript_type_95176", text: "Convert typedef to TypeScript type."}
+
 var Convert_all_typedef_to_TypeScript_types = &Message{code: 95177, category: CategoryMessage, key: "Convert_all_typedef_to_TypeScript_types_95177", text: "Convert all typedef to TypeScript types."}
+
 var Move_to_file = &Message{code: 95178, category: CategoryMessage, key: "Move_to_file_95178", text: "Move to file"}
+
 var Cannot_move_to_file_selected_file_is_invalid = &Message{code: 95179, category: CategoryMessage, key: "Cannot_move_to_file_selected_file_is_invalid_95179", text: "Cannot move to file, selected file is invalid"}
+
 var Use_import_type = &Message{code: 95180, category: CategoryMessage, key: "Use_import_type_95180", text: "Use 'import type'"}
+
 var Use_type_0 = &Message{code: 95181, category: CategoryMessage, key: "Use_type_0_95181", text: "Use 'type {0}'"}
+
 var Fix_all_with_type_only_imports = &Message{code: 95182, category: CategoryMessage, key: "Fix_all_with_type_only_imports_95182", text: "Fix all with type-only imports"}
+
 var Cannot_move_statements_to_the_selected_file = &Message{code: 95183, category: CategoryMessage, key: "Cannot_move_statements_to_the_selected_file_95183", text: "Cannot move statements to the selected file"}
+
 var Inline_variable = &Message{code: 95184, category: CategoryMessage, key: "Inline_variable_95184", text: "Inline variable"}
+
 var Could_not_find_variable_to_inline = &Message{code: 95185, category: CategoryMessage, key: "Could_not_find_variable_to_inline_95185", text: "Could not find variable to inline."}
+
 var Variables_with_multiple_declarations_cannot_be_inlined = &Message{code: 95186, category: CategoryMessage, key: "Variables_with_multiple_declarations_cannot_be_inlined_95186", text: "Variables with multiple declarations cannot be inlined."}
+
 var Add_missing_comma_for_object_member_completion_0 = &Message{code: 95187, category: CategoryMessage, key: "Add_missing_comma_for_object_member_completion_0_95187", text: "Add missing comma for object member completion '{0}'."}
+
 var Add_missing_parameter_to_0 = &Message{code: 95188, category: CategoryMessage, key: "Add_missing_parameter_to_0_95188", text: "Add missing parameter to '{0}'"}
+
 var Add_missing_parameters_to_0 = &Message{code: 95189, category: CategoryMessage, key: "Add_missing_parameters_to_0_95189", text: "Add missing parameters to '{0}'"}
+
 var Add_all_missing_parameters = &Message{code: 95190, category: CategoryMessage, key: "Add_all_missing_parameters_95190", text: "Add all missing parameters"}
+
 var Add_optional_parameter_to_0 = &Message{code: 95191, category: CategoryMessage, key: "Add_optional_parameter_to_0_95191", text: "Add optional parameter to '{0}'"}
+
 var Add_optional_parameters_to_0 = &Message{code: 95192, category: CategoryMessage, key: "Add_optional_parameters_to_0_95192", text: "Add optional parameters to '{0}'"}
+
 var Add_all_optional_parameters = &Message{code: 95193, category: CategoryMessage, key: "Add_all_optional_parameters_95193", text: "Add all optional parameters"}
+
 var Wrap_in_parentheses = &Message{code: 95194, category: CategoryMessage, key: "Wrap_in_parentheses_95194", text: "Wrap in parentheses"}
+
 var Wrap_all_invalid_decorator_expressions_in_parentheses = &Message{code: 95195, category: CategoryMessage, key: "Wrap_all_invalid_decorator_expressions_in_parentheses_95195", text: "Wrap all invalid decorator expressions in parentheses"}
+
 var Add_resolution_mode_import_attribute = &Message{code: 95196, category: CategoryMessage, key: "Add_resolution_mode_import_attribute_95196", text: "Add 'resolution-mode' import attribute"}
+
 var Add_resolution_mode_import_attribute_to_all_type_only_imports_that_need_it = &Message{code: 95197, category: CategoryMessage, key: "Add_resolution_mode_import_attribute_to_all_type_only_imports_that_need_it_95197", text: "Add 'resolution-mode' import attribute to all type-only imports that need it"}
+
 var Do_not_print_diagnostics = &Message{code: 100000, category: CategoryMessage, key: "Do_not_print_diagnostics_100000", text: "Do not print diagnostics."}
+
 var Run_in_single_threaded_mode = &Message{code: 100001, category: CategoryMessage, key: "Run_in_single_threaded_mode_100001", text: "Run in single threaded mode."}
+
 var Generate_pprof_CPU_Slashmemory_profiles_to_the_given_directory = &Message{code: 100002, category: CategoryMessage, key: "Generate_pprof_CPU_Slashmemory_profiles_to_the_given_directory_100002", text: "Generate pprof CPU/memory profiles to the given directory."}

--- a/internal/diagnostics/generate.go
+++ b/internal/diagnostics/generate.go
@@ -88,7 +88,7 @@ func main() {
 			buf.WriteString(`, reportsDeprecated: true`)
 		}
 
-		buf.WriteString("}\n")
+		buf.WriteString("}\n\n")
 	}
 
 	formatted, err := format.Source(buf.Bytes())

--- a/internal/lsp/lsproto/_generate/generate.mjs
+++ b/internal/lsp/lsproto/_generate/generate.mjs
@@ -634,8 +634,8 @@ function main() {
         fs.writeFileSync(out, generatedCode);
 
         // Format with gofmt
-        const gofmt = which.sync("gofmt");
-        cp.execFileSync(gofmt, ["-w", out]);
+        const gofmt = which.sync("go");
+        cp.execFileSync(gofmt, ["tool", "mvdan.cc/gofumpt", "-lang=go1.24", "-w", out]);
 
         console.log(`Successfully generated ${out}`);
     }

--- a/internal/lsp/lsproto/lsp_generated.go
+++ b/internal/lsp/lsproto/lsp_generated.go
@@ -983,8 +983,7 @@ type InitializeError struct {
 	Retry bool `json:"retry"`
 }
 
-type InitializedParams struct {
-}
+type InitializedParams struct{}
 
 // The parameters of a change configuration notification.
 type DidChangeConfigurationParams struct {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -21,6 +21,8 @@ import (
 )
 
 //go:generate go tool golang.org/x/tools/cmd/stringer -type=Kind -output=project_stringer_generated.go
+//go:generate go tool mvdan.cc/gofumpt -lang=go1.24 -w project_stringer_generated.go
+
 const hr = "-----------------------------------------------"
 
 var projectNamer = &namer{}

--- a/internal/testutil/projecttestutil/clientmock_generated.go
+++ b/internal/testutil/projecttestutil/clientmock_generated.go
@@ -84,9 +84,7 @@ func (mock *ClientMock) RefreshDiagnostics(ctx context.Context) error {
 	mock.calls.RefreshDiagnostics = append(mock.calls.RefreshDiagnostics, callInfo)
 	mock.lockRefreshDiagnostics.Unlock()
 	if mock.RefreshDiagnosticsFunc == nil {
-		var (
-			errOut error
-		)
+		var errOut error
 		return errOut
 	}
 	return mock.RefreshDiagnosticsFunc(ctx)
@@ -121,9 +119,7 @@ func (mock *ClientMock) UnwatchFiles(ctx context.Context, handle project.Watcher
 	mock.calls.UnwatchFiles = append(mock.calls.UnwatchFiles, callInfo)
 	mock.lockUnwatchFiles.Unlock()
 	if mock.UnwatchFilesFunc == nil {
-		var (
-			errOut error
-		)
+		var errOut error
 		return errOut
 	}
 	return mock.UnwatchFilesFunc(ctx, handle)

--- a/internal/testutil/projecttestutil/projecttestutil.go
+++ b/internal/testutil/projecttestutil/projecttestutil.go
@@ -19,6 +19,7 @@ import (
 )
 
 //go:generate go tool github.com/matryer/moq -stub -fmt goimports -pkg projecttestutil -out clientmock_generated.go ../../project Client
+//go:generate go tool mvdan.cc/gofumpt -lang=go1.24 -w clientmock_generated.go
 
 type TestTypingsInstallerOptions struct {
 	TypesRegistry         []string

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -5,6 +5,7 @@ import (
 )
 
 //go:generate go tool github.com/matryer/moq -fmt goimports -out vfsmock/mock_generated.go -pkg vfsmock . FS
+//go:generate go tool mvdan.cc/gofumpt -lang=go1.24 -w vfsmock/mock_generated.go
 
 // FS is a file system abstraction.
 type FS interface {

--- a/internal/vfs/vfsmock/mock_generated.go
+++ b/internal/vfs/vfsmock/mock_generated.go
@@ -124,8 +124,7 @@ type FSMock struct {
 			Path string
 		}
 		// UseCaseSensitiveFileNames holds details about calls to the UseCaseSensitiveFileNames method.
-		UseCaseSensitiveFileNames []struct {
-		}
+		UseCaseSensitiveFileNames []struct{}
 		// WalkDir holds details about calls to the WalkDir method.
 		WalkDir []struct {
 			// Root is the root argument value.
@@ -384,8 +383,7 @@ func (mock *FSMock) UseCaseSensitiveFileNames() bool {
 	if mock.UseCaseSensitiveFileNamesFunc == nil {
 		panic("FSMock.UseCaseSensitiveFileNamesFunc: method is nil but FS.UseCaseSensitiveFileNames was just called")
 	}
-	callInfo := struct {
-	}{}
+	callInfo := struct{}{}
 	mock.lockUseCaseSensitiveFileNames.Lock()
 	mock.calls.UseCaseSensitiveFileNames = append(mock.calls.UseCaseSensitiveFileNames, callInfo)
 	mock.lockUseCaseSensitiveFileNames.Unlock()
@@ -396,10 +394,8 @@ func (mock *FSMock) UseCaseSensitiveFileNames() bool {
 // Check the length with:
 //
 //	len(mockedFS.UseCaseSensitiveFileNamesCalls())
-func (mock *FSMock) UseCaseSensitiveFileNamesCalls() []struct {
-} {
-	var calls []struct {
-	}
+func (mock *FSMock) UseCaseSensitiveFileNamesCalls() []struct{} {
+	var calls []struct{}
 	mock.lockUseCaseSensitiveFileNames.RLock()
 	calls = mock.calls.UseCaseSensitiveFileNames
 	mock.lockUseCaseSensitiveFileNames.RUnlock()


### PR DESCRIPTION
https://github.com/golang/go/issues/73959 will cause gopls to format generated files, which will probably get annoying when browsing around and (accidentally) hitting save, especially given we use gofumpt and not gofmt.

Preemptively format all of our generated files.