### PR TITLE
Port finding default project finder code

### DIFF
--- a/internal/compiler/fileloader.go
+++ b/internal/compiler/fileloader.go
@@ -200,7 +200,7 @@ func (p *fileLoader) addProjectReferenceTasks() {
 		opts: p.opts,
 		host: p.opts.Host,
 	}
-	projectReferences := p.opts.Config.ProjectReferences()
+	projectReferences := p.opts.Config.ResolvedProjectReferencePaths()
 	if len(projectReferences) == 0 {
 		return
 	}

--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -124,7 +124,7 @@ func (p *Program) GetRedirectForResolution(file ast.HasFileName) *tsoptions.Pars
 }
 
 func (p *Program) ForEachResolvedProjectReference(
-	fn func(path tspath.Path, config *tsoptions.ParsedCommandLine) bool,
+	fn func(path tspath.Path, config *tsoptions.ParsedCommandLine),
 ) {
 	p.projectReferenceFileMapper.forEachResolvedProjectReference(fn)
 }

--- a/internal/compiler/projectreferencefilemapper.go
+++ b/internal/compiler/projectreferencefilemapper.go
@@ -140,7 +140,7 @@ func (mapper *projectReferenceFileMapper) getResolvedReferenceFor(path tspath.Pa
 }
 
 func (mapper *projectReferenceFileMapper) forEachResolvedProjectReference(
-	fn func(path tspath.Path, config *tsoptions.ParsedCommandLine) bool,
+	fn func(path tspath.Path, config *tsoptions.ParsedCommandLine),
 ) {
 	if mapper.opts.Config.ConfigFile == nil {
 		return
@@ -150,14 +150,13 @@ func (mapper *projectReferenceFileMapper) forEachResolvedProjectReference(
 }
 
 func (mapper *projectReferenceFileMapper) forEachResolvedReferenceWorker(
-	referenes []tspath.Path,
-	fn func(path tspath.Path, config *tsoptions.ParsedCommandLine) bool,
+	references []tspath.Path,
+	fn func(path tspath.Path, config *tsoptions.ParsedCommandLine),
 ) {
-	for _, path := range referenes {
+	for _, path := range references {
 		config, _ := mapper.configToProjectReference[path]
-		if !fn(path, config) {
-			return
-		}
+		fn(path, config)
+		mapper.forEachResolvedReferenceWorker(mapper.referencesInConfigFile[path], fn)
 	}
 }
 

--- a/internal/compiler/projectreferenceparsetask.go
+++ b/internal/compiler/projectreferenceparsetask.go
@@ -25,7 +25,7 @@ func (t *projectReferenceParseTask) start(loader *fileLoader) {
 			t.resolved.ParseInputOutputNames()
 		})
 	}
-	subReferences := t.resolved.ProjectReferences()
+	subReferences := t.resolved.ResolvedProjectReferencePaths()
 	if len(subReferences) == 0 {
 		return
 	}
@@ -36,13 +36,10 @@ func getSubTasksOfProjectReferenceParseTask(t *projectReferenceParseTask) []*pro
 	return t.subTasks
 }
 
