### PR TITLE
Override diagnostic about baseUrl path checks

### DIFF
--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -608,7 +608,6 @@ func (p *Program) verifyCompilerOptions() {
 				createDiagnosticForOptionPathKeyValue(key, i, diagnostics.Substitution_0_in_pattern_1_can_have_at_most_one_Asterisk_character, subst, key)
 			}
 			if !tspath.PathIsRelative(subst) && !tspath.PathIsAbsolute(subst) {
-				// !!! This needs a better message that doesn't mention baseUrl
 				createDiagnosticForOptionPathKeyValue(key, i, diagnostics.Non_relative_paths_are_not_allowed_Did_you_forget_a_leading_Slash)
 			}
 		}

--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -609,7 +609,7 @@ func (p *Program) verifyCompilerOptions() {
 			}
 			if !tspath.PathIsRelative(subst) && !tspath.PathIsAbsolute(subst) {
 				// !!! This needs a better message that doesn't mention baseUrl
-				createDiagnosticForOptionPathKeyValue(key, i, diagnostics.Non_relative_paths_are_not_allowed_when_baseUrl_is_not_set_Did_you_forget_a_leading_Slash)
+				createDiagnosticForOptionPathKeyValue(key, i, diagnostics.Non_relative_paths_are_not_allowed_Did_you_forget_a_leading_Slash)
 			}
 		}
 	}

--- a/internal/diagnostics/diagnostics_generated.go
+++ b/internal/diagnostics/diagnostics_generated.go
@@ -2306,7 +2306,7 @@ var The_inferred_type_of_0_references_a_type_with_a_cyclic_structure_which_canno
 
 var Option_0_cannot_be_specified_when_option_jsx_is_1 = &Message{code: 5089, category: CategoryError, key: "Option_0_cannot_be_specified_when_option_jsx_is_1_5089", text: "Option '{0}' cannot be specified when option 'jsx' is '{1}'."}
 
-var Non_relative_paths_are_not_allowed_when_baseUrl_is_not_set_Did_you_forget_a_leading_Slash = &Message{code: 5090, category: CategoryError, key: "Non_relative_paths_are_not_allowed_when_baseUrl_is_not_set_Did_you_forget_a_leading_Slash_5090", text: "Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?"}
+var Non_relative_paths_are_not_allowed_Did_you_forget_a_leading_Slash = &Message{code: 5090, category: CategoryError, key: "Non_relative_paths_are_not_allowed_Did_you_forget_a_leading_Slash_5090", text: "Non-relative paths are not allowed. Did you forget a leading './'?"}
 
 var Option_preserveConstEnums_cannot_be_disabled_when_0_is_enabled = &Message{code: 5091, category: CategoryError, key: "Option_preserveConstEnums_cannot_be_disabled_when_0_is_enabled_5091", text: "Option 'preserveConstEnums' cannot be disabled when '{0}' is enabled."}
 

--- a/internal/diagnostics/extraDiagnosticMessages.json
+++ b/internal/diagnostics/extraDiagnosticMessages.json
@@ -10,5 +10,9 @@
     "Generate pprof CPU/memory profiles to the given directory.": {
         "category": "Message",
         "code": 100002
+    },
+    "Non-relative paths are not allowed. Did you forget a leading './'?": {
+        "category": "Error",
+        "code": 5090
     }
 }

--- a/internal/diagnostics/generate.go
+++ b/internal/diagnostics/generate.go
@@ -113,13 +113,13 @@ func readRawMessages(p string) map[int]*diagnosticMessage {
 		return nil
 	}
 
-	codeToNessage := make(map[int]*diagnosticMessage, len(rawMessages))
+	codeToMessage := make(map[int]*diagnosticMessage, len(rawMessages))
 	for k, m := range rawMessages {
 		m.key = k
-		codeToNessage[m.Code] = m
+		codeToMessage[m.Code] = m
 	}
 
