### PR TITLE
Move version from source file to document registry

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -9994,10 +9994,6 @@ type SourceFile struct {
 	lineMapMu sync.RWMutex
 	lineMap   []core.TextPos
 
-	// Fields set by document registry
-
-	Version int
-
 	// Fields set by language service
 
 	tokenCacheMu sync.Mutex

--- a/internal/project/documentregistry.go
+++ b/internal/project/documentregistry.go
@@ -27,6 +27,7 @@ func newRegistryKey(options *core.CompilerOptions, path tspath.Path, scriptKind 
 
 type registryEntry struct {
 	sourceFile *ast.SourceFile
+	version    int
 	refCount   int
 	mu         sync.Mutex
 }
@@ -94,28 +95,36 @@ func (r *DocumentRegistry) getDocumentWorker(
 	if entry, ok := r.documents.Load(key); ok {
 		// We have an entry for this file. However, it may be for a different version of
 		// the script snapshot. If so, update it appropriately.
-		if entry.sourceFile.Version != scriptInfoVersion {
+		if entry.version != scriptInfoVersion {
 			sourceFile := parser.ParseSourceFile(scriptInfo.fileName, scriptInfo.path, scriptInfoText, scriptTarget, scanner.JSDocParsingModeParseAll)
-			sourceFile.Version = scriptInfoVersion
 			entry.mu.Lock()
 			defer entry.mu.Unlock()
 			entry.sourceFile = sourceFile
+			entry.version = scriptInfoVersion
 		}
 		entry.refCount++
 		return entry.sourceFile
 	} else {
 		// Have never seen this file with these settings. Create a new source file for it.
 		sourceFile := parser.ParseSourceFile(scriptInfo.fileName, scriptInfo.path, scriptInfoText, scriptTarget, scanner.JSDocParsingModeParseAll)
-		sourceFile.Version = scriptInfoVersion
 		entry, _ := r.documents.LoadOrStore(key, &registryEntry{
 			sourceFile: sourceFile,
 			refCount:   0,
+			version:    scriptInfoVersion,
 		})
 		entry.mu.Lock()
 		defer entry.mu.Unlock()
 		entry.refCount++
 		return entry.sourceFile
 	}
+}
+
+func (r *DocumentRegistry) getFileVersion(file *ast.SourceFile, options *core.CompilerOptions) int {
+	key := newRegistryKey(options, file.Path(), file.ScriptKind)
+	if entry, ok := r.documents.Load(key); ok {
+		return entry.version
+	}
+	return -1
 }
 
 // size should only be used for testing.

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -46,7 +46,7 @@ type snapshot struct {
 func (s *snapshot) GetLineMap(fileName string) *ls.LineMap {
 	file := s.program.GetSourceFile(fileName)
 	scriptInfo := s.project.host.GetScriptInfoByPath(file.Path())
-	if file.Version == scriptInfo.Version() {
+	if s.project.getFileVersion(file, s.program.Options()) == scriptInfo.Version() {
 		return scriptInfo.LineMap()
 	}
 	return ls.ComputeLineStarts(file.Text())
@@ -1013,12 +1013,13 @@ func (p *Project) print(writeFileNames bool, writeFileExplanation bool, writeFil
 		builder.WriteString("\n\tFiles (0) NoProgram\n")
 	} else {
 		sourceFiles := p.program.GetSourceFiles()
+		options := p.program.Options()
 		builder.WriteString(fmt.Sprintf("\n\tFiles (%d)\n", len(sourceFiles)))
 		if writeFileNames {
 			for _, sourceFile := range sourceFiles {
 				builder.WriteString("\n\t\t" + sourceFile.FileName())
 				if writeFileVersionAndText {
-					builder.WriteString(fmt.Sprintf(" %d %s", sourceFile.Version, sourceFile.Text()))
+					builder.WriteString(fmt.Sprintf(" %d %s", p.getFileVersion(sourceFile, options), sourceFile.Text()))
 				}
 			}
 			// !!!
@@ -1027,6 +1028,10 @@ func (p *Project) print(writeFileNames bool, writeFileExplanation bool, writeFil
 	}
 	builder.WriteString(hr)
 	return builder.String()
+}
+
+func (p *Project) getFileVersion(file *ast.SourceFile, options *core.CompilerOptions) int {
+	return p.host.DocumentRegistry().getFileVersion(file, options)
 }
 
 func (p *Project) Log(s string) {


### PR DESCRIPTION
The version really only concerns the project and document registry, so I moved it there to avoid a data race in #991 where we cache `SourceFile`s.