-func createProjectReferenceParseTasks(projectReferences []*core.ProjectReference) []*projectReferenceParseTask {
-	tasks := make([]*projectReferenceParseTask, 0, len(projectReferences))
-	for _, reference := range projectReferences {
-		configName := core.ResolveProjectReferencePath(reference)
-		tasks = append(tasks, &projectReferenceParseTask{
+func createProjectReferenceParseTasks(projectReferences []string) []*projectReferenceParseTask {
+	return core.Map(projectReferences, func(configName string) *projectReferenceParseTask {
+		return &projectReferenceParseTask{
 			configName: configName,
-		})
-	}
-	return tasks
+		}
+	})
 }

--- a/internal/project/defaultprojectfinder.go
+++ b/internal/project/defaultprojectfinder.go
@@ -1,0 +1,375 @@
+package project
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/microsoft/typescript-go/internal/collections"
+	"github.com/microsoft/typescript-go/internal/core"
+	"github.com/microsoft/typescript-go/internal/tsoptions"
+	"github.com/microsoft/typescript-go/internal/tspath"
+)
+
+type defaultProjectFinder struct {
+	service                         *Service
+	configFileForOpenFiles          map[tspath.Path]string            // default config project for open files
+	configFilesAncestorForOpenFiles map[tspath.Path]map[string]string // ancestor config file for open files
+}
+
+func (f *defaultProjectFinder) computeConfigFileName(fileName string, info *ScriptInfo, skipSearchInDirectoryOfFile bool) string {
+	projectRootPath := f.service.openFiles[info.path]
+	searchPath := tspath.GetDirectoryPath(fileName)
+	result, _ := tspath.ForEachAncestorDirectory(searchPath, func(directory string) (result string, stop bool) {
+		tsconfigPath := tspath.CombinePaths(directory, "tsconfig.json")
+		if !skipSearchInDirectoryOfFile && f.service.FS().FileExists(tsconfigPath) {
+			return tsconfigPath, true
+		}
+		jsconfigPath := tspath.CombinePaths(directory, "jsconfig.json")
+		if !skipSearchInDirectoryOfFile && f.service.FS().FileExists(jsconfigPath) {
+			return jsconfigPath, true
+		}
+		if strings.HasSuffix(directory, "/node_modules") {
+			return "", true
+		}
+		if projectRootPath != "" && !tspath.ContainsPath(projectRootPath, directory, f.service.comparePathsOptions) {
+			return "", true
+		}
+		skipSearchInDirectoryOfFile = false
+		return "", false
+	})
+	f.service.logf("getConfigFileNameForFile:: File: %s ProjectRootPath: %s:: Result: %s", fileName, projectRootPath, result)
+	return result
+}
+
+func (f *defaultProjectFinder) getConfigFileNameForFile(info *ScriptInfo, loadKind projectLoadKind) string {
+	if info.isDynamic {
+		return ""
+	}
+
+	configName, ok := f.configFileForOpenFiles[info.path]
+	if ok {
+		return configName
+	}
+
+	if loadKind == projectLoadKindFind {
+		return ""
+	}
+
+	fileName := f.computeConfigFileName(info.fileName, info, false)
+
+	if _, ok := f.service.openFiles[info.path]; ok {
+		f.configFileForOpenFiles[info.path] = fileName
+	}
+	return fileName
+}
+
+func (f *defaultProjectFinder) getAncestorConfigFileName(info *ScriptInfo, configFileName string, loadKind projectLoadKind) string {
+	if info.isDynamic {
+		return ""
+	}
+
+	ancestorConfigMap, ok := f.configFilesAncestorForOpenFiles[info.path]
+	if ok {
+		ancestorConfigName, found := ancestorConfigMap[configFileName]
+		if found {
+			return ancestorConfigName
+		}
+	}
+
+	if loadKind == projectLoadKindFind {
+		return ""
+	}
+
+	// Look for config in parent folders of config file
+	fileName := f.computeConfigFileName(configFileName, info, true)
+
+	if _, ok := f.service.openFiles[info.path]; ok {
+		ancestorConfigMap, ok := f.configFilesAncestorForOpenFiles[info.path]
+		if !ok {
+			ancestorConfigMap = make(map[string]string)
+			f.configFilesAncestorForOpenFiles[info.path] = ancestorConfigMap
+		}
+		ancestorConfigMap[configFileName] = fileName
+	}
+	return fileName
+}
+
+func (f *defaultProjectFinder) findOrAcquireConfig(
+	info *ScriptInfo,
+	configFileName string,
+	configFilePath tspath.Path,
+	loadKind projectLoadKind,
+) *tsoptions.ParsedCommandLine {
+	switch loadKind {
+	case projectLoadKindFind:
+		return f.service.configFileRegistry.getConfig(configFilePath)
+	case projectLoadKindCreate:
+		return f.service.configFileRegistry.acquireConfig(configFileName, configFilePath, nil, info)
+	default:
+		panic(fmt.Sprintf("unknown project load kind: %d", loadKind))
+	}
+}
+
+func (f *defaultProjectFinder) findOrCreateProject(
+	configFileName string,
+	configFilePath tspath.Path,
+	loadKind projectLoadKind,
+) *Project {
+	project := f.service.ConfiguredProject(configFilePath)
+	if project == nil {
+		if loadKind == projectLoadKindFind {
+			return nil
+		}
+		project = f.service.createConfiguredProject(configFileName, configFilePath)
+	}
+	return project
+}
+
+func (f *defaultProjectFinder) isDefaultConfigForScriptInfo(
+	info *ScriptInfo,
+	configFileName string,
+	configFilePath tspath.Path,
+	config *tsoptions.ParsedCommandLine,
+	loadKind projectLoadKind,
+	result *openScriptInfoProjectResult,
+) bool {
+	// This currently happens only when finding project for open script info first time file is opened
+	// Set seen based on project if present of for config file if its not yet created
+	if !result.addSeenConfig(configFilePath, loadKind) {
+		return false
+	}
+
+	// If the file is listed in root files, then only we can use this project as default project
+	if !config.MatchesFileName(info.fileName) {
+		return false
+	}
+
+	// Ensure the project is uptodate and created since the file may belong to this project
+	project := f.findOrCreateProject(configFileName, configFilePath, loadKind)
+	return f.isDefaultProject(info, project, loadKind, result)
+}
+
+func (f *defaultProjectFinder) isDefaultProject(
+	info *ScriptInfo,
+	project *Project,
+	loadKind projectLoadKind,
+	result *openScriptInfoProjectResult,
+) bool {
+	if project == nil {
+		return false
+	}
+
+	// Skip already looked up projects
+	if !result.addSeenProject(project, loadKind) {
+		return false
+	}
+	// Make sure project is upto date when in create mode
+	if loadKind == projectLoadKindCreate {
+		project.updateGraph()
+	}
+	// If script info belongs to this project, use this as default config project
+	if project.containsScriptInfo(info) {
+		if !project.isSourceFromProjectReference(info) {
+			result.setProject(project)
+			return true
+		} else if !result.hasFallbackDefault() {
+			// Use this project as default if no other project is found
+			result.setFallbackDefault(project)
+		}
+	}
+	return false
+}
+
+func (f *defaultProjectFinder) tryFindDefaultConfiguredProjectFromReferences(
+	info *ScriptInfo,
+	config *tsoptions.ParsedCommandLine,
+	loadKind projectLoadKind,
+	result *openScriptInfoProjectResult,
+) bool {
+	if len(config.ProjectReferences()) == 0 {
+		return false
+	}
+	wg := core.NewWorkGroup(false)
+	f.tryFindDefaultConfiguredProjectFromReferencesWorker(info, config, loadKind, result, wg)
+	wg.RunAndWait()
+	return result.isDone()
+}
+
+func (f *defaultProjectFinder) tryFindDefaultConfiguredProjectFromReferencesWorker(
+	info *ScriptInfo,
+	config *tsoptions.ParsedCommandLine,
+	loadKind projectLoadKind,
+	result *openScriptInfoProjectResult,
+	wg core.WorkGroup,
+) {
+	if config.CompilerOptions().DisableReferencedProjectLoad.IsTrue() {
+		loadKind = projectLoadKindFind
+	}
+	for _, childConfigFileName := range config.ResolvedProjectReferencePaths() {
+		wg.Queue(func() {
+			childConfigFilePath := f.service.toPath(childConfigFileName)
+			childConfig := f.findOrAcquireConfig(info, childConfigFileName, childConfigFilePath, loadKind)
+			if childConfig == nil || f.isDefaultConfigForScriptInfo(info, childConfigFileName, childConfigFilePath, childConfig, loadKind, result) {
+				return
+			}
+			// Search in references if we cant find default project in current config
+			f.tryFindDefaultConfiguredProjectFromReferencesWorker(info, childConfig, loadKind, result, wg)
+		})
+	}
+}
+
+func (f *defaultProjectFinder) tryFindDefaultConfiguredProjectFromAncestor(
+	info *ScriptInfo,
+	configFileName string,
+	config *tsoptions.ParsedCommandLine,
+	loadKind projectLoadKind,
+	result *openScriptInfoProjectResult,
+) bool {
+	if config != nil && config.CompilerOptions().DisableSolutionSearching.IsTrue() {
+		return false
+	}
+	if ancestorConfigName := f.getAncestorConfigFileName(info, configFileName, loadKind); ancestorConfigName != "" {
+		return f.tryFindDefaultConfiguredProjectForScriptInfo(info, ancestorConfigName, loadKind, result)
+	}
+	return false
+}
+
+func (f *defaultProjectFinder) tryFindDefaultConfiguredProjectForScriptInfo(
+	info *ScriptInfo,
+	configFileName string,
+	loadKind projectLoadKind,
+	result *openScriptInfoProjectResult,
+) bool {
+	// Lookup from parsedConfig if available
+	configFilePath := f.service.toPath(configFileName)
+	config := f.findOrAcquireConfig(info, configFileName, configFilePath, loadKind)
+	if config != nil {
+		if config.CompilerOptions().Composite == core.TSTrue {
+			if f.isDefaultConfigForScriptInfo(info, configFileName, configFilePath, config, loadKind, result) {
+				return true
+			}
+		} else if len(config.FileNames()) > 0 {
+			project := f.findOrCreateProject(configFileName, configFilePath, loadKind)
+			if f.isDefaultProject(info, project, loadKind, result) {
+				return true
+			}
+		}
+		// Lookup in references
+		if f.tryFindDefaultConfiguredProjectFromReferences(info, config, loadKind, result) {
+			return true
+		}
+	}
+	// Lookup in ancestor projects
+	if f.tryFindDefaultConfiguredProjectFromAncestor(info, configFileName, config, loadKind, result) {
+		return true
+	}
+	return false
+}
+
+func (f *defaultProjectFinder) tryFindDefaultConfiguredProjectForOpenScriptInfo(
+	info *ScriptInfo,
+	loadKind projectLoadKind,
+) *openScriptInfoProjectResult {
+	if configFileName := f.getConfigFileNameForFile(info, loadKind); configFileName != "" {
+		var result openScriptInfoProjectResult
+		f.tryFindDefaultConfiguredProjectForScriptInfo(info, configFileName, loadKind, &result)
+		if result.project == nil && result.fallbackDefault != nil {
+			result.setProject(result.fallbackDefault)
+		}
+		return &result
+	}
+	return nil
+}
+
+func (f *defaultProjectFinder) tryFindDefaultConfiguredProjectAndLoadAncestorsForOpenScriptInfo(
+	info *ScriptInfo,
+	projectLoadKind projectLoadKind,
+) *openScriptInfoProjectResult {
+	result := f.tryFindDefaultConfiguredProjectForOpenScriptInfo(info, projectLoadKind)
+	if result != nil && result.project != nil {
+		// !!! sheetal todo this later
+		// // Create ancestor tree for findAllRefs (dont load them right away)
+		// forEachAncestorProjectLoad(
+		// 	info,
+		// 	tsconfigProject!,
+		// 	ancestor => {
+		// 		seenProjects.set(ancestor.project, kind);
+		// 	},
+		// 	kind,
+		// 	`Creating project possibly referencing default composite project ${defaultProject.getProjectName()} of open file ${info.fileName}`,
+		// 	allowDeferredClosed,
+		// 	reloadedProjects,
+		// 	/*searchOnlyPotentialSolution*/ true,
+		// 	delayReloadedConfiguredProjects,
+		// );
+	}
+	return result
+}
+
+func (f *defaultProjectFinder) findDefaultConfiguredProject(scriptInfo *ScriptInfo) *Project {
+	if f.service.isOpenFile(scriptInfo) {
+		result := f.tryFindDefaultConfiguredProjectForOpenScriptInfo(scriptInfo, projectLoadKindFind)
+		if result != nil && result.project != nil && !result.project.deferredClose {
+			return result.project
+		}
+	}
+	return nil
+}
+
+type openScriptInfoProjectResult struct {
+	projectMu         sync.RWMutex
+	project           *Project
+	fallbackDefaultMu sync.RWMutex
+	fallbackDefault   *Project // use this if we cant find actual project
+	seenProjects      collections.SyncMap[*Project, projectLoadKind]
+	seenConfigs       collections.SyncMap[tspath.Path, projectLoadKind]
+}
+
+func (r *openScriptInfoProjectResult) addSeenProject(project *Project, loadKind projectLoadKind) bool {
+	if kind, loaded := r.seenProjects.LoadOrStore(project, loadKind); loaded {
+		if kind >= loadKind {
+			return false
+		}
+		r.seenProjects.Store(project, loadKind)
+	}
+	return true
+}
+
+func (r *openScriptInfoProjectResult) addSeenConfig(configPath tspath.Path, loadKind projectLoadKind) bool {
+	if kind, loaded := r.seenConfigs.LoadOrStore(configPath, loadKind); loaded {
+		if kind >= loadKind {
+			return false
+		}
+		r.seenConfigs.Store(configPath, loadKind)
+	}
+	return true
+}
+
+func (r *openScriptInfoProjectResult) isDone() bool {
+	r.projectMu.RLock()
+	defer r.projectMu.RUnlock()
+	return r.project != nil
+}
+
+func (r *openScriptInfoProjectResult) setProject(project *Project) {
+	r.projectMu.Lock()
+	defer r.projectMu.Unlock()
+	if r.project == nil {
+		r.project = project
+	}
+}
+
+func (r *openScriptInfoProjectResult) hasFallbackDefault() bool {
+	r.fallbackDefaultMu.RLock()
+	defer r.fallbackDefaultMu.RUnlock()
+	return r.fallbackDefault != nil
+}
+
+func (r *openScriptInfoProjectResult) setFallbackDefault(project *Project) {
+	r.fallbackDefaultMu.Lock()
+	defer r.fallbackDefaultMu.Unlock()
+	if r.fallbackDefault == nil {
+		r.fallbackDefault = project
+	}
+}

