### PR TITLE
Type width in error messages

### DIFF
--- a/internal/checker/relater.go
+++ b/internal/checker/relater.go
@@ -4705,7 +4705,14 @@ func (r *Relater) reportRelationError(message *diagnostics.Message, source *Type
 					return
 				}
 			}
-			message = diagnostics.Type_0_is_not_assignable_to_type_1
+
+			includesWideTypes := len(sourceType) > 30 && len(targetType) > 30 
+			isPretty := r.c.compilerOptions.Pretty == core.TSTrue
+			if isPretty && includesWideTypes {
+				message = diagnostics.Type_Colon_0_is_not_assignable_to_type_Colon_1
+			} else {
+				message = diagnostics.Type_0_is_not_assignable_to_type_1
+			}
 		}
 	}
 	switch r.getChainMessage(0) {

--- a/internal/diagnostics/diagnostics_generated.go
+++ b/internal/diagnostics/diagnostics_generated.go
@@ -1990,6 +1990,10 @@ var Using_JSX_fragments_requires_fragment_factory_0_to_be_in_scope_but_it_could_
 
 var Import_assertions_have_been_replaced_by_import_attributes_Use_with_instead_of_assert = &Message{code: 2880, category: CategoryError, key: "Import_assertions_have_been_replaced_by_import_attributes_Use_with_instead_of_assert_2880", text: "Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'."}
 
+var This_expression_is_never_nullish = &Message{code: 2881, category: CategoryError, key: "This_expression_is_never_nullish_2881", text: "This expression is never nullish."}
+
+var Type_Colon_0_is_not_assignable_to_type_Colon_1 = &Message{code: 2882, category: CategoryError, key: "Type_Colon_0_is_not_assignable_to_type_Colon_1_2882", text: "Type:\n  {0}\n\nis not assignable to type:\n  {1}\n"}
+
 var Import_declaration_0_is_using_private_name_1 = &Message{code: 4000, category: CategoryError, key: "Import_declaration_0_is_using_private_name_1_4000", text: "Import declaration '{0}' is using private name '{1}'."}
 
 var Type_parameter_0_of_exported_class_has_or_is_using_private_name_1 = &Message{code: 4002, category: CategoryError, key: "Type_parameter_0_of_exported_class_has_or_is_using_private_name_1_4002", text: "Type parameter '{0}' of exported class has or is using private name '{1}'."}

--- a/testdata/baselines/reference/compiler/prettyFormatLongTypes.errors.txt
+++ b/testdata/baselines/reference/compiler/prettyFormatLongTypes.errors.txt
@@ -1,0 +1,62 @@
+[96mprettyFormatLongTypes.ts[0m:[93m6[0m:[93m1[0m - [91merror[0m[90m TS2882: [0mType:
+  { b: { c: { e: { f: string; }; }; }; }
+
+is not assignable to type:
+  { b: { c: { e: { f: number; }; }; }; }
+
+  The types of 'b.c.e.f' are incompatible between these types.
+    Type 'string' is not assignable to type 'number'.
+
+[7m6[0m a = b;
+[7m [0m [91m~[0m
+
+[96mprettyFormatLongTypes.ts[0m:[93m9[0m:[93m1[0m - [91merror[0m[90m TS2322: [0mType 'string' is not assignable to type '{ b: { c: { e: { f: number; }; }; }; }'.
+
+[7m9[0m a = c;
+[7m [0m [91m~[0m
+
+[96mprettyFormatLongTypes.ts[0m:[93m12[0m:[93m1[0m - [91merror[0m[90m TS2322: [0mType '{ b: { c: { e: { f: number; }; }; }; }' is not assignable to type 'string'.
+
+[7m12[0m c = a;
+[7m  [0m [91m~[0m
+
+[96mprettyFormatLongTypes.ts[0m:[93m15[0m:[93m1[0m - [91merror[0m[90m TS2322: [0mType 'boolean' is not assignable to type 'string'.
+
+[7m15[0m c = false;
+[7m  [0m [91m~[0m
+
+
+==== prettyFormatLongTypes.ts (4 errors) ====
+    let a = { b: { c: { e: { f: 123 } } } };
+    let b = { b: { c: { e: { f: "123" } } } };
+    let c = "test";
+    
+    // both the source and target types are wide enough enough trigger pretty printing
+    a = b;
+    ~
+!!! error TS2882: Type:
+!!! error TS2882:   { b: { c: { e: { f: string; }; }; }; }
+!!! error TS2882: 
+!!! error TS2882: is not assignable to type:
+!!! error TS2882:   { b: { c: { e: { f: number; }; }; }; }
+!!! error TS2882: 
+!!! error TS2882:   The types of 'b.c.e.f' are incompatible between these types.
+!!! error TS2882:     Type 'string' is not assignable to type 'number'.
+    
+    // only the source type is wide enough to trigger pretty printing
+    a = c;
+    ~
+!!! error TS2322: Type 'string' is not assignable to type '{ b: { c: { e: { f: number; }; }; }; }'.
+    
+    // only the target type is wide enough to trigger pretty printing
+    c = a;
+    ~
+!!! error TS2322: Type '{ b: { c: { e: { f: number; }; }; }; }' is not assignable to type 'string'.
+    
+    // neither the source nor the target type is wide enough to trigger pretty printing
+    c = false;
+    ~
+!!! error TS2322: Type 'boolean' is not assignable to type 'string'.
+    
+Found 4 errors in the same file, starting at: prettyFormatLongTypes.ts[90m:6[0m
+

--- a/testdata/baselines/reference/compiler/prettyFormatLongTypes.js
+++ b/testdata/baselines/reference/compiler/prettyFormatLongTypes.js
@@ -1,0 +1,32 @@
+//// [tests/cases/compiler/prettyFormatLongTypes.ts] ////
+
+//// [prettyFormatLongTypes.ts]
+let a = { b: { c: { e: { f: 123 } } } };
+let b = { b: { c: { e: { f: "123" } } } };
+let c = "test";
+
+// both the source and target types are wide enough enough trigger pretty printing
+a = b;
+
+// only the source type is wide enough to trigger pretty printing
+a = c;
+
+// only the target type is wide enough to trigger pretty printing
+c = a;
+
+// neither the source nor the target type is wide enough to trigger pretty printing
+c = false;
+
+
+//// [prettyFormatLongTypes.js]
+let a = { b: { c: { e: { f: 123 } } } };
+let b = { b: { c: { e: { f: "123" } } } };
+let c = "test";
+// both the source and target types are wide enough enough trigger pretty printing
+a = b;
+// only the source type is wide enough to trigger pretty printing
+a = c;
+// only the target type is wide enough to trigger pretty printing
+c = a;
+// neither the source nor the target type is wide enough to trigger pretty printing
+c = false;

--- a/testdata/baselines/reference/compiler/prettyFormatLongTypes.symbols
+++ b/testdata/baselines/reference/compiler/prettyFormatLongTypes.symbols
@@ -1,0 +1,39 @@
+//// [tests/cases/compiler/prettyFormatLongTypes.ts] ////
+
+=== prettyFormatLongTypes.ts ===
+let a = { b: { c: { e: { f: 123 } } } };
+>a : Symbol(a, Decl(prettyFormatLongTypes.ts, 0, 3))
+>b : Symbol(b, Decl(prettyFormatLongTypes.ts, 0, 9))
+>c : Symbol(c, Decl(prettyFormatLongTypes.ts, 0, 14))
+>e : Symbol(e, Decl(prettyFormatLongTypes.ts, 0, 19))
+>f : Symbol(f, Decl(prettyFormatLongTypes.ts, 0, 24))
+
+let b = { b: { c: { e: { f: "123" } } } };
+>b : Symbol(b, Decl(prettyFormatLongTypes.ts, 1, 3))
+>b : Symbol(b, Decl(prettyFormatLongTypes.ts, 1, 9))
+>c : Symbol(c, Decl(prettyFormatLongTypes.ts, 1, 14))
+>e : Symbol(e, Decl(prettyFormatLongTypes.ts, 1, 19))
+>f : Symbol(f, Decl(prettyFormatLongTypes.ts, 1, 24))
+
+let c = "test";
+>c : Symbol(c, Decl(prettyFormatLongTypes.ts, 2, 3))
+
+// both the source and target types are wide enough enough trigger pretty printing
+a = b;
+>a : Symbol(a, Decl(prettyFormatLongTypes.ts, 0, 3))
+>b : Symbol(b, Decl(prettyFormatLongTypes.ts, 1, 3))
+
+// only the source type is wide enough to trigger pretty printing
+a = c;
+>a : Symbol(a, Decl(prettyFormatLongTypes.ts, 0, 3))
+>c : Symbol(c, Decl(prettyFormatLongTypes.ts, 2, 3))
+
+// only the target type is wide enough to trigger pretty printing
+c = a;
+>c : Symbol(c, Decl(prettyFormatLongTypes.ts, 2, 3))
+>a : Symbol(a, Decl(prettyFormatLongTypes.ts, 0, 3))
+
+// neither the source nor the target type is wide enough to trigger pretty printing
+c = false;
+>c : Symbol(c, Decl(prettyFormatLongTypes.ts, 2, 3))
+

--- a/testdata/baselines/reference/compiler/prettyFormatLongTypes.types
+++ b/testdata/baselines/reference/compiler/prettyFormatLongTypes.types
@@ -1,0 +1,55 @@
+//// [tests/cases/compiler/prettyFormatLongTypes.ts] ////
+
+=== prettyFormatLongTypes.ts ===
+let a = { b: { c: { e: { f: 123 } } } };
+>a : { b: { c: { e: { f: number; }; }; }; }
+>{ b: { c: { e: { f: 123 } } } } : { b: { c: { e: { f: number; }; }; }; }
+>b : { c: { e: { f: number; }; }; }
+>{ c: { e: { f: 123 } } } : { c: { e: { f: number; }; }; }
+>c : { e: { f: number; }; }
+>{ e: { f: 123 } } : { e: { f: number; }; }
+>e : { f: number; }
+>{ f: 123 } : { f: number; }
+>f : number
+>123 : 123
+
+let b = { b: { c: { e: { f: "123" } } } };
+>b : { b: { c: { e: { f: string; }; }; }; }
+>{ b: { c: { e: { f: "123" } } } } : { b: { c: { e: { f: string; }; }; }; }
+>b : { c: { e: { f: string; }; }; }
+>{ c: { e: { f: "123" } } } : { c: { e: { f: string; }; }; }
+>c : { e: { f: string; }; }
+>{ e: { f: "123" } } : { e: { f: string; }; }
+>e : { f: string; }
+>{ f: "123" } : { f: string; }
+>f : string
+>"123" : "123"
+
+let c = "test";
+>c : string
+>"test" : "test"
+
+// both the source and target types are wide enough enough trigger pretty printing
+a = b;
+>a = b : { b: { c: { e: { f: string; }; }; }; }
+>a : { b: { c: { e: { f: number; }; }; }; }
+>b : { b: { c: { e: { f: string; }; }; }; }
+
+// only the source type is wide enough to trigger pretty printing
+a = c;
+>a = c : string
+>a : { b: { c: { e: { f: number; }; }; }; }
+>c : string
+
+// only the target type is wide enough to trigger pretty printing
+c = a;
+>c = a : { b: { c: { e: { f: number; }; }; }; }
+>c : string
+>a : { b: { c: { e: { f: number; }; }; }; }
+
+// neither the source nor the target type is wide enough to trigger pretty printing
+c = false;
+>c = false : false
+>c : string
+>false : false
+

--- a/testdata/tests/cases/compiler/prettyFormatLongTypes.ts
+++ b/testdata/tests/cases/compiler/prettyFormatLongTypes.ts
@@ -1,0 +1,17 @@
+// @pretty: true
+
+let a = { b: { c: { e: { f: 123 } } } };
+let b = { b: { c: { e: { f: "123" } } } };
+let c = "test";
+
+// both the source and target types are wide enough enough trigger pretty printing
+a = b;
+
+// only the source type is wide enough to trigger pretty printing
+a = c;
+
+// only the target type is wide enough to trigger pretty printing
+c = a;
+
+// neither the source nor the target type is wide enough to trigger pretty printing
+c = false;


### PR DESCRIPTION
Fixes https://github.com/microsoft/TypeScript/issues/45896

Currently the complier will print "... is not assignable..." errors on a single line
```
prettyFormatLongTypes.ts: - error TS2882: Type '{ b: { c: { e: { f: string; }; }; }; }' is not assignable to type '{ b: { c: { e: { f: number; }; }; }; }'
 The types of 'b.c.e.f' are incompatible between these types.
    Type 'string' is not assignable to type 'number'.
```

This PR puts types onto their own lines when they are >30 characters in length
```
prettyFormatLongTypes.ts: - error TS2882: Type:
  { b: { c: { e: { f: string; }; }; }; }

is not assignable to type:
  { b: { c: { e: { f: number; }; }; }; }

  The types of 'b.c.e.f' are incompatible between these types.
    Type 'string' is not assignable to type 'number'.
```

This PR is the typescrpt-go version of this PR https://github.com/microsoft/TypeScript/pull/61829 and needs to be merged after that PR has been merged to main so the internal submodule can be updated.