### PR TITLE
Fix setup-go restore key

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -36,7 +36,7 @@ runs:
       run: |
         if [[ "$CACHE_FROM_PREVIOUS_RUN" == "true" ]]; then
           echo "key=$PREFIX-$CACHE_NAME-$RUN_ID" >> $GITHUB_OUTPUT
-          echo "restore-keys=$PREFIX-$CACHE_NAME" >> $GITHUB_OUTPUT
+          echo "restore-keys=$PREFIX-$CACHE_NAME-" >> $GITHUB_OUTPUT
         else
           echo "key=$PREFIX-$CACHE_NAME" >> $GITHUB_OUTPUT
           echo "restore-keys=$PREFIX" >> $GITHUB_OUTPUT

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -35,11 +35,11 @@ runs:
       shell: bash
       run: |
         if [[ "$CACHE_FROM_PREVIOUS_RUN" == "true" ]]; then
-          echo "key=$PREFIX-$CACHE_NAME-$RUN_ID" >> $GITHUB_OUTPUT
-          echo "restore-keys=$PREFIX-$CACHE_NAME-" >> $GITHUB_OUTPUT
+          echo "key=$PREFIX-$CACHE_NAME-run-$RUN_ID" >> $GITHUB_OUTPUT
+          echo "restore-keys=$PREFIX-$CACHE_NAME-run-" >> $GITHUB_OUTPUT
         else
           echo "key=$PREFIX-$CACHE_NAME" >> $GITHUB_OUTPUT
-          echo "restore-keys=$PREFIX" >> $GITHUB_OUTPUT
+          echo "restore-keys=$PREFIX-" >> $GITHUB_OUTPUT
         fi
 
       env:


### PR DESCRIPTION
The restore key I used was wrong; it was exactly matching an older cache entry rather than falling back on the previous run. Change the way we handle restore keys to avoid this.