### PR TITLE
Use absolute paths in error messages for CI environments

### DIFF
--- a/internal/diagnosticwriter/diagnosticwriter.go
+++ b/internal/diagnosticwriter/diagnosticwriter.go
@@ -17,7 +17,8 @@ import (
 
 type FormattingOptions struct {
 	tspath.ComparePathsOptions
-	NewLine string
+	NewLine       string
+	AbsolutePaths bool
 }
 
 const (
@@ -214,7 +215,7 @@ func writeWithStyleAndReset(output io.Writer, text string, formatStyle string) {
 func WriteLocation(output io.Writer, file *ast.SourceFile, pos int, formatOpts *FormattingOptions, writeWithStyleAndReset FormattedWriter) {
 	firstLine, firstChar := scanner.GetLineAndCharacterOfPosition(file, pos)
 	var relativeFileName string
-	if formatOpts != nil {
+	if formatOpts != nil && !formatOpts.AbsolutePaths {
 		relativeFileName = tspath.ConvertToRelativePath(file.FileName(), formatOpts.ComparePathsOptions)
 	} else {
 		relativeFileName = file.FileName()
@@ -354,7 +355,7 @@ func prettyPathForFileError(file *ast.SourceFile, fileErrors []*ast.Diagnostic, 
 	}
 	line, _ := scanner.GetLineAndCharacterOfPosition(file, fileErrors[0].Loc().Pos())
 	fileName := file.FileName()
-	if tspath.PathIsAbsolute(fileName) && tspath.PathIsAbsolute(formatOpts.CurrentDirectory) {
+	if tspath.PathIsAbsolute(fileName) && tspath.PathIsAbsolute(formatOpts.CurrentDirectory) && !formatOpts.AbsolutePaths {
 		fileName = tspath.ConvertToRelativePath(file.FileName(), formatOpts.ComparePathsOptions)
 	}
 	return fmt.Sprintf("%s%s:%d%s",

--- a/internal/execute/outputs.go
+++ b/internal/execute/outputs.go
@@ -3,6 +3,7 @@ package execute
 import (
 	"fmt"
 	"io"
+	"os"
 	"runtime"
 	"slices"
 	"strconv"
@@ -26,6 +27,7 @@ func getFormatOptsOfSys(sys System) *diagnosticwriter.FormattingOptions {
 			CurrentDirectory:          sys.GetCurrentDirectory(),
 			UseCaseSensitiveFileNames: sys.FS().UseCaseSensitiveFileNames(),
 		},
+		AbsolutePaths: os.Getenv("GITHUB_ACTIONS") != "",
 	}
 }
 


### PR DESCRIPTION
This solves the same need as [tsc-absolute](https://github.com/microsoft/TypeScript/issues/7238) or [this patch](https://github.com/microsoft/TypeScript/issues/36221#issuecomment-2106656302)

Errors reported by `tsc` are normally automatically surfaced as annotations in GitHub PRs, using Problem Matchers

However this fails to work in monorepos where multiple typescript projects exist. See [this blog post](https://christopher.xyz/2023/04/04/github-actions-problem-matchers.html) for more details.

cc https://github.com/microsoft/TypeScript/issues/7238 https://github.com/microsoft/TypeScript/issues/36221

(Opening for visibility; I understand divergence from Strada is being avoided at this point)
