### PR TITLE
Ensure we use the right checker in declaration diagnostics, fix lifetime

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -30572,7 +30572,7 @@ func (c *Checker) GetTypeAtLocation(node *ast.Node) *Type {
 	return c.getTypeOfNode(node)
 }
 
-func (c *Checker) GetEmitResolver(file *ast.SourceFile) *emitResolver {
+func (c *Checker) GetEmitResolver() *emitResolver {
 	c.emitResolverOnce.Do(func() {
 		c.emitResolver = &emitResolver{checker: c}
 	})

--- a/internal/checker/nodebuilderimpl.go
+++ b/internal/checker/nodebuilderimpl.go
@@ -1450,7 +1450,7 @@ func (b *nodeBuilderImpl) symbolToParameterDeclaration(parameterSymbol *ast.Symb
 	}
 	name := b.parameterToParameterDeclarationName(parameterSymbol, parameterDeclaration)
 	// TODO: isOptionalParameter on emit resolver here is silly - hoist to checker and reexpose on emit resolver?
-	isOptional := parameterDeclaration != nil && b.ch.GetEmitResolver(nil).isOptionalParameter(parameterDeclaration) || parameterSymbol.CheckFlags&ast.CheckFlagsOptionalParameter != 0
+	isOptional := parameterDeclaration != nil && b.ch.GetEmitResolver().isOptionalParameter(parameterDeclaration) || parameterSymbol.CheckFlags&ast.CheckFlagsOptionalParameter != 0
 	var questionToken *ast.Node
 	if isOptional {
 		questionToken = b.f.NewToken(ast.KindQuestionToken)
@@ -1887,7 +1887,7 @@ func (b *nodeBuilderImpl) serializeTypeForDeclaration(declaration *ast.Declarati
 			}
 		}
 		// !!! TODO: JSDoc, getEmitResolver call is unfortunate layering for the helper - hoist it into checker
-		addUndefinedForParameter := declaration != nil && (ast.IsParameter(declaration) /*|| ast.IsJSDocParameterTag(declaration)*/) && b.ch.GetEmitResolver(nil).requiresAddingImplicitUndefined(declaration, symbol, b.ctx.enclosingDeclaration)
+		addUndefinedForParameter := declaration != nil && (ast.IsParameter(declaration) /*|| ast.IsJSDocParameterTag(declaration)*/) && b.ch.GetEmitResolver().requiresAddingImplicitUndefined(declaration, symbol, b.ctx.enclosingDeclaration)
 		if addUndefinedForParameter {
 			t = b.ch.getOptionalType(t, false)
 		}

--- a/internal/checker/symbolaccessibility.go
+++ b/internal/checker/symbolaccessibility.go
@@ -38,7 +38,7 @@ func (ch *Checker) IsAnySymbolAccessible(symbols []*ast.Symbol, enclosingDeclara
 		if len(accessibleSymbolChain) > 0 {
 			hadAccessibleChain = symbol
 			// TODO: going through emit resolver here is weird. Relayer these APIs.
-			hasAccessibleDeclarations := ch.GetEmitResolver(nil).hasVisibleDeclarations(accessibleSymbolChain[0], shouldComputeAliasesToMakeVisible)
+			hasAccessibleDeclarations := ch.GetEmitResolver().hasVisibleDeclarations(accessibleSymbolChain[0], shouldComputeAliasesToMakeVisible)
 			if hasAccessibleDeclarations != nil {
 				return hasAccessibleDeclarations
 			}

--- a/internal/compiler/emitter.go
+++ b/internal/compiler/emitter.go
@@ -49,9 +49,8 @@ func (e *emitter) emit() {
 	e.emitBuildInfo(e.paths.BuildInfoPath())
 }
 
-func (e *emitter) getDeclarationTransformers(emitContext *printer.EmitContext, sourceFile *ast.SourceFile, declarationFilePath string, declarationMapPath string) []*declarations.DeclarationTransformer {
-	emitResolver := e.host.GetEmitResolver(sourceFile)
-	transform := declarations.NewDeclarationTransformer(e.host, emitResolver, emitContext, e.host.Options(), declarationFilePath, declarationMapPath)
+func (e *emitter) getDeclarationTransformers(emitContext *printer.EmitContext, declarationFilePath string, declarationMapPath string) []*declarations.DeclarationTransformer {
+	transform := declarations.NewDeclarationTransformer(e.host, emitContext, e.host.Options(), declarationFilePath, declarationMapPath)
 	return []*declarations.DeclarationTransformer{transform}
 }
 
@@ -86,7 +85,7 @@ func getScriptTransformers(emitContext *printer.EmitContext, host printer.EmitHo
 	var emitResolver printer.EmitResolver
 	var referenceResolver binder.ReferenceResolver
 	if importElisionEnabled || options.GetJSXTransformEnabled() {
-		emitResolver = host.GetEmitResolver(sourceFile)
+		emitResolver = host.GetEmitResolver()
 		emitResolver.MarkLinkedReferencesRecursively(sourceFile)
 		referenceResolver = emitResolver
 	} else {
@@ -179,7 +178,7 @@ func (e *emitter) emitDeclarationFile(sourceFile *ast.SourceFile, declarationFil
 	var diags []*ast.Diagnostic
 	emitContext, putEmitContext := printer.GetEmitContext()
 	defer putEmitContext()
-	for _, transformer := range e.getDeclarationTransformers(emitContext, sourceFile, declarationFilePath, declarationMapPath) {
+	for _, transformer := range e.getDeclarationTransformers(emitContext, declarationFilePath, declarationMapPath) {
 		sourceFile = transformer.TransformSourceFile(sourceFile)
 		diags = append(diags, transformer.GetDiagnostics()...)
 	}
@@ -378,6 +377,7 @@ type SourceFileMayBeEmittedHost interface {
 	IsSourceFileFromExternalLibrary(file *ast.SourceFile) bool
 	GetCurrentDirectory() string
 	UseCaseSensitiveFileNames() bool
+	SourceFiles() []*ast.SourceFile
 }
 
 func sourceFileMayBeEmitted(sourceFile *ast.SourceFile, host SourceFileMayBeEmittedHost, forceDtsEmit bool) bool {
@@ -435,7 +435,7 @@ func sourceFileMayBeEmitted(sourceFile *ast.SourceFile, host SourceFileMayBeEmit
 	return true
 }
 
-func getSourceFilesToEmit(host printer.EmitHost, targetSourceFile *ast.SourceFile, forceDtsEmit bool) []*ast.SourceFile {
+func getSourceFilesToEmit(host SourceFileMayBeEmittedHost, targetSourceFile *ast.SourceFile, forceDtsEmit bool) []*ast.SourceFile {
 	// !!! outFile not yet implemented, may be deprecated
 	var sourceFiles []*ast.SourceFile
 	if targetSourceFile != nil {
@@ -452,13 +452,13 @@ func isSourceFileNotJson(file *ast.SourceFile) bool {
 	return !ast.IsJsonSourceFile(file)
 }
 
-func getDeclarationDiagnostics(host EmitHost, resolver printer.EmitResolver, file *ast.SourceFile) []*ast.Diagnostic {
+func getDeclarationDiagnostics(host EmitHost, file *ast.SourceFile) []*ast.Diagnostic {
 	fullFiles := core.Filter(getSourceFilesToEmit(host, file, false), isSourceFileNotJson)
 	if !core.Some(fullFiles, func(f *ast.SourceFile) bool { return f == file }) {
 		return []*ast.Diagnostic{}
 	}
 	options := host.Options()
-	transform := declarations.NewDeclarationTransformer(host, resolver, nil, options, "", "")
+	transform := declarations.NewDeclarationTransformer(host, nil, options, "", "")
 	transform.TransformSourceFile(file)
 	return transform.GetDiagnostics()
 }

--- a/internal/printer/emithost.go
+++ b/internal/printer/emithost.go
@@ -25,7 +25,7 @@ type EmitHost interface {
 	IsEmitBlocked(file string) bool
 	WriteFile(fileName string, text string, writeByteOrderMark bool, relatedSourceFiles []*ast.SourceFile, data *WriteFileData) error
 	GetEmitModuleFormatOfFile(file ast.HasFileName) core.ModuleKind
-	GetEmitResolver(file *ast.SourceFile) EmitResolver
+	GetEmitResolver() EmitResolver
 	GetOutputAndProjectReference(path tspath.Path) *tsoptions.OutputDtsAndProjectReference
 	IsSourceFileFromExternalLibrary(file *ast.SourceFile) bool
 }

--- a/internal/transformers/declarations/transform.go
+++ b/internal/transformers/declarations/transform.go
@@ -35,6 +35,7 @@ type DeclarationEmitHost interface {
 	GetOutputPathsFor(file *ast.SourceFile, forceDtsPaths bool) OutputPaths
 	GetResolutionModeOverride(node *ast.Node) core.ResolutionMode
 	GetEffectiveDeclarationFlags(node *ast.Node, flags ast.ModifierFlags) ast.ModifierFlags
+	GetEmitResolver() printer.EmitResolver
 }
 
 type DeclarationTransformer struct {
@@ -60,7 +61,8 @@ type DeclarationTransformer struct {
 	rawLibReferenceDirectives        []*ast.FileReference
 }
 
-func NewDeclarationTransformer(host DeclarationEmitHost, resolver printer.EmitResolver, context *printer.EmitContext, compilerOptions *core.CompilerOptions, declarationFilePath string, declarationMapPath string) *DeclarationTransformer {
+func NewDeclarationTransformer(host DeclarationEmitHost, context *printer.EmitContext, compilerOptions *core.CompilerOptions, declarationFilePath string, declarationMapPath string) *DeclarationTransformer {
+	resolver := host.GetEmitResolver()
 	state := &SymbolTrackerSharedState{isolatedDeclarations: compilerOptions.IsolatedDeclarations.IsTrue(), resolver: resolver}
 	tracker := NewSymbolTracker(host, resolver, state)
 	// TODO: Use new host GetOutputPathsFor method instead of passing in entrypoint paths (which will also better support bundled emit)

--- a/internal/transformers/tstransforms/importelision_test.go
+++ b/internal/transformers/tstransforms/importelision_test.go
@@ -241,7 +241,7 @@ func TestImportElision(t *testing.T) {
 				},
 			})
 
-			emitResolver := c.GetEmitResolver(file)
+			emitResolver := c.GetEmitResolver()
 			emitResolver.MarkLinkedReferencesRecursively(file)
 
 			emitContext := printer.NewEmitContext()


### PR DESCRIPTION
Propagate the request-scoped checker to declaration diagnostics. This was a TODO, and the main source of races. This involved a bunch of surgery but I think the new code makes sense?

Fixes #1160 (probably)