### PR TITLE
Various memory allocation improvements

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -68,6 +68,7 @@ type NodeFactory struct {
 	indexedAccessTypeNodePool         core.Pool[IndexedAccessTypeNode]
 	interfaceDeclarationPool          core.Pool[InterfaceDeclaration]
 	jsdocDeprecatedTagPool            core.Pool[JSDocDeprecatedTag]
+	jsdocParameterOrPropertyTagPool   core.Pool[JSDocParameterOrPropertyTag]
 	jsdocPool                         core.Pool[JSDoc]
 	jsdocTextPool                     core.Pool[JSDocText]
 	jsdocUnknownTagPool               core.Pool[JSDocUnknownTag]
@@ -9288,7 +9289,7 @@ type (
 )
 
 func (f *NodeFactory) newJSDocParameterOrPropertyTag(kind Kind, tagName *IdentifierNode, name *EntityName, isBracketed bool, typeExpression *TypeNode, isNameFirst bool, comment *NodeList) *Node {
-	data := &JSDocParameterOrPropertyTag{}
+	data := f.jsdocParameterOrPropertyTagPool.New()
 	data.TagName = tagName
 	data.name = name
 	data.IsBracketed = isBracketed

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -50,6 +50,7 @@ func visitModifiers(v Visitor, modifiers *ModifierList) bool {
 
 type NodeFactory struct {
 	hooks                             NodeFactoryHooks
+	arrayTypeNodePool                 core.Pool[ArrayTypeNode]
 	binaryExpressionPool              core.Pool[BinaryExpression]
 	blockPool                         core.Pool[Block]
 	callExpressionPool                core.Pool[CallExpression]
@@ -7242,7 +7243,7 @@ type ArrayTypeNode struct {
 }
 
 func (f *NodeFactory) NewArrayTypeNode(elementType *TypeNode) *Node {
-	data := &ArrayTypeNode{}
+	data := f.arrayTypeNodePool.New()
 	data.ElementType = elementType
 	return f.newNode(KindArrayType, data)
 }

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -53,7 +53,9 @@ type NodeFactory struct {
 	binaryExpressionPool              core.Pool[BinaryExpression]
 	blockPool                         core.Pool[Block]
 	callExpressionPool                core.Pool[CallExpression]
+	conditionalExpressionPool         core.Pool[ConditionalExpression]
 	constructSignatureDeclarationPool core.Pool[ConstructSignatureDeclaration]
+	elementAccessExpressionPool       core.Pool[ElementAccessExpression]
 	expressionStatementPool           core.Pool[ExpressionStatement]
 	expressionWithTypeArgumentsPool   core.Pool[ExpressionWithTypeArguments]
 	functionDeclarationPool           core.Pool[FunctionDeclaration]
@@ -61,11 +63,13 @@ type NodeFactory struct {
 	heritageClausePool                core.Pool[HeritageClause]
 	identifierPool                    core.Pool[Identifier]
 	ifStatementPool                   core.Pool[IfStatement]
+	importSpecifierPool               core.Pool[ImportSpecifier]
 	indexedAccessTypeNodePool         core.Pool[IndexedAccessTypeNode]
 	interfaceDeclarationPool          core.Pool[InterfaceDeclaration]
 	jsdocDeprecatedTagPool            core.Pool[JSDocDeprecatedTag]
 	jsdocPool                         core.Pool[JSDoc]
 	jsdocTextPool                     core.Pool[JSDocText]
+	jsdocUnknownTagPool               core.Pool[JSDocUnknownTag]
 	keywordExpressionPool             core.Pool[KeywordExpression]
 	keywordTypeNodePool               core.Pool[KeywordTypeNode]
 	literalTypeNodePool               core.Pool[LiteralTypeNode]
@@ -4248,7 +4252,7 @@ type ImportSpecifier struct {
 }
 
 func (f *NodeFactory) NewImportSpecifier(isTypeOnly bool, propertyName *ModuleExportName, name *IdentifierNode) *Node {
-	data := &ImportSpecifier{}
+	data := f.importSpecifierPool.New()
 	data.IsTypeOnly = isTypeOnly
 	data.PropertyName = propertyName
 	data.name = name
@@ -6017,7 +6021,7 @@ type ConditionalExpression struct {
 }
 
 func (f *NodeFactory) NewConditionalExpression(condition *Expression, questionToken *TokenNode, whenTrue *Expression, colonToken *TokenNode, whenFalse *Expression) *Node {
-	data := &ConditionalExpression{}
+	data := f.conditionalExpressionPool.New()
 	data.Condition = condition
 	data.QuestionToken = questionToken
 	data.WhenTrue = whenTrue
@@ -6124,7 +6128,7 @@ type ElementAccessExpression struct {
 }
 
 func (f *NodeFactory) NewElementAccessExpression(expression *Expression, questionDotToken *TokenNode, argumentExpression *Expression, flags NodeFlags) *Node {
-	data := &ElementAccessExpression{}
+	data := f.elementAccessExpressionPool.New()
 	data.Expression = expression
 	data.QuestionDotToken = questionDotToken
 	data.ArgumentExpression = argumentExpression
@@ -9203,7 +9207,7 @@ type JSDocUnknownTag struct {
 }
 
 func (f *NodeFactory) NewJSDocUnknownTag(tagName *IdentifierNode, comment *NodeList) *Node {
-	data := &JSDocUnknownTag{}
+	data := f.jsdocUnknownTagPool.New()
 	data.TagName = tagName
 	data.Comment = comment
 	return f.newNode(KindJSDocTag, data)

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -49,41 +49,47 @@ func visitModifiers(v Visitor, modifiers *ModifierList) bool {
 // NodeFactory
 
 type NodeFactory struct {
-	hooks                            NodeFactoryHooks
-	binaryExpressionPool             core.Pool[BinaryExpression]
-	blockPool                        core.Pool[Block]
-	callExpressionPool               core.Pool[CallExpression]
-	expressionStatementPool          core.Pool[ExpressionStatement]
-	functionDeclarationPool          core.Pool[FunctionDeclaration]
-	functionTypeNodePool             core.Pool[FunctionTypeNode]
-	identifierPool                   core.Pool[Identifier]
-	ifStatementPool                  core.Pool[IfStatement]
-	interfaceDeclarationPool         core.Pool[InterfaceDeclaration]
-	jsdocPool                        core.Pool[JSDoc]
-	jsdocTextPool                    core.Pool[JSDocText]
-	keywordExpressionPool            core.Pool[KeywordExpression]
-	keywordTypeNodePool              core.Pool[KeywordTypeNode]
-	literalTypeNodePool              core.Pool[LiteralTypeNode]
-	methodSignatureDeclarationPool   core.Pool[MethodSignatureDeclaration]
-	modifierListPool                 core.Pool[ModifierList]
-	nodeListPool                     core.Pool[NodeList]
-	numericLiteralPool               core.Pool[NumericLiteral]
-	parameterDeclarationPool         core.Pool[ParameterDeclaration]
-	parenthesizedExpressionPool      core.Pool[ParenthesizedExpression]
-	parenthesizedTypeNodePool        core.Pool[ParenthesizedTypeNode]
-	prefixUnaryExpressionPool        core.Pool[PrefixUnaryExpression]
-	propertyAccessExpressionPool     core.Pool[PropertyAccessExpression]
-	propertyAssignmentPool           core.Pool[PropertyAssignment]
-	propertySignatureDeclarationPool core.Pool[PropertySignatureDeclaration]
-	returnStatementPool              core.Pool[ReturnStatement]
-	stringLiteralPool                core.Pool[StringLiteral]
-	tokenPool                        core.Pool[Token]
-	typeLiteralNodePool              core.Pool[TypeLiteralNode]
-	typeReferenceNodePool            core.Pool[TypeReferenceNode]
-	unionTypeNodePool                core.Pool[UnionTypeNode]
-	variableDeclarationListPool      core.Pool[VariableDeclarationList]
-	variableDeclarationPool          core.Pool[VariableDeclaration]
-	variableStatementPool            core.Pool[VariableStatement]
+	hooks                             NodeFactoryHooks
+	binaryExpressionPool              core.Pool[BinaryExpression]
+	blockPool                         core.Pool[Block]
+	callExpressionPool                core.Pool[CallExpression]
+	constructSignatureDeclarationPool core.Pool[ConstructSignatureDeclaration]
+	expressionStatementPool           core.Pool[ExpressionStatement]
+	expressionWithTypeArgumentsPool   core.Pool[ExpressionWithTypeArguments]
+	functionDeclarationPool           core.Pool[FunctionDeclaration]
+	functionTypeNodePool              core.Pool[FunctionTypeNode]
+	heritageClausePool                core.Pool[HeritageClause]
+	identifierPool                    core.Pool[Identifier]
+	ifStatementPool                   core.Pool[IfStatement]
+	indexedAccessTypeNodePool         core.Pool[IndexedAccessTypeNode]
+	interfaceDeclarationPool          core.Pool[InterfaceDeclaration]
+	jsdocDeprecatedTagPool            core.Pool[JSDocDeprecatedTag]
+	jsdocPool                         core.Pool[JSDoc]
+	jsdocTextPool                     core.Pool[JSDocText]
+	keywordExpressionPool             core.Pool[KeywordExpression]
+	keywordTypeNodePool               core.Pool[KeywordTypeNode]
+	literalTypeNodePool               core.Pool[LiteralTypeNode]
+	methodSignatureDeclarationPool    core.Pool[MethodSignatureDeclaration]
+	modifierListPool                  core.Pool[ModifierList]
+	nodeListPool                      core.Pool[NodeList]
+	numericLiteralPool                core.Pool[NumericLiteral]
+	parameterDeclarationPool          core.Pool[ParameterDeclaration]
+	parenthesizedExpressionPool       core.Pool[ParenthesizedExpression]
+	parenthesizedTypeNodePool         core.Pool[ParenthesizedTypeNode]
+	prefixUnaryExpressionPool         core.Pool[PrefixUnaryExpression]
+	propertyAccessExpressionPool      core.Pool[PropertyAccessExpression]
+	propertyAssignmentPool            core.Pool[PropertyAssignment]
+	propertySignatureDeclarationPool  core.Pool[PropertySignatureDeclaration]
+	returnStatementPool               core.Pool[ReturnStatement]
+	stringLiteralPool                 core.Pool[StringLiteral]
+	tokenPool                         core.Pool[Token]
+	typeLiteralNodePool               core.Pool[TypeLiteralNode]
+	typeParameterDeclarationPool      core.Pool[TypeParameterDeclaration]
+	typeReferenceNodePool             core.Pool[TypeReferenceNode]
+	unionTypeNodePool                 core.Pool[UnionTypeNode]
+	variableDeclarationListPool       core.Pool[VariableDeclarationList]
+	variableDeclarationPool           core.Pool[VariableDeclaration]
+	variableStatementPool             core.Pool[VariableStatement]
 
 	nodeCount int
 	textCount int
@@ -2174,7 +2180,7 @@ type TypeParameterDeclaration struct {
 }
 
 func (f *NodeFactory) NewTypeParameterDeclaration(modifiers *ModifierList, name *IdentifierNode, constraint *TypeNode, defaultType *TypeNode) *Node {
-	data := &TypeParameterDeclaration{}
+	data := f.typeParameterDeclarationPool.New()
 	data.modifiers = modifiers
 	data.name = name
 	data.Constraint = constraint
@@ -3693,7 +3699,7 @@ type HeritageClause struct {
 }
 
 func (f *NodeFactory) NewHeritageClause(token Kind, types *NodeList) *Node {
-	data := &HeritageClause{}
+	data := f.heritageClausePool.New()
 	data.Token = token
 	data.Types = types
 	return f.newNode(KindHeritageClause, data)
@@ -4895,7 +4901,7 @@ type ConstructSignatureDeclaration struct {
 }
 
 func (f *NodeFactory) NewConstructSignatureDeclaration(typeParameters *NodeList, parameters *NodeList, returnType *TypeNode) *Node {
-	data := &ConstructSignatureDeclaration{}
+	data := f.constructSignatureDeclarationPool.New()
 	data.TypeParameters = typeParameters
 	data.Parameters = parameters
 	data.Type = returnType
@@ -7263,7 +7269,7 @@ type IndexedAccessTypeNode struct {
 }
 
 func (f *NodeFactory) NewIndexedAccessTypeNode(objectType *TypeNode, indexType *TypeNode) *Node {
-	data := &IndexedAccessTypeNode{}
+	data := f.indexedAccessTypeNodePool.New()
 	data.ObjectType = objectType
 	data.IndexType = indexType
 	return f.newNode(KindIndexedAccessType, data)
@@ -7340,7 +7346,7 @@ type ExpressionWithTypeArguments struct {
 }
 
 func (f *NodeFactory) NewExpressionWithTypeArguments(expression *Expression, typeArguments *NodeList) *Node {
-	data := &ExpressionWithTypeArguments{}
+	data := f.expressionWithTypeArgumentsPool.New()
 	data.Expression = expression
 	data.TypeArguments = typeArguments
 	return f.newNode(KindExpressionWithTypeArguments, data)
@@ -9523,7 +9529,7 @@ type JSDocDeprecatedTag struct {
 }
 
 func (f *NodeFactory) NewJSDocDeprecatedTag(tagName *IdentifierNode, comment *NodeList) *Node {
-	data := &JSDocDeprecatedTag{}
+	data := f.jsdocDeprecatedTagPool.New()
 	data.TagName = tagName
 	data.Comment = comment
 	return f.newNode(KindJSDocDeprecatedTag, data)

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -84,6 +84,7 @@ type NodeFactory struct {
 	stringLiteralPool                 core.Pool[StringLiteral]
 	tokenPool                         core.Pool[Token]
 	typeLiteralNodePool               core.Pool[TypeLiteralNode]
+	typeOperatorNodePool              core.Pool[TypeOperatorNode]
 	typeParameterDeclarationPool      core.Pool[TypeParameterDeclaration]
 	typeReferenceNodePool             core.Pool[TypeReferenceNode]
 	unionTypeNodePool                 core.Pool[UnionTypeNode]
@@ -7163,7 +7164,7 @@ type TypeOperatorNode struct {
 }
 
 func (f *NodeFactory) NewTypeOperatorNode(operator Kind, typeNode *TypeNode) *Node {
-	data := &TypeOperatorNode{}
+	data := f.typeOperatorNodePool.New()
 	data.Operator = operator
 	data.Type = typeNode
 	return f.newNode(KindTypeOperator, data)

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -83,6 +83,7 @@ type NodeFactory struct {
 	returnStatementPool               core.Pool[ReturnStatement]
 	stringLiteralPool                 core.Pool[StringLiteral]
 	tokenPool                         core.Pool[Token]
+	typeAliasDeclarationPool          core.Pool[TypeAliasDeclaration]
 	typeLiteralNodePool               core.Pool[TypeLiteralNode]
 	typeOperatorNodePool              core.Pool[TypeOperatorNode]
 	typeParameterDeclarationPool      core.Pool[TypeParameterDeclaration]
@@ -3805,7 +3806,7 @@ type TypeAliasDeclaration struct {
 }
 
 func (f *NodeFactory) newTypeAliasOrJSTypeAliasDeclaration(kind Kind, modifiers *ModifierList, name *IdentifierNode, typeParameters *NodeList, typeNode *TypeNode) *Node {
-	data := &TypeAliasDeclaration{}
+	data := f.typeAliasDeclarationPool.New()
 	data.modifiers = modifiers
 	data.name = name
 	data.TypeParameters = typeParameters

--- a/internal/parser/jsdoc.go
+++ b/internal/parser/jsdoc.go
@@ -477,7 +477,8 @@ func (p *Parser) parseTagComments(indent int, initialMargin *string) *ast.NodeLi
 	commentsPos := p.nodePos()
 	comments := p.jsdocTagCommentsSpace
 	p.jsdocTagCommentsSpace = nil // !!! can parseTagComments call itself?
-	var parts []*ast.Node
+	parts := p.jsdocTagCommentsPartsSpace
+	p.jsdocTagCommentsPartsSpace = nil
 	linkEnd := -1
 	state := jsdocStateBeginningOfLine
 	if indent < 0 {
@@ -596,8 +597,11 @@ loop:
 		p.finishNode(text, commentStart)
 		parts = append(parts, text)
 	}
+
+	p.jsdocTagCommentsPartsSpace = parts[:0]
+
 	if len(parts) > 0 {
-		return p.newNodeList(core.NewTextRange(commentsPos, p.scanner.TokenEnd()), parts)
+		return p.newNodeList(core.NewTextRange(commentsPos, p.scanner.TokenEnd()), p.nodeSlicePool.Clone(parts))
 	}
 	return nil
 }

--- a/internal/parser/jsdoc.go
+++ b/internal/parser/jsdoc.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"bytes"
 	"strings"
 
 	"github.com/microsoft/typescript-go/internal/ast"
@@ -369,21 +368,20 @@ func (p *Parser) skipWhitespaceOrAsterisk() string {
 
 	precedingLineBreak := p.scanner.HasPrecedingLineBreak()
 	seenLineBreak := false
-	// bytes.Buffer instead of strings.Builder so Reset doesn't discard the underlying buffer.
-	var indentText bytes.Buffer
+	indents := make([]string, 0, 4)
 	for (precedingLineBreak && p.token == ast.KindAsteriskToken) || p.token == ast.KindWhitespaceTrivia || p.token == ast.KindNewLineTrivia {
-		indentText.WriteString(p.scanner.TokenText())
+		indents = append(indents, p.scanner.TokenText())
 		if p.token == ast.KindNewLineTrivia {
 			precedingLineBreak = true
 			seenLineBreak = true
-			indentText.Reset()
+			indents = indents[:0]
 		} else if p.token == ast.KindAsteriskToken {
 			precedingLineBreak = false
 		}
 		p.nextTokenJSDoc()
 	}
 	if seenLineBreak {
-		return indentText.String()
+		return strings.Join(indents, "")
 	} else {
 		return ""
 	}

--- a/internal/parser/jsdoc.go
+++ b/internal/parser/jsdoc.go
@@ -33,7 +33,7 @@ func (p *Parser) withJSDoc(node *ast.Node, hasJSDoc bool) []*ast.Node {
 	}
 
 	if p.jsdocCache == nil {
-		p.jsdocCache = make(map[*ast.Node][]*ast.Node)
+		p.jsdocCache = make(map[*ast.Node][]*ast.Node, strings.Count(p.sourceText, "/**"))
 	} else if _, ok := p.jsdocCache[node]; ok {
 		panic("tried to set JSDoc on a node with existing JSDoc")
 	}

--- a/internal/parser/jsdoc.go
+++ b/internal/parser/jsdoc.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"bytes"
 	"strings"
 
 	"github.com/microsoft/typescript-go/internal/ast"
@@ -368,20 +369,21 @@ func (p *Parser) skipWhitespaceOrAsterisk() string {
 
 	precedingLineBreak := p.scanner.HasPrecedingLineBreak()
 	seenLineBreak := false
-	indentText := ""
+	// bytes.Buffer instead of strings.Builder so Reset doesn't discard the underlying buffer.
+	var indentText bytes.Buffer
 	for (precedingLineBreak && p.token == ast.KindAsteriskToken) || p.token == ast.KindWhitespaceTrivia || p.token == ast.KindNewLineTrivia {
-		indentText += p.scanner.TokenText()
+		indentText.WriteString(p.scanner.TokenText())
 		if p.token == ast.KindNewLineTrivia {
 			precedingLineBreak = true
 			seenLineBreak = true
-			indentText = ""
+			indentText.Reset()
 		} else if p.token == ast.KindAsteriskToken {
 			precedingLineBreak = false
 		}
 		p.nextTokenJSDoc()
 	}
 	if seenLineBreak {
-		return indentText
+		return indentText.String()
 	} else {
 		return ""
 	}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -511,9 +511,7 @@ func (p *Parser) parseListIndex(kind ParsingContext, parseElement func(p *Parser
 		}
 	}
 	p.parsingContexts = saveParsingContexts
-	slice := p.nodeSlicePool.NewSlice(len(list))
-	copy(slice, list)
-	return slice
+	return p.nodeSlicePool.Clone(list)
 }
 
 func (p *Parser) parseList(kind ParsingContext, parseElement func(p *Parser) *ast.Node) *ast.NodeList {
@@ -577,9 +575,7 @@ func (p *Parser) parseDelimitedList(kind ParsingContext, parseElement func(p *Pa
 		}
 	}
 	p.parsingContexts = saveParsingContexts
-	slice := p.nodeSlicePool.NewSlice(len(list))
-	copy(slice, list)
-	return p.newNodeList(core.NewTextRange(pos, p.nodePos()), slice)
+	return p.newNodeList(core.NewTextRange(pos, p.nodePos()), p.nodeSlicePool.Clone(list))
 }
 
 // Return a non-nil (but possibly empty) NodeList if parsing was successful, or nil if opening token wasn't found
@@ -3846,9 +3842,7 @@ func (p *Parser) parseModifiersEx(allowDecorators bool, permitConstAsModifier bo
 		}
 	}
 	if len(list) != 0 {
-		nodes := p.nodeSlicePool.NewSlice(len(list))
-		copy(nodes, list)
-		return p.newModifierList(core.NewTextRange(pos, p.nodePos()), nodes)
+		return p.newModifierList(core.NewTextRange(pos, p.nodePos()), p.nodeSlicePool.Clone(list))
 	}
 	return nil
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -66,18 +66,19 @@ type Parser struct {
 	hasDeprecatedTag            bool
 	hasParseError               bool
 
-	identifiers             map[string]string
-	identifierCount         int
-	notParenthesizedArrow   collections.Set[int]
-	nodeSlicePool           core.Pool[*ast.Node]
-	stringSlicePool         core.Pool[string]
-	jsdocCache              map[*ast.Node][]*ast.Node
-	possibleAwaitSpans      []int
-	jsdocCommentsSpace      []string
-	jsdocCommentRangesSpace []ast.CommentRange
-	jsdocTagCommentsSpace   []string
-	reparseList             []*ast.Node
-	commonJSModuleIndicator *ast.Node
+	identifiers                map[string]string
+	identifierCount            int
+	notParenthesizedArrow      collections.Set[int]
+	nodeSlicePool              core.Pool[*ast.Node]
+	stringSlicePool            core.Pool[string]
+	jsdocCache                 map[*ast.Node][]*ast.Node
+	possibleAwaitSpans         []int
+	jsdocCommentsSpace         []string
+	jsdocCommentRangesSpace    []ast.CommentRange
+	jsdocTagCommentsSpace      []string
+	jsdocTagCommentsPartsSpace []*ast.Node
+	reparseList                []*ast.Node
+	commonJSModuleIndicator    *ast.Node
 
 	currentParent        *ast.Node
 	setParentFromContext ast.Visitor

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -2539,12 +2539,12 @@ func (p *Parser) parseUnionOrIntersectionType(operator ast.Kind, parseConstituen
 		typeNode = parseConstituentType(p)
 	}
 	if p.token == operator || hasLeadingOperator {
-		types := p.nodeSlicePool.NewSlice(2)[:1]
+		types := make([]*ast.Node, 1, 8)
 		types[0] = typeNode
 		for p.parseOptional(operator) {
 			types = append(types, p.parseFunctionOrConstructorTypeToError(isUnionType, parseConstituentType))
 		}
-		typeNode = p.createUnionOrIntersectionTypeNode(operator, p.newNodeList(core.NewTextRange(pos, p.nodePos()), types))
+		typeNode = p.createUnionOrIntersectionTypeNode(operator, p.newNodeList(core.NewTextRange(pos, p.nodePos()), p.nodeSlicePool.Clone(types)))
 		p.finishNode(typeNode, pos)
 	}
 	return typeNode

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1426,6 +1426,20 @@ func (s *Scanner) scanIdentifierParts() string {
 func (s *Scanner) scanString(jsxAttributeString bool) string {
 	quote := s.char()
 	s.pos++
+	if !jsxAttributeString {
+		strLen := strings.IndexRune(s.text[s.pos:], quote)
+		if strLen == 0 {
+			s.pos++
+			return ""
+		}
+		if strLen > 0 {
+			str := s.text[s.pos : s.pos+strLen]
+			if !strings.ContainsAny(str, "\r\n\\") {
+				s.pos += strLen + 1
+				return str
+			}
+		}
+	}
 	var sb strings.Builder
 	start := s.pos
 	for {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -641,6 +641,7 @@ func (s *Scanner) Scan() ast.Kind {
 			}
 		case '0':
 			if s.charAt(1) == 'X' || s.charAt(1) == 'x' {
+				start := s.pos
 				s.pos += 2
 				digits := s.scanHexDigits(1, true, true)
 				if digits == "" {
@@ -653,7 +654,12 @@ func (s *Scanner) Scan() ast.Kind {
 				if cachedValue, ok := s.hexNumberCache[digits]; ok {
 					s.tokenValue = cachedValue
 				} else {
-					s.tokenValue = "0x" + digits
+					rawText := s.text[start:s.pos]
+					if strings.HasPrefix(rawText, "0x") && rawText[2:] == digits {
+						s.tokenValue = rawText
+					} else {
+						s.tokenValue = "0x" + digits
+					}
 					s.hexNumberCache[digits] = s.tokenValue
 				}
 				s.tokenFlags |= ast.TokenFlagsHexSpecifier

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1426,6 +1426,7 @@ func (s *Scanner) scanIdentifierParts() string {
 func (s *Scanner) scanString(jsxAttributeString bool) string {
 	quote := s.char()
 	s.pos++
+	// Fast path for simple strings without escape sequences.
 	if !jsxAttributeString {
 		strLen := strings.IndexRune(s.text[s.pos:], quote)
 		if strLen == 0 {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1427,18 +1427,16 @@ func (s *Scanner) scanString(jsxAttributeString bool) string {
 	quote := s.char()
 	s.pos++
 	// Fast path for simple strings without escape sequences.
-	if !jsxAttributeString {
-		strLen := strings.IndexRune(s.text[s.pos:], quote)
-		if strLen == 0 {
-			s.pos++
-			return ""
-		}
-		if strLen > 0 {
-			str := s.text[s.pos : s.pos+strLen]
-			if !strings.ContainsAny(str, "\r\n\\") {
-				s.pos += strLen + 1
-				return str
-			}
+	strLen := strings.IndexRune(s.text[s.pos:], quote)
+	if strLen == 0 {
+		s.pos++
+		return ""
+	}
+	if strLen > 0 {
+		str := s.text[s.pos : s.pos+strLen]
+		if !jsxAttributeString && !strings.ContainsAny(str, "\r\n\\") {
+			s.pos += strLen + 1
+			return str
 		}
 	}
 	var sb strings.Builder


### PR DESCRIPTION
Grab bag of memory-allocation improvements:

```
goos: linux
goarch: amd64
pkg: github.com/microsoft/typescript-go/internal/parser
cpu: Intel(R) Core(TM) i9-10900K CPU @ 3.70GHz
                                                             │   old.txt   │              new.txt               │
                                                             │   sec/op    │   sec/op     vs base               │
Parse/empty.ts/tsc-20                                          507.2n ± 1%   515.4n ± 1%  +1.63% (p=0.000 n=10)
Parse/empty.ts/server-20                                       506.9n ± 2%   518.9n ± 1%  +2.38% (p=0.000 n=10)
Parse/checker.ts/tsc-20                                        46.67m ± 1%   46.68m ± 2%       ~ (p=0.971 n=10)
Parse/checker.ts/server-20                                     47.39m ± 2%   47.23m ± 1%       ~ (p=0.481 n=10)
Parse/dom.generated.d.ts/tsc-20                                15.85m ± 2%   15.68m ± 1%       ~ (p=0.089 n=10)
Parse/dom.generated.d.ts/server-20                             22.85m ± 1%   22.67m ± 1%       ~ (p=0.052 n=10)
Parse/Herebyfile.mjs/tsc-20                                    878.0µ ± 1%   867.1µ ± 1%  -1.25% (p=0.000 n=10)
Parse/Herebyfile.mjs/server-20                                 878.6µ ± 1%   873.1µ ± 1%  -0.63% (p=0.023 n=10)
Parse/jsxComplexSignatureHasApplicabilityError.tsx/tsc-20      264.4µ ± 1%   267.7µ ± 1%  +1.26% (p=0.001 n=10)
Parse/jsxComplexSignatureHasApplicabilityError.tsx/server-20   398.8µ ± 1%   397.7µ ± 1%       ~ (p=0.529 n=10)
geomean                                                        664.3µ        664.9µ       +0.09%
```
```
                                                             │   old.txt    │                new.txt                │
                                                             │     B/op     │     B/op      vs base                 │
Parse/empty.ts/tsc-20                                            880.0 ± 0%     880.0 ± 0%       ~ (p=1.000 n=10) ¹
Parse/empty.ts/server-20                                         880.0 ± 0%     880.0 ± 0%       ~ (p=1.000 n=10) ¹
Parse/checker.ts/tsc-20                                        25.68Mi ± 0%   25.74Mi ± 0%  +0.24% (p=0.000 n=10)
Parse/checker.ts/server-20                                     25.86Mi ± 0%   25.91Mi ± 0%  +0.17% (p=0.000 n=10)
Parse/dom.generated.d.ts/tsc-20                                9.243Mi ± 0%   9.253Mi ± 0%  +0.11% (p=0.000 n=10)
Parse/dom.generated.d.ts/server-20                             11.31Mi ± 0%   11.02Mi ± 0%  -2.58% (p=0.000 n=10)
Parse/Herebyfile.mjs/tsc-20                                    453.6Ki ± 0%   447.1Ki ± 0%  -1.44% (p=0.000 n=10)
Parse/Herebyfile.mjs/server-20                                 453.6Ki ± 0%   447.1Ki ± 0%  -1.44% (p=0.000 n=10)
Parse/jsxComplexSignatureHasApplicabilityError.tsx/tsc-20      164.8Ki ± 0%   176.0Ki ± 0%  +6.77% (p=0.000 n=10)
Parse/jsxComplexSignatureHasApplicabilityError.tsx/server-20   244.7Ki ± 0%   248.1Ki ± 0%  +1.42% (p=0.000 n=10)
geomean                                                        464.5Ki        465.9Ki       +0.30%
¹ all samples are equal
```
```
                                                             │   old.txt    │                new.txt                │
                                                             │  allocs/op   │  allocs/op   vs base                  │
Parse/empty.ts/tsc-20                                            4.000 ± 0%    4.000 ± 0%        ~ (p=1.000 n=10) ¹
Parse/empty.ts/server-20                                         4.000 ± 0%    4.000 ± 0%        ~ (p=1.000 n=10) ¹
Parse/checker.ts/tsc-20                                         18.09k ± 0%   11.95k ± 0%  -33.94% (p=0.000 n=10)
Parse/checker.ts/server-20                                      18.41k ± 0%   12.05k ± 0%  -34.55% (p=0.000 n=10)
Parse/dom.generated.d.ts/tsc-20                                11.484k ± 0%   2.661k ± 0%  -76.83% (p=0.000 n=10)
Parse/dom.generated.d.ts/server-20                             13.494k ± 0%   3.119k ± 0%  -76.89% (p=0.000 n=10)
Parse/Herebyfile.mjs/tsc-20                                     1.833k ± 0%   1.462k ± 0%  -20.24% (p=0.000 n=10)
Parse/Herebyfile.mjs/server-20                                  1.833k ± 0%   1.462k ± 0%  -20.24% (p=0.000 n=10)
Parse/jsxComplexSignatureHasApplicabilityError.tsx/tsc-20        278.0 ± 0%    199.0 ± 0%  -28.42% (p=0.000 n=10)
Parse/jsxComplexSignatureHasApplicabilityError.tsx/server-20     404.0 ± 0%    230.0 ± 0%  -43.07% (p=0.000 n=10)
geomean                                                          889.9         533.6       -40.04%
```

We're at the point where none of this seems to measurably change the actual "time" taken in parse, but allocating fewer things is in general better.