### PR TITLE
Run dprint in copilot-setup-steps to prevent network blocking error

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,3 +26,5 @@ jobs:
           cache-name: copilot-setup-steps
       - run: npm i -g @playwright/mcp@0.0.28
       - run: npm ci
+      # pull dprint caches before network access is blocked
+      - run: npx hereby check:format

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -27,4 +27,4 @@ jobs:
       - run: npm i -g @playwright/mcp@0.0.28
       - run: npm ci
       # pull dprint caches before network access is blocked
-      - run: npx hereby check:format
+      - run: npx hereby check:format || true


### PR DESCRIPTION
If this isn't done, runs will fail because the network blocks these requests for the Wasm blobs.