### PR TITLE
Pool EmitContext

### DIFF
--- a/internal/compiler/emitter.go
+++ b/internal/compiler/emitter.go
@@ -133,7 +133,9 @@ func (e *emitter) emitJSFile(sourceFile *ast.SourceFile, jsFilePath string, sour
 		return
 	}
 
-	emitContext := printer.NewEmitContext()
+	emitContext, putEmitContext := printer.GetEmitContext()
+	defer putEmitContext()
+
 	for _, transformer := range getScriptTransformers(emitContext, e.host, sourceFile) {
 		sourceFile = transformer.TransformSourceFile(sourceFile)
 	}
@@ -175,7 +177,8 @@ func (e *emitter) emitDeclarationFile(sourceFile *ast.SourceFile, declarationFil
 	}
 
 	var diags []*ast.Diagnostic
-	emitContext := printer.NewEmitContext()
+	emitContext, putEmitContext := printer.GetEmitContext()
+	defer putEmitContext()
 	for _, transformer := range e.getDeclarationTransformers(emitContext, sourceFile, declarationFilePath, declarationMapPath) {
 		sourceFile = transformer.TransformSourceFile(sourceFile)
 		diags = append(diags, transformer.GetDiagnostics()...)

--- a/internal/testutil/tsbaseline/type_symbol_baseline.go
+++ b/internal/testutil/tsbaseline/type_symbol_baseline.go
@@ -347,7 +347,8 @@ func (walker *typeWriterWalker) writeTypeOrSymbol(node *ast.Node, isSymbolWalk b
 	fileChecker, done := walker.getTypeCheckerForCurrentFile()
 	defer done()
 
-	ctx := printer.NewEmitContext()
+	ctx, putCtx := printer.GetEmitContext()
+	defer putCtx()
 
 	if !isSymbolWalk {
 		// Don't try to get the type of something that's already a type.


### PR DESCRIPTION
These objects can be reused, which is good because we create one of them per file to emit.