### PR TITLE
Ensure pool mutex is locked in GetAllCheckers

### DIFF
--- a/internal/project/checkerpool.go
+++ b/internal/project/checkerpool.go
@@ -87,6 +87,9 @@ func (p *checkerPool) Files(checker *checker.Checker) iter.Seq[*ast.SourceFile] 
 }
 
 func (p *checkerPool) GetAllCheckers(ctx context.Context) ([]*checker.Checker, func()) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	requestID := core.GetRequestID(ctx)
 	if requestID == "" {
 		panic("cannot call GetAllCheckers on a project.checkerPool without a request ID")


### PR DESCRIPTION
This call was the only part of the `CheckerPool` interface implementation that were missing the lock.

Fixes #1168

Could fix the other races (since racy code is UB)