### PR TITLE
Set parents during parse, not bind

### DIFF
--- a/internal/ast/utilities.go
+++ b/internal/ast/utilities.go
@@ -904,8 +904,7 @@ func newParentInChildrenSetter() func(node *Node) bool {
 	}
 
 	state.visit = func(node *Node) bool {
-		if state.parent != nil && node.Parent != state.parent {
-			// Avoid data races on no-ops
+		if state.parent != nil {
 			node.Parent = state.parent
 		}
 		saveParent := state.parent

--- a/internal/execute/tsc.go
+++ b/internal/execute/tsc.go
@@ -78,7 +78,6 @@ func fmtMain(sys System, input, output string) ExitStatus {
 		Path:             pathified,
 		JSDocParsingMode: ast.JSDocParsingModeParseAll,
 	}, text, core.GetScriptKindFromFileName(string(pathified)))
-	ast.SetParentInChildren(sourceFile.AsNode())
 	edits := format.FormatDocument(ctx, sourceFile)
 	newText := applyBulkEdits(text, edits)
 

--- a/internal/format/api_test.go
+++ b/internal/format/api_test.go
@@ -59,7 +59,6 @@ func TestFormat(t *testing.T) {
 			FileName: "/checker.ts",
 			Path:     "/checker.ts",
 		}, text, core.ScriptKindTS)
-		ast.SetParentInChildren(sourceFile.AsNode())
 		edits := format.FormatDocument(ctx, sourceFile)
 		newText := applyBulkEdits(text, edits)
 		assert.Assert(t, len(newText) > 0)
@@ -89,7 +88,6 @@ func BenchmarkFormat(b *testing.B) {
 		FileName: "/checker.ts",
 		Path:     "/checker.ts",
 	}, text, core.ScriptKindTS)