-	return codeToNessage
+	return codeToMessage
 }
 
 var (

--- a/testdata/baselines/reference/submodule/compiler/moduleResolutionWithExtensions_withPaths.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/moduleResolutionWithExtensions_withPaths.errors.txt
@@ -1,6 +1,6 @@
 /tsconfig.json(6,3): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
   Use '"paths": {"*": "./*"}' instead.
-/tsconfig.json(11,14): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+/tsconfig.json(11,14): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 
 
 ==== /tsconfig.json (2 errors) ====
@@ -19,7 +19,7 @@
     		"paths": {
     			"foo/*": ["node_modules/foo/lib/*"]
     			          ~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
     		}
     	}
     }

--- a/testdata/baselines/reference/submodule/compiler/moduleResolutionWithSuffixes_one_externalModule_withPaths.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/moduleResolutionWithSuffixes_one_externalModule_withPaths.errors.txt
@@ -1,7 +1,7 @@
 /tsconfig.json(9,3): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
   Use '"paths": {"*": "./*"}' instead.
-/tsconfig.json(11,21): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
-/tsconfig.json(12,23): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+/tsconfig.json(11,21): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
+/tsconfig.json(12,23): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 
 
 ==== /tsconfig.json (3 errors) ====
@@ -20,10 +20,10 @@
     		"paths": {
     			"some-library": ["node_modules/some-library/lib"],
     			                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
     			"some-library/*": ["node_modules/some-library/lib/*"]
     			                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
     		}
     	}
     }

--- a/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution1_node.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution1_node.errors.txt
@@ -1,5 +1,5 @@
-c:/root/tsconfig.json(5,17): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
-c:/root/tsconfig.json(6,17): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+c:/root/tsconfig.json(5,17): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
+c:/root/tsconfig.json(6,17): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 
 
 ==== c:/root/tsconfig.json (2 errors) ====
@@ -9,10 +9,10 @@ c:/root/tsconfig.json(6,17): error TS5090: Non-relative paths are not allowed wh
                 "*": [
                     "*",
                     ~~~
-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
                     "generated/*"
                     ~~~~~~~~~~~~~
-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
                 ]
             }
         }

--- a/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution1_node.errors.txt.diff
+++ b/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution1_node.errors.txt.diff
@@ -1,0 +1,23 @@
+--- old.pathMappingBasedModuleResolution1_node.errors.txt
++++ new.pathMappingBasedModuleResolution1_node.errors.txt
+@@= skipped -0, +0 lines =@@
+-c:/root/tsconfig.json(5,17): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+-c:/root/tsconfig.json(6,17): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++c:/root/tsconfig.json(5,17): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
++c:/root/tsconfig.json(6,17): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
+
+
+ ==== c:/root/tsconfig.json (2 errors) ====
+@@= skipped -8, +8 lines =@@
+                 "*": [
+                     "*",
+                     ~~~
+-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
+                     "generated/*"
+                     ~~~~~~~~~~~~~
+-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
+                 ]
+             }
+         }

--- a/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution2_node.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution2_node.errors.txt
@@ -2,7 +2,7 @@ root/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please
   Use '"paths": {"*": "./src/*"}' instead.
 root/tsconfig.json(5,13): error TS5061: Pattern '*1*' can have at most one '*' character.
 root/tsconfig.json(5,22): error TS5062: Substitution '*2*' in pattern '*1*' can have at most one '*' character.
-root/tsconfig.json(5,22): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+root/tsconfig.json(5,22): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 
 
 ==== root/tsconfig.json (4 errors) ====
@@ -19,7 +19,7 @@ root/tsconfig.json(5,22): error TS5090: Non-relative paths are not allowed when 
                          ~~~~~
 !!! error TS5062: Substitution '*2*' in pattern '*1*' can have at most one '*' character.
                          ~~~~~
-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
             }
         }
     }

--- a/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution5_node.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution5_node.errors.txt
@@ -1,8 +1,8 @@
 c:/root/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
   Use '"paths": {"*": "./*"}' instead.
-c:/root/tsconfig.json(6,17): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
-c:/root/tsconfig.json(7,17): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
-c:/root/tsconfig.json(10,21): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+c:/root/tsconfig.json(6,17): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
+c:/root/tsconfig.json(7,17): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
+c:/root/tsconfig.json(10,21): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 
 
 ==== c:/root/tsconfig.json (4 errors) ====
