### PR TITLE
Ignore go/allocation-size-overflow in codeql

### DIFF
--- a/.github/codeql/codeql-configuration.yml
+++ b/.github/codeql/codeql-configuration.yml
@@ -9,3 +9,6 @@ query-filters:
   # This query takes too long on complicated string manipulations
   - exclude:
       id: go/unsafe-quoting
+  # Times out in our code.
+  - exclude:
+      id: go/allocation-size-overflow


### PR DESCRIPTION
This rule is now timing out in our repo. Not sure what changed.