-	ast.SetParentInChildren(sourceFile.AsNode())
 
 	b.Run("format checker.ts", func(b *testing.B) {
 		for b.Loop() {

--- a/internal/parser/jsdoc.go
+++ b/internal/parser/jsdoc.go
@@ -139,7 +139,6 @@ func (p *Parser) parseJSDocComment(parent *ast.Node, start int, end int, fullSta
 	p.parsingContexts = p.parsingContexts | ParsingContexts(PCJSDocComment)
 
 	comment := p.parseJSDocCommentWorker(start, end, fullStart, initialIndent)
-	// comment.Parent = parent
 	// move jsdoc diagnostics to jsdocDiagnostics -- for JS files only
 	if p.contextFlags&ast.NodeFlagsJavaScriptFile != 0 {
 		p.jsdocDiagnostics = append(p.jsdocDiagnostics, p.diagnostics[saveDiagnosticsLength:]...)

--- a/internal/parser/jsdoc.go
+++ b/internal/parser/jsdoc.go
@@ -82,11 +82,6 @@ func (p *Parser) parseJSDocTypeExpression(mayOmitBraces bool) *ast.Node {
 	}
 
 	result := p.factory.NewJSDocTypeExpression(t)
-	// normally parent references are set during binding. However, for clients that only need
-	// a syntax tree, and no semantic features, then the binding process is an unnecessary
-	// overhead.  This functions allows us to set all the parents, without all the expense of
-	// binding.
-	ast.SetParentInChildren(result)
 	p.finishNode(result, pos)
 	return result
 }
@@ -107,7 +102,6 @@ func (p *Parser) parseJSDocNameReference() *ast.Node {
 	}
 
 	result := p.factory.NewJSDocNameReference(entityName)
-	ast.SetParentInChildren(result)
 	p.finishNode(result, pos)
 	return result
 }
@@ -145,7 +139,7 @@ func (p *Parser) parseJSDocComment(parent *ast.Node, start int, end int, fullSta
 	p.parsingContexts = p.parsingContexts | ParsingContexts(PCJSDocComment)
 
 	comment := p.parseJSDocCommentWorker(start, end, fullStart, initialIndent)
-	comment.Parent = parent
+	// comment.Parent = parent
 	// move jsdoc diagnostics to jsdocDiagnostics -- for JS files only
 	if p.contextFlags&ast.NodeFlagsJavaScriptFile != 0 {
 		p.jsdocDiagnostics = append(p.jsdocDiagnostics, p.diagnostics[saveDiagnosticsLength:]...)
@@ -457,7 +451,6 @@ func (p *Parser) parseTag(tags []*ast.Node, margin int) *ast.Node {
 		tag = p.parseSeeTag(start, tagName, margin, indentText)
 	case "import":
 		tag = p.parseImportTag(start, tagName, margin, indentText)
-		ast.SetParentInChildren(tag)
 	default:
 		tag = p.parseUnknownTag(start, tagName, margin, indentText)
 	}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -352,6 +352,15 @@ func (p *Parser) finishSourceFile(result *ast.SourceFile, isDeclarationFile bool
 	result.TextCount = p.factory.TextCount()
 	result.IdentifierCount = p.identifierCount
 	result.SetJSDocCache(p.jsdocCache)
+
+	ast.SetParentInChildren(result.AsNode())
+	for parent, children := range p.jsdocCache {
+		for _, child := range children {
+			child.Parent = parent
+			ast.SetParentInChildren(child)
+		}
+	}
+
 	ast.SetExternalModuleIndicator(result, p.opts.ExternalModuleIndicatorOptions)
 }
 

--- a/internal/parser/references.go
+++ b/internal/parser/references.go
@@ -15,7 +15,6 @@ func collectExternalModuleReferences(file *ast.SourceFile) {
 
 	if file.Flags&ast.NodeFlagsPossiblyContainsDynamicImport != 0 || ast.IsInJSFile(file.AsNode()) {
 		ast.ForEachDynamicImportOrRequireCall(file /*includeTypeSpaceImports*/, true /*requireStringLiteralLikeArgument*/, true, func(node *ast.Node, moduleSpecifier *ast.Expression) bool {
-			ast.SetParentInChildren(node) // we need parent data on imports before the program is fully bound, so we ensure it's set here
 			ast.SetImportsOfSourceFile(file, append(file.Imports(), moduleSpecifier))
 			return false
 		})
@@ -31,9 +30,6 @@ func collectModuleReferences(file *ast.SourceFile, node *ast.Statement, inAmbien
 		if moduleNameExpr != nil && ast.IsStringLiteral(moduleNameExpr) {
 			moduleName := moduleNameExpr.AsStringLiteral().Text
 			if moduleName != "" && (!inAmbientModule || !tspath.IsExternalModuleNameRelative(moduleName)) {
-				if node.Kind != ast.KindJSImportDeclaration {
-					ast.SetParentInChildren(node) // we need parent data on imports before the program is fully bound, so we ensure it's set here
-				}
 				ast.SetImportsOfSourceFile(file, append(file.Imports(), moduleNameExpr))
 				// !!! removed `&& p.currentNodeModulesDepth == 0`
 				if file.UsesUriStyleNodeCoreModules != core.TSTrue && !file.IsDeclarationFile {
@@ -50,7 +46,6 @@ func collectModuleReferences(file *ast.SourceFile, node *ast.Statement, inAmbien
 		return
 	}
 	if ast.IsModuleDeclaration(node) && ast.IsAmbientModule(node) && (inAmbientModule || ast.HasSyntacticModifier(node, ast.ModifierFlagsAmbient) || file.IsDeclarationFile) {
-		ast.SetParentInChildren(node)
 		nameText := node.AsModuleDeclaration().Name().Text()
 		// Ambient module declarations can be interpreted as augmentations for some existing external modules.
 		// This will happen in two cases:

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -614,7 +614,6 @@ func TestParenthesizeDecorator(t *testing.T) {
 		},
 	))
 
-	ast.SetParentInChildren(file)
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "@(a + b)\nclass C {\n}")
 }
@@ -651,7 +650,7 @@ func TestParenthesizeComputedPropertyName(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "class C {\n    [(a, b)];\n}")
 }
@@ -681,7 +680,7 @@ func TestParenthesizeArrayLiteral(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "[(a, b)];")
 }
@@ -709,7 +708,7 @@ func TestParenthesizePropertyAccess1(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "(a, b).c;")
 }
@@ -736,7 +735,7 @@ func TestParenthesizePropertyAccess2(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "(a?.b).c;")
 }
@@ -762,7 +761,7 @@ func TestParenthesizePropertyAccess3(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "(new a).b;")
 }
@@ -790,7 +789,7 @@ func TestParenthesizeElementAccess1(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "(a, b)[c];")
 }
@@ -817,7 +816,7 @@ func TestParenthesizeElementAccess2(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "(a?.b)[c];")
 }
@@ -843,7 +842,7 @@ func TestParenthesizeElementAccess3(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "(new a)[b];")
 }