@@ -16,15 +16,15 @@ c:/root/tsconfig.json(10,21): error TS5090: Non-relative paths are not allowed w
                 "*": [
                     "*",
                     ~~~
-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
                     "generated/*"
                     ~~~~~~~~~~~~~
-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
                 ],
                     "components/*": [
                         "shared/components/*"
                         ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
                     ]
             }
         }

--- a/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution7_node.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution7_node.errors.txt
@@ -1,8 +1,8 @@
 c:/root/src/file1.ts(1,17): error TS2307: Cannot find module './project/file2' or its corresponding type declarations.
 c:/root/src/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
   Use '"paths": {"*": "./../*"}' instead.
-c:/root/src/tsconfig.json(6,17): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
-c:/root/src/tsconfig.json(10,17): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+c:/root/src/tsconfig.json(6,17): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
+c:/root/src/tsconfig.json(10,17): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 
 
 ==== c:/root/src/tsconfig.json (3 errors) ====
@@ -16,13 +16,13 @@ c:/root/src/tsconfig.json(10,17): error TS5090: Non-relative paths are not allow
                 "*": [
                     "*",
                     ~~~
-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
                     "c:/shared/*"
                 ],
                 "templates/*": [
                     "generated/src/templates/*"
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
                 ]
             },
             "rootDirs": [

--- a/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution8_node.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution8_node.errors.txt
@@ -1,6 +1,6 @@
 c:/root/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
   Use '"paths": {"*": "./*"}' instead.
-c:/root/tsconfig.json(6,16): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+c:/root/tsconfig.json(6,16): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 
 
 ==== c:/root/tsconfig.json (2 errors) ====
@@ -14,7 +14,7 @@ c:/root/tsconfig.json(6,16): error TS5090: Non-relative paths are not allowed wh
                 "@speedy/*/testing": [
                    "*/dist/index.ts"
                    ~~~~~~~~~~~~~~~~~
-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
                 ]
             }
         }

--- a/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution_withExtension.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution_withExtension.errors.txt
@@ -1,7 +1,7 @@
 /tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
   Use '"paths": {"*": "./*"}' instead.
-/tsconfig.json(5,21): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
-/tsconfig.json(6,21): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+/tsconfig.json(5,21): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
+/tsconfig.json(6,21): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 
 
 ==== /tsconfig.json (3 errors) ====
@@ -14,10 +14,10 @@
             "paths": {
                 "foo": ["foo/foo.ts"],
                         ~~~~~~~~~~~~
-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
                 "bar": ["bar/bar.js"]
                         ~~~~~~~~~~~~
-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
             },
             "allowJs": true,
             "outDir": "bin"

--- a/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution_withExtensionInName.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution_withExtensionInName.errors.txt
@@ -1,6 +1,6 @@
 /tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
   Use '"paths": {"*": "./*"}' instead.
-/tsconfig.json(5,19): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+/tsconfig.json(5,19): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 
 
 ==== /tsconfig.json (2 errors) ====
@@ -13,7 +13,7 @@
             "paths": {
                 "*": ["foo/*"]
                       ~~~~~~~
-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
             }
         }
     }

--- a/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution_withExtension_MapedToNodeModules.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution_withExtension_MapedToNodeModules.errors.txt
@@ -1,7 +1,7 @@
 /tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
   Use '"paths": {"*": "./*"}' instead.
-/tsconfig.json(5,19): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
-/tsconfig.json(5,37): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+/tsconfig.json(5,19): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
+/tsconfig.json(5,37): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 
 
 ==== /tsconfig.json (3 errors) ====
@@ -14,9 +14,9 @@
             "paths": {
                 "*": ["node_modules/*", "src/types"]
                       ~~~~~~~~~~~~~~~~
-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
                                         ~~~~~~~~~~~
-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
             },
             "allowJs": true,
             "outDir": "bin"

--- a/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution_withExtension_failedLookup.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution_withExtension_failedLookup.errors.txt
@@ -1,7 +1,7 @@
 /a.ts(1,21): error TS2307: Cannot find module 'foo' or its corresponding type declarations.
 /tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
   Use '"paths": {"*": "./*"}' instead.
