### PR TITLE
Fix getSymbolAtLocation crash on export declaration

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -30045,7 +30045,7 @@ func (c *Checker) getSymbolAtLocation(node *ast.Node, ignoreErrors bool) *ast.Sy
 		// 3). Require in Javascript
 		// 4). type A = import("./f/*gotToDefinitionHere*/oo")
 		if (ast.IsExternalModuleImportEqualsDeclaration(grandParent) && ast.GetExternalModuleImportEqualsDeclarationExpression(grandParent) == node) ||
-			((parent.Kind == ast.KindImportDeclaration || parent.Kind == ast.KindJSImportDeclaration || parent.Kind == ast.KindExportDeclaration) && parent.AsImportDeclaration().ModuleSpecifier == node) ||
+			((parent.Kind == ast.KindImportDeclaration || parent.Kind == ast.KindJSImportDeclaration || parent.Kind == ast.KindExportDeclaration) && ast.GetExternalModuleName(parent) == node) ||
 			ast.IsVariableDeclarationInitializedToRequire(grandParent) ||
 			(ast.IsLiteralTypeNode(parent) && ast.IsLiteralImportTypeNode(grandParent) && grandParent.AsImportTypeNode().Argument == parent) {
 			return c.resolveExternalModuleName(node, node, ignoreErrors)


### PR DESCRIPTION
With crash:

```
panic handling request textDocument/hover interface conversion: ast.nodeData is *ast.ExportDeclaration, not *ast.ImportDeclaration goroutine 24183 [running]:
runtime/debug.Stack()
	runtime/debug/stack.go:26 +0x64
github.com/microsoft/typescript-go/internal/lsp.(*Server).dispatchLoop.func1.1()
	github.com/microsoft/typescript-go/internal/lsp/server.go:359 +0x50
panic({0x102716c80?, 0x1400fb66210?})
	runtime/panic.go:792 +0x124
github.com/microsoft/typescript-go/internal/ast.(*Node).AsImportDeclaration(...)
	github.com/microsoft/typescript-go/internal/ast/ast.go:1188
github.com/microsoft/typescript-go/internal/checker.(*Checker).getSymbolAtLocation(0x1404be39008, 0x1400052a120, 0x1)
	github.com/microsoft/typescript-go/internal/checker/checker.go:30048 +0xa84
github.com/microsoft/typescript-go/internal/checker.(*Checker).GetSymbolAtLocation(...)
	github.com/microsoft/typescript-go/internal/checker/checker.go:29949
```

This reveals that this code was misported as it checked multiple kinds but then casted it to a specific type (which would have worked in TS with the same property name, unsafely, but not in Go).

Just use `GetExternalModuleName` to do this.