@@ -872,7 +871,7 @@ func TestParenthesizeCall1(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "(a, b)();")
 }
@@ -900,7 +899,7 @@ func TestParenthesizeCall2(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "(a?.b)();")
 }
@@ -927,7 +926,7 @@ func TestParenthesizeCall3(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "(new C)();")
 }
@@ -957,7 +956,7 @@ func TestParenthesizeCall4(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "a((b, c));")
 }
@@ -984,7 +983,7 @@ func TestParenthesizeNew1(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "new (a, b)();")
 }
@@ -1011,7 +1010,7 @@ func TestParenthesizeNew2(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "new (C());")
 }
@@ -1039,7 +1038,7 @@ func TestParenthesizeNew3(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "new C((a, b));")
 }
@@ -1068,7 +1067,7 @@ func TestParenthesizeTaggedTemplate1(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "(a, b) ``;")
 }
@@ -1096,7 +1095,7 @@ func TestParenthesizeTaggedTemplate2(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "(a?.b) ``;")
 }
@@ -1125,7 +1124,7 @@ func TestParenthesizeTypeAssertion1(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "<T>(a + b);")
 }
@@ -1152,7 +1151,7 @@ func TestParenthesizeArrowFunction1(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "() => ({});")
 }
@@ -1184,7 +1183,7 @@ func TestParenthesizeArrowFunction2(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "() => ({}.a);")
 }
@@ -1209,7 +1208,7 @@ func TestParenthesizeDelete(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "delete (a + b);")
 }
@@ -1234,7 +1233,7 @@ func TestParenthesizeVoid(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "void (a + b);")
 }
@@ -1259,7 +1258,7 @@ func TestParenthesizeTypeOf(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "typeof (a + b);")
 }
@@ -1284,7 +1283,7 @@ func TestParenthesizeAwait(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "await (a + b);")
 }
@@ -1407,7 +1406,7 @@ func TestParenthesizeBinary(t *testing.T) {
 					),
 				},
 			))
-			ast.SetParentInChildren(file)
+
 			parsetestutil.MarkSyntheticRecursive(file)
 			emittestutil.CheckEmit(t, nil, file.AsSourceFile(), rec.output+";")
 		})
@@ -1438,7 +1437,7 @@ func TestParenthesizeConditional1(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "(a, b) ? c : d;")
 }
@@ -1467,7 +1466,7 @@ func TestParenthesizeConditional2(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "(a = b) ? c : d;")
 }
@@ -1500,7 +1499,7 @@ func TestParenthesizeConditional3(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "(() => { }) ? a : b;")
 }
@@ -1523,7 +1522,7 @@ func TestParenthesizeConditional4(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "(yield) ? a : b;")
 }
@@ -1552,7 +1551,7 @@ func TestParenthesizeConditional5(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "a ? (b, c) : d;")
 }
@@ -1581,7 +1580,7 @@ func TestParenthesizeConditional6(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "a ? b : (c, d);")
 }
@@ -1607,7 +1606,7 @@ func TestParenthesizeYield1(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "yield (a, b);")
 }
@@ -1643,7 +1642,7 @@ func TestParenthesizeSpreadElement1(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "[...(a, b)];")
 }
@@ -1678,7 +1677,7 @@ func TestParenthesizeSpreadElement2(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "a(...(b, c));")
 }
@@ -1711,7 +1710,7 @@ func TestParenthesizeSpreadElement3(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "new a(...(b, c));")
 }
