### PR TITLE
Assume clause-less imports to be unemittable

### DIFF
--- a/internal/ast/utilities.go
+++ b/internal/ast/utilities.go
@@ -3113,7 +3113,7 @@ func IsPartOfExclusivelyTypeOnlyImportOrExportDeclaration(node *Node) bool {
 func IsEmittableImport(node *Node) bool {
 	switch node.Kind {
 	case KindImportDeclaration:
-		return node.AsImportDeclaration().ImportClause == nil || !node.AsImportDeclaration().ImportClause.IsTypeOnly()
+		return node.AsImportDeclaration().ImportClause != nil && !node.AsImportDeclaration().ImportClause.IsTypeOnly()
 	case KindExportDeclaration:
 		return !node.AsExportDeclaration().IsTypeOnly
 	case KindImportEqualsDeclaration:

--- a/testdata/tests/cases/conformance/moduleResolution/allowImportingTypesDtsExtension2.ts
+++ b/testdata/tests/cases/conformance/moduleResolution/allowImportingTypesDtsExtension2.ts
@@ -1,0 +1,13 @@
+// @strict: true
+// @verbatimModuleSyntax: true,false
+// @noUncheckedSideEffectImports: true,false
+// @noEmit: true
+// @noTypesAndSymbols: true
+
+// https://github.com/microsoft/typescript-go/issues/1190
+
+// @filename: /types.d.ts
+export type MyType = { foo: string; };
+
+// @filename: /index.ts
+import "./types.d.ts";


### PR DESCRIPTION
fixes https://github.com/microsoft/typescript-go/issues/1190