### PR TITLE
Only compare source-file affecting changes in watcher configuration

### DIFF
--- a/internal/execute/watcher.go
+++ b/internal/execute/watcher.go
@@ -54,7 +54,7 @@ func (w *watcher) hasErrorsInTsConfig() bool {
 			}
 			return true
 		}
-		if !reflect.DeepEqual(w.options.CompilerOptions(), configParseResult.CompilerOptions()) {
+		if !reflect.DeepEqual(w.options.CompilerOptions().SourceFileAffecting(), configParseResult.CompilerOptions().SourceFileAffecting()) {
 			// fmt.Fprint(w.sys.Writer(), "build triggered due to config change", w.sys.NewLine())
 			w.configModified = true
 		}


### PR DESCRIPTION
Similar to the issue reported in https://github.com/microsoft/typescript-go/issues/778, #1156 appears to have introduced an issue such that `--watch` mode continuously rebuilds a project due to configuration changes, even if no config changes have occurred.

This PR aims to address that issue by only comparing the configuration subsets that affect source files, while ignoring differences in other parts. It appears from #1156 (although I did not fully understand the scope of those changes) that only the `SourceFileAffecting` changes are passed to the watcher command in the first place, so this change "should" be correct.

I don't claim to have deep knowledge of the full implications of the change otherwise however.