@@ -1744,7 +1743,7 @@ func TestParenthesizeExpressionWithTypeArguments(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "(a, b)<c>;")
 }
@@ -1773,7 +1772,7 @@ func TestParenthesizeAsExpression(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "(a, b) as c;")
 }
@@ -1802,7 +1801,7 @@ func TestParenthesizeSatisfiesExpression(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "(a, b) satisfies c;")
 }
@@ -1828,7 +1827,7 @@ func TestParenthesizeNonNullExpression(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "(a, b)!;")
 }
@@ -1849,7 +1848,7 @@ func TestParenthesizeExpressionStatement1(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "({});")
 }
@@ -1878,7 +1877,7 @@ func TestParenthesizeExpressionStatement2(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "(function () { });")
 }
@@ -1902,7 +1901,7 @@ func TestParenthesizeExpressionStatement3(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "(class {\n});")
 }
@@ -1930,7 +1929,7 @@ func TestParenthesizeExpressionDefault1(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "export default (class {\n});")
 }
@@ -1965,7 +1964,7 @@ func TestParenthesizeExpressionDefault2(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "export default (function () { });")
 }
@@ -1991,7 +1990,7 @@ func TestParenthesizeExpressionDefault3(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "export default (a, b);")
 }
@@ -2020,7 +2019,7 @@ func TestParenthesizeArrayType(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "type _ = (a | b)[];")
 }
@@ -2055,7 +2054,7 @@ func TestParenthesizeOptionalType(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "type _ = [\n    (a | b)?\n];")
 }
@@ -2088,7 +2087,7 @@ func TestParenthesizeUnionType1(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "type _ = a | (() => b);")
 }
@@ -2122,7 +2121,7 @@ func TestParenthesizeUnionType2(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "type _ = (infer a extends b) | c;")
 }
@@ -2156,7 +2155,7 @@ func TestParenthesizeIntersectionType(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "type _ = a & (b | c);")
 }
@@ -2186,7 +2185,7 @@ func TestParenthesizeReadonlyTypeOperator1(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "type _ = readonly (a | b);")
 }
@@ -2212,7 +2211,7 @@ func TestParenthesizeReadonlyTypeOperator2(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "type _ = readonly (keyof a);")
 }
@@ -2242,7 +2241,7 @@ func TestParenthesizeKeyofTypeOperator(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "type _ = keyof (a | b);")
 }
@@ -2272,7 +2271,7 @@ func TestParenthesizeIndexedAccessType(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "type _ = (a | b)[c];")
 }
@@ -2303,7 +2302,7 @@ func TestParenthesizeConditionalType1(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "type _ = (() => a) extends b ? c : d;")
 }
@@ -2333,7 +2332,7 @@ func TestParenthesizeConditionalType2(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "type _ = a extends (b extends c ? d : e) ? f : g;")
 }
@@ -2371,7 +2370,7 @@ func TestParenthesizeConditionalType3(t *testing.T) {
 			),
 		},
 	))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "type _ = a extends () => (infer b extends c) ? d : e;")
 }
@@ -2414,7 +2413,7 @@ func TestParenthesizeConditionalType4(t *testing.T) {
 			),
 		),
 	}))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, nil, file.AsSourceFile(), "type _ = a extends () => (infer b extends c) | d ? e : f;")
 }
@@ -2446,7 +2445,7 @@ func TestNameGeneration(t *testing.T) {
 			}), true),
 		),
 	}))
-	ast.SetParentInChildren(file)
+
 	parsetestutil.MarkSyntheticRecursive(file)
 	emittestutil.CheckEmit(t, ec, file.AsSourceFile(), "var _a;\nfunction f() {\n    var _a;\n}")
 }

--- a/internal/testutil/parsetestutil/parsetestutil.go
+++ b/internal/testutil/parsetestutil/parsetestutil.go
@@ -19,7 +19,6 @@ func ParseTypeScript(text string, jsx bool) *ast.SourceFile {
 		Path:             tspath.Path(fileName),
 		JSDocParsingMode: ast.JSDocParsingModeParseNone,
 	}, text, core.GetScriptKindFromFileName(fileName))
