### PR TITLE
Fix handling of non-file URIs

### DIFF
--- a/internal/ls/converters.go
+++ b/internal/ls/converters.go
@@ -152,11 +152,11 @@ func FileNameToDocumentURI(fileName string) lsproto.DocumentUri {
 	if strings.HasPrefix(fileName, "^/") {
 		scheme, rest, ok := strings.Cut(fileName[2:], "/")
 		if !ok {
-			panic(fmt.Sprintf("invalid file name: %s", fileName))
+			panic("invalid file name: " + fileName)
 		}
 		authority, path, ok := strings.Cut(rest, "/")
 		if !ok {
-			panic(fmt.Sprintf("invalid file name: %s", fileName))
+			panic("invalid file name: " + fileName)
 		}
 		if authority == "ts-nul-authority" {
 			return lsproto.DocumentUri(scheme + ":" + path)

--- a/internal/ls/converters.go
+++ b/internal/ls/converters.go
@@ -86,7 +86,7 @@ func DocumentURIToFileName(uri lsproto.DocumentUri) string {
 		if parsed.Host != "" {
 			return "//" + parsed.Host + parsed.Path
 		}
-		return fixWindowsURIPath(parsed.Path, true)
+		return fixWindowsURIPath(parsed.Path)
 	}
 
 	// Leave all other URIs escaped so we can round-trip them.
@@ -104,16 +104,8 @@ func DocumentURIToFileName(uri lsproto.DocumentUri) string {
 	return "^/" + scheme + "/" + authority + "/" + path
 }
 
-func fixWindowsURIPath(path string, cutLeadingSlash bool) string {
-	var rest string
-	var ok bool
-	if cutLeadingSlash {
-		rest, ok = strings.CutPrefix(path, "/")
-	} else {
-		rest = path
-		ok = true
-	}
-	if ok {
+func fixWindowsURIPath(path string) string {
+	if rest, ok := strings.CutPrefix(path, "/"); ok {
 		if volume, rest, ok := splitVolumePath(rest); ok {
 			return volume + rest
 		}

--- a/internal/ls/converters.go
+++ b/internal/ls/converters.go
@@ -98,7 +98,10 @@ func DocumentURIToFileName(uri lsproto.DocumentUri) string {
 
 	authority := "ts-nul-authority"
 	if rest, ok := strings.CutPrefix(path, "//"); ok {
-		authority, path, _ = strings.Cut(rest, "/")
+		authority, path, ok = strings.Cut(rest, "/")
+		if !ok {
+			panic(fmt.Sprintf("invalid URI: %s", uri))
+		}
 	}
 
 	return "^/" + scheme + "/" + authority + "/" + path
@@ -147,8 +150,14 @@ var extraEscapeReplacer = strings.NewReplacer(
 
 func FileNameToDocumentURI(fileName string) lsproto.DocumentUri {
 	if strings.HasPrefix(fileName, "^/") {
-		scheme, rest, _ := strings.Cut(fileName[2:], "/")
-		authority, path, _ := strings.Cut(rest, "/")
+		scheme, rest, ok := strings.Cut(fileName[2:], "/")
+		if !ok {
+			panic(fmt.Sprintf("invalid file name: %s", fileName))
+		}
+		authority, path, ok := strings.Cut(rest, "/")
+		if !ok {
+			panic(fmt.Sprintf("invalid file name: %s", fileName))
+		}
 		if authority == "ts-nul-authority" {
 			return lsproto.DocumentUri(scheme + ":" + path)
 		}

--- a/internal/ls/converters_test.go
+++ b/internal/ls/converters_test.go
@@ -34,7 +34,8 @@ func TestDocumentURIToFileName(t *testing.T) {
 		{"untitled:Untitled-1", "^/untitled/ts-nul-authority/Untitled-1"},
 		{"untitled:Untitled-1#fragment", "^/untitled/ts-nul-authority/Untitled-1#fragment"},
 		{"untitled:c:/Users/jrieken/Code/abc.txt", "^/untitled/ts-nul-authority/c:/Users/jrieken/Code/abc.txt"},
-		{"untitled:C:/Users/jrieken/Code/abc.txt", "^/untitled/ts-nul-authority/c:/Users/jrieken/Code/abc.txt"},
+		{"untitled:C:/Users/jrieken/Code/abc.txt", "^/untitled/ts-nul-authority/C:/Users/jrieken/Code/abc.txt"},
+		{"untitled://wsl%2Bubuntu/home/jabaile/work/TypeScript-go/newfile.ts", "^/untitled/wsl%2Bubuntu/home/jabaile/work/TypeScript-go/newfile.ts"},
 	}
 
 	for _, test := range tests {
@@ -70,6 +71,7 @@ func TestFileNameToDocumentURI(t *testing.T) {
 
 		{"^/untitled/ts-nul-authority/Untitled-1", "untitled:Untitled-1"},
 		{"^/untitled/ts-nul-authority/c:/Users/jrieken/Code/abc.txt", "untitled:c:/Users/jrieken/Code/abc.txt"},
+		{"^/untitled/ts-nul-authority///wsl%2Bubuntu/home/jabaile/work/TypeScript-go/newfile.ts", "untitled://wsl%2Bubuntu/home/jabaile/work/TypeScript-go/newfile.ts"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This more closely mirrors what VS Code did to fix up paths for tsserver.

Fixes #1096