-/tsconfig.json(5,21): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+/tsconfig.json(5,21): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 
 
 ==== /tsconfig.json (2 errors) ====
@@ -14,7 +14,7 @@
             "paths": {
                 "foo": ["foo/foo.ts"]
                         ~~~~~~~~~~~~
-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
             }
         }
     }

--- a/testdata/baselines/reference/submodule/compiler/pathsValidation4.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathsValidation4.errors.txt
@@ -3,7 +3,7 @@ tsconfig.json(4,9): error TS5102: Option 'baseUrl' has been removed. Please remo
 tsconfig.json(6,11): error TS5061: Pattern '@interface/**/*' can have at most one '*' character.
 tsconfig.json(7,11): error TS5061: Pattern '@service/**/*' can have at most one '*' character.
 tsconfig.json(7,29): error TS5062: Substitution './src/service/**/*' in pattern '@service/**/*' can have at most one '*' character.
-tsconfig.json(8,29): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+tsconfig.json(8,29): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 
 
 ==== tsconfig.json (5 errors) ====
@@ -25,7 +25,7 @@ tsconfig.json(8,29): error TS5090: Non-relative paths are not allowed when 'base
 !!! error TS5062: Substitution './src/service/**/*' in pattern '@service/**/*' can have at most one '*' character.
               "@controller/*": ["controller/*"],
                                 ~~~~~~~~~~~~~~
-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
             }
         }
     }

--- a/testdata/baselines/reference/submodule/compiler/pathsValidation5.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathsValidation5.errors.txt
@@ -1,6 +1,6 @@
-tsconfig.json(5,26): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
-tsconfig.json(6,19): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
-tsconfig.json(7,23): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+tsconfig.json(5,26): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
+tsconfig.json(6,19): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
+tsconfig.json(7,23): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 
 
 ==== tsconfig.json (3 errors) ====
@@ -10,13 +10,13 @@ tsconfig.json(7,23): error TS5090: Non-relative paths are not allowed when 'base
           "paths": {
             "@interface/*": ["src/interface/*"],
                              ~~~~~~~~~~~~~~~~~
-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
             "@blah": ["blah"],
                       ~~~~~~
-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
             "@humbug/*": ["*/generated"]
                           ~~~~~~~~~~~~~
-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
           }
       }
     }

--- a/testdata/baselines/reference/submodule/compiler/pathsValidation5.errors.txt.diff
+++ b/testdata/baselines/reference/submodule/compiler/pathsValidation5.errors.txt.diff
@@ -1,0 +1,29 @@
+--- old.pathsValidation5.errors.txt
++++ new.pathsValidation5.errors.txt
+@@= skipped -0, +0 lines =@@
+-tsconfig.json(5,26): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+-tsconfig.json(6,19): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+-tsconfig.json(7,23): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++tsconfig.json(5,26): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
++tsconfig.json(6,19): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
++tsconfig.json(7,23): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
+
+
+ ==== tsconfig.json (3 errors) ====
+@@= skipped -9, +9 lines =@@
+           "paths": {
+             "@interface/*": ["src/interface/*"],
+                              ~~~~~~~~~~~~~~~~~
+-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
+             "@blah": ["blah"],
+                       ~~~~~~
+-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
+             "@humbug/*": ["*/generated"]
+                           ~~~~~~~~~~~~~
+-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
+           }
+       }
+     }

--- a/testdata/baselines/reference/submodule/compiler/requireOfJsonFileWithoutResolveJsonModuleAndPathMapping.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/requireOfJsonFileWithoutResolveJsonModuleAndPathMapping.errors.txt
@@ -1,8 +1,8 @@
 /a.ts(1,20): error TS2732: Cannot find module 'foo/bar/foobar.json'. Consider using '--resolveJsonModule' to import module with '.json' extension.
 /tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
   Use '"paths": {"*": "./*"}' instead.
-/tsconfig.json(5,19): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
-/tsconfig.json(5,37): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+/tsconfig.json(5,19): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
+/tsconfig.json(5,37): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 
 
 ==== /tsconfig.json (3 errors) ====