-	ast.SetParentInChildren(file.AsNode())
 	return file
 }
 


### PR DESCRIPTION
When loading files, Program construction needs to look a file's imports and resolve them. This requires parent pointers as determining what to do depends on context like the resolution mode, if it's in a require, etc.

This is a problem because binding can happen concurrently on the same AST as the same time as file loading, since ASTs can be reused between Programs.

We've worked around this by setting parents early in the parser just on the imports (was done in strada too), yet that still isn't enough to make the code not race (#970, #1031, #1224).

A simple way to solve this problem is to just make the parser the one in charge of setting pointers, rather than doing it during bind. This is slower, since the binder is already walking the AST and so usually has thing cached. But, it is a lot simpler to reason about.

Below are benchmarks which show the change; the real time itself is the critical number, showing that while in the checker, we save a millisecond in bind, we pay some 4ms for it during parse, likely due to caching / walking overhead.

If this seems undesirable, there are other fixes that we could try:

- Instead of collecting specifiers during parse to later resolve, instead collect the imports themselves, then walk down the tree during file loading to get the specifier, never using parent pointers. That avoids the race, but is a more extensive change to get the helpers to not use parents.
- Force binding to happen _immediately_ after file parse before looking at imports. Realistically, we need every file to have been bound anyway, so this would be "no slower", but would make it a challenge to track how much time was spent in bind.

```
                                                     │   old.txt   │               new2.txt               │
                                                     │   sec/op    │    sec/op     vs base                │
Bind/empty.ts-20                                       301.2n ± 6%   278.1n ± 32%        ~ (p=0.123 n=10)
Bind/checker.ts-20                                     19.52m ± 2%   18.60m ±  1%   -4.72% (p=0.000 n=10)
Bind/dom.generated.d.ts-20                             8.208m ± 0%   7.142m ±  1%  -12.99% (p=0.000 n=10)
Bind/Herebyfile.mjs-20                                 330.2µ ± 1%   310.5µ ±  0%   -5.95% (p=0.000 n=10)
Bind/jsxComplexSignatureHasApplicabilityError.tsx-20   152.6µ ± 1%   137.3µ ±  1%  -10.03% (p=0.000 n=10)
geomean                                                300.1µ        275.1µ         -8.32%
```

```
                                                             │   old.txt   │              new2.txt               │
                                                             │   sec/op    │   sec/op     vs base                │
Parse/empty.ts/tsc-20                                          482.3n ± 1%   518.2n ± 1%   +7.44% (p=0.000 n=10)
Parse/empty.ts/server-20                                       482.3n ± 1%   520.8n ± 1%   +7.99% (p=0.000 n=10)
Parse/checker.ts/tsc-20                                        43.25m ± 1%   48.52m ± 1%  +12.18% (p=0.000 n=10)
Parse/checker.ts/server-20                                     44.46m ± 3%   49.59m ± 2%  +11.54% (p=0.000 n=10)
Parse/dom.generated.d.ts/tsc-20                                15.01m ± 2%   16.15m ± 0%   +7.59% (p=0.000 n=10)
Parse/dom.generated.d.ts/server-20                             22.50m ± 1%   24.12m ± 2%   +7.20% (p=0.000 n=10)
Parse/Herebyfile.mjs/tsc-20                                    820.0µ ± 1%   871.3µ ± 1%   +6.25% (p=0.000 n=10)
Parse/Herebyfile.mjs/server-20                                 814.1µ ± 1%   871.0µ ± 1%   +6.99% (p=0.000 n=10)
Parse/jsxComplexSignatureHasApplicabilityError.tsx/tsc-20      246.9µ ± 2%   261.9µ ± 2%   +6.09% (p=0.000 n=10)
Parse/jsxComplexSignatureHasApplicabilityError.tsx/server-20   383.9µ ± 1%   409.9µ ± 2%   +6.77% (p=0.000 n=10)
geomean                                                        628.1µ        678.3µ        +7.99%
```

Fixes #1224