### PR TITLE
Replace no-default-lib with IsLibFile on Program

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -10012,7 +10012,6 @@ type SourceFile struct {
 	LanguageVariant             core.LanguageVariant
 	ScriptKind                  core.ScriptKind
 	IsDeclarationFile           bool
-	HasNoDefaultLib             bool
 	UsesUriStyleNodeCoreModules core.Tristate
 	Identifiers                 map[string]string
 	IdentifierCount             int
@@ -10138,7 +10137,6 @@ func (node *SourceFile) copyFrom(other *SourceFile) {
 	node.LanguageVariant = other.LanguageVariant
 	node.ScriptKind = other.ScriptKind
 	node.IsDeclarationFile = other.IsDeclarationFile
-	node.HasNoDefaultLib = other.HasNoDefaultLib
 	node.UsesUriStyleNodeCoreModules = other.UsesUriStyleNodeCoreModules
 	node.Identifiers = other.Identifiers
 	node.imports = other.imports

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -539,6 +539,7 @@ type Program interface {
 	GetImportHelpersImportSpecifier(path tspath.Path) *ast.Node
 	SourceFileMayBeEmitted(sourceFile *ast.SourceFile, forceDtsEmit bool) bool
 	IsSourceFromProjectReference(path tspath.Path) bool
+	IsLibFile(path tspath.Path) bool
 	GetSourceAndProjectReference(path tspath.Path) *tsoptions.SourceAndProjectReference
 	GetRedirectForResolution(file ast.HasFileName) *tsoptions.ParsedCommandLine
 	CommonSourceDirectory() string

--- a/internal/checker/relater.go
+++ b/internal/checker/relater.go
@@ -587,7 +587,7 @@ func (c *Checker) elaborateElement(source *Type, target *Type, relation *Relatio
 	issuedElaboration := false
 	if targetProp == nil {
 		indexInfo := c.getApplicableIndexInfo(target, nameType)
-		if indexInfo != nil && indexInfo.declaration != nil && !ast.GetSourceFileOfNode(indexInfo.declaration).HasNoDefaultLib {
+		if indexInfo != nil && indexInfo.declaration != nil && !c.program.IsLibFile(ast.GetSourceFileOfNode(indexInfo.declaration).Path()) {
 			issuedElaboration = true
 			diagnostic.AddRelatedInfo(createDiagnosticForNode(indexInfo.declaration, diagnostics.The_expected_type_comes_from_this_index_signature))
 		}
@@ -602,7 +602,7 @@ func (c *Checker) elaborateElement(source *Type, target *Type, relation *Relatio
 		if propertyName == "" || nameType.flags&TypeFlagsUniqueESSymbol != 0 {
 			propertyName = c.TypeToString(nameType)
 		}
-		if !ast.GetSourceFileOfNode(targetNode).HasNoDefaultLib {
+		if !c.program.IsLibFile(ast.GetSourceFileOfNode(targetNode).Path()) {
 			diagnostic.AddRelatedInfo(createDiagnosticForNode(targetNode, diagnostics.The_expected_type_comes_from_property_0_which_is_declared_here_on_type_1, propertyName, c.TypeToString(target)))
 		}
 	}

--- a/internal/checker/utilities.go
+++ b/internal/checker/utilities.go
@@ -1470,7 +1470,7 @@ func forEachYieldExpression(body *ast.Node, visitor func(expr *ast.Node)) {
 func SkipTypeChecking(sourceFile *ast.SourceFile, options *core.CompilerOptions, host Program) bool {
 	return options.NoCheck.IsTrue() ||
 		options.SkipLibCheck.IsTrue() && sourceFile.IsDeclarationFile ||
-		options.SkipDefaultLibCheck.IsTrue() && sourceFile.HasNoDefaultLib ||
+		options.SkipDefaultLibCheck.IsTrue() && host.IsLibFile(sourceFile.Path()) ||
 		host.IsSourceFromProjectReference(sourceFile.Path()) ||
 		!canIncludeBindAndCheckDiagnostics(sourceFile, options)
 }

--- a/internal/compiler/fileloader.go
+++ b/internal/compiler/fileloader.go
@@ -50,6 +50,7 @@ type processedFiles struct {
 	sourceFileMetaDatas           map[tspath.Path]ast.SourceFileMetaData
 	jsxRuntimeImportSpecifiers    map[tspath.Path]*jsxRuntimeImportSpecifier
 	importHelpersImportSpecifiers map[tspath.Path]*ast.Node
+	libFiles                      collections.Set[tspath.Path]
 	// List of present unsupported extensions
 	unsupportedExtensions                []string
 	sourceFilesFoundSearchingNodeModules collections.Set[tspath.Path]
@@ -130,6 +131,7 @@ func processAllProgramFiles(
 	var importHelpersImportSpecifiers map[tspath.Path]*ast.Node
 	var unsupportedExtensions []string
 	var sourceFilesFoundSearchingNodeModules collections.Set[tspath.Path]
+	var libFileSet collections.Set[tspath.Path]
 
 	loader.parseTasks.collect(&loader, loader.rootTasks, func(task *parseTask, _ []tspath.Path) {
 		if task.isRedirected {
@@ -148,6 +150,7 @@ func processAllProgramFiles(
 		}
 		if task.isLib {
 			libFiles = append(libFiles, file)
+			libFileSet.Add(path)
 		} else {
 			files = append(files, file)
 		}
@@ -197,6 +200,7 @@ func processAllProgramFiles(
 		importHelpersImportSpecifiers:        importHelpersImportSpecifiers,
 		unsupportedExtensions:                unsupportedExtensions,
 		sourceFilesFoundSearchingNodeModules: sourceFilesFoundSearchingNodeModules,
+		libFiles:                             libFileSet,
 	}
 }
 

--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -213,7 +213,6 @@ func (p *Program) initCheckerPool() {
 func canReplaceFileInProgram(file1 *ast.SourceFile, file2 *ast.SourceFile) bool {
 	return file2 != nil &&
 		file1.ParseOptions() == file2.ParseOptions() &&
-		file1.HasNoDefaultLib == file2.HasNoDefaultLib &&
 		file1.UsesUriStyleNodeCoreModules == file2.UsesUriStyleNodeCoreModules &&
 		slices.EqualFunc(file1.Imports(), file2.Imports(), equalModuleSpecifiers) &&
 		slices.EqualFunc(file1.ModuleAugmentations, file2.ModuleAugmentations, equalModuleAugmentationNames) &&
@@ -640,6 +639,10 @@ func (p *Program) GetModeForUsageLocation(sourceFile ast.HasFileName, location *
 
 func (p *Program) GetDefaultResolutionModeForFile(sourceFile ast.HasFileName) core.ResolutionMode {
 	return getDefaultResolutionModeForFile(sourceFile.FileName(), p.sourceFileMetaDatas[sourceFile.Path()], p.projectReferenceFileMapper.getCompilerOptionsForFile(sourceFile))
+}
+
+func (p *Program) IsLibFile(path tspath.Path) bool {
+	return p.libFiles.Has(path)
 }
 
 func (p *Program) CommonSourceDirectory() string {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -6544,7 +6544,6 @@ func (p *Parser) processPragmasIntoFields(context *ast.SourceFile) {
 	context.TypeReferenceDirectives = nil
 	context.LibReferenceDirectives = nil
 	// context.AmdDependencies = nil
-	context.HasNoDefaultLib = false
 	for _, pragma := range context.Pragmas {
 		switch pragma.Name {
 		case "reference":
@@ -6556,7 +6555,7 @@ func (p *Parser) processPragmasIntoFields(context *ast.SourceFile) {
 			noDefaultLib, noDefaultLibOk := pragma.Args["no-default-lib"]
 			switch {
 			case noDefaultLibOk && noDefaultLib.Value == "true":
-				context.HasNoDefaultLib = true
+				// Ignored.
 			case typesOk:
 				var parsed core.ResolutionMode
 				if resolutionModeOk {

--- a/internal/transformers/declarations/transform.go
+++ b/internal/transformers/declarations/transform.go
@@ -196,7 +196,6 @@ func (tx *DeclarationTransformer) transformSourceFile(node *ast.SourceFile) *ast
 	result := tx.Factory().UpdateSourceFile(node, combinedStatements)
 	result.AsSourceFile().LibReferenceDirectives = tx.getLibReferences()
 	result.AsSourceFile().TypeReferenceDirectives = tx.getTypeReferences()
-	result.AsSourceFile().HasNoDefaultLib = node.HasNoDefaultLib
 	result.AsSourceFile().IsDeclarationFile = true
 	result.AsSourceFile().ReferencedFiles = tx.getReferencedFiles(outputFilePath)
 	return result.AsNode()

--- a/internal/transformers/tstransforms/importelision_test.go
+++ b/internal/transformers/tstransforms/importelision_test.go
@@ -156,6 +156,10 @@ func (p *fakeProgram) GetResolvedModules() map[tspath.Path]module.ModeAwareCache
 	panic("unimplemented")
 }
 
+func (p *fakeProgram) IsLibFile(path tspath.Path) bool {
+	return false
+}
+
 func TestImportElision(t *testing.T) {
 	t.Parallel()
 	data := []struct {

--- a/testdata/baselines/reference/submodule/conformance/1.0lib-noErrors.errors.txt
+++ b/testdata/baselines/reference/submodule/conformance/1.0lib-noErrors.errors.txt
@@ -1,0 +1,1248 @@
+1.0lib-noErrors.ts(130,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'Object' must be of type 'ObjectConstructor', but here has type '{ (): any; (value: any): any; new (value?: any): Object; prototype: Object; getPrototypeOf(o: any): any; getOwnPropertyDescriptor(o: any, p: string): PropertyDescriptor; getOwnPropertyNames(o: any): string[]; create(o: any, properties?: PropertyDescriptorMap): any; defineProperty(o: any, p: string, attributes: PropertyDescriptor): any; defineProperties(o: any, properties: PropertyDescriptorMap): any; seal(o: any): any; freeze(o: any): any; preventExtensions(o: any): any; isSealed(o: any): boolean; isFrozen(o: any): boolean; isExtensible(o: any): boolean; keys(o: any): string[]; }'.
+1.0lib-noErrors.ts(251,5): error TS2687: All declarations of 'length' must have identical modifiers.
+1.0lib-noErrors.ts(258,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'Function' must be of type 'FunctionConstructor', but here has type '{ (...args: string[]): Function; new (...args: string[]): Function; prototype: Function; }'.
+1.0lib-noErrors.ts(414,5): error TS2687: All declarations of 'length' must have identical modifiers.
+1.0lib-noErrors.ts(430,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'String' must be of type 'StringConstructor', but here has type '{ (value?: any): string; new (value?: any): String; prototype: String; fromCharCode(...codes: number[]): string; }'.
+1.0lib-noErrors.ts(439,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'Boolean' must be of type 'BooleanConstructor', but here has type '{ (value?: any): boolean; new (value?: any): Boolean; prototype: Boolean; }'.
+1.0lib-noErrors.ts(472,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'Number' must be of type 'NumberConstructor', but here has type '{ (value?: any): number; new (value?: any): Number; prototype: Number; MAX_VALUE: number; MIN_VALUE: number; NaN: number; NEGATIVE_INFINITY: number; POSITIVE_INFINITY: number; }'.
+1.0lib-noErrors.ts(504,5): error TS2687: All declarations of 'E' must have identical modifiers.
+1.0lib-noErrors.ts(506,5): error TS2687: All declarations of 'LN10' must have identical modifiers.
+1.0lib-noErrors.ts(508,5): error TS2687: All declarations of 'LN2' must have identical modifiers.
+1.0lib-noErrors.ts(510,5): error TS2687: All declarations of 'LOG2E' must have identical modifiers.
+1.0lib-noErrors.ts(512,5): error TS2687: All declarations of 'LOG10E' must have identical modifiers.
+1.0lib-noErrors.ts(514,5): error TS2687: All declarations of 'PI' must have identical modifiers.
+1.0lib-noErrors.ts(516,5): error TS2687: All declarations of 'SQRT1_2' must have identical modifiers.
+1.0lib-noErrors.ts(518,5): error TS2687: All declarations of 'SQRT2' must have identical modifiers.
+1.0lib-noErrors.ts(767,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'Date' must be of type 'DateConstructor', but here has type '{ (): string; new (): Date; new (value: number): Date; new (value: string): Date; new (year: number, month: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number): Date; prototype: Date; parse(s: string): number; UTC(year: number, month: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number): number; now(): number; }'.
+1.0lib-noErrors.ts(840,5): error TS2687: All declarations of 'source' must have identical modifiers.
+1.0lib-noErrors.ts(843,5): error TS2687: All declarations of 'global' must have identical modifiers.
+1.0lib-noErrors.ts(846,5): error TS2687: All declarations of 'ignoreCase' must have identical modifiers.
+1.0lib-noErrors.ts(849,5): error TS2687: All declarations of 'multiline' must have identical modifiers.
+1.0lib-noErrors.ts(856,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'RegExp' must be of type 'RegExpConstructor', but here has type '{ (pattern: string, flags?: string): RegExp; new (pattern: string, flags?: string): RegExp; $1: string; $2: string; $3: string; $4: string; $5: string; $6: string; $7: string; $8: string; $9: string; lastMatch: string; }'.
+1.0lib-noErrors.ts(877,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'Error' must be of type 'ErrorConstructor', but here has type '{ (message?: string): Error; new (message?: string): Error; prototype: Error; }'.
+1.0lib-noErrors.ts(885,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'EvalError' must be of type 'EvalErrorConstructor', but here has type '{ (message?: string): EvalError; new (message?: string): EvalError; prototype: EvalError; }'.
+1.0lib-noErrors.ts(893,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'RangeError' must be of type 'RangeErrorConstructor', but here has type '{ (message?: string): RangeError; new (message?: string): RangeError; prototype: RangeError; }'.
+1.0lib-noErrors.ts(901,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'ReferenceError' must be of type 'ReferenceErrorConstructor', but here has type '{ (message?: string): ReferenceError; new (message?: string): ReferenceError; prototype: ReferenceError; }'.
+1.0lib-noErrors.ts(909,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'SyntaxError' must be of type 'SyntaxErrorConstructor', but here has type '{ (message?: string): SyntaxError; new (message?: string): SyntaxError; prototype: SyntaxError; }'.
+1.0lib-noErrors.ts(917,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'TypeError' must be of type 'TypeErrorConstructor', but here has type '{ (message?: string): TypeError; new (message?: string): TypeError; prototype: TypeError; }'.
+1.0lib-noErrors.ts(925,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'URIError' must be of type 'URIErrorConstructor', but here has type '{ (message?: string): URIError; new (message?: string): URIError; prototype: URIError; }'.
+1.0lib-noErrors.ts(1134,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'Array' must be of type 'ArrayConstructor', but here has type '{ (arrayLength?: number): any[]; <T>(arrayLength: number): T[]; <T>(...items: T[]): T[]; new (arrayLength?: number): any[]; new <T>(arrayLength: number): T[]; new <T>(...items: T[]): T[]; isArray(arg: any): boolean; prototype: any[]; }'.
+
+
+==== 1.0lib-noErrors.ts (29 errors) ====
+    /* *****************************************************************************
+    Copyright (c) Microsoft Corporation. All rights reserved. 
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+    this file except in compliance with the License. You may obtain a copy of the
+    License at http://www.apache.org/licenses/LICENSE-2.0  
+     
+    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+    WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, 
+    MERCHANTABLITY OR NON-INFRINGEMENT. 
+     
+    See the Apache Version 2.0 License for specific language governing permissions
+    and limitations under the License.
+    ***************************************************************************** */
+    
+    /// <reference no-default-lib="true"/>
+    
+    /////////////////////////////
+    /// ECMAScript APIs
+    /////////////////////////////
+    
+    declare var NaN: number;
+    declare var Infinity: number;
+    
+    /**
+      * Evaluates JavaScript code and executes it. 
+      * @param x A String value that contains valid JavaScript code.
+      */
+    declare function eval(x: string): any;
+    
+    /**
+      * Converts A string to an integer.
+      * @param s A string to convert into a number.
+      * @param radix A value between 2 and 36 that specifies the base of the number in numString. 
+      * If this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.
+      * All other strings are considered decimal.
+      */
+    declare function parseInt(s: string, radix?: number): number;
+    
+    /**
+      * Converts a string to a floating-point number. 
+      * @param string A string that contains a floating-point number. 
+      */
+    declare function parseFloat(string: string): number;
+    
+    /**
+      * Returns a Boolean value that indicates whether a value is the reserved value NaN (not a number). 
+      * @param number A numeric value.
+      */
+    declare function isNaN(number: number): boolean;
+    
+    /** 
+      * Determines whether a supplied number is finite.
+      * @param number Any numeric value.
+      */
+    declare function isFinite(number: number): boolean;
+    
+    /**
+      * Gets the unencoded version of an encoded Uniform Resource Identifier (URI).
+      * @param encodedURI A value representing an encoded URI.
+      */
+    declare function decodeURI(encodedURI: string): string;
+    
+    /**
+      * Gets the unencoded version of an encoded component of a Uniform Resource Identifier (URI).
+      * @param encodedURIComponent A value representing an encoded URI component.
+      */
+    declare function decodeURIComponent(encodedURIComponent: string): string;
+    
+    /** 
+      * Encodes a text string as a valid Uniform Resource Identifier (URI)
+      * @param uri A value representing an encoded URI.
+      */
+    declare function encodeURI(uri: string): string;
+    
+    /**
+      * Encodes a text string as a valid component of a Uniform Resource Identifier (URI).
+      * @param uriComponent A value representing an encoded URI component.
+      */
+    declare function encodeURIComponent(uriComponent: string | number | boolean): string;
+    
+    interface PropertyDescriptor {
+        configurable?: boolean;
+        enumerable?: boolean;
+        value?: any;
+        writable?: boolean;
+        get?(): any;
+        set?(v: any): void;
+    }
+    
+    interface PropertyDescriptorMap {
+        [s: string]: PropertyDescriptor;
+    }
+    
+    interface Object {
+        /** The initial value of Object.prototype.constructor is the standard built-in Object constructor. */
+        constructor: Function;
+    
+        /** Returns a string representation of an object. */
+        toString(): string;
+    
+        /** Returns a date converted to a string using the current locale. */
+        toLocaleString(): string;
+    
+        /** Returns the primitive value of the specified object. */
+        valueOf(): Object;
+    
+        /**
+          * Determines whether an object has a property with the specified name. 
+          * @param v A property name.
+          */
+        hasOwnProperty(v: string): boolean;
+    
+        /**
+          * Determines whether an object exists in another object's prototype chain. 
+          * @param v Another object whose prototype chain is to be checked.
+          */
+        isPrototypeOf(v: Object): boolean;
+    
+        /** 
+          * Determines whether a specified property is enumerable.
+          * @param v A property name.
+          */
+        propertyIsEnumerable(v: string): boolean;
+    }
+    
+    /**
+      * Provides functionality common to all JavaScript objects.
+      */
+    declare var Object: {
+                ~~~~~~
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'Object' must be of type 'ObjectConstructor', but here has type '{ (): any; (value: any): any; new (value?: any): Object; prototype: Object; getPrototypeOf(o: any): any; getOwnPropertyDescriptor(o: any, p: string): PropertyDescriptor; getOwnPropertyNames(o: any): string[]; create(o: any, properties?: PropertyDescriptorMap): any; defineProperty(o: any, p: string, attributes: PropertyDescriptor): any; defineProperties(o: any, properties: PropertyDescriptorMap): any; seal(o: any): any; freeze(o: any): any; preventExtensions(o: any): any; isSealed(o: any): boolean; isFrozen(o: any): boolean; isExtensible(o: any): boolean; keys(o: any): string[]; }'.
+!!! related TS6203 lib.es5.d.ts:--:--: 'Object' was also declared here.
+        new (value?: any): Object;
+        (): any;
+        (value: any): any;
+    
+        /** A reference to the prototype for a class of objects. */
+        prototype: Object;
+    
+        /** 
+          * Returns the prototype of an object. 
+          * @param o The object that references the prototype.
+          */
+        getPrototypeOf(o: any): any;
+    
+        /**
+          * Gets the own property descriptor of the specified object. 
+          * An own property descriptor is one that is defined directly on the object and is not inherited from the object's prototype. 
+          * @param o Object that contains the property.
+          * @param p Name of the property.
+        */
+        getOwnPropertyDescriptor(o: any, p: string): PropertyDescriptor;
+    
+        /** 
+          * Returns the names of the own properties of an object. The own properties of an object are those that are defined directly 
+          * on that object, and are not inherited from the object's prototype. The properties of an object include both fields (objects) and functions.
+          * @param o Object that contains the own properties.
+          */
+        getOwnPropertyNames(o: any): string[];
+    
+        /** 
+          * Creates an object that has the specified prototype, and that optionally contains specified properties.
+          * @param o Object to use as a prototype. May be null
+          * @param properties JavaScript object that contains one or more property descriptors. 
+          */
+        create(o: any, properties?: PropertyDescriptorMap): any;
+    
+        /**
+          * Adds a property to an object, or modifies attributes of an existing property. 
+          * @param o Object on which to add or modify the property. This can be a native JavaScript object (that is, a user-defined object or a built in object) or a DOM object.
+          * @param p The property name.
+          * @param attributes Descriptor for the property. It can be for a data property or an accessor property.
+          */
+        defineProperty(o: any, p: string, attributes: PropertyDescriptor): any;
+    
+        /**
+          * Adds one or more properties to an object, and/or modifies attributes of existing properties. 
+          * @param o Object on which to add or modify the properties. This can be a native JavaScript object or a DOM object.
+          * @param properties JavaScript object that contains one or more descriptor objects. Each descriptor object describes a data property or an accessor property.
+          */
+        defineProperties(o: any, properties: PropertyDescriptorMap): any;
+    
+        /**
+          * Prevents the modification of attributes of existing properties, and prevents the addition of new properties.
+          * @param o Object on which to lock the attributes. 
+          */
+        seal(o: any): any;
+    
+        /**
+          * Prevents the modification of existing property attributes and values, and prevents the addition of new properties.
+          * @param o Object on which to lock the attributes.
+          */
+        freeze(o: any): any;
+    
+        /**
+          * Prevents the addition of new properties to an object.
+          * @param o Object to make non-extensible. 
+          */
+        preventExtensions(o: any): any;
+    
+        /**
+          * Returns true if existing property attributes cannot be modified in an object and new properties cannot be added to the object.
+          * @param o Object to test. 
+          */
+        isSealed(o: any): boolean;
+    
+        /**
+          * Returns true if existing property attributes and values cannot be modified in an object, and new properties cannot be added to the object.
+          * @param o Object to test.  
+          */
+        isFrozen(o: any): boolean;
+    
+        /**
+          * Returns a value that indicates whether new properties can be added to an object.
+          * @param o Object to test. 
+          */
+        isExtensible(o: any): boolean;
+    
+        /**
+          * Returns the names of the enumerable properties and methods of an object.
+          * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
+          */
+        keys(o: any): string[];
+    }
+    
+    /**
+      * Creates a new function.
+      */
+    interface Function {
+        /**
+          * Calls the function, substituting the specified object for the this value of the function, and the specified array for the arguments of the function.
+          * @param thisArg The object to be used as the this object.
+          * @param argArray A set of arguments to be passed to the function.
+          */
+        apply(thisArg: any, argArray?: any): any;
+    
+        /**
+          * Calls a method of an object, substituting another object for the current object.
+          * @param thisArg The object to be used as the current object.
+          * @param argArray A list of arguments to be passed to the method.
+          */
+        call(thisArg: any, ...argArray: any[]): any;
+    
+        /**
+          * For a given function, creates a bound function that has the same body as the original function. 
+          * The this object of the bound function is associated with the specified object, and has the specified initial parameters.
+          * @param thisArg An object to which the this keyword can refer inside the new function.
+          * @param argArray A list of arguments to be passed to the new function.
+          */
+        bind(thisArg: any, ...argArray: any[]): any;
+    
+        prototype: any;
+        length: number;
+        ~~~~~~
+!!! error TS2687: All declarations of 'length' must have identical modifiers.
+    
+        // Non-standard extensions
+        arguments: any;
+        caller: Function;
+    }
+    
+    declare var Function: {
+                ~~~~~~~~
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'Function' must be of type 'FunctionConstructor', but here has type '{ (...args: string[]): Function; new (...args: string[]): Function; prototype: Function; }'.
+!!! related TS6203 lib.es5.d.ts:--:--: 'Function' was also declared here.
+        /** 
+          * Creates a new function.
+          * @param args A list of arguments the function accepts.
+          */
+        new (...args: string[]): Function;
+        (...args: string[]): Function;
+        prototype: Function;
+    }
+    
+    interface IArguments {
+        [index: number]: any;
+        length: number;
+        callee: Function;
+    }
+    
+    interface String {
+        /** Returns a string representation of a string. */
+        toString(): string;
+    
+        /**
+          * Returns the character at the specified index.
+          * @param pos The zero-based index of the desired character.
+          */
+        charAt(pos: number): string;
+    
+        /** 
+          * Returns the Unicode value of the character at the specified location.
+          * @param index The zero-based index of the desired character. If there is no character at the specified index, NaN is returned.
+          */
+        charCodeAt(index: number): number;
+    
+        /**
+          * Returns a string that contains the concatenation of two or more strings.
+          * @param strings The strings to append to the end of the string.  
+          */
+        concat(...strings: string[]): string;
+    
+        /**
+          * Returns the position of the first occurrence of a substring. 
+          * @param searchString The substring to search for in the string
+          * @param position The index at which to begin searching the String object. If omitted, search starts at the beginning of the string.
+          */
+        indexOf(searchString: string, position?: number): number;
+    
+        /**
+          * Returns the last occurrence of a substring in the string.
+          * @param searchString The substring to search for.
+          * @param position The index at which to begin searching. If omitted, the search begins at the end of the string.
+          */
+        lastIndexOf(searchString: string, position?: number): number;
+    
+        /**
+          * Determines whether two strings are equivalent in the current locale.
+          * @param that String to compare to target string
+          */
+        localeCompare(that: string): number;
+    
+        /** 
+          * Matches a string with a regular expression, and returns an array containing the results of that search.
+          * @param regexp A variable name or string literal containing the regular expression pattern and flags.
+          */
+        match(regexp: string): string[];
+    
+        /** 
+          * Matches a string with a regular expression, and returns an array containing the results of that search.
+          * @param regexp A regular expression object that contains the regular expression pattern and applicable flags. 
+          */
+        match(regexp: RegExp): string[];
+    
+        /**
+          * Replaces text in a string, using a regular expression or search string.
+          * @param searchValue A String object or string literal that represents the regular expression
+          * @param replaceValue A String object or string literal containing the text to replace for every successful match of rgExp in stringObj.
+          */
+        replace(searchValue: string, replaceValue: string): string;
+    
+        /**
+          * Replaces text in a string, using a regular expression or search string.
+          * @param searchValue A String object or string literal that represents the regular expression
+          * @param replaceValue A function that returns the replacement text.
+          */
+        replace(searchValue: string, replaceValue: (substring: string, ...args: any[]) => string): string;
+    
+        /**
+          * Replaces text in a string, using a regular expression or search string.
+          * @param searchValue A Regular Expression object containing the regular expression pattern and applicable flags
+          * @param replaceValue A String object or string literal containing the text to replace for every successful match of rgExp in stringObj.
+          */
+        replace(searchValue: RegExp, replaceValue: string): string;
+    
+        /**
+          * Replaces text in a string, using a regular expression or search string.
+          * @param searchValue A Regular Expression object containing the regular expression pattern and applicable flags
+          * @param replaceValue A function that returns the replacement text.
+          */
+        replace(searchValue: RegExp, replaceValue: (substring: string, ...args: any[]) => string): string;
+    
+        /**
+          * Finds the first substring match in a regular expression search.
+          * @param regexp The regular expression pattern and applicable flags. 
+          */
+        search(regexp: string): number;
+    
+        /**
+          * Finds the first substring match in a regular expression search.
+          * @param regexp The regular expression pattern and applicable flags. 
+          */
+        search(regexp: RegExp): number;
+    
+        /**
+          * Returns a section of a string.
+          * @param start The index to the beginning of the specified portion of stringObj. 
+          * @param end The index to the end of the specified portion of stringObj. The substring includes the characters up to, but not including, the character indicated by end. 
+          * If this value is not specified, the substring continues to the end of stringObj.
+          */
+        slice(start?: number, end?: number): string;
+    
+        /**
+          * Split a string into substrings using the specified separator and return them as an array.
+          * @param separator A string that identifies character or characters to use in separating the string. If omitted, a single-element array containing the entire string is returned. 
+          * @param limit A value used to limit the number of elements returned in the array.
+          */
+        split(separator: string, limit?: number): string[];
+    
+        /**
+          * Split a string into substrings using the specified separator and return them as an array.
+          * @param separator A Regular Express that identifies character or characters to use in separating the string. If omitted, a single-element array containing the entire string is returned. 
+          * @param limit A value used to limit the number of elements returned in the array.
+          */
+        split(separator: RegExp, limit?: number): string[];
+    
+        /**
+          * Returns the substring at the specified location within a String object. 
+          * @param start The zero-based index number indicating the beginning of the substring.
+          * @param end Zero-based index number indicating the end of the substring. The substring includes the characters up to, but not including, the character indicated by end.
+          * If end is omitted, the characters from start through the end of the original string are returned.
+          */
+        substring(start: number, end?: number): string;
+    
+        /** Converts all the alphabetic characters in a string to lowercase. */
+        toLowerCase(): string;
+    
+        /** Converts all alphabetic characters to lowercase, taking into account the host environment's current locale. */
+        toLocaleLowerCase(): string;
+    
+        /** Converts all the alphabetic characters in a string to uppercase. */
+        toUpperCase(): string;
+    
+        /** Returns a string where all alphabetic characters have been converted to uppercase, taking into account the host environment's current locale. */
+        toLocaleUpperCase(): string;
+    
+        /** Removes the leading and trailing white space and line terminator characters from a string. */
+        trim(): string;
+    
+        /** Returns the length of a String object. */
+        length: number;
+        ~~~~~~
+!!! error TS2687: All declarations of 'length' must have identical modifiers.
+    
+        // IE extensions
+        /**
+          * Gets a substring beginning at the specified location and having the specified length.
+          * @param from The starting position of the desired substring. The index of the first character in the string is zero.
+          * @param length The number of characters to include in the returned substring.
+          */
+        substr(from: number, length?: number): string;
+    
+        [index: number]: string;
+    }
+    
+    /** 
+      * Allows manipulation and formatting of text strings and determination and location of substrings within strings. 
+      */
+    declare var String: {
+                ~~~~~~
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'String' must be of type 'StringConstructor', but here has type '{ (value?: any): string; new (value?: any): String; prototype: String; fromCharCode(...codes: number[]): string; }'.
+!!! related TS6203 lib.es5.d.ts:--:--: 'String' was also declared here.
+        new (value?: any): String;
+        (value?: any): string;
+        prototype: String;
+        fromCharCode(...codes: number[]): string;
+    }
+    
+    interface Boolean {
+    }
+    declare var Boolean: {
+                ~~~~~~~
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'Boolean' must be of type 'BooleanConstructor', but here has type '{ (value?: any): boolean; new (value?: any): Boolean; prototype: Boolean; }'.
+!!! related TS6203 lib.es5.d.ts:--:--: 'Boolean' was also declared here.
+        new (value?: any): Boolean;
+        (value?: any): boolean;
+        prototype: Boolean;
+    }
+    
+    interface Number {
+        /**
+          * Returns a string representation of an object.
+          * @param radix Specifies a radix for converting numeric values to strings. This value is only used for numbers.
+          */
+        toString(radix?: number): string;
+    
+        /** 
+          * Returns a string representing a number in fixed-point notation.
+          * @param fractionDigits Number of digits after the decimal point. Must be in the range 0 - 20, inclusive.
+          */
+        toFixed(fractionDigits?: number): string;
+    
+        /**
+          * Returns a string containing a number represented in exponential notation.
+          * @param fractionDigits Number of digits after the decimal point. Must be in the range 0 - 20, inclusive.
+          */
+        toExponential(fractionDigits?: number): string;
+    
+        /**
+          * Returns a string containing a number represented either in exponential or fixed-point notation with a specified number of digits.
+          * @param precision Number of significant digits. Must be in the range 1 - 21, inclusive.
+          */
+        toPrecision(precision?: number): string;
+    }
+    
+    /** An object that represents a number of any kind. All JavaScript numbers are 64-bit floating-point numbers. */
+    declare var Number: {
+                ~~~~~~
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'Number' must be of type 'NumberConstructor', but here has type '{ (value?: any): number; new (value?: any): Number; prototype: Number; MAX_VALUE: number; MIN_VALUE: number; NaN: number; NEGATIVE_INFINITY: number; POSITIVE_INFINITY: number; }'.
+!!! related TS6203 lib.es5.d.ts:--:--: 'Number' was also declared here.
+        new (value?: any): Number;
+        (value?: any): number;
+        prototype: Number;
+    
+        /** The largest number that can be represented in JavaScript. Equal to approximately 1.79E+308. */
+        MAX_VALUE: number;
+    
+        /** The closest number to zero that can be represented in JavaScript. Equal to approximately 5.00E-324. */
+        MIN_VALUE: number;
+    
+        /** 
+          * A value that is not a number.
+          * In equality comparisons, NaN does not equal any value, including itself. To test whether a value is equivalent to NaN, use the isNaN function.
+          */
+        NaN: number;
+    
+        /** 
+          * A value that is less than the largest negative number that can be represented in JavaScript.
+          * JavaScript displays NEGATIVE_INFINITY values as -infinity. 
+          */
+        NEGATIVE_INFINITY: number;
+    
+        /**
+          * A value greater than the largest number that can be represented in JavaScript. 
+          * JavaScript displays POSITIVE_INFINITY values as infinity. 
+          */
+        POSITIVE_INFINITY: number;
+    }
+    
+    interface Math {
+        /** The mathematical constant e. This is Euler's number, the base of natural logarithms. */
+        E: number;
+        ~
+!!! error TS2687: All declarations of 'E' must have identical modifiers.
+        /** The natural logarithm of 10. */
+        LN10: number;
+        ~~~~
+!!! error TS2687: All declarations of 'LN10' must have identical modifiers.
+        /** The natural logarithm of 2. */
+        LN2: number;
+        ~~~
+!!! error TS2687: All declarations of 'LN2' must have identical modifiers.
+        /** The base-2 logarithm of e. */
+        LOG2E: number;
+        ~~~~~
+!!! error TS2687: All declarations of 'LOG2E' must have identical modifiers.
+        /** The base-10 logarithm of e. */
+        LOG10E: number;
+        ~~~~~~
+!!! error TS2687: All declarations of 'LOG10E' must have identical modifiers.
+        /** Pi. This is the ratio of the circumference of a circle to its diameter. */
+        PI: number;
+        ~~
+!!! error TS2687: All declarations of 'PI' must have identical modifiers.
+        /** The square root of 0.5, or, equivalently, one divided by the square root of 2. */
+        SQRT1_2: number;
+        ~~~~~~~
+!!! error TS2687: All declarations of 'SQRT1_2' must have identical modifiers.
+        /** The square root of 2. */
+        SQRT2: number;
+        ~~~~~
+!!! error TS2687: All declarations of 'SQRT2' must have identical modifiers.
+        /**
+          * Returns the absolute value of a number (the value without regard to whether it is positive or negative). 
+          * For example, the absolute value of -5 is the same as the absolute value of 5.
+          * @param x A numeric expression for which the absolute value is needed.
+          */
+        abs(x: number): number;
+        /**
+          * Returns the arc cosine (or inverse cosine) of a number. 
+          * @param x A numeric expression.
+          */
+        acos(x: number): number;
+        /** 
+          * Returns the arcsine of a number. 
+          * @param x A numeric expression.
+          */
+        asin(x: number): number;
+        /**
+          * Returns the arctangent of a number. 
+          * @param x A numeric expression for which the arctangent is needed.
+          */
+        atan(x: number): number;
+        /**
+          * Returns the angle (in radians) from the X axis to a point (y,x).
+          * @param y A numeric expression representing the cartesian y-coordinate.
+          * @param x A numeric expression representing the cartesian x-coordinate.
+          */
+        atan2(y: number, x: number): number;
+        /**
+          * Returns the smallest number greater than or equal to its numeric argument. 
+          * @param x A numeric expression.
+          */
+        ceil(x: number): number;
+        /**
+          * Returns the cosine of a number. 
+          * @param x A numeric expression that contains an angle measured in radians.
+          */
+        cos(x: number): number;
+        /**
+          * Returns e (the base of natural logarithms) raised to a power. 
+          * @param x A numeric expression representing the power of e.
+          */
+        exp(x: number): number;
+        /**
+          * Returns the greatest number less than or equal to its numeric argument. 
+          * @param x A numeric expression.
+          */
+        floor(x: number): number;
+        /**
+          * Returns the natural logarithm (base e) of a number. 
+          * @param x A numeric expression.
+          */
+        log(x: number): number;
+        /**
+          * Returns the larger of a set of supplied numeric expressions. 
+          * @param values Numeric expressions to be evaluated.
+          */
+        max(...values: number[]): number;
+        /**
+          * Returns the smaller of a set of supplied numeric expressions. 
+          * @param values Numeric expressions to be evaluated.
+          */
+        min(...values: number[]): number;
+        /**
+          * Returns the value of a base expression taken to a specified power. 
+          * @param x The base value of the expression.
+          * @param y The exponent value of the expression.
+          */
+        pow(x: number, y: number): number;
+        /** Returns a pseudorandom number between 0 and 1. */
+        random(): number;
+        /** 
+          * Returns a supplied numeric expression rounded to the nearest number.
+          * @param x The value to be rounded to the nearest number.
+          */
+        round(x: number): number;
+        /**
+          * Returns the sine of a number.
+          * @param x A numeric expression that contains an angle measured in radians.
+          */
+        sin(x: number): number;
+        /**
+          * Returns the square root of a number.
+          * @param x A numeric expression.
+          */
+        sqrt(x: number): number;
+        /**
+          * Returns the tangent of a number.
+          * @param x A numeric expression that contains an angle measured in radians.
+          */
+        tan(x: number): number;
+    }
+    /** An intrinsic object that provides basic mathematics functionality and constants. */
+    declare var Math: Math;
+    
+    /** Enables basic storage and retrieval of dates and times. */
+    interface Date {
+        /** Returns a string representation of a date. The format of the string depends on the locale. */
+        toString(): string;
+        /** Returns a date as a string value. */
+        toDateString(): string;
+        /** Returns a time as a string value. */
+        toTimeString(): string;
+        /** Returns a value as a string value appropriate to the host environment's current locale. */
+        toLocaleString(): string;
+        /** Returns a date as a string value appropriate to the host environment's current locale. */
+        toLocaleDateString(): string;
+        /** Returns a time as a string value appropriate to the host environment's current locale. */
+        toLocaleTimeString(): string;
+        /** Returns the stored time value in milliseconds since midnight, January 1, 1970 UTC. */
+        valueOf(): number;
+        /** Gets the time value in milliseconds. */
+        getTime(): number;
+        /** Gets the year, using local time. */
+        getFullYear(): number;
+        /** Gets the year using Universal Coordinated Time (UTC). */
+        getUTCFullYear(): number;
+        /** Gets the month, using local time. */
+        getMonth(): number;
+        /** Gets the month of a Date object using Universal Coordinated Time (UTC). */
+        getUTCMonth(): number;
+        /** Gets the day-of-the-month, using local time. */
+        getDate(): number;
+        /** Gets the day-of-the-month, using Universal Coordinated Time (UTC). */
+        getUTCDate(): number;
+        /** Gets the day of the week, using local time. */
+        getDay(): number;
+        /** Gets the day of the week using Universal Coordinated Time (UTC). */
+        getUTCDay(): number;
+        /** Gets the hours in a date, using local time. */
+        getHours(): number;
+        /** Gets the hours value in a Date object using Universal Coordinated Time (UTC). */
+        getUTCHours(): number;
+        /** Gets the minutes of a Date object, using local time. */
+        getMinutes(): number;
+        /** Gets the minutes of a Date object using Universal Coordinated Time (UTC). */
+        getUTCMinutes(): number;
+        /** Gets the seconds of a Date object, using local time. */
+        getSeconds(): number;
+        /** Gets the seconds of a Date object using Universal Coordinated Time (UTC). */
+        getUTCSeconds(): number;
+        /** Gets the milliseconds of a Date, using local time. */
+        getMilliseconds(): number;
+        /** Gets the milliseconds of a Date object using Universal Coordinated Time (UTC). */
+        getUTCMilliseconds(): number;
+        /** Gets the difference in minutes between Universal Coordinated Time (UTC) and the time on the local computer. */
+        getTimezoneOffset(): number;
+        /** 
+          * Sets the date and time value in the Date object.
+          * @param time A numeric value representing the number of elapsed milliseconds since midnight, January 1, 1970 GMT. 
+          */
+        setTime(time: number): number;
+        /**
+          * Sets the milliseconds value in the Date object using local time. 
+          * @param ms A numeric value equal to the millisecond value.
+          */
+        setMilliseconds(ms: number): number;
+        /** 
+          * Sets the milliseconds value in the Date object using Universal Coordinated Time (UTC).
+          * @param ms A numeric value equal to the millisecond value. 
+          */
+        setUTCMilliseconds(ms: number): number;
+    
+        /**
+          * Sets the seconds value in the Date object using local time. 
+          * @param sec A numeric value equal to the seconds value.
+          * @param ms A numeric value equal to the milliseconds value.
+          */
+        setSeconds(sec: number, ms?: number): number;
+        /**
+          * Sets the seconds value in the Date object using Universal Coordinated Time (UTC).
+          * @param sec A numeric value equal to the seconds value.
+          * @param ms A numeric value equal to the milliseconds value.
+          */
+        setUTCSeconds(sec: number, ms?: number): number;
+        /**
+          * Sets the minutes value in the Date object using local time. 
+          * @param min A numeric value equal to the minutes value. 
+          * @param sec A numeric value equal to the seconds value. 
+          * @param ms A numeric value equal to the milliseconds value.
+          */
+        setMinutes(min: number, sec?: number, ms?: number): number;
+        /**
+          * Sets the minutes value in the Date object using Universal Coordinated Time (UTC).
+          * @param min A numeric value equal to the minutes value. 
+          * @param sec A numeric value equal to the seconds value. 
+          * @param ms A numeric value equal to the milliseconds value.
+          */
+        setUTCMinutes(min: number, sec?: number, ms?: number): number;
+        /**
+          * Sets the hour value in the Date object using local time.
+          * @param hours A numeric value equal to the hours value.
+          * @param min A numeric value equal to the minutes value.
+          * @param sec A numeric value equal to the seconds value. 
+          * @param ms A numeric value equal to the milliseconds value.
+          */
+        setHours(hours: number, min?: number, sec?: number, ms?: number): number;
+        /**
+          * Sets the hours value in the Date object using Universal Coordinated Time (UTC).
+          * @param hours A numeric value equal to the hours value.
+          * @param min A numeric value equal to the minutes value.
+          * @param sec A numeric value equal to the seconds value. 
+          * @param ms A numeric value equal to the milliseconds value.
+          */
+        setUTCHours(hours: number, min?: number, sec?: number, ms?: number): number;
+        /**
+          * Sets the numeric day-of-the-month value of the Date object using local time. 
+          * @param date A numeric value equal to the day of the month.
+          */
+        setDate(date: number): number;
+        /** 
+          * Sets the numeric day of the month in the Date object using Universal Coordinated Time (UTC).
+          * @param date A numeric value equal to the day of the month. 
+          */
+        setUTCDate(date: number): number;
+        /** 
+          * Sets the month value in the Date object using local time. 
+          * @param month A numeric value equal to the month. The value for January is 0, and other month values follow consecutively. 
+          * @param date A numeric value representing the day of the month. If this value is not supplied, the value from a call to the getDate method is used.
+          */
+        setMonth(month: number, date?: number): number;
+        /**
+          * Sets the month value in the Date object using Universal Coordinated Time (UTC).
+          * @param month A numeric value equal to the month. The value for January is 0, and other month values follow consecutively.
+          * @param date A numeric value representing the day of the month. If it is not supplied, the value from a call to the getUTCDate method is used.
+          */
+        setUTCMonth(month: number, date?: number): number;
+        /**
+          * Sets the year of the Date object using local time.
+          * @param year A numeric value for the year.
+          * @param month A zero-based numeric value for the month (0 for January, 11 for December). Must be specified if numDate is specified.
+          * @param date A numeric value equal for the day of the month.
+          */
+        setFullYear(year: number, month?: number, date?: number): number;
+        /**
+          * Sets the year value in the Date object using Universal Coordinated Time (UTC).
+          * @param year A numeric value equal to the year.
+          * @param month A numeric value equal to the month. The value for January is 0, and other month values follow consecutively. Must be supplied if numDate is supplied.
+          * @param date A numeric value equal to the day of the month.
+          */
+        setUTCFullYear(year: number, month?: number, date?: number): number;
+        /** Returns a date converted to a string using Universal Coordinated Time (UTC). */
+        toUTCString(): string;
+        /** Returns a date as a string value in ISO format. */
+        toISOString(): string;
+        /** Used by the JSON.stringify method to enable the transformation of an object's data for JavaScript Object Notation (JSON) serialization. */
+        toJSON(key?: any): string;
+    }
+    
+    declare var Date: {
+                ~~~~
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'Date' must be of type 'DateConstructor', but here has type '{ (): string; new (): Date; new (value: number): Date; new (value: string): Date; new (year: number, month: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number): Date; prototype: Date; parse(s: string): number; UTC(year: number, month: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number): number; now(): number; }'.
+!!! related TS6203 lib.es5.d.ts:--:--: 'Date' was also declared here.
+        new (): Date;
+        new (value: number): Date;
+        new (value: string): Date;
+        new (year: number, month: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number): Date;
+        (): string;
+        prototype: Date;
+        /**
+          * Parses a string containing a date, and returns the number of milliseconds between that date and midnight, January 1, 1970.
+          * @param s A date string
+          */
+        parse(s: string): number;
+        /**
+          * Returns the number of milliseconds between midnight, January 1, 1970 Universal Coordinated Time (UTC) (or GMT) and the specified date. 
+          * @param year The full year designation is required for cross-century date accuracy. If year is between 0 and 99 is used, then year is assumed to be 1900 + year.
+          * @param month The month as an number between 0 and 11 (January to December).
+          * @param date The date as an number between 1 and 31.
+          * @param hours Must be supplied if minutes is supplied. An number from 0 to 23 (midnight to 11pm) that specifies the hour.
+          * @param minutes Must be supplied if seconds is supplied. An number from 0 to 59 that specifies the minutes.
+          * @param seconds Must be supplied if milliseconds is supplied. An number from 0 to 59 that specifies the seconds.
+          * @param ms An number from 0 to 999 that specifies the milliseconds.
+          */
+        UTC(year: number, month: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number): number;
+        now(): number;
+    }
+    
+    interface RegExpExecArray {
+        [index: number]: string;
+        length: number;
+    
+        index: number;
+        input: string;
+    
+        toString(): string;
+        toLocaleString(): string;
+        concat(...items: string[][]): string[];
+        join(separator?: string): string;
+        pop(): string;
+        push(...items: string[]): number;
+        reverse(): string[];
+        shift(): string;
+        slice(start?: number, end?: number): string[];
+        sort(compareFn?: (a: string, b: string) => number): string[];
+        splice(start: number): string[];
+        splice(start: number, deleteCount: number, ...items: string[]): string[];
+        unshift(...items: string[]): number;
+    
+        indexOf(searchElement: string, fromIndex?: number): number;
+        lastIndexOf(searchElement: string, fromIndex?: number): number;
+        every(callbackfn: (value: string, index: number, array: string[]) => boolean, thisArg?: any): boolean;
+        some(callbackfn: (value: string, index: number, array: string[]) => boolean, thisArg?: any): boolean;
+        forEach(callbackfn: (value: string, index: number, array: string[]) => void, thisArg?: any): void;
+        map(callbackfn: (value: string, index: number, array: string[]) => any, thisArg?: any): any[];
+        filter(callbackfn: (value: string, index: number, array: string[]) => boolean, thisArg?: any): string[];
+        reduce(callbackfn: (previousValue: any, currentValue: any, currentIndex: number, array: string[]) => any, initialValue?: any): any;
+        reduceRight(callbackfn: (previousValue: any, currentValue: any, currentIndex: number, array: string[]) => any, initialValue?: any): any;
+    }
+    
+    
+    interface RegExp {
+        /** 
+          * Executes a search on a string using a regular expression pattern, and returns an array containing the results of that search.
+          * @param string The String object or string literal on which to perform the search.
+          */
+        exec(string: string): RegExpExecArray;
+    
+        /** 
+          * Returns a Boolean value that indicates whether or not a pattern exists in a searched string.
+          * @param string String on which to perform the search.
+          */
+        test(string: string): boolean;
+    
+        /** Returns a copy of the text of the regular expression pattern. Read-only. The rgExp argument is a Regular expression object. It can be a variable name or a literal. */
+        source: string;
+        ~~~~~~
+!!! error TS2687: All declarations of 'source' must have identical modifiers.
+    
+        /** Returns a Boolean value indicating the state of the global flag (g) used with a regular expression. Default is false. Read-only. */
+        global: boolean;
+        ~~~~~~
+!!! error TS2687: All declarations of 'global' must have identical modifiers.
+    
+        /** Returns a Boolean value indicating the state of the ignoreCase flag (i) used with a regular expression. Default is false. Read-only. */
+        ignoreCase: boolean;
+        ~~~~~~~~~~
+!!! error TS2687: All declarations of 'ignoreCase' must have identical modifiers.
+    
+        /** Returns a Boolean value indicating the state of the multiline flag (m) used with a regular expression. Default is false. Read-only. */
+        multiline: boolean;
+        ~~~~~~~~~
+!!! error TS2687: All declarations of 'multiline' must have identical modifiers.
+    
+        lastIndex: number;
+    
+        // Non-standard extensions
+        compile(): RegExp;
+    }
+    declare var RegExp: {
+                ~~~~~~
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'RegExp' must be of type 'RegExpConstructor', but here has type '{ (pattern: string, flags?: string): RegExp; new (pattern: string, flags?: string): RegExp; $1: string; $2: string; $3: string; $4: string; $5: string; $6: string; $7: string; $8: string; $9: string; lastMatch: string; }'.
+!!! related TS6203 lib.es5.d.ts:--:--: 'RegExp' was also declared here.
+        new (pattern: string, flags?: string): RegExp;
+        (pattern: string, flags?: string): RegExp;
+    
+        // Non-standard extensions
+        $1: string;
+        $2: string;
+        $3: string;
+        $4: string;
+        $5: string;
+        $6: string;
+        $7: string;
+        $8: string;
+        $9: string;
+        lastMatch: string;
+    }
+    
+    interface Error {
+        name: string;
+        message: string;
+    }
+    declare var Error: {
+                ~~~~~
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'Error' must be of type 'ErrorConstructor', but here has type '{ (message?: string): Error; new (message?: string): Error; prototype: Error; }'.
+!!! related TS6203 lib.es5.d.ts:--:--: 'Error' was also declared here.
+        new (message?: string): Error;
+        (message?: string): Error;
+        prototype: Error;
+    }
+    
+    interface EvalError extends Error {
+    }
+    declare var EvalError: {
+                ~~~~~~~~~
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'EvalError' must be of type 'EvalErrorConstructor', but here has type '{ (message?: string): EvalError; new (message?: string): EvalError; prototype: EvalError; }'.
+!!! related TS6203 lib.es5.d.ts:--:--: 'EvalError' was also declared here.
+        new (message?: string): EvalError;
+        (message?: string): EvalError;
+        prototype: EvalError;
+    }
+    
+    interface RangeError extends Error {
+    }
+    declare var RangeError: {
+                ~~~~~~~~~~
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'RangeError' must be of type 'RangeErrorConstructor', but here has type '{ (message?: string): RangeError; new (message?: string): RangeError; prototype: RangeError; }'.
+!!! related TS6203 lib.es5.d.ts:--:--: 'RangeError' was also declared here.
+        new (message?: string): RangeError;
+        (message?: string): RangeError;
+        prototype: RangeError;
+    }
+    
+    interface ReferenceError extends Error {
+    }
+    declare var ReferenceError: {
+                ~~~~~~~~~~~~~~
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'ReferenceError' must be of type 'ReferenceErrorConstructor', but here has type '{ (message?: string): ReferenceError; new (message?: string): ReferenceError; prototype: ReferenceError; }'.
+!!! related TS6203 lib.es5.d.ts:--:--: 'ReferenceError' was also declared here.
+        new (message?: string): ReferenceError;
+        (message?: string): ReferenceError;
+        prototype: ReferenceError;
+    }
+    
+    interface SyntaxError extends Error {
+    }
+    declare var SyntaxError: {
+                ~~~~~~~~~~~
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'SyntaxError' must be of type 'SyntaxErrorConstructor', but here has type '{ (message?: string): SyntaxError; new (message?: string): SyntaxError; prototype: SyntaxError; }'.
+!!! related TS6203 lib.es5.d.ts:--:--: 'SyntaxError' was also declared here.
+        new (message?: string): SyntaxError;
+        (message?: string): SyntaxError;
+        prototype: SyntaxError;
+    }
+    
+    interface TypeError extends Error {
+    }
+    declare var TypeError: {
+                ~~~~~~~~~
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'TypeError' must be of type 'TypeErrorConstructor', but here has type '{ (message?: string): TypeError; new (message?: string): TypeError; prototype: TypeError; }'.
+!!! related TS6203 lib.es5.d.ts:--:--: 'TypeError' was also declared here.
+        new (message?: string): TypeError;
+        (message?: string): TypeError;
+        prototype: TypeError;
+    }
+    
+    interface URIError extends Error {
+    }
+    declare var URIError: {
+                ~~~~~~~~
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'URIError' must be of type 'URIErrorConstructor', but here has type '{ (message?: string): URIError; new (message?: string): URIError; prototype: URIError; }'.
+!!! related TS6203 lib.es5.d.ts:--:--: 'URIError' was also declared here.
+        new (message?: string): URIError;
+        (message?: string): URIError;
+        prototype: URIError;
+    }
+    
+    interface JSON {
+        /**
+          * Converts a JavaScript Object Notation (JSON) string into an object.
+          * @param text A valid JSON string.
+          * @param reviver A function that transforms the results. This function is called for each member of the object. 
+          * If a member contains nested objects, the nested objects are transformed before the parent object is. 
+          */
+        parse(text: string, reviver?: (key: any, value: any) => any): any;
+        /**
+          * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
+          * @param value A JavaScript value, usually an object or array, to be converted.
+          */
+        stringify(value: any): string;
+        /**
+          * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
+          * @param value A JavaScript value, usually an object or array, to be converted.
+          * @param replacer A function that transforms the results.
+          */
+        stringify(value: any, replacer: (key: string, value: any) => any): string;
+        /**
+          * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
+          * @param value A JavaScript value, usually an object or array, to be converted.
+          * @param replacer Array that transforms the results.
+          */
+        stringify(value: any, replacer: any[]): string;
+        /**
+          * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
+          * @param value A JavaScript value, usually an object or array, to be converted.
+          * @param replacer A function that transforms the results.
+          * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
+          */
+        stringify(value: any, replacer: (key: string, value: any) => any, space: any): string;
+        /**
+          * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
+          * @param value A JavaScript value, usually an object or array, to be converted.
+          * @param replacer Array that transforms the results.
+          * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
+          */
+        stringify(value: any, replacer: any[], space: any): string;
+    }
+    /**
+      * An intrinsic object that provides functions to convert JavaScript values to and from the JavaScript Object Notation (JSON) format.
+      */
+    declare var JSON: JSON;
+    
+    
+    /////////////////////////////
+    /// ECMAScript Array API (specially handled by compiler)
+    /////////////////////////////
+    
+    interface Array<T> {
+        /**
+          * Returns a string representation of an array.
+          */
+        toString(): string;
+        toLocaleString(): string;
+        /**
+          * Combines two or more arrays.
+          * @param items Additional items to add to the end of array1.
+          */
+        concat<U extends T[]>(...items: U[]): T[];
+        /**
+          * Combines two or more arrays.
+          * @param items Additional items to add to the end of array1.
+          */
+        concat(...items: T[]): T[];
+        /**
+          * Adds all the elements of an array separated by the specified separator string.
+          * @param separator A string used to separate one element of an array from the next in the resulting String. If omitted, the array elements are separated with a comma.
+          */
+        join(separator?: string): string;
+        /**
+          * Removes the last element from an array and returns it.
+          */
+        pop(): T;
+        /**
+          * Appends new elements to an array, and returns the new length of the array.
+          * @param items New elements of the Array.
+          */
+        push(...items: T[]): number;
+        /**
+          * Reverses the elements in an Array. 
+          */
+        reverse(): T[];
+        /**
+          * Removes the first element from an array and returns it.
+          */
+        shift(): T;
+        /** 
+          * Returns a section of an array.
+          * @param start The beginning of the specified portion of the array.
+          * @param end The end of the specified portion of the array.
+          */
+        slice(start?: number, end?: number): T[];
+    
+        /**
+          * Sorts an array.
+          * @param compareFn The name of the function used to determine the order of the elements. If omitted, the elements are sorted in ascending, ASCII character order.
+          */
+        sort(compareFn?: (a: T, b: T) => number): T[];
+    
+        /**
+          * Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements.
+          * @param start The zero-based location in the array from which to start removing elements.
+          */
+        splice(start: number): T[];
+    
+        /**
+          * Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements.
+          * @param start The zero-based location in the array from which to start removing elements.
+          * @param deleteCount The number of elements to remove.
+          * @param items Elements to insert into the array in place of the deleted elements.
+          */
+        splice(start: number, deleteCount: number, ...items: T[]): T[];
+    
+        /**
+          * Inserts new elements at the start of an array.
+          * @param items  Elements to insert at the start of the Array.
+          */
+        unshift(...items: T[]): number;
+    
+        /**
+          * Returns the index of the first occurrence of a value in an array.
+          * @param searchElement The value to locate in the array.
+          * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the search starts at index 0.
+          */
+        indexOf(searchElement: T, fromIndex?: number): number;
+    
+        /**
+          * Returns the index of the last occurrence of a specified value in an array.
+          * @param searchElement The value to locate in the array.
+          * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the search starts at the last index in the array.
+          */
+        lastIndexOf(searchElement: T, fromIndex?: number): number;
+    
+        /**
+          * Determines whether all the members of an array satisfy the specified test.
+          * @param callbackfn A function that accepts up to three arguments. The every method calls the callbackfn function for each element in array1 until the callbackfn returns false, or until the end of the array.
+          * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+          */
+        every(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean;
+    
+        /**
+          * Determines whether the specified callback function returns true for any element of an array.
+          * @param callbackfn A function that accepts up to three arguments. The some method calls the callbackfn function for each element in array1 until the callbackfn returns true, or until the end of the array.
+          * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+          */
+        some(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean;
+    
+        /**
+          * Performs the specified action for each element in an array.
+          * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the array. 
+          * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+          */
+        forEach(callbackfn: (value: T, index: number, array: T[]) => void, thisArg?: any): void;
+    
+        /**
+          * Calls a defined callback function on each element of an array, and returns an array that contains the results.
+          * @param callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array. 
+          * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+          */
+        map<U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): U[];
+    
+        /**
+          * Returns the elements of an array that meet the condition specified in a callback function. 
+          * @param callbackfn A function that accepts up to three arguments. The filter method calls the callbackfn function one time for each element in the array. 
+          * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+          */
+        filter(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): T[];
+    
+        /**
+          * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+          * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
+          * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+          */
+        reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T;
+        /**
+          * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+          * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
+          * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+          */
+        reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
+    
+        /** 
+          * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+          * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array. 
+          * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+          */
+        reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T;
+        /** 
+          * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+          * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array. 
+          * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+          */
+        reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
+    
+        /**
+          * Gets or sets the length of the array. This is a number one higher than the highest element defined in an array.
+          */
+        length: number;
+    
+        [n: number]: T;
+    }
+    declare var Array: {
+                ~~~~~
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'Array' must be of type 'ArrayConstructor', but here has type '{ (arrayLength?: number): any[]; <T>(arrayLength: number): T[]; <T>(...items: T[]): T[]; new (arrayLength?: number): any[]; new <T>(arrayLength: number): T[]; new <T>(...items: T[]): T[]; isArray(arg: any): boolean; prototype: any[]; }'.
+!!! related TS6203 lib.es5.d.ts:--:--: 'Array' was also declared here.
+        new (arrayLength?: number): any[];
+        new <T>(arrayLength: number): T[];
+        new <T>(...items: T[]): T[];
+        (arrayLength?: number): any[];
+        <T>(arrayLength: number): T[];
+        <T>(...items: T[]): T[];
+        isArray(arg: any): boolean;
+        prototype: Array<any>;
+    }

--- a/testdata/baselines/reference/submodule/conformance/1.0lib-noErrors.errors.txt.diff
+++ b/testdata/baselines/reference/submodule/conformance/1.0lib-noErrors.errors.txt.diff
@@ -1,0 +1,1252 @@
+--- old.1.0lib-noErrors.errors.txt
++++ new.1.0lib-noErrors.errors.txt
+@@= skipped -0, +0 lines =@@
+-<no content>
++1.0lib-noErrors.ts(130,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'Object' must be of type 'ObjectConstructor', but here has type '{ (): any; (value: any): any; new (value?: any): Object; prototype: Object; getPrototypeOf(o: any): any; getOwnPropertyDescriptor(o: any, p: string): PropertyDescriptor; getOwnPropertyNames(o: any): string[]; create(o: any, properties?: PropertyDescriptorMap): any; defineProperty(o: any, p: string, attributes: PropertyDescriptor): any; defineProperties(o: any, properties: PropertyDescriptorMap): any; seal(o: any): any; freeze(o: any): any; preventExtensions(o: any): any; isSealed(o: any): boolean; isFrozen(o: any): boolean; isExtensible(o: any): boolean; keys(o: any): string[]; }'.
++1.0lib-noErrors.ts(251,5): error TS2687: All declarations of 'length' must have identical modifiers.
++1.0lib-noErrors.ts(258,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'Function' must be of type 'FunctionConstructor', but here has type '{ (...args: string[]): Function; new (...args: string[]): Function; prototype: Function; }'.
++1.0lib-noErrors.ts(414,5): error TS2687: All declarations of 'length' must have identical modifiers.
++1.0lib-noErrors.ts(430,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'String' must be of type 'StringConstructor', but here has type '{ (value?: any): string; new (value?: any): String; prototype: String; fromCharCode(...codes: number[]): string; }'.
++1.0lib-noErrors.ts(439,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'Boolean' must be of type 'BooleanConstructor', but here has type '{ (value?: any): boolean; new (value?: any): Boolean; prototype: Boolean; }'.
++1.0lib-noErrors.ts(472,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'Number' must be of type 'NumberConstructor', but here has type '{ (value?: any): number; new (value?: any): Number; prototype: Number; MAX_VALUE: number; MIN_VALUE: number; NaN: number; NEGATIVE_INFINITY: number; POSITIVE_INFINITY: number; }'.
++1.0lib-noErrors.ts(504,5): error TS2687: All declarations of 'E' must have identical modifiers.
++1.0lib-noErrors.ts(506,5): error TS2687: All declarations of 'LN10' must have identical modifiers.
++1.0lib-noErrors.ts(508,5): error TS2687: All declarations of 'LN2' must have identical modifiers.
++1.0lib-noErrors.ts(510,5): error TS2687: All declarations of 'LOG2E' must have identical modifiers.
++1.0lib-noErrors.ts(512,5): error TS2687: All declarations of 'LOG10E' must have identical modifiers.
++1.0lib-noErrors.ts(514,5): error TS2687: All declarations of 'PI' must have identical modifiers.
++1.0lib-noErrors.ts(516,5): error TS2687: All declarations of 'SQRT1_2' must have identical modifiers.
++1.0lib-noErrors.ts(518,5): error TS2687: All declarations of 'SQRT2' must have identical modifiers.
++1.0lib-noErrors.ts(767,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'Date' must be of type 'DateConstructor', but here has type '{ (): string; new (): Date; new (value: number): Date; new (value: string): Date; new (year: number, month: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number): Date; prototype: Date; parse(s: string): number; UTC(year: number, month: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number): number; now(): number; }'.
++1.0lib-noErrors.ts(840,5): error TS2687: All declarations of 'source' must have identical modifiers.
++1.0lib-noErrors.ts(843,5): error TS2687: All declarations of 'global' must have identical modifiers.
++1.0lib-noErrors.ts(846,5): error TS2687: All declarations of 'ignoreCase' must have identical modifiers.
++1.0lib-noErrors.ts(849,5): error TS2687: All declarations of 'multiline' must have identical modifiers.
++1.0lib-noErrors.ts(856,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'RegExp' must be of type 'RegExpConstructor', but here has type '{ (pattern: string, flags?: string): RegExp; new (pattern: string, flags?: string): RegExp; $1: string; $2: string; $3: string; $4: string; $5: string; $6: string; $7: string; $8: string; $9: string; lastMatch: string; }'.
++1.0lib-noErrors.ts(877,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'Error' must be of type 'ErrorConstructor', but here has type '{ (message?: string): Error; new (message?: string): Error; prototype: Error; }'.
++1.0lib-noErrors.ts(885,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'EvalError' must be of type 'EvalErrorConstructor', but here has type '{ (message?: string): EvalError; new (message?: string): EvalError; prototype: EvalError; }'.
++1.0lib-noErrors.ts(893,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'RangeError' must be of type 'RangeErrorConstructor', but here has type '{ (message?: string): RangeError; new (message?: string): RangeError; prototype: RangeError; }'.
++1.0lib-noErrors.ts(901,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'ReferenceError' must be of type 'ReferenceErrorConstructor', but here has type '{ (message?: string): ReferenceError; new (message?: string): ReferenceError; prototype: ReferenceError; }'.
++1.0lib-noErrors.ts(909,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'SyntaxError' must be of type 'SyntaxErrorConstructor', but here has type '{ (message?: string): SyntaxError; new (message?: string): SyntaxError; prototype: SyntaxError; }'.
++1.0lib-noErrors.ts(917,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'TypeError' must be of type 'TypeErrorConstructor', but here has type '{ (message?: string): TypeError; new (message?: string): TypeError; prototype: TypeError; }'.
++1.0lib-noErrors.ts(925,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'URIError' must be of type 'URIErrorConstructor', but here has type '{ (message?: string): URIError; new (message?: string): URIError; prototype: URIError; }'.
++1.0lib-noErrors.ts(1134,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'Array' must be of type 'ArrayConstructor', but here has type '{ (arrayLength?: number): any[]; <T>(arrayLength: number): T[]; <T>(...items: T[]): T[]; new (arrayLength?: number): any[]; new <T>(arrayLength: number): T[]; new <T>(...items: T[]): T[]; isArray(arg: any): boolean; prototype: any[]; }'.
++
++
++==== 1.0lib-noErrors.ts (29 errors) ====
++    /* *****************************************************************************
++    Copyright (c) Microsoft Corporation. All rights reserved. 
++    Licensed under the Apache License, Version 2.0 (the "License"); you may not use
++    this file except in compliance with the License. You may obtain a copy of the
++    License at http://www.apache.org/licenses/LICENSE-2.0  
++     
++    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
++    KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
++    WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, 
++    MERCHANTABLITY OR NON-INFRINGEMENT. 
++     
++    See the Apache Version 2.0 License for specific language governing permissions
++    and limitations under the License.
++    ***************************************************************************** */
++    
++    /// <reference no-default-lib="true"/>
++    
++    /////////////////////////////
++    /// ECMAScript APIs
++    /////////////////////////////
++    
++    declare var NaN: number;
++    declare var Infinity: number;
++    
++    /**
++      * Evaluates JavaScript code and executes it. 
++      * @param x A String value that contains valid JavaScript code.
++      */
++    declare function eval(x: string): any;
++    
++    /**
++      * Converts A string to an integer.
++      * @param s A string to convert into a number.
++      * @param radix A value between 2 and 36 that specifies the base of the number in numString. 
++      * If this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.
++      * All other strings are considered decimal.
++      */
++    declare function parseInt(s: string, radix?: number): number;
++    
++    /**
++      * Converts a string to a floating-point number. 
++      * @param string A string that contains a floating-point number. 
++      */
++    declare function parseFloat(string: string): number;
++    
++    /**
++      * Returns a Boolean value that indicates whether a value is the reserved value NaN (not a number). 
++      * @param number A numeric value.
++      */
++    declare function isNaN(number: number): boolean;
++    
++    /** 
++      * Determines whether a supplied number is finite.
++      * @param number Any numeric value.
++      */
++    declare function isFinite(number: number): boolean;
++    
++    /**
++      * Gets the unencoded version of an encoded Uniform Resource Identifier (URI).
++      * @param encodedURI A value representing an encoded URI.
++      */
++    declare function decodeURI(encodedURI: string): string;
++    
++    /**
++      * Gets the unencoded version of an encoded component of a Uniform Resource Identifier (URI).
++      * @param encodedURIComponent A value representing an encoded URI component.
++      */
++    declare function decodeURIComponent(encodedURIComponent: string): string;
++    
++    /** 
++      * Encodes a text string as a valid Uniform Resource Identifier (URI)
++      * @param uri A value representing an encoded URI.
++      */
++    declare function encodeURI(uri: string): string;
++    
++    /**
++      * Encodes a text string as a valid component of a Uniform Resource Identifier (URI).
++      * @param uriComponent A value representing an encoded URI component.
++      */
++    declare function encodeURIComponent(uriComponent: string | number | boolean): string;
++    
++    interface PropertyDescriptor {
++        configurable?: boolean;
++        enumerable?: boolean;
++        value?: any;
++        writable?: boolean;
++        get?(): any;
++        set?(v: any): void;
++    }
++    
++    interface PropertyDescriptorMap {
++        [s: string]: PropertyDescriptor;
++    }
++    
++    interface Object {
++        /** The initial value of Object.prototype.constructor is the standard built-in Object constructor. */
++        constructor: Function;
++    
++        /** Returns a string representation of an object. */
++        toString(): string;
++    
++        /** Returns a date converted to a string using the current locale. */
++        toLocaleString(): string;
++    
++        /** Returns the primitive value of the specified object. */
++        valueOf(): Object;
++    
++        /**
++          * Determines whether an object has a property with the specified name. 
++          * @param v A property name.
++          */
++        hasOwnProperty(v: string): boolean;
++    
++        /**
++          * Determines whether an object exists in another object's prototype chain. 
++          * @param v Another object whose prototype chain is to be checked.
++          */
++        isPrototypeOf(v: Object): boolean;
++    
++        /** 
++          * Determines whether a specified property is enumerable.
++          * @param v A property name.
++          */
++        propertyIsEnumerable(v: string): boolean;
++    }
++    
++    /**
++      * Provides functionality common to all JavaScript objects.
++      */
++    declare var Object: {
++                ~~~~~~
++!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'Object' must be of type 'ObjectConstructor', but here has type '{ (): any; (value: any): any; new (value?: any): Object; prototype: Object; getPrototypeOf(o: any): any; getOwnPropertyDescriptor(o: any, p: string): PropertyDescriptor; getOwnPropertyNames(o: any): string[]; create(o: any, properties?: PropertyDescriptorMap): any; defineProperty(o: any, p: string, attributes: PropertyDescriptor): any; defineProperties(o: any, properties: PropertyDescriptorMap): any; seal(o: any): any; freeze(o: any): any; preventExtensions(o: any): any; isSealed(o: any): boolean; isFrozen(o: any): boolean; isExtensible(o: any): boolean; keys(o: any): string[]; }'.
++!!! related TS6203 lib.es5.d.ts:--:--: 'Object' was also declared here.
++        new (value?: any): Object;
++        (): any;
++        (value: any): any;
++    
++        /** A reference to the prototype for a class of objects. */
++        prototype: Object;
++    
++        /** 
++          * Returns the prototype of an object. 
++          * @param o The object that references the prototype.
++          */
++        getPrototypeOf(o: any): any;
++    
++        /**
++          * Gets the own property descriptor of the specified object. 
++          * An own property descriptor is one that is defined directly on the object and is not inherited from the object's prototype. 
++          * @param o Object that contains the property.
++          * @param p Name of the property.
++        */
++        getOwnPropertyDescriptor(o: any, p: string): PropertyDescriptor;
++    
++        /** 
++          * Returns the names of the own properties of an object. The own properties of an object are those that are defined directly 
++          * on that object, and are not inherited from the object's prototype. The properties of an object include both fields (objects) and functions.
++          * @param o Object that contains the own properties.
++          */
++        getOwnPropertyNames(o: any): string[];
++    
++        /** 
++          * Creates an object that has the specified prototype, and that optionally contains specified properties.
++          * @param o Object to use as a prototype. May be null
++          * @param properties JavaScript object that contains one or more property descriptors. 
++          */
++        create(o: any, properties?: PropertyDescriptorMap): any;
++    
++        /**
++          * Adds a property to an object, or modifies attributes of an existing property. 
++          * @param o Object on which to add or modify the property. This can be a native JavaScript object (that is, a user-defined object or a built in object) or a DOM object.
++          * @param p The property name.
++          * @param attributes Descriptor for the property. It can be for a data property or an accessor property.
++          */
++        defineProperty(o: any, p: string, attributes: PropertyDescriptor): any;
++    
++        /**
++          * Adds one or more properties to an object, and/or modifies attributes of existing properties. 
++          * @param o Object on which to add or modify the properties. This can be a native JavaScript object or a DOM object.
++          * @param properties JavaScript object that contains one or more descriptor objects. Each descriptor object describes a data property or an accessor property.
++          */
++        defineProperties(o: any, properties: PropertyDescriptorMap): any;
++    
++        /**
++          * Prevents the modification of attributes of existing properties, and prevents the addition of new properties.
++          * @param o Object on which to lock the attributes. 
++          */
++        seal(o: any): any;
++    
++        /**
++          * Prevents the modification of existing property attributes and values, and prevents the addition of new properties.
++          * @param o Object on which to lock the attributes.
++          */
++        freeze(o: any): any;
++    
++        /**
++          * Prevents the addition of new properties to an object.
++          * @param o Object to make non-extensible. 
++          */
++        preventExtensions(o: any): any;
++    
++        /**
++          * Returns true if existing property attributes cannot be modified in an object and new properties cannot be added to the object.
++          * @param o Object to test. 
++          */
++        isSealed(o: any): boolean;
++    
++        /**
++          * Returns true if existing property attributes and values cannot be modified in an object, and new properties cannot be added to the object.
++          * @param o Object to test.  
++          */
++        isFrozen(o: any): boolean;
++    
++        /**
++          * Returns a value that indicates whether new properties can be added to an object.
++          * @param o Object to test. 
++          */
++        isExtensible(o: any): boolean;
++    
++        /**
++          * Returns the names of the enumerable properties and methods of an object.
++          * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
++          */
++        keys(o: any): string[];
++    }
++    
++    /**
++      * Creates a new function.
++      */
++    interface Function {
++        /**
++          * Calls the function, substituting the specified object for the this value of the function, and the specified array for the arguments of the function.
++          * @param thisArg The object to be used as the this object.
++          * @param argArray A set of arguments to be passed to the function.
++          */
++        apply(thisArg: any, argArray?: any): any;
++    
++        /**
++          * Calls a method of an object, substituting another object for the current object.
++          * @param thisArg The object to be used as the current object.
++          * @param argArray A list of arguments to be passed to the method.
++          */
++        call(thisArg: any, ...argArray: any[]): any;
++    
++        /**
++          * For a given function, creates a bound function that has the same body as the original function. 
++          * The this object of the bound function is associated with the specified object, and has the specified initial parameters.
++          * @param thisArg An object to which the this keyword can refer inside the new function.
++          * @param argArray A list of arguments to be passed to the new function.
++          */
++        bind(thisArg: any, ...argArray: any[]): any;
++    
++        prototype: any;
++        length: number;
++        ~~~~~~
++!!! error TS2687: All declarations of 'length' must have identical modifiers.
++    
++        // Non-standard extensions
++        arguments: any;
++        caller: Function;
++    }
++    
++    declare var Function: {
++                ~~~~~~~~
++!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'Function' must be of type 'FunctionConstructor', but here has type '{ (...args: string[]): Function; new (...args: string[]): Function; prototype: Function; }'.
++!!! related TS6203 lib.es5.d.ts:--:--: 'Function' was also declared here.
++        /** 
++          * Creates a new function.
++          * @param args A list of arguments the function accepts.
++          */
++        new (...args: string[]): Function;
++        (...args: string[]): Function;
++        prototype: Function;
++    }
++    
++    interface IArguments {
++        [index: number]: any;
++        length: number;
++        callee: Function;
++    }
++    
++    interface String {
++        /** Returns a string representation of a string. */
++        toString(): string;
++    
++        /**
++          * Returns the character at the specified index.
++          * @param pos The zero-based index of the desired character.
++          */
++        charAt(pos: number): string;
++    
++        /** 
++          * Returns the Unicode value of the character at the specified location.
++          * @param index The zero-based index of the desired character. If there is no character at the specified index, NaN is returned.
++          */
++        charCodeAt(index: number): number;
++    
++        /**
++          * Returns a string that contains the concatenation of two or more strings.
++          * @param strings The strings to append to the end of the string.  
++          */
++        concat(...strings: string[]): string;
++    
++        /**
++          * Returns the position of the first occurrence of a substring. 
++          * @param searchString The substring to search for in the string
++          * @param position The index at which to begin searching the String object. If omitted, search starts at the beginning of the string.
++          */
++        indexOf(searchString: string, position?: number): number;
++    
++        /**
++          * Returns the last occurrence of a substring in the string.
++          * @param searchString The substring to search for.
++          * @param position The index at which to begin searching. If omitted, the search begins at the end of the string.
++          */
++        lastIndexOf(searchString: string, position?: number): number;
++    
++        /**
++          * Determines whether two strings are equivalent in the current locale.
++          * @param that String to compare to target string
++          */
++        localeCompare(that: string): number;
++    
++        /** 
++          * Matches a string with a regular expression, and returns an array containing the results of that search.
++          * @param regexp A variable name or string literal containing the regular expression pattern and flags.
++          */
++        match(regexp: string): string[];
++    
++        /** 
++          * Matches a string with a regular expression, and returns an array containing the results of that search.
++          * @param regexp A regular expression object that contains the regular expression pattern and applicable flags. 
++          */
++        match(regexp: RegExp): string[];
++    
++        /**
++          * Replaces text in a string, using a regular expression or search string.
++          * @param searchValue A String object or string literal that represents the regular expression
++          * @param replaceValue A String object or string literal containing the text to replace for every successful match of rgExp in stringObj.
++          */
++        replace(searchValue: string, replaceValue: string): string;
++    
++        /**
++          * Replaces text in a string, using a regular expression or search string.
++          * @param searchValue A String object or string literal that represents the regular expression
++          * @param replaceValue A function that returns the replacement text.
++          */
++        replace(searchValue: string, replaceValue: (substring: string, ...args: any[]) => string): string;
++    
++        /**
++          * Replaces text in a string, using a regular expression or search string.
++          * @param searchValue A Regular Expression object containing the regular expression pattern and applicable flags
++          * @param replaceValue A String object or string literal containing the text to replace for every successful match of rgExp in stringObj.
++          */
++        replace(searchValue: RegExp, replaceValue: string): string;
++    
++        /**
++          * Replaces text in a string, using a regular expression or search string.
++          * @param searchValue A Regular Expression object containing the regular expression pattern and applicable flags
++          * @param replaceValue A function that returns the replacement text.
++          */
++        replace(searchValue: RegExp, replaceValue: (substring: string, ...args: any[]) => string): string;
++    
++        /**
++          * Finds the first substring match in a regular expression search.
++          * @param regexp The regular expression pattern and applicable flags. 
++          */
++        search(regexp: string): number;
++    
++        /**
++          * Finds the first substring match in a regular expression search.
++          * @param regexp The regular expression pattern and applicable flags. 
++          */
++        search(regexp: RegExp): number;
++    
++        /**
++          * Returns a section of a string.
++          * @param start The index to the beginning of the specified portion of stringObj. 
++          * @param end The index to the end of the specified portion of stringObj. The substring includes the characters up to, but not including, the character indicated by end. 
++          * If this value is not specified, the substring continues to the end of stringObj.
++          */
++        slice(start?: number, end?: number): string;
++    
++        /**
++          * Split a string into substrings using the specified separator and return them as an array.
++          * @param separator A string that identifies character or characters to use in separating the string. If omitted, a single-element array containing the entire string is returned. 
++          * @param limit A value used to limit the number of elements returned in the array.
++          */
++        split(separator: string, limit?: number): string[];
++    
++        /**
++          * Split a string into substrings using the specified separator and return them as an array.
++          * @param separator A Regular Express that identifies character or characters to use in separating the string. If omitted, a single-element array containing the entire string is returned. 
++          * @param limit A value used to limit the number of elements returned in the array.
++          */
++        split(separator: RegExp, limit?: number): string[];
++    
++        /**
++          * Returns the substring at the specified location within a String object. 
++          * @param start The zero-based index number indicating the beginning of the substring.
++          * @param end Zero-based index number indicating the end of the substring. The substring includes the characters up to, but not including, the character indicated by end.
++          * If end is omitted, the characters from start through the end of the original string are returned.
++          */
++        substring(start: number, end?: number): string;
++    
++        /** Converts all the alphabetic characters in a string to lowercase. */
++        toLowerCase(): string;
++    
++        /** Converts all alphabetic characters to lowercase, taking into account the host environment's current locale. */
++        toLocaleLowerCase(): string;
++    
++        /** Converts all the alphabetic characters in a string to uppercase. */
++        toUpperCase(): string;
++    
++        /** Returns a string where all alphabetic characters have been converted to uppercase, taking into account the host environment's current locale. */
++        toLocaleUpperCase(): string;
++    
++        /** Removes the leading and trailing white space and line terminator characters from a string. */
++        trim(): string;
++    
++        /** Returns the length of a String object. */
++        length: number;
++        ~~~~~~
++!!! error TS2687: All declarations of 'length' must have identical modifiers.
++    
++        // IE extensions
++        /**
++          * Gets a substring beginning at the specified location and having the specified length.
++          * @param from The starting position of the desired substring. The index of the first character in the string is zero.
++          * @param length The number of characters to include in the returned substring.
++          */
++        substr(from: number, length?: number): string;
++    
++        [index: number]: string;
++    }
++    
++    /** 
++      * Allows manipulation and formatting of text strings and determination and location of substrings within strings. 
++      */
++    declare var String: {
++                ~~~~~~
++!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'String' must be of type 'StringConstructor', but here has type '{ (value?: any): string; new (value?: any): String; prototype: String; fromCharCode(...codes: number[]): string; }'.
++!!! related TS6203 lib.es5.d.ts:--:--: 'String' was also declared here.
++        new (value?: any): String;
++        (value?: any): string;
++        prototype: String;
++        fromCharCode(...codes: number[]): string;
++    }
++    
++    interface Boolean {
++    }
++    declare var Boolean: {
++                ~~~~~~~
++!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'Boolean' must be of type 'BooleanConstructor', but here has type '{ (value?: any): boolean; new (value?: any): Boolean; prototype: Boolean; }'.
++!!! related TS6203 lib.es5.d.ts:--:--: 'Boolean' was also declared here.
++        new (value?: any): Boolean;
++        (value?: any): boolean;
++        prototype: Boolean;
++    }
++    
++    interface Number {
++        /**
++          * Returns a string representation of an object.
++          * @param radix Specifies a radix for converting numeric values to strings. This value is only used for numbers.
++          */
++        toString(radix?: number): string;
++    
++        /** 
++          * Returns a string representing a number in fixed-point notation.
++          * @param fractionDigits Number of digits after the decimal point. Must be in the range 0 - 20, inclusive.
++          */
++        toFixed(fractionDigits?: number): string;
++    
++        /**
++          * Returns a string containing a number represented in exponential notation.
++          * @param fractionDigits Number of digits after the decimal point. Must be in the range 0 - 20, inclusive.
++          */
++        toExponential(fractionDigits?: number): string;
++    
++        /**
++          * Returns a string containing a number represented either in exponential or fixed-point notation with a specified number of digits.
++          * @param precision Number of significant digits. Must be in the range 1 - 21, inclusive.
++          */
++        toPrecision(precision?: number): string;
++    }
++    
++    /** An object that represents a number of any kind. All JavaScript numbers are 64-bit floating-point numbers. */
++    declare var Number: {
++                ~~~~~~
++!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'Number' must be of type 'NumberConstructor', but here has type '{ (value?: any): number; new (value?: any): Number; prototype: Number; MAX_VALUE: number; MIN_VALUE: number; NaN: number; NEGATIVE_INFINITY: number; POSITIVE_INFINITY: number; }'.
++!!! related TS6203 lib.es5.d.ts:--:--: 'Number' was also declared here.
++        new (value?: any): Number;
++        (value?: any): number;
++        prototype: Number;
++    
++        /** The largest number that can be represented in JavaScript. Equal to approximately 1.79E+308. */
++        MAX_VALUE: number;
++    
++        /** The closest number to zero that can be represented in JavaScript. Equal to approximately 5.00E-324. */
++        MIN_VALUE: number;
++    
++        /** 
++          * A value that is not a number.
++          * In equality comparisons, NaN does not equal any value, including itself. To test whether a value is equivalent to NaN, use the isNaN function.
++          */
++        NaN: number;
++    
++        /** 
++          * A value that is less than the largest negative number that can be represented in JavaScript.
++          * JavaScript displays NEGATIVE_INFINITY values as -infinity. 
++          */
++        NEGATIVE_INFINITY: number;
++    
++        /**
++          * A value greater than the largest number that can be represented in JavaScript. 
++          * JavaScript displays POSITIVE_INFINITY values as infinity. 
++          */
++        POSITIVE_INFINITY: number;
++    }
++    
++    interface Math {
++        /** The mathematical constant e. This is Euler's number, the base of natural logarithms. */
++        E: number;
++        ~
++!!! error TS2687: All declarations of 'E' must have identical modifiers.
++        /** The natural logarithm of 10. */
++        LN10: number;
++        ~~~~
++!!! error TS2687: All declarations of 'LN10' must have identical modifiers.
++        /** The natural logarithm of 2. */
++        LN2: number;
++        ~~~
++!!! error TS2687: All declarations of 'LN2' must have identical modifiers.
++        /** The base-2 logarithm of e. */
++        LOG2E: number;
++        ~~~~~
++!!! error TS2687: All declarations of 'LOG2E' must have identical modifiers.
++        /** The base-10 logarithm of e. */
++        LOG10E: number;
++        ~~~~~~
++!!! error TS2687: All declarations of 'LOG10E' must have identical modifiers.
++        /** Pi. This is the ratio of the circumference of a circle to its diameter. */
++        PI: number;
++        ~~
++!!! error TS2687: All declarations of 'PI' must have identical modifiers.
++        /** The square root of 0.5, or, equivalently, one divided by the square root of 2. */
++        SQRT1_2: number;
++        ~~~~~~~
++!!! error TS2687: All declarations of 'SQRT1_2' must have identical modifiers.
++        /** The square root of 2. */
++        SQRT2: number;
++        ~~~~~
++!!! error TS2687: All declarations of 'SQRT2' must have identical modifiers.
++        /**
++          * Returns the absolute value of a number (the value without regard to whether it is positive or negative). 
++          * For example, the absolute value of -5 is the same as the absolute value of 5.
++          * @param x A numeric expression for which the absolute value is needed.
++          */
++        abs(x: number): number;
++        /**
++          * Returns the arc cosine (or inverse cosine) of a number. 
++          * @param x A numeric expression.
++          */
++        acos(x: number): number;
++        /** 
++          * Returns the arcsine of a number. 
++          * @param x A numeric expression.
++          */
++        asin(x: number): number;
++        /**
++          * Returns the arctangent of a number. 
++          * @param x A numeric expression for which the arctangent is needed.
++          */
++        atan(x: number): number;
++        /**
++          * Returns the angle (in radians) from the X axis to a point (y,x).
++          * @param y A numeric expression representing the cartesian y-coordinate.
++          * @param x A numeric expression representing the cartesian x-coordinate.
++          */
++        atan2(y: number, x: number): number;
++        /**
++          * Returns the smallest number greater than or equal to its numeric argument. 
++          * @param x A numeric expression.
++          */
++        ceil(x: number): number;
++        /**
++          * Returns the cosine of a number. 
++          * @param x A numeric expression that contains an angle measured in radians.
++          */
++        cos(x: number): number;
++        /**
++          * Returns e (the base of natural logarithms) raised to a power. 
++          * @param x A numeric expression representing the power of e.
++          */
++        exp(x: number): number;
++        /**
++          * Returns the greatest number less than or equal to its numeric argument. 
++          * @param x A numeric expression.
++          */
++        floor(x: number): number;
++        /**
++          * Returns the natural logarithm (base e) of a number. 
++          * @param x A numeric expression.
++          */
++        log(x: number): number;
++        /**
++          * Returns the larger of a set of supplied numeric expressions. 
++          * @param values Numeric expressions to be evaluated.
++          */
++        max(...values: number[]): number;
++        /**
++          * Returns the smaller of a set of supplied numeric expressions. 
++          * @param values Numeric expressions to be evaluated.
++          */
++        min(...values: number[]): number;
++        /**
++          * Returns the value of a base expression taken to a specified power. 
++          * @param x The base value of the expression.
++          * @param y The exponent value of the expression.
++          */
++        pow(x: number, y: number): number;
++        /** Returns a pseudorandom number between 0 and 1. */
++        random(): number;
++        /** 
++          * Returns a supplied numeric expression rounded to the nearest number.
++          * @param x The value to be rounded to the nearest number.
++          */
++        round(x: number): number;
++        /**
++          * Returns the sine of a number.
++          * @param x A numeric expression that contains an angle measured in radians.
++          */
++        sin(x: number): number;
++        /**
++          * Returns the square root of a number.
++          * @param x A numeric expression.
++          */
++        sqrt(x: number): number;
++        /**
++          * Returns the tangent of a number.
++          * @param x A numeric expression that contains an angle measured in radians.
++          */
++        tan(x: number): number;
++    }
++    /** An intrinsic object that provides basic mathematics functionality and constants. */
++    declare var Math: Math;
++    
++    /** Enables basic storage and retrieval of dates and times. */
++    interface Date {
++        /** Returns a string representation of a date. The format of the string depends on the locale. */
++        toString(): string;
++        /** Returns a date as a string value. */
++        toDateString(): string;
++        /** Returns a time as a string value. */
++        toTimeString(): string;
++        /** Returns a value as a string value appropriate to the host environment's current locale. */
++        toLocaleString(): string;
++        /** Returns a date as a string value appropriate to the host environment's current locale. */
++        toLocaleDateString(): string;
++        /** Returns a time as a string value appropriate to the host environment's current locale. */
++        toLocaleTimeString(): string;
++        /** Returns the stored time value in milliseconds since midnight, January 1, 1970 UTC. */
++        valueOf(): number;
++        /** Gets the time value in milliseconds. */
++        getTime(): number;
++        /** Gets the year, using local time. */
++        getFullYear(): number;
++        /** Gets the year using Universal Coordinated Time (UTC). */
++        getUTCFullYear(): number;
++        /** Gets the month, using local time. */
++        getMonth(): number;
++        /** Gets the month of a Date object using Universal Coordinated Time (UTC). */
++        getUTCMonth(): number;
++        /** Gets the day-of-the-month, using local time. */
++        getDate(): number;
++        /** Gets the day-of-the-month, using Universal Coordinated Time (UTC). */
++        getUTCDate(): number;
++        /** Gets the day of the week, using local time. */
++        getDay(): number;
++        /** Gets the day of the week using Universal Coordinated Time (UTC). */
++        getUTCDay(): number;
++        /** Gets the hours in a date, using local time. */
++        getHours(): number;
++        /** Gets the hours value in a Date object using Universal Coordinated Time (UTC). */
++        getUTCHours(): number;
++        /** Gets the minutes of a Date object, using local time. */
++        getMinutes(): number;
++        /** Gets the minutes of a Date object using Universal Coordinated Time (UTC). */
++        getUTCMinutes(): number;
++        /** Gets the seconds of a Date object, using local time. */
++        getSeconds(): number;
++        /** Gets the seconds of a Date object using Universal Coordinated Time (UTC). */
++        getUTCSeconds(): number;
++        /** Gets the milliseconds of a Date, using local time. */
++        getMilliseconds(): number;
++        /** Gets the milliseconds of a Date object using Universal Coordinated Time (UTC). */
++        getUTCMilliseconds(): number;
++        /** Gets the difference in minutes between Universal Coordinated Time (UTC) and the time on the local computer. */
++        getTimezoneOffset(): number;
++        /** 
++          * Sets the date and time value in the Date object.
++          * @param time A numeric value representing the number of elapsed milliseconds since midnight, January 1, 1970 GMT. 
++          */
++        setTime(time: number): number;
++        /**
++          * Sets the milliseconds value in the Date object using local time. 
++          * @param ms A numeric value equal to the millisecond value.
++          */
++        setMilliseconds(ms: number): number;
++        /** 
++          * Sets the milliseconds value in the Date object using Universal Coordinated Time (UTC).
++          * @param ms A numeric value equal to the millisecond value. 
++          */
++        setUTCMilliseconds(ms: number): number;
++    
++        /**
++          * Sets the seconds value in the Date object using local time. 
++          * @param sec A numeric value equal to the seconds value.
++          * @param ms A numeric value equal to the milliseconds value.
++          */
++        setSeconds(sec: number, ms?: number): number;
++        /**
++          * Sets the seconds value in the Date object using Universal Coordinated Time (UTC).
++          * @param sec A numeric value equal to the seconds value.
++          * @param ms A numeric value equal to the milliseconds value.
++          */
++        setUTCSeconds(sec: number, ms?: number): number;
++        /**
++          * Sets the minutes value in the Date object using local time. 
++          * @param min A numeric value equal to the minutes value. 
++          * @param sec A numeric value equal to the seconds value. 
++          * @param ms A numeric value equal to the milliseconds value.
++          */
++        setMinutes(min: number, sec?: number, ms?: number): number;
++        /**
++          * Sets the minutes value in the Date object using Universal Coordinated Time (UTC).
++          * @param min A numeric value equal to the minutes value. 
++          * @param sec A numeric value equal to the seconds value. 
++          * @param ms A numeric value equal to the milliseconds value.
++          */
++        setUTCMinutes(min: number, sec?: number, ms?: number): number;
++        /**
++          * Sets the hour value in the Date object using local time.
++          * @param hours A numeric value equal to the hours value.
++          * @param min A numeric value equal to the minutes value.
++          * @param sec A numeric value equal to the seconds value. 
++          * @param ms A numeric value equal to the milliseconds value.
++          */
++        setHours(hours: number, min?: number, sec?: number, ms?: number): number;
++        /**
++          * Sets the hours value in the Date object using Universal Coordinated Time (UTC).
++          * @param hours A numeric value equal to the hours value.
++          * @param min A numeric value equal to the minutes value.
++          * @param sec A numeric value equal to the seconds value. 
++          * @param ms A numeric value equal to the milliseconds value.
++          */
++        setUTCHours(hours: number, min?: number, sec?: number, ms?: number): number;
++        /**
++          * Sets the numeric day-of-the-month value of the Date object using local time. 
++          * @param date A numeric value equal to the day of the month.
++          */
++        setDate(date: number): number;
++        /** 
++          * Sets the numeric day of the month in the Date object using Universal Coordinated Time (UTC).
++          * @param date A numeric value equal to the day of the month. 
++          */
++        setUTCDate(date: number): number;
++        /** 
++          * Sets the month value in the Date object using local time. 
++          * @param month A numeric value equal to the month. The value for January is 0, and other month values follow consecutively. 
++          * @param date A numeric value representing the day of the month. If this value is not supplied, the value from a call to the getDate method is used.
++          */
++        setMonth(month: number, date?: number): number;
++        /**
++          * Sets the month value in the Date object using Universal Coordinated Time (UTC).
++          * @param month A numeric value equal to the month. The value for January is 0, and other month values follow consecutively.
++          * @param date A numeric value representing the day of the month. If it is not supplied, the value from a call to the getUTCDate method is used.
++          */
++        setUTCMonth(month: number, date?: number): number;
++        /**
++          * Sets the year of the Date object using local time.
++          * @param year A numeric value for the year.
++          * @param month A zero-based numeric value for the month (0 for January, 11 for December). Must be specified if numDate is specified.
++          * @param date A numeric value equal for the day of the month.
++          */
++        setFullYear(year: number, month?: number, date?: number): number;
++        /**
++          * Sets the year value in the Date object using Universal Coordinated Time (UTC).
++          * @param year A numeric value equal to the year.
++          * @param month A numeric value equal to the month. The value for January is 0, and other month values follow consecutively. Must be supplied if numDate is supplied.
++          * @param date A numeric value equal to the day of the month.
++          */
++        setUTCFullYear(year: number, month?: number, date?: number): number;
++        /** Returns a date converted to a string using Universal Coordinated Time (UTC). */
++        toUTCString(): string;
++        /** Returns a date as a string value in ISO format. */
++        toISOString(): string;
++        /** Used by the JSON.stringify method to enable the transformation of an object's data for JavaScript Object Notation (JSON) serialization. */
++        toJSON(key?: any): string;
++    }
++    
++    declare var Date: {
++                ~~~~
++!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'Date' must be of type 'DateConstructor', but here has type '{ (): string; new (): Date; new (value: number): Date; new (value: string): Date; new (year: number, month: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number): Date; prototype: Date; parse(s: string): number; UTC(year: number, month: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number): number; now(): number; }'.
++!!! related TS6203 lib.es5.d.ts:--:--: 'Date' was also declared here.
++        new (): Date;
++        new (value: number): Date;
++        new (value: string): Date;
++        new (year: number, month: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number): Date;
++        (): string;
++        prototype: Date;
++        /**
++          * Parses a string containing a date, and returns the number of milliseconds between that date and midnight, January 1, 1970.
++          * @param s A date string
++          */
++        parse(s: string): number;
++        /**
++          * Returns the number of milliseconds between midnight, January 1, 1970 Universal Coordinated Time (UTC) (or GMT) and the specified date. 
++          * @param year The full year designation is required for cross-century date accuracy. If year is between 0 and 99 is used, then year is assumed to be 1900 + year.
++          * @param month The month as an number between 0 and 11 (January to December).
++          * @param date The date as an number between 1 and 31.
++          * @param hours Must be supplied if minutes is supplied. An number from 0 to 23 (midnight to 11pm) that specifies the hour.
++          * @param minutes Must be supplied if seconds is supplied. An number from 0 to 59 that specifies the minutes.
++          * @param seconds Must be supplied if milliseconds is supplied. An number from 0 to 59 that specifies the seconds.
++          * @param ms An number from 0 to 999 that specifies the milliseconds.
++          */
++        UTC(year: number, month: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number): number;
++        now(): number;
++    }
++    
++    interface RegExpExecArray {
++        [index: number]: string;
++        length: number;
++    
++        index: number;
++        input: string;
++    
++        toString(): string;
++        toLocaleString(): string;
++        concat(...items: string[][]): string[];
++        join(separator?: string): string;
++        pop(): string;
++        push(...items: string[]): number;
++        reverse(): string[];
++        shift(): string;
++        slice(start?: number, end?: number): string[];
++        sort(compareFn?: (a: string, b: string) => number): string[];
++        splice(start: number): string[];
++        splice(start: number, deleteCount: number, ...items: string[]): string[];
++        unshift(...items: string[]): number;
++    
++        indexOf(searchElement: string, fromIndex?: number): number;
++        lastIndexOf(searchElement: string, fromIndex?: number): number;
++        every(callbackfn: (value: string, index: number, array: string[]) => boolean, thisArg?: any): boolean;
++        some(callbackfn: (value: string, index: number, array: string[]) => boolean, thisArg?: any): boolean;
++        forEach(callbackfn: (value: string, index: number, array: string[]) => void, thisArg?: any): void;
++        map(callbackfn: (value: string, index: number, array: string[]) => any, thisArg?: any): any[];
++        filter(callbackfn: (value: string, index: number, array: string[]) => boolean, thisArg?: any): string[];
++        reduce(callbackfn: (previousValue: any, currentValue: any, currentIndex: number, array: string[]) => any, initialValue?: any): any;
++        reduceRight(callbackfn: (previousValue: any, currentValue: any, currentIndex: number, array: string[]) => any, initialValue?: any): any;
++    }
++    
++    
++    interface RegExp {
++        /** 
++          * Executes a search on a string using a regular expression pattern, and returns an array containing the results of that search.
++          * @param string The String object or string literal on which to perform the search.
++          */
++        exec(string: string): RegExpExecArray;
++    
++        /** 
++          * Returns a Boolean value that indicates whether or not a pattern exists in a searched string.
++          * @param string String on which to perform the search.
++          */
++        test(string: string): boolean;
++    
++        /** Returns a copy of the text of the regular expression pattern. Read-only. The rgExp argument is a Regular expression object. It can be a variable name or a literal. */
++        source: string;
++        ~~~~~~
++!!! error TS2687: All declarations of 'source' must have identical modifiers.
++    
++        /** Returns a Boolean value indicating the state of the global flag (g) used with a regular expression. Default is false. Read-only. */
++        global: boolean;
++        ~~~~~~
++!!! error TS2687: All declarations of 'global' must have identical modifiers.
++    
++        /** Returns a Boolean value indicating the state of the ignoreCase flag (i) used with a regular expression. Default is false. Read-only. */
++        ignoreCase: boolean;
++        ~~~~~~~~~~
++!!! error TS2687: All declarations of 'ignoreCase' must have identical modifiers.
++    
++        /** Returns a Boolean value indicating the state of the multiline flag (m) used with a regular expression. Default is false. Read-only. */
++        multiline: boolean;
++        ~~~~~~~~~
++!!! error TS2687: All declarations of 'multiline' must have identical modifiers.
++    
++        lastIndex: number;
++    
++        // Non-standard extensions
++        compile(): RegExp;
++    }
++    declare var RegExp: {
++                ~~~~~~
++!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'RegExp' must be of type 'RegExpConstructor', but here has type '{ (pattern: string, flags?: string): RegExp; new (pattern: string, flags?: string): RegExp; $1: string; $2: string; $3: string; $4: string; $5: string; $6: string; $7: string; $8: string; $9: string; lastMatch: string; }'.
++!!! related TS6203 lib.es5.d.ts:--:--: 'RegExp' was also declared here.
++        new (pattern: string, flags?: string): RegExp;
++        (pattern: string, flags?: string): RegExp;
++    
++        // Non-standard extensions
++        $1: string;
++        $2: string;
++        $3: string;
++        $4: string;
++        $5: string;
++        $6: string;
++        $7: string;
++        $8: string;
++        $9: string;
++        lastMatch: string;
++    }
++    
++    interface Error {
++        name: string;
++        message: string;
++    }
++    declare var Error: {
++                ~~~~~
++!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'Error' must be of type 'ErrorConstructor', but here has type '{ (message?: string): Error; new (message?: string): Error; prototype: Error; }'.
++!!! related TS6203 lib.es5.d.ts:--:--: 'Error' was also declared here.
++        new (message?: string): Error;
++        (message?: string): Error;
++        prototype: Error;
++    }
++    
++    interface EvalError extends Error {
++    }
++    declare var EvalError: {
++                ~~~~~~~~~
++!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'EvalError' must be of type 'EvalErrorConstructor', but here has type '{ (message?: string): EvalError; new (message?: string): EvalError; prototype: EvalError; }'.
++!!! related TS6203 lib.es5.d.ts:--:--: 'EvalError' was also declared here.
++        new (message?: string): EvalError;
++        (message?: string): EvalError;
++        prototype: EvalError;
++    }
++    
++    interface RangeError extends Error {
++    }
++    declare var RangeError: {
++                ~~~~~~~~~~
++!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'RangeError' must be of type 'RangeErrorConstructor', but here has type '{ (message?: string): RangeError; new (message?: string): RangeError; prototype: RangeError; }'.
++!!! related TS6203 lib.es5.d.ts:--:--: 'RangeError' was also declared here.
++        new (message?: string): RangeError;
++        (message?: string): RangeError;
++        prototype: RangeError;
++    }
++    
++    interface ReferenceError extends Error {
++    }
++    declare var ReferenceError: {
++                ~~~~~~~~~~~~~~
++!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'ReferenceError' must be of type 'ReferenceErrorConstructor', but here has type '{ (message?: string): ReferenceError; new (message?: string): ReferenceError; prototype: ReferenceError; }'.
++!!! related TS6203 lib.es5.d.ts:--:--: 'ReferenceError' was also declared here.
++        new (message?: string): ReferenceError;
++        (message?: string): ReferenceError;
++        prototype: ReferenceError;
++    }
++    
++    interface SyntaxError extends Error {
++    }
++    declare var SyntaxError: {
++                ~~~~~~~~~~~
++!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'SyntaxError' must be of type 'SyntaxErrorConstructor', but here has type '{ (message?: string): SyntaxError; new (message?: string): SyntaxError; prototype: SyntaxError; }'.
++!!! related TS6203 lib.es5.d.ts:--:--: 'SyntaxError' was also declared here.
++        new (message?: string): SyntaxError;
++        (message?: string): SyntaxError;
++        prototype: SyntaxError;
++    }
++    
++    interface TypeError extends Error {
++    }
++    declare var TypeError: {
++                ~~~~~~~~~
++!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'TypeError' must be of type 'TypeErrorConstructor', but here has type '{ (message?: string): TypeError; new (message?: string): TypeError; prototype: TypeError; }'.
++!!! related TS6203 lib.es5.d.ts:--:--: 'TypeError' was also declared here.
++        new (message?: string): TypeError;
++        (message?: string): TypeError;
++        prototype: TypeError;
++    }
++    
++    interface URIError extends Error {
++    }
++    declare var URIError: {
++                ~~~~~~~~
++!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'URIError' must be of type 'URIErrorConstructor', but here has type '{ (message?: string): URIError; new (message?: string): URIError; prototype: URIError; }'.
++!!! related TS6203 lib.es5.d.ts:--:--: 'URIError' was also declared here.
++        new (message?: string): URIError;
++        (message?: string): URIError;
++        prototype: URIError;
++    }
++    
++    interface JSON {
++        /**
++          * Converts a JavaScript Object Notation (JSON) string into an object.
++          * @param text A valid JSON string.
++          * @param reviver A function that transforms the results. This function is called for each member of the object. 
++          * If a member contains nested objects, the nested objects are transformed before the parent object is. 
++          */
++        parse(text: string, reviver?: (key: any, value: any) => any): any;
++        /**
++          * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
++          * @param value A JavaScript value, usually an object or array, to be converted.
++          */
++        stringify(value: any): string;
++        /**
++          * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
++          * @param value A JavaScript value, usually an object or array, to be converted.
++          * @param replacer A function that transforms the results.
++          */
++        stringify(value: any, replacer: (key: string, value: any) => any): string;
++        /**
++          * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
++          * @param value A JavaScript value, usually an object or array, to be converted.
++          * @param replacer Array that transforms the results.
++          */
++        stringify(value: any, replacer: any[]): string;
++        /**
++          * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
++          * @param value A JavaScript value, usually an object or array, to be converted.
++          * @param replacer A function that transforms the results.
++          * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
++          */
++        stringify(value: any, replacer: (key: string, value: any) => any, space: any): string;
++        /**
++          * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
++          * @param value A JavaScript value, usually an object or array, to be converted.
++          * @param replacer Array that transforms the results.
++          * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
++          */
++        stringify(value: any, replacer: any[], space: any): string;
++    }
++    /**
++      * An intrinsic object that provides functions to convert JavaScript values to and from the JavaScript Object Notation (JSON) format.
++      */
++    declare var JSON: JSON;
++    
++    
++    /////////////////////////////
++    /// ECMAScript Array API (specially handled by compiler)
++    /////////////////////////////
++    
++    interface Array<T> {
++        /**
++          * Returns a string representation of an array.
++          */
++        toString(): string;
++        toLocaleString(): string;
++        /**
++          * Combines two or more arrays.
++          * @param items Additional items to add to the end of array1.
++          */
++        concat<U extends T[]>(...items: U[]): T[];
++        /**
++          * Combines two or more arrays.
++          * @param items Additional items to add to the end of array1.
++          */
++        concat(...items: T[]): T[];
++        /**
++          * Adds all the elements of an array separated by the specified separator string.
++          * @param separator A string used to separate one element of an array from the next in the resulting String. If omitted, the array elements are separated with a comma.
++          */
++        join(separator?: string): string;
++        /**
++          * Removes the last element from an array and returns it.
++          */
++        pop(): T;
++        /**
++          * Appends new elements to an array, and returns the new length of the array.
++          * @param items New elements of the Array.
++          */
++        push(...items: T[]): number;
++        /**
++          * Reverses the elements in an Array. 
++          */
++        reverse(): T[];
++        /**
++          * Removes the first element from an array and returns it.
++          */
++        shift(): T;
++        /** 
++          * Returns a section of an array.
++          * @param start The beginning of the specified portion of the array.
++          * @param end The end of the specified portion of the array.
++          */
++        slice(start?: number, end?: number): T[];
++    
++        /**
++          * Sorts an array.
++          * @param compareFn The name of the function used to determine the order of the elements. If omitted, the elements are sorted in ascending, ASCII character order.
++          */
++        sort(compareFn?: (a: T, b: T) => number): T[];
++    
++        /**
++          * Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements.
++          * @param start The zero-based location in the array from which to start removing elements.
++          */
++        splice(start: number): T[];
++    
++        /**
++          * Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements.
++          * @param start The zero-based location in the array from which to start removing elements.
++          * @param deleteCount The number of elements to remove.
++          * @param items Elements to insert into the array in place of the deleted elements.
++          */
++        splice(start: number, deleteCount: number, ...items: T[]): T[];
++    
++        /**
++          * Inserts new elements at the start of an array.
++          * @param items  Elements to insert at the start of the Array.
++          */
++        unshift(...items: T[]): number;
++    
++        /**
++          * Returns the index of the first occurrence of a value in an array.
++          * @param searchElement The value to locate in the array.
++          * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the search starts at index 0.
++          */
++        indexOf(searchElement: T, fromIndex?: number): number;
++    
++        /**
++          * Returns the index of the last occurrence of a specified value in an array.
++          * @param searchElement The value to locate in the array.
++          * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the search starts at the last index in the array.
++          */
++        lastIndexOf(searchElement: T, fromIndex?: number): number;
++    
++        /**
++          * Determines whether all the members of an array satisfy the specified test.
++          * @param callbackfn A function that accepts up to three arguments. The every method calls the callbackfn function for each element in array1 until the callbackfn returns false, or until the end of the array.
++          * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
++          */
++        every(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean;
++    
++        /**
++          * Determines whether the specified callback function returns true for any element of an array.
++          * @param callbackfn A function that accepts up to three arguments. The some method calls the callbackfn function for each element in array1 until the callbackfn returns true, or until the end of the array.
++          * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
++          */
++        some(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean;
++    
++        /**
++          * Performs the specified action for each element in an array.
++          * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the array. 
++          * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
++          */
++        forEach(callbackfn: (value: T, index: number, array: T[]) => void, thisArg?: any): void;
++    
++        /**
++          * Calls a defined callback function on each element of an array, and returns an array that contains the results.
++          * @param callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array. 
++          * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
++          */
++        map<U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): U[];
++    
++        /**
++          * Returns the elements of an array that meet the condition specified in a callback function. 
++          * @param callbackfn A function that accepts up to three arguments. The filter method calls the callbackfn function one time for each element in the array. 
++          * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
++          */
++        filter(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): T[];
++    
++        /**
++          * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
++          * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
++          * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
++          */
++        reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T;
++        /**
++          * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
++          * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
++          * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
++          */
++        reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
++    
++        /** 
++          * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
++          * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array. 
++          * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
++          */
++        reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T;
++        /** 
++          * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
++          * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array. 
++          * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
++          */
++        reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
++    
++        /**
++          * Gets or sets the length of the array. This is a number one higher than the highest element defined in an array.
++          */
++        length: number;
++    
++        [n: number]: T;
++    }
++    declare var Array: {
++                ~~~~~
++!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'Array' must be of type 'ArrayConstructor', but here has type '{ (arrayLength?: number): any[]; <T>(arrayLength: number): T[]; <T>(...items: T[]): T[]; new (arrayLength?: number): any[]; new <T>(arrayLength: number): T[]; new <T>(...items: T[]): T[]; isArray(arg: any): boolean; prototype: any[]; }'.
++!!! related TS6203 lib.es5.d.ts:--:--: 'Array' was also declared here.
++        new (arrayLength?: number): any[];
++        new <T>(arrayLength: number): T[];
++        new <T>(...items: T[]): T[];
++        (arrayLength?: number): any[];
++        <T>(arrayLength: number): T[];
++        <T>(...items: T[]): T[];
++        isArray(arg: any): boolean;
++        prototype: Array<any>;
++    }


### PR DESCRIPTION
`no-default-lib` in a file no longer has any effect. Instead, the file loader keeps track of which files are libs, which is then used later for `skipDefaultLibCheck`.

This creates a load of errors in `1.0lib-noErrors.ts`, which is our test for `no-default-lib`.