### PR TITLE
Do less allocation in JSDoc parsing

### DIFF
--- a/internal/api/encoder/encoder.go
+++ b/internal/api/encoder/encoder.go
@@ -774,7 +774,7 @@ func recordNodeStrings(node *ast.Node, strs *stringTable) uint32 {
 	case ast.KindNoSubstitutionTemplateLiteral:
 		return strs.add(node.AsNoSubstitutionTemplateLiteral().Text, node.Kind, node.Pos(), node.End())
 	case ast.KindJSDocText:
-		return strs.add(node.AsJSDocText().Text, node.Kind, node.Pos(), node.End())
+		return strs.add(node.AsJSDocText().Text(), node.Kind, node.Pos(), node.End())
 	default:
 		panic(fmt.Sprintf("Unexpected node kind %v", node.Kind))
 	}

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -296,7 +296,7 @@ func (n *Node) Text() string {
 	case KindRegularExpressionLiteral:
 		return n.AsRegularExpressionLiteral().Text
 	case KindJSDocText:
-		return n.AsJSDocText().Text
+		return strings.Join(n.AsJSDocText().text, "")
 	}
 	panic(fmt.Sprintf("Unhandled case in Node.Text: %T", n.data))
 }
@@ -8814,7 +8814,7 @@ type JSDocTagBase struct {
 
 type JSDocCommentBase struct {
 	NodeBase
-	Text string
+	text []string
 }
 
 // JSDoc comments
@@ -8822,15 +8822,15 @@ type JSDocText struct {
 	JSDocCommentBase
 }
 
-func (f *NodeFactory) NewJSDocText(text string) *Node {
+func (f *NodeFactory) NewJSDocText(text []string) *Node {
 	data := f.jsdocTextPool.New()
-	data.Text = text
+	data.text = text
 	f.textCount++
 	return f.newNode(KindJSDocText, data)
 }
 
 func (node *JSDocText) Clone(f NodeFactoryCoercible) *Node {
-	return cloneNode(f.AsNodeFactory().NewJSDocText(node.Text), node.AsNode(), f.AsNodeFactory().hooks)
+	return cloneNode(f.AsNodeFactory().NewJSDocText(node.text), node.AsNode(), f.AsNodeFactory().hooks)
 }
 
 type JSDocLink struct {
@@ -8838,16 +8838,16 @@ type JSDocLink struct {
 	name *Node // optional (should only be EntityName)
 }
 
-func (f *NodeFactory) NewJSDocLink(name *Node, text string) *Node {
+func (f *NodeFactory) NewJSDocLink(name *Node, text []string) *Node {
 	data := &JSDocLink{}
 	data.name = name
-	data.Text = text
+	data.text = text
 	f.textCount++
 	return f.newNode(KindJSDocLink, data)
 }
 
-func (f *NodeFactory) UpdateJSDocLink(node *JSDocLink, name *Node, text string) *Node {
-	if name != node.name || text != node.Text {
+func (f *NodeFactory) UpdateJSDocLink(node *JSDocLink, name *Node, text []string) *Node {
+	if name != node.name || !core.Same(text, node.text) {
 		return updateNode(f.NewJSDocLink(name, text), node.AsNode(), f.hooks)
 	}
 	return node.AsNode()
@@ -8858,11 +8858,11 @@ func (node *JSDocLink) ForEachChild(v Visitor) bool {
 }
 
 func (node *JSDocLink) VisitEachChild(v *NodeVisitor) *Node {
-	return v.Factory.UpdateJSDocLink(node, v.visitNode(node.name), node.Text)
+	return v.Factory.UpdateJSDocLink(node, v.visitNode(node.name), node.text)
 }
 
 func (node *JSDocLink) Clone(f NodeFactoryCoercible) *Node {
-	return cloneNode(f.AsNodeFactory().NewJSDocLink(node.Name(), node.Text), node.AsNode(), f.AsNodeFactory().hooks)
+	return cloneNode(f.AsNodeFactory().NewJSDocLink(node.Name(), node.text), node.AsNode(), f.AsNodeFactory().hooks)
 }
 
 func (node *JSDocLink) Name() *DeclarationName {
@@ -8874,16 +8874,16 @@ type JSDocLinkPlain struct {
 	name *Node // optional (should only be EntityName)
 }
 
-func (f *NodeFactory) NewJSDocLinkPlain(name *Node, text string) *Node {
+func (f *NodeFactory) NewJSDocLinkPlain(name *Node, text []string) *Node {
 	data := &JSDocLinkPlain{}
 	data.name = name
-	data.Text = text
+	data.text = text
 	f.textCount++
 	return f.newNode(KindJSDocLinkPlain, data)
 }
 
-func (f *NodeFactory) UpdateJSDocLinkPlain(node *JSDocLinkPlain, name *Node, text string) *Node {
-	if name != node.name || text != node.Text {
+func (f *NodeFactory) UpdateJSDocLinkPlain(node *JSDocLinkPlain, name *Node, text []string) *Node {
+	if name != node.name || !core.Same(text, node.text) {
 		return updateNode(f.NewJSDocLinkPlain(name, text), node.AsNode(), f.hooks)
 	}
 	return node.AsNode()
@@ -8894,11 +8894,11 @@ func (node *JSDocLinkPlain) ForEachChild(v Visitor) bool {
 }
 
 func (node *JSDocLinkPlain) VisitEachChild(v *NodeVisitor) *Node {
-	return v.Factory.UpdateJSDocLinkPlain(node, v.visitNode(node.name), node.Text)
+	return v.Factory.UpdateJSDocLinkPlain(node, v.visitNode(node.name), node.text)
 }
 
 func (node *JSDocLinkPlain) Clone(f NodeFactoryCoercible) *Node {
-	return cloneNode(f.AsNodeFactory().NewJSDocLinkPlain(node.Name(), node.Text), node.AsNode(), f.AsNodeFactory().hooks)
+	return cloneNode(f.AsNodeFactory().NewJSDocLinkPlain(node.Name(), node.text), node.AsNode(), f.AsNodeFactory().hooks)
 }
 
 func (node *JSDocLinkPlain) Name() *DeclarationName {
@@ -8910,16 +8910,16 @@ type JSDocLinkCode struct {
 	name *Node // optional (should only be EntityName)
 }
 
-func (f *NodeFactory) NewJSDocLinkCode(name *Node, text string) *Node {
+func (f *NodeFactory) NewJSDocLinkCode(name *Node, text []string) *Node {
 	data := &JSDocLinkCode{}
 	data.name = name
-	data.Text = text
+	data.text = text
 	f.textCount++
 	return f.newNode(KindJSDocLinkCode, data)
 }
 
-func (f *NodeFactory) UpdateJSDocLinkCode(node *JSDocLinkCode, name *Node, text string) *Node {
-	if name != node.name || text != node.Text {
+func (f *NodeFactory) UpdateJSDocLinkCode(node *JSDocLinkCode, name *Node, text []string) *Node {
+	if name != node.name || !core.Same(text, node.text) {
 		return updateNode(f.NewJSDocLinkCode(name, text), node.AsNode(), f.hooks)
 	}
 	return node.AsNode()
@@ -8930,11 +8930,11 @@ func (node *JSDocLinkCode) ForEachChild(v Visitor) bool {
 }
 
 func (node *JSDocLinkCode) VisitEachChild(v *NodeVisitor) *Node {
-	return v.Factory.UpdateJSDocLinkCode(node, v.visitNode(node.name), node.Text)
+	return v.Factory.UpdateJSDocLinkCode(node, v.visitNode(node.name), node.text)
 }
 
 func (node *JSDocLinkCode) Clone(f NodeFactoryCoercible) *Node {
-	return cloneNode(f.AsNodeFactory().NewJSDocLinkCode(node.Name(), node.Text), node.AsNode(), f.AsNodeFactory().hooks)
+	return cloneNode(f.AsNodeFactory().NewJSDocLinkCode(node.Name(), node.text), node.AsNode(), f.AsNodeFactory().hooks)
 }
 
 func (node *JSDocLinkCode) Name() *DeclarationName {

--- a/internal/core/pool.go
+++ b/internal/core/pool.go
@@ -49,6 +49,15 @@ func (p *Pool[T]) NewSlice1(t T) []T {
 	return slice
 }
 
+func (p *Pool[T]) Clone(t []T) []T {
+	if len(t) == 0 {
+		return nil
+	}
+	slice := p.NewSlice(len(t))
+	copy(slice, t)
+	return slice
+}
+
 func nextPoolSize(size int) int {
 	// This compiles down branch-free.
 	size = max(size, 1)

--- a/internal/ls/hover.go
+++ b/internal/ls/hover.go
@@ -395,10 +395,10 @@ func writeComments(b *strings.Builder, comments []*ast.Node) {
 	for _, comment := range comments {
 		switch comment.Kind {
 		case ast.KindJSDocText:
-			b.WriteString(comment.AsJSDocText().Text)
+			b.WriteString(comment.Text())
 		case ast.KindJSDocLink:
 			name := comment.Name()
-			text := comment.AsJSDocLink().Text
+			text := comment.AsJSDocLink().Text()
 			if name != nil {
 				if text == "" {
 					writeEntityName(b, name)

--- a/internal/parser/jsdoc.go
+++ b/internal/parser/jsdoc.go
@@ -256,7 +256,7 @@ loop:
 				if linkEnd == start {
 					comments = removeLeadingNewlines(comments)
 				}
-				jsdocText := p.factory.NewJSDocText(strings.Join(comments, ""))
+				jsdocText := p.factory.NewJSDocText(p.stringSlicePool.Clone(comments))
 				p.finishNodeWithEnd(jsdocText, linkEnd, commentEnd)
 				commentParts = append(commentParts, jsdocText, link)
 				comments = comments[:0]
@@ -283,9 +283,8 @@ loop:
 		commentsPos = p.scanner.TokenFullStart()
 	}
 
-	trimmedComments := trimEnd(strings.Join(comments, ""))
-	if len(trimmedComments) > 0 {
-		jsdocText := p.factory.NewJSDocText(trimmedComments)
+	if len(comments) > 0 {
+		jsdocText := p.factory.NewJSDocText(p.stringSlicePool.Clone(comments))
 		p.finishNodeWithEnd(jsdocText, linkEnd, commentsPos)
 		commentParts = append(commentParts, jsdocText)
 	}
@@ -529,7 +528,7 @@ loop:
 			linkStart := p.scanner.TokenEnd() - 1
 			link := p.parseJSDocLink(linkStart)
 			if link != nil {
-				text := p.factory.NewJSDocText(strings.Join(comments, ""))
+				text := p.factory.NewJSDocText(p.stringSlicePool.Clone(comments))
 				var commentStart int
 				if linkEnd > -1 {
 					commentStart = linkEnd
@@ -583,15 +582,14 @@ loop:
 	p.jsdocTagCommentsSpace = comments[:0]
 
 	comments = removeLeadingNewlines(comments)
-	trimmedComments := trimEnd(strings.Join(comments, ""))
-	if len(trimmedComments) > 0 {
+	if len(comments) > 0 {
 		var commentStart int
 		if linkEnd > -1 {
 			commentStart = linkEnd
 		} else {
 			commentStart = commentsPos
 		}
-		text := p.factory.NewJSDocText(trimmedComments)
+		text := p.factory.NewJSDocText(p.stringSlicePool.Clone(comments))
 		p.finishNode(text, commentStart)
 		parts = append(parts, text)
 	}
@@ -620,11 +618,11 @@ func (p *Parser) parseJSDocLink(start int) *ast.Node {
 	var create *ast.Node
 	switch linkType {
 	case "link":
-		create = p.factory.NewJSDocLink(name, strings.Join(text, ""))
+		create = p.factory.NewJSDocLink(name, text)
 	case "linkcode":
-		create = p.factory.NewJSDocLinkCode(name, strings.Join(text, ""))
+		create = p.factory.NewJSDocLinkCode(name, text)
 	default:
-		create = p.factory.NewJSDocLinkPlain(name, strings.Join(text, ""))
+		create = p.factory.NewJSDocLinkPlain(name, text)
 	}
 	p.finishNodeWithEnd(create, start, p.scanner.TokenEnd())
 	return create

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -70,6 +70,7 @@ type Parser struct {
 	identifierCount         int
 	notParenthesizedArrow   collections.Set[int]
 	nodeSlicePool           core.Pool[*ast.Node]
+	stringSlicePool         core.Pool[string]
 	jsdocCache              map[*ast.Node][]*ast.Node
 	possibleAwaitSpans      []int
 	jsdocCommentsSpace      []string


### PR DESCRIPTION
One of the largest allocators when parsing code for the editor is JSDoc parsing. By deferring JSDoc part joining until `Text()` is called, we can save a bunch of memory allocations, and make parsing out the DOM types ~5% faster.

```
goos: linux
goarch: amd64
pkg: github.com/microsoft/typescript-go/internal/parser
cpu: Intel(R) Core(TM) i9-10900K CPU @ 3.70GHz
                                                             │   old.txt   │              new.txt               │
                                                             │   sec/op    │   sec/op     vs base               │
Parse/empty.ts/tsc-20                                          527.5n ± 4%   523.9n ± 1%       ~ (p=0.072 n=10)
Parse/empty.ts/server-20                                       524.1n ± 1%   527.3n ± 1%       ~ (p=0.138 n=10)
Parse/checker.ts/tsc-20                                        48.66m ± 2%   47.70m ± 1%  -1.97% (p=0.002 n=10)
Parse/checker.ts/server-20                                     48.88m ± 4%   49.15m ± 1%       ~ (p=0.912 n=10)
Parse/dom.generated.d.ts/tsc-20                                16.39m ± 2%   16.11m ± 1%  -1.69% (p=0.023 n=10)
Parse/dom.generated.d.ts/server-20                             24.56m ± 2%   23.54m ± 3%  -4.13% (p=0.000 n=10)
Parse/Herebyfile.mjs/tsc-20                                    884.3µ ± 1%   881.8µ ± 1%       ~ (p=0.143 n=10)
Parse/Herebyfile.mjs/server-20                                 886.8µ ± 3%   880.6µ ± 2%       ~ (p=0.165 n=10)
Parse/jsxComplexSignatureHasApplicabilityError.tsx/tsc-20      267.4µ ± 2%   265.2µ ± 2%  -0.80% (p=0.015 n=10)
Parse/jsxComplexSignatureHasApplicabilityError.tsx/server-20   419.1µ ± 2%   403.0µ ± 3%  -3.83% (p=0.000 n=10)
geomean                                                        686.5µ        677.5µ       -1.31%
```
```
                                                             │   old.txt    │                new.txt                │
                                                             │     B/op     │     B/op      vs base                 │
Parse/empty.ts/tsc-20                                            881.0 ± 0%     881.0 ± 0%       ~ (p=1.000 n=10) ¹
Parse/empty.ts/server-20                                         881.0 ± 0%     881.0 ± 0%       ~ (p=1.000 n=10) ¹
Parse/checker.ts/tsc-20                                        25.67Mi ± 0%   25.66Mi ± 0%       ~ (p=0.684 n=10)
Parse/checker.ts/server-20                                     25.84Mi ± 0%   25.84Mi ± 0%  +0.02% (p=0.023 n=10)
Parse/dom.generated.d.ts/tsc-20                                9.154Mi ± 0%   9.153Mi ± 0%       ~ (p=0.971 n=10)
Parse/dom.generated.d.ts/server-20                             11.51Mi ± 0%   11.22Mi ± 0%  -2.52% (p=0.000 n=10)
Parse/Herebyfile.mjs/tsc-20                                    447.6Ki ± 0%   448.3Ki ± 0%  +0.15% (p=0.000 n=10)
Parse/Herebyfile.mjs/server-20                                 447.6Ki ± 0%   448.3Ki ± 0%  +0.15% (p=0.000 n=10)
Parse/jsxComplexSignatureHasApplicabilityError.tsx/tsc-20      162.3Ki ± 0%   162.2Ki ± 0%  -0.02% (p=0.000 n=10)
Parse/jsxComplexSignatureHasApplicabilityError.tsx/server-20   239.1Ki ± 0%   242.1Ki ± 0%  +1.28% (p=0.000 n=10)
geomean                                                        461.9Ki        461.4Ki       -0.10%
¹ all samples are equal
```
```
                                                             │   old.txt   │                new.txt                │
                                                             │  allocs/op  │  allocs/op   vs base                  │
Parse/empty.ts/tsc-20                                           4.000 ± 0%    4.000 ± 0%        ~ (p=1.000 n=10) ¹
Parse/empty.ts/server-20                                        4.000 ± 0%    4.000 ± 0%        ~ (p=1.000 n=10) ¹
Parse/checker.ts/tsc-20                                        29.18k ± 0%   29.18k ± 0%   -0.02% (p=0.000 n=10)
Parse/checker.ts/server-20                                     29.80k ± 0%   29.50k ± 0%   -1.00% (p=0.000 n=10)
Parse/dom.generated.d.ts/tsc-20                                23.01k ± 0%   23.01k ± 0%        ~ (p=0.582 n=10)
Parse/dom.generated.d.ts/server-20                             30.46k ± 0%   25.02k ± 0%  -17.86% (p=0.000 n=10)
Parse/Herebyfile.mjs/tsc-20                                    1.880k ± 0%   1.887k ± 0%   +0.37% (p=0.000 n=10)
Parse/Herebyfile.mjs/server-20                                 1.880k ± 0%   1.887k ± 0%   +0.37% (p=0.000 n=10)
Parse/jsxComplexSignatureHasApplicabilityError.tsx/tsc-20       331.0 ± 0%    331.0 ± 0%        ~ (p=1.000 n=10) ¹
Parse/jsxComplexSignatureHasApplicabilityError.tsx/server-20    597.0 ± 0%    457.0 ± 0%  -23.45% (p=0.000 n=10)
geomean                                                        1.211k        1.156k        -4.56%
¹ all samples are equal
```