@@ -15,9 +15,9 @@
             "paths": {
                 "*": ["node_modules/*", "src/types"]
                       ~~~~~~~~~~~~~~~~
-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
                                         ~~~~~~~~~~~
-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
             },
             "allowJs": true,
             "outDir": "bin"

--- a/testdata/baselines/reference/submodule/compiler/requireOfJsonFile_PathMapping.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/requireOfJsonFile_PathMapping.errors.txt
@@ -1,7 +1,7 @@
 /tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
   Use '"paths": {"*": "./*"}' instead.
-/tsconfig.json(5,19): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
-/tsconfig.json(5,37): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+/tsconfig.json(5,19): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
+/tsconfig.json(5,37): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 
 
 ==== /tsconfig.json (3 errors) ====
@@ -14,9 +14,9 @@
             "paths": {
                 "*": ["node_modules/*", "src/types"]
                       ~~~~~~~~~~~~~~~~
-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
                                         ~~~~~~~~~~~
-!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
             },
             "allowJs": true,
             "outDir": "bin"

--- a/testdata/baselines/reference/submoduleAccepted/compiler/moduleResolutionWithExtensions_withPaths.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/moduleResolutionWithExtensions_withPaths.errors.txt.diff
@@ -4,7 +4,7 @@
 -<no content>
 +/tsconfig.json(6,3): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
 +  Use '"paths": {"*": "./*"}' instead.
-+/tsconfig.json(11,14): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++/tsconfig.json(11,14): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +
 +
 +==== /tsconfig.json (2 errors) ====
@@ -23,7 +23,7 @@
 +    		"paths": {
 +    			"foo/*": ["node_modules/foo/lib/*"]
 +    			          ~~~~~~~~~~~~~~~~~~~~~~~~
-+!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +    		}
 +    	}
 +    }

--- a/testdata/baselines/reference/submoduleAccepted/compiler/moduleResolutionWithSuffixes_one_externalModule_withPaths.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/moduleResolutionWithSuffixes_one_externalModule_withPaths.errors.txt.diff
@@ -4,8 +4,8 @@
 -<no content>
 +/tsconfig.json(9,3): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
 +  Use '"paths": {"*": "./*"}' instead.
-+/tsconfig.json(11,21): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
-+/tsconfig.json(12,23): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++/tsconfig.json(11,21): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
++/tsconfig.json(12,23): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +
 +
 +==== /tsconfig.json (3 errors) ====
@@ -24,10 +24,10 @@
 +    		"paths": {
 +    			"some-library": ["node_modules/some-library/lib"],
 +    			                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-+!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +    			"some-library/*": ["node_modules/some-library/lib/*"]
 +    			                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-+!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +    		}
 +    	}
 +    }

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution2_node.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution2_node.errors.txt.diff
@@ -8,7 +8,7 @@
 -
 -
 -==== root/tsconfig.json (2 errors) ====
-+root/tsconfig.json(5,22): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++root/tsconfig.json(5,22): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +
 +
 +==== root/tsconfig.json (4 errors) ====
@@ -25,7 +25,7 @@
                           ~~~~~
  !!! error TS5062: Substitution '*2*' in pattern '*1*' can have at most one '*' character.
 +                         ~~~~~
-+!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
              }
          }
      }

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution5_node.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution5_node.errors.txt.diff
@@ -4,9 +4,9 @@
 -<no content>
 +c:/root/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
 +  Use '"paths": {"*": "./*"}' instead.
-+c:/root/tsconfig.json(6,17): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
-+c:/root/tsconfig.json(7,17): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
-+c:/root/tsconfig.json(10,21): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++c:/root/tsconfig.json(6,17): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
++c:/root/tsconfig.json(7,17): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
++c:/root/tsconfig.json(10,21): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +
 +
 +==== c:/root/tsconfig.json (4 errors) ====
@@ -20,15 +20,15 @@
 +                "*": [
 +                    "*",
 +                    ~~~
-+!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +                    "generated/*"
 +                    ~~~~~~~~~~~~~
-+!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +                ],
 +                    "components/*": [
 +                        "shared/components/*"
 +                        ~~~~~~~~~~~~~~~~~~~~~
-+!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +                    ]
 +            }
 +        }

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution7_node.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution7_node.errors.txt.diff
@@ -5,8 +5,8 @@
 +c:/root/src/file1.ts(1,17): error TS2307: Cannot find module './project/file2' or its corresponding type declarations.
 +c:/root/src/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
 +  Use '"paths": {"*": "./../*"}' instead.
