### PR TITLE
Enable the noCheck emit consistency test

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -30564,18 +30564,11 @@ func (c *Checker) GetTypeAtLocation(node *ast.Node) *Type {
 	return c.getTypeOfNode(node)
 }
 
-func (c *Checker) GetEmitResolver(file *ast.SourceFile, skipDiagnostics bool) *emitResolver {
+func (c *Checker) GetEmitResolver(file *ast.SourceFile) *emitResolver {
 	c.emitResolverOnce.Do(func() {
 		c.emitResolver = &emitResolver{checker: c}
 	})
 
-	if !skipDiagnostics {
-		// Ensure we have all the type information in place for this file so that all the
-		// emitter questions of this resolver will return the right information.
-		c.emitResolver.checkerMu.Lock()
-		defer c.emitResolver.checkerMu.Unlock()
-		c.checkSourceFile(context.Background(), file)
-	}
 	return c.emitResolver
 }
 

--- a/internal/checker/nodebuilderimpl.go
+++ b/internal/checker/nodebuilderimpl.go
@@ -1450,7 +1450,7 @@ func (b *nodeBuilderImpl) symbolToParameterDeclaration(parameterSymbol *ast.Symb
 	}
 	name := b.parameterToParameterDeclarationName(parameterSymbol, parameterDeclaration)
 	// TODO: isOptionalParameter on emit resolver here is silly - hoist to checker and reexpose on emit resolver?
-	isOptional := parameterDeclaration != nil && b.ch.GetEmitResolver(nil, true).isOptionalParameter(parameterDeclaration) || parameterSymbol.CheckFlags&ast.CheckFlagsOptionalParameter != 0
+	isOptional := parameterDeclaration != nil && b.ch.GetEmitResolver(nil).isOptionalParameter(parameterDeclaration) || parameterSymbol.CheckFlags&ast.CheckFlagsOptionalParameter != 0
 	var questionToken *ast.Node
 	if isOptional {
 		questionToken = b.f.NewToken(ast.KindQuestionToken)
@@ -1887,7 +1887,7 @@ func (b *nodeBuilderImpl) serializeTypeForDeclaration(declaration *ast.Declarati
 			}
 		}
 		// !!! TODO: JSDoc, getEmitResolver call is unfortunate layering for the helper - hoist it into checker
-		addUndefinedForParameter := declaration != nil && (ast.IsParameter(declaration) /*|| ast.IsJSDocParameterTag(declaration)*/) && b.ch.GetEmitResolver(nil, true).requiresAddingImplicitUndefined(declaration, symbol, b.ctx.enclosingDeclaration)
+		addUndefinedForParameter := declaration != nil && (ast.IsParameter(declaration) /*|| ast.IsJSDocParameterTag(declaration)*/) && b.ch.GetEmitResolver(nil).requiresAddingImplicitUndefined(declaration, symbol, b.ctx.enclosingDeclaration)
 		if addUndefinedForParameter {
 			t = b.ch.getOptionalType(t, false)
 		}

--- a/internal/checker/symbolaccessibility.go
+++ b/internal/checker/symbolaccessibility.go
@@ -38,7 +38,7 @@ func (ch *Checker) IsAnySymbolAccessible(symbols []*ast.Symbol, enclosingDeclara
 		if len(accessibleSymbolChain) > 0 {
 			hadAccessibleChain = symbol
 			// TODO: going through emit resolver here is weird. Relayer these APIs.
-			hasAccessibleDeclarations := ch.GetEmitResolver(nil, true).hasVisibleDeclarations(accessibleSymbolChain[0], shouldComputeAliasesToMakeVisible)
+			hasAccessibleDeclarations := ch.GetEmitResolver(nil).hasVisibleDeclarations(accessibleSymbolChain[0], shouldComputeAliasesToMakeVisible)
 			if hasAccessibleDeclarations != nil {
 				return hasAccessibleDeclarations
 			}

--- a/internal/compiler/emitHost.go
+++ b/internal/compiler/emitHost.go
@@ -32,7 +32,7 @@ type EmitHost interface {
 	GetCurrentDirectory() string
 	CommonSourceDirectory() string
 	IsEmitBlocked(file string) bool
-	GetEmitResolver(file *ast.SourceFile, skipDiagnostics bool) printer.EmitResolver
+	GetEmitResolver(file *ast.SourceFile) printer.EmitResolver
 }
 
 var _ EmitHost = (*emitHost)(nil)
@@ -83,7 +83,7 @@ func (host *emitHost) GetRedirectTargets(path tspath.Path) []string {
 }
 
 func (host *emitHost) GetEffectiveDeclarationFlags(node *ast.Node, flags ast.ModifierFlags) ast.ModifierFlags {
-	return host.GetEmitResolver(ast.GetSourceFileOfNode(node), true).GetEffectiveDeclarationFlags(node, flags)
+	return host.GetEmitResolver(ast.GetSourceFileOfNode(node)).GetEffectiveDeclarationFlags(node, flags)
 }
 
 func (host *emitHost) GetOutputPathsFor(file *ast.SourceFile, forceDtsPaths bool) declarations.OutputPaths {
@@ -92,7 +92,7 @@ func (host *emitHost) GetOutputPathsFor(file *ast.SourceFile, forceDtsPaths bool
 }
 
 func (host *emitHost) GetResolutionModeOverride(node *ast.Node) core.ResolutionMode {
-	return host.GetEmitResolver(ast.GetSourceFileOfNode(node), true).GetResolutionModeOverride(node)
+	return host.GetEmitResolver(ast.GetSourceFileOfNode(node)).GetResolutionModeOverride(node)
 }
 
 func (host *emitHost) GetSourceFileFromReference(origin *ast.SourceFile, ref *ast.FileReference) *ast.SourceFile {
@@ -116,13 +116,13 @@ func (host *emitHost) WriteFile(fileName string, text string, writeByteOrderMark
 	return host.program.Host().FS().WriteFile(fileName, text, writeByteOrderMark)
 }
 
-func (host *emitHost) GetEmitResolver(file *ast.SourceFile, skipDiagnostics bool) printer.EmitResolver {
+func (host *emitHost) GetEmitResolver(file *ast.SourceFile) printer.EmitResolver {
 	// The context and done function don't matter in tsc, currently the only caller of this function.
 	// But if this ever gets used by LSP code, we'll need to thread the context properly and pass the
 	// done function to the caller to ensure resources are cleaned up at the end of the request.
 	checker, done := host.program.GetTypeCheckerForFile(context.TODO(), file)
 	defer done()
-	return checker.GetEmitResolver(file, skipDiagnostics)
+	return checker.GetEmitResolver(file)
 }
 
 func (host *emitHost) IsSourceFileFromExternalLibrary(file *ast.SourceFile) bool {

--- a/internal/compiler/emitter.go
+++ b/internal/compiler/emitter.go
@@ -50,7 +50,7 @@ func (e *emitter) emit() {
 }
 
 func (e *emitter) getDeclarationTransformers(emitContext *printer.EmitContext, sourceFile *ast.SourceFile, declarationFilePath string, declarationMapPath string) []*declarations.DeclarationTransformer {
-	emitResolver := e.host.GetEmitResolver(sourceFile, false /*skipDiagnostics*/) // !!! conditionally skip diagnostics
+	emitResolver := e.host.GetEmitResolver(sourceFile)
 	transform := declarations.NewDeclarationTransformer(e.host, emitResolver, emitContext, e.host.Options(), declarationFilePath, declarationMapPath)
 	return []*declarations.DeclarationTransformer{transform}
 }
@@ -86,7 +86,7 @@ func getScriptTransformers(emitContext *printer.EmitContext, host printer.EmitHo
 	var emitResolver printer.EmitResolver
 	var referenceResolver binder.ReferenceResolver
 	if importElisionEnabled || options.GetJSXTransformEnabled() {
-		emitResolver = host.GetEmitResolver(sourceFile, false /*skipDiagnostics*/) // !!! conditionally skip diagnostics
+		emitResolver = host.GetEmitResolver(sourceFile)
 		emitResolver.MarkLinkedReferencesRecursively(sourceFile)
 		referenceResolver = emitResolver
 	} else {

--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -460,7 +460,7 @@ func (p *Program) getDeclarationDiagnosticsForFile(_ctx context.Context, sourceF
 	}
 
 	host := &emitHost{program: p}
-	diagnostics := getDeclarationDiagnostics(host, host.GetEmitResolver(sourceFile, true), sourceFile)
+	diagnostics := getDeclarationDiagnostics(host, host.GetEmitResolver(sourceFile), sourceFile)
 	diagnostics, _ = p.declarationDiagnosticCache.LoadOrStore(sourceFile, diagnostics)
 	return diagnostics
 }

--- a/internal/printer/emithost.go
+++ b/internal/printer/emithost.go
@@ -25,7 +25,7 @@ type EmitHost interface {
 	IsEmitBlocked(file string) bool
 	WriteFile(fileName string, text string, writeByteOrderMark bool, relatedSourceFiles []*ast.SourceFile, data *WriteFileData) error
 	GetEmitModuleFormatOfFile(file ast.HasFileName) core.ModuleKind
-	GetEmitResolver(file *ast.SourceFile, skipDiagnostics bool) EmitResolver
+	GetEmitResolver(file *ast.SourceFile) EmitResolver
 	GetOutputAndProjectReference(path tspath.Path) *tsoptions.OutputDtsAndProjectReference
 	IsSourceFileFromExternalLibrary(file *ast.SourceFile) bool
 }

--- a/internal/testutil/baseline/baseline.go
+++ b/internal/testutil/baseline/baseline.go
@@ -104,7 +104,7 @@ func readFileOrNoContent(fileName string) string {
 	return string(content)
 }
 
-func diffText(oldName string, newName string, expected string, actual string) string {
+func DiffText(oldName string, newName string, expected string, actual string) string {
 	lines := patience.Diff(stringutil.SplitLines(expected), stringutil.SplitLines(actual))
 	return patience.UnifiedDiffTextWithOptions(lines, patience.UnifiedDiffOptions{
 		Precontext:  3,
@@ -121,7 +121,7 @@ func getBaselineDiff(t *testing.T, actual string, expected string, fileName stri
 	if actual == expected {
 		return NoContent
 	}
-	s := diffText("old."+fileName, "new."+fileName, expected, actual)
+	s := DiffText("old."+fileName, "new."+fileName, expected, actual)
 
 	// Remove line numbers from unified diff headers; this avoids adding/deleting
 	// lines in our baselines from causing knock-on header changes later in the diff.

--- a/internal/transformers/tstransforms/importelision_test.go
+++ b/internal/transformers/tstransforms/importelision_test.go
@@ -237,7 +237,7 @@ func TestImportElision(t *testing.T) {
 				},
 			})
 
-			emitResolver := c.GetEmitResolver(file, false /*skipDiagnostics*/)
+			emitResolver := c.GetEmitResolver(file)
 			emitResolver.MarkLinkedReferencesRecursively(file)
 
 			emitContext := printer.NewEmitContext()


### PR DESCRIPTION
Present, but commented out, these tests are important to have on as I port emit features, as they point out places where the `EmitResolver` fails to lazily calculate things emit needs. I'm also removing the eager-diagnostics behavior from emit resolver construction entirely. With emit often happening on many separate threads, it is basically never a good idea to require an emit resolver generate diagnostics - right now we lock on a single checker across emit threads, but we can and probably should swap to a pooled checker/emitresolver model and remove all those locks, just like we do for LS requests. Any questions an emit resolver answers really do just have to be lazy-calculation-safe under a concurrent model.