### PR TITLE
Rename transform-relevant subtree facts with what they actually should track

### DIFF
--- a/internal/ast/subtreefacts.go
+++ b/internal/ast/subtreefacts.go
@@ -8,18 +8,22 @@ type SubtreeFacts int32
 
 const (
 	// Facts
-	// - Flags used to indicate that a node or subtree contains syntax specific to a particular ECMAScript variant.
+	// - Flags used to indicate that a node or subtree contains syntax relevant to a specific transform
 
 	SubtreeContainsTypeScript SubtreeFacts = 1 << iota
 	SubtreeContainsJsx
-	SubtreeContainsESNext
-	SubtreeContainsES2022
-	SubtreeContainsES2021
-	SubtreeContainsES2020
-	SubtreeContainsES2019
-	SubtreeContainsES2018
-	SubtreeContainsES2017
-	SubtreeContainsES2016
+	SubtreeContainsESDecorators
+	SubtreeContainsUsing
+	SubtreeContainsClassStaticBlocks
+	SubtreeContainsESClassFields
+	SubtreeContainsLogicalAssignments
+	SubtreeContainsNullishCoalescing
+	SubtreeContainsOptionalChaining
+	SubtreeContainsMissingCatchClauseVariable
+	SubtreeContainsESObjectRestOrSpread
+	SubtreeContainsForAwaitOrAsyncGenerator
+	SubtreeContainsAnyAwait
+	SubtreeContainsExponentiationOperator
 
 	// Markers
 	// - Flags used to indicate that a node or subtree contains a particular kind of syntax.
@@ -36,6 +40,17 @@ const (
 
 	SubtreeFactsComputed              // NOTE: This should always be last
 	SubtreeFactsNone     SubtreeFacts = 0
+
+	// Aliases (unused, for documentation purposes only - correspond to combinations in transformers/estransforms/definitions.go)
+
+	SubtreeContainsESNext = SubtreeContainsESDecorators | SubtreeContainsUsing
+	SubtreeContainsES2022 = SubtreeContainsClassStaticBlocks | SubtreeContainsESClassFields
+	SubtreeContainsES2021 = SubtreeContainsLogicalAssignments
+	SubtreeContainsES2020 = SubtreeContainsNullishCoalescing | SubtreeContainsOptionalChaining
+	SubtreeContainsES2019 = SubtreeContainsMissingCatchClauseVariable
+	SubtreeContainsES2018 = SubtreeContainsESObjectRestOrSpread | SubtreeContainsForAwaitOrAsyncGenerator
+	SubtreeContainsES2017 = SubtreeContainsAnyAwait
+	SubtreeContainsES2016 = SubtreeContainsExponentiationOperator
 
 	// Scope Exclusions
 	// - Bitmasks that exclude flags from propagating out of a specific context

--- a/internal/transformers/estransforms/optionalcatch.go
+++ b/internal/transformers/estransforms/optionalcatch.go
@@ -11,7 +11,7 @@ type optionalCatchTransformer struct {
 }
 
 func (ch *optionalCatchTransformer) visit(node *ast.Node) *ast.Node {
-	if node.SubtreeFacts()&ast.SubtreeContainsES2019 == 0 {
+	if node.SubtreeFacts()&ast.SubtreeContainsMissingCatchClauseVariable == 0 {
 		return node
 	}
 	switch node.Kind {

--- a/internal/transformers/estransforms/using.go
+++ b/internal/transformers/estransforms/using.go
@@ -33,7 +33,7 @@ const (
 )
 
 func (tx *usingDeclarationTransformer) visit(node *ast.Node) *ast.Node {
-	if node.SubtreeFacts()&ast.SubtreeContainsESNext == 0 {
+	if node.SubtreeFacts()&ast.SubtreeContainsUsing == 0 {
 		return node
 	}
 


### PR DESCRIPTION
Following up my comments in #1270, this PR adjusts the terminology used in the subtree facts enum to make plain it's about optimizing transformations. The old names are left in as aliases for reference when porting code, but you should really use (one of) what they alias. This renaming already called out some nodes which set `ContainsESXXXX` flags but didn't have corresponding transform logic, causing us to needlessly perform traversals on ASTs containing those node kinds (namely, `bigint`s and `import.meta` were big offenders that triggered a no-op `es2020` transform, and an `async` modifier would guarantee a function hits both the `es2018` and `es2017` transforms, even though the containing function set the more specific individual transform flag already).