### PR TITLE
Cache CompilerOptions.SourceFileAffecting

### DIFF
--- a/internal/compiler/fileloader.go
+++ b/internal/compiler/fileloader.go
@@ -278,7 +278,7 @@ func (p *fileLoader) loadSourceFileMetaData(fileName string) *ast.SourceFileMeta
 
 func (p *fileLoader) parseSourceFile(t *parseTask) *ast.SourceFile {
 	path := p.toPath(t.normalizedFilePath)
-	sourceFile := p.opts.Host.GetSourceFile(t.normalizedFilePath, path, p.projectReferenceFileMapper.getCompilerOptionsForFile(t).SourceFileAffecting(), t.metadata) // TODO(jakebailey): cache :(
+	sourceFile := p.opts.Host.GetSourceFile(t.normalizedFilePath, path, p.projectReferenceFileMapper.getCompilerOptionsForFile(t).SourceFileAffecting(), t.metadata)
 	return sourceFile
 }
 

--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -304,7 +304,7 @@ func (p *Program) BindSourceFiles() {
 	for _, file := range p.files {
 		if !file.IsBound() {
 			wg.Queue(func() {
-				binder.BindSourceFile(file, p.Options().SourceFileAffecting())
+				binder.BindSourceFile(file, p.projectReferenceFileMapper.getCompilerOptionsForFile(file).SourceFileAffecting())
 			})
 		}
 	}
@@ -595,7 +595,7 @@ func compactAndMergeRelatedInfos(diagnostics []*ast.Diagnostic) []*ast.Diagnosti
 func (p *Program) getDiagnosticsHelper(ctx context.Context, sourceFile *ast.SourceFile, ensureBound bool, ensureChecked bool, getDiagnostics func(context.Context, *ast.SourceFile) []*ast.Diagnostic) []*ast.Diagnostic {
 	if sourceFile != nil {
 		if ensureBound {
-			binder.BindSourceFile(sourceFile, p.Options().SourceFileAffecting())
+			binder.BindSourceFile(sourceFile, p.projectReferenceFileMapper.getCompilerOptionsForFile(sourceFile).SourceFileAffecting())
 		}
 		return SortAndDeduplicateDiagnostics(getDiagnostics(ctx, sourceFile))
 	}

--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -41,9 +41,6 @@ type Program struct {
 	nodeModules map[string]*ast.SourceFile
 	checkerPool CheckerPool
 
-	sourceAffectingCompilerOptionsOnce sync.Once
-	sourceAffectingCompilerOptions     *core.SourceFileAffectingCompilerOptions
-
 	comparePathsOptions tspath.ComparePathsOptions
 
 	processedFiles
@@ -302,19 +299,12 @@ func (p *Program) singleThreaded() bool {
 	return p.opts.SingleThreaded.DefaultIfUnknown(p.Options().SingleThreaded).IsTrue()
 }
 
-func (p *Program) getSourceAffectingCompilerOptions() *core.SourceFileAffectingCompilerOptions {
-	p.sourceAffectingCompilerOptionsOnce.Do(func() {
-		p.sourceAffectingCompilerOptions = p.Options().SourceFileAffecting()
-	})
-	return p.sourceAffectingCompilerOptions
-}
-
 func (p *Program) BindSourceFiles() {
 	wg := core.NewWorkGroup(p.singleThreaded())
 	for _, file := range p.files {
 		if !file.IsBound() {
 			wg.Queue(func() {
-				binder.BindSourceFile(file, p.getSourceAffectingCompilerOptions())
+				binder.BindSourceFile(file, p.Options().SourceFileAffecting())
 			})
 		}
 	}
@@ -605,7 +595,7 @@ func compactAndMergeRelatedInfos(diagnostics []*ast.Diagnostic) []*ast.Diagnosti
 func (p *Program) getDiagnosticsHelper(ctx context.Context, sourceFile *ast.SourceFile, ensureBound bool, ensureChecked bool, getDiagnostics func(context.Context, *ast.SourceFile) []*ast.Diagnostic) []*ast.Diagnostic {
 	if sourceFile != nil {
 		if ensureBound {
-			binder.BindSourceFile(sourceFile, p.getSourceAffectingCompilerOptions())
+			binder.BindSourceFile(sourceFile, p.Options().SourceFileAffecting())
 		}
 		return SortAndDeduplicateDiagnostics(getDiagnostics(ctx, sourceFile))
 	}

--- a/internal/tsoptions/commandlineparser_test.go
+++ b/internal/tsoptions/commandlineparser_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/microsoft/typescript-go/internal/core"
 	"github.com/microsoft/typescript-go/internal/diagnostics"
 	"github.com/microsoft/typescript-go/internal/diagnosticwriter"
@@ -173,7 +174,7 @@ func (f commandLineSubScenario) assertParseResult(t *testing.T) {
 		newParsedCompilerOptions := &core.CompilerOptions{}
 		e := json.Unmarshal(o, newParsedCompilerOptions)
 		assert.NilError(t, e)
-		assert.DeepEqual(t, tsBaseline.options, newParsedCompilerOptions)
+		assert.DeepEqual(t, tsBaseline.options, newParsedCompilerOptions, cmpopts.IgnoreUnexported(core.CompilerOptions{}))
 
 		newParsedWatchOptions := core.WatchOptions{}
 		e = json.Unmarshal(o, &newParsedWatchOptions)

--- a/internal/tsoptions/tsconfigparsing_test.go
+++ b/internal/tsoptions/tsconfigparsing_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/microsoft/typescript-go/internal/core"
 	"github.com/microsoft/typescript-go/internal/diagnosticwriter"
 	"github.com/microsoft/typescript-go/internal/parser"
@@ -863,7 +864,7 @@ func TestParseSrcCompiler(t *testing.T) {
 		SourceMap:                  core.TSTrue,
 		UseUnknownInCatchVariables: core.TSFalse,
 		Pretty:                     core.TSTrue,
-	})
+	}, cmpopts.IgnoreUnexported(core.CompilerOptions{}))
 
 	fileNames := parseConfigFileContent.ParsedConfig.FileNames
 	relativePaths := make([]string, 0, len(fileNames))


### PR DESCRIPTION
Enabled by #1106, we can now cache the SourceFileAffecting function's results on the CompilerOptions struct itself.