### PR TITLE
fix(1342): adjust node ranges to ignore trivia

### DIFF
--- a/internal/ls/findallreferences.go
+++ b/internal/ls/findallreferences.go
@@ -419,7 +419,7 @@ func (l *LanguageService) convertSymbolAndEntryToLocation(s *SymbolAndEntries) [
 	for _, ref := range s.references {
 		if ref.textRange == nil {
 			sourceFile := ast.GetSourceFileOfNode(ref.node)
-			ref.textRange = l.createLspRangeFromNode(ref.node, ast.GetSourceFileOfNode(ref.node))
+			ref.textRange = l.getRangeOfNode(ref.node, sourceFile, nil /*endNode*/)
 			ref.fileName = sourceFile.FileName()
 		}
 		locations = append(locations, &lsproto.Location{

--- a/internal/ls/findallreferences_test.go
+++ b/internal/ls/findallreferences_test.go
@@ -241,6 +241,19 @@ class C extends [|/*3*/Base|] { }`,
 				"3": collections.NewSetFromItems("2", "3"),
 			},
 		},
+		{
+			title: "findAllRefsTrivia",
+			input: `export interface A {
+    /** Comment */
+    [|/*m1*/method|](): string;
+    /** Comment */
+    [|/*m2*/method|](format: string): string;
+}`,
+			expectedLocations: map[string]*collections.Set[string]{
+				"m1": collections.NewSetFromItems("m1", "m2"),
+				"m2": collections.NewSetFromItems("m1", "m2"),
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/ls/findallreferencesexport_test.go
+++ b/internal/ls/findallreferencesexport_test.go
@@ -13,7 +13,7 @@ func (l *LanguageService) GetExpectedReferenceFromMarker(fileName string, pos in
 	node := astnav.GetTouchingPropertyName(sourceFile, pos)
 	return &lsproto.Location{
 		Uri:   FileNameToDocumentURI(fileName),
-		Range: *l.createLspRangeFromNode(node, sourceFile),
+		Range: *l.getRangeOfNode(node, sourceFile, nil /*endNode*/),
 	}
 }
 


### PR DESCRIPTION
Fixes #1342

---

https://github.com/microsoft/TypeScript/blob/833a8d492c728d606454865e8c0fee84842f9f10/src/services/findAllReferences.ts#L745

https://github.com/microsoft/TypeScript/blob/833a8d492c728d606454865e8c0fee84842f9f10/src/services/findAllReferences.ts#L872-L884

---

https://github.com/user-attachments/assets/810cfb6c-d78d-49b4-ad50-b16360d59631


