### PR TITLE
Maybe fix parent setting race

### DIFF
--- a/internal/binder/binder.go
+++ b/internal/binder/binder.go
@@ -584,7 +584,7 @@ func (b *Binder) bind(node *ast.Node) bool {
 	if node == nil {
 		return false
 	}
-	if node.Parent == nil || node.Parent.Flags&ast.NodeFlagsReparsed != 0 {
+	if node.Parent == nil || node.Parent != b.parent && node.Parent.Flags&ast.NodeFlagsReparsed != 0 {
 		node.Parent = b.parent
 	}
 	saveInStrictMode := b.inStrictMode

--- a/internal/binder/binder.go
+++ b/internal/binder/binder.go
@@ -584,7 +584,7 @@ func (b *Binder) bind(node *ast.Node) bool {
 	if node == nil {
 		return false
 	}
-	if node.Parent == nil || node.Parent != b.parent && node.Parent.Flags&ast.NodeFlagsReparsed != 0 {
+	if node.Parent == nil || (node.Parent != b.parent && node.Parent.Flags&ast.NodeFlagsReparsed != 0) {
 		node.Parent = b.parent
 	}
 	saveInStrictMode := b.inStrictMode


### PR DESCRIPTION
The only think I can think for #1224 is that we're hitting the reparsed case where we want to overwrite the parent, but have already done so somewhere else (as in, during references collection originally), so are writing the same value back and create a race. That's what #970 fixed for other cases, but #1031 might have added that back for the reparsed cases?

It's not 100% clear to me anymore why the special case exists to always reassign reparsed parents, though. But, removing it changes baselines in ways that look wrong, so it must be doing something and I just don't remember why it matters anymore.

Or, maybe this PR won't work, because the issue is _explicitly_ that reparsed case not meshing well?

Fixes #1224

(maybe?)