### PR TITLE
add error handling to fourslash parsing

### DIFF
--- a/internal/fourslash/test_parser.go
+++ b/internal/fourslash/test_parser.go
@@ -2,6 +2,7 @@ package fourslash
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -56,11 +57,15 @@ func ParseTestData(t *testing.T, contents string, fileName string) TestData {
 	markerPositions := make(map[string]*Marker)
 	var markers []*Marker
 	var ranges []*RangeMarker
-	filesWithMarker, symlinks, _, globalOptions := testrunner.ParseTestFilesAndSymlinks(
+
+	filesWithMarker, symlinks, _, globalOptions, e := testrunner.ParseTestFilesAndSymlinks(
 		contents,
 		fileName,
 		parseFileContent,
 	)
+	if e != "" {
+		t.Fatalf("Error parsing fourslash data: %s", e)
+	}
 
 	hasTSConfig := false
 	for _, file := range filesWithMarker {
@@ -138,7 +143,7 @@ const (
 	stateInObjectMarker
 )
 
-func parseFileContent(fileName string, content string, fileOptions map[string]string) *testFileWithMarkers {
+func parseFileContent(fileName string, content string, fileOptions map[string]string) (*testFileWithMarkers, string) {
 	fileName = tspath.GetNormalizedAbsolutePath(fileName, "/")
 
 	// The file content (minus metacharacters) so far
@@ -159,7 +164,7 @@ func parseFileContent(fileName string, content string, fileOptions map[string]st
 	column := 1
 
 	// The current marker (or maybe multi-line comment?) we're parsing, possibly
-	var openMarker locationInformation
+	var openMarker *locationInformation
 
 	// The latest position of the start of an unflushed plain text area
 	lastNormalCharPosition := 0
@@ -197,7 +202,7 @@ func parseFileContent(fileName string, content string, fileOptions map[string]st
 			} else if previousCharacter == '|' && currentCharacter == ']' {
 				// found a range end
 				if len(openRanges) == 0 {
-					reportError(fileName, line, column, "Found range end with no matching start.")
+					return nil, reportError(fileName, line, column, "Found range end with no matching start.")
 				}
 				rangeStart := openRanges[len(openRanges)-1]
 				openRanges = openRanges[:len(openRanges)-1]
@@ -219,7 +224,7 @@ func parseFileContent(fileName string, content string, fileOptions map[string]st
 			} else if previousCharacter == '/' && currentCharacter == '*' {
 				// found a possible marker start
 				state = stateInSlashStarMarker
-				openMarker = locationInformation{
+				openMarker = &locationInformation{
 					position:       (i - 1) - difference,
 					sourcePosition: i - 1,
 					sourceLine:     line,
@@ -228,7 +233,7 @@ func parseFileContent(fileName string, content string, fileOptions map[string]st
 			} else if previousCharacter == '{' && currentCharacter == '|' {
 				// found an object marker start
 				state = stateInObjectMarker
-				openMarker = locationInformation{
+				openMarker = &locationInformation{
 					position:       (i - 1) - difference,
 					sourcePosition: i - 1,
 					sourceLine:     line,
@@ -240,7 +245,10 @@ func parseFileContent(fileName string, content string, fileOptions map[string]st
 			// Object markers are only ever terminated by |} and have no content restrictions
 			if previousCharacter == '|' && currentCharacter == '}' {
 				objectMarkerData := strings.TrimSpace(content[openMarker.sourcePosition+2 : i-1])
-				marker := getObjectMarker(fileName, openMarker, objectMarkerData)
+				marker, e := getObjectMarker(fileName, openMarker, objectMarkerData)
+				if e != "" {
+					return nil, e
+				}
 
 				if len(openRanges) > 0 {
 					openRanges[len(openRanges)-1].marker = marker
@@ -252,7 +260,7 @@ func parseFileContent(fileName string, content string, fileOptions map[string]st
 				difference += i + 1 - openMarker.sourcePosition
 
 				// Reset the state
-				openMarker = locationInformation{}
+				openMarker = nil
 				state = stateNone
 			}
 		case stateInSlashStarMarker:
@@ -276,7 +284,7 @@ func parseFileContent(fileName string, content string, fileOptions map[string]st
 				difference += i + 1 - openMarker.sourcePosition
 
 				// Reset the state
-				openMarker = locationInformation{}
+				openMarker = nil
 				state = stateNone
 			} else if !(stringutil.IsDigit(currentCharacter) ||
 				stringutil.IsASCIILetter(currentCharacter) ||
@@ -289,7 +297,7 @@ func parseFileContent(fileName string, content string, fileOptions map[string]st
 					// Bail out the text we've gathered so far back into the output
 					flush(i)
 					lastNormalCharPosition = i
-					openMarker = locationInformation{}
+					openMarker = nil
 					state = stateNone
 				}
 			}
@@ -308,6 +316,15 @@ func parseFileContent(fileName string, content string, fileOptions map[string]st
 
 	// Add the remaining text
 	flush(-1)
+
+	if len(openRanges) > 0 {
+		openRange := openRanges[0]
+		return nil, reportError(fileName, openRange.sourceLine, openRange.sourceColumn, "Unterminated range.")
+	}
+
+	if openMarker != nil {
+		return nil, reportError(fileName, openMarker.sourceLine, openMarker.sourceColumn, "Unterminated marker.")
+	}
 
 	outputString := output.String()
 	// Set LS positions for markers
@@ -338,22 +355,20 @@ func parseFileContent(fileName string, content string, fileOptions map[string]st
 		file:    testFileInfo,
 		markers: markers,
 		ranges:  rangeMarkers,
-	}
+	}, ""
 }
 
-func getObjectMarker(fileName string, location locationInformation, text string) *Marker {
+func getObjectMarker(fileName string, location *locationInformation, text string) (*Marker, string) {
 	// Attempt to parse the marker value as JSON
 	var v interface{}
 	e := json.Unmarshal([]byte("{ "+text+" }"), &v)
 
 	if e != nil {
-		reportError(fileName, location.sourceLine, location.sourceColumn, "Unable to parse marker text "+text)
-		return nil
+		return nil, reportError(fileName, location.sourceLine, location.sourceColumn, "Unable to parse marker text "+text)
 	}
 	markerValue, ok := v.(map[string]interface{})
 	if !ok || len(markerValue) == 0 {
-		reportError(fileName, location.sourceLine, location.sourceColumn, "Object markers can not be empty")
-		return nil
+		return nil, reportError(fileName, location.sourceLine, location.sourceColumn, "Object markers can not be empty")
 	}
 
 	marker := &Marker{
@@ -369,10 +384,9 @@ func getObjectMarker(fileName string, location locationInformation, text string)
 		}
 	}
 
-	return marker
+	return marker, ""
 }
 
-func reportError(fileName string, line int, col int, message string) {
-	// !!! not implemented
-	// errorMessage := fileName + "(" + string(line) + "," + string(col) + "): " + message;
+func reportError(fileName string, line int, col int, message string) string {
+	return fmt.Sprintf("%v (%v,%v): %v", fileName, line, col, message)
 }

--- a/internal/testrunner/test_case_parser.go
+++ b/internal/testrunner/test_case_parser.go
@@ -50,8 +50,8 @@ func makeUnitsFromTest(code string, fileName string) testCaseContent {
 	testUnits, symlinks, currentDirectory, _, _ := ParseTestFilesAndSymlinks(
 		code,
 		fileName,
-		func(filename string, content string, fileOptions map[string]string) (*testUnit, string) {
-			return &testUnit{content: content, name: filename}, ""
+		func(filename string, content string, fileOptions map[string]string) (*testUnit, error) {
+			return &testUnit{content: content, name: filename}, nil
 		},
 	)
 	if currentDirectory == "" {
@@ -108,8 +108,8 @@ func makeUnitsFromTest(code string, fileName string) testCaseContent {
 func ParseTestFilesAndSymlinks[T any](
 	code string,
 	fileName string,
-	parseFile func(filename string, content string, fileOptions map[string]string) (T, string),
-) (units []T, symlinks map[string]string, currentDir string, globalOptions map[string]string, e string) {
+	parseFile func(filename string, content string, fileOptions map[string]string) (T, error),
+) (units []T, symlinks map[string]string, currentDir string, globalOptions map[string]string, e error) {
 	// List of all the subfiles we've parsed out
 	var testUnits []T
 
@@ -119,7 +119,7 @@ func ParseTestFilesAndSymlinks[T any](
 	var currentFileContent strings.Builder
 	var currentFileName string
 	var currentDirectory string
-	var parseError string
+	var parseError error
 	currentFileOptions := make(map[string]string)
 	symlinks = make(map[string]string)
 	globalOptions = make(map[string]string)
@@ -155,7 +155,7 @@ func ParseTestFilesAndSymlinks[T any](
 			if currentFileName != "" {
 				// Store result file
 				newTestFile, e := parseFile(currentFileName, currentFileContent.String(), currentFileOptions)
-				if e != "" {
+				if e != nil {
 					parseError = e
 					break
 				}
@@ -190,7 +190,7 @@ func ParseTestFilesAndSymlinks[T any](
 	}
 
 	// if there are no parse errors so far, parse the rest of the file
-	if parseError == "" {
+	if parseError == nil {
 		// EOF, push whatever remains
 		newTestFile2, e := parseFile(currentFileName, currentFileContent.String(), currentFileOptions)
 

--- a/internal/testrunner/test_case_parser.go
+++ b/internal/testrunner/test_case_parser.go
@@ -47,11 +47,11 @@ var fourslashDirectives = []string{"emitthisfile"}
 // Given a test file containing // @FileName directives,
 // return an array of named units of code to be added to an existing compiler instance.
 func makeUnitsFromTest(code string, fileName string) testCaseContent {
-	testUnits, symlinks, currentDirectory, _ := ParseTestFilesAndSymlinks(
+	testUnits, symlinks, currentDirectory, _, _ := ParseTestFilesAndSymlinks(
 		code,
 		fileName,
-		func(filename string, content string, fileOptions map[string]string) *testUnit {
-			return &testUnit{content: content, name: filename}
+		func(filename string, content string, fileOptions map[string]string) (*testUnit, string) {
+			return &testUnit{content: content, name: filename}, ""
 		},
 	)
 	if currentDirectory == "" {
@@ -108,8 +108,8 @@ func makeUnitsFromTest(code string, fileName string) testCaseContent {
 func ParseTestFilesAndSymlinks[T any](
 	code string,
 	fileName string,
-	parseFile func(filename string, content string, fileOptions map[string]string) T,
-) (units []T, symlinks map[string]string, currentDir string, globalOptions map[string]string) {
+	parseFile func(filename string, content string, fileOptions map[string]string) (T, string),
+) (units []T, symlinks map[string]string, currentDir string, globalOptions map[string]string, e string) {
 	// List of all the subfiles we've parsed out
 	var testUnits []T
 
@@ -119,6 +119,7 @@ func ParseTestFilesAndSymlinks[T any](
 	var currentFileContent strings.Builder
 	var currentFileName string
 	var currentDirectory string
+	var parseError string
 	currentFileOptions := make(map[string]string)
 	symlinks = make(map[string]string)
 	globalOptions = make(map[string]string)
@@ -153,7 +154,11 @@ func ParseTestFilesAndSymlinks[T any](
 			// New metadata statement after having collected some code to go with the previous metadata
 			if currentFileName != "" {
 				// Store result file
-				newTestFile := parseFile(currentFileName, currentFileContent.String(), currentFileOptions)
+				newTestFile, e := parseFile(currentFileName, currentFileContent.String(), currentFileOptions)
+				if e != "" {
+					parseError = e
+					break
+				}
 				testUnits = append(testUnits, newTestFile)
 
 				// Reset local data
@@ -184,11 +189,16 @@ func ParseTestFilesAndSymlinks[T any](
 		currentFileName = tspath.GetBaseFileName(fileName)
 	}
 
-	// EOF, push whatever remains
-	newTestFile2 := parseFile(currentFileName, currentFileContent.String(), currentFileOptions)
-	testUnits = append(testUnits, newTestFile2)
+	// if there are no parse errors so far, parse the rest of the file
+	if parseError == "" {
+		// EOF, push whatever remains
+		newTestFile2, e := parseFile(currentFileName, currentFileContent.String(), currentFileOptions)
 
-	return testUnits, symlinks, currentDirectory, globalOptions
+		parseError = e
+		testUnits = append(testUnits, newTestFile2)
+	}
+
+	return testUnits, symlinks, currentDirectory, globalOptions, parseError
 }
 
 func extractCompilerSettings(content string) rawCompilerSettings {


### PR DESCRIPTION
In strada's fourslash, tests would exit immediately if fourslash parsing failed. This PR adds an error + early exit for fourslash tests

Follow up to #1175. 