### PR TITLE
Add extra test entrypoint for formatter for profiling

### DIFF
--- a/internal/execute/fmt_test.go
+++ b/internal/execute/fmt_test.go
@@ -1,0 +1,95 @@
+package execute
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/microsoft/typescript-go/internal/bundled"
+	"github.com/microsoft/typescript-go/internal/core"
+	"github.com/microsoft/typescript-go/internal/repo"
+	"github.com/microsoft/typescript-go/internal/tspath"
+	"github.com/microsoft/typescript-go/internal/vfs"
+	"github.com/microsoft/typescript-go/internal/vfs/osvfs"
+)
+
+func BenchmarkFormat(b *testing.B) {
+	checkerPath := tspath.CombinePaths(repo.TypeScriptSubmodulePath, "src", "compiler", "checker.ts")
+
+	tmp := b.TempDir()
+	sys := newSystem()
+
+	var count int
+
+	b.ReportAllocs()
+	time.Sleep(5 * time.Second)
+	for b.Loop() {
+		out := tspath.CombinePaths(tmp, fmt.Sprintf("out%d.ts", count))
+		code := fmtMain(sys, checkerPath, out)
+		if code != 0 {
+			b.Fatalf("Unexpected exit code: %d", code)
+		}
+	}
+}
+
+type osSys struct {
+	writer             io.Writer
+	fs                 vfs.FS
+	defaultLibraryPath string
+	newLine            string
+	cwd                string
+	start              time.Time
+}
+
+func (s *osSys) SinceStart() time.Duration {
+	return time.Since(s.start)
+}
+
+func (s *osSys) Now() time.Time {
+	return time.Now()
+}
+
+func (s *osSys) FS() vfs.FS {
+	return s.fs
+}
+
+func (s *osSys) DefaultLibraryPath() string {
+	return s.defaultLibraryPath
+}
+
+func (s *osSys) GetCurrentDirectory() string {
+	return s.cwd
+}
+
+func (s *osSys) NewLine() string {
+	return s.newLine
+}
+
+func (s *osSys) Writer() io.Writer {
+	return s.writer
+}
+
+func (s *osSys) EndWrite() {
+	// do nothing, this is needed in the interface for testing
+	// todo: revisit if improving tsc/build/watch unittest baselines
+}
+
+func newSystem() *osSys {
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error getting current directory: %v\n", err)
+		os.Exit(int(ExitStatusInvalidProject_OutputsSkipped))
+	}
+
+	return &osSys{
+		cwd:                tspath.NormalizePath(cwd),
+		fs:                 bundled.WrapFS(osvfs.FS()),
+		defaultLibraryPath: bundled.LibPath(),
+		writer:             os.Stdout,
+		newLine:            core.IfElse(runtime.GOOS == "windows", "\r\n", "\n"),
+		start:              time.Now(),
+	}
+}

--- a/internal/execute/tsc.go
+++ b/internal/execute/tsc.go
@@ -49,8 +49,8 @@ func CommandLine(sys System, cb cbType, commandLineArgs []string) ExitStatus {
 			fmt.Fprint(sys.Writer(), "Build mode is currently unsupported."+sys.NewLine())
 			sys.EndWrite()
 			return ExitStatusNotImplemented
-		case "-f":
-			return fmtMain(sys, commandLineArgs[1], commandLineArgs[1])
+			// case "-f":
+			// 	return fmtMain(sys, commandLineArgs[1], commandLineArgs[1])
 		}
 	}
 

