### PR TITLE
Fix out of bounds error in `recreateBindingPattern`

### DIFF
--- a/internal/transformers/declarations/transform.go
+++ b/internal/transformers/declarations/transform.go
@@ -667,7 +667,7 @@ func (tx *DeclarationTransformer) recreateBindingPattern(input *ast.BindingPatte
 		return nil
 	}
 	if len(results) == 1 {
-		return results[1]
+		return results[0]
 	}
 	return tx.Factory().NewSyntaxList(results)
 }


### PR DESCRIPTION
If the length of the array is 1, the first item is at index 0, not index 1.