### PR TITLE
Generate LSP request IDs atomically

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -11,6 +11,7 @@ import (
 	"runtime/debug"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"syscall"
 
 	"github.com/microsoft/typescript-go/internal/collections"
@@ -124,7 +125,7 @@ type Server struct {
 
 	stderr io.Writer
 
-	clientSeq               int32
+	clientSeq               atomic.Int32
 	requestQueue            chan *lsproto.RequestMessage
 	outgoingQueue           chan *lsproto.Message
 	pendingClientRequests   map[lsproto.ID]pendingClientRequest
@@ -399,8 +400,7 @@ func (s *Server) writeLoop(ctx context.Context) error {
 }
 
 func (s *Server) sendRequest(ctx context.Context, method lsproto.Method, params any) (any, error) {
-	s.clientSeq++
-	id := lsproto.NewIDString(fmt.Sprintf("ts%d", s.clientSeq))
+	id := lsproto.NewIDString(fmt.Sprintf("ts%d", s.clientSeq.Add(1)))
 	req := lsproto.NewRequestMessage(method, id, params)
 
 	responseChan := make(chan *lsproto.ResponseMessage, 1)


### PR DESCRIPTION
```
WARNING: DATA RACE
Read at 0x00c000232a50 by goroutine 1006:
  github.com/microsoft/typescript-go/internal/lsp.(*Server).sendRequest()
      /home/jabaile/work/TypeScript-go/internal/lsp/server.go:402 +0x91
  github.com/microsoft/typescript-go/internal/lsp.(*Server).WatchFiles()
      /home/jabaile/work/TypeScript-go/internal/lsp/server.go:198 +0x36c
  github.com/microsoft/typescript-go/internal/project.(*watchedFiles[go.shape.[]string]).update()
      /home/jabaile/work/TypeScript-go/internal/project/watch.go:85 +0xbc1
  github.com/microsoft/typescript-go/internal/project.(*ConfigFileRegistry).updateRootFilesWatch()
      /home/jabaile/work/TypeScript-go/internal/project/configfileregistry.go:134 +0x990
  github.com/microsoft/typescript-go/internal/project.(*ConfigFileRegistry).AcquireConfig()
      /home/jabaile/work/TypeScript-go/internal/project/configfileregistry.go:111 +0x5c4
  github.com/microsoft/typescript-go/internal/project.(*Project).GetResolvedProjectReference()
      /home/jabaile/work/TypeScript-go/internal/project/project.go:290 +0x88
  github.com/microsoft/typescript-go/internal/compiler.(*projectReferenceParseTask).start()
      /home/jabaile/work/TypeScript-go/internal/compiler/projectreferenceparsetask.go:19 +0xde
  github.com/microsoft/typescript-go/internal/compiler.(*fileLoaderWorker[go.shape.*github.com/microsoft/typescript-go/internal/compiler.projectReferenceParseTask]).start.func1()
      /home/jabaile/work/TypeScript-go/internal/compiler/fileloadertask.go:35 +0x63
  github.com/microsoft/typescript-go/internal/core.(*parallelWorkGroup).Queue.func1()
      /home/jabaile/work/TypeScript-go/internal/core/workgroup.go:39 +0x8d

Previous write at 0x00c000232a50 by goroutine 1007:
  github.com/microsoft/typescript-go/internal/lsp.(*Server).sendRequest()
      /home/jabaile/work/TypeScript-go/internal/lsp/server.go:402 +0xad
  github.com/microsoft/typescript-go/internal/lsp.(*Server).WatchFiles()
      /home/jabaile/work/TypeScript-go/internal/lsp/server.go:198 +0x36c
  github.com/microsoft/typescript-go/internal/project.(*watchedFiles[go.shape.[]string]).update()
      /home/jabaile/work/TypeScript-go/internal/project/watch.go:85 +0xbc1
  github.com/microsoft/typescript-go/internal/project.(*ConfigFileRegistry).updateRootFilesWatch()
      /home/jabaile/work/TypeScript-go/internal/project/configfileregistry.go:134 +0x990
  github.com/microsoft/typescript-go/internal/project.(*ConfigFileRegistry).AcquireConfig()
      /home/jabaile/work/TypeScript-go/internal/project/configfileregistry.go:111 +0x5c4
  github.com/microsoft/typescript-go/internal/project.(*Project).GetResolvedProjectReference()
      /home/jabaile/work/TypeScript-go/internal/project/project.go:290 +0x88
  github.com/microsoft/typescript-go/internal/compiler.(*projectReferenceParseTask).start()
      /home/jabaile/work/TypeScript-go/internal/compiler/projectreferenceparsetask.go:19 +0xde
  github.com/microsoft/typescript-go/internal/compiler.(*fileLoaderWorker[go.shape.*github.com/microsoft/typescript-go/internal/compiler.projectReferenceParseTask]).start.func1()
      /home/jabaile/work/TypeScript-go/internal/compiler/fileloadertask.go:35 +0x63
  github.com/microsoft/typescript-go/internal/core.(*parallelWorkGroup).Queue.func1()
      /home/jabaile/work/TypeScript-go/internal/core/workgroup.go:39 +0x8d
```