### PR TITLE
Don't lint on macOS in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,8 +176,9 @@ jobs:
             main: true
           - os: windows-latest
             skip: ${{ github.event_name == 'merge_group' }}
-          - os: macos-latest
-            skip: ${{ github.event_name == 'merge_group' }}
+          # Skip macOS; we do not have any build tag'd files that require checking.
+          # - os: macos-latest
+          #   skip: ${{ github.event_name == 'merge_group' }}
           - os: ubuntu-latest
             name: 'noembed'
             noembed: true


### PR DESCRIPTION
There's no real need to do this; we have no code that's gated by `//go:build darwin` or similar. We do need to check against Linux, Windows, and `noembed`, though.

Dropping this mainly to get rid of one more job that depends on the very limited macOS runner pool.