--- a/internal/project/defaultprojectfinder_test.go
+++ b/internal/project/defaultprojectfinder_test.go
@@ -1,0 +1,307 @@
+package project_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/bundled"
+	"github.com/microsoft/typescript-go/internal/core"
+	"github.com/microsoft/typescript-go/internal/project"
+	"github.com/microsoft/typescript-go/internal/testutil/projecttestutil"
+	"github.com/microsoft/typescript-go/internal/tspath"
+	"gotest.tools/v3/assert"
+)
+
+func TestDefaultProjectFinder(t *testing.T) {
+	t.Parallel()
+
+	if !bundled.Embedded {
+		t.Skip("bundled files are not embedded")
+	}
+
+	t.Run("when project found is solution referencing default project directly", func(t *testing.T) {
+		t.Parallel()
+		files := filesForSolutionConfigFile([]string{"./tsconfig-src.json"}, "", nil)
+		service, _ := projecttestutil.Setup(files, nil)
+		service.OpenFile("/user/username/projects/myproject/src/main.ts", files["/user/username/projects/myproject/src/main.ts"].(string), core.ScriptKindTS, "")
+		assert.Equal(t, len(service.Projects()), 1)
+		srcProject := service.ConfiguredProject(tspath.Path("/user/username/projects/myproject/tsconfig-src.json"))
+		assert.Assert(t, srcProject != nil)
+		_, project := service.EnsureDefaultProjectForFile("/user/username/projects/myproject/src/main.ts")
+		assert.Equal(t, project, srcProject)
+		service.CloseFile("/user/username/projects/myproject/src/main.ts")
+		service.OpenFile("/user/username/workspaces/dummy/dummy.ts", "const x = 1;", core.ScriptKindTS, "/user/username/workspaces/dummy")
+		assert.Equal(t, len(service.Projects()), 1)
+		assert.Assert(t, service.InferredProject(tspath.Path("/user/username/workspaces/dummy")) != nil)
+		configFileExists(t, service, tspath.Path("/user/username/projects/myproject/tsconfig.json"), false)
+		configFileExists(t, service, tspath.Path("/user/username/projects/myproject/tsconfig-src.json"), false)
+	})
+
+	t.Run("when project found is solution referencing default project indirectly", func(t *testing.T) {
+		t.Parallel()
+		files := filesForSolutionConfigFile([]string{"./tsconfig-indirect1.json", "./tsconfig-indirect2.json"}, "", nil)
+		applyIndirectProjectFiles(files, 1, "")
+		applyIndirectProjectFiles(files, 2, "")
+		service, _ := projecttestutil.Setup(files, nil)
+		service.OpenFile("/user/username/projects/myproject/src/main.ts", files["/user/username/projects/myproject/src/main.ts"].(string), core.ScriptKindTS, "")
+		assert.Equal(t, len(service.Projects()), 1)
+		srcProject := service.ConfiguredProject(tspath.Path("/user/username/projects/myproject/tsconfig-src.json"))
+		assert.Assert(t, srcProject != nil)
+		_, project := service.EnsureDefaultProjectForFile("/user/username/projects/myproject/src/main.ts")
+		assert.Equal(t, project, srcProject)
+		service.CloseFile("/user/username/projects/myproject/src/main.ts")
+		service.OpenFile("/user/username/workspaces/dummy/dummy.ts", "const x = 1;", core.ScriptKindTS, "/user/username/workspaces/dummy")
+		assert.Equal(t, len(service.Projects()), 1)
+		assert.Assert(t, service.InferredProject(tspath.Path("/user/username/workspaces/dummy")) != nil)
+		configFileExists(t, service, tspath.Path("/user/username/projects/myproject/tsconfig.json"), false)
+		configFileExists(t, service, tspath.Path("/user/username/projects/myproject/tsconfig-src.json"), false)
+		configFileExists(t, service, tspath.Path("/user/username/projects/myproject/tsconfig-indirect1.json"), false)
+		configFileExists(t, service, tspath.Path("/user/username/projects/myproject/tsconfig-indirect2.json"), false)
+	})
+
+	t.Run("when project found is solution with disableReferencedProjectLoad referencing default project directly", func(t *testing.T) {
+		t.Parallel()
+		files := filesForSolutionConfigFile([]string{"./tsconfig-src.json"}, `"disableReferencedProjectLoad": true`, nil)
+		service, _ := projecttestutil.Setup(files, nil)
+		service.OpenFile("/user/username/projects/myproject/src/main.ts", files["/user/username/projects/myproject/src/main.ts"].(string), core.ScriptKindTS, "")
+		assert.Equal(t, len(service.Projects()), 1)
+		assert.Assert(t, service.ConfiguredProject(tspath.Path("/user/username/projects/myproject/tsconfig-src.json")) == nil)
+		// Should not create referenced project
+		_, proj := service.EnsureDefaultProjectForFile("/user/username/projects/myproject/src/main.ts")
+		assert.Equal(t, proj.Kind(), project.KindInferred)
+		service.CloseFile("/user/username/projects/myproject/src/main.ts")
+		service.OpenFile("/user/username/workspaces/dummy/dummy.ts", "const x = 1;", core.ScriptKindTS, "/user/username/workspaces/dummy")
+		assert.Equal(t, len(service.Projects()), 1)
+		assert.Assert(t, service.InferredProject(tspath.Path("/user/username/workspaces/dummy")) != nil)
+		configFileExists(t, service, tspath.Path("/user/username/projects/myproject/tsconfig.json"), false)
+		configFileExists(t, service, tspath.Path("/user/username/projects/myproject/tsconfig-src.json"), false)
+	})
+
+	t.Run("when project found is solution referencing default project indirectly through  with disableReferencedProjectLoad", func(t *testing.T) {
+		t.Parallel()
+		files := filesForSolutionConfigFile([]string{"./tsconfig-indirect1.json"}, "", nil)
+		applyIndirectProjectFiles(files, 1, `"disableReferencedProjectLoad": true`)
+		service, _ := projecttestutil.Setup(files, nil)
+		service.OpenFile("/user/username/projects/myproject/src/main.ts", files["/user/username/projects/myproject/src/main.ts"].(string), core.ScriptKindTS, "")
+		assert.Equal(t, len(service.Projects()), 1)
+		assert.Assert(t, service.ConfiguredProject(tspath.Path("/user/username/projects/myproject/tsconfig-src.json")) == nil)
+		// Inferred project because no default is found
+		_, proj := service.EnsureDefaultProjectForFile("/user/username/projects/myproject/src/main.ts")
+		assert.Equal(t, proj.Kind(), project.KindInferred)
+		service.CloseFile("/user/username/projects/myproject/src/main.ts")
+		service.OpenFile("/user/username/workspaces/dummy/dummy.ts", "const x = 1;", core.ScriptKindTS, "/user/username/workspaces/dummy")
+		assert.Equal(t, len(service.Projects()), 1)
+		assert.Assert(t, service.InferredProject(tspath.Path("/user/username/workspaces/dummy")) != nil)
+		configFileExists(t, service, tspath.Path("/user/username/projects/myproject/tsconfig.json"), false)
+		configFileExists(t, service, tspath.Path("/user/username/projects/myproject/tsconfig-src.json"), false)
+		configFileExists(t, service, tspath.Path("/user/username/projects/myproject/tsconfig-indirect1.json"), false)
+	})
+
+	t.Run("when project found is solution referencing default project indirectly through  with disableReferencedProjectLoad in one but without it in another", func(t *testing.T) {
+		t.Parallel()
+		files := filesForSolutionConfigFile([]string{"./tsconfig-indirect1.json", "./tsconfig-indirect2.json"}, "", nil)
+		applyIndirectProjectFiles(files, 1, `"disableReferencedProjectLoad": true`)
+		applyIndirectProjectFiles(files, 2, "")
+		service, _ := projecttestutil.Setup(files, nil)
+		service.OpenFile("/user/username/projects/myproject/src/main.ts", files["/user/username/projects/myproject/src/main.ts"].(string), core.ScriptKindTS, "")
+		assert.Equal(t, len(service.Projects()), 1)
+		srcProject := service.ConfiguredProject(tspath.Path("/user/username/projects/myproject/tsconfig-src.json"))
+		assert.Assert(t, srcProject != nil)
+		// Default project is found through one indirect
+		_, proj := service.EnsureDefaultProjectForFile("/user/username/projects/myproject/src/main.ts")
+		assert.Equal(t, proj, srcProject)
+		service.CloseFile("/user/username/projects/myproject/src/main.ts")
+		service.OpenFile("/user/username/workspaces/dummy/dummy.ts", "const x = 1;", core.ScriptKindTS, "/user/username/workspaces/dummy")
+		assert.Equal(t, len(service.Projects()), 1)
+		assert.Assert(t, service.InferredProject(tspath.Path("/user/username/workspaces/dummy")) != nil)
+		configFileExists(t, service, tspath.Path("/user/username/projects/myproject/tsconfig.json"), false)
+		configFileExists(t, service, tspath.Path("/user/username/projects/myproject/tsconfig-src.json"), false)
+		configFileExists(t, service, tspath.Path("/user/username/projects/myproject/tsconfig-indirect1.json"), false)
+		configFileExists(t, service, tspath.Path("/user/username/projects/myproject/tsconfig-indirect2.json"), false)
+	})
+
+	t.Run("when project found is project with own files referencing the file from referenced project", func(t *testing.T) {
+		t.Parallel()
+		files := filesForSolutionConfigFile([]string{"./tsconfig-src.json"}, "", []string{"./own/main.ts"})
+		files["/user/username/projects/myproject/own/main.ts"] = `
+			import { foo } from '../src/main';
+			foo;
+			export function bar() {}
+		`
+		service, _ := projecttestutil.Setup(files, nil)
+		service.OpenFile("/user/username/projects/myproject/src/main.ts", files["/user/username/projects/myproject/src/main.ts"].(string), core.ScriptKindTS, "")
+		assert.Equal(t, len(service.Projects()), 2)
+		srcProject := service.ConfiguredProject(tspath.Path("/user/username/projects/myproject/tsconfig-src.json"))
+		assert.Assert(t, srcProject != nil)
+		assert.Assert(t, service.ConfiguredProject(tspath.Path("/user/username/projects/myproject/tsconfig.json")) != nil)
+		_, project := service.EnsureDefaultProjectForFile("/user/username/projects/myproject/src/main.ts")
+		assert.Equal(t, project, srcProject)
+		service.CloseFile("/user/username/projects/myproject/src/main.ts")
+		service.OpenFile("/user/username/workspaces/dummy/dummy.ts", "const x = 1;", core.ScriptKindTS, "/user/username/workspaces/dummy")
+		assert.Equal(t, len(service.Projects()), 1)
+		assert.Assert(t, service.InferredProject(tspath.Path("/user/username/workspaces/dummy")) != nil)
+		configFileExists(t, service, tspath.Path("/user/username/projects/myproject/tsconfig.json"), false)
+		configFileExists(t, service, tspath.Path("/user/username/projects/myproject/tsconfig-src.json"), false)
+	})
+
+	t.Run("when file is not part of first config tree found, looks into ancestor folder and its references to find default project", func(t *testing.T) {
+		t.Parallel()
+		files := map[string]any{
+			"/home/src/projects/project/app/Component-demos.ts": `
+                import * as helpers from 'demos/helpers';
+                export const demo = () => {
+                    helpers;
+                }
+            `,
+			"/home/src/projects/project/app/Component.ts": `export const Component = () => {}`,
+			"/home/src/projects/project/app/tsconfig.json": `{
+				"compilerOptions": {
+					"composite": true,
+					"outDir": "../app-dist/",
+				},
+				"include": ["**/*"],
+				"exclude": ["**/*-demos.*"],
+			}`,
+			"/home/src/projects/project/demos/helpers.ts": "export const foo = 1;",
+			"/home/src/projects/project/demos/tsconfig.json": `{
+				"compilerOptions": {
+					"composite": true,
+					"rootDir": "../",
+					"outDir": "../demos-dist/",
+					"paths": {
+						"demos/*": ["./*"],
+					},
+				},
+				"include": [
+					"**/*",
+					"../app/**/*-demos.*",
+				],
+			}`,
+			"/home/src/projects/project/tsconfig.json": `{
+				"compilerOptions": {
+					"outDir": "./dist/",
+				},
+				"references": [
+					{ "path": "./demos/tsconfig.json" },
+					{ "path": "./app/tsconfig.json" },
+				],
+				"files": []
+			}`,
+		}
+		service, _ := projecttestutil.Setup(files, nil)
+		service.OpenFile("/home/src/projects/project/app/Component-demos.ts", files["/home/src/projects/project/app/Component-demos.ts"].(string), core.ScriptKindTS, "")
+		assert.Equal(t, len(service.Projects()), 1)
+		demoProject := service.ConfiguredProject(tspath.Path("/home/src/projects/project/demos/tsconfig.json"))
+		assert.Assert(t, demoProject != nil)
+		configFileExists(t, service, tspath.Path("/home/src/projects/project/app/tsconfig.json"), true)
+		configFileExists(t, service, tspath.Path("/home/src/projects/project/demos/tsconfig.json"), true)
+		configFileExists(t, service, tspath.Path("/home/src/projects/project/tsconfig.json"), true)
+		_, project := service.EnsureDefaultProjectForFile("/home/src/projects/project/app/Component-demos.ts")
+		assert.Equal(t, project, demoProject)
+		service.CloseFile("/home/src/projects/project/app/Component-demos.ts")
+		service.OpenFile("/user/username/workspaces/dummy/dummy.ts", "const x = 1;", core.ScriptKindTS, "/user/username/workspaces/dummy")
+		assert.Equal(t, len(service.Projects()), 1)
+		assert.Assert(t, service.InferredProject(tspath.Path("/user/username/workspaces/dummy")) != nil)
+		configFileExists(t, service, tspath.Path("/home/src/projects/project/app/tsconfig.json"), false)
+		configFileExists(t, service, tspath.Path("/home/src/projects/project/demos/tsconfig.json"), false)
+		configFileExists(t, service, tspath.Path("/home/src/projects/project/tsconfig.json"), false)
+	})
+
+	t.Run("when dts file is next to ts file and included as root in referenced project", func(t *testing.T) {
+		t.Parallel()
+		files := map[string]any{
+			"/home/src/projects/project/src/index.d.ts": `
+                 declare global {
+                    interface Window {
+                        electron: ElectronAPI
+                        api: unknown
+                    }
+                }
+            `,
+			"/home/src/projects/project/src/index.ts": `const api = {}`,
+			"/home/src/projects/project/tsconfig.json": `{
+				"include": [
+					"src/*.d.ts",
+				],
+				"references": [{ "path": "./tsconfig.node.json" }],
+			}`,
+			"/home/src/projects/project/tsconfig.node.json": `{
+				include: ["src/**/*"],
+                compilerOptions: {
+                    composite: true,
+                },
+			}`,
+		}
+		service, _ := projecttestutil.Setup(files, nil)
+		service.OpenFile("/home/src/projects/project/src/index.d.ts", files["/home/src/projects/project/src/index.d.ts"].(string), core.ScriptKindTS, "")
+		assert.Equal(t, len(service.Projects()), 2)
+		assert.Assert(t, service.ConfiguredProject(tspath.Path("/home/src/projects/project/tsconfig.json")) != nil)
+		_, proj := service.EnsureDefaultProjectForFile("/home/src/projects/project/src/index.d.ts")
+		assert.Equal(t, proj.Kind(), project.KindInferred)
+	})
+}
+
+func filesForSolutionConfigFile(solutionRefs []string, compilerOptions string, ownFiles []string) map[string]any {
+	var compilerOptionsStr string
+	if compilerOptions != "" {
+		compilerOptionsStr = fmt.Sprintf(`"compilerOptions": {
+			%s
+		},`, compilerOptions)
+	}
+	var ownFilesStr string
+	if len(ownFiles) > 0 {
+		ownFilesStr = strings.Join(ownFiles, ",")
+	}
+	files := map[string]any{
+		"/user/username/projects/myproject/tsconfig.json": fmt.Sprintf(`{
+			%s
+			"files": [%s],
+			"references": [
+				%s
+			]
+		}`, compilerOptionsStr, ownFilesStr, strings.Join(core.Map(solutionRefs, func(ref string) string {
+			return fmt.Sprintf(`{ "path": "%s" }`, ref)
+		}), ",")),
+		"/user/username/projects/myproject/tsconfig-src.json": `{
+			"compilerOptions": {
+				"composite": true,
+				"outDir": "./target",
+			},
+			"include": ["./src/**/*"]
+		}`,
+		"/user/username/projects/myproject/src/main.ts": `
+			import { foo } from './src/helpers/functions';
+			export { foo };`,
+		"/user/username/projects/myproject/src/helpers/functions.ts": `export const foo = 1;`,
+	}
+	return files
+}
+
+func applyIndirectProjectFiles(files map[string]any, projectIndex int, compilerOptions string) {
+	for k, v := range filesForIndirectProject(projectIndex, compilerOptions) {
+		files[k] = v
+	}
+}
+
+func filesForIndirectProject(projectIndex int, compilerOptions string) map[string]any {
+	files := map[string]any{
+		fmt.Sprintf("/user/username/projects/myproject/tsconfig-indirect%d.json", projectIndex): fmt.Sprintf(`{
+			"compilerOptions": {
+				"composite": true,
+				"outDir": "./target/",
+				%s
+			},
+			"files": [
+				"./indirect%d/main.ts"
+			],
+			"references": [
+				{
+				"path": "./tsconfig-src.json"
+				}
+			]
+		}`, compilerOptions, projectIndex),
+		fmt.Sprintf("/user/username/projects/myproject/indirect%d/main.ts", projectIndex): `export const indirect = 1;`,
+	}
+	return files
+}