-+c:/root/src/tsconfig.json(6,17): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
-+c:/root/src/tsconfig.json(10,17): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++c:/root/src/tsconfig.json(6,17): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
++c:/root/src/tsconfig.json(10,17): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +
 +
 +==== c:/root/src/tsconfig.json (3 errors) ====
@@ -20,13 +20,13 @@
 +                "*": [
 +                    "*",
 +                    ~~~
-+!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +                    "c:/shared/*"
 +                ],
 +                "templates/*": [
 +                    "generated/src/templates/*"
 +                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-+!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +                ]
 +            },
 +            "rootDirs": [

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution8_node.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution8_node.errors.txt.diff
@@ -4,7 +4,7 @@
 -<no content>
 +c:/root/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
 +  Use '"paths": {"*": "./*"}' instead.
-+c:/root/tsconfig.json(6,16): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++c:/root/tsconfig.json(6,16): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +
 +
 +==== c:/root/tsconfig.json (2 errors) ====
@@ -18,7 +18,7 @@
 +                "@speedy/*/testing": [
 +                   "*/dist/index.ts"
 +                   ~~~~~~~~~~~~~~~~~
-+!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +                ]
 +            }
 +        }

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution_withExtension.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution_withExtension.errors.txt.diff
@@ -4,8 +4,8 @@
 -<no content>
 +/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
 +  Use '"paths": {"*": "./*"}' instead.
-+/tsconfig.json(5,21): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
-+/tsconfig.json(6,21): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++/tsconfig.json(5,21): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
++/tsconfig.json(6,21): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +
 +
 +==== /tsconfig.json (3 errors) ====
@@ -18,10 +18,10 @@
 +            "paths": {
 +                "foo": ["foo/foo.ts"],
 +                        ~~~~~~~~~~~~
-+!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +                "bar": ["bar/bar.js"]
 +                        ~~~~~~~~~~~~
-+!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +            },
 +            "allowJs": true,
 +            "outDir": "bin"

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution_withExtensionInName.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution_withExtensionInName.errors.txt.diff
@@ -4,7 +4,7 @@
 -<no content>
 +/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
 +  Use '"paths": {"*": "./*"}' instead.
-+/tsconfig.json(5,19): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++/tsconfig.json(5,19): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +
 +
 +==== /tsconfig.json (2 errors) ====
@@ -17,7 +17,7 @@
 +            "paths": {
 +                "*": ["foo/*"]
 +                      ~~~~~~~
-+!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +            }
 +        }
 +    }

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution_withExtension_MapedToNodeModules.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution_withExtension_MapedToNodeModules.errors.txt.diff
@@ -4,8 +4,8 @@
 -<no content>
 +/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
 +  Use '"paths": {"*": "./*"}' instead.
-+/tsconfig.json(5,19): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
-+/tsconfig.json(5,37): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++/tsconfig.json(5,19): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
++/tsconfig.json(5,37): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +
 +
 +==== /tsconfig.json (3 errors) ====
@@ -18,9 +18,9 @@
 +            "paths": {
 +                "*": ["node_modules/*", "src/types"]
 +                      ~~~~~~~~~~~~~~~~
-+!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +                                        ~~~~~~~~~~~
-+!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +            },
 +            "allowJs": true,
 +            "outDir": "bin"

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution_withExtension_failedLookup.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution_withExtension_failedLookup.errors.txt.diff
@@ -7,7 +7,7 @@
 -==== /tsconfig.json (0 errors) ====
 +/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
 +  Use '"paths": {"*": "./*"}' instead.
-+/tsconfig.json(5,21): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++/tsconfig.json(5,21): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +
 +
 +==== /tsconfig.json (2 errors) ====
