### PR TITLE
Add stubs for missing downlevel feature transforms, organize transforms by purpose

### DIFF
--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/microsoft/typescript-go/internal/printer"
 	"github.com/microsoft/typescript-go/internal/testutil/emittestutil"
 	"github.com/microsoft/typescript-go/internal/testutil/parsetestutil"
-	"github.com/microsoft/typescript-go/internal/transformers"
+	"github.com/microsoft/typescript-go/internal/transformers/tstransforms"
 )
 
 func TestEmit(t *testing.T) {
@@ -2504,7 +2504,7 @@ func TestPartiallyEmittedExpression(t *testing.T) {
     .expression;`, false /*jsx*/)
 
 	emitContext := printer.NewEmitContext()
-	file = transformers.NewTypeEraserTransformer(emitContext, compilerOptions).TransformSourceFile(file)
+	file = tstransforms.NewTypeEraserTransformer(emitContext, compilerOptions).TransformSourceFile(file)
 	emittestutil.CheckEmit(t, emitContext, file.AsSourceFile(), `return container.parent
     .left
     .expression

--- a/internal/transformers/chain.go
+++ b/internal/transformers/chain.go
@@ -1,0 +1,44 @@
+package transformers
+
+import (
+	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/printer"
+)
+
+type chainedTransformer struct {
+	Transformer
+	components []*Transformer
+}
+
+func (ch *chainedTransformer) visit(node *ast.Node) *ast.Node {
+	if node.Kind != ast.KindSourceFile {
+		panic("Chained transform passed non-sourcefile initial node")
+	}
+	result := node.AsSourceFile()
+	for _, t := range ch.components {
+		result = t.TransformSourceFile(result)
+	}
+	return result.AsNode()
+}
+
+type TransformerFactory = func(emitContext *printer.EmitContext) *Transformer
+
+// Chains transforms in left-to-right order, running them one at a time in order (as opposed to interleaved at each node)
+// - the resulting combined transform only operates on SourceFile nodes
+func Chain(transforms ...TransformerFactory) TransformerFactory {
+	if len(transforms) < 2 {
+		if len(transforms) == 0 {
+			panic("Expected some number of transforms to chain, but got none")
+		}
+		return transforms[0]
+	}
+	return func(emitContext *printer.EmitContext) *Transformer {
+		constructed := make([]*Transformer, 0, len(transforms))
+		for _, t := range transforms {
+			// TODO: flatten nested chains?
+			constructed = append(constructed, t(emitContext))
+		}
+		ch := &chainedTransformer{components: constructed}
+		return ch.NewTransformer(ch.visit, emitContext)
+	}
+}

--- a/internal/transformers/estransforms/async.go
+++ b/internal/transformers/estransforms/async.go
@@ -1,0 +1,20 @@
+package estransforms
+
+import (
+	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/printer"
+	"github.com/microsoft/typescript-go/internal/transformers"
+)
+
+type asyncTransformer struct {
+	transformers.Transformer
+}
+
+func (ch *asyncTransformer) visit(node *ast.Node) *ast.Node {
+	return node // !!!
+}
+
+func newAsyncTransformer(emitContext *printer.EmitContext) *transformers.Transformer {
+	tx := &asyncTransformer{}
+	return tx.NewTransformer(tx.visit, emitContext)
+}

--- a/internal/transformers/estransforms/classfields.go
+++ b/internal/transformers/estransforms/classfields.go
@@ -1,0 +1,20 @@
+package estransforms
+
+import (
+	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/printer"
+	"github.com/microsoft/typescript-go/internal/transformers"
+)
+
+type classFieldsTransformer struct {
+	transformers.Transformer
+}
+
+func (ch *classFieldsTransformer) visit(node *ast.Node) *ast.Node {
+	return node // !!!
+}
+
+func newClassFieldsTransformer(emitContext *printer.EmitContext) *transformers.Transformer {
+	tx := &classFieldsTransformer{}
+	return tx.NewTransformer(tx.visit, emitContext)
+}

--- a/internal/transformers/estransforms/classstatic.go
+++ b/internal/transformers/estransforms/classstatic.go
@@ -1,0 +1,20 @@
+package estransforms
+
+import (
+	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/printer"
+	"github.com/microsoft/typescript-go/internal/transformers"
+)
+
+type classStaticBlockTransformer struct {
+	transformers.Transformer
+}
+
+func (ch *classStaticBlockTransformer) visit(node *ast.Node) *ast.Node {
+	return node // !!!
+}
+
+func newClassStaticBlockTransformer(emitContext *printer.EmitContext) *transformers.Transformer {
+	tx := &classStaticBlockTransformer{}
+	return tx.NewTransformer(tx.visit, emitContext)
+}

--- a/internal/transformers/estransforms/classthis.go
+++ b/internal/transformers/estransforms/classthis.go
@@ -1,4 +1,4 @@
-package transformers
+package estransforms
 
 import (
 	"github.com/microsoft/typescript-go/internal/ast"

--- a/internal/transformers/estransforms/definitions.go
+++ b/internal/transformers/estransforms/definitions.go
@@ -41,6 +41,6 @@ func GetESTransformer(options *core.CompilerOptions, emitContext *printer.EmitCo
 	case core.ScriptTargetES2016:
 		return NewES2017Transformer(emitContext)
 	default: // other, older, option, transform maximally
-		return NewES2017Transformer(emitContext)
+		return NewES2016Transformer(emitContext)
 	}
 }

--- a/internal/transformers/estransforms/definitions.go
+++ b/internal/transformers/estransforms/definitions.go
@@ -1,0 +1,46 @@
+package estransforms
+
+import (
+	"github.com/microsoft/typescript-go/internal/core"
+	"github.com/microsoft/typescript-go/internal/printer"
+	"github.com/microsoft/typescript-go/internal/transformers"
+)
+
+// !!! TODO: This fixed layering scheme assumes you can't swap out the es decorator transform for the legacy one,
+// or the proper es class field transform for the legacy one
+var (
+	NewESNextTransformer = transformers.Chain(newESDecoratorTransformer, newUsingDeclarationTransformer)
+	// 2025: only module system syntax (import attributes, json modules), untransformed regex modifiers
+	// 2024: no new downlevel syntax
+	// 2023: no new downlevel syntax
+	NewES2022Transformer = transformers.Chain(NewESNextTransformer, newClassStaticBlockTransformer, newClassFieldsTransformer)    // !!! top level await? not transformed, just errored on at lower targets - also more of a module system feature anyway
+	NewES2021Transformer = transformers.Chain(NewES2022Transformer, newLogicalAssignmentTransformer)                              // !!! numeric seperators? always elided by printer?
+	NewES2020Transformer = transformers.Chain(NewES2021Transformer, newNullishCoalescingTransformer, newOptionalChainTransformer) // also dynamic import - module system feature
+	NewES2019Transformer = transformers.Chain(NewES2020Transformer, newOptionalCatchTransformer)
+	NewES2018Transformer = transformers.Chain(NewES2019Transformer, newObjectRestSpreadTransformer, newforawaitTransformer)
+	NewES2017Transformer = transformers.Chain(NewES2018Transformer, newAsyncTransformer)
+	NewES2016Transformer = transformers.Chain(NewES2017Transformer, newExponentiationTransformer)
+)
+
+func GetESTransformer(options *core.CompilerOptions, emitContext *printer.EmitContext) *transformers.Transformer {
+	switch options.GetEmitScriptTarget() {
+	case core.ScriptTargetESNext:
+		return nil // no transforms needed
+	case /*core.ScriptTargetES2025,*/ core.ScriptTargetES2024, core.ScriptTargetES2023, core.ScriptTargetES2022:
+		return NewESNextTransformer(emitContext)
+	case core.ScriptTargetES2021:
+		return NewES2022Transformer(emitContext)
+	case core.ScriptTargetES2020:
+		return NewES2021Transformer(emitContext)
+	case core.ScriptTargetES2019:
+		return NewES2020Transformer(emitContext)
+	case core.ScriptTargetES2018:
+		return NewES2019Transformer(emitContext)
+	case core.ScriptTargetES2017:
+		return NewES2018Transformer(emitContext)
+	case core.ScriptTargetES2016:
+		return NewES2017Transformer(emitContext)
+	default: // other, older, option, transform maximally
+		return NewES2017Transformer(emitContext)
+	}
+}

--- a/internal/transformers/estransforms/esdecorator.go
+++ b/internal/transformers/estransforms/esdecorator.go
@@ -1,0 +1,20 @@
+package estransforms
+
+import (
+	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/printer"
+	"github.com/microsoft/typescript-go/internal/transformers"
+)
+
+type esDecoratorTransformer struct {
+	transformers.Transformer
+}
+
+func (ch *esDecoratorTransformer) visit(node *ast.Node) *ast.Node {
+	return node // !!!
+}
+
+func newESDecoratorTransformer(emitContext *printer.EmitContext) *transformers.Transformer {
+	tx := &esDecoratorTransformer{}
+	return tx.NewTransformer(tx.visit, emitContext)
+}

--- a/internal/transformers/estransforms/exponentiation.go
+++ b/internal/transformers/estransforms/exponentiation.go
@@ -1,0 +1,20 @@
+package estransforms
+
+import (
+	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/printer"
+	"github.com/microsoft/typescript-go/internal/transformers"
+)
+
+type exponentiationTransformer struct {
+	transformers.Transformer
+}
+
+func (ch *exponentiationTransformer) visit(node *ast.Node) *ast.Node {
+	return node // !!!
+}
+
+func newExponentiationTransformer(emitContext *printer.EmitContext) *transformers.Transformer {
+	tx := &exponentiationTransformer{}
+	return tx.NewTransformer(tx.visit, emitContext)
+}

--- a/internal/transformers/estransforms/forawait.go
+++ b/internal/transformers/estransforms/forawait.go
@@ -1,0 +1,20 @@
+package estransforms
+
+import (
+	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/printer"
+	"github.com/microsoft/typescript-go/internal/transformers"
+)
+
+type forawaitTransformer struct {
+	transformers.Transformer
+}
+
+func (ch *forawaitTransformer) visit(node *ast.Node) *ast.Node {
+	return node // !!!
+}
+
+func newforawaitTransformer(emitContext *printer.EmitContext) *transformers.Transformer {
+	tx := &forawaitTransformer{}
+	return tx.NewTransformer(tx.visit, emitContext)
+}

--- a/internal/transformers/estransforms/logicalassignment.go
+++ b/internal/transformers/estransforms/logicalassignment.go
@@ -1,0 +1,20 @@
+package estransforms
+
+import (
+	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/printer"
+	"github.com/microsoft/typescript-go/internal/transformers"
+)
+
+type logicalAssignmentTransformer struct {
+	transformers.Transformer
+}
+
+func (ch *logicalAssignmentTransformer) visit(node *ast.Node) *ast.Node {
+	return node // !!!
+}
+
+func newLogicalAssignmentTransformer(emitContext *printer.EmitContext) *transformers.Transformer {
+	tx := &logicalAssignmentTransformer{}
+	return tx.NewTransformer(tx.visit, emitContext)
+}

--- a/internal/transformers/estransforms/namedevaluation.go
+++ b/internal/transformers/estransforms/namedevaluation.go
@@ -1,4 +1,4 @@
-package transformers
+package estransforms
 
 import (
 	"slices"

--- a/internal/transformers/estransforms/nullishcoalescing.go
+++ b/internal/transformers/estransforms/nullishcoalescing.go
@@ -1,0 +1,20 @@
+package estransforms
+
+import (
+	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/printer"
+	"github.com/microsoft/typescript-go/internal/transformers"
+)
+
+type nullishCoalescingTransformer struct {
+	transformers.Transformer
+}
+
+func (ch *nullishCoalescingTransformer) visit(node *ast.Node) *ast.Node {
+	return node // !!!
+}
+
+func newNullishCoalescingTransformer(emitContext *printer.EmitContext) *transformers.Transformer {
+	tx := &nullishCoalescingTransformer{}
+	return tx.NewTransformer(tx.visit, emitContext)
+}

--- a/internal/transformers/estransforms/objectrestspread.go
+++ b/internal/transformers/estransforms/objectrestspread.go
@@ -1,0 +1,20 @@
+package estransforms
+
+import (
+	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/printer"
+	"github.com/microsoft/typescript-go/internal/transformers"
+)
+
+type objectRestSpreadTransformer struct {
+	transformers.Transformer
+}
+
+func (ch *objectRestSpreadTransformer) visit(node *ast.Node) *ast.Node {
+	return node // !!!
+}
+
+func newObjectRestSpreadTransformer(emitContext *printer.EmitContext) *transformers.Transformer {
+	tx := &objectRestSpreadTransformer{}
+	return tx.NewTransformer(tx.visit, emitContext)
+}

--- a/internal/transformers/estransforms/optionalcatch.go
+++ b/internal/transformers/estransforms/optionalcatch.go
@@ -1,0 +1,20 @@
+package estransforms
+
+import (
+	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/printer"
+	"github.com/microsoft/typescript-go/internal/transformers"
+)
+
+type optionalCatchTransformer struct {
+	transformers.Transformer
+}
+
+func (ch *optionalCatchTransformer) visit(node *ast.Node) *ast.Node {
+	return node // !!!
+}
+
+func newOptionalCatchTransformer(emitContext *printer.EmitContext) *transformers.Transformer {
+	tx := &optionalCatchTransformer{}
+	return tx.NewTransformer(tx.visit, emitContext)
+}

--- a/internal/transformers/estransforms/optionalchain.go
+++ b/internal/transformers/estransforms/optionalchain.go
@@ -1,0 +1,20 @@
+package estransforms
+
+import (
+	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/printer"
+	"github.com/microsoft/typescript-go/internal/transformers"
+)
+
+type optionalChainTransformer struct {
+	transformers.Transformer
+}
+
+func (ch *optionalChainTransformer) visit(node *ast.Node) *ast.Node {
+	return node // !!!
+}
+
+func newOptionalChainTransformer(emitContext *printer.EmitContext) *transformers.Transformer {
+	tx := &optionalChainTransformer{}
+	return tx.NewTransformer(tx.visit, emitContext)
+}

--- a/internal/transformers/estransforms/utilities.go
+++ b/internal/transformers/estransforms/utilities.go
@@ -1,0 +1,20 @@
+package estransforms
+
+import (
+	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/printer"
+	"github.com/microsoft/typescript-go/internal/transformers"
+)
+
+func convertClassDeclarationToClassExpression(emitContext *printer.EmitContext, node *ast.ClassDeclaration) *ast.Expression {
+	updated := emitContext.Factory.NewClassExpression(
+		transformers.ExtractModifiers(emitContext, node.Modifiers(), ^ast.ModifierFlagsExportDefault),
+		node.Name(),
+		node.TypeParameters,
+		node.HeritageClauses,
+		node.Members,
+	)
+	emitContext.SetOriginal(updated, node.AsNode())
+	updated.Loc = node.Loc
+	return updated
+}

--- a/internal/transformers/jsxtransforms/utilities.go
+++ b/internal/transformers/jsxtransforms/utilities.go
@@ -1,0 +1,20 @@
+package jsxtransforms
+
+import "github.com/microsoft/typescript-go/internal/ast"
+
+func createExpressionFromEntityName(factory ast.NodeFactoryCoercible, node *ast.Node) *ast.Expression {
+	if ast.IsQualifiedName(node) {
+		left := createExpressionFromEntityName(factory, node.AsQualifiedName().Left)
+		// TODO(rbuckton): Does this need to be parented?
+		right := node.AsQualifiedName().Right.Clone(factory.AsNodeFactory())
+		right.Loc = node.AsQualifiedName().Right.Loc
+		right.Parent = node.AsQualifiedName().Right.Parent
+		return factory.AsNodeFactory().NewPropertyAccessExpression(left, nil, right, ast.NodeFlagsNone)
+	} else {
+		// TODO(rbuckton): Does this need to be parented?
+		res := node.Clone(factory.AsNodeFactory())
+		res.Loc = node.Loc
+		res.Parent = node.Parent
+		return res
+	}
+}

--- a/internal/transformers/modifiervisitor.go
+++ b/internal/transformers/modifiervisitor.go
@@ -18,7 +18,7 @@ func (v *modifierVisitor) visit(node *ast.Node) *ast.Node {
 	return node
 }
 
-func extractModifiers(emitContext *printer.EmitContext, modifiers *ast.ModifierList, allowed ast.ModifierFlags) *ast.ModifierList {
+func ExtractModifiers(emitContext *printer.EmitContext, modifiers *ast.ModifierList, allowed ast.ModifierFlags) *ast.ModifierList {
 	if modifiers == nil {
 		return nil
 	}

--- a/internal/transformers/moduletransforms/commonjsmodule.go
+++ b/internal/transformers/moduletransforms/commonjsmodule.go
@@ -1,4 +1,4 @@
-package transformers
+package moduletransforms
 
 import (
 	"slices"
@@ -8,11 +8,12 @@ import (
 	"github.com/microsoft/typescript-go/internal/collections"
 	"github.com/microsoft/typescript-go/internal/core"
 	"github.com/microsoft/typescript-go/internal/printer"
+	"github.com/microsoft/typescript-go/internal/transformers"
 	"github.com/microsoft/typescript-go/internal/tspath"
 )
 
 type CommonJSModuleTransformer struct {
-	Transformer
+	transformers.Transformer
 	topLevelVisitor           *ast.NodeVisitor // visits statements at top level of a module
 	topLevelNestedVisitor     *ast.NodeVisitor // visits nested statements at top level of a module
 	discardedValueVisitor     *ast.NodeVisitor // visits expressions whose values would be discarded at runtime
@@ -28,7 +29,7 @@ type CommonJSModuleTransformer struct {
 	currentNode               *ast.Node // used for ancestor tracking via pushNode/popNode to detect expression identifiers
 }
 
-func NewCommonJSModuleTransformer(emitContext *printer.EmitContext, compilerOptions *core.CompilerOptions, resolver binder.ReferenceResolver, getEmitModuleFormatOfFile func(file ast.HasFileName) core.ModuleKind) *Transformer {
+func NewCommonJSModuleTransformer(emitContext *printer.EmitContext, compilerOptions *core.CompilerOptions, resolver binder.ReferenceResolver, getEmitModuleFormatOfFile func(file ast.HasFileName) core.ModuleKind) *transformers.Transformer {
 	if resolver == nil {
 		resolver = binder.NewReferenceResolver(compilerOptions, binder.ReferenceResolverHooks{})
 	}
@@ -172,7 +173,7 @@ func (tx *CommonJSModuleTransformer) visitNoStack(node *ast.Node, resultIsDiscar
 	case ast.KindIdentifier:
 		node = tx.visitIdentifier(node)
 	default:
-		node = tx.visitor.VisitEachChild(node)
+		node = tx.Visitor().VisitEachChild(node)
 	}
 
 	return node
@@ -234,7 +235,7 @@ func (tx *CommonJSModuleTransformer) visitSourceFile(node *ast.SourceFile) *ast.
 	}
 
 	tx.currentSourceFile = node
-	tx.currentModuleInfo = collectExternalModuleInfo(node, tx.compilerOptions, tx.emitContext, tx.resolver)
+	tx.currentModuleInfo = collectExternalModuleInfo(node, tx.compilerOptions, tx.EmitContext(), tx.resolver)
 	updated := tx.transformCommonJSModule(node)
 	tx.currentSourceFile = nil
 	tx.currentModuleInfo = nil
@@ -254,27 +255,27 @@ func (tx *CommonJSModuleTransformer) shouldEmitUnderscoreUnderscoreESModule() bo
 }
 
 func (tx *CommonJSModuleTransformer) createUnderscoreUnderscoreESModule() *ast.Statement {
-	statement := tx.factory.NewExpressionStatement(
-		tx.factory.NewCallExpression(
-			tx.factory.NewPropertyAccessExpression(
-				tx.factory.NewIdentifier("Object"),
+	statement := tx.Factory().NewExpressionStatement(
+		tx.Factory().NewCallExpression(
+			tx.Factory().NewPropertyAccessExpression(
+				tx.Factory().NewIdentifier("Object"),
 				nil, /*questionDotToken*/
-				tx.factory.NewIdentifier("defineProperty"),
+				tx.Factory().NewIdentifier("defineProperty"),
 				ast.NodeFlagsNone,
 			),
 			nil, /*questionDotToken*/
 			nil, /*typeArguments*/
-			tx.factory.NewNodeList([]*ast.Node{
-				tx.factory.NewIdentifier("exports"),
-				tx.factory.NewStringLiteral("__esModule"),
-				tx.factory.NewObjectLiteralExpression(
-					tx.factory.NewNodeList([]*ast.Node{
-						tx.factory.NewPropertyAssignment(
+			tx.Factory().NewNodeList([]*ast.Node{
+				tx.Factory().NewIdentifier("exports"),
+				tx.Factory().NewStringLiteral("__esModule"),
+				tx.Factory().NewObjectLiteralExpression(
+					tx.Factory().NewNodeList([]*ast.Node{
+						tx.Factory().NewPropertyAssignment(
 							nil, /*modifiers*/
-							tx.factory.NewIdentifier("value"),
+							tx.Factory().NewIdentifier("value"),
 							nil, /*postfixToken*/
 							nil, /*typeNode*/
-							tx.factory.NewTrueExpression(),
+							tx.Factory().NewTrueExpression(),
 						),
 					}),
 					false, /*multiLine*/
@@ -283,25 +284,25 @@ func (tx *CommonJSModuleTransformer) createUnderscoreUnderscoreESModule() *ast.S
 			ast.NodeFlagsNone,
 		),
 	)
-	tx.emitContext.SetEmitFlags(statement, printer.EFCustomPrologue)
+	tx.EmitContext().SetEmitFlags(statement, printer.EFCustomPrologue)
 	return statement
 }
 
 func (tx *CommonJSModuleTransformer) transformCommonJSModule(node *ast.SourceFile) *ast.Node {
-	tx.emitContext.StartVariableEnvironment()
+	tx.EmitContext().StartVariableEnvironment()
 
 	// emit standard prologue directives (e.g. "use strict")
-	prologue, rest := tx.factory.SplitStandardPrologue(node.Statements.Nodes)
+	prologue, rest := tx.Factory().SplitStandardPrologue(node.Statements.Nodes)
 	statements := slices.Clone(prologue)
 
 	// ensure "use strict" if not present
 	if ast.IsExternalModule(tx.currentSourceFile) ||
 		tx.compilerOptions.AlwaysStrict.DefaultIfUnknown(tx.compilerOptions.Strict).IsTrue() {
-		statements = tx.factory.EnsureUseStrict(statements)
+		statements = tx.Factory().EnsureUseStrict(statements)
 	}
 
 	// emit custom prologues from other transformations
-	custom, rest := tx.factory.SplitCustomPrologue(rest)
+	custom, rest := tx.Factory().SplitCustomPrologue(rest)
 	statements = append(statements, core.FirstResult(tx.topLevelVisitor.VisitSlice(custom))...)
 
 	// emits `Object.defineProperty(exports, "__esModule", { value: true });` at the top of the file
@@ -315,30 +316,30 @@ func (tx *CommonJSModuleTransformer) transformCommonJSModule(node *ast.SourceFil
 		const chunkSize = 50
 		l := len(tx.currentModuleInfo.exportedNames)
 		for i := 0; i < l; i += chunkSize {
-			right := tx.factory.NewVoidZeroExpression()
+			right := tx.Factory().NewVoidZeroExpression()
 			for _, nextId := range tx.currentModuleInfo.exportedNames[i:min(i+chunkSize, l)] {
 				var left *ast.Expression
 				if nextId.Kind == ast.KindStringLiteral {
-					left = tx.factory.NewElementAccessExpression(
-						tx.factory.NewIdentifier("exports"),
+					left = tx.Factory().NewElementAccessExpression(
+						tx.Factory().NewIdentifier("exports"),
 						nil, /*questionDotToken*/
-						tx.factory.NewStringLiteralFromNode(nextId),
+						tx.Factory().NewStringLiteralFromNode(nextId),
 						ast.NodeFlagsNone,
 					)
 				} else {
-					name := nextId.Clone(tx.factory)
-					tx.emitContext.SetEmitFlags(name, printer.EFNoSourceMap) // TODO: Strada emits comments here, but shouldn't
-					left = tx.factory.NewPropertyAccessExpression(
-						tx.factory.NewIdentifier("exports"),
+					name := nextId.Clone(tx.Factory())
+					tx.EmitContext().SetEmitFlags(name, printer.EFNoSourceMap) // TODO: Strada emits comments here, but shouldn't
+					left = tx.Factory().NewPropertyAccessExpression(
+						tx.Factory().NewIdentifier("exports"),
 						nil, /*questionDotToken*/
 						name,
 						ast.NodeFlagsNone,
 					)
 				}
-				right = tx.factory.NewAssignmentExpression(left, right)
+				right = tx.Factory().NewAssignmentExpression(left, right)
 			}
-			statement := tx.factory.NewExpressionStatement(right)
-			tx.emitContext.AddEmitFlags(statement, printer.EFCustomPrologue)
+			statement := tx.Factory().NewExpressionStatement(right)
+			tx.EmitContext().AddEmitFlags(statement, printer.EFCustomPrologue)
 			statements = append(statements, statement)
 		}
 	}
@@ -358,24 +359,24 @@ func (tx *CommonJSModuleTransformer) transformCommonJSModule(node *ast.SourceFil
 	statements = tx.appendExportEqualsIfNeeded(statements)
 
 	// merge temp variables into the statement list
-	statements = tx.emitContext.EndAndMergeVariableEnvironment(statements)
+	statements = tx.EmitContext().EndAndMergeVariableEnvironment(statements)
 
-	statementList := tx.factory.NewNodeList(statements)
+	statementList := tx.Factory().NewNodeList(statements)
 	statementList.Loc = node.Statements.Loc
-	result := tx.factory.UpdateSourceFile(node, statementList).AsSourceFile()
-	tx.emitContext.AddEmitHelper(result.AsNode(), tx.emitContext.ReadEmitHelpers()...)
+	result := tx.Factory().UpdateSourceFile(node, statementList).AsSourceFile()
+	tx.EmitContext().AddEmitHelper(result.AsNode(), tx.EmitContext().ReadEmitHelpers()...)
 
-	externalHelpersImportDeclaration := createExternalHelpersImportDeclarationIfNeeded(tx.emitContext, result, tx.compilerOptions, tx.getEmitModuleFormatOfFile(node), false /*hasExportStarsToExportValues*/, false /*hasImportStar*/, false /*hasImportDefault*/)
+	externalHelpersImportDeclaration := createExternalHelpersImportDeclarationIfNeeded(tx.EmitContext(), result, tx.compilerOptions, tx.getEmitModuleFormatOfFile(node), false /*hasExportStarsToExportValues*/, false /*hasImportStar*/, false /*hasImportDefault*/)
 	if externalHelpersImportDeclaration != nil {
-		prologue, rest := tx.factory.SplitStandardPrologue(result.Statements.Nodes)
-		custom, rest := tx.factory.SplitCustomPrologue(rest)
+		prologue, rest := tx.Factory().SplitStandardPrologue(result.Statements.Nodes)
+		custom, rest := tx.Factory().SplitCustomPrologue(rest)
 		statements := slices.Clone(prologue)
 		statements = append(statements, custom...)
 		statements = append(statements, tx.topLevelVisitor.VisitNode(externalHelpersImportDeclaration))
 		statements = append(statements, rest...)
-		statementList := tx.factory.NewNodeList(statements)
+		statementList := tx.Factory().NewNodeList(statements)
 		statementList.Loc = result.Statements.Loc
-		result = tx.factory.UpdateSourceFile(result, statementList).AsSourceFile()
+		result = tx.Factory().UpdateSourceFile(result, statementList).AsSourceFile()
 	}
 
 	return result.AsNode()
@@ -386,22 +387,22 @@ func (tx *CommonJSModuleTransformer) transformCommonJSModule(node *ast.SourceFil
 // - The `statements` parameter is a statement list to which the down-level export statements are to be appended.
 func (tx *CommonJSModuleTransformer) appendExportEqualsIfNeeded(statements []*ast.Statement) []*ast.Statement {
 	if tx.currentModuleInfo.exportEquals != nil {
-		expressionResult := tx.visitor.VisitNode(tx.currentModuleInfo.exportEquals.Expression)
+		expressionResult := tx.Visitor().VisitNode(tx.currentModuleInfo.exportEquals.Expression)
 		if expressionResult != nil {
-			statement := tx.factory.NewExpressionStatement(
-				tx.factory.NewAssignmentExpression(
-					tx.factory.NewPropertyAccessExpression(
-						tx.factory.NewIdentifier("module"),
+			statement := tx.Factory().NewExpressionStatement(
+				tx.Factory().NewAssignmentExpression(
+					tx.Factory().NewPropertyAccessExpression(
+						tx.Factory().NewIdentifier("module"),
 						nil, /*questionDotToken*/
-						tx.factory.NewIdentifier("exports"),
+						tx.Factory().NewIdentifier("exports"),
 						ast.NodeFlagsNone,
 					),
 					expressionResult,
 				),
 			)
 
-			tx.emitContext.AssignCommentAndSourceMapRanges(statement, tx.currentModuleInfo.exportEquals.AsNode())
-			tx.emitContext.AddEmitFlags(statement, printer.EFNoComments)
+			tx.EmitContext().AssignCommentAndSourceMapRanges(statement, tx.currentModuleInfo.exportEquals.AsNode())
+			tx.EmitContext().AddEmitFlags(statement, printer.EFNoComments)
 			statements = append(statements, statement)
 		}
 	}
@@ -483,7 +484,7 @@ func (tx *CommonJSModuleTransformer) appendExportsOfBindingElement(statements []
 				statements = tx.appendExportsOfBindingElement(statements, element, isForInOrOfInitializer)
 			}
 		}
-	} else if !isGeneratedIdentifier(tx.emitContext, decl.Name()) &&
+	} else if !transformers.IsGeneratedIdentifier(tx.EmitContext(), decl.Name()) &&
 		(!ast.IsVariableDeclaration(decl) || decl.Initializer() != nil || isForInOrOfInitializer) {
 		statements = tx.appendExportsOfDeclaration(statements, decl, nil /*seen*/, false /*liveBinding*/)
 	}
@@ -504,12 +505,12 @@ func (tx *CommonJSModuleTransformer) appendExportsOfClassOrFunctionDeclaration(s
 	if ast.HasSyntacticModifier(decl, ast.ModifierFlagsExport) {
 		var exportName *ast.IdentifierNode
 		if ast.HasSyntacticModifier(decl, ast.ModifierFlagsDefault) {
-			exportName = tx.factory.NewIdentifier("default")
+			exportName = tx.Factory().NewIdentifier("default")
 		} else {
-			exportName = tx.factory.GetDeclarationName(decl)
+			exportName = tx.Factory().GetDeclarationName(decl)
 		}
 
-		exportValue := tx.factory.GetLocalName(decl)
+		exportValue := tx.Factory().GetLocalName(decl)
 		statements = tx.appendExportStatement(statements, seen, exportName, exportValue, &decl.Loc, false /*allowComments*/, false /*liveBinding*/)
 	}
 
@@ -534,7 +535,7 @@ func (tx *CommonJSModuleTransformer) appendExportsOfDeclaration(statements []*as
 	}
 
 	if name := decl.Name(); tx.currentModuleInfo.exportSpecifiers.Len() > 0 && name != nil && ast.IsIdentifier(name) {
-		name = tx.factory.GetDeclarationName(decl)
+		name = tx.Factory().GetDeclarationName(decl)
 		exportSpecifiers := tx.currentModuleInfo.exportSpecifiers.Get(name.Text())
 		if len(exportSpecifiers) > 0 {
 			exportValue := tx.visitExpressionIdentifier(name)
@@ -572,13 +573,13 @@ func (tx *CommonJSModuleTransformer) appendExportStatement(statements []*ast.Sta
 //   - The `location` parameter is the location to use for source maps and comments for the export.
 //   - The `allowComments` parameter indicates whether to emit comments for the statement.
 func (tx *CommonJSModuleTransformer) createExportStatement(name *ast.ModuleExportName, value *ast.Expression, location *core.TextRange, allowComments bool, liveBinding bool) *ast.Statement {
-	statement := tx.factory.NewExpressionStatement(tx.createExportExpression(name, value, nil /*location*/, liveBinding))
+	statement := tx.Factory().NewExpressionStatement(tx.createExportExpression(name, value, nil /*location*/, liveBinding))
 	if location != nil {
-		tx.emitContext.SetCommentRange(statement, *location)
+		tx.EmitContext().SetCommentRange(statement, *location)
 	}
-	tx.emitContext.AddEmitFlags(statement, printer.EFStartOnNewLine)
+	tx.EmitContext().AddEmitFlags(statement, printer.EFStartOnNewLine)
 	if !allowComments {
-		tx.emitContext.AddEmitFlags(statement, printer.EFNoComments)
+		tx.EmitContext().AddEmitFlags(statement, printer.EFNoComments)
 	}
 	return statement
 }
@@ -593,42 +594,42 @@ func (tx *CommonJSModuleTransformer) createExportExpression(name *ast.ModuleExpo
 	if liveBinding {
 		// For a live binding we emit a getter on `exports` that returns the value:
 		//  Object.defineProperty(exports, "<name>", { enumerable: true, get: function () { return <value>; } });
-		expression = tx.factory.NewCallExpression(
-			tx.factory.NewPropertyAccessExpression(
-				tx.factory.NewIdentifier("Object"),
+		expression = tx.Factory().NewCallExpression(
+			tx.Factory().NewPropertyAccessExpression(
+				tx.Factory().NewIdentifier("Object"),
 				nil, /*questionDotToken*/
-				tx.factory.NewIdentifier("defineProperty"),
+				tx.Factory().NewIdentifier("defineProperty"),
 				ast.NodeFlagsNone,
 			),
 			nil, /*questionDotToken*/
 			nil, /*typeArguments*/
-			tx.factory.NewNodeList([]*ast.Node{
-				tx.factory.NewIdentifier("exports"),
-				tx.factory.NewStringLiteralFromNode(name),
-				tx.factory.NewObjectLiteralExpression(
-					tx.factory.NewNodeList([]*ast.Node{
-						tx.factory.NewPropertyAssignment(
+			tx.Factory().NewNodeList([]*ast.Node{
+				tx.Factory().NewIdentifier("exports"),
+				tx.Factory().NewStringLiteralFromNode(name),
+				tx.Factory().NewObjectLiteralExpression(
+					tx.Factory().NewNodeList([]*ast.Node{
+						tx.Factory().NewPropertyAssignment(
 							nil, /*modifiers*/
-							tx.factory.NewIdentifier("enumerable"),
+							tx.Factory().NewIdentifier("enumerable"),
 							nil, /*postfixToken*/
 							nil, /*typeNode*/
-							tx.factory.NewTrueExpression(),
+							tx.Factory().NewTrueExpression(),
 						),
-						tx.factory.NewPropertyAssignment(
+						tx.Factory().NewPropertyAssignment(
 							nil, /*modifiers*/
-							tx.factory.NewIdentifier("get"),
+							tx.Factory().NewIdentifier("get"),
 							nil, /*postfixToken*/
 							nil, /*typeNode*/
-							tx.factory.NewFunctionExpression(
+							tx.Factory().NewFunctionExpression(
 								nil, /*modifiers*/
 								nil, /*asteriskToken*/
 								nil, /*name*/
 								nil, /*typeParameters*/
-								tx.factory.NewNodeList([]*ast.Node{}),
+								tx.Factory().NewNodeList([]*ast.Node{}),
 								nil, /*type*/
-								tx.factory.NewBlock(
-									tx.factory.NewNodeList([]*ast.Node{
-										tx.factory.NewReturnStatement(value),
+								tx.Factory().NewBlock(
+									tx.Factory().NewNodeList([]*ast.Node{
+										tx.Factory().NewReturnStatement(value),
 									}),
 									false, /*multiLine*/
 								),
@@ -646,26 +647,26 @@ func (tx *CommonJSModuleTransformer) createExportExpression(name *ast.ModuleExpo
 		if name.Kind == ast.KindStringLiteral {
 			// emits:
 			//  exports["<name>"] = <value>;
-			left = tx.factory.NewElementAccessExpression(
-				tx.factory.NewIdentifier("exports"),
+			left = tx.Factory().NewElementAccessExpression(
+				tx.Factory().NewIdentifier("exports"),
 				nil, /*questionDotToken*/
-				tx.factory.NewStringLiteralFromNode(name),
+				tx.Factory().NewStringLiteralFromNode(name),
 				ast.NodeFlagsNone,
 			)
 		} else {
 			// emits:
 			//  exports.<name> = <value>;
-			left = tx.factory.NewPropertyAccessExpression(
-				tx.factory.NewIdentifier("exports"),
+			left = tx.Factory().NewPropertyAccessExpression(
+				tx.Factory().NewIdentifier("exports"),
 				nil, /*questionDotToken*/
-				name.Clone(tx.factory),
+				name.Clone(tx.Factory()),
 				ast.NodeFlagsNone,
 			)
 		}
-		expression = tx.factory.NewAssignmentExpression(left, value)
+		expression = tx.Factory().NewAssignmentExpression(left, value)
 	}
 	if location != nil {
-		tx.emitContext.SetCommentRange(expression, *location)
+		tx.EmitContext().SetCommentRange(expression, *location)
 	}
 	return expression
 }
@@ -673,37 +674,37 @@ func (tx *CommonJSModuleTransformer) createExportExpression(name *ast.ModuleExpo
 // Creates a `require()` call to import an external module.
 func (tx *CommonJSModuleTransformer) createRequireCall(node *ast.Node /*ImportDeclaration | ImportEqualsDeclaration | ExportDeclaration*/) *ast.Node {
 	var args []*ast.Expression
-	moduleName := getExternalModuleNameLiteral(tx.factory, node, tx.currentSourceFile, nil /*host*/, nil /*resolver*/, tx.compilerOptions)
+	moduleName := getExternalModuleNameLiteral(tx.Factory(), node, tx.currentSourceFile, nil /*host*/, nil /*resolver*/, tx.compilerOptions)
 	if moduleName != nil {
-		args = append(args, rewriteModuleSpecifier(tx.emitContext, moduleName, tx.compilerOptions))
+		args = append(args, rewriteModuleSpecifier(tx.EmitContext(), moduleName, tx.compilerOptions))
 	}
-	return tx.factory.NewCallExpression(
-		tx.factory.NewIdentifier("require"),
+	return tx.Factory().NewCallExpression(
+		tx.Factory().NewIdentifier("require"),
 		nil, /*questionDotToken*/
 		nil, /*typeArguments*/
-		tx.factory.NewNodeList(args),
+		tx.Factory().NewNodeList(args),
 		ast.NodeFlagsNone)
 }
 
 func (tx *CommonJSModuleTransformer) getHelperExpressionForExport(node *ast.ExportDeclaration, innerExpr *ast.Expression) *ast.Expression {
-	if !tx.compilerOptions.GetESModuleInterop() || tx.emitContext.EmitFlags(node.AsNode())&printer.EFNeverApplyImportHelper != 0 {
+	if !tx.compilerOptions.GetESModuleInterop() || tx.EmitContext().EmitFlags(node.AsNode())&printer.EFNeverApplyImportHelper != 0 {
 		return innerExpr
 	}
 	if getExportNeedsImportStarHelper(node) {
-		return tx.visitor.VisitNode(tx.factory.NewImportStarHelper(innerExpr))
+		return tx.Visitor().VisitNode(tx.Factory().NewImportStarHelper(innerExpr))
 	}
 	return innerExpr
 }
 
 func (tx *CommonJSModuleTransformer) getHelperExpressionForImport(node *ast.ImportDeclaration, innerExpr *ast.Expression) *ast.Expression {
-	if !tx.compilerOptions.GetESModuleInterop() || tx.emitContext.EmitFlags(node.AsNode())&printer.EFNeverApplyImportHelper != 0 {
+	if !tx.compilerOptions.GetESModuleInterop() || tx.EmitContext().EmitFlags(node.AsNode())&printer.EFNeverApplyImportHelper != 0 {
 		return innerExpr
 	}
 	if getImportNeedsImportStarHelper(node) {
-		return tx.visitor.VisitNode(tx.factory.NewImportStarHelper(innerExpr))
+		return tx.Visitor().VisitNode(tx.Factory().NewImportStarHelper(innerExpr))
 	}
 	if getImportNeedsImportDefaultHelper(node) {
-		return tx.visitor.VisitNode(tx.factory.NewImportDefaultHelper(innerExpr))
+		return tx.Visitor().VisitNode(tx.Factory().NewImportDefaultHelper(innerExpr))
 	}
 	return innerExpr
 }
@@ -711,9 +712,9 @@ func (tx *CommonJSModuleTransformer) getHelperExpressionForImport(node *ast.Impo
 func (tx *CommonJSModuleTransformer) visitTopLevelImportDeclaration(node *ast.ImportDeclaration) *ast.Node {
 	if node.ImportClause == nil {
 		// import "mod";
-		statement := tx.factory.NewExpressionStatement(tx.createRequireCall(node.AsNode()))
-		tx.emitContext.SetOriginal(statement, node.AsNode())
-		tx.emitContext.AssignCommentAndSourceMapRanges(statement, node.AsNode())
+		statement := tx.Factory().NewExpressionStatement(tx.createRequireCall(node.AsNode()))
+		tx.EmitContext().SetOriginal(statement, node.AsNode())
+		tx.EmitContext().AssignCommentAndSourceMapRanges(statement, node.AsNode())
 		return statement
 	}
 
@@ -723,8 +724,8 @@ func (tx *CommonJSModuleTransformer) visitTopLevelImportDeclaration(node *ast.Im
 	if namespaceDeclaration != nil && !ast.IsDefaultImport(node.AsNode()) {
 		// import * as n from "mod";
 		variables = append(variables,
-			tx.factory.NewVariableDeclaration(
-				namespaceDeclaration.Name().Clone(tx.factory),
+			tx.Factory().NewVariableDeclaration(
+				namespaceDeclaration.Name().Clone(tx.Factory()),
 				nil, /*exclamationToken*/
 				nil, /*type*/
 				tx.getHelperExpressionForImport(node, tx.createRequireCall(node.AsNode())),
@@ -736,8 +737,8 @@ func (tx *CommonJSModuleTransformer) visitTopLevelImportDeclaration(node *ast.Im
 		// import d, { x, y } from "mod";
 		// import d, * as n from "mod";
 		variables = append(variables,
-			tx.factory.NewVariableDeclaration(
-				tx.factory.NewGeneratedNameForNode(node.AsNode()),
+			tx.Factory().NewVariableDeclaration(
+				tx.Factory().NewGeneratedNameForNode(node.AsNode()),
 				nil, /*exclamationToken*/
 				nil, /*type*/
 				tx.getHelperExpressionForImport(node, tx.createRequireCall(node.AsNode())),
@@ -746,29 +747,29 @@ func (tx *CommonJSModuleTransformer) visitTopLevelImportDeclaration(node *ast.Im
 
 		if namespaceDeclaration != nil && ast.IsDefaultImport(node.AsNode()) {
 			variables = append(variables,
-				tx.factory.NewVariableDeclaration(
-					namespaceDeclaration.Name().Clone(tx.factory),
+				tx.Factory().NewVariableDeclaration(
+					namespaceDeclaration.Name().Clone(tx.Factory()),
 					nil, /*exclamationToken*/
 					nil, /*type*/
-					tx.factory.NewGeneratedNameForNode(node.AsNode()),
+					tx.Factory().NewGeneratedNameForNode(node.AsNode()),
 				),
 			)
 		}
 	}
 
-	varStatement := tx.factory.NewVariableStatement(
+	varStatement := tx.Factory().NewVariableStatement(
 		nil, /*modifiers*/
-		tx.factory.NewVariableDeclarationList(
+		tx.Factory().NewVariableDeclarationList(
 			ast.NodeFlagsConst,
-			tx.factory.NewNodeList(variables),
+			tx.Factory().NewNodeList(variables),
 		),
 	)
 
-	tx.emitContext.SetOriginal(varStatement, node.AsNode())
-	tx.emitContext.AssignCommentAndSourceMapRanges(varStatement, node.AsNode())
+	tx.EmitContext().SetOriginal(varStatement, node.AsNode())
+	tx.EmitContext().AssignCommentAndSourceMapRanges(varStatement, node.AsNode())
 	statements = append(statements, varStatement)
 	statements = tx.appendExportsOfImportDeclaration(statements, node)
-	return singleOrMany(statements, tx.factory)
+	return transformers.SingleOrMany(statements, tx.Factory())
 }
 
 func (tx *CommonJSModuleTransformer) visitTopLevelImportEqualsDeclaration(node *ast.ImportEqualsDeclaration) *ast.Node {
@@ -780,7 +781,7 @@ func (tx *CommonJSModuleTransformer) visitTopLevelImportEqualsDeclaration(node *
 	var statements []*ast.Statement
 	if ast.HasSyntacticModifier(node.AsNode(), ast.ModifierFlagsExport) {
 		// export import m = require("mod");
-		statement := tx.factory.NewExpressionStatement(
+		statement := tx.Factory().NewExpressionStatement(
 			tx.createExportExpression(
 				node.Name(),
 				tx.createRequireCall(node.AsNode()),
@@ -789,18 +790,18 @@ func (tx *CommonJSModuleTransformer) visitTopLevelImportEqualsDeclaration(node *
 			),
 		)
 
-		tx.emitContext.SetOriginal(statement, node.AsNode())
-		tx.emitContext.AssignCommentAndSourceMapRanges(statement, node.AsNode())
+		tx.EmitContext().SetOriginal(statement, node.AsNode())
+		tx.EmitContext().AssignCommentAndSourceMapRanges(statement, node.AsNode())
 		statements = append(statements, statement)
 	} else {
 		// import m = require("mod");
-		statement := tx.factory.NewVariableStatement(
+		statement := tx.Factory().NewVariableStatement(
 			nil, /*modifiers*/
-			tx.factory.NewVariableDeclarationList(
+			tx.Factory().NewVariableDeclarationList(
 				ast.NodeFlagsConst,
-				tx.factory.NewNodeList([]*ast.VariableDeclarationNode{
-					tx.factory.NewVariableDeclaration(
-						node.Name().Clone(tx.factory),
+				tx.Factory().NewNodeList([]*ast.VariableDeclarationNode{
+					tx.Factory().NewVariableDeclaration(
+						node.Name().Clone(tx.Factory()),
 						nil, /*exclamationToken*/
 						nil, /*typeNode*/
 						tx.createRequireCall(node.AsNode()),
@@ -808,13 +809,13 @@ func (tx *CommonJSModuleTransformer) visitTopLevelImportEqualsDeclaration(node *
 				}),
 			),
 		)
-		tx.emitContext.SetOriginal(statement, node.AsNode())
-		tx.emitContext.AssignCommentAndSourceMapRanges(statement, node.AsNode())
+		tx.EmitContext().SetOriginal(statement, node.AsNode())
+		tx.EmitContext().AssignCommentAndSourceMapRanges(statement, node.AsNode())
 		statements = append(statements, statement)
 	}
 
 	statements = tx.appendExportsOfDeclaration(statements, node.AsNode(), nil /*seen*/, false /*liveBinding*/)
-	return singleOrMany(statements, tx.factory)
+	return transformers.SingleOrMany(statements, tx.Factory())
 }
 
 func (tx *CommonJSModuleTransformer) visitTopLevelExportDeclaration(node *ast.ExportDeclaration) *ast.Node {
@@ -824,16 +825,16 @@ func (tx *CommonJSModuleTransformer) visitTopLevelExportDeclaration(node *ast.Ex
 		return nil
 	}
 
-	generatedName := tx.factory.NewGeneratedNameForNode(node.AsNode())
+	generatedName := tx.Factory().NewGeneratedNameForNode(node.AsNode())
 	if node.ExportClause != nil && ast.IsNamedExports(node.ExportClause) {
 		// export { x, y } from "mod";
 		var statements []*ast.Statement
-		varStatement := tx.factory.NewVariableStatement(
+		varStatement := tx.Factory().NewVariableStatement(
 			nil, /*modifiers*/
-			tx.factory.NewVariableDeclarationList(
+			tx.Factory().NewVariableDeclarationList(
 				ast.NodeFlagsConst,
-				tx.factory.NewNodeList([]*ast.VariableDeclarationNode{
-					tx.factory.NewVariableDeclaration(
+				tx.Factory().NewNodeList([]*ast.VariableDeclarationNode{
+					tx.Factory().NewVariableDeclaration(
 						generatedName,
 						nil, /*exclamationToken*/
 						nil, /*type*/
@@ -842,37 +843,37 @@ func (tx *CommonJSModuleTransformer) visitTopLevelExportDeclaration(node *ast.Ex
 				}),
 			),
 		)
-		tx.emitContext.SetOriginal(varStatement, node.AsNode())
-		tx.emitContext.AssignCommentAndSourceMapRanges(varStatement, node.AsNode())
+		tx.EmitContext().SetOriginal(varStatement, node.AsNode())
+		tx.EmitContext().AssignCommentAndSourceMapRanges(varStatement, node.AsNode())
 		statements = append(statements, varStatement)
 
 		for _, specifier := range node.ExportClause.AsNamedExports().Elements.Nodes {
 			specifierName := specifier.PropertyNameOrName()
 			exportNeedsImportDefault := tx.compilerOptions.GetESModuleInterop() &&
-				tx.emitContext.EmitFlags(node.AsNode())&printer.EFNeverApplyImportHelper == 0 &&
+				tx.EmitContext().EmitFlags(node.AsNode())&printer.EFNeverApplyImportHelper == 0 &&
 				ast.ModuleExportNameIsDefault(specifierName)
 
 			var target *ast.Node
 			if exportNeedsImportDefault {
-				target = tx.factory.NewImportDefaultHelper(generatedName)
+				target = tx.Factory().NewImportDefaultHelper(generatedName)
 			} else {
 				target = generatedName
 			}
 
 			var exportName *ast.Node
 			if ast.IsStringLiteral(specifier.Name()) {
-				exportName = tx.factory.NewStringLiteralFromNode(specifier.Name())
+				exportName = tx.Factory().NewStringLiteralFromNode(specifier.Name())
 			} else {
-				exportName = tx.factory.GetExportName(specifier.AsNode())
+				exportName = tx.Factory().GetExportName(specifier.AsNode())
 			}
 
 			var exportedValue *ast.Node
 			if ast.IsStringLiteral(specifierName) {
-				exportedValue = tx.factory.NewElementAccessExpression(target, nil /*questionDotToken*/, specifierName, ast.NodeFlagsNone)
+				exportedValue = tx.Factory().NewElementAccessExpression(target, nil /*questionDotToken*/, specifierName, ast.NodeFlagsNone)
 			} else {
-				exportedValue = tx.factory.NewPropertyAccessExpression(target, nil /*questionDotToken*/, specifierName, ast.NodeFlagsNone)
+				exportedValue = tx.Factory().NewPropertyAccessExpression(target, nil /*questionDotToken*/, specifierName, ast.NodeFlagsNone)
 			}
-			statement := tx.factory.NewExpressionStatement(
+			statement := tx.Factory().NewExpressionStatement(
 				tx.createExportExpression(
 					exportName,
 					exportedValue,
@@ -880,12 +881,12 @@ func (tx *CommonJSModuleTransformer) visitTopLevelExportDeclaration(node *ast.Ex
 					true, /*liveBinding*/
 				),
 			)
-			tx.emitContext.SetOriginal(statement, specifier.AsNode())
-			tx.emitContext.AssignCommentAndSourceMapRanges(statement, specifier.AsNode())
+			tx.EmitContext().SetOriginal(statement, specifier.AsNode())
+			tx.EmitContext().AssignCommentAndSourceMapRanges(statement, specifier.AsNode())
 			statements = append(statements, statement)
 		}
 
-		return singleOrMany(statements, tx.factory)
+		return transformers.SingleOrMany(statements, tx.Factory())
 	}
 
 	if node.ExportClause != nil {
@@ -893,11 +894,11 @@ func (tx *CommonJSModuleTransformer) visitTopLevelExportDeclaration(node *ast.Ex
 		// export * as default from "mod";
 		var exportName *ast.Node
 		if ast.IsStringLiteral(node.ExportClause.Name()) {
-			exportName = tx.factory.NewStringLiteralFromNode(node.ExportClause.Name())
+			exportName = tx.Factory().NewStringLiteralFromNode(node.ExportClause.Name())
 		} else {
-			exportName = node.ExportClause.Name().Clone(tx.factory)
+			exportName = node.ExportClause.Name().Clone(tx.Factory())
 		}
-		statement := tx.factory.NewExpressionStatement(
+		statement := tx.Factory().NewExpressionStatement(
 			tx.createExportExpression(
 				exportName,
 				tx.getHelperExpressionForExport(
@@ -908,17 +909,17 @@ func (tx *CommonJSModuleTransformer) visitTopLevelExportDeclaration(node *ast.Ex
 				false, /*liveBinding*/
 			),
 		)
-		tx.emitContext.SetOriginal(statement, node.AsNode())
-		tx.emitContext.AssignCommentAndSourceMapRanges(statement, node.AsNode())
+		tx.EmitContext().SetOriginal(statement, node.AsNode())
+		tx.EmitContext().AssignCommentAndSourceMapRanges(statement, node.AsNode())
 		return statement
 	}
 
 	// export * from "mod";
-	statement := tx.factory.NewExpressionStatement(
-		tx.visitor.VisitNode(tx.factory.NewExportStarHelper(tx.createRequireCall(node.AsNode()), tx.factory.NewIdentifier("exports"))),
+	statement := tx.Factory().NewExpressionStatement(
+		tx.Visitor().VisitNode(tx.Factory().NewExportStarHelper(tx.createRequireCall(node.AsNode()), tx.Factory().NewIdentifier("exports"))),
 	)
-	tx.emitContext.SetOriginal(statement, node.AsNode())
-	tx.emitContext.AssignCommentAndSourceMapRanges(statement, node.AsNode())
+	tx.EmitContext().SetOriginal(statement, node.AsNode())
+	tx.EmitContext().AssignCommentAndSourceMapRanges(statement, node.AsNode())
 	return statement
 }
 
@@ -928,8 +929,8 @@ func (tx *CommonJSModuleTransformer) visitTopLevelExportAssignment(node *ast.Exp
 	}
 
 	return tx.createExportStatement(
-		tx.factory.NewIdentifier("default"),
-		tx.visitor.VisitNode(node.Expression),
+		tx.Factory().NewIdentifier("default"),
+		tx.Visitor().VisitNode(node.Expression),
 		&node.Loc, /*location*/
 		true,      /*allowComments*/
 		false,     /*liveBinding*/
@@ -938,37 +939,37 @@ func (tx *CommonJSModuleTransformer) visitTopLevelExportAssignment(node *ast.Exp
 
 func (tx *CommonJSModuleTransformer) visitTopLevelFunctionDeclaration(node *ast.FunctionDeclaration) *ast.Node {
 	if ast.HasSyntacticModifier(node.AsNode(), ast.ModifierFlagsExport) {
-		return tx.factory.UpdateFunctionDeclaration(
+		return tx.Factory().UpdateFunctionDeclaration(
 			node,
-			extractModifiers(tx.emitContext, node.Modifiers(), ^ast.ModifierFlagsExportDefault),
+			transformers.ExtractModifiers(tx.EmitContext(), node.Modifiers(), ^ast.ModifierFlagsExportDefault),
 			node.AsteriskToken,
-			tx.factory.GetDeclarationName(node.AsNode()),
+			tx.Factory().GetDeclarationName(node.AsNode()),
 			nil, /*typeParameters*/
-			tx.visitor.VisitNodes(node.Parameters),
+			tx.Visitor().VisitNodes(node.Parameters),
 			nil, /*type*/
-			tx.visitor.VisitNode(node.Body),
+			tx.Visitor().VisitNode(node.Body),
 		)
 	} else {
-		return tx.visitor.VisitEachChild(node.AsNode())
+		return tx.Visitor().VisitEachChild(node.AsNode())
 	}
 }
 
 func (tx *CommonJSModuleTransformer) visitTopLevelClassDeclaration(node *ast.ClassDeclaration) *ast.Node {
 	var statements []*ast.Statement
 	if ast.HasSyntacticModifier(node.AsNode(), ast.ModifierFlagsExport) {
-		statements = append(statements, tx.factory.UpdateClassDeclaration(
+		statements = append(statements, tx.Factory().UpdateClassDeclaration(
 			node,
-			tx.visitor.VisitModifiers(extractModifiers(tx.emitContext, node.Modifiers(), ^ast.ModifierFlagsExportDefault)),
-			tx.factory.GetDeclarationName(node.AsNode()),
+			tx.Visitor().VisitModifiers(transformers.ExtractModifiers(tx.EmitContext(), node.Modifiers(), ^ast.ModifierFlagsExportDefault)),
+			tx.Factory().GetDeclarationName(node.AsNode()),
 			nil, /*typeParameters*/
-			tx.visitor.VisitNodes(node.HeritageClauses),
-			tx.visitor.VisitNodes(node.Members),
+			tx.Visitor().VisitNodes(node.HeritageClauses),
+			tx.Visitor().VisitNodes(node.Members),
 		))
 	} else {
-		statements = append(statements, tx.visitor.VisitEachChild(node.AsNode()))
+		statements = append(statements, tx.Visitor().VisitEachChild(node.AsNode()))
 	}
 	statements = tx.appendExportsOfClassOrFunctionDeclaration(statements, node.AsNode())
-	return singleOrMany(statements, tx.factory)
+	return transformers.SingleOrMany(statements, tx.Factory())
 }
 
 func (tx *CommonJSModuleTransformer) visitTopLevelVariableStatement(node *ast.VariableStatement) *ast.Node {
@@ -981,18 +982,18 @@ func (tx *CommonJSModuleTransformer) visitTopLevelVariableStatement(node *ast.Va
 
 		commitPendingVariables := func() {
 			if len(variables) > 0 {
-				variableList := tx.factory.NewNodeList(variables)
+				variableList := tx.Factory().NewNodeList(variables)
 				variableList.Loc = node.DeclarationList.AsVariableDeclarationList().Declarations.Loc
-				statement := tx.factory.UpdateVariableStatement(
+				statement := tx.Factory().UpdateVariableStatement(
 					node,
 					modifiers,
-					tx.factory.UpdateVariableDeclarationList(
+					tx.Factory().UpdateVariableDeclarationList(
 						node.DeclarationList.AsVariableDeclarationList(),
 						variableList,
 					),
 				)
 				if len(statements) > 0 {
-					tx.emitContext.AddEmitFlags(statement, printer.EFNoComments)
+					tx.EmitContext().AddEmitFlags(statement, printer.EFNoComments)
 				}
 				statements = append(statements, statement)
 				variables = nil
@@ -1001,10 +1002,10 @@ func (tx *CommonJSModuleTransformer) visitTopLevelVariableStatement(node *ast.Va
 
 		commitPendingExpressions := func() {
 			if len(expressions) > 0 {
-				statement := tx.factory.NewExpressionStatement(tx.factory.InlineExpressions(expressions))
-				tx.emitContext.AssignCommentAndSourceMapRanges(statement, node.AsNode())
+				statement := tx.Factory().NewExpressionStatement(tx.Factory().InlineExpressions(expressions))
+				tx.EmitContext().AssignCommentAndSourceMapRanges(statement, node.AsNode())
 				if len(statements) > 0 {
-					tx.emitContext.AddEmitFlags(statement, printer.EFNoComments)
+					tx.EmitContext().AddEmitFlags(statement, printer.EFNoComments)
 				}
 				statements = append(statements, statement)
 				expressions = nil
@@ -1025,7 +1026,7 @@ func (tx *CommonJSModuleTransformer) visitTopLevelVariableStatement(node *ast.Va
 		for _, variable := range node.DeclarationList.AsVariableDeclarationList().Declarations.Nodes {
 			v := variable.AsVariableDeclaration()
 
-			if ast.IsIdentifier(v.Name()) && isLocalName(tx.emitContext, v.Name()) {
+			if ast.IsIdentifier(v.Name()) && transformers.IsLocalName(tx.EmitContext(), v.Name()) {
 				// A "local name" generally means a variable declaration that *shouldn't* be
 				// converted to `exports.x = ...`, even if the declaration is exported. This
 				// usually indicates a class or function declaration that was converted into
@@ -1034,18 +1035,18 @@ func (tx *CommonJSModuleTransformer) visitTopLevelVariableStatement(node *ast.Va
 				// an `export { x }` declaration will follow.
 
 				if modifiers == nil {
-					modifiers = extractModifiers(tx.emitContext, node.Modifiers(), ^ast.ModifierFlagsExportDefault)
+					modifiers = transformers.ExtractModifiers(tx.EmitContext(), node.Modifiers(), ^ast.ModifierFlagsExportDefault)
 				}
 
 				if v.Initializer != nil {
-					variable = tx.factory.UpdateVariableDeclaration(
+					variable = tx.Factory().UpdateVariableDeclaration(
 						v,
 						v.Name(),
 						nil, /*exclamationToken*/
 						nil, /*type*/
 						tx.createExportExpression(
 							v.Name(),
-							tx.visitor.VisitNode(v.Initializer),
+							tx.Visitor().VisitNode(v.Initializer),
 							nil,
 							false, /*liveBinding*/
 						),
@@ -1056,29 +1057,29 @@ func (tx *CommonJSModuleTransformer) visitTopLevelVariableStatement(node *ast.Va
 			} else if v.Initializer != nil && !ast.IsBindingPattern(v.Name()) && (ast.IsArrowFunction(v.Initializer) || (ast.IsFunctionExpression(v.Initializer) || ast.IsClassExpression(v.Initializer)) && v.Initializer.Name() == nil) {
 				// preserve variable declarations for functions and classes to assign names
 
-				pushVariable(tx.factory.NewVariableDeclaration(
+				pushVariable(tx.Factory().NewVariableDeclaration(
 					v.Name(),
 					v.ExclamationToken,
 					v.Type,
-					tx.visitor.VisitNode(v.Initializer),
+					tx.Visitor().VisitNode(v.Initializer),
 				))
 
-				propertyAccess := tx.factory.NewPropertyAccessExpression(
-					tx.factory.NewIdentifier("exports"),
+				propertyAccess := tx.Factory().NewPropertyAccessExpression(
+					tx.Factory().NewIdentifier("exports"),
 					nil, /*questionDotToken*/
 					v.Name(),
 					ast.NodeFlagsNone,
 				)
-				tx.emitContext.AssignCommentAndSourceMapRanges(propertyAccess, v.Name())
+				tx.EmitContext().AssignCommentAndSourceMapRanges(propertyAccess, v.Name())
 
-				pushExpression(tx.factory.NewAssignmentExpression(
+				pushExpression(tx.Factory().NewAssignmentExpression(
 					propertyAccess,
-					v.Name().Clone(tx.factory),
+					v.Name().Clone(tx.Factory()),
 				))
 			} else {
-				expression := convertVariableDeclarationToAssignmentExpression(tx.emitContext, v)
+				expression := transformers.ConvertVariableDeclarationToAssignmentExpression(tx.EmitContext(), v)
 				if expression != nil {
-					pushExpression(tx.visitor.VisitNode(expression))
+					pushExpression(tx.Visitor().VisitNode(expression))
 				}
 			}
 		}
@@ -1086,7 +1087,7 @@ func (tx *CommonJSModuleTransformer) visitTopLevelVariableStatement(node *ast.Va
 		commitPendingVariables()
 		commitPendingExpressions()
 		statements = tx.appendExportsOfVariableStatement(statements, node)
-		return singleOrMany(statements, tx.factory)
+		return transformers.SingleOrMany(statements, tx.Factory())
 	}
 	return tx.visitTopLevelNestedVariableStatement(node)
 }
@@ -1095,9 +1096,9 @@ func (tx *CommonJSModuleTransformer) visitTopLevelVariableStatement(node *ast.Va
 // exported with `export {}`.
 func (tx *CommonJSModuleTransformer) visitTopLevelNestedVariableStatement(node *ast.VariableStatement) *ast.Node {
 	var statements []*ast.Statement
-	statements = append(statements, tx.visitor.VisitEachChild(node.AsNode()))
+	statements = append(statements, tx.Visitor().VisitEachChild(node.AsNode()))
 	statements = tx.appendExportsOfVariableStatement(statements, node)
-	return singleOrMany(statements, tx.factory)
+	return transformers.SingleOrMany(statements, tx.Factory())
 }
 
 // Visits a top-level nested `for` statement as it may contain `var` declarations that are hoisted and may still be
@@ -1116,29 +1117,29 @@ func (tx *CommonJSModuleTransformer) visitTopLevelNestedForStatement(node *ast.F
 
 			var statements []*ast.Statement
 			varDeclList := tx.discardedValueVisitor.VisitNode(node.Initializer)
-			varStatement := tx.factory.NewVariableStatement(nil /*modifiers*/, varDeclList)
+			varStatement := tx.Factory().NewVariableStatement(nil /*modifiers*/, varDeclList)
 			statements = append(statements, varStatement)
 			statements = append(statements, exportStatements...)
 
-			condition := tx.visitor.VisitNode(node.Condition)
+			condition := tx.Visitor().VisitNode(node.Condition)
 			incrementor := tx.discardedValueVisitor.VisitNode(node.Incrementor)
-			body := tx.emitContext.VisitIterationBody(node.Statement, tx.topLevelNestedVisitor)
-			statements = append(statements, tx.factory.UpdateForStatement(
+			body := tx.EmitContext().VisitIterationBody(node.Statement, tx.topLevelNestedVisitor)
+			statements = append(statements, tx.Factory().UpdateForStatement(
 				node,
 				nil, /*initializer*/
 				condition,
 				incrementor,
 				body,
 			))
-			return singleOrMany(statements, tx.factory)
+			return transformers.SingleOrMany(statements, tx.Factory())
 		}
 	}
-	return tx.factory.UpdateForStatement(
+	return tx.Factory().UpdateForStatement(
 		node,
 		tx.discardedValueVisitor.VisitNode(node.Initializer),
-		tx.visitor.VisitNode(node.Condition),
+		tx.Visitor().VisitNode(node.Condition),
 		tx.discardedValueVisitor.VisitNode(node.Incrementor),
-		tx.emitContext.VisitIterationBody(node.Statement, tx.topLevelNestedVisitor),
+		tx.EmitContext().VisitIterationBody(node.Statement, tx.topLevelNestedVisitor),
 	)
 }
 
@@ -1160,54 +1161,54 @@ func (tx *CommonJSModuleTransformer) visitTopLevelNestedForInOrOfStatement(node 
 			//   }
 
 			initializer := tx.discardedValueVisitor.VisitNode(node.Initializer)
-			expression := tx.visitor.VisitNode(node.Expression)
-			body := tx.emitContext.VisitIterationBody(node.Statement, tx.topLevelNestedVisitor)
+			expression := tx.Visitor().VisitNode(node.Expression)
+			body := tx.EmitContext().VisitIterationBody(node.Statement, tx.topLevelNestedVisitor)
 			if ast.IsBlock(body) {
 				block := body.AsBlock()
 				bodyStatements := append(exportStatements, block.Statements.Nodes...)
-				bodyStatementList := tx.factory.NewNodeList(bodyStatements)
+				bodyStatementList := tx.Factory().NewNodeList(bodyStatements)
 				bodyStatementList.Loc = block.Statements.Loc
-				body = tx.factory.UpdateBlock(block, bodyStatementList)
+				body = tx.Factory().UpdateBlock(block, bodyStatementList)
 			} else {
 				bodyStatements := append(exportStatements, body)
-				body = tx.factory.NewBlock(tx.factory.NewNodeList(bodyStatements), true /*multiLine*/)
+				body = tx.Factory().NewBlock(tx.Factory().NewNodeList(bodyStatements), true /*multiLine*/)
 			}
-			return tx.factory.UpdateForInOrOfStatement(node, node.AwaitModifier, initializer, expression, body)
+			return tx.Factory().UpdateForInOrOfStatement(node, node.AwaitModifier, initializer, expression, body)
 		}
 	}
-	return tx.factory.UpdateForInOrOfStatement(
+	return tx.Factory().UpdateForInOrOfStatement(
 		node,
 		node.AwaitModifier,
 		tx.discardedValueVisitor.VisitNode(node.Initializer),
-		tx.visitor.VisitNode(node.Expression),
-		tx.emitContext.VisitIterationBody(node.Statement, tx.topLevelNestedVisitor),
+		tx.Visitor().VisitNode(node.Expression),
+		tx.EmitContext().VisitIterationBody(node.Statement, tx.topLevelNestedVisitor),
 	)
 }
 
 // Visits a top-level nested `do` statement as it may contain `var` declarations that are hoisted and may still be
 // exported with `export {}`.
 func (tx *CommonJSModuleTransformer) visitTopLevelNestedDoStatement(node *ast.DoStatement) *ast.Node {
-	return tx.factory.UpdateDoStatement(
+	return tx.Factory().UpdateDoStatement(
 		node,
-		tx.emitContext.VisitIterationBody(node.Statement, tx.topLevelNestedVisitor),
-		tx.visitor.VisitNode(node.Expression),
+		tx.EmitContext().VisitIterationBody(node.Statement, tx.topLevelNestedVisitor),
+		tx.Visitor().VisitNode(node.Expression),
 	)
 }
 
 // Visits a top-level nested `while` statement as it may contain `var` declarations that are hoisted and may still be
 // exported with `export {}`.
 func (tx *CommonJSModuleTransformer) visitTopLevelNestedWhileStatement(node *ast.WhileStatement) *ast.Node {
-	return tx.factory.UpdateWhileStatement(
+	return tx.Factory().UpdateWhileStatement(
 		node,
-		tx.visitor.VisitNode(node.Expression),
-		tx.emitContext.VisitIterationBody(node.Statement, tx.topLevelNestedVisitor),
+		tx.Visitor().VisitNode(node.Expression),
+		tx.EmitContext().VisitIterationBody(node.Statement, tx.topLevelNestedVisitor),
 	)
 }
 
 // Visits a top-level nested labeled statement as it may contain `var` declarations that are hoisted and may still be
 // exported with `export {}`.
 func (tx *CommonJSModuleTransformer) visitTopLevelNestedLabeledStatement(node *ast.LabeledStatement) *ast.Node {
-	return tx.factory.UpdateLabeledStatement(
+	return tx.Factory().UpdateLabeledStatement(
 		node,
 		node.Label,
 		tx.topLevelNestedVisitor.VisitEmbeddedStatement(node.Statement),
@@ -1217,9 +1218,9 @@ func (tx *CommonJSModuleTransformer) visitTopLevelNestedLabeledStatement(node *a
 // Visits a top-level nested `with` statement as it may contain `var` declarations that are hoisted and may still be
 // exported with `export {}`.
 func (tx *CommonJSModuleTransformer) visitTopLevelNestedWithStatement(node *ast.WithStatement) *ast.Node {
-	return tx.factory.UpdateWithStatement(
+	return tx.Factory().UpdateWithStatement(
 		node,
-		tx.visitor.VisitNode(node.Expression),
+		tx.Visitor().VisitNode(node.Expression),
 		tx.topLevelNestedVisitor.VisitEmbeddedStatement(node.Statement),
 	)
 }
@@ -1227,9 +1228,9 @@ func (tx *CommonJSModuleTransformer) visitTopLevelNestedWithStatement(node *ast.
 // Visits a top-level nested `if` statement as it may contain `var` declarations that are hoisted and may still be
 // exported with `export {}`.
 func (tx *CommonJSModuleTransformer) visitTopLevelNestedIfStatement(node *ast.IfStatement) *ast.Node {
-	return tx.factory.UpdateIfStatement(
+	return tx.Factory().UpdateIfStatement(
 		node,
-		tx.visitor.VisitNode(node.Expression),
+		tx.Visitor().VisitNode(node.Expression),
 		tx.topLevelNestedVisitor.VisitEmbeddedStatement(node.ThenStatement),
 		tx.topLevelNestedVisitor.VisitEmbeddedStatement(node.ElseStatement),
 	)
@@ -1238,9 +1239,9 @@ func (tx *CommonJSModuleTransformer) visitTopLevelNestedIfStatement(node *ast.If
 // Visits a top-level nested `switch` statement as it may contain `var` declarations that are hoisted and may still be
 // exported with `export {}`.
 func (tx *CommonJSModuleTransformer) visitTopLevelNestedSwitchStatement(node *ast.SwitchStatement) *ast.Node {
-	return tx.factory.UpdateSwitchStatement(
+	return tx.Factory().UpdateSwitchStatement(
 		node,
-		tx.visitor.VisitNode(node.Expression),
+		tx.Visitor().VisitNode(node.Expression),
 		tx.topLevelNestedVisitor.VisitNode(node.CaseBlock),
 	)
 }
@@ -1254,9 +1255,9 @@ func (tx *CommonJSModuleTransformer) visitTopLevelNestedCaseBlock(node *ast.Case
 // Visits a top-level nested `case` or `default` clause as it may contain `var` declarations that are hoisted and may
 // still be exported with `export {}`.
 func (tx *CommonJSModuleTransformer) visitTopLevelNestedCaseOrDefaultClause(node *ast.CaseOrDefaultClause) *ast.Node {
-	return tx.factory.UpdateCaseOrDefaultClause(
+	return tx.Factory().UpdateCaseOrDefaultClause(
 		node,
-		tx.visitor.VisitNode(node.Expression),
+		tx.Visitor().VisitNode(node.Expression),
 		tx.topLevelNestedVisitor.VisitNodes(node.Statements),
 	)
 }
@@ -1270,7 +1271,7 @@ func (tx *CommonJSModuleTransformer) visitTopLevelNestedTryStatement(node *ast.T
 // Visits a top-level nested `catch` clause as it may contain `var` declarations that are hoisted and may still be
 // exported with `export {}`.
 func (tx *CommonJSModuleTransformer) visitTopLevelNestedCatchClause(node *ast.CatchClause) *ast.Node {
-	return tx.factory.UpdateCatchClause(
+	return tx.Factory().UpdateCatchClause(
 		node,
 		node.VariableDeclaration,
 		tx.topLevelNestedVisitor.VisitNode(node.Block),
@@ -1284,22 +1285,22 @@ func (tx *CommonJSModuleTransformer) visitTopLevelNestedBlock(node *ast.Block) *
 }
 
 func (tx *CommonJSModuleTransformer) visitForStatement(node *ast.ForStatement) *ast.Node {
-	return tx.factory.UpdateForStatement(
+	return tx.Factory().UpdateForStatement(
 		node,
 		tx.discardedValueVisitor.VisitNode(node.Initializer),
-		tx.visitor.VisitNode(node.Condition),
+		tx.Visitor().VisitNode(node.Condition),
 		tx.discardedValueVisitor.VisitNode(node.Incrementor),
-		tx.emitContext.VisitIterationBody(node.Statement, tx.topLevelNestedVisitor),
+		tx.EmitContext().VisitIterationBody(node.Statement, tx.topLevelNestedVisitor),
 	)
 }
 
 func (tx *CommonJSModuleTransformer) visitForInOrOfStatement(node *ast.ForInOrOfStatement) *ast.Node {
-	return tx.factory.UpdateForInOrOfStatement(
+	return tx.Factory().UpdateForInOrOfStatement(
 		node,
 		node.AwaitModifier,
 		tx.discardedValueVisitor.VisitNode(node.Initializer),
-		tx.visitor.VisitNode(node.Expression),
-		tx.emitContext.VisitIterationBody(node.Statement, tx.topLevelNestedVisitor),
+		tx.Visitor().VisitNode(node.Expression),
+		tx.EmitContext().VisitIterationBody(node.Statement, tx.topLevelNestedVisitor),
 	)
 }
 
@@ -1315,14 +1316,14 @@ func (tx *CommonJSModuleTransformer) visitVoidExpression(node *ast.VoidExpressio
 
 // Visits a parenthesized expression whose value may be discarded at runtime.
 func (tx *CommonJSModuleTransformer) visitParenthesizedExpression(node *ast.ParenthesizedExpression, resultIsDiscarded bool) *ast.Node {
-	expression := core.IfElse(resultIsDiscarded, tx.discardedValueVisitor, tx.visitor).VisitNode(node.Expression)
-	return tx.factory.UpdateParenthesizedExpression(node, expression)
+	expression := core.IfElse(resultIsDiscarded, tx.discardedValueVisitor, tx.Visitor()).VisitNode(node.Expression)
+	return tx.Factory().UpdateParenthesizedExpression(node, expression)
 }
 
 // Visits a partially emitted expression whose value may be discarded at runtime.
 func (tx *CommonJSModuleTransformer) visitPartiallyEmittedExpression(node *ast.PartiallyEmittedExpression, resultIsDiscarded bool) *ast.Node {
-	expression := core.IfElse(resultIsDiscarded, tx.discardedValueVisitor, tx.visitor).VisitNode(node.Expression)
-	return tx.factory.UpdatePartiallyEmittedExpression(node, expression)
+	expression := core.IfElse(resultIsDiscarded, tx.discardedValueVisitor, tx.Visitor()).VisitNode(node.Expression)
+	return tx.Factory().UpdatePartiallyEmittedExpression(node, expression)
 }
 
 // Visits a binary expression whose value may be discarded, or which might contain an assignment to an exported
@@ -1336,7 +1337,7 @@ func (tx *CommonJSModuleTransformer) visitBinaryExpression(node *ast.BinaryExpre
 		return tx.visitCommaExpression(node, resultIsDiscarded)
 	}
 
-	return tx.visitor.VisitEachChild(node.AsNode())
+	return tx.Visitor().VisitEachChild(node.AsNode())
 }
 
 func (tx *CommonJSModuleTransformer) visitAssignmentExpression(node *ast.BinaryExpression) *ast.Node {
@@ -1351,12 +1352,12 @@ func (tx *CommonJSModuleTransformer) visitAssignmentExpression(node *ast.BinaryE
 	// - We do not transform identifiers tagged with the LocalName flag.
 	// - We only transform identifiers that are exported at the top level.
 	if ast.IsIdentifier(node.Left) &&
-		(!isGeneratedIdentifier(tx.emitContext, node.Left) || isFileLevelReservedGeneratedIdentifier(tx.emitContext, node.Left)) &&
-		!isLocalName(tx.emitContext, node.Left) {
+		(!transformers.IsGeneratedIdentifier(tx.EmitContext(), node.Left) || isFileLevelReservedGeneratedIdentifier(tx.EmitContext(), node.Left)) &&
+		!transformers.IsLocalName(tx.EmitContext(), node.Left) {
 		exportedNames := tx.getExports(node.Left)
 		if len(exportedNames) > 0 {
 			// For each additional export of the declaration, apply an export assignment.
-			expression := tx.visitor.VisitEachChild(node.AsNode())
+			expression := tx.Visitor().VisitEachChild(node.AsNode())
 			for _, exportName := range exportedNames {
 				expression = tx.createExportExpression(exportName, expression, &node.Loc /*location*/, false /*liveBinding*/)
 			}
@@ -1364,26 +1365,26 @@ func (tx *CommonJSModuleTransformer) visitAssignmentExpression(node *ast.BinaryE
 		}
 	}
 
-	return tx.visitor.VisitEachChild(node.AsNode())
+	return tx.Visitor().VisitEachChild(node.AsNode())
 }
 
 // Visits a destructuring assignment which might target an exported identifier.
 func (tx *CommonJSModuleTransformer) visitDestructuringAssignment(node *ast.BinaryExpression) *ast.Node {
-	return tx.factory.UpdateBinaryExpression(
+	return tx.Factory().UpdateBinaryExpression(
 		node,
 		nil, /*modifiers*/
 		tx.assignmentPatternVisitor.VisitNode(node.Left),
 		nil, /*typeNode*/
 		node.OperatorToken,
-		tx.visitor.VisitNode(node.Right),
+		tx.Visitor().VisitNode(node.Right),
 	)
 }
 
 func (tx *CommonJSModuleTransformer) visitAssignmentProperty(node *ast.PropertyAssignment) *ast.Node {
-	return tx.factory.UpdatePropertyAssignment(
+	return tx.Factory().UpdatePropertyAssignment(
 		node,
 		nil, /*modifiers*/
-		tx.visitor.VisitNode(node.Name()),
+		tx.Visitor().VisitNode(node.Name()),
 		nil, /*postfixToken*/
 		nil, /*typeNode*/
 		tx.assignmentPatternVisitor.VisitNode(node.Initializer),
@@ -1393,50 +1394,50 @@ func (tx *CommonJSModuleTransformer) visitAssignmentProperty(node *ast.PropertyA
 func (tx *CommonJSModuleTransformer) visitShorthandAssignmentProperty(node *ast.ShorthandPropertyAssignment) *ast.Node {
 	target := tx.visitDestructuringAssignmentTargetNoStack(node.Name())
 	if ast.IsIdentifier(target) {
-		return tx.factory.UpdateShorthandPropertyAssignment(
+		return tx.Factory().UpdateShorthandPropertyAssignment(
 			node,
 			nil, /*modifiers*/
 			target,
 			nil, /*postfixToken*/
 			nil, /*typeNode*/
 			node.EqualsToken,
-			tx.visitor.VisitNode(node.ObjectAssignmentInitializer),
+			tx.Visitor().VisitNode(node.ObjectAssignmentInitializer),
 		)
 	}
 	if node.ObjectAssignmentInitializer != nil {
 		equalsToken := node.EqualsToken
 		if equalsToken == nil {
-			equalsToken = tx.factory.NewToken(ast.KindEqualsToken)
+			equalsToken = tx.Factory().NewToken(ast.KindEqualsToken)
 		}
-		target = tx.factory.NewBinaryExpression(
+		target = tx.Factory().NewBinaryExpression(
 			nil, /*modifiers*/
 			target,
 			nil, /*typeNode*/
 			equalsToken,
-			tx.visitor.VisitNode(node.ObjectAssignmentInitializer),
+			tx.Visitor().VisitNode(node.ObjectAssignmentInitializer),
 		)
 	}
-	updated := tx.factory.NewPropertyAssignment(
+	updated := tx.Factory().NewPropertyAssignment(
 		nil, /*modifiers*/
 		node.Name(),
 		nil, /*postfixToken*/
 		nil, /*typeNode*/
 		target,
 	)
-	tx.emitContext.SetOriginal(updated, node.AsNode())
-	tx.emitContext.AssignCommentAndSourceMapRanges(updated, node.AsNode())
+	tx.EmitContext().SetOriginal(updated, node.AsNode())
+	tx.EmitContext().AssignCommentAndSourceMapRanges(updated, node.AsNode())
 	return updated
 }
 
 func (tx *CommonJSModuleTransformer) visitAssignmentRestProperty(node *ast.SpreadAssignment) *ast.Node {
-	return tx.factory.UpdateSpreadAssignment(
+	return tx.Factory().UpdateSpreadAssignment(
 		node,
 		tx.visitDestructuringAssignmentTarget(node.Expression),
 	)
 }
 
 func (tx *CommonJSModuleTransformer) visitAssignmentRestElement(node *ast.SpreadElement) *ast.Node {
-	return tx.factory.UpdateSpreadElement(
+	return tx.Factory().UpdateSpreadElement(
 		node,
 		tx.visitDestructuringAssignmentTarget(node.Expression),
 	)
@@ -1446,13 +1447,13 @@ func (tx *CommonJSModuleTransformer) visitAssignmentElement(node *ast.Node) *ast
 	if ast.IsBinaryExpression(node) {
 		n := node.AsBinaryExpression()
 		if n.OperatorToken.Kind == ast.KindEqualsToken {
-			return tx.factory.UpdateBinaryExpression(
+			return tx.Factory().UpdateBinaryExpression(
 				n,
 				nil, /*modifiers*/
 				tx.visitDestructuringAssignmentTarget(n.Left),
 				nil, /*typeNode*/
 				n.OperatorToken,
-				tx.visitor.VisitNode(n.Right),
+				tx.Visitor().VisitNode(n.Right),
 			)
 		}
 	}
@@ -1475,8 +1476,8 @@ func (tx *CommonJSModuleTransformer) visitDestructuringAssignmentTarget(node *as
 
 func (tx *CommonJSModuleTransformer) visitDestructuringAssignmentTargetNoStack(node *ast.Node) *ast.Node {
 	if ast.IsIdentifier(node) &&
-		(!isGeneratedIdentifier(tx.emitContext, node) || isFileLevelReservedGeneratedIdentifier(tx.emitContext, node)) &&
-		!isLocalName(tx.emitContext, node) {
+		(!transformers.IsGeneratedIdentifier(tx.EmitContext(), node) || isFileLevelReservedGeneratedIdentifier(tx.EmitContext(), node)) &&
+		!transformers.IsLocalName(tx.EmitContext(), node) {
 		expression := tx.visitExpressionIdentifier(node)
 		exportedNames := tx.getExports(node)
 		if len(exportedNames) > 0 {
@@ -1487,18 +1488,18 @@ func (tx *CommonJSModuleTransformer) visitDestructuringAssignmentTargetNoStack(n
 			// to:
 			//  { x: { set value(v) { exports.x = x = v; } }.value } = y
 
-			value := tx.factory.NewUniqueNameEx("value", printer.AutoGenerateOptions{
+			value := tx.Factory().NewUniqueNameEx("value", printer.AutoGenerateOptions{
 				Flags: printer.GeneratedIdentifierFlagsOptimistic,
 			})
-			expression = tx.factory.NewAssignmentExpression(expression, value)
+			expression = tx.Factory().NewAssignmentExpression(expression, value)
 
 			for _, exportName := range exportedNames {
 				expression = tx.createExportExpression(exportName, expression, nil /*location*/, false /*liveBinding*/)
 			}
 
-			statement := tx.factory.NewExpressionStatement(expression)
-			statementList := tx.factory.NewNodeList([]*ast.Node{statement})
-			param := tx.factory.NewParameterDeclaration(
+			statement := tx.Factory().NewExpressionStatement(expression)
+			statementList := tx.Factory().NewNodeList([]*ast.Node{statement})
+			param := tx.Factory().NewParameterDeclaration(
 				nil, /*modifiers*/
 				nil, /*dotDotDotToken*/
 				value,
@@ -1506,17 +1507,17 @@ func (tx *CommonJSModuleTransformer) visitDestructuringAssignmentTargetNoStack(n
 				nil, /*type*/
 				nil, /*initializer*/
 			)
-			valueSetter := tx.factory.NewSetAccessorDeclaration(
+			valueSetter := tx.Factory().NewSetAccessorDeclaration(
 				nil, /*modifiers*/
-				tx.factory.NewIdentifier("value"),
+				tx.Factory().NewIdentifier("value"),
 				nil, /*typeParameters*/
-				tx.factory.NewNodeList([]*ast.Node{param}),
+				tx.Factory().NewNodeList([]*ast.Node{param}),
 				nil, /*returnType*/
-				tx.factory.NewBlock(statementList, false /*multiLine*/),
+				tx.Factory().NewBlock(statementList, false /*multiLine*/),
 			)
-			propertyList := tx.factory.NewNodeList([]*ast.Node{valueSetter})
-			expression = tx.factory.NewObjectLiteralExpression(propertyList, false /*multiLine*/)
-			expression = tx.factory.NewPropertyAccessExpression(expression, nil /*questionDotToken*/, tx.factory.NewIdentifier("value"), ast.NodeFlagsNone)
+			propertyList := tx.Factory().NewNodeList([]*ast.Node{valueSetter})
+			expression = tx.Factory().NewObjectLiteralExpression(propertyList, false /*multiLine*/)
+			expression = tx.Factory().NewPropertyAccessExpression(expression, nil /*questionDotToken*/, tx.Factory().NewIdentifier("value"), ast.NodeFlagsNone)
 		}
 		return expression
 	}
@@ -1527,8 +1528,8 @@ func (tx *CommonJSModuleTransformer) visitDestructuringAssignmentTargetNoStack(n
 // Visits a comma expression whose left-hand value is always discard, and whose right-hand value may be discarded at runtime.
 func (tx *CommonJSModuleTransformer) visitCommaExpression(node *ast.BinaryExpression, resultIsDiscarded bool) *ast.Node {
 	left := tx.discardedValueVisitor.VisitNode(node.Left)
-	right := core.IfElse(resultIsDiscarded, tx.discardedValueVisitor, tx.visitor).VisitNode(node.Right)
-	return tx.factory.UpdateBinaryExpression(node, nil /*modifiers*/, left, nil /*typeNode*/, node.OperatorToken, right)
+	right := core.IfElse(resultIsDiscarded, tx.discardedValueVisitor, tx.Visitor()).VisitNode(node.Right)
+	return tx.Factory().UpdateBinaryExpression(node, nil /*modifiers*/, left, nil /*typeNode*/, node.OperatorToken, right)
 }
 
 // Visits a prefix unary expression that might modify an exported identifier.
@@ -1544,7 +1545,7 @@ func (tx *CommonJSModuleTransformer) visitPrefixUnaryExpression(node *ast.Prefix
 	// - We only transform identifiers that are exported at the top level.
 	if (node.Operator == ast.KindPlusPlusToken || node.Operator == ast.KindMinusMinusToken) &&
 		ast.IsIdentifier(node.Operand) &&
-		!isLocalName(tx.emitContext, node.Operand) {
+		!transformers.IsLocalName(tx.EmitContext(), node.Operand) {
 		exportedNames := tx.getExports(node.Operand)
 		if len(exportedNames) > 0 {
 			// given:
@@ -1558,15 +1559,15 @@ func (tx *CommonJSModuleTransformer) visitPrefixUnaryExpression(node *ast.Prefix
 			// note:
 			//   after the operation, `exports.x` will hold the value of `x` after the increment.
 
-			expression := tx.factory.UpdatePrefixUnaryExpression(node, tx.visitor.VisitNode(node.Operand))
+			expression := tx.Factory().UpdatePrefixUnaryExpression(node, tx.Visitor().VisitNode(node.Operand))
 			for _, exportName := range exportedNames {
 				expression = tx.createExportExpression(exportName, expression, nil /*location*/, false /*liveBinding*/)
-				tx.emitContext.AssignCommentAndSourceMapRanges(expression, node.AsNode())
+				tx.EmitContext().AssignCommentAndSourceMapRanges(expression, node.AsNode())
 			}
 			return expression
 		}
 	}
-	return tx.visitor.VisitEachChild(node.AsNode())
+	return tx.Visitor().VisitEachChild(node.AsNode())
 }
 
 // Visits a postfix unary expression that might modify an exported identifier.
@@ -1582,7 +1583,7 @@ func (tx *CommonJSModuleTransformer) visitPostfixUnaryExpression(node *ast.Postf
 	// - We only transform identifiers that are exported at the top level.
 	if (node.Operator == ast.KindPlusPlusToken || node.Operator == ast.KindMinusMinusToken) &&
 		ast.IsIdentifier(node.Operand) &&
-		!isLocalName(tx.emitContext, node.Operand) {
+		!transformers.IsLocalName(tx.EmitContext(), node.Operand) {
 		exportedNames := tx.getExports(node.Operand)
 		if len(exportedNames) > 0 {
 			// given (value is discarded):
@@ -1610,33 +1611,33 @@ func (tx *CommonJSModuleTransformer) visitPostfixUnaryExpression(node *ast.Postf
 			//   `y` will hold the value of `x` before the increment.
 
 			var temp *ast.IdentifierNode
-			expression := tx.factory.UpdatePostfixUnaryExpression(node, tx.visitor.VisitNode(node.Operand))
+			expression := tx.Factory().UpdatePostfixUnaryExpression(node, tx.Visitor().VisitNode(node.Operand))
 			if !resultIsDiscarded {
-				temp = tx.factory.NewTempVariable()
-				tx.emitContext.AddVariableDeclaration(temp)
+				temp = tx.Factory().NewTempVariable()
+				tx.EmitContext().AddVariableDeclaration(temp)
 
-				expression = tx.factory.NewAssignmentExpression(temp, expression)
-				tx.emitContext.AssignCommentAndSourceMapRanges(expression, node.AsNode())
+				expression = tx.Factory().NewAssignmentExpression(temp, expression)
+				tx.EmitContext().AssignCommentAndSourceMapRanges(expression, node.AsNode())
 			}
 
-			expression = tx.factory.NewCommaExpression(expression, node.Operand.Clone(tx.factory))
-			tx.emitContext.AssignCommentAndSourceMapRanges(expression, node.AsNode())
+			expression = tx.Factory().NewCommaExpression(expression, node.Operand.Clone(tx.Factory()))
+			tx.EmitContext().AssignCommentAndSourceMapRanges(expression, node.AsNode())
 
 			for _, exportName := range exportedNames {
 				expression = tx.createExportExpression(exportName, expression, nil /*location*/, false /*liveBinding*/)
-				tx.emitContext.AssignCommentAndSourceMapRanges(expression, node.AsNode())
+				tx.EmitContext().AssignCommentAndSourceMapRanges(expression, node.AsNode())
 			}
 
 			if temp != nil {
-				expression = tx.factory.NewCommaExpression(expression, temp.AsNode())
-				tx.emitContext.AssignCommentAndSourceMapRanges(expression, node.AsNode())
+				expression = tx.Factory().NewCommaExpression(expression, temp.AsNode())
+				tx.EmitContext().AssignCommentAndSourceMapRanges(expression, node.AsNode())
 			}
 
 			return expression
 		}
 	}
 
-	return tx.visitor.VisitEachChild(node.AsNode())
+	return tx.Visitor().VisitEachChild(node.AsNode())
 }
 
 // Visits a call expression that might reference an imported symbol and thus require an indirect call, or that might
@@ -1656,8 +1657,8 @@ func (tx *CommonJSModuleTransformer) visitCallExpression(node *ast.CallExpressio
 		return tx.shimOrRewriteImportOrRequireCall(node.AsCallExpression())
 	}
 	if ast.IsIdentifier(node.Expression) &&
-		!isGeneratedIdentifier(tx.emitContext, node.Expression) &&
-		!isHelperName(tx.emitContext, node.Expression) {
+		!transformers.IsGeneratedIdentifier(tx.EmitContext(), node.Expression) &&
+		!transformers.IsHelperName(tx.EmitContext(), node.Expression) {
 		// given:
 		//   import { f } from "mod";
 		//   f();
@@ -1667,19 +1668,19 @@ func (tx *CommonJSModuleTransformer) visitCallExpression(node *ast.CallExpressio
 		// note:
 		//   the indirect call is applied by the printer by way of the `EFIndirectCall` emit flag.
 		expression := tx.visitExpressionIdentifier(node.Expression)
-		updated := tx.factory.UpdateCallExpression(
+		updated := tx.Factory().UpdateCallExpression(
 			node,
 			expression,
 			node.QuestionDotToken,
 			nil, /*typeArguments*/
-			tx.visitor.VisitNodes(node.Arguments),
+			tx.Visitor().VisitNodes(node.Arguments),
 		)
 		if !ast.IsIdentifier(expression) {
-			tx.emitContext.AddEmitFlags(updated, printer.EFIndirectCall)
+			tx.EmitContext().AddEmitFlags(updated, printer.EFIndirectCall)
 		}
 		return updated
 	}
-	return tx.visitor.VisitEachChild(node.AsNode())
+	return tx.Visitor().VisitEachChild(node.AsNode())
 }
 
 func (tx *CommonJSModuleTransformer) shouldTransformImportCall() bool {
@@ -1688,11 +1689,11 @@ func (tx *CommonJSModuleTransformer) shouldTransformImportCall() bool {
 
 func (tx *CommonJSModuleTransformer) visitImportCallExpression(node *ast.CallExpression, rewriteOrShim bool) *ast.Node {
 	if tx.moduleKind == core.ModuleKindNone && tx.languageVersion >= core.ScriptTargetES2020 {
-		return tx.visitor.VisitEachChild(node.AsNode())
+		return tx.Visitor().VisitEachChild(node.AsNode())
 	}
 
-	externalModuleName := getExternalModuleNameLiteral(tx.factory, node.AsNode(), tx.currentSourceFile, nil /*host*/, nil /*resolver*/, tx.compilerOptions)
-	firstArgument := tx.visitor.VisitNode(core.FirstOrNil(node.Arguments.Nodes))
+	externalModuleName := getExternalModuleNameLiteral(tx.Factory(), node.AsNode(), tx.currentSourceFile, nil /*host*/, nil /*resolver*/, tx.compilerOptions)
+	firstArgument := tx.Visitor().VisitNode(core.FirstOrNil(node.Arguments.Nodes))
 
 	// Only use the external module name if it differs from the first argument. This allows us to preserve the quote style of the argument on output.
 	var argument *ast.Expression
@@ -1700,9 +1701,9 @@ func (tx *CommonJSModuleTransformer) visitImportCallExpression(node *ast.CallExp
 		argument = externalModuleName
 	} else if firstArgument != nil && rewriteOrShim {
 		if ast.IsStringLiteral(firstArgument) {
-			argument = rewriteModuleSpecifier(tx.emitContext, firstArgument, tx.compilerOptions)
+			argument = rewriteModuleSpecifier(tx.EmitContext(), firstArgument, tx.compilerOptions)
 		} else {
-			argument = tx.factory.NewRewriteRelativeImportExtensionsHelper(firstArgument, tx.compilerOptions.Jsx == core.JsxEmitPreserve)
+			argument = tx.Factory().NewRewriteRelativeImportExtensionsHelper(firstArgument, tx.compilerOptions.Jsx == core.JsxEmitPreserve)
 		}
 	} else {
 		argument = firstArgument
@@ -1724,55 +1725,55 @@ func (tx *CommonJSModuleTransformer) createImportCallExpressionCommonJS(arg *ast
 	var promiseResolveArguments []*ast.Expression
 	if needSyncEval {
 		promiseResolveArguments = []*ast.Expression{
-			tx.factory.NewTemplateExpression(
-				tx.factory.NewTemplateHead("", "", ast.TokenFlagsNone),
-				tx.factory.NewNodeList([]*ast.TemplateSpanNode{
-					tx.factory.NewTemplateSpan(arg, tx.factory.NewTemplateTail("", "", ast.TokenFlagsNone)),
+			tx.Factory().NewTemplateExpression(
+				tx.Factory().NewTemplateHead("", "", ast.TokenFlagsNone),
+				tx.Factory().NewNodeList([]*ast.TemplateSpanNode{
+					tx.Factory().NewTemplateSpan(arg, tx.Factory().NewTemplateTail("", "", ast.TokenFlagsNone)),
 				}),
 			),
 		}
 	}
-	promiseResolveCall := tx.factory.NewCallExpression(
-		tx.factory.NewPropertyAccessExpression(
-			tx.factory.NewIdentifier("Promise"),
+	promiseResolveCall := tx.Factory().NewCallExpression(
+		tx.Factory().NewPropertyAccessExpression(
+			tx.Factory().NewIdentifier("Promise"),
 			nil, /*questionDotToken*/
-			tx.factory.NewIdentifier("resolve"),
+			tx.Factory().NewIdentifier("resolve"),
 			ast.NodeFlagsNone,
 		),
 		nil, /*questionDotToken*/
 		nil, /*typeArguments*/
-		tx.factory.NewNodeList(promiseResolveArguments),
+		tx.Factory().NewNodeList(promiseResolveArguments),
 		ast.NodeFlagsNone,
 	)
 
 	var requireArguments []*ast.Expression
 	if needSyncEval {
 		requireArguments = []*ast.Expression{
-			tx.factory.NewIdentifier("s"),
+			tx.Factory().NewIdentifier("s"),
 		}
 	} else if arg != nil {
 		requireArguments = []*ast.Expression{arg}
 	}
 
-	requireCall := tx.factory.NewCallExpression(
-		tx.factory.NewIdentifier("require"),
+	requireCall := tx.Factory().NewCallExpression(
+		tx.Factory().NewIdentifier("require"),
 		nil, /*questionDotToken*/
 		nil, /*typeArguments*/
-		tx.factory.NewNodeList(requireArguments),
+		tx.Factory().NewNodeList(requireArguments),
 		ast.NodeFlagsNone,
 	)
 
 	if tx.compilerOptions.GetESModuleInterop() {
-		requireCall = tx.factory.NewImportStarHelper(requireCall)
+		requireCall = tx.Factory().NewImportStarHelper(requireCall)
 	}
 
 	var parameters []*ast.ParameterDeclarationNode
 	if needSyncEval {
 		parameters = []*ast.ParameterDeclarationNode{
-			tx.factory.NewParameterDeclaration(
+			tx.Factory().NewParameterDeclaration(
 				nil, /*modifiers*/
 				nil, /*dotDotDotToken*/
-				tx.factory.NewIdentifier("s"),
+				tx.Factory().NewIdentifier("s"),
 				nil, /*questionToken*/
 				nil, /*type*/
 				nil, /*initializer*/
@@ -1780,54 +1781,54 @@ func (tx *CommonJSModuleTransformer) createImportCallExpressionCommonJS(arg *ast
 		}
 	}
 
-	function := tx.factory.NewArrowFunction(
+	function := tx.Factory().NewArrowFunction(
 		nil, /*modifiers*/
 		nil, /*typeParameters*/
-		tx.factory.NewNodeList(parameters),
+		tx.Factory().NewNodeList(parameters),
 		nil, /*type*/
-		tx.factory.NewToken(ast.KindEqualsGreaterThanToken), /*equalsGreaterThanToken*/
+		tx.Factory().NewToken(ast.KindEqualsGreaterThanToken), /*equalsGreaterThanToken*/
 		requireCall,
 	)
 
-	downleveledImport := tx.factory.NewCallExpression(
-		tx.factory.NewPropertyAccessExpression(
+	downleveledImport := tx.Factory().NewCallExpression(
+		tx.Factory().NewPropertyAccessExpression(
 			promiseResolveCall,
 			nil, /*questionDotToken*/
-			tx.factory.NewIdentifier("then"),
+			tx.Factory().NewIdentifier("then"),
 			ast.NodeFlagsNone,
 		),
 		nil, /*questionDotToken*/
 		nil, /*typeArguments*/
-		tx.factory.NewNodeList([]*ast.Expression{function}),
+		tx.Factory().NewNodeList([]*ast.Expression{function}),
 		ast.NodeFlagsNone,
 	)
 	return downleveledImport
 }
 
 func (tx *CommonJSModuleTransformer) shimOrRewriteImportOrRequireCall(node *ast.CallExpression) *ast.Node {
-	expression := tx.visitor.VisitNode(node.Expression)
+	expression := tx.Visitor().VisitNode(node.Expression)
 	argumentsList := node.Arguments
 	if len(node.Arguments.Nodes) > 0 {
 		firstArgument := node.Arguments.Nodes[0]
 		firstArgumentChanged := false
 		if ast.IsStringLiteralLike(firstArgument) {
-			rewritten := rewriteModuleSpecifier(tx.emitContext, firstArgument, tx.compilerOptions)
+			rewritten := rewriteModuleSpecifier(tx.EmitContext(), firstArgument, tx.compilerOptions)
 			firstArgumentChanged = rewritten != firstArgument
 			firstArgument = rewritten
 		} else {
-			firstArgument = tx.factory.NewRewriteRelativeImportExtensionsHelper(firstArgument, tx.compilerOptions.Jsx == core.JsxEmitPreserve)
+			firstArgument = tx.Factory().NewRewriteRelativeImportExtensionsHelper(firstArgument, tx.compilerOptions.Jsx == core.JsxEmitPreserve)
 			firstArgumentChanged = true
 		}
 
-		rest, restChanged := tx.visitor.VisitSlice(node.Arguments.Nodes[1:])
+		rest, restChanged := tx.Visitor().VisitSlice(node.Arguments.Nodes[1:])
 		if firstArgumentChanged || restChanged {
 			arguments := append([]*ast.Expression{firstArgument}, rest...)
-			argumentsList = tx.factory.NewNodeList(arguments)
+			argumentsList = tx.Factory().NewNodeList(arguments)
 			argumentsList.Loc = node.Arguments.Loc
 		}
 	}
 
-	return tx.factory.UpdateCallExpression(
+	return tx.Factory().UpdateCallExpression(
 		node,
 		expression,
 		node.QuestionDotToken,
@@ -1838,7 +1839,7 @@ func (tx *CommonJSModuleTransformer) shimOrRewriteImportOrRequireCall(node *ast.
 
 // Visits a tagged template expression that might reference an imported symbol and thus require an indirect call.
 func (tx *CommonJSModuleTransformer) visitTaggedTemplateExpression(node *ast.TaggedTemplateExpression) *ast.Node {
-	if ast.IsIdentifier(node.Tag) && !isGeneratedIdentifier(tx.emitContext, node.Tag) && !isHelperName(tx.emitContext, node.Tag) {
+	if ast.IsIdentifier(node.Tag) && !transformers.IsGeneratedIdentifier(tx.EmitContext(), node.Tag) && !transformers.IsHelperName(tx.EmitContext(), node.Tag) {
 		// given:
 		//   import { f } from "mod";
 		//   f``;
@@ -1849,19 +1850,19 @@ func (tx *CommonJSModuleTransformer) visitTaggedTemplateExpression(node *ast.Tag
 		//   the indirect call is applied by the printer by way of the `EFIndirectCall` emit flag.
 
 		expression := tx.visitExpressionIdentifier(node.Tag)
-		updated := tx.factory.UpdateTaggedTemplateExpression(
+		updated := tx.Factory().UpdateTaggedTemplateExpression(
 			node,
 			expression,
 			nil, /*questionDotToken*/
 			nil, /*typeArguments*/
-			tx.visitor.VisitNode(node.Template),
+			tx.Visitor().VisitNode(node.Template),
 		)
 		if !ast.IsIdentifier(expression) {
-			tx.emitContext.AddEmitFlags(updated, printer.EFIndirectCall)
+			tx.EmitContext().AddEmitFlags(updated, printer.EFIndirectCall)
 		}
 		return updated
 	}
-	return tx.visitor.VisitEachChild(node.AsNode())
+	return tx.Visitor().VisitEachChild(node.AsNode())
 }
 
 // Visits a shorthand property assignment that might reference an imported or exported symbol.
@@ -1873,29 +1874,29 @@ func (tx *CommonJSModuleTransformer) visitShorthandPropertyAssignment(node *ast.
 		// destructuring assignment
 		expression := exportedOrImportedName
 		if node.ObjectAssignmentInitializer != nil {
-			expression = tx.factory.NewAssignmentExpression(
+			expression = tx.Factory().NewAssignmentExpression(
 				expression,
-				tx.visitor.VisitNode(node.ObjectAssignmentInitializer),
+				tx.Visitor().VisitNode(node.ObjectAssignmentInitializer),
 			)
 		}
-		assignment := tx.factory.NewPropertyAssignment(nil /*modifiers*/, name, nil /*postfixToken*/, nil /*typeNode*/, expression)
+		assignment := tx.Factory().NewPropertyAssignment(nil /*modifiers*/, name, nil /*postfixToken*/, nil /*typeNode*/, expression)
 		assignment.Loc = node.Loc
-		tx.emitContext.AssignCommentAndSourceMapRanges(assignment, node.AsNode())
+		tx.EmitContext().AssignCommentAndSourceMapRanges(assignment, node.AsNode())
 		return assignment
 	}
-	return tx.factory.UpdateShorthandPropertyAssignment(node,
+	return tx.Factory().UpdateShorthandPropertyAssignment(node,
 		nil, /*modifiers*/
 		exportedOrImportedName,
 		nil, /*postfixToken*/
 		nil, /*typeNode*/
 		node.EqualsToken,
-		tx.visitor.VisitNode(node.ObjectAssignmentInitializer),
+		tx.Visitor().VisitNode(node.ObjectAssignmentInitializer),
 	)
 }
 
 // Visits an identifier that, if it is in an expression position, might reference an imported or exported symbol.
 func (tx *CommonJSModuleTransformer) visitIdentifier(node *ast.IdentifierNode) *ast.Node {
-	if isIdentifierReference(node, tx.parentNode) {
+	if transformers.IsIdentifierReference(node, tx.parentNode) {
 		return tx.visitExpressionIdentifier(node)
 	}
 	return node
@@ -1903,59 +1904,59 @@ func (tx *CommonJSModuleTransformer) visitIdentifier(node *ast.IdentifierNode) *
 
 // Visits an identifier in an expression position that might reference an imported or exported symbol.
 func (tx *CommonJSModuleTransformer) visitExpressionIdentifier(node *ast.IdentifierNode) *ast.Node {
-	if info := tx.emitContext.GetAutoGenerateInfo(node); !(info != nil && !info.Flags.HasAllowNameSubstitution()) &&
-		!isHelperName(tx.emitContext, node) &&
-		!isLocalName(tx.emitContext, node) &&
-		!isDeclarationNameOfEnumOrNamespace(tx.emitContext, node) {
-		exportContainer := tx.resolver.GetReferencedExportContainer(tx.emitContext.MostOriginal(node), isExportName(tx.emitContext, node))
+	if info := tx.EmitContext().GetAutoGenerateInfo(node); !(info != nil && !info.Flags.HasAllowNameSubstitution()) &&
+		!transformers.IsHelperName(tx.EmitContext(), node) &&
+		!transformers.IsLocalName(tx.EmitContext(), node) &&
+		!isDeclarationNameOfEnumOrNamespace(tx.EmitContext(), node) {
+		exportContainer := tx.resolver.GetReferencedExportContainer(tx.EmitContext().MostOriginal(node), transformers.IsExportName(tx.EmitContext(), node))
 		if exportContainer != nil && ast.IsSourceFile(exportContainer) {
-			reference := tx.factory.NewPropertyAccessExpression(
-				tx.factory.NewIdentifier("exports"),
+			reference := tx.Factory().NewPropertyAccessExpression(
+				tx.Factory().NewIdentifier("exports"),
 				nil, /*questionDotToken*/
-				node.Clone(tx.factory),
+				node.Clone(tx.Factory()),
 				ast.NodeFlagsNone,
 			)
-			tx.emitContext.AssignCommentAndSourceMapRanges(reference, node)
+			tx.EmitContext().AssignCommentAndSourceMapRanges(reference, node)
 			reference.Loc = node.Loc
 			return reference
 		}
 
-		importDeclaration := tx.resolver.GetReferencedImportDeclaration(tx.emitContext.MostOriginal(node))
+		importDeclaration := tx.resolver.GetReferencedImportDeclaration(tx.EmitContext().MostOriginal(node))
 		if importDeclaration != nil {
 			if ast.IsImportClause(importDeclaration) {
-				reference := tx.factory.NewPropertyAccessExpression(
-					tx.factory.NewGeneratedNameForNode(importDeclaration.Parent),
+				reference := tx.Factory().NewPropertyAccessExpression(
+					tx.Factory().NewGeneratedNameForNode(importDeclaration.Parent),
 					nil, /*questionDotToken*/
-					tx.factory.NewIdentifier("default"),
+					tx.Factory().NewIdentifier("default"),
 					ast.NodeFlagsNone,
 				)
-				tx.emitContext.AssignCommentAndSourceMapRanges(reference, node)
+				tx.EmitContext().AssignCommentAndSourceMapRanges(reference, node)
 				reference.Loc = node.Loc
 				return reference
 			}
 			if ast.IsImportSpecifier(importDeclaration) {
 				name := importDeclaration.AsImportSpecifier().PropertyNameOrName()
 				decl := ast.FindAncestor(importDeclaration, ast.IsImportDeclaration)
-				target := tx.factory.NewGeneratedNameForNode(core.Coalesce(decl, importDeclaration))
+				target := tx.Factory().NewGeneratedNameForNode(core.Coalesce(decl, importDeclaration))
 				var reference *ast.Node
 				if ast.IsStringLiteral(name) {
-					reference = tx.factory.NewElementAccessExpression(
+					reference = tx.Factory().NewElementAccessExpression(
 						target,
 						nil, /*questionDotToken*/
-						tx.factory.NewStringLiteralFromNode(name),
+						tx.Factory().NewStringLiteralFromNode(name),
 						ast.NodeFlagsNone,
 					)
 				} else {
-					referenceName := name.Clone(tx.factory)
-					tx.emitContext.AddEmitFlags(referenceName, printer.EFNoSourceMap|printer.EFNoComments)
-					reference = tx.factory.NewPropertyAccessExpression(
+					referenceName := name.Clone(tx.Factory())
+					tx.EmitContext().AddEmitFlags(referenceName, printer.EFNoSourceMap|printer.EFNoComments)
+					reference = tx.Factory().NewPropertyAccessExpression(
 						target,
 						nil, /*questionDotToken*/
 						referenceName,
 						ast.NodeFlagsNone,
 					)
 				}
-				tx.emitContext.AssignCommentAndSourceMapRanges(reference, node)
+				tx.EmitContext().AssignCommentAndSourceMapRanges(reference, node)
 				reference.Loc = node.Loc
 				return reference
 			}
@@ -1966,8 +1967,8 @@ func (tx *CommonJSModuleTransformer) visitExpressionIdentifier(node *ast.Identif
 
 // Gets the exported names of an identifier, if it is exported.
 func (tx *CommonJSModuleTransformer) getExports(name *ast.IdentifierNode) []*ast.ModuleExportName {
-	if !isGeneratedIdentifier(tx.emitContext, name) {
-		importDeclaration := tx.resolver.GetReferencedImportDeclaration(tx.emitContext.MostOriginal(name))
+	if !transformers.IsGeneratedIdentifier(tx.EmitContext(), name) {
+		importDeclaration := tx.resolver.GetReferencedImportDeclaration(tx.EmitContext().MostOriginal(name))
 		if importDeclaration != nil {
 			return tx.currentModuleInfo.exportedBindings.Get(importDeclaration)
 		}
@@ -1976,7 +1977,7 @@ func (tx *CommonJSModuleTransformer) getExports(name *ast.IdentifierNode) []*ast
 		// we analyze all value exports of a symbol.
 		var bindingsSet collections.Set[*ast.ModuleExportName]
 		var bindings []*ast.ModuleExportName
-		declarations := tx.resolver.GetReferencedValueDeclarations(tx.emitContext.MostOriginal(name))
+		declarations := tx.resolver.GetReferencedValueDeclarations(tx.EmitContext().MostOriginal(name))
 		if declarations != nil {
 			for _, declaration := range declarations {
 				exportedBindings := tx.currentModuleInfo.exportedBindings.Get(declaration)
@@ -1989,7 +1990,7 @@ func (tx *CommonJSModuleTransformer) getExports(name *ast.IdentifierNode) []*ast
 			}
 			return bindings
 		}
-	} else if isFileLevelReservedGeneratedIdentifier(tx.emitContext, name) {
+	} else if isFileLevelReservedGeneratedIdentifier(tx.EmitContext(), name) {
 		exportSpecifiers := tx.currentModuleInfo.exportSpecifiers.Get(name.Text())
 		if exportSpecifiers != nil {
 			var exportedNames []*ast.ModuleExportName

--- a/internal/transformers/moduletransforms/commonjsmodule_test.go
+++ b/internal/transformers/moduletransforms/commonjsmodule_test.go
@@ -1,4 +1,4 @@
-package transformers
+package moduletransforms_test
 
 import (
 	"testing"
@@ -9,6 +9,8 @@ import (
 	"github.com/microsoft/typescript-go/internal/printer"
 	"github.com/microsoft/typescript-go/internal/testutil/emittestutil"
 	"github.com/microsoft/typescript-go/internal/testutil/parsetestutil"
+	"github.com/microsoft/typescript-go/internal/transformers/moduletransforms"
+	"github.com/microsoft/typescript-go/internal/transformers/tstransforms"
 )
 
 func fakeGetEmitModuleFormatOfFile(file ast.HasFileName) core.ModuleKind {
@@ -1046,8 +1048,8 @@ exports.a = a;`,
 			emitContext := printer.NewEmitContext()
 			resolver := binder.NewReferenceResolver(compilerOptions, binder.ReferenceResolverHooks{})
 
-			file = NewRuntimeSyntaxTransformer(emitContext, compilerOptions, resolver).TransformSourceFile(file)
-			file = NewCommonJSModuleTransformer(emitContext, compilerOptions, resolver, fakeGetEmitModuleFormatOfFile).TransformSourceFile(file)
+			file = tstransforms.NewRuntimeSyntaxTransformer(emitContext, compilerOptions, resolver).TransformSourceFile(file)
+			file = moduletransforms.NewCommonJSModuleTransformer(emitContext, compilerOptions, resolver, fakeGetEmitModuleFormatOfFile).TransformSourceFile(file)
 			emittestutil.CheckEmit(t, emitContext, file, rec.output)
 		})
 	}

--- a/internal/transformers/moduletransforms/esmodule_test.go
+++ b/internal/transformers/moduletransforms/esmodule_test.go
@@ -1,4 +1,4 @@
-package transformers
+package moduletransforms_test
 
 import (
 	"testing"
@@ -9,6 +9,8 @@ import (
 	"github.com/microsoft/typescript-go/internal/printer"
 	"github.com/microsoft/typescript-go/internal/testutil/emittestutil"
 	"github.com/microsoft/typescript-go/internal/testutil/parsetestutil"
+	"github.com/microsoft/typescript-go/internal/transformers/moduletransforms"
+	"github.com/microsoft/typescript-go/internal/transformers/tstransforms"
 )
 
 func TestESModuleTransformer(t *testing.T) {
@@ -238,8 +240,8 @@ var __rewriteRelativeImportExtension;`,
 			emitContext := printer.NewEmitContext()
 			resolver := binder.NewReferenceResolver(compilerOptions, binder.ReferenceResolverHooks{})
 
-			file = NewRuntimeSyntaxTransformer(emitContext, compilerOptions, resolver).TransformSourceFile(file)
-			file = NewESModuleTransformer(emitContext, compilerOptions, resolver, fakeGetEmitModuleFormatOfFile).TransformSourceFile(file)
+			file = tstransforms.NewRuntimeSyntaxTransformer(emitContext, compilerOptions, resolver).TransformSourceFile(file)
+			file = moduletransforms.NewESModuleTransformer(emitContext, compilerOptions, resolver, fakeGetEmitModuleFormatOfFile).TransformSourceFile(file)
 			emittestutil.CheckEmit(t, emitContext, file, rec.output)
 		})
 	}

--- a/internal/transformers/moduletransforms/externalmoduleinfo.go
+++ b/internal/transformers/moduletransforms/externalmoduleinfo.go
@@ -1,4 +1,4 @@
-package transformers
+package moduletransforms
 
 import (
 	"slices"
@@ -9,6 +9,7 @@ import (
 	"github.com/microsoft/typescript-go/internal/core"
 	"github.com/microsoft/typescript-go/internal/printer"
 	"github.com/microsoft/typescript-go/internal/stringutil"
+	"github.com/microsoft/typescript-go/internal/transformers"
 )
 
 type externalModuleInfo struct {
@@ -237,7 +238,7 @@ func (c *externalModuleInfoCollector) collectExportedVariableInfo(decl *ast.Node
 		text := decl.Name().Text()
 		if c.addUniqueExport(text) {
 			c.addExportedName(decl.Name())
-			if isLocalName(c.emitContext, decl.Name()) {
+			if transformers.IsLocalName(c.emitContext, decl.Name()) {
 				c.addExportedBinding(decl, decl.Name())
 			}
 		}

--- a/internal/transformers/moduletransforms/impliedmodule.go
+++ b/internal/transformers/moduletransforms/impliedmodule.go
@@ -1,22 +1,23 @@
-package transformers
+package moduletransforms
 
 import (
 	"github.com/microsoft/typescript-go/internal/ast"
 	"github.com/microsoft/typescript-go/internal/binder"
 	"github.com/microsoft/typescript-go/internal/core"
 	"github.com/microsoft/typescript-go/internal/printer"
+	"github.com/microsoft/typescript-go/internal/transformers"
 )
 
 type ImpliedModuleTransformer struct {
-	Transformer
+	transformers.Transformer
 	compilerOptions           *core.CompilerOptions
 	resolver                  binder.ReferenceResolver
 	getEmitModuleFormatOfFile func(file ast.HasFileName) core.ModuleKind
-	cjsTransformer            *Transformer
-	esmTransformer            *Transformer
+	cjsTransformer            *transformers.Transformer
+	esmTransformer            *transformers.Transformer
 }
 
-func NewImpliedModuleTransformer(emitContext *printer.EmitContext, compilerOptions *core.CompilerOptions, resolver binder.ReferenceResolver, getEmitModuleFormatOfFile func(file ast.HasFileName) core.ModuleKind) *Transformer {
+func NewImpliedModuleTransformer(emitContext *printer.EmitContext, compilerOptions *core.CompilerOptions, resolver binder.ReferenceResolver, getEmitModuleFormatOfFile func(file ast.HasFileName) core.ModuleKind) *transformers.Transformer {
 	if resolver == nil {
 		resolver = binder.NewReferenceResolver(compilerOptions, binder.ReferenceResolverHooks{})
 	}
@@ -39,15 +40,15 @@ func (tx *ImpliedModuleTransformer) visitSourceFile(node *ast.SourceFile) *ast.N
 
 	format := tx.getEmitModuleFormatOfFile(node)
 
-	var transformer *Transformer
+	var transformer *transformers.Transformer
 	if format >= core.ModuleKindES2015 {
 		if tx.esmTransformer == nil {
-			tx.esmTransformer = NewESModuleTransformer(tx.emitContext, tx.compilerOptions, tx.resolver, tx.getEmitModuleFormatOfFile)
+			tx.esmTransformer = NewESModuleTransformer(tx.EmitContext(), tx.compilerOptions, tx.resolver, tx.getEmitModuleFormatOfFile)
 		}
 		transformer = tx.esmTransformer
 	} else {
 		if tx.cjsTransformer == nil {
-			tx.cjsTransformer = NewCommonJSModuleTransformer(tx.emitContext, tx.compilerOptions, tx.resolver, tx.getEmitModuleFormatOfFile)
+			tx.cjsTransformer = NewCommonJSModuleTransformer(tx.EmitContext(), tx.compilerOptions, tx.resolver, tx.getEmitModuleFormatOfFile)
 		}
 		transformer = tx.cjsTransformer
 	}

--- a/internal/transformers/moduletransforms/utilities.go
+++ b/internal/transformers/moduletransforms/utilities.go
@@ -1,0 +1,132 @@
+package moduletransforms
+
+import (
+	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/core"
+	"github.com/microsoft/typescript-go/internal/outputpaths"
+	"github.com/microsoft/typescript-go/internal/printer"
+	"github.com/microsoft/typescript-go/internal/tspath"
+)
+
+func isDeclarationNameOfEnumOrNamespace(emitContext *printer.EmitContext, node *ast.IdentifierNode) bool {
+	if original := emitContext.MostOriginal(node); original != nil && original.Parent != nil {
+		switch original.Parent.Kind {
+		case ast.KindEnumDeclaration, ast.KindModuleDeclaration:
+			return original == original.Parent.Name()
+		}
+	}
+	return false
+}
+
+func rewriteModuleSpecifier(emitContext *printer.EmitContext, node *ast.Expression, compilerOptions *core.CompilerOptions) *ast.Expression {
+	if node == nil || !ast.IsStringLiteral(node) || !core.ShouldRewriteModuleSpecifier(node.Text(), compilerOptions) {
+		return node
+	}
+	updatedText := tspath.ChangeExtension(node.Text(), outputpaths.GetOutputExtension(node.Text(), compilerOptions.Jsx))
+	if updatedText != node.Text() {
+		updated := emitContext.Factory.NewStringLiteral(updatedText)
+		// !!! set quote style
+		emitContext.SetOriginal(updated, node)
+		emitContext.AssignCommentAndSourceMapRanges(updated, node)
+		return updated
+	}
+	return node
+}
+
+func createEmptyImports(factory *printer.NodeFactory) *ast.Statement {
+	return factory.NewExportDeclaration(
+		nil,   /*modifiers*/
+		false, /*isTypeOnly*/
+		factory.NewNamedExports(factory.NewNodeList(nil)),
+		nil, /*moduleSpecifier*/
+		nil, /*attributes*/
+	)
+}
+
+// Get the name of a target module from an import/export declaration as should be written in the emitted output.
+// The emitted output name can be different from the input if:
+//  1. The module has a /// <amd-module name="<new name>" />
+//  2. --out or --outFile is used, making the name relative to the rootDir
+//     3- The containing SourceFile has an entry in renamedDependencies for the import as requested by some module loaders (e.g. System).
+//
+// Otherwise, a new StringLiteral node representing the module name will be returned.
+func getExternalModuleNameLiteral(factory *printer.NodeFactory, importNode *ast.Node /*ImportDeclaration | ExportDeclaration | ImportEqualsDeclaration | ImportCall*/, sourceFile *ast.SourceFile, host any /*EmitHost*/, resolver printer.EmitResolver, compilerOptions *core.CompilerOptions) *ast.StringLiteralNode {
+	moduleName := ast.GetExternalModuleName(importNode)
+	if moduleName != nil && ast.IsStringLiteral(moduleName) {
+		name := tryGetModuleNameFromDeclaration(importNode, host, factory, resolver, compilerOptions)
+		if name == nil {
+			name = tryRenameExternalModule(factory, moduleName, sourceFile)
+		}
+		if name == nil {
+			name = factory.NewStringLiteral(moduleName.Text())
+		}
+		return name
+	}
+	return nil
+}
+
+// Get the name of a module as should be written in the emitted output.
+// The emitted output name can be different from the input if:
+//  1. The module has a /// <amd-module name="<new name>" />
+//  2. --out or --outFile is used, making the name relative to the rootDir
+//
+// Otherwise, a new StringLiteral node representing the module name will be returned.
+func tryGetModuleNameFromFile(factory *printer.NodeFactory, file *ast.SourceFile, host any /*EmitHost*/, options *core.CompilerOptions) *ast.StringLiteralNode {
+	if file == nil {
+		return nil
+	}
+	// !!!
+	// if file.moduleName {
+	// 	return factory.createStringLiteral(file.moduleName)
+	// }
+	if !file.IsDeclarationFile && len(options.OutFile) > 0 {
+		return factory.NewStringLiteral(getExternalModuleNameFromPath(host, file.FileName(), "" /*referencePath*/))
+	}
+	return nil
+}
+
+func tryGetModuleNameFromDeclaration(declaration *ast.Node /*ImportEqualsDeclaration | ImportDeclaration | ExportDeclaration | ImportCall*/, host any /*EmitHost*/, factory *printer.NodeFactory, resolver printer.EmitResolver, compilerOptions *core.CompilerOptions) *ast.StringLiteralNode {
+	if resolver == nil {
+		return nil
+	}
+	return tryGetModuleNameFromFile(factory, resolver.GetExternalModuleFileFromDeclaration(declaration), host, compilerOptions)
+}
+
+// Resolves a local path to a path which is absolute to the base of the emit
+func getExternalModuleNameFromPath(host any /*ResolveModuleNameResolutionHost*/, fileName string, referencePath string) string {
+	// !!!
+	return ""
+}
+
+// Some bundlers (SystemJS builder) sometimes want to rename dependencies.
+// Here we check if alternative name was provided for a given moduleName and return it if possible.
+func tryRenameExternalModule(factory *printer.NodeFactory, moduleName *ast.LiteralExpression, sourceFile *ast.SourceFile) *ast.StringLiteralNode {
+	// !!!
+	return nil
+}
+
+func isFileLevelReservedGeneratedIdentifier(emitContext *printer.EmitContext, name *ast.IdentifierNode) bool {
+	info := emitContext.GetAutoGenerateInfo(name)
+	return info != nil &&
+		info.Flags.IsFileLevel() &&
+		info.Flags.IsOptimistic() &&
+		info.Flags.IsReservedInNestedScopes()
+}
+
+// Used in the module transformer to check if an expression is reasonably without sideeffect,
+//
+//	and thus better to copy into multiple places rather than to cache in a temporary variable
+//	- this is mostly subjective beyond the requirement that the expression not be sideeffecting
+func isSimpleCopiableExpression(expression *ast.Expression) bool {
+	return ast.IsStringLiteralLike(expression) ||
+		ast.IsNumericLiteral(expression) ||
+		ast.IsKeywordKind(expression.Kind) ||
+		ast.IsIdentifier(expression)
+}
+
+// A simple inlinable expression is an expression which can be copied into multiple locations
+// without risk of repeating any sideeffects and whose value could not possibly change between
+// any such locations
+func isSimpleInlineableExpression(expression *ast.Expression) bool {
+	return !ast.IsIdentifier(expression) && isSimpleCopiableExpression(expression)
+}

--- a/internal/transformers/transformer.go
+++ b/internal/transformers/transformer.go
@@ -2,8 +2,6 @@ package transformers
 
 import (
 	"github.com/microsoft/typescript-go/internal/ast"
-	"github.com/microsoft/typescript-go/internal/binder"
-	"github.com/microsoft/typescript-go/internal/core"
 	"github.com/microsoft/typescript-go/internal/printer"
 )
 
@@ -40,75 +38,4 @@ func (tx *Transformer) Factory() *printer.NodeFactory {
 
 func (tx *Transformer) TransformSourceFile(file *ast.SourceFile) *ast.SourceFile {
 	return tx.visitor.VisitSourceFile(file)
-}
-
-func getModuleTransformer(emitContext *printer.EmitContext, options *core.CompilerOptions, resolver binder.ReferenceResolver, getEmitModuleFormatOfFile func(file ast.HasFileName) core.ModuleKind) *Transformer {
-	switch options.GetEmitModuleKind() {
-	case core.ModuleKindPreserve:
-		// `ESModuleTransformer` contains logic for preserving CJS input syntax in `--module preserve`
-		return NewESModuleTransformer(emitContext, options, resolver, getEmitModuleFormatOfFile)
-
-	case core.ModuleKindESNext,
-		core.ModuleKindES2022,
-		core.ModuleKindES2020,
-		core.ModuleKindES2015,
-		core.ModuleKindNode18,
-		core.ModuleKindNode16,
-		core.ModuleKindNodeNext,
-		core.ModuleKindCommonJS:
-		return NewImpliedModuleTransformer(emitContext, options, resolver, getEmitModuleFormatOfFile)
-
-	default:
-		return NewCommonJSModuleTransformer(emitContext, options, resolver, getEmitModuleFormatOfFile)
-	}
-}
-
-func GetScriptTransformers(emitContext *printer.EmitContext, host printer.EmitHost, sourceFile *ast.SourceFile) []*Transformer {
-	var tx []*Transformer
-	options := host.Options()
-	languageVersion := options.GetEmitScriptTarget()
-
-	// JS files don't use reference calculations as they don't do import elision, no need to calculate it
-	importElisionEnabled := !options.VerbatimModuleSyntax.IsTrue() && !ast.IsInJSFile(sourceFile.AsNode())
-
-	var emitResolver printer.EmitResolver
-	var referenceResolver binder.ReferenceResolver
-	if importElisionEnabled || options.GetJSXTransformEnabled() {
-		emitResolver = host.GetEmitResolver(sourceFile, false /*skipDiagnostics*/) // !!! conditionally skip diagnostics
-		emitResolver.MarkLinkedReferencesRecursively(sourceFile)
-		referenceResolver = emitResolver
-	} else {
-		referenceResolver = binder.NewReferenceResolver(options, binder.ReferenceResolverHooks{})
-	}
-
-	// transform TypeScript syntax
-	{
-		// erase types
-		tx = append(tx, NewTypeEraserTransformer(emitContext, options))
-
-		// elide imports
-		if importElisionEnabled {
-			tx = append(tx, NewImportElisionTransformer(emitContext, options, emitResolver))
-		}
-
-		// transform `enum`, `namespace`, and parameter properties
-		tx = append(tx, NewRuntimeSyntaxTransformer(emitContext, options, referenceResolver))
-	}
-
-	// !!! transform legacy decorator syntax
-	if options.GetJSXTransformEnabled() {
-		tx = append(tx, NewJSXTransformer(emitContext, options, emitResolver))
-	}
-
-	if languageVersion < core.ScriptTargetESNext {
-		tx = append(tx, NewESNextTransformer(emitContext))
-	}
-
-	// !!! transform native decorator syntax
-	// !!! transform class field syntax
-	// !!! transform other language targets
-
-	// transform module syntax
-	tx = append(tx, getModuleTransformer(emitContext, options, referenceResolver, host.GetEmitModuleFormatOfFile))
-	return tx
 }

--- a/internal/transformers/tstransforms/importelision_test.go
+++ b/internal/transformers/tstransforms/importelision_test.go
@@ -1,4 +1,4 @@
-package transformers
+package tstransforms_test
 
 import (
 	"testing"
@@ -12,6 +12,7 @@ import (
 	"github.com/microsoft/typescript-go/internal/printer"
 	"github.com/microsoft/typescript-go/internal/testutil/emittestutil"
 	"github.com/microsoft/typescript-go/internal/testutil/parsetestutil"
+	"github.com/microsoft/typescript-go/internal/transformers/tstransforms"
 	"github.com/microsoft/typescript-go/internal/tsoptions"
 	"github.com/microsoft/typescript-go/internal/tspath"
 )
@@ -240,8 +241,8 @@ func TestImportElision(t *testing.T) {
 			emitResolver.MarkLinkedReferencesRecursively(file)
 
 			emitContext := printer.NewEmitContext()
-			file = NewTypeEraserTransformer(emitContext, compilerOptions).TransformSourceFile(file)
-			file = NewImportElisionTransformer(emitContext, compilerOptions, emitResolver).TransformSourceFile(file)
+			file = tstransforms.NewTypeEraserTransformer(emitContext, compilerOptions).TransformSourceFile(file)
+			file = tstransforms.NewImportElisionTransformer(emitContext, compilerOptions, emitResolver).TransformSourceFile(file)
 			emittestutil.CheckEmit(t, nil, file, rec.output)
 		})
 	}

--- a/internal/transformers/tstransforms/runtimesyntax_test.go
+++ b/internal/transformers/tstransforms/runtimesyntax_test.go
@@ -1,4 +1,4 @@
-package transformers
+package tstransforms_test
 
 import (
 	"testing"
@@ -8,6 +8,7 @@ import (
 	"github.com/microsoft/typescript-go/internal/printer"
 	"github.com/microsoft/typescript-go/internal/testutil/emittestutil"
 	"github.com/microsoft/typescript-go/internal/testutil/parsetestutil"
+	"github.com/microsoft/typescript-go/internal/transformers/tstransforms"
 )
 
 func TestEnumTransformer(t *testing.T) {
@@ -236,7 +237,7 @@ var E;
 			binder.BindSourceFile(file)
 			emitContext := printer.NewEmitContext()
 			resolver := binder.NewReferenceResolver(options, binder.ReferenceResolverHooks{})
-			emittestutil.CheckEmit(t, emitContext, NewRuntimeSyntaxTransformer(emitContext, options, resolver).TransformSourceFile(file), rec.output)
+			emittestutil.CheckEmit(t, emitContext, tstransforms.NewRuntimeSyntaxTransformer(emitContext, options, resolver).TransformSourceFile(file), rec.output)
 		})
 	}
 }
@@ -414,7 +415,7 @@ func TestNamespaceTransformer(t *testing.T) {
 			binder.BindSourceFile(file)
 			emitContext := printer.NewEmitContext()
 			resolver := binder.NewReferenceResolver(options, binder.ReferenceResolverHooks{})
-			emittestutil.CheckEmit(t, emitContext, NewRuntimeSyntaxTransformer(emitContext, options, resolver).TransformSourceFile(file), rec.output)
+			emittestutil.CheckEmit(t, emitContext, tstransforms.NewRuntimeSyntaxTransformer(emitContext, options, resolver).TransformSourceFile(file), rec.output)
 		})
 	}
 }
@@ -450,8 +451,8 @@ func TestParameterPropertyTransformer(t *testing.T) {
 			binder.BindSourceFile(file)
 			emitContext := printer.NewEmitContext()
 			resolver := binder.NewReferenceResolver(options, binder.ReferenceResolverHooks{})
-			file = NewTypeEraserTransformer(emitContext, options).TransformSourceFile(file)
-			file = NewRuntimeSyntaxTransformer(emitContext, options, resolver).TransformSourceFile(file)
+			file = tstransforms.NewTypeEraserTransformer(emitContext, options).TransformSourceFile(file)
+			file = tstransforms.NewRuntimeSyntaxTransformer(emitContext, options, resolver).TransformSourceFile(file)
 			emittestutil.CheckEmit(t, emitContext, file, rec.output)
 		})
 	}

--- a/internal/transformers/tstransforms/typeeraser_test.go
+++ b/internal/transformers/tstransforms/typeeraser_test.go
@@ -1,4 +1,4 @@
-package transformers
+package tstransforms_test
 
 import (
 	"testing"
@@ -7,6 +7,7 @@ import (
 	"github.com/microsoft/typescript-go/internal/printer"
 	"github.com/microsoft/typescript-go/internal/testutil/emittestutil"
 	"github.com/microsoft/typescript-go/internal/testutil/parsetestutil"
+	"github.com/microsoft/typescript-go/internal/transformers/tstransforms"
 )
 
 func TestTypeEraser(t *testing.T) {
@@ -98,7 +99,7 @@ func TestTypeEraser(t *testing.T) {
 			if rec.vms {
 				compilerOptions.VerbatimModuleSyntax = core.TSTrue
 			}
-			emittestutil.CheckEmit(t, nil, NewTypeEraserTransformer(printer.NewEmitContext(), compilerOptions).TransformSourceFile(file), rec.output)
+			emittestutil.CheckEmit(t, nil, tstransforms.NewTypeEraserTransformer(printer.NewEmitContext(), compilerOptions).TransformSourceFile(file), rec.output)
 		})
 	}
 }

--- a/internal/transformers/tstransforms/utilities.go
+++ b/internal/transformers/tstransforms/utilities.go
@@ -1,0 +1,41 @@
+package tstransforms
+
+import (
+	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/jsnum"
+	"github.com/microsoft/typescript-go/internal/printer"
+)
+
+func convertEntityNameToExpression(emitContext *printer.EmitContext, name *ast.EntityName) *ast.Expression {
+	if ast.IsQualifiedName(name) {
+		left := convertEntityNameToExpression(emitContext, name.AsQualifiedName().Left)
+		right := name.AsQualifiedName().Right
+		prop := emitContext.Factory.NewPropertyAccessExpression(left, nil /*questionDotToken*/, right, ast.NodeFlagsNone)
+		emitContext.SetOriginal(prop, name)
+		emitContext.AssignCommentAndSourceMapRanges(prop, name)
+		return prop
+	}
+	return name.Clone(emitContext.Factory)
+}
+
+func constantExpression(value any, factory *printer.NodeFactory) *ast.Expression {
+	switch value := value.(type) {
+	case string:
+		return factory.NewStringLiteral(value)
+	case jsnum.Number:
+		if value.IsInf() || value.IsNaN() {
+			return nil
+		}
+		if value < 0 {
+			return factory.NewPrefixUnaryExpression(ast.KindMinusToken, constantExpression(-value, factory))
+		}
+		return factory.NewNumericLiteral(value.String())
+	}
+	return nil
+}
+
+func isInstantiatedModule(node *ast.ModuleDeclarationNode, preserveConstEnums bool) bool {
+	moduleState := ast.GetModuleInstanceState(node)
+	return moduleState == ast.ModuleInstanceStateInstantiated ||
+		(preserveConstEnums && moduleState == ast.ModuleInstanceStateConstEnumOnly)
+}

--- a/internal/transformers/utilities.go
+++ b/internal/transformers/utilities.go
@@ -4,40 +4,26 @@ import (
 	"slices"
 
 	"github.com/microsoft/typescript-go/internal/ast"
-	"github.com/microsoft/typescript-go/internal/core"
-	"github.com/microsoft/typescript-go/internal/jsnum"
-	"github.com/microsoft/typescript-go/internal/outputpaths"
 	"github.com/microsoft/typescript-go/internal/printer"
-	"github.com/microsoft/typescript-go/internal/tspath"
 )
 
-func isGeneratedIdentifier(emitContext *printer.EmitContext, name *ast.IdentifierNode) bool {
+func IsGeneratedIdentifier(emitContext *printer.EmitContext, name *ast.IdentifierNode) bool {
 	return emitContext.HasAutoGenerateInfo(name)
 }
 
-func isHelperName(emitContext *printer.EmitContext, name *ast.IdentifierNode) bool {
+func IsHelperName(emitContext *printer.EmitContext, name *ast.IdentifierNode) bool {
 	return emitContext.EmitFlags(name)&printer.EFHelperName != 0
 }
 
-func isLocalName(emitContext *printer.EmitContext, name *ast.IdentifierNode) bool {
+func IsLocalName(emitContext *printer.EmitContext, name *ast.IdentifierNode) bool {
 	return emitContext.EmitFlags(name)&printer.EFLocalName != 0
 }
 
-func isExportName(emitContext *printer.EmitContext, name *ast.IdentifierNode) bool {
+func IsExportName(emitContext *printer.EmitContext, name *ast.IdentifierNode) bool {
 	return emitContext.EmitFlags(name)&printer.EFExportName != 0
 }
 
-func isDeclarationNameOfEnumOrNamespace(emitContext *printer.EmitContext, node *ast.IdentifierNode) bool {
-	if original := emitContext.MostOriginal(node); original != nil && original.Parent != nil {
-		switch original.Parent.Kind {
-		case ast.KindEnumDeclaration, ast.KindModuleDeclaration:
-			return original == original.Parent.Name()
-		}
-	}
-	return false
-}
-
-func isIdentifierReference(name *ast.IdentifierNode, parent *ast.Node) bool {
+func IsIdentifierReference(name *ast.IdentifierNode, parent *ast.Node) bool {
 	switch parent.Kind {
 	case ast.KindBinaryExpression,
 		ast.KindPrefixUnaryExpression,
@@ -127,28 +113,6 @@ func isIdentifierReference(name *ast.IdentifierNode, parent *ast.Node) bool {
 	}
 }
 
-func constantExpression(value any, factory *printer.NodeFactory) *ast.Expression {
-	switch value := value.(type) {
-	case string:
-		return factory.NewStringLiteral(value)
-	case jsnum.Number:
-		if value.IsInf() || value.IsNaN() {
-			return nil
-		}
-		if value < 0 {
-			return factory.NewPrefixUnaryExpression(ast.KindMinusToken, constantExpression(-value, factory))
-		}
-		return factory.NewNumericLiteral(value.String())
-	}
-	return nil
-}
-
-func isInstantiatedModule(node *ast.ModuleDeclarationNode, preserveConstEnums bool) bool {
-	moduleState := ast.GetModuleInstanceState(node)
-	return moduleState == ast.ModuleInstanceStateInstantiated ||
-		(preserveConstEnums && moduleState == ast.ModuleInstanceStateConstEnumOnly)
-}
-
 func convertBindingElementToArrayAssignmentElement(emitContext *printer.EmitContext, element *ast.BindingElement) *ast.Expression {
 	if element.Name() == nil {
 		elision := emitContext.Factory.NewOmittedExpression()
@@ -206,7 +170,7 @@ func convertBindingElementToObjectAssignmentElement(emitContext *printer.EmitCon
 	return assignment
 }
 
-func convertBindingPatternToAssignmentPattern(emitContext *printer.EmitContext, element *ast.BindingPattern) *ast.Expression {
+func ConvertBindingPatternToAssignmentPattern(emitContext *printer.EmitContext, element *ast.BindingPattern) *ast.Expression {
 	switch element.Kind {
 	case ast.KindArrayBindingPattern:
 		return convertBindingElementToArrayAssignmentPattern(emitContext, element)
@@ -245,12 +209,12 @@ func convertBindingElementToArrayAssignmentPattern(emitContext *printer.EmitCont
 
 func convertBindingNameToAssignmentElementTarget(emitContext *printer.EmitContext, element *ast.Node) *ast.Expression {
 	if ast.IsBindingPattern(element) {
-		return convertBindingPatternToAssignmentPattern(emitContext, element.AsBindingPattern())
+		return ConvertBindingPatternToAssignmentPattern(emitContext, element.AsBindingPattern())
 	}
 	return element
 }
 
-func convertVariableDeclarationToAssignmentExpression(emitContext *printer.EmitContext, element *ast.VariableDeclaration) *ast.Expression {
+func ConvertVariableDeclarationToAssignmentExpression(emitContext *printer.EmitContext, element *ast.VariableDeclaration) *ast.Expression {
 	if element.Initializer == nil {
 		return nil
 	}
@@ -261,164 +225,9 @@ func convertVariableDeclarationToAssignmentExpression(emitContext *printer.EmitC
 	return assignment
 }
 
-func convertEntityNameToExpression(emitContext *printer.EmitContext, name *ast.EntityName) *ast.Expression {
-	if ast.IsQualifiedName(name) {
-		left := convertEntityNameToExpression(emitContext, name.AsQualifiedName().Left)
-		right := name.AsQualifiedName().Right
-		prop := emitContext.Factory.NewPropertyAccessExpression(left, nil /*questionDotToken*/, right, ast.NodeFlagsNone)
-		emitContext.SetOriginal(prop, name)
-		emitContext.AssignCommentAndSourceMapRanges(prop, name)
-		return prop
-	}
-	return name.Clone(emitContext.Factory)
-}
-
-// Get the name of a target module from an import/export declaration as should be written in the emitted output.
-// The emitted output name can be different from the input if:
-//  1. The module has a /// <amd-module name="<new name>" />
-//  2. --out or --outFile is used, making the name relative to the rootDir
-//     3- The containing SourceFile has an entry in renamedDependencies for the import as requested by some module loaders (e.g. System).
-//
-// Otherwise, a new StringLiteral node representing the module name will be returned.
-func getExternalModuleNameLiteral(factory *printer.NodeFactory, importNode *ast.Node /*ImportDeclaration | ExportDeclaration | ImportEqualsDeclaration | ImportCall*/, sourceFile *ast.SourceFile, host any /*EmitHost*/, resolver printer.EmitResolver, compilerOptions *core.CompilerOptions) *ast.StringLiteralNode {
-	moduleName := ast.GetExternalModuleName(importNode)
-	if moduleName != nil && ast.IsStringLiteral(moduleName) {
-		name := tryGetModuleNameFromDeclaration(importNode, host, factory, resolver, compilerOptions)
-		if name == nil {
-			name = tryRenameExternalModule(factory, moduleName, sourceFile)
-		}
-		if name == nil {
-			name = factory.NewStringLiteral(moduleName.Text())
-		}
-		return name
-	}
-	return nil
-}
-
-// Get the name of a module as should be written in the emitted output.
-// The emitted output name can be different from the input if:
-//  1. The module has a /// <amd-module name="<new name>" />
-//  2. --out or --outFile is used, making the name relative to the rootDir
-//
-// Otherwise, a new StringLiteral node representing the module name will be returned.
-func tryGetModuleNameFromFile(factory *printer.NodeFactory, file *ast.SourceFile, host any /*EmitHost*/, options *core.CompilerOptions) *ast.StringLiteralNode {
-	if file == nil {
-		return nil
-	}
-	// !!!
-	// if file.moduleName {
-	// 	return factory.createStringLiteral(file.moduleName)
-	// }
-	if !file.IsDeclarationFile && len(options.OutFile) > 0 {
-		return factory.NewStringLiteral(getExternalModuleNameFromPath(host, file.FileName(), "" /*referencePath*/))
-	}
-	return nil
-}
-
-func tryGetModuleNameFromDeclaration(declaration *ast.Node /*ImportEqualsDeclaration | ImportDeclaration | ExportDeclaration | ImportCall*/, host any /*EmitHost*/, factory *printer.NodeFactory, resolver printer.EmitResolver, compilerOptions *core.CompilerOptions) *ast.StringLiteralNode {
-	if resolver == nil {
-		return nil
-	}
-	return tryGetModuleNameFromFile(factory, resolver.GetExternalModuleFileFromDeclaration(declaration), host, compilerOptions)
-}
-
-// Resolves a local path to a path which is absolute to the base of the emit
-func getExternalModuleNameFromPath(host any /*ResolveModuleNameResolutionHost*/, fileName string, referencePath string) string {
-	// !!!
-	return ""
-}
-
-// Some bundlers (SystemJS builder) sometimes want to rename dependencies.
-// Here we check if alternative name was provided for a given moduleName and return it if possible.
-func tryRenameExternalModule(factory *printer.NodeFactory, moduleName *ast.LiteralExpression, sourceFile *ast.SourceFile) *ast.StringLiteralNode {
-	// !!!
-	return nil
-}
-
-func rewriteModuleSpecifier(emitContext *printer.EmitContext, node *ast.Expression, compilerOptions *core.CompilerOptions) *ast.Expression {
-	if node == nil || !ast.IsStringLiteral(node) || !core.ShouldRewriteModuleSpecifier(node.Text(), compilerOptions) {
-		return node
-	}
-	updatedText := tspath.ChangeExtension(node.Text(), outputpaths.GetOutputExtension(node.Text(), compilerOptions.Jsx))
-	if updatedText != node.Text() {
-		updated := emitContext.Factory.NewStringLiteral(updatedText)
-		// !!! set quote style
-		emitContext.SetOriginal(updated, node)
-		emitContext.AssignCommentAndSourceMapRanges(updated, node)
-		return updated
-	}
-	return node
-}
-
-func singleOrMany(nodes []*ast.Node, factory *printer.NodeFactory) *ast.Node {
+func SingleOrMany(nodes []*ast.Node, factory *printer.NodeFactory) *ast.Node {
 	if len(nodes) == 1 {
 		return nodes[0]
 	}
 	return factory.NewSyntaxList(nodes)
-}
-
-func isFileLevelReservedGeneratedIdentifier(emitContext *printer.EmitContext, name *ast.IdentifierNode) bool {
-	info := emitContext.GetAutoGenerateInfo(name)
-	return info != nil &&
-		info.Flags.IsFileLevel() &&
-		info.Flags.IsOptimistic() &&
-		info.Flags.IsReservedInNestedScopes()
-}
-
-func createEmptyImports(factory *printer.NodeFactory) *ast.Statement {
-	return factory.NewExportDeclaration(
-		nil,   /*modifiers*/
-		false, /*isTypeOnly*/
-		factory.NewNamedExports(factory.NewNodeList(nil)),
-		nil, /*moduleSpecifier*/
-		nil, /*attributes*/
-	)
-}
-
-// Used in the module transformer to check if an expression is reasonably without sideeffect,
-//
-//	and thus better to copy into multiple places rather than to cache in a temporary variable
-//	- this is mostly subjective beyond the requirement that the expression not be sideeffecting
-func isSimpleCopiableExpression(expression *ast.Expression) bool {
-	return ast.IsStringLiteralLike(expression) ||
-		ast.IsNumericLiteral(expression) ||
-		ast.IsKeywordKind(expression.Kind) ||
-		ast.IsIdentifier(expression)
-}
-
-// A simple inlinable expression is an expression which can be copied into multiple locations
-// without risk of repeating any sideeffects and whose value could not possibly change between
-// any such locations
-func isSimpleInlineableExpression(expression *ast.Expression) bool {
-	return !ast.IsIdentifier(expression) && isSimpleCopiableExpression(expression)
-}
-
-func convertClassDeclarationToClassExpression(emitContext *printer.EmitContext, node *ast.ClassDeclaration) *ast.Expression {
-	updated := emitContext.Factory.NewClassExpression(
-		extractModifiers(emitContext, node.Modifiers(), ^ast.ModifierFlagsExportDefault),
-		node.Name(),
-		node.TypeParameters,
-		node.HeritageClauses,
-		node.Members,
-	)
-	emitContext.SetOriginal(updated, node.AsNode())
-	updated.Loc = node.Loc
-	return updated
-}
-
-func createExpressionFromEntityName(factory ast.NodeFactoryCoercible, node *ast.Node) *ast.Expression {
-	if ast.IsQualifiedName(node) {
-		left := createExpressionFromEntityName(factory, node.AsQualifiedName().Left)
-		// TODO(rbuckton): Does this need to be parented?
-		right := node.AsQualifiedName().Right.Clone(factory.AsNodeFactory())
-		right.Loc = node.AsQualifiedName().Right.Loc
-		right.Parent = node.AsQualifiedName().Right.Parent
-		return factory.AsNodeFactory().NewPropertyAccessExpression(left, nil, right, ast.NodeFlagsNone)
-	} else {
-		// TODO(rbuckton): Does this need to be parented?
-		res := node.Clone(factory.AsNodeFactory())
-		res.Loc = node.Loc
-		res.Parent = node.Parent
-		return res
-	}
 }


### PR DESCRIPTION
Making this its' own PR (since it's a pure refactor) aughta make reviewing the followups with each feature transform implementation _much_ easier, as each transform has its' own associated baseline diff changes.

With this change, the root `transformers` package only contains the definition of a root `Transformer` object and utilities used by multiple classes of transforms. In practice, this doesn't change much for consumers, since only a single function in the emitter ever touches the actual transform factory functions and is the only place package names really needed to change. The organization is just for maintenance purposes, since the count of files in the folder was starting to get unwieldy with individual es transforms (and the count of those is guaranteed to increase as time goes on).