### PR TITLE
Fix nil panic on heritage clause in grammar checks

### DIFF
--- a/internal/checker/grammarchecks.go
+++ b/internal/checker/grammarchecks.go
@@ -931,6 +931,9 @@ func (c *Checker) checkGrammarClassDeclarationHeritageClauses(node *ast.ClassLik
 				}
 
 				for _, j := range node.JSDoc(file) {
+					if j.AsJSDoc().Tags == nil {
+						continue
+					}
 					for _, tag := range j.AsJSDoc().Tags.Nodes {
 						if tag.Kind == ast.KindJSDocAugmentsTag {
 							target := typeNodes[0].AsExpressionWithTypeArguments()

--- a/testdata/baselines/reference/conformance/jsdocClassNoTags.js
+++ b/testdata/baselines/reference/conformance/jsdocClassNoTags.js
@@ -1,0 +1,17 @@
+//// [tests/cases/conformance/jsdoc/jsdocClassNoTags.ts] ////
+
+//// [jsdocClassNoTags.ts]
+class B {
+}
+/** this is a test */
+class C extends B {
+}
+
+
+
+//// [jsdocClassNoTags.js]
+class B {
+}
+/** this is a test */
+class C extends B {
+}

--- a/testdata/baselines/reference/conformance/jsdocClassNoTags.symbols
+++ b/testdata/baselines/reference/conformance/jsdocClassNoTags.symbols
@@ -1,0 +1,13 @@
+//// [tests/cases/conformance/jsdoc/jsdocClassNoTags.ts] ////
+
+=== jsdocClassNoTags.ts ===
+class B {
+>B : Symbol(B, Decl(jsdocClassNoTags.ts, 0, 0))
+}
+/** this is a test */
+class C extends B {
+>C : Symbol(C, Decl(jsdocClassNoTags.ts, 1, 1))
+>B : Symbol(B, Decl(jsdocClassNoTags.ts, 0, 0))
+}
+
+

--- a/testdata/baselines/reference/conformance/jsdocClassNoTags.types
+++ b/testdata/baselines/reference/conformance/jsdocClassNoTags.types
@@ -1,0 +1,13 @@
+//// [tests/cases/conformance/jsdoc/jsdocClassNoTags.ts] ////
+
+=== jsdocClassNoTags.ts ===
+class B {
+>B : B
+}
+/** this is a test */
+class C extends B {
+>C : C
+>B : B
+}
+
+

--- a/testdata/tests/cases/conformance/jsdoc/jsdocClassNoTags.ts
+++ b/testdata/tests/cases/conformance/jsdoc/jsdocClassNoTags.ts
@@ -1,0 +1,6 @@
+class B {
+}
+/** this is a test */
+class C extends B {
+}
+


### PR DESCRIPTION
Iterating JSDoc.Tags.Nodes panics if there are no tags. You can iterate nil but not a slice on something that is nil. Expect to see more panics like this on any new code, because we're not tracking nil in the type system anymore.

Fixes #1171 