@@ -20,7 +20,7 @@
              "paths": {
                  "foo": ["foo/foo.ts"]
 +                        ~~~~~~~~~~~~
-+!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
              }
          }
      }

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathsValidation4.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathsValidation4.errors.txt.diff
@@ -9,7 +9,7 @@
 -
 -
 -==== tsconfig.json (3 errors) ====
-+tsconfig.json(8,29): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++tsconfig.json(8,29): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +
 +
 +==== tsconfig.json (5 errors) ====
@@ -28,7 +28,7 @@
  !!! error TS5062: Substitution './src/service/**/*' in pattern '@service/**/*' can have at most one '*' character.
                "@controller/*": ["controller/*"],
 +                                ~~~~~~~~~~~~~~
-+!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
              }
          }
      }

--- a/testdata/baselines/reference/submoduleAccepted/compiler/requireOfJsonFileWithoutResolveJsonModuleAndPathMapping.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/requireOfJsonFileWithoutResolveJsonModuleAndPathMapping.errors.txt.diff
@@ -7,8 +7,8 @@
 -==== /tsconfig.json (0 errors) ====
 +/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
 +  Use '"paths": {"*": "./*"}' instead.
-+/tsconfig.json(5,19): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
-+/tsconfig.json(5,37): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++/tsconfig.json(5,19): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
++/tsconfig.json(5,37): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +
 +
 +==== /tsconfig.json (3 errors) ====
@@ -21,9 +21,9 @@
              "paths": {
                  "*": ["node_modules/*", "src/types"]
 +                      ~~~~~~~~~~~~~~~~
-+!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +                                        ~~~~~~~~~~~
-+!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
              },
              "allowJs": true,
              "outDir": "bin"

--- a/testdata/baselines/reference/submoduleAccepted/compiler/requireOfJsonFile_PathMapping.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/requireOfJsonFile_PathMapping.errors.txt.diff
@@ -4,8 +4,8 @@
 -<no content>
 +/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
 +  Use '"paths": {"*": "./*"}' instead.
-+/tsconfig.json(5,19): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
-+/tsconfig.json(5,37): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++/tsconfig.json(5,19): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
++/tsconfig.json(5,37): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +
 +
 +==== /tsconfig.json (3 errors) ====
@@ -18,9 +18,9 @@
 +            "paths": {
 +                "*": ["node_modules/*", "src/types"]
 +                      ~~~~~~~~~~~~~~~~
-+!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +                                        ~~~~~~~~~~~
-+!!! error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
++!!! error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +            },
 +            "allowJs": true,
 +            "outDir": "bin"

--- a/testdata/baselines/reference/tsc/extends/configDir-template-with-commandline.js
+++ b/testdata/baselines/reference/tsc/extends/configDir-template-with-commandline.js
@@ -63,7 +63,7 @@ CompilerOptions::{
     "explainFiles": true
 }
 Output::
-[96mtsconfig.json[0m:[93m3[0m:[93m2[0m - [91merror[0m[90m TS5090: [0mNon-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+[96mtsconfig.json[0m:[93m3[0m:[93m2[0m - [91merror[0m[90m TS5090: [0mNon-relative paths are not allowed. Did you forget a leading './'?
 
 [7m3[0m  "compilerOptions": {
 [7m [0m [91m ~~~~~~~~~~~~~~~~~[0m

--- a/testdata/baselines/reference/tsc/extends/configDir-template.js
+++ b/testdata/baselines/reference/tsc/extends/configDir-template.js
@@ -62,7 +62,7 @@ CompilerOptions::{
     "explainFiles": true
 }
 Output::
-[96mtsconfig.json[0m:[93m3[0m:[93m2[0m - [91merror[0m[90m TS5090: [0mNon-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+[96mtsconfig.json[0m:[93m3[0m:[93m2[0m - [91merror[0m[90m TS5090: [0mNon-relative paths are not allowed. Did you forget a leading './'?
 
 [7m3[0m  "compilerOptions": {
 [7m [0m [91m ~~~~~~~~~~~~~~~~~[0m


### PR DESCRIPTION
Addresses https://github.com/microsoft/typescript-go/pull/1381#issuecomment-3074930384

The diagnostic generator now lets us override diagnostics for this repo, so I dropped the mention of baseUrl.