--- a/internal/tsoptions/parsedcommandline.go
+++ b/internal/tsoptions/parsedcommandline.go
@@ -33,6 +33,9 @@ type ParsedCommandLine struct {
 
 	commonSourceDirectory     string
 	commonSourceDirectoryOnce sync.Once
+
+	resolvedProjectReferencePaths     []string
+	resolvedProjectReferencePathsOnce sync.Once
 }
 
 type SourceAndProjectReference struct {
@@ -191,6 +194,20 @@ func (p *ParsedCommandLine) FileNames() []string {
 
 func (p *ParsedCommandLine) ProjectReferences() []*core.ProjectReference {
 	return p.ParsedConfig.ProjectReferences
+}
+
+func (p *ParsedCommandLine) ResolvedProjectReferencePaths() []string {
+	p.resolvedProjectReferencePathsOnce.Do(func() {
+		if p.ParsedConfig.ProjectReferences == nil {
+			return
+		}
+		resolvedProjectReferencePaths := make([]string, 0, len(p.ParsedConfig.ProjectReferences))
+		for _, ref := range p.ParsedConfig.ProjectReferences {
+			resolvedProjectReferencePaths = append(resolvedProjectReferencePaths, core.ResolveProjectReferencePath(ref))
+		}
+		p.resolvedProjectReferencePaths = resolvedProjectReferencePaths
+	})
+	return p.resolvedProjectReferencePaths
 }
 
 func (p *ParsedCommandLine) ExtendedSourceFiles() []string {


### PR DESCRIPTION
- Adds loading config to check if the project can be default configured project by matching file names instead of creating project if its composite otherwise creates the project to check
- Looks into referenced projects to find default if the found tsconfig cannot be default project
- Looks into parent folder's tsconfig.json if default not found in the first found tsconfig and its references