### PR TITLE
Save off another closure in emitResolver

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -30574,7 +30574,7 @@ func (c *Checker) GetTypeAtLocation(node *ast.Node) *Type {
 
 func (c *Checker) GetEmitResolver(file *ast.SourceFile) *emitResolver {
 	c.emitResolverOnce.Do(func() {
-		c.emitResolver = &emitResolver{checker: c}
+		c.emitResolver = newEmitResolver(c)
 	})
 
 	return c.emitResolver


### PR DESCRIPTION
This accounts for basically all of the allocs in declaration emit (and therefore, declaration diags in the editor, where this is 30% of all allocs). For `tsc -p ./src/compiler`, the number of allocs is reduced from 4431617 to 3552713.