--- a/internal/format/context.go
+++ b/internal/format/context.go
@@ -86,8 +86,8 @@ func GetDefaultFormatCodeSettings(newLineCharacter string) *FormatCodeSettings {
 }
 
 type formattingContext struct {
-	currentTokenSpan   *TextRangeWithKind
-	nextTokenSpan      *TextRangeWithKind
+	currentTokenSpan   TextRangeWithKind
+	nextTokenSpan      TextRangeWithKind
 	contextNode        *ast.Node
 	currentTokenParent *ast.Node
 	nextTokenParent    *ast.Node
@@ -117,15 +117,9 @@ func NewFormattingContext(file *ast.SourceFile, kind FormatRequestKind, options 
 	return res
 }
 
-func (this *formattingContext) UpdateContext(cur *TextRangeWithKind, curParent *ast.Node, next *TextRangeWithKind, nextParent *ast.Node, commonParent *ast.Node) {
-	if cur == nil {
-		panic("nil current range in update context")
-	}
+func (this *formattingContext) UpdateContext(cur TextRangeWithKind, curParent *ast.Node, next TextRangeWithKind, nextParent *ast.Node, commonParent *ast.Node) {
 	if curParent == nil {
 		panic("nil current range node parent in update context")
-	}
-	if next == nil {
-		panic("nil next range in update context")
 	}
 	if nextParent == nil {
 		panic("nil next range node parent in update context")

--- a/internal/format/indent.go
+++ b/internal/format/indent.go
@@ -152,7 +152,11 @@ func getActualIndentationForListItem(node *ast.Node, sourceFile *ast.SourceFile,
 		if listIndentsChild {
 			delta = options.IndentSize
 		}
-		return getActualIndentationForListStartLine(containingList, sourceFile, options) + delta
+		res := getActualIndentationForListStartLine(containingList, sourceFile, options)
+		if res == -1 {
+			return delta
+		}
+		return res + delta
 	}
 	return -1
 }

--- a/internal/format/rulecontext.go
+++ b/internal/format/rulecontext.go
@@ -15,11 +15,11 @@ import (
 ///
 
 type (
-	optionSelector    = func(options *FormatCodeSettings) core.Tristate
-	anyOptionSelector = func(options *FormatCodeSettings) any
+	optionSelector                  = func(options *FormatCodeSettings) core.Tristate
+	anyOptionSelector[T comparable] = func(options *FormatCodeSettings) T
 )
 
-func semicolonOption(options *FormatCodeSettings) any { return options.Semicolons }
+func semicolonOption(options *FormatCodeSettings) SemicolonPreference { return options.Semicolons }
 func insertSpaceAfterCommaDelimiterOption(options *FormatCodeSettings) core.Tristate {
 	return options.InsertSpaceAfterCommaDelimiter
 }
@@ -96,7 +96,7 @@ func indentSwitchCaseOption(options *FormatCodeSettings) core.Tristate {
 	return options.IndentSwitchCase
 }
 
-func optionEquals(optionName anyOptionSelector, optionValue any) contextPredicate {
+func optionEquals[T comparable](optionName anyOptionSelector[T], optionValue T) contextPredicate {
 	return func(context *formattingContext) bool {
 		if context.Options == nil {
 			return false

--- a/internal/format/rulecontext.go
+++ b/internal/format/rulecontext.go
@@ -494,7 +494,7 @@ func isConstructorSignatureContext(context *formattingContext) bool {
 	return context.contextNode.Kind == ast.KindConstructSignature
 }
 
-func isTypeArgumentOrParameterOrAssertion(token *TextRangeWithKind, parent *ast.Node) bool {
+func isTypeArgumentOrParameterOrAssertion(token TextRangeWithKind, parent *ast.Node) bool {
 	if token.Kind != ast.KindLessThanToken && token.Kind != ast.KindGreaterThanToken {
 		return false
 	}

--- a/internal/format/rulesmap.go
+++ b/internal/format/rulesmap.go
@@ -22,6 +22,9 @@ func getRules(context *formattingContext) []*ruleImpl {
 						continue outer
 					}
 				}
+				if len(rules) == 0 {
+					rules = make([]*ruleImpl, 0, len(bucket))
+				}
 				rules = append(rules, rule)
 				ruleActionMask |= rule.Action()
 			}

--- a/internal/format/rulesmap.go
+++ b/internal/format/rulesmap.go
@@ -7,10 +7,9 @@ import (
 	"github.com/microsoft/typescript-go/internal/ast"
 )
 
-func getRules(context *formattingContext) []*ruleImpl {
+func getRules(context *formattingContext, rules []*ruleImpl) []*ruleImpl {
 	bucket := getRulesMap()[getRuleBucketIndex(context.currentTokenSpan.Kind, context.nextTokenSpan.Kind)]
 	if len(bucket) > 0 {
-		var rules []*ruleImpl
 		ruleActionMask := ruleActionNone
 	outer:
 		for _, rule := range bucket {
@@ -22,16 +21,13 @@ func getRules(context *formattingContext) []*ruleImpl {
 						continue outer
 					}
 				}
-				if len(rules) == 0 {
-					rules = make([]*ruleImpl, 0, len(bucket))
-				}
 				rules = append(rules, rule)
 				ruleActionMask |= rule.Action()
 			}
 		}
 		return rules
 	}
-	return nil
+	return rules
 }
 
 func getRuleBucketIndex(row ast.Kind, column ast.Kind) int {

--- a/internal/format/scanner.go
+++ b/internal/format/scanner.go
@@ -27,15 +27,16 @@ type tokenInfo struct {
 }
 
 type formattingScanner struct {
-	s              *scanner.Scanner
-	startPos       int
-	endPos         int
-	savedPos       int
-	lastTokenInfo  *tokenInfo
-	lastScanAction scanAction
-	leadingTrivia  []TextRangeWithKind
-	trailingTrivia []TextRangeWithKind
-	wasNewLine     bool
+	s                *scanner.Scanner
+	startPos         int
+	endPos           int
+	savedPos         int
+	hasLastTokenInfo bool
+	lastTokenInfo    tokenInfo
+	lastScanAction   scanAction
+	leadingTrivia    []TextRangeWithKind
+	trailingTrivia   []TextRangeWithKind
+	wasNewLine       bool
 }
 
 func newFormattingScanner(text string, languageVariant core.LanguageVariant, startPos int, endPos int, worker *formatSpanWorker) []core.TextChange {
@@ -54,14 +55,14 @@ func newFormattingScanner(text string, languageVariant core.LanguageVariant, sta
 
 	res := worker.execute(fmtScn)
 
-	fmtScn.lastTokenInfo = nil
+	fmtScn.hasLastTokenInfo = false
 	scan.Reset()
 
 	return res
 }
 
 func (s *formattingScanner) advance() {
-	s.lastTokenInfo = nil
+	s.hasLastTokenInfo = false
 	isStarted := s.s.TokenFullStart() != s.startPos
 
 	if isStarted {
@@ -124,7 +125,7 @@ func (s *formattingScanner) shouldRescanJsxText(node *ast.Node) bool {
 	if ast.IsJsxText(node) {
 		return true
 	}
-	if !ast.IsJsxElement(node) || s.lastTokenInfo == nil {
+	if !ast.IsJsxElement(node) || s.hasLastTokenInfo == false {
 		return false
 	}
 
@@ -160,14 +161,14 @@ const (
 	actionRescanJsxAttributeValue
 )
 
-func fixTokenKind(tokenInfo *tokenInfo, container *ast.Node) *tokenInfo {
+func fixTokenKind(tokenInfo tokenInfo, container *ast.Node) tokenInfo {
 	if ast.IsTokenKind(container.Kind) && tokenInfo.token.Kind != container.Kind {
 		tokenInfo.token.Kind = container.Kind
 	}
 	return tokenInfo
 }
 
-func (s *formattingScanner) readTokenInfo(n *ast.Node) *tokenInfo {
+func (s *formattingScanner) readTokenInfo(n *ast.Node) tokenInfo {
 	// Debug.assert(isOnToken()); // !!!
 
 	// normally scanner returns the smallest available token
@@ -190,14 +191,15 @@ func (s *formattingScanner) readTokenInfo(n *ast.Node) *tokenInfo {
 		expectedScanAction = actionScan
 	}
 
-	if s.lastTokenInfo != nil && expectedScanAction == s.lastScanAction {
+	if s.hasLastTokenInfo && expectedScanAction == s.lastScanAction {
 		// readTokenInfo was called before with the same expected scan action.
 		// No need to re-scan text, return existing 'lastTokenInfo'
 		// it is ok to call fixTokenKind here since it does not affect
 		// what portion of text is consumed. In contrast rescanning can change it,
 		// i.e. for '>=' when originally scanner eats just one character
 		// and rescanning forces it to consume more.
-		return fixTokenKind(s.lastTokenInfo, n)
+		s.lastTokenInfo = fixTokenKind(s.lastTokenInfo, n)
+		return s.lastTokenInfo
 	}
 
 	if s.s.TokenFullStart() != s.savedPos {
@@ -237,13 +239,15 @@ func (s *formattingScanner) readTokenInfo(n *ast.Node) *tokenInfo {
 		}
 	}
 
-	s.lastTokenInfo = &tokenInfo{
+	s.hasLastTokenInfo = true
+	s.lastTokenInfo = tokenInfo{
 		leadingTrivia:  slices.Clone(s.leadingTrivia),
 		token:          token,
 		trailingTrivia: slices.Clone(s.trailingTrivia),
 	}
+	s.lastTokenInfo = fixTokenKind(s.lastTokenInfo, n)
 
-	return fixTokenKind(s.lastTokenInfo, n)
+	return s.lastTokenInfo
 }
 
 func (s *formattingScanner) getNextToken(n *ast.Node, expectedScanAction scanAction) ast.Kind {
@@ -298,7 +302,7 @@ func (s *formattingScanner) readEOFTokenRange() TextRangeWithKind {
 
 func (s *formattingScanner) isOnToken() bool {
 	current := s.s.Token()
-	if s.lastTokenInfo != nil {
+	if s.hasLastTokenInfo {
 		current = s.lastTokenInfo.token.Kind
 	}
 	return current != ast.KindEndOfFile && !ast.IsTrivia(current)
@@ -306,7 +310,7 @@ func (s *formattingScanner) isOnToken() bool {
 
 func (s *formattingScanner) isOnEOF() bool {
 	current := s.s.Token()
-	if s.lastTokenInfo != nil {
+	if s.hasLastTokenInfo {
 		current = s.lastTokenInfo.token.Kind
 	}
 	return current == ast.KindEndOfFile
@@ -316,7 +320,7 @@ func (s *formattingScanner) skipToEndOf(r *core.TextRange) {
 	s.s.ResetTokenState(r.End())
 	s.savedPos = s.s.TokenFullStart()
 	s.lastScanAction = actionScan
-	s.lastTokenInfo = nil
+	s.hasLastTokenInfo = false
 	s.wasNewLine = false
 	s.leadingTrivia = nil
 	s.trailingTrivia = nil
@@ -326,7 +330,7 @@ func (s *formattingScanner) skipToStartOf(r *core.TextRange) {
 	s.s.ResetTokenState(r.Pos())
 	s.savedPos = s.s.TokenFullStart()
 	s.lastScanAction = actionScan
-	s.lastTokenInfo = nil
+	s.hasLastTokenInfo = false
 	s.wasNewLine = false
 	s.leadingTrivia = nil
 	s.trailingTrivia = nil
@@ -341,7 +345,7 @@ func (s *formattingScanner) lastTrailingTriviaWasNewLine() bool {
 }
 
 func (s *formattingScanner) getTokenFullStart() int {
-	if s.lastTokenInfo != nil {
+	if s.hasLastTokenInfo {
 		return s.lastTokenInfo.token.Loc.Pos()
 	}
 	return s.s.TokenFullStart()

--- a/internal/format/scanner.go
+++ b/internal/format/scanner.go
@@ -13,17 +13,17 @@ type TextRangeWithKind struct {
 	Kind ast.Kind
 }
 
-func NewTextRangeWithKind(pos int, end int, kind ast.Kind) *TextRangeWithKind {
-	return &TextRangeWithKind{
+func NewTextRangeWithKind(pos int, end int, kind ast.Kind) TextRangeWithKind {
+	return TextRangeWithKind{
 		Loc:  core.NewTextRange(pos, end),
 		Kind: kind,
 	}
 }
 
 type tokenInfo struct {
-	leadingTrivia  []*TextRangeWithKind
-	token          *TextRangeWithKind
-	trailingTrivia []*TextRangeWithKind
+	leadingTrivia  []TextRangeWithKind
+	token          TextRangeWithKind
+	trailingTrivia []TextRangeWithKind
 }
 
 type formattingScanner struct {
@@ -33,8 +33,8 @@ type formattingScanner struct {
 	savedPos       int
 	lastTokenInfo  *tokenInfo
 	lastScanAction scanAction
-	leadingTrivia  []*TextRangeWithKind
-	trailingTrivia []*TextRangeWithKind
+	leadingTrivia  []TextRangeWithKind
+	trailingTrivia []TextRangeWithKind
 	wasNewLine     bool
 }
 
@@ -287,7 +287,7 @@ func (s *formattingScanner) getNextToken(n *ast.Node, expectedScanAction scanAct
 	return token
 }
 
-func (s *formattingScanner) readEOFTokenRange() *TextRangeWithKind {
+func (s *formattingScanner) readEOFTokenRange() TextRangeWithKind {
 	// Debug.assert(isOnEOF()); // !!!
 	return NewTextRangeWithKind(
 		s.s.TokenFullStart(),
@@ -332,7 +332,7 @@ func (s *formattingScanner) skipToStartOf(r *core.TextRange) {
 	s.trailingTrivia = nil
 }
 
-func (s *formattingScanner) getCurrentLeadingTrivia() []*TextRangeWithKind {
+func (s *formattingScanner) getCurrentLeadingTrivia() []TextRangeWithKind {
 	return s.leadingTrivia
 }
 

--- a/internal/format/span.go
+++ b/internal/format/span.go
@@ -548,7 +548,11 @@ func (w *formatSpanWorker) computeIndentation(node *ast.Node, startLine int, inh
 			argumentStartsOnSameLineAsPreviousArgument(parent, node, startLine, w.sourceFile) {
 			return parentDynamicIndentation.getIndentation(), delta
 		} else {
-			return parentDynamicIndentation.getIndentation() + parentDynamicIndentation.getDelta(node), delta
+			i := parentDynamicIndentation.getIndentation()
+			if i == -1 {
+				return parentDynamicIndentation.getIndentation(), delta
+			}
+			return i + parentDynamicIndentation.getDelta(node), delta
 		}
 	}
 

--- a/internal/format/span.go
+++ b/internal/format/span.go
@@ -491,7 +491,7 @@ func (w *formatSpanWorker) processChildNodes(
 			if w.formattingScanner.isOnToken() {
 				tokenInfo = w.formattingScanner.readTokenInfo(parent)
 			} else {
-				tokenInfo = nil
+				return
 			}
 		}
 
@@ -499,7 +499,7 @@ func (w *formatSpanWorker) processChildNodes(
 		// there might be the case when current token matches end token but does not considered as one
 		// function (x: function) <--
 		// without this check close paren will be interpreted as list end token for function expression which is wrong
-		if tokenInfo != nil && tokenInfo.token.Kind == listEndToken && tokenInfo.token.Loc.ContainedBy(parent.Loc) {
+		if tokenInfo.token.Kind == listEndToken && tokenInfo.token.Loc.ContainedBy(parent.Loc) {
 			// consume list end token
 			w.consumeTokenAndAdvanceScanner(tokenInfo, parent, listDynamicIndentation, parent /*isListEndToken*/, true)
 		}
@@ -1002,7 +1002,7 @@ func (w *formatSpanWorker) recordInsert(start int, text string) {
 	}
 }
 
-func (w *formatSpanWorker) consumeTokenAndAdvanceScanner(currentTokenInfo *tokenInfo, parent *ast.Node, dynamicIndenation *dynamicIndenter, container *ast.Node, isListEndToken bool) {
+func (w *formatSpanWorker) consumeTokenAndAdvanceScanner(currentTokenInfo tokenInfo, parent *ast.Node, dynamicIndenation *dynamicIndenter, container *ast.Node, isListEndToken bool) {
 	// assert(currentTokenInfo.token.Loc.ContainedBy(parent.Loc)) // !!!
 	lastTriviaWasNewLine := w.formattingScanner.lastTrailingTriviaWasNewLine()
 	indentToken := false


### PR DESCRIPTION
And throw in a bugfix and a few memory use improvements for the formatter. Combined, these lower the total count of allocations from around 2 million to 750k per `checker.ts` format. Byte-wise, it goes from around 113MB allocated to 83MB (36% savings). These, in turn, help performance on cache-limited systems substantially.