### PR TITLE
Don't allocate empty slice for named members

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -21118,6 +21118,9 @@ func (c *Checker) getDefaultOrUnknownFromTypeParameter(t *Type) *Type {
 }
 
 func (c *Checker) getNamedMembers(members ast.SymbolTable) []*ast.Symbol {
+	if len(members) == 0 {
+		return nil
+	}
 	result := make([]*ast.Symbol, 0, len(members))
 	for id, symbol := range members {
 		if c.isNamedMember(symbol, id) {


### PR DESCRIPTION
This shaves off a few allocs in vscode.