### PR TITLE
Convert read file content directly to strings

### DIFF
--- a/internal/repo/paths.go
+++ b/internal/repo/paths.go
@@ -46,6 +46,10 @@ var typeScriptSubmoduleExists = sync.OnceValue(func() bool {
 	return true
 })
 
+func TypeScriptSubmoduleExists() bool {
+	return typeScriptSubmoduleExists()
+}
+
 type skippable interface {
 	Helper()
 	Skipf(format string, args ...any)

--- a/internal/vfs/internal/internal.go
+++ b/internal/vfs/internal/internal.go
@@ -148,7 +148,7 @@ func (vfs *Common) ReadFile(path string) (contents string, ok bool) {
 	}
 
 	// An invariant of any underlying filesystem is that the bytes returned
-	// are immtuable, otherwise anyone using the filesystem would end up
+	// are immutable, otherwise anyone using the filesystem would end up
 	// with data races.
 	//
 	// This means that we can safely convert the bytes to a string directly,

--- a/internal/vfs/internal/internal.go
+++ b/internal/vfs/internal/internal.go
@@ -1,11 +1,12 @@
 package internal
 
 import (
-	"bytes"
 	"encoding/binary"
 	"fmt"
 	"io/fs"
+	"strings"
 	"unicode/utf16"
+	"unsafe"
 
 	"github.com/microsoft/typescript-go/internal/tspath"
 	"github.com/microsoft/typescript-go/internal/vfs"
@@ -146,30 +147,38 @@ func (vfs *Common) ReadFile(path string) (contents string, ok bool) {
 		return "", false
 	}
 
-	return decodeBytes(b)
+	// An invariant of any underlying filesystem is that the bytes returned
+	// are immtuable, otherwise anyone using the filesystem would end up
+	// with data races.
+	//
+	// This means that we can safely convert the bytes to a string directly,
+	// saving a copy.
+	s := unsafe.String(&b[0], len(b))
+
+	return decodeBytes(s)
 }
 
-func decodeBytes(b []byte) (contents string, ok bool) {
+func decodeBytes(s string) (contents string, ok bool) {
 	var bom [2]byte
-	if len(b) >= 2 {
-		bom = [2]byte{b[0], b[1]}
+	if len(s) >= 2 {
+		bom = [2]byte{s[0], s[1]}
 		switch bom {
 		case [2]byte{0xFF, 0xFE}:
-			return decodeUtf16(b[2:], binary.LittleEndian), true
+			return decodeUtf16(s[2:], binary.LittleEndian), true
 		case [2]byte{0xFE, 0xFF}:
-			return decodeUtf16(b[2:], binary.BigEndian), true
+			return decodeUtf16(s[2:], binary.BigEndian), true
 		}
 	}
-	if len(b) >= 3 && b[0] == 0xEF && b[1] == 0xBB && b[2] == 0xBF {
-		b = b[3:]
+	if len(s) >= 3 && s[0] == 0xEF && s[1] == 0xBB && s[2] == 0xBF {
+		s = s[3:]
 	}
 
-	return string(b), true
+	return string(s), true
 }
 
-func decodeUtf16(b []byte, order binary.ByteOrder) string {
-	ints := make([]uint16, len(b)/2)
-	if err := binary.Read(bytes.NewReader(b), order, &ints); err != nil {
+func decodeUtf16(s string, order binary.ByteOrder) string {
+	ints := make([]uint16, len(s)/2)
+	if err := binary.Read(strings.NewReader(s), order, &ints); err != nil {
 		return ""
 	}
 	return string(utf16.Decode(ints))

--- a/internal/vfs/internal/internal.go
+++ b/internal/vfs/internal/internal.go
@@ -173,7 +173,7 @@ func decodeBytes(s string) (contents string, ok bool) {
 		s = s[3:]
 	}
 
-	return string(s), true
+	return s, true
 }
 
 func decodeUtf16(s string, order binary.ByteOrder) string {

--- a/internal/vfs/internal/internal.go
+++ b/internal/vfs/internal/internal.go
@@ -153,6 +153,10 @@ func (vfs *Common) ReadFile(path string) (contents string, ok bool) {
 	//
 	// This means that we can safely convert the bytes to a string directly,
 	// saving a copy.
+	if len(b) == 0 {
+		return "", true
+	}
+
 	s := unsafe.String(&b[0], len(b))
 
 	return decodeBytes(s)

--- a/internal/vfs/vfs_test.go
+++ b/internal/vfs/vfs_test.go
@@ -1,0 +1,65 @@
+package vfs_test
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/microsoft/typescript-go/internal/repo"
+	"github.com/microsoft/typescript-go/internal/tspath"
+	"github.com/microsoft/typescript-go/internal/vfs"
+	"github.com/microsoft/typescript-go/internal/vfs/osvfs"
+	"github.com/microsoft/typescript-go/internal/vfs/vfstest"
+	"gotest.tools/v3/assert"
+)
+
+func BenchmarkReadFile(b *testing.B) {
+	type bench struct {
+		name string
+		fs   vfs.FS
+		path string
+	}
+
+	osFS := osvfs.FS()
+
+	const smallData = "hello, world"
+	tmpdir := tspath.NormalizeSlashes(b.TempDir())
+	osSmallDataPath := tspath.CombinePaths(tmpdir, "foo.ts")
+	err := osFS.WriteFile(osSmallDataPath, smallData, false)
+	assert.NilError(b, err)
+
+	tests := []bench{
+		{"MapFS small", vfstest.FromMap(fstest.MapFS{
+			"/foo.ts": &fstest.MapFile{
+				Data: []byte(smallData),
+			},
+		}, true), "/foo.ts"},
+		{"OS small", osFS, osSmallDataPath},
+	}
+
+	if repo.TypeScriptSubmoduleExists() {
+		checkerPath := tspath.CombinePaths(tspath.NormalizeSlashes(repo.TypeScriptSubmodulePath), "src", "compiler", "checker.ts")
+
+		checkerContents, ok := osFS.ReadFile(checkerPath)
+		assert.Assert(b, ok)
+
+		tests = append(tests, bench{
+			"MapFS checker.ts",
+			vfstest.FromMap(fstest.MapFS{
+				"/checker.ts": &fstest.MapFile{
+					Data: []byte(checkerContents),
+				},
+			}, true),
+			"/checker.ts",
+		})
+		tests = append(tests, bench{"OS checker.ts", osFS, checkerPath})
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				_, _ = tt.fs.ReadFile(tt.path)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I don't like unsafe, but in this case I believe it to be reasonable.

When reading from a filesystem, the returned bytes must necessarily never be touched by the underlying filesystem ever again. Otherwise, the caller would experience data races or be unable to modify the data. This means that in effect, the FS is guaranteed to no longer "own" that data, and the caller can do whatever it wants with it.

Our FS abstraction works with strings, but the underlying FSs all provide `[]byte`. Given the above, we can skip the typical `string` to `[]byte` copy and "safely" use `unsafe.String` to directly convert it.

This nets about a 50% improvement in time and memory allocation on non-trivial files. It's not much, but for larger files like `checker.ts`, it means going from a 1 ms read to a 0.5 ms read.

I'm not totally sure if we should do this (other stuff is more expensive), but this is an improvement, so...

```
goos: linux
goarch: amd64
pkg: github.com/microsoft/typescript-go/internal/vfs
cpu: Intel(R) Core(TM) i9-10900K CPU @ 3.70GHz
                             │   old.txt    │               new.txt               │
                             │    sec/op    │   sec/op     vs base                │
ReadFile/MapFS_small-20         296.9n ± 0%   277.5n ± 1%   -6.52% (p=0.000 n=10)
ReadFile/OS_small-20            4.657µ ± 0%   4.723µ ± 1%   +1.41% (p=0.000 n=10)
ReadFile/MapFS_checker.ts-20   1067.8µ ± 6%   498.6µ ± 3%  -53.31% (p=0.000 n=10)
ReadFile/OS_checker.ts-20       833.4µ ± 7%   315.8µ ± 2%  -62.11% (p=0.000 n=10)
geomean                         33.30µ        21.31µ       -36.00%
```
```
                             │   old.txt    │               new.txt                │
                             │     B/op     │     B/op      vs base                │
ReadFile/MapFS_small-20          152.0 ± 0%     136.0 ± 0%  -10.53% (p=0.000 n=10)
ReadFile/OS_small-20            1016.0 ± 0%    1000.0 ± 0%   -1.57% (p=0.000 n=10)
ReadFile/MapFS_checker.ts-20   5.906Mi ± 0%   2.953Mi ± 0%  -50.00% (p=0.000 n=10)
ReadFile/OS_checker.ts-20      5.907Mi ± 0%   2.954Mi ± 0%  -50.00% (p=0.000 n=10)
geomean                        48.18Ki        33.00Ki       -31.50%
```
```
                             │  old.txt   │              new.txt               │
                             │ allocs/op  │ allocs/op   vs base                │
ReadFile/MapFS_small-20        5.000 ± 0%   4.000 ± 0%  -20.00% (p=0.000 n=10)
ReadFile/OS_small-20           11.00 ± 0%   10.00 ± 0%   -9.09% (p=0.000 n=10)
ReadFile/MapFS_checker.ts-20   5.000 ± 0%   4.000 ± 0%  -20.00% (p=0.000 n=10)
ReadFile/OS_checker.ts-20      11.00 ± 0%   10.00 ± 0%   -9.09% (p=0.000 n=10)
geomean                        7.416        6.325       -14.72%
```