### PR TITLE
Pool more top nodes

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -53,16 +53,20 @@ type NodeFactory struct {
 	blockPool                        core.Pool[Block]
 	callExpressionPool               core.Pool[CallExpression]
 	expressionStatementPool          core.Pool[ExpressionStatement]
+	functionDeclarationPool          core.Pool[FunctionDeclaration]
 	identifierPool                   core.Pool[Identifier]
 	ifStatementPool                  core.Pool[IfStatement]
 	jsdocPool                        core.Pool[JSDoc]
 	jsdocTextPool                    core.Pool[JSDocText]
+	keywordExpressionPool            core.Pool[KeywordExpression]
 	keywordTypeNodePool              core.Pool[KeywordTypeNode]
 	literalTypeNodePool              core.Pool[LiteralTypeNode]
 	modifierListPool                 core.Pool[ModifierList]
 	nodeListPool                     core.Pool[NodeList]
+	numericLiteralPool               core.Pool[NumericLiteral]
 	parameterDeclarationPool         core.Pool[ParameterDeclaration]
 	parenthesizedExpressionPool      core.Pool[ParenthesizedExpression]
+	prefixUnaryExpressionPool        core.Pool[PrefixUnaryExpression]
 	propertyAccessExpressionPool     core.Pool[PropertyAccessExpression]
 	propertyAssignmentPool           core.Pool[PropertyAssignment]
 	propertySignatureDeclarationPool core.Pool[PropertySignatureDeclaration]
@@ -70,6 +74,7 @@ type NodeFactory struct {
 	stringLiteralPool                core.Pool[StringLiteral]
 	tokenPool                        core.Pool[Token]
 	typeReferenceNodePool            core.Pool[TypeReferenceNode]
+	unionTypeNodePool                core.Pool[UnionTypeNode]
 	variableDeclarationListPool      core.Pool[VariableDeclarationList]
 	variableDeclarationPool          core.Pool[VariableDeclaration]
 	variableStatementPool            core.Pool[VariableStatement]
@@ -3466,7 +3471,7 @@ type FunctionDeclaration struct {
 }
 
 func (f *NodeFactory) NewFunctionDeclaration(modifiers *ModifierList, asteriskToken *TokenNode, name *IdentifierNode, typeParameters *NodeList, parameters *NodeList, returnType *TypeNode, body *BlockNode) *Node {
-	data := &FunctionDeclaration{}
+	data := f.functionDeclarationPool.New()
 	data.modifiers = modifiers
 	data.AsteriskToken = asteriskToken
 	data.name = name
@@ -5433,7 +5438,7 @@ type KeywordExpression struct {
 }
 
 func (f *NodeFactory) NewKeywordExpression(kind Kind) *Node {
-	return f.newNode(kind, &KeywordExpression{})
+	return f.newNode(kind, f.keywordExpressionPool.New())
 }
 
 func (node *KeywordExpression) Clone(f NodeFactoryCoercible) *Node {
@@ -5489,7 +5494,7 @@ type NumericLiteral struct {
 }
 
 func (f *NodeFactory) NewNumericLiteral(text string) *Node {
-	data := &NumericLiteral{}
+	data := f.numericLiteralPool.New()
 	data.Text = text
 	f.textCount++
 	return f.newNode(KindNumericLiteral, data)
@@ -5638,7 +5643,7 @@ type PrefixUnaryExpression struct {
 }
 
 func (f *NodeFactory) NewPrefixUnaryExpression(operator Kind, operand *Expression) *Node {
-	data := &PrefixUnaryExpression{}
+	data := f.prefixUnaryExpressionPool.New()
 	data.Operator = operator
 	data.Operand = operand
 	return f.newNode(KindPrefixUnaryExpression, data)
@@ -7035,7 +7040,7 @@ func (f *NodeFactory) UpdateUnionTypeNode(node *UnionTypeNode, types *TypeList) 
 }
 
 func (f *NodeFactory) NewUnionTypeNode(types *NodeList) *Node {
-	data := &UnionTypeNode{}
+	data := f.unionTypeNodePool.New()
 	data.Types = types
 	return f.newNode(KindUnionType, data)
 }

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -54,18 +54,22 @@ type NodeFactory struct {
 	callExpressionPool               core.Pool[CallExpression]
 	expressionStatementPool          core.Pool[ExpressionStatement]
 	functionDeclarationPool          core.Pool[FunctionDeclaration]
+	functionTypeNodePool             core.Pool[FunctionTypeNode]
 	identifierPool                   core.Pool[Identifier]
 	ifStatementPool                  core.Pool[IfStatement]
+	interfaceDeclarationPool         core.Pool[InterfaceDeclaration]
 	jsdocPool                        core.Pool[JSDoc]
 	jsdocTextPool                    core.Pool[JSDocText]
 	keywordExpressionPool            core.Pool[KeywordExpression]
 	keywordTypeNodePool              core.Pool[KeywordTypeNode]
 	literalTypeNodePool              core.Pool[LiteralTypeNode]
+	methodSignatureDeclarationPool   core.Pool[MethodSignatureDeclaration]
 	modifierListPool                 core.Pool[ModifierList]
 	nodeListPool                     core.Pool[NodeList]
 	numericLiteralPool               core.Pool[NumericLiteral]
 	parameterDeclarationPool         core.Pool[ParameterDeclaration]
 	parenthesizedExpressionPool      core.Pool[ParenthesizedExpression]
+	parenthesizedTypeNodePool        core.Pool[ParenthesizedTypeNode]
 	prefixUnaryExpressionPool        core.Pool[PrefixUnaryExpression]
 	propertyAccessExpressionPool     core.Pool[PropertyAccessExpression]
 	propertyAssignmentPool           core.Pool[PropertyAssignment]
@@ -73,6 +77,7 @@ type NodeFactory struct {
 	returnStatementPool              core.Pool[ReturnStatement]
 	stringLiteralPool                core.Pool[StringLiteral]
 	tokenPool                        core.Pool[Token]
+	typeLiteralNodePool              core.Pool[TypeLiteralNode]
 	typeReferenceNodePool            core.Pool[TypeReferenceNode]
 	unionTypeNodePool                core.Pool[UnionTypeNode]
 	variableDeclarationListPool      core.Pool[VariableDeclarationList]
@@ -3727,7 +3732,7 @@ type InterfaceDeclaration struct {
 }
 
 func (f *NodeFactory) NewInterfaceDeclaration(modifiers *ModifierList, name *IdentifierNode, typeParameters *NodeList, heritageClauses *NodeList, members *NodeList) *Node {
-	data := &InterfaceDeclaration{}
+	data := f.interfaceDeclarationPool.New()
 	data.modifiers = modifiers
 	data.name = name
 	data.TypeParameters = typeParameters
@@ -5129,7 +5134,7 @@ type MethodSignatureDeclaration struct {
 }
 
 func (f *NodeFactory) NewMethodSignatureDeclaration(modifiers *ModifierList, name *PropertyName, postfixToken *TokenNode, typeParameters *NodeList, parameters *NodeList, returnType *TypeNode) *Node {
-	data := &MethodSignatureDeclaration{}
+	data := f.methodSignatureDeclarationPool.New()
 	data.modifiers = modifiers
 	data.name = name
 	data.PostfixToken = postfixToken
@@ -7723,7 +7728,7 @@ type TypeLiteralNode struct {
 }
 
 func (f *NodeFactory) NewTypeLiteralNode(members *NodeList) *Node {
-	data := &TypeLiteralNode{}
+	data := f.typeLiteralNodePool.New()
 	data.Members = members
 	return f.newNode(KindTypeLiteral, data)
 }
@@ -7914,7 +7919,7 @@ type ParenthesizedTypeNode struct {
 }
 
 func (f *NodeFactory) NewParenthesizedTypeNode(typeNode *TypeNode) *Node {
-	data := &ParenthesizedTypeNode{}
+	data := f.parenthesizedTypeNodePool.New()
 	data.Type = typeNode
 	return f.newNode(KindParenthesizedType, data)
 }
@@ -7962,7 +7967,7 @@ type FunctionTypeNode struct {
 }
 
 func (f *NodeFactory) NewFunctionTypeNode(typeParameters *NodeList, parameters *NodeList, returnType *TypeNode) *Node {
-	data := &FunctionTypeNode{}
+	data := f.functionTypeNodePool.New()
 	data.TypeParameters = typeParameters
 	data.Parameters = parameters
 	data.Type = returnType


### PR DESCRIPTION
I looked at the top allocators again; pooling a few more nodes speeds up parsing the DOM types by 3%, reducing allocations in the DOM types by some 50% in the best case.

```
goos: linux
goarch: amd64
pkg: github.com/microsoft/typescript-go/internal/parser
cpu: Intel(R) Core(TM) i9-10900K CPU @ 3.70GHz
                                                             │   old.txt   │              new.txt               │
                                                             │   sec/op    │   sec/op     vs base               │
Parse/empty.ts/tsc-20                                          527.5n ± 4%   524.1n ± 2%       ~ (p=0.190 n=10)
Parse/empty.ts/server-20                                       524.1n ± 1%   527.3n ± 1%       ~ (p=0.118 n=10)
Parse/checker.ts/tsc-20                                        48.66m ± 2%   47.70m ± 3%       ~ (p=0.063 n=10)
Parse/checker.ts/server-20                                     48.88m ± 4%   48.17m ± 3%       ~ (p=0.075 n=10)
Parse/dom.generated.d.ts/tsc-20                                16.39m ± 2%   15.86m ± 1%  -3.21% (p=0.000 n=10)
Parse/dom.generated.d.ts/server-20                             24.56m ± 2%   23.92m ± 2%  -2.59% (p=0.003 n=10)
Parse/Herebyfile.mjs/tsc-20                                    884.3µ ± 1%   875.5µ ± 2%  -1.00% (p=0.011 n=10)
Parse/Herebyfile.mjs/server-20                                 886.8µ ± 3%   877.1µ ± 2%       ~ (p=0.052 n=10)
Parse/jsxComplexSignatureHasApplicabilityError.tsx/tsc-20      267.4µ ± 2%   268.0µ ± 2%       ~ (p=0.684 n=10)
Parse/jsxComplexSignatureHasApplicabilityError.tsx/server-20   419.1µ ± 2%   418.2µ ± 3%       ~ (p=0.853 n=10)
geomean                                                        686.5µ        678.7µ       -1.14%
```
```
                                                             │   old.txt    │                new.txt                │
                                                             │     B/op     │     B/op      vs base                 │
Parse/empty.ts/tsc-20                                            881.0 ± 0%     881.0 ± 0%       ~ (p=1.000 n=10) ¹
Parse/empty.ts/server-20                                         881.0 ± 0%     881.0 ± 0%       ~ (p=1.000 n=10) ¹
Parse/checker.ts/tsc-20                                        25.67Mi ± 0%   25.69Mi ± 0%  +0.08% (p=0.000 n=10)
Parse/checker.ts/server-20                                     25.84Mi ± 0%   25.86Mi ± 0%  +0.08% (p=0.000 n=10)
Parse/dom.generated.d.ts/tsc-20                                9.154Mi ± 0%   9.248Mi ± 0%  +1.02% (p=0.000 n=10)
Parse/dom.generated.d.ts/server-20                             11.51Mi ± 0%   11.60Mi ± 0%  +0.81% (p=0.000 n=10)
Parse/Herebyfile.mjs/tsc-20                                    447.6Ki ± 0%   450.0Ki ± 0%  +0.54% (p=0.000 n=10)
Parse/Herebyfile.mjs/server-20                                 447.6Ki ± 0%   450.0Ki ± 0%  +0.54% (p=0.000 n=10)
Parse/jsxComplexSignatureHasApplicabilityError.tsx/tsc-20      162.3Ki ± 0%   164.9Ki ± 0%  +1.64% (p=0.000 n=10)
Parse/jsxComplexSignatureHasApplicabilityError.tsx/server-20   239.1Ki ± 0%   241.7Ki ± 0%  +1.11% (p=0.000 n=10)
geomean                                                        461.9Ki        464.6Ki       +0.58%
¹ all samples are equal
```
```
                                                             │   old.txt   │                new.txt                │
                                                             │  allocs/op  │  allocs/op   vs base                  │
Parse/empty.ts/tsc-20                                           4.000 ± 0%    4.000 ± 0%        ~ (p=1.000 n=10) ¹
Parse/empty.ts/server-20                                        4.000 ± 0%    4.000 ± 0%        ~ (p=1.000 n=10) ¹
Parse/checker.ts/tsc-20                                        29.18k ± 0%   18.10k ± 0%  -37.99% (p=0.000 n=10)
Parse/checker.ts/server-20                                     29.80k ± 0%   18.71k ± 0%  -37.21% (p=0.000 n=10)
Parse/dom.generated.d.ts/tsc-20                                23.01k ± 0%   11.49k ± 0%  -50.07% (p=0.000 n=10)
Parse/dom.generated.d.ts/server-20                             30.46k ± 0%   18.94k ± 0%  -37.82% (p=0.000 n=10)
Parse/Herebyfile.mjs/tsc-20                                    1.880k ± 0%   1.818k ± 0%   -3.30% (p=0.000 n=10)
Parse/Herebyfile.mjs/server-20                                 1.880k ± 0%   1.818k ± 0%   -3.30% (p=0.000 n=10)
Parse/jsxComplexSignatureHasApplicabilityError.tsx/tsc-20       331.0 ± 0%    278.0 ± 0%  -16.01% (p=0.000 n=10)
Parse/jsxComplexSignatureHasApplicabilityError.tsx/server-20    597.0 ± 0%    544.0 ± 0%   -8.88% (p=0.000 n=10)
geomean                                                        1.211k         948.4       -21.71%
¹ all samples are equal
```