### PR TITLE
Use strict subtype relation in `getCommonSupertype`

### DIFF
--- a/testdata/baselines/reference/compiler/strictBestCommonSupertype.symbols
+++ b/testdata/baselines/reference/compiler/strictBestCommonSupertype.symbols
@@ -1,0 +1,64 @@
+//// [tests/cases/compiler/strictBestCommonSupertype.ts] ////
+
+=== strictBestCommonSupertype.ts ===
+// https://github.com/microsoft/typescript-go/issues/1222
+
+class Store<T = object> {
+>Store : Symbol(Store, Decl(strictBestCommonSupertype.ts, 0, 0))
+>T : Symbol(T, Decl(strictBestCommonSupertype.ts, 2, 12))
+
+    select<K>(mapFn: (state: T) => K) {};
+>select : Symbol(select, Decl(strictBestCommonSupertype.ts, 2, 25))
+>K : Symbol(K, Decl(strictBestCommonSupertype.ts, 3, 11))
+>mapFn : Symbol(mapFn, Decl(strictBestCommonSupertype.ts, 3, 14))
+>state : Symbol(state, Decl(strictBestCommonSupertype.ts, 3, 22))
+>T : Symbol(T, Decl(strictBestCommonSupertype.ts, 2, 12))
+>K : Symbol(K, Decl(strictBestCommonSupertype.ts, 3, 11))
+}
+
+const store: Store = inject(Store);
+>store : Symbol(store, Decl(strictBestCommonSupertype.ts, 6, 5))
+>Store : Symbol(Store, Decl(strictBestCommonSupertype.ts, 0, 0))
+>inject : Symbol(inject, Decl(strictBestCommonSupertype.ts, 6, 35))
+>Store : Symbol(Store, Decl(strictBestCommonSupertype.ts, 0, 0))
+
+function inject<T>(token: ProviderToken<T>): T {
+>inject : Symbol(inject, Decl(strictBestCommonSupertype.ts, 6, 35))
+>T : Symbol(T, Decl(strictBestCommonSupertype.ts, 8, 16))
+>token : Symbol(token, Decl(strictBestCommonSupertype.ts, 8, 19))
+>ProviderToken : Symbol(ProviderToken, Decl(strictBestCommonSupertype.ts, 14, 1))
+>T : Symbol(T, Decl(strictBestCommonSupertype.ts, 8, 16))
+>T : Symbol(T, Decl(strictBestCommonSupertype.ts, 8, 16))
+
+    return {} as T;
+>T : Symbol(T, Decl(strictBestCommonSupertype.ts, 8, 16))
+}
+
+interface Type<T> extends Function {
+>Type : Symbol(Type, Decl(strictBestCommonSupertype.ts, 10, 1))
+>T : Symbol(T, Decl(strictBestCommonSupertype.ts, 12, 15))
+>Function : Symbol(Function, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+    new (...args: any[]): T;
+>args : Symbol(args, Decl(strictBestCommonSupertype.ts, 13, 9))
+>T : Symbol(T, Decl(strictBestCommonSupertype.ts, 12, 15))
+}
+
+type ProviderToken<T> = Type<T> | AbstractType<T>;
+>ProviderToken : Symbol(ProviderToken, Decl(strictBestCommonSupertype.ts, 14, 1))
+>T : Symbol(T, Decl(strictBestCommonSupertype.ts, 16, 19))
+>Type : Symbol(Type, Decl(strictBestCommonSupertype.ts, 10, 1))
+>T : Symbol(T, Decl(strictBestCommonSupertype.ts, 16, 19))
+>AbstractType : Symbol(AbstractType, Decl(strictBestCommonSupertype.ts, 16, 50))
+>T : Symbol(T, Decl(strictBestCommonSupertype.ts, 16, 19))
+
+interface AbstractType<T> extends Function {
+>AbstractType : Symbol(AbstractType, Decl(strictBestCommonSupertype.ts, 16, 50))
+>T : Symbol(T, Decl(strictBestCommonSupertype.ts, 18, 23))
+>Function : Symbol(Function, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+    prototype: T;
+>prototype : Symbol(prototype, Decl(strictBestCommonSupertype.ts, 18, 44))
+>T : Symbol(T, Decl(strictBestCommonSupertype.ts, 18, 23))
+}
+

--- a/testdata/baselines/reference/compiler/strictBestCommonSupertype.types
+++ b/testdata/baselines/reference/compiler/strictBestCommonSupertype.types
@@ -1,0 +1,42 @@
+//// [tests/cases/compiler/strictBestCommonSupertype.ts] ////
+
+=== strictBestCommonSupertype.ts ===
+// https://github.com/microsoft/typescript-go/issues/1222
+
+class Store<T = object> {
+>Store : Store<T>
+
+    select<K>(mapFn: (state: T) => K) {};
+>select : <K>(mapFn: (state: T) => K) => void
+>mapFn : (state: T) => K
+>state : T
+}
+
+const store: Store = inject(Store);
+>store : Store<object>
+>inject(Store) : Store<any>
+>inject : <T>(token: ProviderToken<T>) => T
+>Store : typeof Store
+
+function inject<T>(token: ProviderToken<T>): T {
+>inject : <T>(token: ProviderToken<T>) => T
+>token : ProviderToken<T>
+
+    return {} as T;
+>{} as T : T
+>{} : {}
+}
+
+interface Type<T> extends Function {
+    new (...args: any[]): T;
+>args : any[]
+}
+
+type ProviderToken<T> = Type<T> | AbstractType<T>;
+>ProviderToken : ProviderToken<T>
+
+interface AbstractType<T> extends Function {
+    prototype: T;
+>prototype : T
+}
+

--- a/testdata/tests/cases/compiler/strictBestCommonSupertype.ts
+++ b/testdata/tests/cases/compiler/strictBestCommonSupertype.ts
@@ -1,0 +1,24 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/typescript-go/issues/1222
+
+class Store<T = object> {
+    select<K>(mapFn: (state: T) => K) {};
+}
+
+const store: Store = inject(Store);
+
+function inject<T>(token: ProviderToken<T>): T {
+    return {} as T;
+}
+
+interface Type<T> extends Function {
+    new (...args: any[]): T;
+}
+
+type ProviderToken<T> = Type<T> | AbstractType<T>;
+
+interface AbstractType<T> extends Function {
+    prototype: T;
+}


### PR DESCRIPTION
This is a port of https://github.com/microsoft/TypeScript/pull/61903.

Fixes #1222.