### PR TITLE
Verify required properties in generated LSP code

### DIFF
--- a/internal/lsp/lsproto/_generate/generate.mjs
+++ b/internal/lsp/lsproto/_generate/generate.mjs
@@ -422,17 +422,25 @@ function generateCode() {
         const requiredProps = structure.properties?.filter(p => !p.optional) || [];
         if (requiredProps.length > 0) {
             writeLine(`func (s *${structure.name}) UnmarshalJSON(data []byte) error {`);
-            writeLine(`\t// Check required keys`);
-            writeLine(`\tkeys, err := getJSONKeys(data)`);
-            writeLine(`\tif err != nil {`);
+            writeLine(`\t// Check required props`);
+            writeLine(`\ttype requiredProps struct {`);
+            for (const prop of requiredProps) {
+                writeLine(`\t\t${titleCase(prop.name)} requiredProp \`json:"${prop.name}"\``);
+            }
+            writeLine(`}`);
+            writeLine("");
+
+            writeLine(`\tvar keys requiredProps`);
+            writeLine(`\tif err := json.Unmarshal(data, &keys); err != nil {`);
             writeLine(`\t\treturn err`);
             writeLine(`\t}`);
-            writeLine(``);
+            writeLine("");
 
+            // writeLine(`\t// Check for missing required keys`);
             for (const prop of requiredProps) {
-                writeLine(`\tif _, ok := keys["${prop.name}"]; !ok {`);
+                writeLine(`if !keys.${titleCase(prop.name)} {`);
                 writeLine(`\t\treturn fmt.Errorf("required key '${prop.name}' is missing")`);
-                writeLine(`\t}`);
+                writeLine(`}`);
             }
 
             writeLine(``);

--- a/internal/lsp/lsproto/lsp.go
+++ b/internal/lsp/lsproto/lsp.go
@@ -3,6 +3,8 @@ package lsproto
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/go-json-experiment/json/jsontext"
 )
 
 type DocumentUri string // !!!
@@ -73,4 +75,24 @@ func assertOnlyOne(message string, values ...bool) {
 	if count != 1 {
 		panic(message)
 	}
+}
+
+type nothing struct{}
+
+func (nothing) UnmarshalJSON(data []byte) error {
+	return nil
+}
+
+func (nothing) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	return dec.SkipValue()
+}
+
+type jsonKeys map[string]nothing
+
+func getJSONKeys(b []byte) (jsonKeys, error) {
+	var m jsonKeys
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JSON keys: %w", err)
+	}
+	return m, nil
 }

--- a/internal/lsp/lsproto/lsp.go
+++ b/internal/lsp/lsproto/lsp.go
@@ -96,3 +96,7 @@ func getJSONKeys(b []byte) (jsonKeys, error) {
 	}
 	return m, nil
 }
+
+func ptrTo[T any](v T) *T {
+	return &v
+}

--- a/internal/lsp/lsproto/lsp.go
+++ b/internal/lsp/lsproto/lsp.go
@@ -77,26 +77,18 @@ func assertOnlyOne(message string, values ...bool) {
 	}
 }
 
-type nothing struct{}
+func ptrTo[T any](v T) *T {
+	return &v
+}
 
-func (nothing) UnmarshalJSON(data []byte) error {
+type requiredProp bool
+
+func (v *requiredProp) UnmarshalJSON(data []byte) error {
+	*v = true
 	return nil
 }
 
-func (nothing) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+func (v *requiredProp) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	*v = true
 	return dec.SkipValue()
-}
-
-type jsonKeys map[string]nothing
-
-func getJSONKeys(b []byte) (jsonKeys, error) {
-	var m jsonKeys
-	if err := json.Unmarshal(b, &m); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal JSON keys: %w", err)
-	}
-	return m, nil
-}
-
-func ptrTo[T any](v T) *T {
-	return &v
 }

--- a/internal/lsp/lsproto/lsp_generated.go
+++ b/internal/lsp/lsproto/lsp_generated.go
@@ -26,16 +26,21 @@ type Location struct {
 }
 
 func (s *Location) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Uri   requiredProp `json:"uri"`
+		Range requiredProp `json:"range"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["uri"]; !ok {
+	if !keys.Uri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
-	if _, ok := keys["range"]; !ok {
+	if !keys.Range {
 		return fmt.Errorf("required key 'range' is missing")
 	}
 
@@ -77,16 +82,21 @@ type WorkspaceFolder struct {
 }
 
 func (s *WorkspaceFolder) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Uri  requiredProp `json:"uri"`
+		Name requiredProp `json:"name"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["uri"]; !ok {
+	if !keys.Uri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
-	if _, ok := keys["name"]; !ok {
+	if !keys.Name {
 		return fmt.Errorf("required key 'name' is missing")
 	}
 
@@ -106,13 +116,17 @@ type DidChangeWorkspaceFoldersParams struct {
 }
 
 func (s *DidChangeWorkspaceFoldersParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Event requiredProp `json:"event"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["event"]; !ok {
+	if !keys.Event {
 		return fmt.Errorf("required key 'event' is missing")
 	}
 
@@ -130,13 +144,17 @@ type ConfigurationParams struct {
 }
 
 func (s *ConfigurationParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Items requiredProp `json:"items"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["items"]; !ok {
+	if !keys.Items {
 		return fmt.Errorf("required key 'items' is missing")
 	}
 
@@ -158,13 +176,17 @@ type DocumentColorParams struct {
 }
 
 func (s *DocumentColorParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TextDocument requiredProp `json:"textDocument"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["textDocument"]; !ok {
+	if !keys.TextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
@@ -189,16 +211,21 @@ type ColorInformation struct {
 }
 
 func (s *ColorInformation) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Range requiredProp `json:"range"`
+		Color requiredProp `json:"color"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["range"]; !ok {
+	if !keys.Range {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if _, ok := keys["color"]; !ok {
+	if !keys.Color {
 		return fmt.Errorf("required key 'color' is missing")
 	}
 
@@ -233,19 +260,25 @@ type ColorPresentationParams struct {
 }
 
 func (s *ColorPresentationParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TextDocument requiredProp `json:"textDocument"`
+		Color        requiredProp `json:"color"`
+		Range        requiredProp `json:"range"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["textDocument"]; !ok {
+	if !keys.TextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if _, ok := keys["color"]; !ok {
+	if !keys.Color {
 		return fmt.Errorf("required key 'color' is missing")
 	}
-	if _, ok := keys["range"]; !ok {
+	if !keys.Range {
 		return fmt.Errorf("required key 'range' is missing")
 	}
 
@@ -279,13 +312,17 @@ type ColorPresentation struct {
 }
 
 func (s *ColorPresentation) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Label requiredProp `json:"label"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["label"]; !ok {
+	if !keys.Label {
 		return fmt.Errorf("required key 'label' is missing")
 	}
 
@@ -311,13 +348,17 @@ type TextDocumentRegistrationOptions struct {
 }
 
 func (s *TextDocumentRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		DocumentSelector requiredProp `json:"documentSelector"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["documentSelector"]; !ok {
+	if !keys.DocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
@@ -339,13 +380,17 @@ type FoldingRangeParams struct {
 }
 
 func (s *FoldingRangeParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TextDocument requiredProp `json:"textDocument"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["textDocument"]; !ok {
+	if !keys.TextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
@@ -391,16 +436,21 @@ type FoldingRange struct {
 }
 
 func (s *FoldingRange) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		StartLine requiredProp `json:"startLine"`
+		EndLine   requiredProp `json:"endLine"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["startLine"]; !ok {
+	if !keys.StartLine {
 		return fmt.Errorf("required key 'startLine' is missing")
 	}
-	if _, ok := keys["endLine"]; !ok {
+	if !keys.EndLine {
 		return fmt.Errorf("required key 'endLine' is missing")
 	}
 
@@ -448,16 +498,21 @@ type SelectionRangeParams struct {
 }
 
 func (s *SelectionRangeParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TextDocument requiredProp `json:"textDocument"`
+		Positions    requiredProp `json:"positions"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["textDocument"]; !ok {
+	if !keys.TextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if _, ok := keys["positions"]; !ok {
+	if !keys.Positions {
 		return fmt.Errorf("required key 'positions' is missing")
 	}
 
@@ -484,13 +539,17 @@ type SelectionRange struct {
 }
 
 func (s *SelectionRange) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Range requiredProp `json:"range"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["range"]; !ok {
+	if !keys.Range {
 		return fmt.Errorf("required key 'range' is missing")
 	}
 
@@ -515,13 +574,17 @@ type WorkDoneProgressCreateParams struct {
 }
 
 func (s *WorkDoneProgressCreateParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Token requiredProp `json:"token"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["token"]; !ok {
+	if !keys.Token {
 		return fmt.Errorf("required key 'token' is missing")
 	}
 
@@ -539,13 +602,17 @@ type WorkDoneProgressCancelParams struct {
 }
 
 func (s *WorkDoneProgressCancelParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Token requiredProp `json:"token"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["token"]; !ok {
+	if !keys.Token {
 		return fmt.Errorf("required key 'token' is missing")
 	}
 
@@ -598,25 +665,33 @@ type CallHierarchyItem struct {
 }
 
 func (s *CallHierarchyItem) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Name           requiredProp `json:"name"`
+		Kind           requiredProp `json:"kind"`
+		Uri            requiredProp `json:"uri"`
+		Range          requiredProp `json:"range"`
+		SelectionRange requiredProp `json:"selectionRange"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["name"]; !ok {
+	if !keys.Name {
 		return fmt.Errorf("required key 'name' is missing")
 	}
-	if _, ok := keys["kind"]; !ok {
+	if !keys.Kind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if _, ok := keys["uri"]; !ok {
+	if !keys.Uri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
-	if _, ok := keys["range"]; !ok {
+	if !keys.Range {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if _, ok := keys["selectionRange"]; !ok {
+	if !keys.SelectionRange {
 		return fmt.Errorf("required key 'selectionRange' is missing")
 	}
 
@@ -655,13 +730,17 @@ type CallHierarchyIncomingCallsParams struct {
 }
 
 func (s *CallHierarchyIncomingCallsParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Item requiredProp `json:"item"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["item"]; !ok {
+	if !keys.Item {
 		return fmt.Errorf("required key 'item' is missing")
 	}
 
@@ -689,16 +768,21 @@ type CallHierarchyIncomingCall struct {
 }
 
 func (s *CallHierarchyIncomingCall) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		From       requiredProp `json:"from"`
+		FromRanges requiredProp `json:"fromRanges"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["from"]; !ok {
+	if !keys.From {
 		return fmt.Errorf("required key 'from' is missing")
 	}
-	if _, ok := keys["fromRanges"]; !ok {
+	if !keys.FromRanges {
 		return fmt.Errorf("required key 'fromRanges' is missing")
 	}
 
@@ -722,13 +806,17 @@ type CallHierarchyOutgoingCallsParams struct {
 }
 
 func (s *CallHierarchyOutgoingCallsParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Item requiredProp `json:"item"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["item"]; !ok {
+	if !keys.Item {
 		return fmt.Errorf("required key 'item' is missing")
 	}
 
@@ -757,16 +845,21 @@ type CallHierarchyOutgoingCall struct {
 }
 
 func (s *CallHierarchyOutgoingCall) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		To         requiredProp `json:"to"`
+		FromRanges requiredProp `json:"fromRanges"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["to"]; !ok {
+	if !keys.To {
 		return fmt.Errorf("required key 'to' is missing")
 	}
-	if _, ok := keys["fromRanges"]; !ok {
+	if !keys.FromRanges {
 		return fmt.Errorf("required key 'fromRanges' is missing")
 	}
 
@@ -789,13 +882,17 @@ type SemanticTokensParams struct {
 }
 
 func (s *SemanticTokensParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TextDocument requiredProp `json:"textDocument"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["textDocument"]; !ok {
+	if !keys.TextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
@@ -823,13 +920,17 @@ type SemanticTokens struct {
 }
 
 func (s *SemanticTokens) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Data requiredProp `json:"data"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["data"]; !ok {
+	if !keys.Data {
 		return fmt.Errorf("required key 'data' is missing")
 	}
 
@@ -848,13 +949,17 @@ type SemanticTokensPartialResult struct {
 }
 
 func (s *SemanticTokensPartialResult) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Data requiredProp `json:"data"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["data"]; !ok {
+	if !keys.Data {
 		return fmt.Errorf("required key 'data' is missing")
 	}
 
@@ -887,16 +992,21 @@ type SemanticTokensDeltaParams struct {
 }
 
 func (s *SemanticTokensDeltaParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TextDocument     requiredProp `json:"textDocument"`
+		PreviousResultId requiredProp `json:"previousResultId"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["textDocument"]; !ok {
+	if !keys.TextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if _, ok := keys["previousResultId"]; !ok {
+	if !keys.PreviousResultId {
 		return fmt.Errorf("required key 'previousResultId' is missing")
 	}
 
@@ -921,13 +1031,17 @@ type SemanticTokensDelta struct {
 }
 
 func (s *SemanticTokensDelta) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Edits requiredProp `json:"edits"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["edits"]; !ok {
+	if !keys.Edits {
 		return fmt.Errorf("required key 'edits' is missing")
 	}
 
@@ -946,13 +1060,17 @@ type SemanticTokensDeltaPartialResult struct {
 }
 
 func (s *SemanticTokensDeltaPartialResult) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Edits requiredProp `json:"edits"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["edits"]; !ok {
+	if !keys.Edits {
 		return fmt.Errorf("required key 'edits' is missing")
 	}
 
@@ -977,16 +1095,21 @@ type SemanticTokensRangeParams struct {
 }
 
 func (s *SemanticTokensRangeParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TextDocument requiredProp `json:"textDocument"`
+		Range        requiredProp `json:"range"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["textDocument"]; !ok {
+	if !keys.TextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if _, ok := keys["range"]; !ok {
+	if !keys.Range {
 		return fmt.Errorf("required key 'range' is missing")
 	}
 
@@ -1028,13 +1151,17 @@ type ShowDocumentParams struct {
 }
 
 func (s *ShowDocumentParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Uri requiredProp `json:"uri"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["uri"]; !ok {
+	if !keys.Uri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
@@ -1058,13 +1185,17 @@ type ShowDocumentResult struct {
 }
 
 func (s *ShowDocumentResult) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Success requiredProp `json:"success"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["success"]; !ok {
+	if !keys.Success {
 		return fmt.Errorf("required key 'success' is missing")
 	}
 
@@ -1096,13 +1227,17 @@ type LinkedEditingRanges struct {
 }
 
 func (s *LinkedEditingRanges) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Ranges requiredProp `json:"ranges"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["ranges"]; !ok {
+	if !keys.Ranges {
 		return fmt.Errorf("required key 'ranges' is missing")
 	}
 
@@ -1131,13 +1266,17 @@ type CreateFilesParams struct {
 }
 
 func (s *CreateFilesParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Files requiredProp `json:"files"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["files"]; !ok {
+	if !keys.Files {
 		return fmt.Errorf("required key 'files' is missing")
 	}
 
@@ -1195,13 +1334,17 @@ type FileOperationRegistrationOptions struct {
 }
 
 func (s *FileOperationRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Filters requiredProp `json:"filters"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["filters"]; !ok {
+	if !keys.Filters {
 		return fmt.Errorf("required key 'filters' is missing")
 	}
 
@@ -1224,13 +1367,17 @@ type RenameFilesParams struct {
 }
 
 func (s *RenameFilesParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Files requiredProp `json:"files"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["files"]; !ok {
+	if !keys.Files {
 		return fmt.Errorf("required key 'files' is missing")
 	}
 
@@ -1252,13 +1399,17 @@ type DeleteFilesParams struct {
 }
 
 func (s *DeleteFilesParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Files requiredProp `json:"files"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["files"]; !ok {
+	if !keys.Files {
 		return fmt.Errorf("required key 'files' is missing")
 	}
 
@@ -1295,19 +1446,25 @@ type Moniker struct {
 }
 
 func (s *Moniker) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Scheme     requiredProp `json:"scheme"`
+		Identifier requiredProp `json:"identifier"`
+		Unique     requiredProp `json:"unique"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["scheme"]; !ok {
+	if !keys.Scheme {
 		return fmt.Errorf("required key 'scheme' is missing")
 	}
-	if _, ok := keys["identifier"]; !ok {
+	if !keys.Identifier {
 		return fmt.Errorf("required key 'identifier' is missing")
 	}
-	if _, ok := keys["unique"]; !ok {
+	if !keys.Unique {
 		return fmt.Errorf("required key 'unique' is missing")
 	}
 
@@ -1369,25 +1526,33 @@ type TypeHierarchyItem struct {
 }
 
 func (s *TypeHierarchyItem) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Name           requiredProp `json:"name"`
+		Kind           requiredProp `json:"kind"`
+		Uri            requiredProp `json:"uri"`
+		Range          requiredProp `json:"range"`
+		SelectionRange requiredProp `json:"selectionRange"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["name"]; !ok {
+	if !keys.Name {
 		return fmt.Errorf("required key 'name' is missing")
 	}
-	if _, ok := keys["kind"]; !ok {
+	if !keys.Kind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if _, ok := keys["uri"]; !ok {
+	if !keys.Uri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
-	if _, ok := keys["range"]; !ok {
+	if !keys.Range {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if _, ok := keys["selectionRange"]; !ok {
+	if !keys.SelectionRange {
 		return fmt.Errorf("required key 'selectionRange' is missing")
 	}
 
@@ -1426,13 +1591,17 @@ type TypeHierarchySupertypesParams struct {
 }
 
 func (s *TypeHierarchySupertypesParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Item requiredProp `json:"item"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["item"]; !ok {
+	if !keys.Item {
 		return fmt.Errorf("required key 'item' is missing")
 	}
 
@@ -1458,13 +1627,17 @@ type TypeHierarchySubtypesParams struct {
 }
 
 func (s *TypeHierarchySubtypesParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Item requiredProp `json:"item"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["item"]; !ok {
+	if !keys.Item {
 		return fmt.Errorf("required key 'item' is missing")
 	}
 
@@ -1497,19 +1670,25 @@ type InlineValueParams struct {
 }
 
 func (s *InlineValueParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TextDocument requiredProp `json:"textDocument"`
+		Range        requiredProp `json:"range"`
+		Context      requiredProp `json:"context"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["textDocument"]; !ok {
+	if !keys.TextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if _, ok := keys["range"]; !ok {
+	if !keys.Range {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if _, ok := keys["context"]; !ok {
+	if !keys.Context {
 		return fmt.Errorf("required key 'context' is missing")
 	}
 
@@ -1548,16 +1727,21 @@ type InlayHintParams struct {
 }
 
 func (s *InlayHintParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TextDocument requiredProp `json:"textDocument"`
+		Range        requiredProp `json:"range"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["textDocument"]; !ok {
+	if !keys.TextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if _, ok := keys["range"]; !ok {
+	if !keys.Range {
 		return fmt.Errorf("required key 'range' is missing")
 	}
 
@@ -1622,16 +1806,21 @@ type InlayHint struct {
 }
 
 func (s *InlayHint) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Position requiredProp `json:"position"`
+		Label    requiredProp `json:"label"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["position"]; !ok {
+	if !keys.Position {
 		return fmt.Errorf("required key 'position' is missing")
 	}
-	if _, ok := keys["label"]; !ok {
+	if !keys.Label {
 		return fmt.Errorf("required key 'label' is missing")
 	}
 
@@ -1677,13 +1866,17 @@ type DocumentDiagnosticParams struct {
 }
 
 func (s *DocumentDiagnosticParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TextDocument requiredProp `json:"textDocument"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["textDocument"]; !ok {
+	if !keys.TextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
@@ -1708,13 +1901,17 @@ type DocumentDiagnosticReportPartialResult struct {
 }
 
 func (s *DocumentDiagnosticReportPartialResult) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		RelatedDocuments requiredProp `json:"relatedDocuments"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["relatedDocuments"]; !ok {
+	if !keys.RelatedDocuments {
 		return fmt.Errorf("required key 'relatedDocuments' is missing")
 	}
 
@@ -1734,13 +1931,17 @@ type DiagnosticServerCancellationData struct {
 }
 
 func (s *DiagnosticServerCancellationData) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		RetriggerRequest requiredProp `json:"retriggerRequest"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["retriggerRequest"]; !ok {
+	if !keys.RetriggerRequest {
 		return fmt.Errorf("required key 'retriggerRequest' is missing")
 	}
 
@@ -1777,13 +1978,17 @@ type WorkspaceDiagnosticParams struct {
 }
 
 func (s *WorkspaceDiagnosticParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		PreviousResultIds requiredProp `json:"previousResultIds"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["previousResultIds"]; !ok {
+	if !keys.PreviousResultIds {
 		return fmt.Errorf("required key 'previousResultIds' is missing")
 	}
 
@@ -1807,13 +2012,17 @@ type WorkspaceDiagnosticReport struct {
 }
 
 func (s *WorkspaceDiagnosticReport) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Items requiredProp `json:"items"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["items"]; !ok {
+	if !keys.Items {
 		return fmt.Errorf("required key 'items' is missing")
 	}
 
@@ -1833,13 +2042,17 @@ type WorkspaceDiagnosticReportPartialResult struct {
 }
 
 func (s *WorkspaceDiagnosticReportPartialResult) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Items requiredProp `json:"items"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["items"]; !ok {
+	if !keys.Items {
 		return fmt.Errorf("required key 'items' is missing")
 	}
 
@@ -1864,16 +2077,21 @@ type DidOpenNotebookDocumentParams struct {
 }
 
 func (s *DidOpenNotebookDocumentParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		NotebookDocument  requiredProp `json:"notebookDocument"`
+		CellTextDocuments requiredProp `json:"cellTextDocuments"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["notebookDocument"]; !ok {
+	if !keys.NotebookDocument {
 		return fmt.Errorf("required key 'notebookDocument' is missing")
 	}
-	if _, ok := keys["cellTextDocuments"]; !ok {
+	if !keys.CellTextDocuments {
 		return fmt.Errorf("required key 'cellTextDocuments' is missing")
 	}
 
@@ -1921,16 +2139,21 @@ type DidChangeNotebookDocumentParams struct {
 }
 
 func (s *DidChangeNotebookDocumentParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		NotebookDocument requiredProp `json:"notebookDocument"`
+		Change           requiredProp `json:"change"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["notebookDocument"]; !ok {
+	if !keys.NotebookDocument {
 		return fmt.Errorf("required key 'notebookDocument' is missing")
 	}
-	if _, ok := keys["change"]; !ok {
+	if !keys.Change {
 		return fmt.Errorf("required key 'change' is missing")
 	}
 
@@ -1952,13 +2175,17 @@ type DidSaveNotebookDocumentParams struct {
 }
 
 func (s *DidSaveNotebookDocumentParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		NotebookDocument requiredProp `json:"notebookDocument"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["notebookDocument"]; !ok {
+	if !keys.NotebookDocument {
 		return fmt.Errorf("required key 'notebookDocument' is missing")
 	}
 
@@ -1983,16 +2210,21 @@ type DidCloseNotebookDocumentParams struct {
 }
 
 func (s *DidCloseNotebookDocumentParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		NotebookDocument  requiredProp `json:"notebookDocument"`
+		CellTextDocuments requiredProp `json:"cellTextDocuments"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["notebookDocument"]; !ok {
+	if !keys.NotebookDocument {
 		return fmt.Errorf("required key 'notebookDocument' is missing")
 	}
-	if _, ok := keys["cellTextDocuments"]; !ok {
+	if !keys.CellTextDocuments {
 		return fmt.Errorf("required key 'cellTextDocuments' is missing")
 	}
 
@@ -2020,13 +2252,17 @@ type InlineCompletionParams struct {
 }
 
 func (s *InlineCompletionParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Context requiredProp `json:"context"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["context"]; !ok {
+	if !keys.Context {
 		return fmt.Errorf("required key 'context' is missing")
 	}
 
@@ -2052,13 +2288,17 @@ type InlineCompletionList struct {
 }
 
 func (s *InlineCompletionList) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Items requiredProp `json:"items"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["items"]; !ok {
+	if !keys.Items {
 		return fmt.Errorf("required key 'items' is missing")
 	}
 
@@ -2090,13 +2330,17 @@ type InlineCompletionItem struct {
 }
 
 func (s *InlineCompletionItem) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		InsertText requiredProp `json:"insertText"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["insertText"]; !ok {
+	if !keys.InsertText {
 		return fmt.Errorf("required key 'insertText' is missing")
 	}
 
@@ -2133,13 +2377,17 @@ type TextDocumentContentParams struct {
 }
 
 func (s *TextDocumentContentParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Uri requiredProp `json:"uri"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["uri"]; !ok {
+	if !keys.Uri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
@@ -2165,13 +2413,17 @@ type TextDocumentContentResult struct {
 }
 
 func (s *TextDocumentContentResult) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Text requiredProp `json:"text"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["text"]; !ok {
+	if !keys.Text {
 		return fmt.Errorf("required key 'text' is missing")
 	}
 
@@ -2204,13 +2456,17 @@ type TextDocumentContentRefreshParams struct {
 }
 
 func (s *TextDocumentContentRefreshParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Uri requiredProp `json:"uri"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["uri"]; !ok {
+	if !keys.Uri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
@@ -2227,13 +2483,17 @@ type RegistrationParams struct {
 }
 
 func (s *RegistrationParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Registrations requiredProp `json:"registrations"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["registrations"]; !ok {
+	if !keys.Registrations {
 		return fmt.Errorf("required key 'registrations' is missing")
 	}
 
@@ -2250,13 +2510,17 @@ type UnregistrationParams struct {
 }
 
 func (s *UnregistrationParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Unregisterations requiredProp `json:"unregisterations"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["unregisterations"]; !ok {
+	if !keys.Unregisterations {
 		return fmt.Errorf("required key 'unregisterations' is missing")
 	}
 
@@ -2285,13 +2549,17 @@ type InitializeResult struct {
 }
 
 func (s *InitializeResult) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Capabilities requiredProp `json:"capabilities"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["capabilities"]; !ok {
+	if !keys.Capabilities {
 		return fmt.Errorf("required key 'capabilities' is missing")
 	}
 
@@ -2315,13 +2583,17 @@ type InitializeError struct {
 }
 
 func (s *InitializeError) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Retry requiredProp `json:"retry"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["retry"]; !ok {
+	if !keys.Retry {
 		return fmt.Errorf("required key 'retry' is missing")
 	}
 
@@ -2342,13 +2614,17 @@ type DidChangeConfigurationParams struct {
 }
 
 func (s *DidChangeConfigurationParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Settings requiredProp `json:"settings"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["settings"]; !ok {
+	if !keys.Settings {
 		return fmt.Errorf("required key 'settings' is missing")
 	}
 
@@ -2374,16 +2650,21 @@ type ShowMessageParams struct {
 }
 
 func (s *ShowMessageParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Type    requiredProp `json:"type"`
+		Message requiredProp `json:"message"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["type"]; !ok {
+	if !keys.Type {
 		return fmt.Errorf("required key 'type' is missing")
 	}
-	if _, ok := keys["message"]; !ok {
+	if !keys.Message {
 		return fmt.Errorf("required key 'message' is missing")
 	}
 
@@ -2408,16 +2689,21 @@ type ShowMessageRequestParams struct {
 }
 
 func (s *ShowMessageRequestParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Type    requiredProp `json:"type"`
+		Message requiredProp `json:"message"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["type"]; !ok {
+	if !keys.Type {
 		return fmt.Errorf("required key 'type' is missing")
 	}
-	if _, ok := keys["message"]; !ok {
+	if !keys.Message {
 		return fmt.Errorf("required key 'message' is missing")
 	}
 
@@ -2437,13 +2723,17 @@ type MessageActionItem struct {
 }
 
 func (s *MessageActionItem) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Title requiredProp `json:"title"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["title"]; !ok {
+	if !keys.Title {
 		return fmt.Errorf("required key 'title' is missing")
 	}
 
@@ -2465,16 +2755,21 @@ type LogMessageParams struct {
 }
 
 func (s *LogMessageParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Type    requiredProp `json:"type"`
+		Message requiredProp `json:"message"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["type"]; !ok {
+	if !keys.Type {
 		return fmt.Errorf("required key 'type' is missing")
 	}
-	if _, ok := keys["message"]; !ok {
+	if !keys.Message {
 		return fmt.Errorf("required key 'message' is missing")
 	}
 
@@ -2494,13 +2789,17 @@ type DidOpenTextDocumentParams struct {
 }
 
 func (s *DidOpenTextDocumentParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TextDocument requiredProp `json:"textDocument"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["textDocument"]; !ok {
+	if !keys.TextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
@@ -2534,16 +2833,21 @@ type DidChangeTextDocumentParams struct {
 }
 
 func (s *DidChangeTextDocumentParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TextDocument   requiredProp `json:"textDocument"`
+		ContentChanges requiredProp `json:"contentChanges"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["textDocument"]; !ok {
+	if !keys.TextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if _, ok := keys["contentChanges"]; !ok {
+	if !keys.ContentChanges {
 		return fmt.Errorf("required key 'contentChanges' is missing")
 	}
 
@@ -2565,13 +2869,17 @@ type TextDocumentChangeRegistrationOptions struct {
 }
 
 func (s *TextDocumentChangeRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		SyncKind requiredProp `json:"syncKind"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["syncKind"]; !ok {
+	if !keys.SyncKind {
 		return fmt.Errorf("required key 'syncKind' is missing")
 	}
 
@@ -2592,13 +2900,17 @@ type DidCloseTextDocumentParams struct {
 }
 
 func (s *DidCloseTextDocumentParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TextDocument requiredProp `json:"textDocument"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["textDocument"]; !ok {
+	if !keys.TextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
@@ -2621,13 +2933,17 @@ type DidSaveTextDocumentParams struct {
 }
 
 func (s *DidSaveTextDocumentParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TextDocument requiredProp `json:"textDocument"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["textDocument"]; !ok {
+	if !keys.TextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
@@ -2656,16 +2972,21 @@ type WillSaveTextDocumentParams struct {
 }
 
 func (s *WillSaveTextDocumentParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TextDocument requiredProp `json:"textDocument"`
+		Reason       requiredProp `json:"reason"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["textDocument"]; !ok {
+	if !keys.TextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if _, ok := keys["reason"]; !ok {
+	if !keys.Reason {
 		return fmt.Errorf("required key 'reason' is missing")
 	}
 
@@ -2690,16 +3011,21 @@ type TextEdit struct {
 }
 
 func (s *TextEdit) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Range   requiredProp `json:"range"`
+		NewText requiredProp `json:"newText"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["range"]; !ok {
+	if !keys.Range {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if _, ok := keys["newText"]; !ok {
+	if !keys.NewText {
 		return fmt.Errorf("required key 'newText' is missing")
 	}
 
@@ -2719,13 +3045,17 @@ type DidChangeWatchedFilesParams struct {
 }
 
 func (s *DidChangeWatchedFilesParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Changes requiredProp `json:"changes"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["changes"]; !ok {
+	if !keys.Changes {
 		return fmt.Errorf("required key 'changes' is missing")
 	}
 
@@ -2744,13 +3074,17 @@ type DidChangeWatchedFilesRegistrationOptions struct {
 }
 
 func (s *DidChangeWatchedFilesRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Watchers requiredProp `json:"watchers"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["watchers"]; !ok {
+	if !keys.Watchers {
 		return fmt.Errorf("required key 'watchers' is missing")
 	}
 
@@ -2777,16 +3111,21 @@ type PublishDiagnosticsParams struct {
 }
 
 func (s *PublishDiagnosticsParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Uri         requiredProp `json:"uri"`
+		Diagnostics requiredProp `json:"diagnostics"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["uri"]; !ok {
+	if !keys.Uri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
-	if _, ok := keys["diagnostics"]; !ok {
+	if !keys.Diagnostics {
 		return fmt.Errorf("required key 'diagnostics' is missing")
 	}
 
@@ -2953,13 +3292,17 @@ type CompletionItem struct {
 }
 
 func (s *CompletionItem) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Label requiredProp `json:"label"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["label"]; !ok {
+	if !keys.Label {
 		return fmt.Errorf("required key 'label' is missing")
 	}
 
@@ -3039,16 +3382,21 @@ type CompletionList struct {
 }
 
 func (s *CompletionList) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		IsIncomplete requiredProp `json:"isIncomplete"`
+		Items        requiredProp `json:"items"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["isIncomplete"]; !ok {
+	if !keys.IsIncomplete {
 		return fmt.Errorf("required key 'isIncomplete' is missing")
 	}
-	if _, ok := keys["items"]; !ok {
+	if !keys.Items {
 		return fmt.Errorf("required key 'items' is missing")
 	}
 
@@ -3086,13 +3434,17 @@ type Hover struct {
 }
 
 func (s *Hover) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Contents requiredProp `json:"contents"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["contents"]; !ok {
+	if !keys.Contents {
 		return fmt.Errorf("required key 'contents' is missing")
 	}
 
@@ -3161,13 +3513,17 @@ type SignatureHelp struct {
 }
 
 func (s *SignatureHelp) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Signatures requiredProp `json:"signatures"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["signatures"]; !ok {
+	if !keys.Signatures {
 		return fmt.Errorf("required key 'signatures' is missing")
 	}
 
@@ -3210,13 +3566,17 @@ type ReferenceParams struct {
 }
 
 func (s *ReferenceParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Context requiredProp `json:"context"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["context"]; !ok {
+	if !keys.Context {
 		return fmt.Errorf("required key 'context' is missing")
 	}
 
@@ -3257,13 +3617,17 @@ type DocumentHighlight struct {
 }
 
 func (s *DocumentHighlight) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Range requiredProp `json:"range"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["range"]; !ok {
+	if !keys.Range {
 		return fmt.Errorf("required key 'range' is missing")
 	}
 
@@ -3292,13 +3656,17 @@ type DocumentSymbolParams struct {
 }
 
 func (s *DocumentSymbolParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TextDocument requiredProp `json:"textDocument"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["textDocument"]; !ok {
+	if !keys.TextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
@@ -3336,13 +3704,17 @@ type SymbolInformation struct {
 }
 
 func (s *SymbolInformation) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Location requiredProp `json:"location"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["location"]; !ok {
+	if !keys.Location {
 		return fmt.Errorf("required key 'location' is missing")
 	}
 
@@ -3396,22 +3768,29 @@ type DocumentSymbol struct {
 }
 
 func (s *DocumentSymbol) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Name           requiredProp `json:"name"`
+		Kind           requiredProp `json:"kind"`
+		Range          requiredProp `json:"range"`
+		SelectionRange requiredProp `json:"selectionRange"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["name"]; !ok {
+	if !keys.Name {
 		return fmt.Errorf("required key 'name' is missing")
 	}
-	if _, ok := keys["kind"]; !ok {
+	if !keys.Kind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if _, ok := keys["range"]; !ok {
+	if !keys.Range {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if _, ok := keys["selectionRange"]; !ok {
+	if !keys.SelectionRange {
 		return fmt.Errorf("required key 'selectionRange' is missing")
 	}
 
@@ -3452,19 +3831,25 @@ type CodeActionParams struct {
 }
 
 func (s *CodeActionParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TextDocument requiredProp `json:"textDocument"`
+		Range        requiredProp `json:"range"`
+		Context      requiredProp `json:"context"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["textDocument"]; !ok {
+	if !keys.TextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if _, ok := keys["range"]; !ok {
+	if !keys.Range {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if _, ok := keys["context"]; !ok {
+	if !keys.Context {
 		return fmt.Errorf("required key 'context' is missing")
 	}
 
@@ -3505,16 +3890,21 @@ type Command struct {
 }
 
 func (s *Command) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Title   requiredProp `json:"title"`
+		Command requiredProp `json:"command"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["title"]; !ok {
+	if !keys.Title {
 		return fmt.Errorf("required key 'title' is missing")
 	}
-	if _, ok := keys["command"]; !ok {
+	if !keys.Command {
 		return fmt.Errorf("required key 'command' is missing")
 	}
 
@@ -3592,13 +3982,17 @@ type CodeAction struct {
 }
 
 func (s *CodeAction) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Title requiredProp `json:"title"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["title"]; !ok {
+	if !keys.Title {
 		return fmt.Errorf("required key 'title' is missing")
 	}
 
@@ -3641,13 +4035,17 @@ type WorkspaceSymbolParams struct {
 }
 
 func (s *WorkspaceSymbolParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Query requiredProp `json:"query"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["query"]; !ok {
+	if !keys.Query {
 		return fmt.Errorf("required key 'query' is missing")
 	}
 
@@ -3683,13 +4081,17 @@ type WorkspaceSymbol struct {
 }
 
 func (s *WorkspaceSymbol) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Location requiredProp `json:"location"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["location"]; !ok {
+	if !keys.Location {
 		return fmt.Errorf("required key 'location' is missing")
 	}
 
@@ -3719,13 +4121,17 @@ type CodeLensParams struct {
 }
 
 func (s *CodeLensParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TextDocument requiredProp `json:"textDocument"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["textDocument"]; !ok {
+	if !keys.TextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
@@ -3758,13 +4164,17 @@ type CodeLens struct {
 }
 
 func (s *CodeLens) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Range requiredProp `json:"range"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["range"]; !ok {
+	if !keys.Range {
 		return fmt.Errorf("required key 'range' is missing")
 	}
 
@@ -3794,13 +4204,17 @@ type DocumentLinkParams struct {
 }
 
 func (s *DocumentLinkParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TextDocument requiredProp `json:"textDocument"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["textDocument"]; !ok {
+	if !keys.TextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
@@ -3839,13 +4253,17 @@ type DocumentLink struct {
 }
 
 func (s *DocumentLink) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Range requiredProp `json:"range"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["range"]; !ok {
+	if !keys.Range {
 		return fmt.Errorf("required key 'range' is missing")
 	}
 
@@ -3878,16 +4296,21 @@ type DocumentFormattingParams struct {
 }
 
 func (s *DocumentFormattingParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TextDocument requiredProp `json:"textDocument"`
+		Options      requiredProp `json:"options"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["textDocument"]; !ok {
+	if !keys.TextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if _, ok := keys["options"]; !ok {
+	if !keys.Options {
 		return fmt.Errorf("required key 'options' is missing")
 	}
 
@@ -3923,19 +4346,25 @@ type DocumentRangeFormattingParams struct {
 }
 
 func (s *DocumentRangeFormattingParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TextDocument requiredProp `json:"textDocument"`
+		Range        requiredProp `json:"range"`
+		Options      requiredProp `json:"options"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["textDocument"]; !ok {
+	if !keys.TextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if _, ok := keys["range"]; !ok {
+	if !keys.Range {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if _, ok := keys["options"]; !ok {
+	if !keys.Options {
 		return fmt.Errorf("required key 'options' is missing")
 	}
 
@@ -3976,19 +4405,25 @@ type DocumentRangesFormattingParams struct {
 }
 
 func (s *DocumentRangesFormattingParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TextDocument requiredProp `json:"textDocument"`
+		Ranges       requiredProp `json:"ranges"`
+		Options      requiredProp `json:"options"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["textDocument"]; !ok {
+	if !keys.TextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if _, ok := keys["ranges"]; !ok {
+	if !keys.Ranges {
 		return fmt.Errorf("required key 'ranges' is missing")
 	}
-	if _, ok := keys["options"]; !ok {
+	if !keys.Options {
 		return fmt.Errorf("required key 'options' is missing")
 	}
 
@@ -4025,22 +4460,29 @@ type DocumentOnTypeFormattingParams struct {
 }
 
 func (s *DocumentOnTypeFormattingParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TextDocument requiredProp `json:"textDocument"`
+		Position     requiredProp `json:"position"`
+		Ch           requiredProp `json:"ch"`
+		Options      requiredProp `json:"options"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["textDocument"]; !ok {
+	if !keys.TextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if _, ok := keys["position"]; !ok {
+	if !keys.Position {
 		return fmt.Errorf("required key 'position' is missing")
 	}
-	if _, ok := keys["ch"]; !ok {
+	if !keys.Ch {
 		return fmt.Errorf("required key 'ch' is missing")
 	}
-	if _, ok := keys["options"]; !ok {
+	if !keys.Options {
 		return fmt.Errorf("required key 'options' is missing")
 	}
 
@@ -4078,19 +4520,25 @@ type RenameParams struct {
 }
 
 func (s *RenameParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TextDocument requiredProp `json:"textDocument"`
+		Position     requiredProp `json:"position"`
+		NewName      requiredProp `json:"newName"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["textDocument"]; !ok {
+	if !keys.TextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if _, ok := keys["position"]; !ok {
+	if !keys.Position {
 		return fmt.Errorf("required key 'position' is missing")
 	}
-	if _, ok := keys["newName"]; !ok {
+	if !keys.NewName {
 		return fmt.Errorf("required key 'newName' is missing")
 	}
 
@@ -4129,13 +4577,17 @@ type ExecuteCommandParams struct {
 }
 
 func (s *ExecuteCommandParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Command requiredProp `json:"command"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["command"]; !ok {
+	if !keys.Command {
 		return fmt.Errorf("required key 'command' is missing")
 	}
 
@@ -4174,13 +4626,17 @@ type ApplyWorkspaceEditParams struct {
 }
 
 func (s *ApplyWorkspaceEditParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Edit requiredProp `json:"edit"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["edit"]; !ok {
+	if !keys.Edit {
 		return fmt.Errorf("required key 'edit' is missing")
 	}
 
@@ -4213,13 +4669,17 @@ type ApplyWorkspaceEditResult struct {
 }
 
 func (s *ApplyWorkspaceEditResult) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Applied requiredProp `json:"applied"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["applied"]; !ok {
+	if !keys.Applied {
 		return fmt.Errorf("required key 'applied' is missing")
 	}
 
@@ -4264,16 +4724,21 @@ type WorkDoneProgressBegin struct {
 }
 
 func (s *WorkDoneProgressBegin) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Kind  requiredProp `json:"kind"`
+		Title requiredProp `json:"title"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["kind"]; !ok {
+	if !keys.Kind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if _, ok := keys["title"]; !ok {
+	if !keys.Title {
 		return fmt.Errorf("required key 'title' is missing")
 	}
 
@@ -4315,13 +4780,17 @@ type WorkDoneProgressReport struct {
 }
 
 func (s *WorkDoneProgressReport) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Kind requiredProp `json:"kind"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["kind"]; !ok {
+	if !keys.Kind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
 
@@ -4345,13 +4814,17 @@ type WorkDoneProgressEnd struct {
 }
 
 func (s *WorkDoneProgressEnd) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Kind requiredProp `json:"kind"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["kind"]; !ok {
+	if !keys.Kind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
 
@@ -4369,13 +4842,17 @@ type SetTraceParams struct {
 }
 
 func (s *SetTraceParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Value requiredProp `json:"value"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["value"]; !ok {
+	if !keys.Value {
 		return fmt.Errorf("required key 'value' is missing")
 	}
 
@@ -4394,13 +4871,17 @@ type LogTraceParams struct {
 }
 
 func (s *LogTraceParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Message requiredProp `json:"message"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["message"]; !ok {
+	if !keys.Message {
 		return fmt.Errorf("required key 'message' is missing")
 	}
 
@@ -4419,13 +4900,17 @@ type CancelParams struct {
 }
 
 func (s *CancelParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Id requiredProp `json:"id"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["id"]; !ok {
+	if !keys.Id {
 		return fmt.Errorf("required key 'id' is missing")
 	}
 
@@ -4446,16 +4931,21 @@ type ProgressParams struct {
 }
 
 func (s *ProgressParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Token requiredProp `json:"token"`
+		Value requiredProp `json:"value"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["token"]; !ok {
+	if !keys.Token {
 		return fmt.Errorf("required key 'token' is missing")
 	}
-	if _, ok := keys["value"]; !ok {
+	if !keys.Value {
 		return fmt.Errorf("required key 'value' is missing")
 	}
 
@@ -4479,16 +4969,21 @@ type TextDocumentPositionParams struct {
 }
 
 func (s *TextDocumentPositionParams) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TextDocument requiredProp `json:"textDocument"`
+		Position     requiredProp `json:"position"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["textDocument"]; !ok {
+	if !keys.TextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if _, ok := keys["position"]; !ok {
+	if !keys.Position {
 		return fmt.Errorf("required key 'position' is missing")
 	}
 
@@ -4535,19 +5030,25 @@ type LocationLink struct {
 }
 
 func (s *LocationLink) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TargetUri            requiredProp `json:"targetUri"`
+		TargetRange          requiredProp `json:"targetRange"`
+		TargetSelectionRange requiredProp `json:"targetSelectionRange"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["targetUri"]; !ok {
+	if !keys.TargetUri {
 		return fmt.Errorf("required key 'targetUri' is missing")
 	}
-	if _, ok := keys["targetRange"]; !ok {
+	if !keys.TargetRange {
 		return fmt.Errorf("required key 'targetRange' is missing")
 	}
-	if _, ok := keys["targetSelectionRange"]; !ok {
+	if !keys.TargetSelectionRange {
 		return fmt.Errorf("required key 'targetSelectionRange' is missing")
 	}
 
@@ -4584,16 +5085,21 @@ type Range struct {
 }
 
 func (s *Range) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Start requiredProp `json:"start"`
+		End   requiredProp `json:"end"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["start"]; !ok {
+	if !keys.Start {
 		return fmt.Errorf("required key 'start' is missing")
 	}
-	if _, ok := keys["end"]; !ok {
+	if !keys.End {
 		return fmt.Errorf("required key 'end' is missing")
 	}
 
@@ -4632,16 +5138,21 @@ type WorkspaceFoldersChangeEvent struct {
 }
 
 func (s *WorkspaceFoldersChangeEvent) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Added   requiredProp `json:"added"`
+		Removed requiredProp `json:"removed"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["added"]; !ok {
+	if !keys.Added {
 		return fmt.Errorf("required key 'added' is missing")
 	}
-	if _, ok := keys["removed"]; !ok {
+	if !keys.Removed {
 		return fmt.Errorf("required key 'removed' is missing")
 	}
 
@@ -4669,13 +5180,17 @@ type TextDocumentIdentifier struct {
 }
 
 func (s *TextDocumentIdentifier) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Uri requiredProp `json:"uri"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["uri"]; !ok {
+	if !keys.Uri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
@@ -4703,22 +5218,29 @@ type Color struct {
 }
 
 func (s *Color) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Red   requiredProp `json:"red"`
+		Green requiredProp `json:"green"`
+		Blue  requiredProp `json:"blue"`
+		Alpha requiredProp `json:"alpha"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["red"]; !ok {
+	if !keys.Red {
 		return fmt.Errorf("required key 'red' is missing")
 	}
-	if _, ok := keys["green"]; !ok {
+	if !keys.Green {
 		return fmt.Errorf("required key 'green' is missing")
 	}
-	if _, ok := keys["blue"]; !ok {
+	if !keys.Blue {
 		return fmt.Errorf("required key 'blue' is missing")
 	}
-	if _, ok := keys["alpha"]; !ok {
+	if !keys.Alpha {
 		return fmt.Errorf("required key 'alpha' is missing")
 	}
 
@@ -4784,16 +5306,21 @@ type Position struct {
 }
 
 func (s *Position) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Line      requiredProp `json:"line"`
+		Character requiredProp `json:"character"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["line"]; !ok {
+	if !keys.Line {
 		return fmt.Errorf("required key 'line' is missing")
 	}
-	if _, ok := keys["character"]; !ok {
+	if !keys.Character {
 		return fmt.Errorf("required key 'character' is missing")
 	}
 
@@ -4833,13 +5360,17 @@ type SemanticTokensOptions struct {
 }
 
 func (s *SemanticTokensOptions) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Legend requiredProp `json:"legend"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["legend"]; !ok {
+	if !keys.Legend {
 		return fmt.Errorf("required key 'legend' is missing")
 	}
 
@@ -4868,16 +5399,21 @@ type SemanticTokensEdit struct {
 }
 
 func (s *SemanticTokensEdit) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Start       requiredProp `json:"start"`
+		DeleteCount requiredProp `json:"deleteCount"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["start"]; !ok {
+	if !keys.Start {
 		return fmt.Errorf("required key 'start' is missing")
 	}
-	if _, ok := keys["deleteCount"]; !ok {
+	if !keys.DeleteCount {
 		return fmt.Errorf("required key 'deleteCount' is missing")
 	}
 
@@ -4904,13 +5440,17 @@ type FileCreate struct {
 }
 
 func (s *FileCreate) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Uri requiredProp `json:"uri"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["uri"]; !ok {
+	if !keys.Uri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
@@ -4941,16 +5481,21 @@ type TextDocumentEdit struct {
 }
 
 func (s *TextDocumentEdit) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TextDocument requiredProp `json:"textDocument"`
+		Edits        requiredProp `json:"edits"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["textDocument"]; !ok {
+	if !keys.TextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if _, ok := keys["edits"]; !ok {
+	if !keys.Edits {
 		return fmt.Errorf("required key 'edits' is missing")
 	}
 
@@ -4978,16 +5523,21 @@ type CreateFile struct {
 }
 
 func (s *CreateFile) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Kind requiredProp `json:"kind"`
+		Uri  requiredProp `json:"uri"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["kind"]; !ok {
+	if !keys.Kind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if _, ok := keys["uri"]; !ok {
+	if !keys.Uri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
@@ -5021,19 +5571,25 @@ type RenameFile struct {
 }
 
 func (s *RenameFile) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Kind   requiredProp `json:"kind"`
+		OldUri requiredProp `json:"oldUri"`
+		NewUri requiredProp `json:"newUri"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["kind"]; !ok {
+	if !keys.Kind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if _, ok := keys["oldUri"]; !ok {
+	if !keys.OldUri {
 		return fmt.Errorf("required key 'oldUri' is missing")
 	}
-	if _, ok := keys["newUri"]; !ok {
+	if !keys.NewUri {
 		return fmt.Errorf("required key 'newUri' is missing")
 	}
 
@@ -5065,16 +5621,21 @@ type DeleteFile struct {
 }
 
 func (s *DeleteFile) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Kind requiredProp `json:"kind"`
+		Uri  requiredProp `json:"uri"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["kind"]; !ok {
+	if !keys.Kind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if _, ok := keys["uri"]; !ok {
+	if !keys.Uri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
@@ -5108,13 +5669,17 @@ type ChangeAnnotation struct {
 }
 
 func (s *ChangeAnnotation) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Label requiredProp `json:"label"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["label"]; !ok {
+	if !keys.Label {
 		return fmt.Errorf("required key 'label' is missing")
 	}
 
@@ -5141,13 +5706,17 @@ type FileOperationFilter struct {
 }
 
 func (s *FileOperationFilter) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Pattern requiredProp `json:"pattern"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["pattern"]; !ok {
+	if !keys.Pattern {
 		return fmt.Errorf("required key 'pattern' is missing")
 	}
 
@@ -5172,16 +5741,21 @@ type FileRename struct {
 }
 
 func (s *FileRename) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		OldUri requiredProp `json:"oldUri"`
+		NewUri requiredProp `json:"newUri"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["oldUri"]; !ok {
+	if !keys.OldUri {
 		return fmt.Errorf("required key 'oldUri' is missing")
 	}
-	if _, ok := keys["newUri"]; !ok {
+	if !keys.NewUri {
 		return fmt.Errorf("required key 'newUri' is missing")
 	}
 
@@ -5203,13 +5777,17 @@ type FileDelete struct {
 }
 
 func (s *FileDelete) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Uri requiredProp `json:"uri"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["uri"]; !ok {
+	if !keys.Uri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
@@ -5243,16 +5821,21 @@ type InlineValueContext struct {
 }
 
 func (s *InlineValueContext) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		FrameId         requiredProp `json:"frameId"`
+		StoppedLocation requiredProp `json:"stoppedLocation"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["frameId"]; !ok {
+	if !keys.FrameId {
 		return fmt.Errorf("required key 'frameId' is missing")
 	}
-	if _, ok := keys["stoppedLocation"]; !ok {
+	if !keys.StoppedLocation {
 		return fmt.Errorf("required key 'stoppedLocation' is missing")
 	}
 
@@ -5277,16 +5860,21 @@ type InlineValueText struct {
 }
 
 func (s *InlineValueText) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Range requiredProp `json:"range"`
+		Text  requiredProp `json:"text"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["range"]; !ok {
+	if !keys.Range {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if _, ok := keys["text"]; !ok {
+	if !keys.Text {
 		return fmt.Errorf("required key 'text' is missing")
 	}
 
@@ -5317,16 +5905,21 @@ type InlineValueVariableLookup struct {
 }
 
 func (s *InlineValueVariableLookup) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Range               requiredProp `json:"range"`
+		CaseSensitiveLookup requiredProp `json:"caseSensitiveLookup"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["range"]; !ok {
+	if !keys.Range {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if _, ok := keys["caseSensitiveLookup"]; !ok {
+	if !keys.CaseSensitiveLookup {
 		return fmt.Errorf("required key 'caseSensitiveLookup' is missing")
 	}
 
@@ -5355,13 +5948,17 @@ type InlineValueEvaluatableExpression struct {
 }
 
 func (s *InlineValueEvaluatableExpression) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Range requiredProp `json:"range"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["range"]; !ok {
+	if !keys.Range {
 		return fmt.Errorf("required key 'range' is missing")
 	}
 
@@ -5415,13 +6012,17 @@ type InlayHintLabelPart struct {
 }
 
 func (s *InlayHintLabelPart) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Value requiredProp `json:"value"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["value"]; !ok {
+	if !keys.Value {
 		return fmt.Errorf("required key 'value' is missing")
 	}
 
@@ -5469,16 +6070,21 @@ type MarkupContent struct {
 }
 
 func (s *MarkupContent) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Kind  requiredProp `json:"kind"`
+		Value requiredProp `json:"value"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["kind"]; !ok {
+	if !keys.Kind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if _, ok := keys["value"]; !ok {
+	if !keys.Value {
 		return fmt.Errorf("required key 'value' is missing")
 	}
 
@@ -5551,16 +6157,21 @@ type FullDocumentDiagnosticReport struct {
 }
 
 func (s *FullDocumentDiagnosticReport) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Kind  requiredProp `json:"kind"`
+		Items requiredProp `json:"items"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["kind"]; !ok {
+	if !keys.Kind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if _, ok := keys["items"]; !ok {
+	if !keys.Items {
 		return fmt.Errorf("required key 'items' is missing")
 	}
 
@@ -5591,16 +6202,21 @@ type UnchangedDocumentDiagnosticReport struct {
 }
 
 func (s *UnchangedDocumentDiagnosticReport) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Kind     requiredProp `json:"kind"`
+		ResultId requiredProp `json:"resultId"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["kind"]; !ok {
+	if !keys.Kind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if _, ok := keys["resultId"]; !ok {
+	if !keys.ResultId {
 		return fmt.Errorf("required key 'resultId' is missing")
 	}
 
@@ -5634,16 +6250,21 @@ type DiagnosticOptions struct {
 }
 
 func (s *DiagnosticOptions) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		InterFileDependencies requiredProp `json:"interFileDependencies"`
+		WorkspaceDiagnostics  requiredProp `json:"workspaceDiagnostics"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["interFileDependencies"]; !ok {
+	if !keys.InterFileDependencies {
 		return fmt.Errorf("required key 'interFileDependencies' is missing")
 	}
-	if _, ok := keys["workspaceDiagnostics"]; !ok {
+	if !keys.WorkspaceDiagnostics {
 		return fmt.Errorf("required key 'workspaceDiagnostics' is missing")
 	}
 
@@ -5672,16 +6293,21 @@ type PreviousResultId struct {
 }
 
 func (s *PreviousResultId) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Uri   requiredProp `json:"uri"`
+		Value requiredProp `json:"value"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["uri"]; !ok {
+	if !keys.Uri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
-	if _, ok := keys["value"]; !ok {
+	if !keys.Value {
 		return fmt.Errorf("required key 'value' is missing")
 	}
 
@@ -5719,22 +6345,29 @@ type NotebookDocument struct {
 }
 
 func (s *NotebookDocument) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Uri          requiredProp `json:"uri"`
+		NotebookType requiredProp `json:"notebookType"`
+		Version      requiredProp `json:"version"`
+		Cells        requiredProp `json:"cells"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["uri"]; !ok {
+	if !keys.Uri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
-	if _, ok := keys["notebookType"]; !ok {
+	if !keys.NotebookType {
 		return fmt.Errorf("required key 'notebookType' is missing")
 	}
-	if _, ok := keys["version"]; !ok {
+	if !keys.Version {
 		return fmt.Errorf("required key 'version' is missing")
 	}
-	if _, ok := keys["cells"]; !ok {
+	if !keys.Cells {
 		return fmt.Errorf("required key 'cells' is missing")
 	}
 
@@ -5768,22 +6401,29 @@ type TextDocumentItem struct {
 }
 
 func (s *TextDocumentItem) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Uri        requiredProp `json:"uri"`
+		LanguageId requiredProp `json:"languageId"`
+		Version    requiredProp `json:"version"`
+		Text       requiredProp `json:"text"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["uri"]; !ok {
+	if !keys.Uri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
-	if _, ok := keys["languageId"]; !ok {
+	if !keys.LanguageId {
 		return fmt.Errorf("required key 'languageId' is missing")
 	}
-	if _, ok := keys["version"]; !ok {
+	if !keys.Version {
 		return fmt.Errorf("required key 'version' is missing")
 	}
-	if _, ok := keys["text"]; !ok {
+	if !keys.Text {
 		return fmt.Errorf("required key 'text' is missing")
 	}
 
@@ -5821,13 +6461,17 @@ type NotebookDocumentSyncOptions struct {
 }
 
 func (s *NotebookDocumentSyncOptions) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		NotebookSelector requiredProp `json:"notebookSelector"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["notebookSelector"]; !ok {
+	if !keys.NotebookSelector {
 		return fmt.Errorf("required key 'notebookSelector' is missing")
 	}
 
@@ -5852,16 +6496,21 @@ type VersionedNotebookDocumentIdentifier struct {
 }
 
 func (s *VersionedNotebookDocumentIdentifier) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Version requiredProp `json:"version"`
+		Uri     requiredProp `json:"uri"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["version"]; !ok {
+	if !keys.Version {
 		return fmt.Errorf("required key 'version' is missing")
 	}
-	if _, ok := keys["uri"]; !ok {
+	if !keys.Uri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
@@ -5896,13 +6545,17 @@ type NotebookDocumentIdentifier struct {
 }
 
 func (s *NotebookDocumentIdentifier) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Uri requiredProp `json:"uri"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["uri"]; !ok {
+	if !keys.Uri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
@@ -5928,13 +6581,17 @@ type InlineCompletionContext struct {
 }
 
 func (s *InlineCompletionContext) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TriggerKind requiredProp `json:"triggerKind"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["triggerKind"]; !ok {
+	if !keys.TriggerKind {
 		return fmt.Errorf("required key 'triggerKind' is missing")
 	}
 
@@ -5967,16 +6624,21 @@ type StringValue struct {
 }
 
 func (s *StringValue) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Kind  requiredProp `json:"kind"`
+		Value requiredProp `json:"value"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["kind"]; !ok {
+	if !keys.Kind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if _, ok := keys["value"]; !ok {
+	if !keys.Value {
 		return fmt.Errorf("required key 'value' is missing")
 	}
 
@@ -6009,13 +6671,17 @@ type TextDocumentContentOptions struct {
 }
 
 func (s *TextDocumentContentOptions) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Schemes requiredProp `json:"schemes"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["schemes"]; !ok {
+	if !keys.Schemes {
 		return fmt.Errorf("required key 'schemes' is missing")
 	}
 
@@ -6041,16 +6707,21 @@ type Registration struct {
 }
 
 func (s *Registration) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Id     requiredProp `json:"id"`
+		Method requiredProp `json:"method"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["id"]; !ok {
+	if !keys.Id {
 		return fmt.Errorf("required key 'id' is missing")
 	}
-	if _, ok := keys["method"]; !ok {
+	if !keys.Method {
 		return fmt.Errorf("required key 'method' is missing")
 	}
 
@@ -6075,16 +6746,21 @@ type Unregistration struct {
 }
 
 func (s *Unregistration) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Id     requiredProp `json:"id"`
+		Method requiredProp `json:"method"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["id"]; !ok {
+	if !keys.Id {
 		return fmt.Errorf("required key 'id' is missing")
 	}
-	if _, ok := keys["method"]; !ok {
+	if !keys.Method {
 		return fmt.Errorf("required key 'method' is missing")
 	}
 
@@ -6147,19 +6823,25 @@ type InitializeParamsBase struct {
 }
 
 func (s *InitializeParamsBase) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		ProcessId    requiredProp `json:"processId"`
+		RootUri      requiredProp `json:"rootUri"`
+		Capabilities requiredProp `json:"capabilities"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["processId"]; !ok {
+	if !keys.ProcessId {
 		return fmt.Errorf("required key 'processId' is missing")
 	}
-	if _, ok := keys["rootUri"]; !ok {
+	if !keys.RootUri {
 		return fmt.Errorf("required key 'rootUri' is missing")
 	}
-	if _, ok := keys["capabilities"]; !ok {
+	if !keys.Capabilities {
 		return fmt.Errorf("required key 'capabilities' is missing")
 	}
 
@@ -6353,13 +7035,17 @@ type ServerInfo struct {
 }
 
 func (s *ServerInfo) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Name requiredProp `json:"name"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["name"]; !ok {
+	if !keys.Name {
 		return fmt.Errorf("required key 'name' is missing")
 	}
 
@@ -6381,13 +7067,17 @@ type VersionedTextDocumentIdentifier struct {
 }
 
 func (s *VersionedTextDocumentIdentifier) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Version requiredProp `json:"version"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["version"]; !ok {
+	if !keys.Version {
 		return fmt.Errorf("required key 'version' is missing")
 	}
 
@@ -6417,16 +7107,21 @@ type FileEvent struct {
 }
 
 func (s *FileEvent) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Uri  requiredProp `json:"uri"`
+		Type requiredProp `json:"type"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["uri"]; !ok {
+	if !keys.Uri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
-	if _, ok := keys["type"]; !ok {
+	if !keys.Type {
 		return fmt.Errorf("required key 'type' is missing")
 	}
 
@@ -6452,13 +7147,17 @@ type FileSystemWatcher struct {
 }
 
 func (s *FileSystemWatcher) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		GlobPattern requiredProp `json:"globPattern"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["globPattern"]; !ok {
+	if !keys.GlobPattern {
 		return fmt.Errorf("required key 'globPattern' is missing")
 	}
 
@@ -6516,16 +7215,21 @@ type Diagnostic struct {
 }
 
 func (s *Diagnostic) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Range   requiredProp `json:"range"`
+		Message requiredProp `json:"message"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["range"]; !ok {
+	if !keys.Range {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if _, ok := keys["message"]; !ok {
+	if !keys.Message {
 		return fmt.Errorf("required key 'message' is missing")
 	}
 
@@ -6556,13 +7260,17 @@ type CompletionContext struct {
 }
 
 func (s *CompletionContext) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TriggerKind requiredProp `json:"triggerKind"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["triggerKind"]; !ok {
+	if !keys.TriggerKind {
 		return fmt.Errorf("required key 'triggerKind' is missing")
 	}
 
@@ -6603,19 +7311,25 @@ type InsertReplaceEdit struct {
 }
 
 func (s *InsertReplaceEdit) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		NewText requiredProp `json:"newText"`
+		Insert  requiredProp `json:"insert"`
+		Replace requiredProp `json:"replace"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["newText"]; !ok {
+	if !keys.NewText {
 		return fmt.Errorf("required key 'newText' is missing")
 	}
-	if _, ok := keys["insert"]; !ok {
+	if !keys.Insert {
 		return fmt.Errorf("required key 'insert' is missing")
 	}
-	if _, ok := keys["replace"]; !ok {
+	if !keys.Replace {
 		return fmt.Errorf("required key 'replace' is missing")
 	}
 
@@ -6797,16 +7511,21 @@ type SignatureHelpContext struct {
 }
 
 func (s *SignatureHelpContext) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TriggerKind requiredProp `json:"triggerKind"`
+		IsRetrigger requiredProp `json:"isRetrigger"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["triggerKind"]; !ok {
+	if !keys.TriggerKind {
 		return fmt.Errorf("required key 'triggerKind' is missing")
 	}
-	if _, ok := keys["isRetrigger"]; !ok {
+	if !keys.IsRetrigger {
 		return fmt.Errorf("required key 'isRetrigger' is missing")
 	}
 
@@ -6851,13 +7570,17 @@ type SignatureInformation struct {
 }
 
 func (s *SignatureInformation) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Label requiredProp `json:"label"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["label"]; !ok {
+	if !keys.Label {
 		return fmt.Errorf("required key 'label' is missing")
 	}
 
@@ -6901,13 +7624,17 @@ type ReferenceContext struct {
 }
 
 func (s *ReferenceContext) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		IncludeDeclaration requiredProp `json:"includeDeclaration"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["includeDeclaration"]; !ok {
+	if !keys.IncludeDeclaration {
 		return fmt.Errorf("required key 'includeDeclaration' is missing")
 	}
 
@@ -6950,16 +7677,21 @@ type BaseSymbolInformation struct {
 }
 
 func (s *BaseSymbolInformation) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Name requiredProp `json:"name"`
+		Kind requiredProp `json:"kind"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["name"]; !ok {
+	if !keys.Name {
 		return fmt.Errorf("required key 'name' is missing")
 	}
-	if _, ok := keys["kind"]; !ok {
+	if !keys.Kind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
 
@@ -7008,13 +7740,17 @@ type CodeActionContext struct {
 }
 
 func (s *CodeActionContext) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Diagnostics requiredProp `json:"diagnostics"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["diagnostics"]; !ok {
+	if !keys.Diagnostics {
 		return fmt.Errorf("required key 'diagnostics' is missing")
 	}
 
@@ -7039,13 +7775,17 @@ type CodeActionDisabled struct {
 }
 
 func (s *CodeActionDisabled) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Reason requiredProp `json:"reason"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["reason"]; !ok {
+	if !keys.Reason {
 		return fmt.Errorf("required key 'reason' is missing")
 	}
 
@@ -7100,13 +7840,17 @@ type LocationUriOnly struct {
 }
 
 func (s *LocationUriOnly) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Uri requiredProp `json:"uri"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["uri"]; !ok {
+	if !keys.Uri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
@@ -7170,16 +7914,21 @@ type FormattingOptions struct {
 }
 
 func (s *FormattingOptions) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TabSize      requiredProp `json:"tabSize"`
+		InsertSpaces requiredProp `json:"insertSpaces"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["tabSize"]; !ok {
+	if !keys.TabSize {
 		return fmt.Errorf("required key 'tabSize' is missing")
 	}
-	if _, ok := keys["insertSpaces"]; !ok {
+	if !keys.InsertSpaces {
 		return fmt.Errorf("required key 'insertSpaces' is missing")
 	}
 
@@ -7222,13 +7971,17 @@ type DocumentOnTypeFormattingOptions struct {
 }
 
 func (s *DocumentOnTypeFormattingOptions) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		FirstTriggerCharacter requiredProp `json:"firstTriggerCharacter"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["firstTriggerCharacter"]; !ok {
+	if !keys.FirstTriggerCharacter {
 		return fmt.Errorf("required key 'firstTriggerCharacter' is missing")
 	}
 
@@ -7259,16 +8012,21 @@ type PrepareRenamePlaceholder struct {
 }
 
 func (s *PrepareRenamePlaceholder) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Range       requiredProp `json:"range"`
+		Placeholder requiredProp `json:"placeholder"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["range"]; !ok {
+	if !keys.Range {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if _, ok := keys["placeholder"]; !ok {
+	if !keys.Placeholder {
 		return fmt.Errorf("required key 'placeholder' is missing")
 	}
 
@@ -7287,13 +8045,17 @@ type PrepareRenameDefaultBehavior struct {
 }
 
 func (s *PrepareRenameDefaultBehavior) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		DefaultBehavior requiredProp `json:"defaultBehavior"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["defaultBehavior"]; !ok {
+	if !keys.DefaultBehavior {
 		return fmt.Errorf("required key 'defaultBehavior' is missing")
 	}
 
@@ -7314,13 +8076,17 @@ type ExecuteCommandOptions struct {
 }
 
 func (s *ExecuteCommandOptions) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Commands requiredProp `json:"commands"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["commands"]; !ok {
+	if !keys.Commands {
 		return fmt.Errorf("required key 'commands' is missing")
 	}
 
@@ -7354,16 +8120,21 @@ type SemanticTokensLegend struct {
 }
 
 func (s *SemanticTokensLegend) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		TokenTypes     requiredProp `json:"tokenTypes"`
+		TokenModifiers requiredProp `json:"tokenModifiers"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["tokenTypes"]; !ok {
+	if !keys.TokenTypes {
 		return fmt.Errorf("required key 'tokenTypes' is missing")
 	}
-	if _, ok := keys["tokenModifiers"]; !ok {
+	if !keys.TokenModifiers {
 		return fmt.Errorf("required key 'tokenModifiers' is missing")
 	}
 
@@ -7397,13 +8168,17 @@ type OptionalVersionedTextDocumentIdentifier struct {
 }
 
 func (s *OptionalVersionedTextDocumentIdentifier) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Version requiredProp `json:"version"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["version"]; !ok {
+	if !keys.Version {
 		return fmt.Errorf("required key 'version' is missing")
 	}
 
@@ -7428,13 +8203,17 @@ type AnnotatedTextEdit struct {
 }
 
 func (s *AnnotatedTextEdit) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		AnnotationId requiredProp `json:"annotationId"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["annotationId"]; !ok {
+	if !keys.AnnotationId {
 		return fmt.Errorf("required key 'annotationId' is missing")
 	}
 
@@ -7465,16 +8244,21 @@ type SnippetTextEdit struct {
 }
 
 func (s *SnippetTextEdit) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Range   requiredProp `json:"range"`
+		Snippet requiredProp `json:"snippet"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["range"]; !ok {
+	if !keys.Range {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if _, ok := keys["snippet"]; !ok {
+	if !keys.Snippet {
 		return fmt.Errorf("required key 'snippet' is missing")
 	}
 
@@ -7500,13 +8284,17 @@ type ResourceOperation struct {
 }
 
 func (s *ResourceOperation) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Kind requiredProp `json:"kind"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["kind"]; !ok {
+	if !keys.Kind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
 
@@ -7570,13 +8358,17 @@ type FileOperationPattern struct {
 }
 
 func (s *FileOperationPattern) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Glob requiredProp `json:"glob"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["glob"]; !ok {
+	if !keys.Glob {
 		return fmt.Errorf("required key 'glob' is missing")
 	}
 
@@ -7605,16 +8397,21 @@ type WorkspaceFullDocumentDiagnosticReport struct {
 }
 
 func (s *WorkspaceFullDocumentDiagnosticReport) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Uri     requiredProp `json:"uri"`
+		Version requiredProp `json:"version"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["uri"]; !ok {
+	if !keys.Uri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
-	if _, ok := keys["version"]; !ok {
+	if !keys.Version {
 		return fmt.Errorf("required key 'version' is missing")
 	}
 
@@ -7644,16 +8441,21 @@ type WorkspaceUnchangedDocumentDiagnosticReport struct {
 }
 
 func (s *WorkspaceUnchangedDocumentDiagnosticReport) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Uri     requiredProp `json:"uri"`
+		Version requiredProp `json:"version"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["uri"]; !ok {
+	if !keys.Uri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
-	if _, ok := keys["version"]; !ok {
+	if !keys.Version {
 		return fmt.Errorf("required key 'version' is missing")
 	}
 
@@ -7694,16 +8496,21 @@ type NotebookCell struct {
 }
 
 func (s *NotebookCell) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Kind     requiredProp `json:"kind"`
+		Document requiredProp `json:"document"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["kind"]; !ok {
+	if !keys.Kind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if _, ok := keys["document"]; !ok {
+	if !keys.Document {
 		return fmt.Errorf("required key 'document' is missing")
 	}
 
@@ -7730,13 +8537,17 @@ type NotebookDocumentFilterWithNotebook struct {
 }
 
 func (s *NotebookDocumentFilterWithNotebook) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Notebook requiredProp `json:"notebook"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["notebook"]; !ok {
+	if !keys.Notebook {
 		return fmt.Errorf("required key 'notebook' is missing")
 	}
 
@@ -7761,13 +8572,17 @@ type NotebookDocumentFilterWithCells struct {
 }
 
 func (s *NotebookDocumentFilterWithCells) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Cells requiredProp `json:"cells"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["cells"]; !ok {
+	if !keys.Cells {
 		return fmt.Errorf("required key 'cells' is missing")
 	}
 
@@ -7810,16 +8625,21 @@ type SelectedCompletionInfo struct {
 }
 
 func (s *SelectedCompletionInfo) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Range requiredProp `json:"range"`
+		Text  requiredProp `json:"text"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["range"]; !ok {
+	if !keys.Range {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if _, ok := keys["text"]; !ok {
+	if !keys.Text {
 		return fmt.Errorf("required key 'text' is missing")
 	}
 
@@ -7846,13 +8666,17 @@ type ClientInfo struct {
 }
 
 func (s *ClientInfo) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Name requiredProp `json:"name"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["name"]; !ok {
+	if !keys.Name {
 		return fmt.Errorf("required key 'name' is missing")
 	}
 
@@ -7949,16 +8773,21 @@ type TextDocumentContentChangePartial struct {
 }
 
 func (s *TextDocumentContentChangePartial) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Range requiredProp `json:"range"`
+		Text  requiredProp `json:"text"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["range"]; !ok {
+	if !keys.Range {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if _, ok := keys["text"]; !ok {
+	if !keys.Text {
 		return fmt.Errorf("required key 'text' is missing")
 	}
 
@@ -7979,13 +8808,17 @@ type TextDocumentContentChangeWholeDocument struct {
 }
 
 func (s *TextDocumentContentChangeWholeDocument) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Text requiredProp `json:"text"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["text"]; !ok {
+	if !keys.Text {
 		return fmt.Errorf("required key 'text' is missing")
 	}
 
@@ -8006,13 +8839,17 @@ type CodeDescription struct {
 }
 
 func (s *CodeDescription) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Href requiredProp `json:"href"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["href"]; !ok {
+	if !keys.Href {
 		return fmt.Errorf("required key 'href' is missing")
 	}
 
@@ -8036,16 +8873,21 @@ type DiagnosticRelatedInformation struct {
 }
 
 func (s *DiagnosticRelatedInformation) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Location requiredProp `json:"location"`
+		Message  requiredProp `json:"message"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["location"]; !ok {
+	if !keys.Location {
 		return fmt.Errorf("required key 'location' is missing")
 	}
-	if _, ok := keys["message"]; !ok {
+	if !keys.Message {
 		return fmt.Errorf("required key 'message' is missing")
 	}
 
@@ -8068,16 +8910,21 @@ type EditRangeWithInsertReplace struct {
 }
 
 func (s *EditRangeWithInsertReplace) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Insert  requiredProp `json:"insert"`
+		Replace requiredProp `json:"replace"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["insert"]; !ok {
+	if !keys.Insert {
 		return fmt.Errorf("required key 'insert' is missing")
 	}
-	if _, ok := keys["replace"]; !ok {
+	if !keys.Replace {
 		return fmt.Errorf("required key 'replace' is missing")
 	}
 
@@ -8110,16 +8957,21 @@ type MarkedStringWithLanguage struct {
 }
 
 func (s *MarkedStringWithLanguage) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Language requiredProp `json:"language"`
+		Value    requiredProp `json:"value"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["language"]; !ok {
+	if !keys.Language {
 		return fmt.Errorf("required key 'language' is missing")
 	}
-	if _, ok := keys["value"]; !ok {
+	if !keys.Value {
 		return fmt.Errorf("required key 'value' is missing")
 	}
 
@@ -8155,13 +9007,17 @@ type ParameterInformation struct {
 }
 
 func (s *ParameterInformation) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Label requiredProp `json:"label"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["label"]; !ok {
+	if !keys.Label {
 		return fmt.Errorf("required key 'label' is missing")
 	}
 
@@ -8194,16 +9050,21 @@ type CodeActionKindDocumentation struct {
 }
 
 func (s *CodeActionKindDocumentation) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Kind    requiredProp `json:"kind"`
+		Command requiredProp `json:"command"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["kind"]; !ok {
+	if !keys.Kind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if _, ok := keys["command"]; !ok {
+	if !keys.Command {
 		return fmt.Errorf("required key 'command' is missing")
 	}
 
@@ -8235,13 +9096,17 @@ type NotebookCellTextDocumentFilter struct {
 }
 
 func (s *NotebookCellTextDocumentFilter) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Notebook requiredProp `json:"notebook"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["notebook"]; !ok {
+	if !keys.Notebook {
 		return fmt.Errorf("required key 'notebook' is missing")
 	}
 
@@ -8274,13 +9139,17 @@ type ExecutionSummary struct {
 }
 
 func (s *ExecutionSummary) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		ExecutionOrder requiredProp `json:"executionOrder"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["executionOrder"]; !ok {
+	if !keys.ExecutionOrder {
 		return fmt.Errorf("required key 'executionOrder' is missing")
 	}
 
@@ -8299,13 +9168,17 @@ type NotebookCellLanguage struct {
 }
 
 func (s *NotebookCellLanguage) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Language requiredProp `json:"language"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["language"]; !ok {
+	if !keys.Language {
 		return fmt.Errorf("required key 'language' is missing")
 	}
 
@@ -8332,13 +9205,17 @@ type NotebookDocumentCellChangeStructure struct {
 }
 
 func (s *NotebookDocumentCellChangeStructure) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Array requiredProp `json:"array"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["array"]; !ok {
+	if !keys.Array {
 		return fmt.Errorf("required key 'array' is missing")
 	}
 
@@ -8362,16 +9239,21 @@ type NotebookDocumentCellContentChanges struct {
 }
 
 func (s *NotebookDocumentCellContentChanges) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Document requiredProp `json:"document"`
+		Changes  requiredProp `json:"changes"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["document"]; !ok {
+	if !keys.Document {
 		return fmt.Errorf("required key 'document' is missing")
 	}
-	if _, ok := keys["changes"]; !ok {
+	if !keys.Changes {
 		return fmt.Errorf("required key 'changes' is missing")
 	}
 
@@ -8611,13 +9493,17 @@ type NotebookDocumentClientCapabilities struct {
 }
 
 func (s *NotebookDocumentClientCapabilities) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Synchronization requiredProp `json:"synchronization"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["synchronization"]; !ok {
+	if !keys.Synchronization {
 		return fmt.Errorf("required key 'synchronization' is missing")
 	}
 
@@ -8747,16 +9633,21 @@ type RelativePattern struct {
 }
 
 func (s *RelativePattern) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		BaseUri requiredProp `json:"baseUri"`
+		Pattern requiredProp `json:"pattern"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["baseUri"]; !ok {
+	if !keys.BaseUri {
 		return fmt.Errorf("required key 'baseUri' is missing")
 	}
-	if _, ok := keys["pattern"]; !ok {
+	if !keys.Pattern {
 		return fmt.Errorf("required key 'pattern' is missing")
 	}
 
@@ -8788,13 +9679,17 @@ type TextDocumentFilterLanguage struct {
 }
 
 func (s *TextDocumentFilterLanguage) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Language requiredProp `json:"language"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["language"]; !ok {
+	if !keys.Language {
 		return fmt.Errorf("required key 'language' is missing")
 	}
 
@@ -8827,13 +9722,17 @@ type TextDocumentFilterScheme struct {
 }
 
 func (s *TextDocumentFilterScheme) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Scheme requiredProp `json:"scheme"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["scheme"]; !ok {
+	if !keys.Scheme {
 		return fmt.Errorf("required key 'scheme' is missing")
 	}
 
@@ -8866,13 +9765,17 @@ type TextDocumentFilterPattern struct {
 }
 
 func (s *TextDocumentFilterPattern) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Pattern requiredProp `json:"pattern"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["pattern"]; !ok {
+	if !keys.Pattern {
 		return fmt.Errorf("required key 'pattern' is missing")
 	}
 
@@ -8901,13 +9804,17 @@ type NotebookDocumentFilterNotebookType struct {
 }
 
 func (s *NotebookDocumentFilterNotebookType) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		NotebookType requiredProp `json:"notebookType"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["notebookType"]; !ok {
+	if !keys.NotebookType {
 		return fmt.Errorf("required key 'notebookType' is missing")
 	}
 
@@ -8936,13 +9843,17 @@ type NotebookDocumentFilterScheme struct {
 }
 
 func (s *NotebookDocumentFilterScheme) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Scheme requiredProp `json:"scheme"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["scheme"]; !ok {
+	if !keys.Scheme {
 		return fmt.Errorf("required key 'scheme' is missing")
 	}
 
@@ -8971,13 +9882,17 @@ type NotebookDocumentFilterPattern struct {
 }
 
 func (s *NotebookDocumentFilterPattern) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Pattern requiredProp `json:"pattern"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["pattern"]; !ok {
+	if !keys.Pattern {
 		return fmt.Errorf("required key 'pattern' is missing")
 	}
 
@@ -9007,16 +9922,21 @@ type NotebookCellArrayChange struct {
 }
 
 func (s *NotebookCellArrayChange) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Start       requiredProp `json:"start"`
+		DeleteCount requiredProp `json:"deleteCount"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["start"]; !ok {
+	if !keys.Start {
 		return fmt.Errorf("required key 'start' is missing")
 	}
-	if _, ok := keys["deleteCount"]; !ok {
+	if !keys.DeleteCount {
 		return fmt.Errorf("required key 'deleteCount' is missing")
 	}
 
@@ -9662,22 +10582,29 @@ type SemanticTokensClientCapabilities struct {
 }
 
 func (s *SemanticTokensClientCapabilities) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Requests       requiredProp `json:"requests"`
+		TokenTypes     requiredProp `json:"tokenTypes"`
+		TokenModifiers requiredProp `json:"tokenModifiers"`
+		Formats        requiredProp `json:"formats"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["requests"]; !ok {
+	if !keys.Requests {
 		return fmt.Errorf("required key 'requests' is missing")
 	}
-	if _, ok := keys["tokenTypes"]; !ok {
+	if !keys.TokenTypes {
 		return fmt.Errorf("required key 'tokenTypes' is missing")
 	}
-	if _, ok := keys["tokenModifiers"]; !ok {
+	if !keys.TokenModifiers {
 		return fmt.Errorf("required key 'tokenModifiers' is missing")
 	}
-	if _, ok := keys["formats"]; !ok {
+	if !keys.Formats {
 		return fmt.Errorf("required key 'formats' is missing")
 	}
 
@@ -9800,13 +10727,17 @@ type ShowDocumentClientCapabilities struct {
 }
 
 func (s *ShowDocumentClientCapabilities) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Support requiredProp `json:"support"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["support"]; !ok {
+	if !keys.Support {
 		return fmt.Errorf("required key 'support' is missing")
 	}
 
@@ -9830,16 +10761,21 @@ type StaleRequestSupportOptions struct {
 }
 
 func (s *StaleRequestSupportOptions) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Cancel                 requiredProp `json:"cancel"`
+		RetryOnContentModified requiredProp `json:"retryOnContentModified"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["cancel"]; !ok {
+	if !keys.Cancel {
 		return fmt.Errorf("required key 'cancel' is missing")
 	}
-	if _, ok := keys["retryOnContentModified"]; !ok {
+	if !keys.RetryOnContentModified {
 		return fmt.Errorf("required key 'retryOnContentModified' is missing")
 	}
 
@@ -9864,13 +10800,17 @@ type RegularExpressionsClientCapabilities struct {
 }
 
 func (s *RegularExpressionsClientCapabilities) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Engine requiredProp `json:"engine"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["engine"]; !ok {
+	if !keys.Engine {
 		return fmt.Errorf("required key 'engine' is missing")
 	}
 
@@ -9901,13 +10841,17 @@ type MarkdownClientCapabilities struct {
 }
 
 func (s *MarkdownClientCapabilities) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Parser requiredProp `json:"parser"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["parser"]; !ok {
+	if !keys.Parser {
 		return fmt.Errorf("required key 'parser' is missing")
 	}
 
@@ -9949,13 +10893,17 @@ type ClientSymbolTagOptions struct {
 }
 
 func (s *ClientSymbolTagOptions) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		ValueSet requiredProp `json:"valueSet"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["valueSet"]; !ok {
+	if !keys.ValueSet {
 		return fmt.Errorf("required key 'valueSet' is missing")
 	}
 
@@ -9975,13 +10923,17 @@ type ClientSymbolResolveOptions struct {
 }
 
 func (s *ClientSymbolResolveOptions) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Properties requiredProp `json:"properties"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["properties"]; !ok {
+	if !keys.Properties {
 		return fmt.Errorf("required key 'properties' is missing")
 	}
 
@@ -10126,13 +11078,17 @@ type ClientCodeActionLiteralOptions struct {
 }
 
 func (s *ClientCodeActionLiteralOptions) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		CodeActionKind requiredProp `json:"codeActionKind"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["codeActionKind"]; !ok {
+	if !keys.CodeActionKind {
 		return fmt.Errorf("required key 'codeActionKind' is missing")
 	}
 
@@ -10151,13 +11107,17 @@ type ClientCodeActionResolveOptions struct {
 }
 
 func (s *ClientCodeActionResolveOptions) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Properties requiredProp `json:"properties"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["properties"]; !ok {
+	if !keys.Properties {
 		return fmt.Errorf("required key 'properties' is missing")
 	}
 
@@ -10176,13 +11136,17 @@ type CodeActionTagOptions struct {
 }
 
 func (s *CodeActionTagOptions) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		ValueSet requiredProp `json:"valueSet"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["valueSet"]; !ok {
+	if !keys.ValueSet {
 		return fmt.Errorf("required key 'valueSet' is missing")
 	}
 
@@ -10201,13 +11165,17 @@ type ClientCodeLensResolveOptions struct {
 }
 
 func (s *ClientCodeLensResolveOptions) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Properties requiredProp `json:"properties"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["properties"]; !ok {
+	if !keys.Properties {
 		return fmt.Errorf("required key 'properties' is missing")
 	}
 
@@ -10279,13 +11247,17 @@ type ClientInlayHintResolveOptions struct {
 }
 
 func (s *ClientInlayHintResolveOptions) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Properties requiredProp `json:"properties"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["properties"]; !ok {
+	if !keys.Properties {
 		return fmt.Errorf("required key 'properties' is missing")
 	}
 
@@ -10312,13 +11284,17 @@ type CompletionItemTagOptions struct {
 }
 
 func (s *CompletionItemTagOptions) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		ValueSet requiredProp `json:"valueSet"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["valueSet"]; !ok {
+	if !keys.ValueSet {
 		return fmt.Errorf("required key 'valueSet' is missing")
 	}
 
@@ -10337,13 +11313,17 @@ type ClientCompletionItemResolveOptions struct {
 }
 
 func (s *ClientCompletionItemResolveOptions) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		Properties requiredProp `json:"properties"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["properties"]; !ok {
+	if !keys.Properties {
 		return fmt.Errorf("required key 'properties' is missing")
 	}
 
@@ -10361,13 +11341,17 @@ type ClientCompletionItemInsertTextModeOptions struct {
 }
 
 func (s *ClientCompletionItemInsertTextModeOptions) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		ValueSet requiredProp `json:"valueSet"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["valueSet"]; !ok {
+	if !keys.ValueSet {
 		return fmt.Errorf("required key 'valueSet' is missing")
 	}
 
@@ -10398,13 +11382,17 @@ type ClientCodeActionKindOptions struct {
 }
 
 func (s *ClientCodeActionKindOptions) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		ValueSet requiredProp `json:"valueSet"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["valueSet"]; !ok {
+	if !keys.ValueSet {
 		return fmt.Errorf("required key 'valueSet' is missing")
 	}
 
@@ -10423,13 +11411,17 @@ type ClientDiagnosticsTagOptions struct {
 }
 
 func (s *ClientDiagnosticsTagOptions) UnmarshalJSON(data []byte) error {
-	// Check required keys
-	keys, err := getJSONKeys(data)
-	if err != nil {
+	// Check required props
+	type requiredProps struct {
+		ValueSet requiredProp `json:"valueSet"`
+	}
+
+	var keys requiredProps
+	if err := json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
 
-	if _, ok := keys["valueSet"]; !ok {
+	if !keys.ValueSet {
 		return fmt.Errorf("required key 'valueSet' is missing")
 	}
 

--- a/internal/lsp/lsproto/lsp_generated.go
+++ b/internal/lsp/lsproto/lsp_generated.go
@@ -25,6 +25,25 @@ type Location struct {
 	Range Range `json:"range"`
 }
 
+func (s *Location) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["uri"]; !ok {
+		return fmt.Errorf("required key 'uri' is missing")
+	}
+	if _, ok := keys["range"]; !ok {
+		return fmt.Errorf("required key 'range' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type LocationAlias Location
+	return json.Unmarshal(data, (*LocationAlias)(s))
+}
+
 type ImplementationRegistrationOptions struct {
 	TextDocumentRegistrationOptions
 	ImplementationOptions
@@ -53,15 +72,66 @@ type WorkspaceFolder struct {
 	Name string `json:"name"`
 }
 
+func (s *WorkspaceFolder) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["uri"]; !ok {
+		return fmt.Errorf("required key 'uri' is missing")
+	}
+	if _, ok := keys["name"]; !ok {
+		return fmt.Errorf("required key 'name' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type WorkspaceFolderAlias WorkspaceFolder
+	return json.Unmarshal(data, (*WorkspaceFolderAlias)(s))
+}
+
 // The parameters of a `workspace/didChangeWorkspaceFolders` notification.
 type DidChangeWorkspaceFoldersParams struct {
 	// The actual workspace folder change event.
 	Event *WorkspaceFoldersChangeEvent `json:"event"`
 }
 
+func (s *DidChangeWorkspaceFoldersParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["event"]; !ok {
+		return fmt.Errorf("required key 'event' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DidChangeWorkspaceFoldersParamsAlias DidChangeWorkspaceFoldersParams
+	return json.Unmarshal(data, (*DidChangeWorkspaceFoldersParamsAlias)(s))
+}
+
 // The parameters of a configuration request.
 type ConfigurationParams struct {
 	Items []*ConfigurationItem `json:"items"`
+}
+
+func (s *ConfigurationParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["items"]; !ok {
+		return fmt.Errorf("required key 'items' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ConfigurationParamsAlias ConfigurationParams
+	return json.Unmarshal(data, (*ConfigurationParamsAlias)(s))
 }
 
 // Parameters for a DocumentColorRequest.
@@ -73,6 +143,22 @@ type DocumentColorParams struct {
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 }
 
+func (s *DocumentColorParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["textDocument"]; !ok {
+		return fmt.Errorf("required key 'textDocument' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DocumentColorParamsAlias DocumentColorParams
+	return json.Unmarshal(data, (*DocumentColorParamsAlias)(s))
+}
+
 // Represents a color range from a document.
 type ColorInformation struct {
 	// The range in the document where this color appears.
@@ -80,6 +166,25 @@ type ColorInformation struct {
 
 	// The actual color value for this color range.
 	Color Color `json:"color"`
+}
+
+func (s *ColorInformation) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["range"]; !ok {
+		return fmt.Errorf("required key 'range' is missing")
+	}
+	if _, ok := keys["color"]; !ok {
+		return fmt.Errorf("required key 'color' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ColorInformationAlias ColorInformation
+	return json.Unmarshal(data, (*ColorInformationAlias)(s))
 }
 
 type DocumentColorRegistrationOptions struct {
@@ -103,6 +208,28 @@ type ColorPresentationParams struct {
 	Range Range `json:"range"`
 }
 
+func (s *ColorPresentationParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["textDocument"]; !ok {
+		return fmt.Errorf("required key 'textDocument' is missing")
+	}
+	if _, ok := keys["color"]; !ok {
+		return fmt.Errorf("required key 'color' is missing")
+	}
+	if _, ok := keys["range"]; !ok {
+		return fmt.Errorf("required key 'range' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ColorPresentationParamsAlias ColorPresentationParams
+	return json.Unmarshal(data, (*ColorPresentationParamsAlias)(s))
+}
+
 type ColorPresentation struct {
 	// The label of this color presentation. It will be shown on the color
 	// picker header. By default this is also the text that is inserted when selecting
@@ -119,6 +246,22 @@ type ColorPresentation struct {
 	AdditionalTextEdits *[]*TextEdit `json:"additionalTextEdits,omitempty"`
 }
 
+func (s *ColorPresentation) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["label"]; !ok {
+		return fmt.Errorf("required key 'label' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ColorPresentationAlias ColorPresentation
+	return json.Unmarshal(data, (*ColorPresentationAlias)(s))
+}
+
 type WorkDoneProgressOptions struct {
 	WorkDoneProgress *bool `json:"workDoneProgress,omitempty"`
 }
@@ -130,6 +273,22 @@ type TextDocumentRegistrationOptions struct {
 	DocumentSelector Nullable[DocumentSelector] `json:"documentSelector"`
 }
 
+func (s *TextDocumentRegistrationOptions) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["documentSelector"]; !ok {
+		return fmt.Errorf("required key 'documentSelector' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type TextDocumentRegistrationOptionsAlias TextDocumentRegistrationOptions
+	return json.Unmarshal(data, (*TextDocumentRegistrationOptionsAlias)(s))
+}
+
 // Parameters for a FoldingRangeRequest.
 type FoldingRangeParams struct {
 	WorkDoneProgressParams
@@ -137,6 +296,22 @@ type FoldingRangeParams struct {
 
 	// The text document.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
+}
+
+func (s *FoldingRangeParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["textDocument"]; !ok {
+		return fmt.Errorf("required key 'textDocument' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type FoldingRangeParamsAlias FoldingRangeParams
+	return json.Unmarshal(data, (*FoldingRangeParamsAlias)(s))
 }
 
 // Represents a folding range. To be valid, start and end line must be bigger than zero and smaller
@@ -169,6 +344,25 @@ type FoldingRange struct {
 	CollapsedText *string `json:"collapsedText,omitempty"`
 }
 
+func (s *FoldingRange) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["startLine"]; !ok {
+		return fmt.Errorf("required key 'startLine' is missing")
+	}
+	if _, ok := keys["endLine"]; !ok {
+		return fmt.Errorf("required key 'endLine' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type FoldingRangeAlias FoldingRange
+	return json.Unmarshal(data, (*FoldingRangeAlias)(s))
+}
+
 type FoldingRangeRegistrationOptions struct {
 	TextDocumentRegistrationOptions
 	FoldingRangeOptions
@@ -199,6 +393,25 @@ type SelectionRangeParams struct {
 	Positions []Position `json:"positions"`
 }
 
+func (s *SelectionRangeParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["textDocument"]; !ok {
+		return fmt.Errorf("required key 'textDocument' is missing")
+	}
+	if _, ok := keys["positions"]; !ok {
+		return fmt.Errorf("required key 'positions' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type SelectionRangeParamsAlias SelectionRangeParams
+	return json.Unmarshal(data, (*SelectionRangeParamsAlias)(s))
+}
+
 // A selection range represents a part of a selection hierarchy. A selection range
 // may have a parent selection range that contains it.
 type SelectionRange struct {
@@ -207,6 +420,22 @@ type SelectionRange struct {
 
 	// The parent selection range containing this range. Therefore `parent.range` must contain `this.range`.
 	Parent *SelectionRange `json:"parent,omitempty"`
+}
+
+func (s *SelectionRange) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["range"]; !ok {
+		return fmt.Errorf("required key 'range' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type SelectionRangeAlias SelectionRange
+	return json.Unmarshal(data, (*SelectionRangeAlias)(s))
 }
 
 type SelectionRangeRegistrationOptions struct {
@@ -220,9 +449,41 @@ type WorkDoneProgressCreateParams struct {
 	Token ProgressToken `json:"token"`
 }
 
+func (s *WorkDoneProgressCreateParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["token"]; !ok {
+		return fmt.Errorf("required key 'token' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type WorkDoneProgressCreateParamsAlias WorkDoneProgressCreateParams
+	return json.Unmarshal(data, (*WorkDoneProgressCreateParamsAlias)(s))
+}
+
 type WorkDoneProgressCancelParams struct {
 	// The token to be used to report progress.
 	Token ProgressToken `json:"token"`
+}
+
+func (s *WorkDoneProgressCancelParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["token"]; !ok {
+		return fmt.Errorf("required key 'token' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type WorkDoneProgressCancelParamsAlias WorkDoneProgressCancelParams
+	return json.Unmarshal(data, (*WorkDoneProgressCancelParamsAlias)(s))
 }
 
 // The parameter of a `textDocument/prepareCallHierarchy` request.
@@ -265,6 +526,34 @@ type CallHierarchyItem struct {
 	Data *any `json:"data,omitempty"`
 }
 
+func (s *CallHierarchyItem) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["name"]; !ok {
+		return fmt.Errorf("required key 'name' is missing")
+	}
+	if _, ok := keys["kind"]; !ok {
+		return fmt.Errorf("required key 'kind' is missing")
+	}
+	if _, ok := keys["uri"]; !ok {
+		return fmt.Errorf("required key 'uri' is missing")
+	}
+	if _, ok := keys["range"]; !ok {
+		return fmt.Errorf("required key 'range' is missing")
+	}
+	if _, ok := keys["selectionRange"]; !ok {
+		return fmt.Errorf("required key 'selectionRange' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type CallHierarchyItemAlias CallHierarchyItem
+	return json.Unmarshal(data, (*CallHierarchyItemAlias)(s))
+}
+
 // Call hierarchy options used during static or dynamic registration.
 //
 // Since: 3.16.0
@@ -284,6 +573,22 @@ type CallHierarchyIncomingCallsParams struct {
 	Item *CallHierarchyItem `json:"item"`
 }
 
+func (s *CallHierarchyIncomingCallsParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["item"]; !ok {
+		return fmt.Errorf("required key 'item' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type CallHierarchyIncomingCallsParamsAlias CallHierarchyIncomingCallsParams
+	return json.Unmarshal(data, (*CallHierarchyIncomingCallsParamsAlias)(s))
+}
+
 // Represents an incoming call, e.g. a caller of a method or constructor.
 //
 // Since: 3.16.0
@@ -296,6 +601,25 @@ type CallHierarchyIncomingCall struct {
 	FromRanges []Range `json:"fromRanges"`
 }
 
+func (s *CallHierarchyIncomingCall) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["from"]; !ok {
+		return fmt.Errorf("required key 'from' is missing")
+	}
+	if _, ok := keys["fromRanges"]; !ok {
+		return fmt.Errorf("required key 'fromRanges' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type CallHierarchyIncomingCallAlias CallHierarchyIncomingCall
+	return json.Unmarshal(data, (*CallHierarchyIncomingCallAlias)(s))
+}
+
 // The parameter of a `callHierarchy/outgoingCalls` request.
 //
 // Since: 3.16.0
@@ -304,6 +628,22 @@ type CallHierarchyOutgoingCallsParams struct {
 	PartialResultParams
 
 	Item *CallHierarchyItem `json:"item"`
+}
+
+func (s *CallHierarchyOutgoingCallsParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["item"]; !ok {
+		return fmt.Errorf("required key 'item' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type CallHierarchyOutgoingCallsParamsAlias CallHierarchyOutgoingCallsParams
+	return json.Unmarshal(data, (*CallHierarchyOutgoingCallsParamsAlias)(s))
 }
 
 // Represents an outgoing call, e.g. calling a getter from a method or a method from a constructor etc.
@@ -319,6 +659,25 @@ type CallHierarchyOutgoingCall struct {
 	FromRanges []Range `json:"fromRanges"`
 }
 
+func (s *CallHierarchyOutgoingCall) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["to"]; !ok {
+		return fmt.Errorf("required key 'to' is missing")
+	}
+	if _, ok := keys["fromRanges"]; !ok {
+		return fmt.Errorf("required key 'fromRanges' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type CallHierarchyOutgoingCallAlias CallHierarchyOutgoingCall
+	return json.Unmarshal(data, (*CallHierarchyOutgoingCallAlias)(s))
+}
+
 // Since: 3.16.0
 type SemanticTokensParams struct {
 	WorkDoneProgressParams
@@ -326,6 +685,22 @@ type SemanticTokensParams struct {
 
 	// The text document.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
+}
+
+func (s *SemanticTokensParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["textDocument"]; !ok {
+		return fmt.Errorf("required key 'textDocument' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type SemanticTokensParamsAlias SemanticTokensParams
+	return json.Unmarshal(data, (*SemanticTokensParamsAlias)(s))
 }
 
 // Since: 3.16.0
@@ -340,9 +715,41 @@ type SemanticTokens struct {
 	Data []uint32 `json:"data"`
 }
 
+func (s *SemanticTokens) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["data"]; !ok {
+		return fmt.Errorf("required key 'data' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type SemanticTokensAlias SemanticTokens
+	return json.Unmarshal(data, (*SemanticTokensAlias)(s))
+}
+
 // Since: 3.16.0
 type SemanticTokensPartialResult struct {
 	Data []uint32 `json:"data"`
+}
+
+func (s *SemanticTokensPartialResult) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["data"]; !ok {
+		return fmt.Errorf("required key 'data' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type SemanticTokensPartialResultAlias SemanticTokensPartialResult
+	return json.Unmarshal(data, (*SemanticTokensPartialResultAlias)(s))
 }
 
 // Since: 3.16.0
@@ -365,6 +772,25 @@ type SemanticTokensDeltaParams struct {
 	PreviousResultId string `json:"previousResultId"`
 }
 
+func (s *SemanticTokensDeltaParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["textDocument"]; !ok {
+		return fmt.Errorf("required key 'textDocument' is missing")
+	}
+	if _, ok := keys["previousResultId"]; !ok {
+		return fmt.Errorf("required key 'previousResultId' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type SemanticTokensDeltaParamsAlias SemanticTokensDeltaParams
+	return json.Unmarshal(data, (*SemanticTokensDeltaParamsAlias)(s))
+}
+
 // Since: 3.16.0
 type SemanticTokensDelta struct {
 	ResultId *string `json:"resultId,omitempty"`
@@ -373,9 +799,41 @@ type SemanticTokensDelta struct {
 	Edits []*SemanticTokensEdit `json:"edits"`
 }
 
+func (s *SemanticTokensDelta) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["edits"]; !ok {
+		return fmt.Errorf("required key 'edits' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type SemanticTokensDeltaAlias SemanticTokensDelta
+	return json.Unmarshal(data, (*SemanticTokensDeltaAlias)(s))
+}
+
 // Since: 3.16.0
 type SemanticTokensDeltaPartialResult struct {
 	Edits []*SemanticTokensEdit `json:"edits"`
+}
+
+func (s *SemanticTokensDeltaPartialResult) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["edits"]; !ok {
+		return fmt.Errorf("required key 'edits' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type SemanticTokensDeltaPartialResultAlias SemanticTokensDeltaPartialResult
+	return json.Unmarshal(data, (*SemanticTokensDeltaPartialResultAlias)(s))
 }
 
 // Since: 3.16.0
@@ -388,6 +846,25 @@ type SemanticTokensRangeParams struct {
 
 	// The range the semantic tokens are requested for.
 	Range Range `json:"range"`
+}
+
+func (s *SemanticTokensRangeParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["textDocument"]; !ok {
+		return fmt.Errorf("required key 'textDocument' is missing")
+	}
+	if _, ok := keys["range"]; !ok {
+		return fmt.Errorf("required key 'range' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type SemanticTokensRangeParamsAlias SemanticTokensRangeParams
+	return json.Unmarshal(data, (*SemanticTokensRangeParamsAlias)(s))
 }
 
 // Params to show a resource in the UI.
@@ -415,12 +892,44 @@ type ShowDocumentParams struct {
 	Selection *Range `json:"selection,omitempty"`
 }
 
+func (s *ShowDocumentParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["uri"]; !ok {
+		return fmt.Errorf("required key 'uri' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ShowDocumentParamsAlias ShowDocumentParams
+	return json.Unmarshal(data, (*ShowDocumentParamsAlias)(s))
+}
+
 // The result of a showDocument request.
 //
 // Since: 3.16.0
 type ShowDocumentResult struct {
 	// A boolean indicating if the show was successful.
 	Success bool `json:"success"`
+}
+
+func (s *ShowDocumentResult) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["success"]; !ok {
+		return fmt.Errorf("required key 'success' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ShowDocumentResultAlias ShowDocumentResult
+	return json.Unmarshal(data, (*ShowDocumentResultAlias)(s))
 }
 
 type LinkedEditingRangeParams struct {
@@ -442,6 +951,22 @@ type LinkedEditingRanges struct {
 	WordPattern *string `json:"wordPattern,omitempty"`
 }
 
+func (s *LinkedEditingRanges) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["ranges"]; !ok {
+		return fmt.Errorf("required key 'ranges' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type LinkedEditingRangesAlias LinkedEditingRanges
+	return json.Unmarshal(data, (*LinkedEditingRangesAlias)(s))
+}
+
 type LinkedEditingRangeRegistrationOptions struct {
 	TextDocumentRegistrationOptions
 	LinkedEditingRangeOptions
@@ -455,6 +980,22 @@ type LinkedEditingRangeRegistrationOptions struct {
 type CreateFilesParams struct {
 	// An array of all files/folders created in this operation.
 	Files []*FileCreate `json:"files"`
+}
+
+func (s *CreateFilesParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["files"]; !ok {
+		return fmt.Errorf("required key 'files' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type CreateFilesParamsAlias CreateFilesParams
+	return json.Unmarshal(data, (*CreateFilesParamsAlias)(s))
 }
 
 // A workspace edit represents changes to many resources managed in the workspace. The edit
@@ -502,6 +1043,22 @@ type FileOperationRegistrationOptions struct {
 	Filters []*FileOperationFilter `json:"filters"`
 }
 
+func (s *FileOperationRegistrationOptions) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["filters"]; !ok {
+		return fmt.Errorf("required key 'filters' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type FileOperationRegistrationOptionsAlias FileOperationRegistrationOptions
+	return json.Unmarshal(data, (*FileOperationRegistrationOptionsAlias)(s))
+}
+
 // The parameters sent in notifications/requests for user-initiated renames of
 // files.
 //
@@ -512,6 +1069,22 @@ type RenameFilesParams struct {
 	Files []*FileRename `json:"files"`
 }
 
+func (s *RenameFilesParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["files"]; !ok {
+		return fmt.Errorf("required key 'files' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type RenameFilesParamsAlias RenameFilesParams
+	return json.Unmarshal(data, (*RenameFilesParamsAlias)(s))
+}
+
 // The parameters sent in notifications/requests for user-initiated deletes of
 // files.
 //
@@ -519,6 +1092,22 @@ type RenameFilesParams struct {
 type DeleteFilesParams struct {
 	// An array of all files/folders deleted in this operation.
 	Files []*FileDelete `json:"files"`
+}
+
+func (s *DeleteFilesParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["files"]; !ok {
+		return fmt.Errorf("required key 'files' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DeleteFilesParamsAlias DeleteFilesParams
+	return json.Unmarshal(data, (*DeleteFilesParamsAlias)(s))
 }
 
 type MonikerParams struct {
@@ -543,6 +1132,28 @@ type Moniker struct {
 
 	// The moniker kind if known.
 	Kind *MonikerKind `json:"kind,omitempty"`
+}
+
+func (s *Moniker) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["scheme"]; !ok {
+		return fmt.Errorf("required key 'scheme' is missing")
+	}
+	if _, ok := keys["identifier"]; !ok {
+		return fmt.Errorf("required key 'identifier' is missing")
+	}
+	if _, ok := keys["unique"]; !ok {
+		return fmt.Errorf("required key 'unique' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type MonikerAlias Moniker
+	return json.Unmarshal(data, (*MonikerAlias)(s))
 }
 
 type MonikerRegistrationOptions struct {
@@ -591,6 +1202,34 @@ type TypeHierarchyItem struct {
 	Data *any `json:"data,omitempty"`
 }
 
+func (s *TypeHierarchyItem) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["name"]; !ok {
+		return fmt.Errorf("required key 'name' is missing")
+	}
+	if _, ok := keys["kind"]; !ok {
+		return fmt.Errorf("required key 'kind' is missing")
+	}
+	if _, ok := keys["uri"]; !ok {
+		return fmt.Errorf("required key 'uri' is missing")
+	}
+	if _, ok := keys["range"]; !ok {
+		return fmt.Errorf("required key 'range' is missing")
+	}
+	if _, ok := keys["selectionRange"]; !ok {
+		return fmt.Errorf("required key 'selectionRange' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type TypeHierarchyItemAlias TypeHierarchyItem
+	return json.Unmarshal(data, (*TypeHierarchyItemAlias)(s))
+}
+
 // Type hierarchy options used during static or dynamic registration.
 //
 // Since: 3.17.0
@@ -610,6 +1249,22 @@ type TypeHierarchySupertypesParams struct {
 	Item *TypeHierarchyItem `json:"item"`
 }
 
+func (s *TypeHierarchySupertypesParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["item"]; !ok {
+		return fmt.Errorf("required key 'item' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type TypeHierarchySupertypesParamsAlias TypeHierarchySupertypesParams
+	return json.Unmarshal(data, (*TypeHierarchySupertypesParamsAlias)(s))
+}
+
 // The parameter of a `typeHierarchy/subtypes` request.
 //
 // Since: 3.17.0
@@ -618,6 +1273,22 @@ type TypeHierarchySubtypesParams struct {
 	PartialResultParams
 
 	Item *TypeHierarchyItem `json:"item"`
+}
+
+func (s *TypeHierarchySubtypesParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["item"]; !ok {
+		return fmt.Errorf("required key 'item' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type TypeHierarchySubtypesParamsAlias TypeHierarchySubtypesParams
+	return json.Unmarshal(data, (*TypeHierarchySubtypesParamsAlias)(s))
 }
 
 // A parameter literal used in inline value requests.
@@ -635,6 +1306,28 @@ type InlineValueParams struct {
 	// Additional information about the context in which inline values were
 	// requested.
 	Context *InlineValueContext `json:"context"`
+}
+
+func (s *InlineValueParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["textDocument"]; !ok {
+		return fmt.Errorf("required key 'textDocument' is missing")
+	}
+	if _, ok := keys["range"]; !ok {
+		return fmt.Errorf("required key 'range' is missing")
+	}
+	if _, ok := keys["context"]; !ok {
+		return fmt.Errorf("required key 'context' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type InlineValueParamsAlias InlineValueParams
+	return json.Unmarshal(data, (*InlineValueParamsAlias)(s))
 }
 
 // Inline value options used during static or dynamic registration.
@@ -657,6 +1350,25 @@ type InlayHintParams struct {
 
 	// The document range for which inlay hints should be computed.
 	Range Range `json:"range"`
+}
+
+func (s *InlayHintParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["textDocument"]; !ok {
+		return fmt.Errorf("required key 'textDocument' is missing")
+	}
+	if _, ok := keys["range"]; !ok {
+		return fmt.Errorf("required key 'range' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type InlayHintParamsAlias InlayHintParams
+	return json.Unmarshal(data, (*InlayHintParamsAlias)(s))
 }
 
 // Inlay hint information.
@@ -708,6 +1420,25 @@ type InlayHint struct {
 	Data *any `json:"data,omitempty"`
 }
 
+func (s *InlayHint) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["position"]; !ok {
+		return fmt.Errorf("required key 'position' is missing")
+	}
+	if _, ok := keys["label"]; !ok {
+		return fmt.Errorf("required key 'label' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type InlayHintAlias InlayHint
+	return json.Unmarshal(data, (*InlayHintAlias)(s))
+}
+
 // Inlay hint options used during static or dynamic registration.
 //
 // Since: 3.17.0
@@ -734,6 +1465,22 @@ type DocumentDiagnosticParams struct {
 	PreviousResultId *string `json:"previousResultId,omitempty"`
 }
 
+func (s *DocumentDiagnosticParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["textDocument"]; !ok {
+		return fmt.Errorf("required key 'textDocument' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DocumentDiagnosticParamsAlias DocumentDiagnosticParams
+	return json.Unmarshal(data, (*DocumentDiagnosticParamsAlias)(s))
+}
+
 // A partial result for a document diagnostic report.
 //
 // Since: 3.17.0
@@ -741,11 +1488,43 @@ type DocumentDiagnosticReportPartialResult struct {
 	RelatedDocuments map[DocumentUri]FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport `json:"relatedDocuments"`
 }
 
+func (s *DocumentDiagnosticReportPartialResult) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["relatedDocuments"]; !ok {
+		return fmt.Errorf("required key 'relatedDocuments' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DocumentDiagnosticReportPartialResultAlias DocumentDiagnosticReportPartialResult
+	return json.Unmarshal(data, (*DocumentDiagnosticReportPartialResultAlias)(s))
+}
+
 // Cancellation data returned from a diagnostic request.
 //
 // Since: 3.17.0
 type DiagnosticServerCancellationData struct {
 	RetriggerRequest bool `json:"retriggerRequest"`
+}
+
+func (s *DiagnosticServerCancellationData) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["retriggerRequest"]; !ok {
+		return fmt.Errorf("required key 'retriggerRequest' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DiagnosticServerCancellationDataAlias DiagnosticServerCancellationData
+	return json.Unmarshal(data, (*DiagnosticServerCancellationDataAlias)(s))
 }
 
 // Diagnostic registration options.
@@ -772,6 +1551,22 @@ type WorkspaceDiagnosticParams struct {
 	PreviousResultIds []PreviousResultId `json:"previousResultIds"`
 }
 
+func (s *WorkspaceDiagnosticParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["previousResultIds"]; !ok {
+		return fmt.Errorf("required key 'previousResultIds' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type WorkspaceDiagnosticParamsAlias WorkspaceDiagnosticParams
+	return json.Unmarshal(data, (*WorkspaceDiagnosticParamsAlias)(s))
+}
+
 // A workspace diagnostic report.
 //
 // Since: 3.17.0
@@ -779,11 +1574,43 @@ type WorkspaceDiagnosticReport struct {
 	Items []WorkspaceDocumentDiagnosticReport `json:"items"`
 }
 
+func (s *WorkspaceDiagnosticReport) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["items"]; !ok {
+		return fmt.Errorf("required key 'items' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type WorkspaceDiagnosticReportAlias WorkspaceDiagnosticReport
+	return json.Unmarshal(data, (*WorkspaceDiagnosticReportAlias)(s))
+}
+
 // A partial result for a workspace diagnostic report.
 //
 // Since: 3.17.0
 type WorkspaceDiagnosticReportPartialResult struct {
 	Items []WorkspaceDocumentDiagnosticReport `json:"items"`
+}
+
+func (s *WorkspaceDiagnosticReportPartialResult) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["items"]; !ok {
+		return fmt.Errorf("required key 'items' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type WorkspaceDiagnosticReportPartialResultAlias WorkspaceDiagnosticReportPartialResult
+	return json.Unmarshal(data, (*WorkspaceDiagnosticReportPartialResultAlias)(s))
 }
 
 // The params sent in an open notebook document notification.
@@ -796,6 +1623,25 @@ type DidOpenNotebookDocumentParams struct {
 	// The text documents that represent the content
 	// of a notebook cell.
 	CellTextDocuments []*TextDocumentItem `json:"cellTextDocuments"`
+}
+
+func (s *DidOpenNotebookDocumentParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["notebookDocument"]; !ok {
+		return fmt.Errorf("required key 'notebookDocument' is missing")
+	}
+	if _, ok := keys["cellTextDocuments"]; !ok {
+		return fmt.Errorf("required key 'cellTextDocuments' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DidOpenNotebookDocumentParamsAlias DidOpenNotebookDocumentParams
+	return json.Unmarshal(data, (*DidOpenNotebookDocumentParamsAlias)(s))
 }
 
 // Registration options specific to a notebook.
@@ -832,12 +1678,47 @@ type DidChangeNotebookDocumentParams struct {
 	Change *NotebookDocumentChangeEvent `json:"change"`
 }
 
+func (s *DidChangeNotebookDocumentParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["notebookDocument"]; !ok {
+		return fmt.Errorf("required key 'notebookDocument' is missing")
+	}
+	if _, ok := keys["change"]; !ok {
+		return fmt.Errorf("required key 'change' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DidChangeNotebookDocumentParamsAlias DidChangeNotebookDocumentParams
+	return json.Unmarshal(data, (*DidChangeNotebookDocumentParamsAlias)(s))
+}
+
 // The params sent in a save notebook document notification.
 //
 // Since: 3.17.0
 type DidSaveNotebookDocumentParams struct {
 	// The notebook document that got saved.
 	NotebookDocument NotebookDocumentIdentifier `json:"notebookDocument"`
+}
+
+func (s *DidSaveNotebookDocumentParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["notebookDocument"]; !ok {
+		return fmt.Errorf("required key 'notebookDocument' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DidSaveNotebookDocumentParamsAlias DidSaveNotebookDocumentParams
+	return json.Unmarshal(data, (*DidSaveNotebookDocumentParamsAlias)(s))
 }
 
 // The params sent in a close notebook document notification.
@@ -850,6 +1731,25 @@ type DidCloseNotebookDocumentParams struct {
 	// The text documents that represent the content
 	// of a notebook cell that got closed.
 	CellTextDocuments []TextDocumentIdentifier `json:"cellTextDocuments"`
+}
+
+func (s *DidCloseNotebookDocumentParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["notebookDocument"]; !ok {
+		return fmt.Errorf("required key 'notebookDocument' is missing")
+	}
+	if _, ok := keys["cellTextDocuments"]; !ok {
+		return fmt.Errorf("required key 'cellTextDocuments' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DidCloseNotebookDocumentParamsAlias DidCloseNotebookDocumentParams
+	return json.Unmarshal(data, (*DidCloseNotebookDocumentParamsAlias)(s))
 }
 
 // A parameter literal used in inline completion requests.
@@ -866,6 +1766,22 @@ type InlineCompletionParams struct {
 	Context *InlineCompletionContext `json:"context"`
 }
 
+func (s *InlineCompletionParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["context"]; !ok {
+		return fmt.Errorf("required key 'context' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type InlineCompletionParamsAlias InlineCompletionParams
+	return json.Unmarshal(data, (*InlineCompletionParamsAlias)(s))
+}
+
 // Represents a collection of items to be presented in the editor.
 //
 // Since: 3.18.0
@@ -874,6 +1790,22 @@ type InlineCompletionParams struct {
 type InlineCompletionList struct {
 	// The inline completion items
 	Items []*InlineCompletionItem `json:"items"`
+}
+
+func (s *InlineCompletionList) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["items"]; !ok {
+		return fmt.Errorf("required key 'items' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type InlineCompletionListAlias InlineCompletionList
+	return json.Unmarshal(data, (*InlineCompletionListAlias)(s))
 }
 
 // An inline completion item represents a text snippet that is proposed inline to complete text that is being typed.
@@ -893,6 +1825,22 @@ type InlineCompletionItem struct {
 
 	// An optional Command that is executed *after* inserting this completion.
 	Command *Command `json:"command,omitempty"`
+}
+
+func (s *InlineCompletionItem) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["insertText"]; !ok {
+		return fmt.Errorf("required key 'insertText' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type InlineCompletionItemAlias InlineCompletionItem
+	return json.Unmarshal(data, (*InlineCompletionItemAlias)(s))
 }
 
 // Inline completion options used during static or dynamic registration.
@@ -916,6 +1864,22 @@ type TextDocumentContentParams struct {
 	Uri DocumentUri `json:"uri"`
 }
 
+func (s *TextDocumentContentParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["uri"]; !ok {
+		return fmt.Errorf("required key 'uri' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type TextDocumentContentParamsAlias TextDocumentContentParams
+	return json.Unmarshal(data, (*TextDocumentContentParamsAlias)(s))
+}
+
 // Result of the `workspace/textDocumentContent` request.
 //
 // Since: 3.18.0
@@ -927,6 +1891,22 @@ type TextDocumentContentResult struct {
 	// from the returned content due to whitespace and line ending
 	// normalizations done on the client
 	Text string `json:"text"`
+}
+
+func (s *TextDocumentContentResult) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["text"]; !ok {
+		return fmt.Errorf("required key 'text' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type TextDocumentContentResultAlias TextDocumentContentResult
+	return json.Unmarshal(data, (*TextDocumentContentResultAlias)(s))
 }
 
 // Text document content provider registration options.
@@ -949,12 +1929,60 @@ type TextDocumentContentRefreshParams struct {
 	Uri DocumentUri `json:"uri"`
 }
 
+func (s *TextDocumentContentRefreshParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["uri"]; !ok {
+		return fmt.Errorf("required key 'uri' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type TextDocumentContentRefreshParamsAlias TextDocumentContentRefreshParams
+	return json.Unmarshal(data, (*TextDocumentContentRefreshParamsAlias)(s))
+}
+
 type RegistrationParams struct {
 	Registrations []*Registration `json:"registrations"`
 }
 
+func (s *RegistrationParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["registrations"]; !ok {
+		return fmt.Errorf("required key 'registrations' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type RegistrationParamsAlias RegistrationParams
+	return json.Unmarshal(data, (*RegistrationParamsAlias)(s))
+}
+
 type UnregistrationParams struct {
 	Unregisterations []*Unregistration `json:"unregisterations"`
+}
+
+func (s *UnregistrationParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["unregisterations"]; !ok {
+		return fmt.Errorf("required key 'unregisterations' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type UnregistrationParamsAlias UnregistrationParams
+	return json.Unmarshal(data, (*UnregistrationParamsAlias)(s))
 }
 
 type InitializeParams struct {
@@ -973,6 +2001,22 @@ type InitializeResult struct {
 	ServerInfo *ServerInfo `json:"serverInfo,omitempty"`
 }
 
+func (s *InitializeResult) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["capabilities"]; !ok {
+		return fmt.Errorf("required key 'capabilities' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type InitializeResultAlias InitializeResult
+	return json.Unmarshal(data, (*InitializeResultAlias)(s))
+}
+
 // The data type of the ResponseError if the
 // initialize request fails.
 type InitializeError struct {
@@ -983,12 +2027,44 @@ type InitializeError struct {
 	Retry bool `json:"retry"`
 }
 
+func (s *InitializeError) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["retry"]; !ok {
+		return fmt.Errorf("required key 'retry' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type InitializeErrorAlias InitializeError
+	return json.Unmarshal(data, (*InitializeErrorAlias)(s))
+}
+
 type InitializedParams struct{}
 
 // The parameters of a change configuration notification.
 type DidChangeConfigurationParams struct {
 	// The actual changed settings
 	Settings any `json:"settings"`
+}
+
+func (s *DidChangeConfigurationParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["settings"]; !ok {
+		return fmt.Errorf("required key 'settings' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DidChangeConfigurationParamsAlias DidChangeConfigurationParams
+	return json.Unmarshal(data, (*DidChangeConfigurationParamsAlias)(s))
 }
 
 type DidChangeConfigurationRegistrationOptions struct {
@@ -1004,6 +2080,25 @@ type ShowMessageParams struct {
 	Message string `json:"message"`
 }
 
+func (s *ShowMessageParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["type"]; !ok {
+		return fmt.Errorf("required key 'type' is missing")
+	}
+	if _, ok := keys["message"]; !ok {
+		return fmt.Errorf("required key 'message' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ShowMessageParamsAlias ShowMessageParams
+	return json.Unmarshal(data, (*ShowMessageParamsAlias)(s))
+}
+
 type ShowMessageRequestParams struct {
 	// The message type. See MessageType
 	Type MessageType `json:"type"`
@@ -1015,9 +2110,44 @@ type ShowMessageRequestParams struct {
 	Actions *[]*MessageActionItem `json:"actions,omitempty"`
 }
 
+func (s *ShowMessageRequestParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["type"]; !ok {
+		return fmt.Errorf("required key 'type' is missing")
+	}
+	if _, ok := keys["message"]; !ok {
+		return fmt.Errorf("required key 'message' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ShowMessageRequestParamsAlias ShowMessageRequestParams
+	return json.Unmarshal(data, (*ShowMessageRequestParamsAlias)(s))
+}
+
 type MessageActionItem struct {
 	// A short title like 'Retry', 'Open Log' etc.
 	Title string `json:"title"`
+}
+
+func (s *MessageActionItem) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["title"]; !ok {
+		return fmt.Errorf("required key 'title' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type MessageActionItemAlias MessageActionItem
+	return json.Unmarshal(data, (*MessageActionItemAlias)(s))
 }
 
 // The log message parameters.
@@ -1029,10 +2159,45 @@ type LogMessageParams struct {
 	Message string `json:"message"`
 }
 
+func (s *LogMessageParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["type"]; !ok {
+		return fmt.Errorf("required key 'type' is missing")
+	}
+	if _, ok := keys["message"]; !ok {
+		return fmt.Errorf("required key 'message' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type LogMessageParamsAlias LogMessageParams
+	return json.Unmarshal(data, (*LogMessageParamsAlias)(s))
+}
+
 // The parameters sent in an open text document notification
 type DidOpenTextDocumentParams struct {
 	// The document that was opened.
 	TextDocument *TextDocumentItem `json:"textDocument"`
+}
+
+func (s *DidOpenTextDocumentParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["textDocument"]; !ok {
+		return fmt.Errorf("required key 'textDocument' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DidOpenTextDocumentParamsAlias DidOpenTextDocumentParams
+	return json.Unmarshal(data, (*DidOpenTextDocumentParamsAlias)(s))
 }
 
 // The change text document notification's parameters.
@@ -1056,6 +2221,25 @@ type DidChangeTextDocumentParams struct {
 	ContentChanges []TextDocumentContentChangeEvent `json:"contentChanges"`
 }
 
+func (s *DidChangeTextDocumentParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["textDocument"]; !ok {
+		return fmt.Errorf("required key 'textDocument' is missing")
+	}
+	if _, ok := keys["contentChanges"]; !ok {
+		return fmt.Errorf("required key 'contentChanges' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DidChangeTextDocumentParamsAlias DidChangeTextDocumentParams
+	return json.Unmarshal(data, (*DidChangeTextDocumentParamsAlias)(s))
+}
+
 // Describe options to be used when registered for text document change events.
 type TextDocumentChangeRegistrationOptions struct {
 	TextDocumentRegistrationOptions
@@ -1064,10 +2248,42 @@ type TextDocumentChangeRegistrationOptions struct {
 	SyncKind TextDocumentSyncKind `json:"syncKind"`
 }
 
+func (s *TextDocumentChangeRegistrationOptions) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["syncKind"]; !ok {
+		return fmt.Errorf("required key 'syncKind' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type TextDocumentChangeRegistrationOptionsAlias TextDocumentChangeRegistrationOptions
+	return json.Unmarshal(data, (*TextDocumentChangeRegistrationOptionsAlias)(s))
+}
+
 // The parameters sent in a close text document notification
 type DidCloseTextDocumentParams struct {
 	// The document that was closed.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
+}
+
+func (s *DidCloseTextDocumentParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["textDocument"]; !ok {
+		return fmt.Errorf("required key 'textDocument' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DidCloseTextDocumentParamsAlias DidCloseTextDocumentParams
+	return json.Unmarshal(data, (*DidCloseTextDocumentParamsAlias)(s))
 }
 
 // The parameters sent in a save text document notification
@@ -1078,6 +2294,22 @@ type DidSaveTextDocumentParams struct {
 	// Optional the content when saved. Depends on the includeText value
 	// when the save notification was requested.
 	Text *string `json:"text,omitempty"`
+}
+
+func (s *DidSaveTextDocumentParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["textDocument"]; !ok {
+		return fmt.Errorf("required key 'textDocument' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DidSaveTextDocumentParamsAlias DidSaveTextDocumentParams
+	return json.Unmarshal(data, (*DidSaveTextDocumentParamsAlias)(s))
 }
 
 // Save registration options.
@@ -1095,6 +2327,25 @@ type WillSaveTextDocumentParams struct {
 	Reason TextDocumentSaveReason `json:"reason"`
 }
 
+func (s *WillSaveTextDocumentParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["textDocument"]; !ok {
+		return fmt.Errorf("required key 'textDocument' is missing")
+	}
+	if _, ok := keys["reason"]; !ok {
+		return fmt.Errorf("required key 'reason' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type WillSaveTextDocumentParamsAlias WillSaveTextDocumentParams
+	return json.Unmarshal(data, (*WillSaveTextDocumentParamsAlias)(s))
+}
+
 // A text edit applicable to a text document.
 type TextEdit struct {
 	// The range of the text document to be manipulated. To insert
@@ -1106,16 +2357,67 @@ type TextEdit struct {
 	NewText string `json:"newText"`
 }
 
+func (s *TextEdit) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["range"]; !ok {
+		return fmt.Errorf("required key 'range' is missing")
+	}
+	if _, ok := keys["newText"]; !ok {
+		return fmt.Errorf("required key 'newText' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type TextEditAlias TextEdit
+	return json.Unmarshal(data, (*TextEditAlias)(s))
+}
+
 // The watched files change notification's parameters.
 type DidChangeWatchedFilesParams struct {
 	// The actual file events.
 	Changes []*FileEvent `json:"changes"`
 }
 
+func (s *DidChangeWatchedFilesParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["changes"]; !ok {
+		return fmt.Errorf("required key 'changes' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DidChangeWatchedFilesParamsAlias DidChangeWatchedFilesParams
+	return json.Unmarshal(data, (*DidChangeWatchedFilesParamsAlias)(s))
+}
+
 // Describe options to be used when registered for text document change events.
 type DidChangeWatchedFilesRegistrationOptions struct {
 	// The watchers to register.
 	Watchers []*FileSystemWatcher `json:"watchers"`
+}
+
+func (s *DidChangeWatchedFilesRegistrationOptions) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["watchers"]; !ok {
+		return fmt.Errorf("required key 'watchers' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DidChangeWatchedFilesRegistrationOptionsAlias DidChangeWatchedFilesRegistrationOptions
+	return json.Unmarshal(data, (*DidChangeWatchedFilesRegistrationOptionsAlias)(s))
 }
 
 // The publish diagnostic notification's parameters.
@@ -1130,6 +2432,25 @@ type PublishDiagnosticsParams struct {
 
 	// An array of diagnostic information items.
 	Diagnostics []*Diagnostic `json:"diagnostics"`
+}
+
+func (s *PublishDiagnosticsParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["uri"]; !ok {
+		return fmt.Errorf("required key 'uri' is missing")
+	}
+	if _, ok := keys["diagnostics"]; !ok {
+		return fmt.Errorf("required key 'diagnostics' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type PublishDiagnosticsParamsAlias PublishDiagnosticsParams
+	return json.Unmarshal(data, (*PublishDiagnosticsParamsAlias)(s))
 }
 
 // Completion parameters
@@ -1284,6 +2605,22 @@ type CompletionItem struct {
 	Data *any `json:"data,omitempty"`
 }
 
+func (s *CompletionItem) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["label"]; !ok {
+		return fmt.Errorf("required key 'label' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type CompletionItemAlias CompletionItem
+	return json.Unmarshal(data, (*CompletionItemAlias)(s))
+}
+
 // Represents a collection of items to be presented
 // in the editor.
 type CompletionList struct {
@@ -1333,6 +2670,25 @@ type CompletionList struct {
 	Items []*CompletionItem `json:"items"`
 }
 
+func (s *CompletionList) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["isIncomplete"]; !ok {
+		return fmt.Errorf("required key 'isIncomplete' is missing")
+	}
+	if _, ok := keys["items"]; !ok {
+		return fmt.Errorf("required key 'items' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type CompletionListAlias CompletionList
+	return json.Unmarshal(data, (*CompletionListAlias)(s))
+}
+
 // Registration options for a CompletionRequest.
 type CompletionRegistrationOptions struct {
 	TextDocumentRegistrationOptions
@@ -1353,6 +2709,22 @@ type Hover struct {
 	// An optional range inside the text document that is used to
 	// visualize the hover, e.g. by changing the background color.
 	Range *Range `json:"range,omitempty"`
+}
+
+func (s *Hover) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["contents"]; !ok {
+		return fmt.Errorf("required key 'contents' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type HoverAlias Hover
+	return json.Unmarshal(data, (*HoverAlias)(s))
 }
 
 // Registration options for a HoverRequest.
@@ -1410,6 +2782,22 @@ type SignatureHelp struct {
 	ActiveParameter *Nullable[uint32] `json:"activeParameter,omitempty"`
 }
 
+func (s *SignatureHelp) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["signatures"]; !ok {
+		return fmt.Errorf("required key 'signatures' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type SignatureHelpAlias SignatureHelp
+	return json.Unmarshal(data, (*SignatureHelpAlias)(s))
+}
+
 // Registration options for a SignatureHelpRequest.
 type SignatureHelpRegistrationOptions struct {
 	TextDocumentRegistrationOptions
@@ -1438,6 +2826,22 @@ type ReferenceParams struct {
 	Context *ReferenceContext `json:"context"`
 }
 
+func (s *ReferenceParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["context"]; !ok {
+		return fmt.Errorf("required key 'context' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ReferenceParamsAlias ReferenceParams
+	return json.Unmarshal(data, (*ReferenceParamsAlias)(s))
+}
+
 // Registration options for a ReferencesRequest.
 type ReferenceRegistrationOptions struct {
 	TextDocumentRegistrationOptions
@@ -1462,6 +2866,22 @@ type DocumentHighlight struct {
 	Kind *DocumentHighlightKind `json:"kind,omitempty"`
 }
 
+func (s *DocumentHighlight) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["range"]; !ok {
+		return fmt.Errorf("required key 'range' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DocumentHighlightAlias DocumentHighlight
+	return json.Unmarshal(data, (*DocumentHighlightAlias)(s))
+}
+
 // Registration options for a DocumentHighlightRequest.
 type DocumentHighlightRegistrationOptions struct {
 	TextDocumentRegistrationOptions
@@ -1475,6 +2895,22 @@ type DocumentSymbolParams struct {
 
 	// The text document.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
+}
+
+func (s *DocumentSymbolParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["textDocument"]; !ok {
+		return fmt.Errorf("required key 'textDocument' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DocumentSymbolParamsAlias DocumentSymbolParams
+	return json.Unmarshal(data, (*DocumentSymbolParamsAlias)(s))
 }
 
 // Represents information about programming constructs like variables, classes,
@@ -1497,6 +2933,22 @@ type SymbolInformation struct {
 	// syntax tree. It can therefore not be used to re-construct a hierarchy of
 	// the symbols.
 	Location Location `json:"location"`
+}
+
+func (s *SymbolInformation) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["location"]; !ok {
+		return fmt.Errorf("required key 'location' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type SymbolInformationAlias SymbolInformation
+	return json.Unmarshal(data, (*SymbolInformationAlias)(s))
 }
 
 // Represents programming constructs like variables, classes, interfaces etc.
@@ -1537,6 +2989,31 @@ type DocumentSymbol struct {
 	Children *[]*DocumentSymbol `json:"children,omitempty"`
 }
 
+func (s *DocumentSymbol) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["name"]; !ok {
+		return fmt.Errorf("required key 'name' is missing")
+	}
+	if _, ok := keys["kind"]; !ok {
+		return fmt.Errorf("required key 'kind' is missing")
+	}
+	if _, ok := keys["range"]; !ok {
+		return fmt.Errorf("required key 'range' is missing")
+	}
+	if _, ok := keys["selectionRange"]; !ok {
+		return fmt.Errorf("required key 'selectionRange' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DocumentSymbolAlias DocumentSymbol
+	return json.Unmarshal(data, (*DocumentSymbolAlias)(s))
+}
+
 // Registration options for a DocumentSymbolRequest.
 type DocumentSymbolRegistrationOptions struct {
 	TextDocumentRegistrationOptions
@@ -1556,6 +3033,28 @@ type CodeActionParams struct {
 
 	// Context carrying additional information.
 	Context *CodeActionContext `json:"context"`
+}
+
+func (s *CodeActionParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["textDocument"]; !ok {
+		return fmt.Errorf("required key 'textDocument' is missing")
+	}
+	if _, ok := keys["range"]; !ok {
+		return fmt.Errorf("required key 'range' is missing")
+	}
+	if _, ok := keys["context"]; !ok {
+		return fmt.Errorf("required key 'context' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type CodeActionParamsAlias CodeActionParams
+	return json.Unmarshal(data, (*CodeActionParamsAlias)(s))
 }
 
 // Represents a reference to a command. Provides a title which
@@ -1579,6 +3078,25 @@ type Command struct {
 	// Arguments that the command handler should be
 	// invoked with.
 	Arguments *[]any `json:"arguments,omitempty"`
+}
+
+func (s *Command) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["title"]; !ok {
+		return fmt.Errorf("required key 'title' is missing")
+	}
+	if _, ok := keys["command"]; !ok {
+		return fmt.Errorf("required key 'command' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type CommandAlias Command
+	return json.Unmarshal(data, (*CommandAlias)(s))
 }
 
 // A code action represents a change that can be performed in code, e.g. to fix a problem or
@@ -1643,6 +3161,22 @@ type CodeAction struct {
 	Tags *[]CodeActionTag `json:"tags,omitempty"`
 }
 
+func (s *CodeAction) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["title"]; !ok {
+		return fmt.Errorf("required key 'title' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type CodeActionAlias CodeAction
+	return json.Unmarshal(data, (*CodeActionAlias)(s))
+}
+
 // Registration options for a CodeActionRequest.
 type CodeActionRegistrationOptions struct {
 	TextDocumentRegistrationOptions
@@ -1665,6 +3199,22 @@ type WorkspaceSymbolParams struct {
 	Query string `json:"query"`
 }
 
+func (s *WorkspaceSymbolParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["query"]; !ok {
+		return fmt.Errorf("required key 'query' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type WorkspaceSymbolParamsAlias WorkspaceSymbolParams
+	return json.Unmarshal(data, (*WorkspaceSymbolParamsAlias)(s))
+}
+
 // A special workspace symbol that supports locations without a range.
 //
 // See also SymbolInformation.
@@ -1685,6 +3235,22 @@ type WorkspaceSymbol struct {
 	Data *any `json:"data,omitempty"`
 }
 
+func (s *WorkspaceSymbol) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["location"]; !ok {
+		return fmt.Errorf("required key 'location' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type WorkspaceSymbolAlias WorkspaceSymbol
+	return json.Unmarshal(data, (*WorkspaceSymbolAlias)(s))
+}
+
 // Registration options for a WorkspaceSymbolRequest.
 type WorkspaceSymbolRegistrationOptions struct {
 	WorkspaceSymbolOptions
@@ -1697,6 +3263,22 @@ type CodeLensParams struct {
 
 	// The document to request code lens for.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
+}
+
+func (s *CodeLensParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["textDocument"]; !ok {
+		return fmt.Errorf("required key 'textDocument' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type CodeLensParamsAlias CodeLensParams
+	return json.Unmarshal(data, (*CodeLensParamsAlias)(s))
 }
 
 // A code lens represents a command that should be shown along with
@@ -1716,6 +3298,22 @@ type CodeLens struct {
 	Data *any `json:"data,omitempty"`
 }
 
+func (s *CodeLens) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["range"]; !ok {
+		return fmt.Errorf("required key 'range' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type CodeLensAlias CodeLens
+	return json.Unmarshal(data, (*CodeLensAlias)(s))
+}
+
 // Registration options for a CodeLensRequest.
 type CodeLensRegistrationOptions struct {
 	TextDocumentRegistrationOptions
@@ -1729,6 +3327,22 @@ type DocumentLinkParams struct {
 
 	// The document to provide document links for.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
+}
+
+func (s *DocumentLinkParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["textDocument"]; !ok {
+		return fmt.Errorf("required key 'textDocument' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DocumentLinkParamsAlias DocumentLinkParams
+	return json.Unmarshal(data, (*DocumentLinkParamsAlias)(s))
 }
 
 // A document link is a range in a text document that links to an internal or external resource, like another
@@ -1754,6 +3368,22 @@ type DocumentLink struct {
 	Data *any `json:"data,omitempty"`
 }
 
+func (s *DocumentLink) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["range"]; !ok {
+		return fmt.Errorf("required key 'range' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DocumentLinkAlias DocumentLink
+	return json.Unmarshal(data, (*DocumentLinkAlias)(s))
+}
+
 // Registration options for a DocumentLinkRequest.
 type DocumentLinkRegistrationOptions struct {
 	TextDocumentRegistrationOptions
@@ -1769,6 +3399,25 @@ type DocumentFormattingParams struct {
 
 	// The format options.
 	Options *FormattingOptions `json:"options"`
+}
+
+func (s *DocumentFormattingParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["textDocument"]; !ok {
+		return fmt.Errorf("required key 'textDocument' is missing")
+	}
+	if _, ok := keys["options"]; !ok {
+		return fmt.Errorf("required key 'options' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DocumentFormattingParamsAlias DocumentFormattingParams
+	return json.Unmarshal(data, (*DocumentFormattingParamsAlias)(s))
 }
 
 // Registration options for a DocumentFormattingRequest.
@@ -1789,6 +3438,28 @@ type DocumentRangeFormattingParams struct {
 
 	// The format options
 	Options *FormattingOptions `json:"options"`
+}
+
+func (s *DocumentRangeFormattingParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["textDocument"]; !ok {
+		return fmt.Errorf("required key 'textDocument' is missing")
+	}
+	if _, ok := keys["range"]; !ok {
+		return fmt.Errorf("required key 'range' is missing")
+	}
+	if _, ok := keys["options"]; !ok {
+		return fmt.Errorf("required key 'options' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DocumentRangeFormattingParamsAlias DocumentRangeFormattingParams
+	return json.Unmarshal(data, (*DocumentRangeFormattingParamsAlias)(s))
 }
 
 // Registration options for a DocumentRangeFormattingRequest.
@@ -1815,6 +3486,28 @@ type DocumentRangesFormattingParams struct {
 	Options *FormattingOptions `json:"options"`
 }
 
+func (s *DocumentRangesFormattingParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["textDocument"]; !ok {
+		return fmt.Errorf("required key 'textDocument' is missing")
+	}
+	if _, ok := keys["ranges"]; !ok {
+		return fmt.Errorf("required key 'ranges' is missing")
+	}
+	if _, ok := keys["options"]; !ok {
+		return fmt.Errorf("required key 'options' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DocumentRangesFormattingParamsAlias DocumentRangesFormattingParams
+	return json.Unmarshal(data, (*DocumentRangesFormattingParamsAlias)(s))
+}
+
 // The parameters of a DocumentOnTypeFormattingRequest.
 type DocumentOnTypeFormattingParams struct {
 	// The document to format.
@@ -1833,6 +3526,31 @@ type DocumentOnTypeFormattingParams struct {
 
 	// The formatting options.
 	Options *FormattingOptions `json:"options"`
+}
+
+func (s *DocumentOnTypeFormattingParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["textDocument"]; !ok {
+		return fmt.Errorf("required key 'textDocument' is missing")
+	}
+	if _, ok := keys["position"]; !ok {
+		return fmt.Errorf("required key 'position' is missing")
+	}
+	if _, ok := keys["ch"]; !ok {
+		return fmt.Errorf("required key 'ch' is missing")
+	}
+	if _, ok := keys["options"]; !ok {
+		return fmt.Errorf("required key 'options' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DocumentOnTypeFormattingParamsAlias DocumentOnTypeFormattingParams
+	return json.Unmarshal(data, (*DocumentOnTypeFormattingParamsAlias)(s))
 }
 
 // Registration options for a DocumentOnTypeFormattingRequest.
@@ -1857,6 +3575,28 @@ type RenameParams struct {
 	NewName string `json:"newName"`
 }
 
+func (s *RenameParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["textDocument"]; !ok {
+		return fmt.Errorf("required key 'textDocument' is missing")
+	}
+	if _, ok := keys["position"]; !ok {
+		return fmt.Errorf("required key 'position' is missing")
+	}
+	if _, ok := keys["newName"]; !ok {
+		return fmt.Errorf("required key 'newName' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type RenameParamsAlias RenameParams
+	return json.Unmarshal(data, (*RenameParamsAlias)(s))
+}
+
 // Registration options for a RenameRequest.
 type RenameRegistrationOptions struct {
 	TextDocumentRegistrationOptions
@@ -1877,6 +3617,22 @@ type ExecuteCommandParams struct {
 
 	// Arguments that the command should be invoked with.
 	Arguments *[]any `json:"arguments,omitempty"`
+}
+
+func (s *ExecuteCommandParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["command"]; !ok {
+		return fmt.Errorf("required key 'command' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ExecuteCommandParamsAlias ExecuteCommandParams
+	return json.Unmarshal(data, (*ExecuteCommandParamsAlias)(s))
 }
 
 // Registration options for a ExecuteCommandRequest.
@@ -1902,6 +3658,22 @@ type ApplyWorkspaceEditParams struct {
 	Metadata *WorkspaceEditMetadata `json:"metadata,omitempty"`
 }
 
+func (s *ApplyWorkspaceEditParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["edit"]; !ok {
+		return fmt.Errorf("required key 'edit' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ApplyWorkspaceEditParamsAlias ApplyWorkspaceEditParams
+	return json.Unmarshal(data, (*ApplyWorkspaceEditParamsAlias)(s))
+}
+
 // The result returned from the apply workspace edit request.
 //
 // Since: 3.17 renamed from ApplyWorkspaceEditResponse
@@ -1918,6 +3690,22 @@ type ApplyWorkspaceEditResult struct {
 	// contain the index of the change that failed. This property is only available
 	// if the client signals a `failureHandlingStrategy` in its client capabilities.
 	FailedChange *uint32 `json:"failedChange,omitempty"`
+}
+
+func (s *ApplyWorkspaceEditResult) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["applied"]; !ok {
+		return fmt.Errorf("required key 'applied' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ApplyWorkspaceEditResultAlias ApplyWorkspaceEditResult
+	return json.Unmarshal(data, (*ApplyWorkspaceEditResultAlias)(s))
 }
 
 type WorkDoneProgressBegin struct {
@@ -1950,6 +3738,25 @@ type WorkDoneProgressBegin struct {
 	Percentage *uint32 `json:"percentage,omitempty"`
 }
 
+func (s *WorkDoneProgressBegin) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["kind"]; !ok {
+		return fmt.Errorf("required key 'kind' is missing")
+	}
+	if _, ok := keys["title"]; !ok {
+		return fmt.Errorf("required key 'title' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type WorkDoneProgressBeginAlias WorkDoneProgressBegin
+	return json.Unmarshal(data, (*WorkDoneProgressBeginAlias)(s))
+}
+
 type WorkDoneProgressReport struct {
 	Kind StringLiteralReport `json:"kind"`
 
@@ -1975,6 +3782,22 @@ type WorkDoneProgressReport struct {
 	Percentage *uint32 `json:"percentage,omitempty"`
 }
 
+func (s *WorkDoneProgressReport) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["kind"]; !ok {
+		return fmt.Errorf("required key 'kind' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type WorkDoneProgressReportAlias WorkDoneProgressReport
+	return json.Unmarshal(data, (*WorkDoneProgressReportAlias)(s))
+}
+
 type WorkDoneProgressEnd struct {
 	Kind StringLiteralEnd `json:"kind"`
 
@@ -1983,8 +3806,40 @@ type WorkDoneProgressEnd struct {
 	Message *string `json:"message,omitempty"`
 }
 
+func (s *WorkDoneProgressEnd) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["kind"]; !ok {
+		return fmt.Errorf("required key 'kind' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type WorkDoneProgressEndAlias WorkDoneProgressEnd
+	return json.Unmarshal(data, (*WorkDoneProgressEndAlias)(s))
+}
+
 type SetTraceParams struct {
 	Value TraceValue `json:"value"`
+}
+
+func (s *SetTraceParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["value"]; !ok {
+		return fmt.Errorf("required key 'value' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type SetTraceParamsAlias SetTraceParams
+	return json.Unmarshal(data, (*SetTraceParamsAlias)(s))
 }
 
 type LogTraceParams struct {
@@ -1993,9 +3848,41 @@ type LogTraceParams struct {
 	Verbose *string `json:"verbose,omitempty"`
 }
 
+func (s *LogTraceParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["message"]; !ok {
+		return fmt.Errorf("required key 'message' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type LogTraceParamsAlias LogTraceParams
+	return json.Unmarshal(data, (*LogTraceParamsAlias)(s))
+}
+
 type CancelParams struct {
 	// The request id to cancel.
 	Id IntegerOrString `json:"id"`
+}
+
+func (s *CancelParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["id"]; !ok {
+		return fmt.Errorf("required key 'id' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type CancelParamsAlias CancelParams
+	return json.Unmarshal(data, (*CancelParamsAlias)(s))
 }
 
 type ProgressParams struct {
@@ -2006,6 +3893,25 @@ type ProgressParams struct {
 	Value any `json:"value"`
 }
 
+func (s *ProgressParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["token"]; !ok {
+		return fmt.Errorf("required key 'token' is missing")
+	}
+	if _, ok := keys["value"]; !ok {
+		return fmt.Errorf("required key 'value' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ProgressParamsAlias ProgressParams
+	return json.Unmarshal(data, (*ProgressParamsAlias)(s))
+}
+
 // A parameter literal used in requests to pass a text document and a position inside that
 // document.
 type TextDocumentPositionParams struct {
@@ -2014,6 +3920,25 @@ type TextDocumentPositionParams struct {
 
 	// The position inside the text document.
 	Position Position `json:"position"`
+}
+
+func (s *TextDocumentPositionParams) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["textDocument"]; !ok {
+		return fmt.Errorf("required key 'textDocument' is missing")
+	}
+	if _, ok := keys["position"]; !ok {
+		return fmt.Errorf("required key 'position' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type TextDocumentPositionParamsAlias TextDocumentPositionParams
+	return json.Unmarshal(data, (*TextDocumentPositionParamsAlias)(s))
 }
 
 type WorkDoneProgressParams struct {
@@ -2049,6 +3974,28 @@ type LocationLink struct {
 	TargetSelectionRange Range `json:"targetSelectionRange"`
 }
 
+func (s *LocationLink) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["targetUri"]; !ok {
+		return fmt.Errorf("required key 'targetUri' is missing")
+	}
+	if _, ok := keys["targetRange"]; !ok {
+		return fmt.Errorf("required key 'targetRange' is missing")
+	}
+	if _, ok := keys["targetSelectionRange"]; !ok {
+		return fmt.Errorf("required key 'targetSelectionRange' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type LocationLinkAlias LocationLink
+	return json.Unmarshal(data, (*LocationLinkAlias)(s))
+}
+
 // A range in a text document expressed as (zero-based) start and end positions.
 //
 // If you want to specify a range that contains a line including the line ending
@@ -2068,6 +4015,25 @@ type Range struct {
 
 	// The range's end position.
 	End Position `json:"end"`
+}
+
+func (s *Range) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["start"]; !ok {
+		return fmt.Errorf("required key 'start' is missing")
+	}
+	if _, ok := keys["end"]; !ok {
+		return fmt.Errorf("required key 'end' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type RangeAlias Range
+	return json.Unmarshal(data, (*RangeAlias)(s))
 }
 
 type ImplementationOptions struct {
@@ -2095,6 +4061,25 @@ type WorkspaceFoldersChangeEvent struct {
 	Removed []*WorkspaceFolder `json:"removed"`
 }
 
+func (s *WorkspaceFoldersChangeEvent) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["added"]; !ok {
+		return fmt.Errorf("required key 'added' is missing")
+	}
+	if _, ok := keys["removed"]; !ok {
+		return fmt.Errorf("required key 'removed' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type WorkspaceFoldersChangeEventAlias WorkspaceFoldersChangeEvent
+	return json.Unmarshal(data, (*WorkspaceFoldersChangeEventAlias)(s))
+}
+
 type ConfigurationItem struct {
 	// The scope to get the configuration section for.
 	ScopeUri *URI `json:"scopeUri,omitempty"`
@@ -2107,6 +4092,22 @@ type ConfigurationItem struct {
 type TextDocumentIdentifier struct {
 	// The text document's uri.
 	Uri DocumentUri `json:"uri"`
+}
+
+func (s *TextDocumentIdentifier) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["uri"]; !ok {
+		return fmt.Errorf("required key 'uri' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type TextDocumentIdentifierAlias TextDocumentIdentifier
+	return json.Unmarshal(data, (*TextDocumentIdentifierAlias)(s))
 }
 
 // Represents a color in RGBA space.
@@ -2122,6 +4123,31 @@ type Color struct {
 
 	// The alpha component of this color in the range [0-1].
 	Alpha float64 `json:"alpha"`
+}
+
+func (s *Color) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["red"]; !ok {
+		return fmt.Errorf("required key 'red' is missing")
+	}
+	if _, ok := keys["green"]; !ok {
+		return fmt.Errorf("required key 'green' is missing")
+	}
+	if _, ok := keys["blue"]; !ok {
+		return fmt.Errorf("required key 'blue' is missing")
+	}
+	if _, ok := keys["alpha"]; !ok {
+		return fmt.Errorf("required key 'alpha' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ColorAlias Color
+	return json.Unmarshal(data, (*ColorAlias)(s))
 }
 
 type DocumentColorOptions struct {
@@ -2174,6 +4200,25 @@ type Position struct {
 	Character uint32 `json:"character"`
 }
 
+func (s *Position) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["line"]; !ok {
+		return fmt.Errorf("required key 'line' is missing")
+	}
+	if _, ok := keys["character"]; !ok {
+		return fmt.Errorf("required key 'character' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type PositionAlias Position
+	return json.Unmarshal(data, (*PositionAlias)(s))
+}
+
 type SelectionRangeOptions struct {
 	WorkDoneProgressOptions
 }
@@ -2200,6 +4245,22 @@ type SemanticTokensOptions struct {
 	Full *BooleanOrSemanticTokensFullDelta `json:"full,omitempty"`
 }
 
+func (s *SemanticTokensOptions) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["legend"]; !ok {
+		return fmt.Errorf("required key 'legend' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type SemanticTokensOptionsAlias SemanticTokensOptions
+	return json.Unmarshal(data, (*SemanticTokensOptionsAlias)(s))
+}
+
 // Since: 3.16.0
 type SemanticTokensEdit struct {
 	// The start offset of the edit.
@@ -2212,6 +4273,25 @@ type SemanticTokensEdit struct {
 	Data *[]uint32 `json:"data,omitempty"`
 }
 
+func (s *SemanticTokensEdit) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["start"]; !ok {
+		return fmt.Errorf("required key 'start' is missing")
+	}
+	if _, ok := keys["deleteCount"]; !ok {
+		return fmt.Errorf("required key 'deleteCount' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type SemanticTokensEditAlias SemanticTokensEdit
+	return json.Unmarshal(data, (*SemanticTokensEditAlias)(s))
+}
+
 type LinkedEditingRangeOptions struct {
 	WorkDoneProgressOptions
 }
@@ -2222,6 +4302,22 @@ type LinkedEditingRangeOptions struct {
 type FileCreate struct {
 	// A file:// URI for the location of the file/folder being created.
 	Uri string `json:"uri"`
+}
+
+func (s *FileCreate) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["uri"]; !ok {
+		return fmt.Errorf("required key 'uri' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type FileCreateAlias FileCreate
+	return json.Unmarshal(data, (*FileCreateAlias)(s))
 }
 
 // Describes textual changes on a text document. A TextDocumentEdit describes all changes
@@ -2242,6 +4338,25 @@ type TextDocumentEdit struct {
 	Edits []TextEditOrAnnotatedTextEditOrSnippetTextEdit `json:"edits"`
 }
 
+func (s *TextDocumentEdit) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["textDocument"]; !ok {
+		return fmt.Errorf("required key 'textDocument' is missing")
+	}
+	if _, ok := keys["edits"]; !ok {
+		return fmt.Errorf("required key 'edits' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type TextDocumentEditAlias TextDocumentEdit
+	return json.Unmarshal(data, (*TextDocumentEditAlias)(s))
+}
+
 // Create file operation.
 type CreateFile struct {
 	ResourceOperation
@@ -2254,6 +4369,25 @@ type CreateFile struct {
 
 	// Additional options
 	Options *CreateFileOptions `json:"options,omitempty"`
+}
+
+func (s *CreateFile) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["kind"]; !ok {
+		return fmt.Errorf("required key 'kind' is missing")
+	}
+	if _, ok := keys["uri"]; !ok {
+		return fmt.Errorf("required key 'uri' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type CreateFileAlias CreateFile
+	return json.Unmarshal(data, (*CreateFileAlias)(s))
 }
 
 // Rename file operation
@@ -2273,6 +4407,28 @@ type RenameFile struct {
 	Options *RenameFileOptions `json:"options,omitempty"`
 }
 
+func (s *RenameFile) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["kind"]; !ok {
+		return fmt.Errorf("required key 'kind' is missing")
+	}
+	if _, ok := keys["oldUri"]; !ok {
+		return fmt.Errorf("required key 'oldUri' is missing")
+	}
+	if _, ok := keys["newUri"]; !ok {
+		return fmt.Errorf("required key 'newUri' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type RenameFileAlias RenameFile
+	return json.Unmarshal(data, (*RenameFileAlias)(s))
+}
+
 // Delete file operation
 type DeleteFile struct {
 	ResourceOperation
@@ -2285,6 +4441,25 @@ type DeleteFile struct {
 
 	// Delete options.
 	Options *DeleteFileOptions `json:"options,omitempty"`
+}
+
+func (s *DeleteFile) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["kind"]; !ok {
+		return fmt.Errorf("required key 'kind' is missing")
+	}
+	if _, ok := keys["uri"]; !ok {
+		return fmt.Errorf("required key 'uri' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DeleteFileAlias DeleteFile
+	return json.Unmarshal(data, (*DeleteFileAlias)(s))
 }
 
 // Additional information that describes document changes.
@@ -2304,6 +4479,22 @@ type ChangeAnnotation struct {
 	Description *string `json:"description,omitempty"`
 }
 
+func (s *ChangeAnnotation) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["label"]; !ok {
+		return fmt.Errorf("required key 'label' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ChangeAnnotationAlias ChangeAnnotation
+	return json.Unmarshal(data, (*ChangeAnnotationAlias)(s))
+}
+
 // A filter to describe in which file operation requests or notifications
 // the server is interested in receiving.
 //
@@ -2314,6 +4505,22 @@ type FileOperationFilter struct {
 
 	// The actual file operation pattern.
 	Pattern *FileOperationPattern `json:"pattern"`
+}
+
+func (s *FileOperationFilter) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["pattern"]; !ok {
+		return fmt.Errorf("required key 'pattern' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type FileOperationFilterAlias FileOperationFilter
+	return json.Unmarshal(data, (*FileOperationFilterAlias)(s))
 }
 
 // Represents information on a file/folder rename.
@@ -2327,12 +4534,47 @@ type FileRename struct {
 	NewUri string `json:"newUri"`
 }
 
+func (s *FileRename) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["oldUri"]; !ok {
+		return fmt.Errorf("required key 'oldUri' is missing")
+	}
+	if _, ok := keys["newUri"]; !ok {
+		return fmt.Errorf("required key 'newUri' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type FileRenameAlias FileRename
+	return json.Unmarshal(data, (*FileRenameAlias)(s))
+}
+
 // Represents information on a file/folder delete.
 //
 // Since: 3.16.0
 type FileDelete struct {
 	// A file:// URI for the location of the file/folder being deleted.
 	Uri string `json:"uri"`
+}
+
+func (s *FileDelete) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["uri"]; !ok {
+		return fmt.Errorf("required key 'uri' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type FileDeleteAlias FileDelete
+	return json.Unmarshal(data, (*FileDeleteAlias)(s))
 }
 
 type MonikerOptions struct {
@@ -2356,6 +4598,25 @@ type InlineValueContext struct {
 	StoppedLocation Range `json:"stoppedLocation"`
 }
 
+func (s *InlineValueContext) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["frameId"]; !ok {
+		return fmt.Errorf("required key 'frameId' is missing")
+	}
+	if _, ok := keys["stoppedLocation"]; !ok {
+		return fmt.Errorf("required key 'stoppedLocation' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type InlineValueContextAlias InlineValueContext
+	return json.Unmarshal(data, (*InlineValueContextAlias)(s))
+}
+
 // Provide inline value as text.
 //
 // Since: 3.17.0
@@ -2365,6 +4626,25 @@ type InlineValueText struct {
 
 	// The text of the inline value.
 	Text string `json:"text"`
+}
+
+func (s *InlineValueText) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["range"]; !ok {
+		return fmt.Errorf("required key 'range' is missing")
+	}
+	if _, ok := keys["text"]; !ok {
+		return fmt.Errorf("required key 'text' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type InlineValueTextAlias InlineValueText
+	return json.Unmarshal(data, (*InlineValueTextAlias)(s))
 }
 
 // Provide inline value through a variable lookup.
@@ -2384,6 +4664,25 @@ type InlineValueVariableLookup struct {
 	CaseSensitiveLookup bool `json:"caseSensitiveLookup"`
 }
 
+func (s *InlineValueVariableLookup) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["range"]; !ok {
+		return fmt.Errorf("required key 'range' is missing")
+	}
+	if _, ok := keys["caseSensitiveLookup"]; !ok {
+		return fmt.Errorf("required key 'caseSensitiveLookup' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type InlineValueVariableLookupAlias InlineValueVariableLookup
+	return json.Unmarshal(data, (*InlineValueVariableLookupAlias)(s))
+}
+
 // Provide an inline value through an expression evaluation.
 // If only a range is specified, the expression will be extracted from the underlying document.
 // An optional expression can be used to override the extracted expression.
@@ -2396,6 +4695,22 @@ type InlineValueEvaluatableExpression struct {
 
 	// If specified the expression overrides the extracted expression.
 	Expression *string `json:"expression,omitempty"`
+}
+
+func (s *InlineValueEvaluatableExpression) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["range"]; !ok {
+		return fmt.Errorf("required key 'range' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type InlineValueEvaluatableExpressionAlias InlineValueEvaluatableExpression
+	return json.Unmarshal(data, (*InlineValueEvaluatableExpressionAlias)(s))
 }
 
 // Inline value options used during static registration.
@@ -2438,6 +4753,22 @@ type InlayHintLabelPart struct {
 	Command *Command `json:"command,omitempty"`
 }
 
+func (s *InlayHintLabelPart) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["value"]; !ok {
+		return fmt.Errorf("required key 'value' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type InlayHintLabelPartAlias InlayHintLabelPart
+	return json.Unmarshal(data, (*InlayHintLabelPartAlias)(s))
+}
+
 // A `MarkupContent` literal represents a string value which content is interpreted base on its
 // kind flag. Currently the protocol supports `plaintext` and `markdown` as markup kinds.
 //
@@ -2468,6 +4799,25 @@ type MarkupContent struct {
 
 	// The content itself
 	Value string `json:"value"`
+}
+
+func (s *MarkupContent) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["kind"]; !ok {
+		return fmt.Errorf("required key 'kind' is missing")
+	}
+	if _, ok := keys["value"]; !ok {
+		return fmt.Errorf("required key 'value' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type MarkupContentAlias MarkupContent
+	return json.Unmarshal(data, (*MarkupContentAlias)(s))
 }
 
 // Inlay hint options used during static registration.
@@ -2529,6 +4879,25 @@ type FullDocumentDiagnosticReport struct {
 	Items []*Diagnostic `json:"items"`
 }
 
+func (s *FullDocumentDiagnosticReport) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["kind"]; !ok {
+		return fmt.Errorf("required key 'kind' is missing")
+	}
+	if _, ok := keys["items"]; !ok {
+		return fmt.Errorf("required key 'items' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type FullDocumentDiagnosticReportAlias FullDocumentDiagnosticReport
+	return json.Unmarshal(data, (*FullDocumentDiagnosticReportAlias)(s))
+}
+
 // A diagnostic report indicating that the last returned
 // report is still accurate.
 //
@@ -2543,6 +4912,25 @@ type UnchangedDocumentDiagnosticReport struct {
 	// A result id which will be sent on the next
 	// diagnostic request for the same document.
 	ResultId string `json:"resultId"`
+}
+
+func (s *UnchangedDocumentDiagnosticReport) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["kind"]; !ok {
+		return fmt.Errorf("required key 'kind' is missing")
+	}
+	if _, ok := keys["resultId"]; !ok {
+		return fmt.Errorf("required key 'resultId' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type UnchangedDocumentDiagnosticReportAlias UnchangedDocumentDiagnosticReport
+	return json.Unmarshal(data, (*UnchangedDocumentDiagnosticReportAlias)(s))
 }
 
 // Diagnostic options.
@@ -2565,6 +4953,25 @@ type DiagnosticOptions struct {
 	WorkspaceDiagnostics bool `json:"workspaceDiagnostics"`
 }
 
+func (s *DiagnosticOptions) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["interFileDependencies"]; !ok {
+		return fmt.Errorf("required key 'interFileDependencies' is missing")
+	}
+	if _, ok := keys["workspaceDiagnostics"]; !ok {
+		return fmt.Errorf("required key 'workspaceDiagnostics' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DiagnosticOptionsAlias DiagnosticOptions
+	return json.Unmarshal(data, (*DiagnosticOptionsAlias)(s))
+}
+
 // A previous result id in a workspace pull request.
 //
 // Since: 3.17.0
@@ -2575,6 +4982,25 @@ type PreviousResultId struct {
 
 	// The value of the previous result id.
 	Value string `json:"value"`
+}
+
+func (s *PreviousResultId) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["uri"]; !ok {
+		return fmt.Errorf("required key 'uri' is missing")
+	}
+	if _, ok := keys["value"]; !ok {
+		return fmt.Errorf("required key 'value' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type PreviousResultIdAlias PreviousResultId
+	return json.Unmarshal(data, (*PreviousResultIdAlias)(s))
 }
 
 // A notebook document.
@@ -2601,6 +5027,31 @@ type NotebookDocument struct {
 	Cells []*NotebookCell `json:"cells"`
 }
 
+func (s *NotebookDocument) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["uri"]; !ok {
+		return fmt.Errorf("required key 'uri' is missing")
+	}
+	if _, ok := keys["notebookType"]; !ok {
+		return fmt.Errorf("required key 'notebookType' is missing")
+	}
+	if _, ok := keys["version"]; !ok {
+		return fmt.Errorf("required key 'version' is missing")
+	}
+	if _, ok := keys["cells"]; !ok {
+		return fmt.Errorf("required key 'cells' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type NotebookDocumentAlias NotebookDocument
+	return json.Unmarshal(data, (*NotebookDocumentAlias)(s))
+}
+
 // An item to transfer a text document from the client to the
 // server.
 type TextDocumentItem struct {
@@ -2616,6 +5067,31 @@ type TextDocumentItem struct {
 
 	// The content of the opened text document.
 	Text string `json:"text"`
+}
+
+func (s *TextDocumentItem) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["uri"]; !ok {
+		return fmt.Errorf("required key 'uri' is missing")
+	}
+	if _, ok := keys["languageId"]; !ok {
+		return fmt.Errorf("required key 'languageId' is missing")
+	}
+	if _, ok := keys["version"]; !ok {
+		return fmt.Errorf("required key 'version' is missing")
+	}
+	if _, ok := keys["text"]; !ok {
+		return fmt.Errorf("required key 'text' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type TextDocumentItemAlias TextDocumentItem
+	return json.Unmarshal(data, (*TextDocumentItemAlias)(s))
 }
 
 // Options specific to a notebook plus its cells
@@ -2640,6 +5116,22 @@ type NotebookDocumentSyncOptions struct {
 	Save *bool `json:"save,omitempty"`
 }
 
+func (s *NotebookDocumentSyncOptions) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["notebookSelector"]; !ok {
+		return fmt.Errorf("required key 'notebookSelector' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type NotebookDocumentSyncOptionsAlias NotebookDocumentSyncOptions
+	return json.Unmarshal(data, (*NotebookDocumentSyncOptionsAlias)(s))
+}
+
 // A versioned notebook document identifier.
 //
 // Since: 3.17.0
@@ -2649,6 +5141,25 @@ type VersionedNotebookDocumentIdentifier struct {
 
 	// The notebook document's uri.
 	Uri URI `json:"uri"`
+}
+
+func (s *VersionedNotebookDocumentIdentifier) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["version"]; !ok {
+		return fmt.Errorf("required key 'version' is missing")
+	}
+	if _, ok := keys["uri"]; !ok {
+		return fmt.Errorf("required key 'uri' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type VersionedNotebookDocumentIdentifierAlias VersionedNotebookDocumentIdentifier
+	return json.Unmarshal(data, (*VersionedNotebookDocumentIdentifierAlias)(s))
 }
 
 // A change event for a notebook document.
@@ -2672,6 +5183,22 @@ type NotebookDocumentIdentifier struct {
 	Uri URI `json:"uri"`
 }
 
+func (s *NotebookDocumentIdentifier) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["uri"]; !ok {
+		return fmt.Errorf("required key 'uri' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type NotebookDocumentIdentifierAlias NotebookDocumentIdentifier
+	return json.Unmarshal(data, (*NotebookDocumentIdentifierAlias)(s))
+}
+
 // Provides information about the context in which an inline completion was requested.
 //
 // Since: 3.18.0
@@ -2683,6 +5210,22 @@ type InlineCompletionContext struct {
 
 	// Provides information about the currently selected item in the autocomplete widget if it is visible.
 	SelectedCompletionInfo *SelectedCompletionInfo `json:"selectedCompletionInfo,omitempty"`
+}
+
+func (s *InlineCompletionContext) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["triggerKind"]; !ok {
+		return fmt.Errorf("required key 'triggerKind' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type InlineCompletionContextAlias InlineCompletionContext
+	return json.Unmarshal(data, (*InlineCompletionContextAlias)(s))
 }
 
 // A string value used as a snippet is a template which allows to insert text
@@ -2704,6 +5247,25 @@ type StringValue struct {
 	Value string `json:"value"`
 }
 
+func (s *StringValue) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["kind"]; !ok {
+		return fmt.Errorf("required key 'kind' is missing")
+	}
+	if _, ok := keys["value"]; !ok {
+		return fmt.Errorf("required key 'value' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type StringValueAlias StringValue
+	return json.Unmarshal(data, (*StringValueAlias)(s))
+}
+
 // Inline completion options used during static registration.
 //
 // Since: 3.18.0
@@ -2723,6 +5285,22 @@ type TextDocumentContentOptions struct {
 	Schemes []string `json:"schemes"`
 }
 
+func (s *TextDocumentContentOptions) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["schemes"]; !ok {
+		return fmt.Errorf("required key 'schemes' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type TextDocumentContentOptionsAlias TextDocumentContentOptions
+	return json.Unmarshal(data, (*TextDocumentContentOptionsAlias)(s))
+}
+
 // General parameters to register for a notification or to register a provider.
 type Registration struct {
 	// The id used to register the request. The id can be used to deregister
@@ -2736,6 +5314,25 @@ type Registration struct {
 	RegisterOptions *any `json:"registerOptions,omitempty"`
 }
 
+func (s *Registration) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["id"]; !ok {
+		return fmt.Errorf("required key 'id' is missing")
+	}
+	if _, ok := keys["method"]; !ok {
+		return fmt.Errorf("required key 'method' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type RegistrationAlias Registration
+	return json.Unmarshal(data, (*RegistrationAlias)(s))
+}
+
 // General parameters to unregister a request or notification.
 type Unregistration struct {
 	// The id used to unregister the request or notification. Usually an id
@@ -2744,6 +5341,25 @@ type Unregistration struct {
 
 	// The method to unregister for.
 	Method string `json:"method"`
+}
+
+func (s *Unregistration) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["id"]; !ok {
+		return fmt.Errorf("required key 'id' is missing")
+	}
+	if _, ok := keys["method"]; !ok {
+		return fmt.Errorf("required key 'method' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type UnregistrationAlias Unregistration
+	return json.Unmarshal(data, (*UnregistrationAlias)(s))
 }
 
 // The initialize parameters
@@ -2793,6 +5409,28 @@ type InitializeParamsBase struct {
 
 	// The initial trace setting. If omitted trace is disabled ('off').
 	Trace *TraceValue `json:"trace,omitempty"`
+}
+
+func (s *InitializeParamsBase) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["processId"]; !ok {
+		return fmt.Errorf("required key 'processId' is missing")
+	}
+	if _, ok := keys["rootUri"]; !ok {
+		return fmt.Errorf("required key 'rootUri' is missing")
+	}
+	if _, ok := keys["capabilities"]; !ok {
+		return fmt.Errorf("required key 'capabilities' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type InitializeParamsBaseAlias InitializeParamsBase
+	return json.Unmarshal(data, (*InitializeParamsBaseAlias)(s))
 }
 
 type WorkspaceFoldersInitializeParams struct {
@@ -2967,12 +5605,44 @@ type ServerInfo struct {
 	Version *string `json:"version,omitempty"`
 }
 
+func (s *ServerInfo) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["name"]; !ok {
+		return fmt.Errorf("required key 'name' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ServerInfoAlias ServerInfo
+	return json.Unmarshal(data, (*ServerInfoAlias)(s))
+}
+
 // A text document identifier to denote a specific version of a text document.
 type VersionedTextDocumentIdentifier struct {
 	TextDocumentIdentifier
 
 	// The version number of this document.
 	Version int32 `json:"version"`
+}
+
+func (s *VersionedTextDocumentIdentifier) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["version"]; !ok {
+		return fmt.Errorf("required key 'version' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type VersionedTextDocumentIdentifierAlias VersionedTextDocumentIdentifier
+	return json.Unmarshal(data, (*VersionedTextDocumentIdentifierAlias)(s))
 }
 
 // Save options.
@@ -2990,6 +5660,25 @@ type FileEvent struct {
 	Type FileChangeType `json:"type"`
 }
 
+func (s *FileEvent) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["uri"]; !ok {
+		return fmt.Errorf("required key 'uri' is missing")
+	}
+	if _, ok := keys["type"]; !ok {
+		return fmt.Errorf("required key 'type' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type FileEventAlias FileEvent
+	return json.Unmarshal(data, (*FileEventAlias)(s))
+}
+
 type FileSystemWatcher struct {
 	// The glob pattern to watch. See pattern for more detail.
 	//
@@ -3000,6 +5689,22 @@ type FileSystemWatcher struct {
 	// to WatchKind.Create | WatchKind.Change | WatchKind.Delete
 	// which is 7.
 	Kind *WatchKind `json:"kind,omitempty"`
+}
+
+func (s *FileSystemWatcher) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["globPattern"]; !ok {
+		return fmt.Errorf("required key 'globPattern' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type FileSystemWatcherAlias FileSystemWatcher
+	return json.Unmarshal(data, (*FileSystemWatcherAlias)(s))
 }
 
 // Represents a diagnostic, such as a compiler error or warning. Diagnostic objects
@@ -3046,6 +5751,25 @@ type Diagnostic struct {
 	Data *any `json:"data,omitempty"`
 }
 
+func (s *Diagnostic) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["range"]; !ok {
+		return fmt.Errorf("required key 'range' is missing")
+	}
+	if _, ok := keys["message"]; !ok {
+		return fmt.Errorf("required key 'message' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DiagnosticAlias Diagnostic
+	return json.Unmarshal(data, (*DiagnosticAlias)(s))
+}
+
 // Contains additional information about the context in which a completion request is triggered.
 type CompletionContext struct {
 	// How the completion was triggered.
@@ -3054,6 +5778,22 @@ type CompletionContext struct {
 	// The trigger character (a single character) that has trigger code complete.
 	// Is undefined if `triggerKind !== CompletionTriggerKind.TriggerCharacter`
 	TriggerCharacter *string `json:"triggerCharacter,omitempty"`
+}
+
+func (s *CompletionContext) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["triggerKind"]; !ok {
+		return fmt.Errorf("required key 'triggerKind' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type CompletionContextAlias CompletionContext
+	return json.Unmarshal(data, (*CompletionContextAlias)(s))
 }
 
 // Additional details for a completion item label.
@@ -3081,6 +5821,28 @@ type InsertReplaceEdit struct {
 
 	// The range if the replace is requested.
 	Replace Range `json:"replace"`
+}
+
+func (s *InsertReplaceEdit) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["newText"]; !ok {
+		return fmt.Errorf("required key 'newText' is missing")
+	}
+	if _, ok := keys["insert"]; !ok {
+		return fmt.Errorf("required key 'insert' is missing")
+	}
+	if _, ok := keys["replace"]; !ok {
+		return fmt.Errorf("required key 'replace' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type InsertReplaceEditAlias InsertReplaceEdit
+	return json.Unmarshal(data, (*InsertReplaceEditAlias)(s))
 }
 
 // In many cases the items of an actual completion result share the same
@@ -3250,6 +6012,25 @@ type SignatureHelpContext struct {
 	ActiveSignatureHelp *SignatureHelp `json:"activeSignatureHelp,omitempty"`
 }
 
+func (s *SignatureHelpContext) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["triggerKind"]; !ok {
+		return fmt.Errorf("required key 'triggerKind' is missing")
+	}
+	if _, ok := keys["isRetrigger"]; !ok {
+		return fmt.Errorf("required key 'isRetrigger' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type SignatureHelpContextAlias SignatureHelpContext
+	return json.Unmarshal(data, (*SignatureHelpContextAlias)(s))
+}
+
 // Represents the signature of something callable. A signature
 // can have a label, like a function-name, a doc-comment, and
 // a set of parameters.
@@ -3277,6 +6058,22 @@ type SignatureInformation struct {
 	//
 	// Since: 3.16.0
 	ActiveParameter *Nullable[uint32] `json:"activeParameter,omitempty"`
+}
+
+func (s *SignatureInformation) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["label"]; !ok {
+		return fmt.Errorf("required key 'label' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type SignatureInformationAlias SignatureInformation
+	return json.Unmarshal(data, (*SignatureInformationAlias)(s))
 }
 
 // Server Capabilities for a SignatureHelpRequest.
@@ -3307,6 +6104,22 @@ type ReferenceContext struct {
 	IncludeDeclaration bool `json:"includeDeclaration"`
 }
 
+func (s *ReferenceContext) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["includeDeclaration"]; !ok {
+		return fmt.Errorf("required key 'includeDeclaration' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ReferenceContextAlias ReferenceContext
+	return json.Unmarshal(data, (*ReferenceContextAlias)(s))
+}
+
 // Reference options.
 type ReferenceOptions struct {
 	WorkDoneProgressOptions
@@ -3335,6 +6148,25 @@ type BaseSymbolInformation struct {
 	// if necessary). It can't be used to re-infer a hierarchy for the document
 	// symbols.
 	ContainerName *string `json:"containerName,omitempty"`
+}
+
+func (s *BaseSymbolInformation) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["name"]; !ok {
+		return fmt.Errorf("required key 'name' is missing")
+	}
+	if _, ok := keys["kind"]; !ok {
+		return fmt.Errorf("required key 'kind' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type BaseSymbolInformationAlias BaseSymbolInformation
+	return json.Unmarshal(data, (*BaseSymbolInformationAlias)(s))
 }
 
 // Provider options for a DocumentSymbolRequest.
@@ -3370,6 +6202,22 @@ type CodeActionContext struct {
 	TriggerKind *CodeActionTriggerKind `json:"triggerKind,omitempty"`
 }
 
+func (s *CodeActionContext) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["diagnostics"]; !ok {
+		return fmt.Errorf("required key 'diagnostics' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type CodeActionContextAlias CodeActionContext
+	return json.Unmarshal(data, (*CodeActionContextAlias)(s))
+}
+
 // Captures why the code action is currently disabled.
 //
 // Since: 3.18.0
@@ -3378,6 +6226,22 @@ type CodeActionDisabled struct {
 	//
 	// This is displayed in the code actions UI.
 	Reason string `json:"reason"`
+}
+
+func (s *CodeActionDisabled) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["reason"]; !ok {
+		return fmt.Errorf("required key 'reason' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type CodeActionDisabledAlias CodeActionDisabled
+	return json.Unmarshal(data, (*CodeActionDisabledAlias)(s))
 }
 
 // Provider options for a CodeActionRequest.
@@ -3420,6 +6284,22 @@ type CodeActionOptions struct {
 // Since: 3.18.0
 type LocationUriOnly struct {
 	Uri DocumentUri `json:"uri"`
+}
+
+func (s *LocationUriOnly) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["uri"]; !ok {
+		return fmt.Errorf("required key 'uri' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type LocationUriOnlyAlias LocationUriOnly
+	return json.Unmarshal(data, (*LocationUriOnlyAlias)(s))
 }
 
 // Server capabilities for a WorkspaceSymbolRequest.
@@ -3473,6 +6353,25 @@ type FormattingOptions struct {
 	TrimFinalNewlines *bool `json:"trimFinalNewlines,omitempty"`
 }
 
+func (s *FormattingOptions) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["tabSize"]; !ok {
+		return fmt.Errorf("required key 'tabSize' is missing")
+	}
+	if _, ok := keys["insertSpaces"]; !ok {
+		return fmt.Errorf("required key 'insertSpaces' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type FormattingOptionsAlias FormattingOptions
+	return json.Unmarshal(data, (*FormattingOptionsAlias)(s))
+}
+
 // Provider options for a DocumentFormattingRequest.
 type DocumentFormattingOptions struct {
 	WorkDoneProgressOptions
@@ -3499,6 +6398,22 @@ type DocumentOnTypeFormattingOptions struct {
 	MoreTriggerCharacter *[]string `json:"moreTriggerCharacter,omitempty"`
 }
 
+func (s *DocumentOnTypeFormattingOptions) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["firstTriggerCharacter"]; !ok {
+		return fmt.Errorf("required key 'firstTriggerCharacter' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DocumentOnTypeFormattingOptionsAlias DocumentOnTypeFormattingOptions
+	return json.Unmarshal(data, (*DocumentOnTypeFormattingOptionsAlias)(s))
+}
+
 // Provider options for a RenameRequest.
 type RenameOptions struct {
 	WorkDoneProgressOptions
@@ -3516,9 +6431,44 @@ type PrepareRenamePlaceholder struct {
 	Placeholder string `json:"placeholder"`
 }
 
+func (s *PrepareRenamePlaceholder) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["range"]; !ok {
+		return fmt.Errorf("required key 'range' is missing")
+	}
+	if _, ok := keys["placeholder"]; !ok {
+		return fmt.Errorf("required key 'placeholder' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type PrepareRenamePlaceholderAlias PrepareRenamePlaceholder
+	return json.Unmarshal(data, (*PrepareRenamePlaceholderAlias)(s))
+}
+
 // Since: 3.18.0
 type PrepareRenameDefaultBehavior struct {
 	DefaultBehavior bool `json:"defaultBehavior"`
+}
+
+func (s *PrepareRenameDefaultBehavior) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["defaultBehavior"]; !ok {
+		return fmt.Errorf("required key 'defaultBehavior' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type PrepareRenameDefaultBehaviorAlias PrepareRenameDefaultBehavior
+	return json.Unmarshal(data, (*PrepareRenameDefaultBehaviorAlias)(s))
 }
 
 // The server capabilities of a ExecuteCommandRequest.
@@ -3527,6 +6477,22 @@ type ExecuteCommandOptions struct {
 
 	// The commands to be executed on the server
 	Commands []string `json:"commands"`
+}
+
+func (s *ExecuteCommandOptions) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["commands"]; !ok {
+		return fmt.Errorf("required key 'commands' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ExecuteCommandOptionsAlias ExecuteCommandOptions
+	return json.Unmarshal(data, (*ExecuteCommandOptionsAlias)(s))
 }
 
 // Additional data about a workspace edit.
@@ -3546,6 +6512,25 @@ type SemanticTokensLegend struct {
 
 	// The token modifiers a server uses.
 	TokenModifiers []string `json:"tokenModifiers"`
+}
+
+func (s *SemanticTokensLegend) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["tokenTypes"]; !ok {
+		return fmt.Errorf("required key 'tokenTypes' is missing")
+	}
+	if _, ok := keys["tokenModifiers"]; !ok {
+		return fmt.Errorf("required key 'tokenModifiers' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type SemanticTokensLegendAlias SemanticTokensLegend
+	return json.Unmarshal(data, (*SemanticTokensLegendAlias)(s))
 }
 
 // Semantic tokens options to support deltas for full documents
@@ -3568,6 +6553,22 @@ type OptionalVersionedTextDocumentIdentifier struct {
 	Version Nullable[int32] `json:"version"`
 }
 
+func (s *OptionalVersionedTextDocumentIdentifier) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["version"]; !ok {
+		return fmt.Errorf("required key 'version' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type OptionalVersionedTextDocumentIdentifierAlias OptionalVersionedTextDocumentIdentifier
+	return json.Unmarshal(data, (*OptionalVersionedTextDocumentIdentifierAlias)(s))
+}
+
 // A special text edit with an additional change annotation.
 //
 // Since: 3.16.0.
@@ -3576,6 +6577,22 @@ type AnnotatedTextEdit struct {
 
 	// The actual identifier of the change annotation
 	AnnotationId ChangeAnnotationIdentifier `json:"annotationId"`
+}
+
+func (s *AnnotatedTextEdit) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["annotationId"]; !ok {
+		return fmt.Errorf("required key 'annotationId' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type AnnotatedTextEditAlias AnnotatedTextEdit
+	return json.Unmarshal(data, (*AnnotatedTextEditAlias)(s))
 }
 
 // An interactive text edit.
@@ -3594,6 +6611,25 @@ type SnippetTextEdit struct {
 	AnnotationId *ChangeAnnotationIdentifier `json:"annotationId,omitempty"`
 }
 
+func (s *SnippetTextEdit) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["range"]; !ok {
+		return fmt.Errorf("required key 'range' is missing")
+	}
+	if _, ok := keys["snippet"]; !ok {
+		return fmt.Errorf("required key 'snippet' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type SnippetTextEditAlias SnippetTextEdit
+	return json.Unmarshal(data, (*SnippetTextEditAlias)(s))
+}
+
 // A generic resource operation.
 type ResourceOperation struct {
 	// The resource operation kind.
@@ -3603,6 +6639,22 @@ type ResourceOperation struct {
 	//
 	// Since: 3.16.0
 	AnnotationId *ChangeAnnotationIdentifier `json:"annotationId,omitempty"`
+}
+
+func (s *ResourceOperation) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["kind"]; !ok {
+		return fmt.Errorf("required key 'kind' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ResourceOperationAlias ResourceOperation
+	return json.Unmarshal(data, (*ResourceOperationAlias)(s))
 }
 
 // Options to create a file.
@@ -3655,6 +6707,22 @@ type FileOperationPattern struct {
 	Options *FileOperationPatternOptions `json:"options,omitempty"`
 }
 
+func (s *FileOperationPattern) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["glob"]; !ok {
+		return fmt.Errorf("required key 'glob' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type FileOperationPatternAlias FileOperationPattern
+	return json.Unmarshal(data, (*FileOperationPatternAlias)(s))
+}
+
 // A full document diagnostic report for a workspace diagnostic result.
 //
 // Since: 3.17.0
@@ -3669,6 +6737,25 @@ type WorkspaceFullDocumentDiagnosticReport struct {
 	Version Nullable[int32] `json:"version"`
 }
 
+func (s *WorkspaceFullDocumentDiagnosticReport) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["uri"]; !ok {
+		return fmt.Errorf("required key 'uri' is missing")
+	}
+	if _, ok := keys["version"]; !ok {
+		return fmt.Errorf("required key 'version' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type WorkspaceFullDocumentDiagnosticReportAlias WorkspaceFullDocumentDiagnosticReport
+	return json.Unmarshal(data, (*WorkspaceFullDocumentDiagnosticReportAlias)(s))
+}
+
 // An unchanged document diagnostic report for a workspace diagnostic result.
 //
 // Since: 3.17.0
@@ -3681,6 +6768,25 @@ type WorkspaceUnchangedDocumentDiagnosticReport struct {
 	// The version number for which the diagnostics are reported.
 	// If the document is not marked as open `null` can be provided.
 	Version Nullable[int32] `json:"version"`
+}
+
+func (s *WorkspaceUnchangedDocumentDiagnosticReport) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["uri"]; !ok {
+		return fmt.Errorf("required key 'uri' is missing")
+	}
+	if _, ok := keys["version"]; !ok {
+		return fmt.Errorf("required key 'version' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type WorkspaceUnchangedDocumentDiagnosticReportAlias WorkspaceUnchangedDocumentDiagnosticReport
+	return json.Unmarshal(data, (*WorkspaceUnchangedDocumentDiagnosticReportAlias)(s))
 }
 
 // A notebook cell.
@@ -3708,6 +6814,25 @@ type NotebookCell struct {
 	ExecutionSummary *ExecutionSummary `json:"executionSummary,omitempty"`
 }
 
+func (s *NotebookCell) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["kind"]; !ok {
+		return fmt.Errorf("required key 'kind' is missing")
+	}
+	if _, ok := keys["document"]; !ok {
+		return fmt.Errorf("required key 'document' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type NotebookCellAlias NotebookCell
+	return json.Unmarshal(data, (*NotebookCellAlias)(s))
+}
+
 // Since: 3.18.0
 type NotebookDocumentFilterWithNotebook struct {
 	// The notebook to be synced If a string
@@ -3719,6 +6844,22 @@ type NotebookDocumentFilterWithNotebook struct {
 	Cells *[]*NotebookCellLanguage `json:"cells,omitempty"`
 }
 
+func (s *NotebookDocumentFilterWithNotebook) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["notebook"]; !ok {
+		return fmt.Errorf("required key 'notebook' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type NotebookDocumentFilterWithNotebookAlias NotebookDocumentFilterWithNotebook
+	return json.Unmarshal(data, (*NotebookDocumentFilterWithNotebookAlias)(s))
+}
+
 // Since: 3.18.0
 type NotebookDocumentFilterWithCells struct {
 	// The notebook to be synced If a string
@@ -3728,6 +6869,22 @@ type NotebookDocumentFilterWithCells struct {
 
 	// The cells of the matching notebook to be synced.
 	Cells []*NotebookCellLanguage `json:"cells"`
+}
+
+func (s *NotebookDocumentFilterWithCells) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["cells"]; !ok {
+		return fmt.Errorf("required key 'cells' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type NotebookDocumentFilterWithCellsAlias NotebookDocumentFilterWithCells
+	return json.Unmarshal(data, (*NotebookDocumentFilterWithCellsAlias)(s))
 }
 
 // Cell changes to a notebook document.
@@ -3759,6 +6916,25 @@ type SelectedCompletionInfo struct {
 	Text string `json:"text"`
 }
 
+func (s *SelectedCompletionInfo) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["range"]; !ok {
+		return fmt.Errorf("required key 'range' is missing")
+	}
+	if _, ok := keys["text"]; !ok {
+		return fmt.Errorf("required key 'text' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type SelectedCompletionInfoAlias SelectedCompletionInfo
+	return json.Unmarshal(data, (*SelectedCompletionInfoAlias)(s))
+}
+
 // Information about the client
 //
 // Since: 3.15.0
@@ -3770,6 +6946,22 @@ type ClientInfo struct {
 
 	// The client's version as defined by the client.
 	Version *string `json:"version,omitempty"`
+}
+
+func (s *ClientInfo) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["name"]; !ok {
+		return fmt.Errorf("required key 'name' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ClientInfoAlias ClientInfo
+	return json.Unmarshal(data, (*ClientInfoAlias)(s))
 }
 
 // Defines the capabilities provided by the client.
@@ -3855,10 +7047,45 @@ type TextDocumentContentChangePartial struct {
 	Text string `json:"text"`
 }
 
+func (s *TextDocumentContentChangePartial) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["range"]; !ok {
+		return fmt.Errorf("required key 'range' is missing")
+	}
+	if _, ok := keys["text"]; !ok {
+		return fmt.Errorf("required key 'text' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type TextDocumentContentChangePartialAlias TextDocumentContentChangePartial
+	return json.Unmarshal(data, (*TextDocumentContentChangePartialAlias)(s))
+}
+
 // Since: 3.18.0
 type TextDocumentContentChangeWholeDocument struct {
 	// The new text of the whole document.
 	Text string `json:"text"`
+}
+
+func (s *TextDocumentContentChangeWholeDocument) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["text"]; !ok {
+		return fmt.Errorf("required key 'text' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type TextDocumentContentChangeWholeDocumentAlias TextDocumentContentChangeWholeDocument
+	return json.Unmarshal(data, (*TextDocumentContentChangeWholeDocumentAlias)(s))
 }
 
 // Structure to capture a description for an error code.
@@ -3867,6 +7094,22 @@ type TextDocumentContentChangeWholeDocument struct {
 type CodeDescription struct {
 	// An URI to open with more information about the diagnostic error.
 	Href URI `json:"href"`
+}
+
+func (s *CodeDescription) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["href"]; !ok {
+		return fmt.Errorf("required key 'href' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type CodeDescriptionAlias CodeDescription
+	return json.Unmarshal(data, (*CodeDescriptionAlias)(s))
 }
 
 // Represents a related message and source code location for a diagnostic. This should be
@@ -3880,6 +7123,25 @@ type DiagnosticRelatedInformation struct {
 	Message string `json:"message"`
 }
 
+func (s *DiagnosticRelatedInformation) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["location"]; !ok {
+		return fmt.Errorf("required key 'location' is missing")
+	}
+	if _, ok := keys["message"]; !ok {
+		return fmt.Errorf("required key 'message' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type DiagnosticRelatedInformationAlias DiagnosticRelatedInformation
+	return json.Unmarshal(data, (*DiagnosticRelatedInformationAlias)(s))
+}
+
 // Edit range variant that includes ranges for insert and replace operations.
 //
 // Since: 3.18.0
@@ -3887,6 +7149,25 @@ type EditRangeWithInsertReplace struct {
 	Insert Range `json:"insert"`
 
 	Replace Range `json:"replace"`
+}
+
+func (s *EditRangeWithInsertReplace) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["insert"]; !ok {
+		return fmt.Errorf("required key 'insert' is missing")
+	}
+	if _, ok := keys["replace"]; !ok {
+		return fmt.Errorf("required key 'replace' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type EditRangeWithInsertReplaceAlias EditRangeWithInsertReplace
+	return json.Unmarshal(data, (*EditRangeWithInsertReplaceAlias)(s))
 }
 
 // Since: 3.18.0
@@ -3906,6 +7187,25 @@ type MarkedStringWithLanguage struct {
 	Language string `json:"language"`
 
 	Value string `json:"value"`
+}
+
+func (s *MarkedStringWithLanguage) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["language"]; !ok {
+		return fmt.Errorf("required key 'language' is missing")
+	}
+	if _, ok := keys["value"]; !ok {
+		return fmt.Errorf("required key 'value' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type MarkedStringWithLanguageAlias MarkedStringWithLanguage
+	return json.Unmarshal(data, (*MarkedStringWithLanguageAlias)(s))
 }
 
 // Represents a parameter of a callable-signature. A parameter can
@@ -3930,6 +7230,22 @@ type ParameterInformation struct {
 	Documentation *StringOrMarkupContent `json:"documentation,omitempty"`
 }
 
+func (s *ParameterInformation) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["label"]; !ok {
+		return fmt.Errorf("required key 'label' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ParameterInformationAlias ParameterInformation
+	return json.Unmarshal(data, (*ParameterInformationAlias)(s))
+}
+
 // Documentation for a class of code actions.
 //
 // Since: 3.18.0
@@ -3949,6 +7265,25 @@ type CodeActionKindDocumentation struct {
 	Command *Command `json:"command"`
 }
 
+func (s *CodeActionKindDocumentation) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["kind"]; !ok {
+		return fmt.Errorf("required key 'kind' is missing")
+	}
+	if _, ok := keys["command"]; !ok {
+		return fmt.Errorf("required key 'command' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type CodeActionKindDocumentationAlias CodeActionKindDocumentation
+	return json.Unmarshal(data, (*CodeActionKindDocumentationAlias)(s))
+}
+
 // A notebook cell text document filter denotes a cell text
 // document by different properties.
 //
@@ -3965,6 +7300,22 @@ type NotebookCellTextDocumentFilter struct {
 	// Will be matched against the language id of the
 	// notebook cell document. '*' matches every language.
 	Language *string `json:"language,omitempty"`
+}
+
+func (s *NotebookCellTextDocumentFilter) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["notebook"]; !ok {
+		return fmt.Errorf("required key 'notebook' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type NotebookCellTextDocumentFilterAlias NotebookCellTextDocumentFilter
+	return json.Unmarshal(data, (*NotebookCellTextDocumentFilterAlias)(s))
 }
 
 // Matching options for the file operation pattern.
@@ -3986,9 +7337,41 @@ type ExecutionSummary struct {
 	Success *bool `json:"success,omitempty"`
 }
 
+func (s *ExecutionSummary) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["executionOrder"]; !ok {
+		return fmt.Errorf("required key 'executionOrder' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ExecutionSummaryAlias ExecutionSummary
+	return json.Unmarshal(data, (*ExecutionSummaryAlias)(s))
+}
+
 // Since: 3.18.0
 type NotebookCellLanguage struct {
 	Language string `json:"language"`
+}
+
+func (s *NotebookCellLanguage) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["language"]; !ok {
+		return fmt.Errorf("required key 'language' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type NotebookCellLanguageAlias NotebookCellLanguage
+	return json.Unmarshal(data, (*NotebookCellLanguageAlias)(s))
 }
 
 // Structural changes to cells in a notebook document.
@@ -4005,6 +7388,22 @@ type NotebookDocumentCellChangeStructure struct {
 	DidClose *[]TextDocumentIdentifier `json:"didClose,omitempty"`
 }
 
+func (s *NotebookDocumentCellChangeStructure) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["array"]; !ok {
+		return fmt.Errorf("required key 'array' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type NotebookDocumentCellChangeStructureAlias NotebookDocumentCellChangeStructure
+	return json.Unmarshal(data, (*NotebookDocumentCellChangeStructureAlias)(s))
+}
+
 // Content changes to a cell in a notebook document.
 //
 // Since: 3.18.0
@@ -4012,6 +7411,25 @@ type NotebookDocumentCellContentChanges struct {
 	Document VersionedTextDocumentIdentifier `json:"document"`
 
 	Changes []TextDocumentContentChangeEvent `json:"changes"`
+}
+
+func (s *NotebookDocumentCellContentChanges) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["document"]; !ok {
+		return fmt.Errorf("required key 'document' is missing")
+	}
+	if _, ok := keys["changes"]; !ok {
+		return fmt.Errorf("required key 'changes' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type NotebookDocumentCellContentChangesAlias NotebookDocumentCellContentChanges
+	return json.Unmarshal(data, (*NotebookDocumentCellContentChangesAlias)(s))
 }
 
 // Workspace specific client capabilities.
@@ -4240,6 +7658,22 @@ type NotebookDocumentClientCapabilities struct {
 	Synchronization *NotebookDocumentSyncClientCapabilities `json:"synchronization"`
 }
 
+func (s *NotebookDocumentClientCapabilities) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["synchronization"]; !ok {
+		return fmt.Errorf("required key 'synchronization' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type NotebookDocumentClientCapabilitiesAlias NotebookDocumentClientCapabilities
+	return json.Unmarshal(data, (*NotebookDocumentClientCapabilitiesAlias)(s))
+}
+
 type WindowClientCapabilities struct {
 	// It indicates whether the client supports server initiated
 	// progress using the `window/workDoneProgress/create` request.
@@ -4357,6 +7791,25 @@ type RelativePattern struct {
 	Pattern Pattern `json:"pattern"`
 }
 
+func (s *RelativePattern) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["baseUri"]; !ok {
+		return fmt.Errorf("required key 'baseUri' is missing")
+	}
+	if _, ok := keys["pattern"]; !ok {
+		return fmt.Errorf("required key 'pattern' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type RelativePatternAlias RelativePattern
+	return json.Unmarshal(data, (*RelativePatternAlias)(s))
+}
+
 // A document filter where `language` is required field.
 //
 // Since: 3.18.0
@@ -4373,6 +7826,22 @@ type TextDocumentFilterLanguage struct {
 	// relative patterns depends on the client capability
 	// `textDocuments.filters.relativePatternSupport`.
 	Pattern *GlobPattern `json:"pattern,omitempty"`
+}
+
+func (s *TextDocumentFilterLanguage) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["language"]; !ok {
+		return fmt.Errorf("required key 'language' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type TextDocumentFilterLanguageAlias TextDocumentFilterLanguage
+	return json.Unmarshal(data, (*TextDocumentFilterLanguageAlias)(s))
 }
 
 // A document filter where `scheme` is required field.
@@ -4393,6 +7862,22 @@ type TextDocumentFilterScheme struct {
 	Pattern *GlobPattern `json:"pattern,omitempty"`
 }
 
+func (s *TextDocumentFilterScheme) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["scheme"]; !ok {
+		return fmt.Errorf("required key 'scheme' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type TextDocumentFilterSchemeAlias TextDocumentFilterScheme
+	return json.Unmarshal(data, (*TextDocumentFilterSchemeAlias)(s))
+}
+
 // A document filter where `pattern` is required field.
 //
 // Since: 3.18.0
@@ -4411,6 +7896,22 @@ type TextDocumentFilterPattern struct {
 	Pattern GlobPattern `json:"pattern"`
 }
 
+func (s *TextDocumentFilterPattern) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["pattern"]; !ok {
+		return fmt.Errorf("required key 'pattern' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type TextDocumentFilterPatternAlias TextDocumentFilterPattern
+	return json.Unmarshal(data, (*TextDocumentFilterPatternAlias)(s))
+}
+
 // A notebook document filter where `notebookType` is required field.
 //
 // Since: 3.18.0
@@ -4423,6 +7924,22 @@ type NotebookDocumentFilterNotebookType struct {
 
 	// A glob pattern.
 	Pattern *GlobPattern `json:"pattern,omitempty"`
+}
+
+func (s *NotebookDocumentFilterNotebookType) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["notebookType"]; !ok {
+		return fmt.Errorf("required key 'notebookType' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type NotebookDocumentFilterNotebookTypeAlias NotebookDocumentFilterNotebookType
+	return json.Unmarshal(data, (*NotebookDocumentFilterNotebookTypeAlias)(s))
 }
 
 // A notebook document filter where `scheme` is required field.
@@ -4439,6 +7956,22 @@ type NotebookDocumentFilterScheme struct {
 	Pattern *GlobPattern `json:"pattern,omitempty"`
 }
 
+func (s *NotebookDocumentFilterScheme) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["scheme"]; !ok {
+		return fmt.Errorf("required key 'scheme' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type NotebookDocumentFilterSchemeAlias NotebookDocumentFilterScheme
+	return json.Unmarshal(data, (*NotebookDocumentFilterSchemeAlias)(s))
+}
+
 // A notebook document filter where `pattern` is required field.
 //
 // Since: 3.18.0
@@ -4451,6 +7984,22 @@ type NotebookDocumentFilterPattern struct {
 
 	// A glob pattern.
 	Pattern GlobPattern `json:"pattern"`
+}
+
+func (s *NotebookDocumentFilterPattern) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["pattern"]; !ok {
+		return fmt.Errorf("required key 'pattern' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type NotebookDocumentFilterPatternAlias NotebookDocumentFilterPattern
+	return json.Unmarshal(data, (*NotebookDocumentFilterPatternAlias)(s))
 }
 
 // A change describing how to move a `NotebookCell`
@@ -4466,6 +8015,25 @@ type NotebookCellArrayChange struct {
 
 	// The new cells, if any
 	Cells *[]*NotebookCell `json:"cells,omitempty"`
+}
+
+func (s *NotebookCellArrayChange) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["start"]; !ok {
+		return fmt.Errorf("required key 'start' is missing")
+	}
+	if _, ok := keys["deleteCount"]; !ok {
+		return fmt.Errorf("required key 'deleteCount' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type NotebookCellArrayChangeAlias NotebookCellArrayChange
+	return json.Unmarshal(data, (*NotebookCellArrayChangeAlias)(s))
 }
 
 type WorkspaceEditClientCapabilities struct {
@@ -5099,6 +8667,31 @@ type SemanticTokensClientCapabilities struct {
 	AugmentsSyntaxTokens *bool `json:"augmentsSyntaxTokens,omitempty"`
 }
 
+func (s *SemanticTokensClientCapabilities) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["requests"]; !ok {
+		return fmt.Errorf("required key 'requests' is missing")
+	}
+	if _, ok := keys["tokenTypes"]; !ok {
+		return fmt.Errorf("required key 'tokenTypes' is missing")
+	}
+	if _, ok := keys["tokenModifiers"]; !ok {
+		return fmt.Errorf("required key 'tokenModifiers' is missing")
+	}
+	if _, ok := keys["formats"]; !ok {
+		return fmt.Errorf("required key 'formats' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type SemanticTokensClientCapabilitiesAlias SemanticTokensClientCapabilities
+	return json.Unmarshal(data, (*SemanticTokensClientCapabilitiesAlias)(s))
+}
+
 // Client capabilities for the linked editing range request.
 //
 // Since: 3.16.0
@@ -5201,6 +8794,22 @@ type ShowDocumentClientCapabilities struct {
 	Support bool `json:"support"`
 }
 
+func (s *ShowDocumentClientCapabilities) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["support"]; !ok {
+		return fmt.Errorf("required key 'support' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ShowDocumentClientCapabilitiesAlias ShowDocumentClientCapabilities
+	return json.Unmarshal(data, (*ShowDocumentClientCapabilitiesAlias)(s))
+}
+
 // Since: 3.18.0
 type StaleRequestSupportOptions struct {
 	// The client will actively cancel the request.
@@ -5212,6 +8821,25 @@ type StaleRequestSupportOptions struct {
 	RetryOnContentModified []string `json:"retryOnContentModified"`
 }
 
+func (s *StaleRequestSupportOptions) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["cancel"]; !ok {
+		return fmt.Errorf("required key 'cancel' is missing")
+	}
+	if _, ok := keys["retryOnContentModified"]; !ok {
+		return fmt.Errorf("required key 'retryOnContentModified' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type StaleRequestSupportOptionsAlias StaleRequestSupportOptions
+	return json.Unmarshal(data, (*StaleRequestSupportOptionsAlias)(s))
+}
+
 // Client capabilities specific to regular expressions.
 //
 // Since: 3.16.0
@@ -5221,6 +8849,22 @@ type RegularExpressionsClientCapabilities struct {
 
 	// The engine's version.
 	Version *string `json:"version,omitempty"`
+}
+
+func (s *RegularExpressionsClientCapabilities) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["engine"]; !ok {
+		return fmt.Errorf("required key 'engine' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type RegularExpressionsClientCapabilitiesAlias RegularExpressionsClientCapabilities
+	return json.Unmarshal(data, (*RegularExpressionsClientCapabilitiesAlias)(s))
 }
 
 // Client capabilities specific to the used markdown parser.
@@ -5238,6 +8882,22 @@ type MarkdownClientCapabilities struct {
 	//
 	// Since: 3.17.0
 	AllowedTags *[]string `json:"allowedTags,omitempty"`
+}
+
+func (s *MarkdownClientCapabilities) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["parser"]; !ok {
+		return fmt.Errorf("required key 'parser' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type MarkdownClientCapabilitiesAlias MarkdownClientCapabilities
+	return json.Unmarshal(data, (*MarkdownClientCapabilitiesAlias)(s))
 }
 
 // Since: 3.18.0
@@ -5267,11 +8927,43 @@ type ClientSymbolTagOptions struct {
 	ValueSet []SymbolTag `json:"valueSet"`
 }
 
+func (s *ClientSymbolTagOptions) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["valueSet"]; !ok {
+		return fmt.Errorf("required key 'valueSet' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ClientSymbolTagOptionsAlias ClientSymbolTagOptions
+	return json.Unmarshal(data, (*ClientSymbolTagOptionsAlias)(s))
+}
+
 // Since: 3.18.0
 type ClientSymbolResolveOptions struct {
 	// The properties that a client can resolve lazily. Usually
 	// `location.range`
 	Properties []string `json:"properties"`
+}
+
+func (s *ClientSymbolResolveOptions) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["properties"]; !ok {
+		return fmt.Errorf("required key 'properties' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ClientSymbolResolveOptionsAlias ClientSymbolResolveOptions
+	return json.Unmarshal(data, (*ClientSymbolResolveOptionsAlias)(s))
 }
 
 // Since: 3.18.0
@@ -5406,10 +9098,42 @@ type ClientCodeActionLiteralOptions struct {
 	CodeActionKind *ClientCodeActionKindOptions `json:"codeActionKind"`
 }
 
+func (s *ClientCodeActionLiteralOptions) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["codeActionKind"]; !ok {
+		return fmt.Errorf("required key 'codeActionKind' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ClientCodeActionLiteralOptionsAlias ClientCodeActionLiteralOptions
+	return json.Unmarshal(data, (*ClientCodeActionLiteralOptionsAlias)(s))
+}
+
 // Since: 3.18.0
 type ClientCodeActionResolveOptions struct {
 	// The properties that a client can resolve lazily.
 	Properties []string `json:"properties"`
+}
+
+func (s *ClientCodeActionResolveOptions) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["properties"]; !ok {
+		return fmt.Errorf("required key 'properties' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ClientCodeActionResolveOptionsAlias ClientCodeActionResolveOptions
+	return json.Unmarshal(data, (*ClientCodeActionResolveOptionsAlias)(s))
 }
 
 // Since: 3.18.0 - proposed
@@ -5418,10 +9142,42 @@ type CodeActionTagOptions struct {
 	ValueSet []CodeActionTag `json:"valueSet"`
 }
 
+func (s *CodeActionTagOptions) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["valueSet"]; !ok {
+		return fmt.Errorf("required key 'valueSet' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type CodeActionTagOptionsAlias CodeActionTagOptions
+	return json.Unmarshal(data, (*CodeActionTagOptionsAlias)(s))
+}
+
 // Since: 3.18.0
 type ClientCodeLensResolveOptions struct {
 	// The properties that a client can resolve lazily.
 	Properties []string `json:"properties"`
+}
+
+func (s *ClientCodeLensResolveOptions) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["properties"]; !ok {
+		return fmt.Errorf("required key 'properties' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ClientCodeLensResolveOptionsAlias ClientCodeLensResolveOptions
+	return json.Unmarshal(data, (*ClientCodeLensResolveOptionsAlias)(s))
 }
 
 // Since: 3.18.0
@@ -5483,6 +9239,22 @@ type ClientInlayHintResolveOptions struct {
 	Properties []string `json:"properties"`
 }
 
+func (s *ClientInlayHintResolveOptions) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["properties"]; !ok {
+		return fmt.Errorf("required key 'properties' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ClientInlayHintResolveOptionsAlias ClientInlayHintResolveOptions
+	return json.Unmarshal(data, (*ClientInlayHintResolveOptionsAlias)(s))
+}
+
 // Since: 3.18.0
 type ClientShowMessageActionItemOptions struct {
 	// Whether the client supports additional attributes which
@@ -5497,15 +9269,63 @@ type CompletionItemTagOptions struct {
 	ValueSet []CompletionItemTag `json:"valueSet"`
 }
 
+func (s *CompletionItemTagOptions) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["valueSet"]; !ok {
+		return fmt.Errorf("required key 'valueSet' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type CompletionItemTagOptionsAlias CompletionItemTagOptions
+	return json.Unmarshal(data, (*CompletionItemTagOptionsAlias)(s))
+}
+
 // Since: 3.18.0
 type ClientCompletionItemResolveOptions struct {
 	// The properties that a client can resolve lazily.
 	Properties []string `json:"properties"`
 }
 
+func (s *ClientCompletionItemResolveOptions) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["properties"]; !ok {
+		return fmt.Errorf("required key 'properties' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ClientCompletionItemResolveOptionsAlias ClientCompletionItemResolveOptions
+	return json.Unmarshal(data, (*ClientCompletionItemResolveOptionsAlias)(s))
+}
+
 // Since: 3.18.0
 type ClientCompletionItemInsertTextModeOptions struct {
 	ValueSet []InsertTextMode `json:"valueSet"`
+}
+
+func (s *ClientCompletionItemInsertTextModeOptions) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["valueSet"]; !ok {
+		return fmt.Errorf("required key 'valueSet' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ClientCompletionItemInsertTextModeOptionsAlias ClientCompletionItemInsertTextModeOptions
+	return json.Unmarshal(data, (*ClientCompletionItemInsertTextModeOptionsAlias)(s))
 }
 
 // Since: 3.18.0
@@ -5526,10 +9346,42 @@ type ClientCodeActionKindOptions struct {
 	ValueSet []CodeActionKind `json:"valueSet"`
 }
 
+func (s *ClientCodeActionKindOptions) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["valueSet"]; !ok {
+		return fmt.Errorf("required key 'valueSet' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ClientCodeActionKindOptionsAlias ClientCodeActionKindOptions
+	return json.Unmarshal(data, (*ClientCodeActionKindOptionsAlias)(s))
+}
+
 // Since: 3.18.0
 type ClientDiagnosticsTagOptions struct {
 	// The tags supported by the client.
 	ValueSet []DiagnosticTag `json:"valueSet"`
+}
+
+func (s *ClientDiagnosticsTagOptions) UnmarshalJSON(data []byte) error {
+	// Check required keys
+	keys, err := getJSONKeys(data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := keys["valueSet"]; !ok {
+		return fmt.Errorf("required key 'valueSet' is missing")
+	}
+
+	// Use type alias to avoid infinite recursion
+	type ClientDiagnosticsTagOptionsAlias ClientDiagnosticsTagOptions
+	return json.Unmarshal(data, (*ClientDiagnosticsTagOptionsAlias)(s))
 }
 
 // Since: 3.18.0

--- a/internal/lsp/lsproto/lsp_generated.go
+++ b/internal/lsp/lsproto/lsp_generated.go
@@ -39,9 +39,13 @@ func (s *Location) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'range' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type LocationAlias Location
-	return json.Unmarshal(data, (*LocationAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Uri   DocumentUri `json:"uri"`
+		Range Range       `json:"range"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type ImplementationRegistrationOptions struct {
@@ -86,9 +90,13 @@ func (s *WorkspaceFolder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'name' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type WorkspaceFolderAlias WorkspaceFolder
-	return json.Unmarshal(data, (*WorkspaceFolderAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Uri  URI    `json:"uri"`
+		Name string `json:"name"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // The parameters of a `workspace/didChangeWorkspaceFolders` notification.
@@ -108,9 +116,12 @@ func (s *DidChangeWorkspaceFoldersParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'event' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DidChangeWorkspaceFoldersParamsAlias DidChangeWorkspaceFoldersParams
-	return json.Unmarshal(data, (*DidChangeWorkspaceFoldersParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Event *WorkspaceFoldersChangeEvent `json:"event"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // The parameters of a configuration request.
@@ -129,9 +140,12 @@ func (s *ConfigurationParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'items' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ConfigurationParamsAlias ConfigurationParams
-	return json.Unmarshal(data, (*ConfigurationParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Items []*ConfigurationItem `json:"items"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Parameters for a DocumentColorRequest.
@@ -154,9 +168,15 @@ func (s *DocumentColorParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DocumentColorParamsAlias DocumentColorParams
-	return json.Unmarshal(data, (*DocumentColorParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressParams
+		PartialResultParams
+
+		TextDocument TextDocumentIdentifier `json:"textDocument"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Represents a color range from a document.
@@ -182,9 +202,13 @@ func (s *ColorInformation) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'color' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ColorInformationAlias ColorInformation
-	return json.Unmarshal(data, (*ColorInformationAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Range Range `json:"range"`
+		Color Color `json:"color"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type DocumentColorRegistrationOptions struct {
@@ -225,9 +249,17 @@ func (s *ColorPresentationParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'range' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ColorPresentationParamsAlias ColorPresentationParams
-	return json.Unmarshal(data, (*ColorPresentationParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressParams
+		PartialResultParams
+
+		TextDocument TextDocumentIdentifier `json:"textDocument"`
+		Color        Color                  `json:"color"`
+		Range        Range                  `json:"range"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type ColorPresentation struct {
@@ -257,9 +289,14 @@ func (s *ColorPresentation) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'label' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ColorPresentationAlias ColorPresentation
-	return json.Unmarshal(data, (*ColorPresentationAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Label               string       `json:"label"`
+		TextEdit            *TextEdit    `json:"textEdit,omitempty"`
+		AdditionalTextEdits *[]*TextEdit `json:"additionalTextEdits,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type WorkDoneProgressOptions struct {
@@ -284,9 +321,12 @@ func (s *TextDocumentRegistrationOptions) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type TextDocumentRegistrationOptionsAlias TextDocumentRegistrationOptions
-	return json.Unmarshal(data, (*TextDocumentRegistrationOptionsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		DocumentSelector Nullable[DocumentSelector] `json:"documentSelector"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Parameters for a FoldingRangeRequest.
@@ -309,9 +349,15 @@ func (s *FoldingRangeParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type FoldingRangeParamsAlias FoldingRangeParams
-	return json.Unmarshal(data, (*FoldingRangeParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressParams
+		PartialResultParams
+
+		TextDocument TextDocumentIdentifier `json:"textDocument"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Represents a folding range. To be valid, start and end line must be bigger than zero and smaller
@@ -358,9 +404,17 @@ func (s *FoldingRange) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'endLine' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type FoldingRangeAlias FoldingRange
-	return json.Unmarshal(data, (*FoldingRangeAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		StartLine      uint32            `json:"startLine"`
+		StartCharacter *uint32           `json:"startCharacter,omitempty"`
+		EndLine        uint32            `json:"endLine"`
+		EndCharacter   *uint32           `json:"endCharacter,omitempty"`
+		Kind           *FoldingRangeKind `json:"kind,omitempty"`
+		CollapsedText  *string           `json:"collapsedText,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type FoldingRangeRegistrationOptions struct {
@@ -407,9 +461,16 @@ func (s *SelectionRangeParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'positions' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type SelectionRangeParamsAlias SelectionRangeParams
-	return json.Unmarshal(data, (*SelectionRangeParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressParams
+		PartialResultParams
+
+		TextDocument TextDocumentIdentifier `json:"textDocument"`
+		Positions    []Position             `json:"positions"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A selection range represents a part of a selection hierarchy. A selection range
@@ -433,9 +494,13 @@ func (s *SelectionRange) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'range' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type SelectionRangeAlias SelectionRange
-	return json.Unmarshal(data, (*SelectionRangeAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Range  Range           `json:"range"`
+		Parent *SelectionRange `json:"parent,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type SelectionRangeRegistrationOptions struct {
@@ -460,9 +525,12 @@ func (s *WorkDoneProgressCreateParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'token' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type WorkDoneProgressCreateParamsAlias WorkDoneProgressCreateParams
-	return json.Unmarshal(data, (*WorkDoneProgressCreateParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Token ProgressToken `json:"token"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type WorkDoneProgressCancelParams struct {
@@ -481,9 +549,12 @@ func (s *WorkDoneProgressCancelParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'token' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type WorkDoneProgressCancelParamsAlias WorkDoneProgressCancelParams
-	return json.Unmarshal(data, (*WorkDoneProgressCancelParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Token ProgressToken `json:"token"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // The parameter of a `textDocument/prepareCallHierarchy` request.
@@ -549,9 +620,19 @@ func (s *CallHierarchyItem) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'selectionRange' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type CallHierarchyItemAlias CallHierarchyItem
-	return json.Unmarshal(data, (*CallHierarchyItemAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Name           string       `json:"name"`
+		Kind           SymbolKind   `json:"kind"`
+		Tags           *[]SymbolTag `json:"tags,omitempty"`
+		Detail         *string      `json:"detail,omitempty"`
+		Uri            DocumentUri  `json:"uri"`
+		Range          Range        `json:"range"`
+		SelectionRange Range        `json:"selectionRange"`
+		Data           *any         `json:"data,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Call hierarchy options used during static or dynamic registration.
@@ -584,9 +665,15 @@ func (s *CallHierarchyIncomingCallsParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'item' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type CallHierarchyIncomingCallsParamsAlias CallHierarchyIncomingCallsParams
-	return json.Unmarshal(data, (*CallHierarchyIncomingCallsParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressParams
+		PartialResultParams
+
+		Item *CallHierarchyItem `json:"item"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Represents an incoming call, e.g. a caller of a method or constructor.
@@ -615,9 +702,13 @@ func (s *CallHierarchyIncomingCall) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'fromRanges' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type CallHierarchyIncomingCallAlias CallHierarchyIncomingCall
-	return json.Unmarshal(data, (*CallHierarchyIncomingCallAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		From       *CallHierarchyItem `json:"from"`
+		FromRanges []Range            `json:"fromRanges"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // The parameter of a `callHierarchy/outgoingCalls` request.
@@ -641,9 +732,15 @@ func (s *CallHierarchyOutgoingCallsParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'item' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type CallHierarchyOutgoingCallsParamsAlias CallHierarchyOutgoingCallsParams
-	return json.Unmarshal(data, (*CallHierarchyOutgoingCallsParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressParams
+		PartialResultParams
+
+		Item *CallHierarchyItem `json:"item"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Represents an outgoing call, e.g. calling a getter from a method or a method from a constructor etc.
@@ -673,9 +770,13 @@ func (s *CallHierarchyOutgoingCall) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'fromRanges' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type CallHierarchyOutgoingCallAlias CallHierarchyOutgoingCall
-	return json.Unmarshal(data, (*CallHierarchyOutgoingCallAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		To         *CallHierarchyItem `json:"to"`
+		FromRanges []Range            `json:"fromRanges"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Since: 3.16.0
@@ -698,9 +799,15 @@ func (s *SemanticTokensParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type SemanticTokensParamsAlias SemanticTokensParams
-	return json.Unmarshal(data, (*SemanticTokensParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressParams
+		PartialResultParams
+
+		TextDocument TextDocumentIdentifier `json:"textDocument"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Since: 3.16.0
@@ -726,9 +833,13 @@ func (s *SemanticTokens) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'data' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type SemanticTokensAlias SemanticTokens
-	return json.Unmarshal(data, (*SemanticTokensAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		ResultId *string  `json:"resultId,omitempty"`
+		Data     []uint32 `json:"data"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Since: 3.16.0
@@ -747,9 +858,12 @@ func (s *SemanticTokensPartialResult) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'data' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type SemanticTokensPartialResultAlias SemanticTokensPartialResult
-	return json.Unmarshal(data, (*SemanticTokensPartialResultAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Data []uint32 `json:"data"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Since: 3.16.0
@@ -786,9 +900,16 @@ func (s *SemanticTokensDeltaParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'previousResultId' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type SemanticTokensDeltaParamsAlias SemanticTokensDeltaParams
-	return json.Unmarshal(data, (*SemanticTokensDeltaParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressParams
+		PartialResultParams
+
+		TextDocument     TextDocumentIdentifier `json:"textDocument"`
+		PreviousResultId string                 `json:"previousResultId"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Since: 3.16.0
@@ -810,9 +931,13 @@ func (s *SemanticTokensDelta) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'edits' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type SemanticTokensDeltaAlias SemanticTokensDelta
-	return json.Unmarshal(data, (*SemanticTokensDeltaAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		ResultId *string               `json:"resultId,omitempty"`
+		Edits    []*SemanticTokensEdit `json:"edits"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Since: 3.16.0
@@ -831,9 +956,12 @@ func (s *SemanticTokensDeltaPartialResult) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'edits' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type SemanticTokensDeltaPartialResultAlias SemanticTokensDeltaPartialResult
-	return json.Unmarshal(data, (*SemanticTokensDeltaPartialResultAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Edits []*SemanticTokensEdit `json:"edits"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Since: 3.16.0
@@ -862,9 +990,16 @@ func (s *SemanticTokensRangeParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'range' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type SemanticTokensRangeParamsAlias SemanticTokensRangeParams
-	return json.Unmarshal(data, (*SemanticTokensRangeParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressParams
+		PartialResultParams
+
+		TextDocument TextDocumentIdentifier `json:"textDocument"`
+		Range        Range                  `json:"range"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Params to show a resource in the UI.
@@ -903,9 +1038,15 @@ func (s *ShowDocumentParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ShowDocumentParamsAlias ShowDocumentParams
-	return json.Unmarshal(data, (*ShowDocumentParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Uri       URI    `json:"uri"`
+		External  *bool  `json:"external,omitempty"`
+		TakeFocus *bool  `json:"takeFocus,omitempty"`
+		Selection *Range `json:"selection,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // The result of a showDocument request.
@@ -927,9 +1068,12 @@ func (s *ShowDocumentResult) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'success' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ShowDocumentResultAlias ShowDocumentResult
-	return json.Unmarshal(data, (*ShowDocumentResultAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Success bool `json:"success"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type LinkedEditingRangeParams struct {
@@ -962,9 +1106,13 @@ func (s *LinkedEditingRanges) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'ranges' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type LinkedEditingRangesAlias LinkedEditingRanges
-	return json.Unmarshal(data, (*LinkedEditingRangesAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Ranges      []Range `json:"ranges"`
+		WordPattern *string `json:"wordPattern,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type LinkedEditingRangeRegistrationOptions struct {
@@ -993,9 +1141,12 @@ func (s *CreateFilesParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'files' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type CreateFilesParamsAlias CreateFilesParams
-	return json.Unmarshal(data, (*CreateFilesParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Files []*FileCreate `json:"files"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A workspace edit represents changes to many resources managed in the workspace. The edit
@@ -1054,9 +1205,12 @@ func (s *FileOperationRegistrationOptions) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'filters' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type FileOperationRegistrationOptionsAlias FileOperationRegistrationOptions
-	return json.Unmarshal(data, (*FileOperationRegistrationOptionsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Filters []*FileOperationFilter `json:"filters"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // The parameters sent in notifications/requests for user-initiated renames of
@@ -1080,9 +1234,12 @@ func (s *RenameFilesParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'files' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type RenameFilesParamsAlias RenameFilesParams
-	return json.Unmarshal(data, (*RenameFilesParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Files []*FileRename `json:"files"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // The parameters sent in notifications/requests for user-initiated deletes of
@@ -1105,9 +1262,12 @@ func (s *DeleteFilesParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'files' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DeleteFilesParamsAlias DeleteFilesParams
-	return json.Unmarshal(data, (*DeleteFilesParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Files []*FileDelete `json:"files"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type MonikerParams struct {
@@ -1151,9 +1311,15 @@ func (s *Moniker) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'unique' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type MonikerAlias Moniker
-	return json.Unmarshal(data, (*MonikerAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Scheme     string          `json:"scheme"`
+		Identifier string          `json:"identifier"`
+		Unique     UniquenessLevel `json:"unique"`
+		Kind       *MonikerKind    `json:"kind,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type MonikerRegistrationOptions struct {
@@ -1225,9 +1391,19 @@ func (s *TypeHierarchyItem) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'selectionRange' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type TypeHierarchyItemAlias TypeHierarchyItem
-	return json.Unmarshal(data, (*TypeHierarchyItemAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Name           string       `json:"name"`
+		Kind           SymbolKind   `json:"kind"`
+		Tags           *[]SymbolTag `json:"tags,omitempty"`
+		Detail         *string      `json:"detail,omitempty"`
+		Uri            DocumentUri  `json:"uri"`
+		Range          Range        `json:"range"`
+		SelectionRange Range        `json:"selectionRange"`
+		Data           *any         `json:"data,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Type hierarchy options used during static or dynamic registration.
@@ -1260,9 +1436,15 @@ func (s *TypeHierarchySupertypesParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'item' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type TypeHierarchySupertypesParamsAlias TypeHierarchySupertypesParams
-	return json.Unmarshal(data, (*TypeHierarchySupertypesParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressParams
+		PartialResultParams
+
+		Item *TypeHierarchyItem `json:"item"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // The parameter of a `typeHierarchy/subtypes` request.
@@ -1286,9 +1468,15 @@ func (s *TypeHierarchySubtypesParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'item' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type TypeHierarchySubtypesParamsAlias TypeHierarchySubtypesParams
-	return json.Unmarshal(data, (*TypeHierarchySubtypesParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressParams
+		PartialResultParams
+
+		Item *TypeHierarchyItem `json:"item"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A parameter literal used in inline value requests.
@@ -1325,9 +1513,16 @@ func (s *InlineValueParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'context' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type InlineValueParamsAlias InlineValueParams
-	return json.Unmarshal(data, (*InlineValueParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressParams
+
+		TextDocument TextDocumentIdentifier `json:"textDocument"`
+		Range        Range                  `json:"range"`
+		Context      *InlineValueContext    `json:"context"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Inline value options used during static or dynamic registration.
@@ -1366,9 +1561,15 @@ func (s *InlayHintParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'range' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type InlayHintParamsAlias InlayHintParams
-	return json.Unmarshal(data, (*InlayHintParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressParams
+
+		TextDocument TextDocumentIdentifier `json:"textDocument"`
+		Range        Range                  `json:"range"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Inlay hint information.
@@ -1434,9 +1635,19 @@ func (s *InlayHint) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'label' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type InlayHintAlias InlayHint
-	return json.Unmarshal(data, (*InlayHintAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Position     Position                    `json:"position"`
+		Label        StringOrInlayHintLabelParts `json:"label"`
+		Kind         *InlayHintKind              `json:"kind,omitempty"`
+		TextEdits    *[]*TextEdit                `json:"textEdits,omitempty"`
+		Tooltip      *StringOrMarkupContent      `json:"tooltip,omitempty"`
+		PaddingLeft  *bool                       `json:"paddingLeft,omitempty"`
+		PaddingRight *bool                       `json:"paddingRight,omitempty"`
+		Data         *any                        `json:"data,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Inlay hint options used during static or dynamic registration.
@@ -1476,9 +1687,17 @@ func (s *DocumentDiagnosticParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DocumentDiagnosticParamsAlias DocumentDiagnosticParams
-	return json.Unmarshal(data, (*DocumentDiagnosticParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressParams
+		PartialResultParams
+
+		TextDocument     TextDocumentIdentifier `json:"textDocument"`
+		Identifier       *string                `json:"identifier,omitempty"`
+		PreviousResultId *string                `json:"previousResultId,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A partial result for a document diagnostic report.
@@ -1499,9 +1718,12 @@ func (s *DocumentDiagnosticReportPartialResult) UnmarshalJSON(data []byte) error
 		return fmt.Errorf("required key 'relatedDocuments' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DocumentDiagnosticReportPartialResultAlias DocumentDiagnosticReportPartialResult
-	return json.Unmarshal(data, (*DocumentDiagnosticReportPartialResultAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		RelatedDocuments map[DocumentUri]FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport `json:"relatedDocuments"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Cancellation data returned from a diagnostic request.
@@ -1522,9 +1744,12 @@ func (s *DiagnosticServerCancellationData) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'retriggerRequest' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DiagnosticServerCancellationDataAlias DiagnosticServerCancellationData
-	return json.Unmarshal(data, (*DiagnosticServerCancellationDataAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		RetriggerRequest bool `json:"retriggerRequest"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Diagnostic registration options.
@@ -1562,9 +1787,16 @@ func (s *WorkspaceDiagnosticParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'previousResultIds' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type WorkspaceDiagnosticParamsAlias WorkspaceDiagnosticParams
-	return json.Unmarshal(data, (*WorkspaceDiagnosticParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressParams
+		PartialResultParams
+
+		Identifier        *string            `json:"identifier,omitempty"`
+		PreviousResultIds []PreviousResultId `json:"previousResultIds"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A workspace diagnostic report.
@@ -1585,9 +1817,12 @@ func (s *WorkspaceDiagnosticReport) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'items' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type WorkspaceDiagnosticReportAlias WorkspaceDiagnosticReport
-	return json.Unmarshal(data, (*WorkspaceDiagnosticReportAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Items []WorkspaceDocumentDiagnosticReport `json:"items"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A partial result for a workspace diagnostic report.
@@ -1608,9 +1843,12 @@ func (s *WorkspaceDiagnosticReportPartialResult) UnmarshalJSON(data []byte) erro
 		return fmt.Errorf("required key 'items' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type WorkspaceDiagnosticReportPartialResultAlias WorkspaceDiagnosticReportPartialResult
-	return json.Unmarshal(data, (*WorkspaceDiagnosticReportPartialResultAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Items []WorkspaceDocumentDiagnosticReport `json:"items"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // The params sent in an open notebook document notification.
@@ -1639,9 +1877,13 @@ func (s *DidOpenNotebookDocumentParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'cellTextDocuments' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DidOpenNotebookDocumentParamsAlias DidOpenNotebookDocumentParams
-	return json.Unmarshal(data, (*DidOpenNotebookDocumentParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		NotebookDocument  *NotebookDocument   `json:"notebookDocument"`
+		CellTextDocuments []*TextDocumentItem `json:"cellTextDocuments"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Registration options specific to a notebook.
@@ -1692,9 +1934,13 @@ func (s *DidChangeNotebookDocumentParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'change' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DidChangeNotebookDocumentParamsAlias DidChangeNotebookDocumentParams
-	return json.Unmarshal(data, (*DidChangeNotebookDocumentParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		NotebookDocument VersionedNotebookDocumentIdentifier `json:"notebookDocument"`
+		Change           *NotebookDocumentChangeEvent        `json:"change"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // The params sent in a save notebook document notification.
@@ -1716,9 +1962,12 @@ func (s *DidSaveNotebookDocumentParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'notebookDocument' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DidSaveNotebookDocumentParamsAlias DidSaveNotebookDocumentParams
-	return json.Unmarshal(data, (*DidSaveNotebookDocumentParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		NotebookDocument NotebookDocumentIdentifier `json:"notebookDocument"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // The params sent in a close notebook document notification.
@@ -1747,9 +1996,13 @@ func (s *DidCloseNotebookDocumentParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'cellTextDocuments' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DidCloseNotebookDocumentParamsAlias DidCloseNotebookDocumentParams
-	return json.Unmarshal(data, (*DidCloseNotebookDocumentParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		NotebookDocument  NotebookDocumentIdentifier `json:"notebookDocument"`
+		CellTextDocuments []TextDocumentIdentifier   `json:"cellTextDocuments"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A parameter literal used in inline completion requests.
@@ -1777,9 +2030,15 @@ func (s *InlineCompletionParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'context' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type InlineCompletionParamsAlias InlineCompletionParams
-	return json.Unmarshal(data, (*InlineCompletionParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		TextDocumentPositionParams
+		WorkDoneProgressParams
+
+		Context *InlineCompletionContext `json:"context"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Represents a collection of items to be presented in the editor.
@@ -1803,9 +2062,12 @@ func (s *InlineCompletionList) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'items' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type InlineCompletionListAlias InlineCompletionList
-	return json.Unmarshal(data, (*InlineCompletionListAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Items []*InlineCompletionItem `json:"items"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // An inline completion item represents a text snippet that is proposed inline to complete text that is being typed.
@@ -1838,9 +2100,15 @@ func (s *InlineCompletionItem) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'insertText' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type InlineCompletionItemAlias InlineCompletionItem
-	return json.Unmarshal(data, (*InlineCompletionItemAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		InsertText StringOrStringValue `json:"insertText"`
+		FilterText *string             `json:"filterText,omitempty"`
+		Range      *Range              `json:"range,omitempty"`
+		Command    *Command            `json:"command,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Inline completion options used during static or dynamic registration.
@@ -1875,9 +2143,12 @@ func (s *TextDocumentContentParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type TextDocumentContentParamsAlias TextDocumentContentParams
-	return json.Unmarshal(data, (*TextDocumentContentParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Uri DocumentUri `json:"uri"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Result of the `workspace/textDocumentContent` request.
@@ -1904,9 +2175,12 @@ func (s *TextDocumentContentResult) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'text' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type TextDocumentContentResultAlias TextDocumentContentResult
-	return json.Unmarshal(data, (*TextDocumentContentResultAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Text string `json:"text"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Text document content provider registration options.
@@ -1940,9 +2214,12 @@ func (s *TextDocumentContentRefreshParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type TextDocumentContentRefreshParamsAlias TextDocumentContentRefreshParams
-	return json.Unmarshal(data, (*TextDocumentContentRefreshParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Uri DocumentUri `json:"uri"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type RegistrationParams struct {
@@ -1960,9 +2237,12 @@ func (s *RegistrationParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'registrations' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type RegistrationParamsAlias RegistrationParams
-	return json.Unmarshal(data, (*RegistrationParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Registrations []*Registration `json:"registrations"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type UnregistrationParams struct {
@@ -1980,9 +2260,12 @@ func (s *UnregistrationParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'unregisterations' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type UnregistrationParamsAlias UnregistrationParams
-	return json.Unmarshal(data, (*UnregistrationParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Unregisterations []*Unregistration `json:"unregisterations"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type InitializeParams struct {
@@ -2012,9 +2295,13 @@ func (s *InitializeResult) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'capabilities' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type InitializeResultAlias InitializeResult
-	return json.Unmarshal(data, (*InitializeResultAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Capabilities *ServerCapabilities `json:"capabilities"`
+		ServerInfo   *ServerInfo         `json:"serverInfo,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // The data type of the ResponseError if the
@@ -2038,9 +2325,12 @@ func (s *InitializeError) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'retry' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type InitializeErrorAlias InitializeError
-	return json.Unmarshal(data, (*InitializeErrorAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Retry bool `json:"retry"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type InitializedParams struct{}
@@ -2062,9 +2352,12 @@ func (s *DidChangeConfigurationParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'settings' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DidChangeConfigurationParamsAlias DidChangeConfigurationParams
-	return json.Unmarshal(data, (*DidChangeConfigurationParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Settings any `json:"settings"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type DidChangeConfigurationRegistrationOptions struct {
@@ -2094,9 +2387,13 @@ func (s *ShowMessageParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'message' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ShowMessageParamsAlias ShowMessageParams
-	return json.Unmarshal(data, (*ShowMessageParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Type    MessageType `json:"type"`
+		Message string      `json:"message"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type ShowMessageRequestParams struct {
@@ -2124,9 +2421,14 @@ func (s *ShowMessageRequestParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'message' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ShowMessageRequestParamsAlias ShowMessageRequestParams
-	return json.Unmarshal(data, (*ShowMessageRequestParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Type    MessageType           `json:"type"`
+		Message string                `json:"message"`
+		Actions *[]*MessageActionItem `json:"actions,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type MessageActionItem struct {
@@ -2145,9 +2447,12 @@ func (s *MessageActionItem) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'title' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type MessageActionItemAlias MessageActionItem
-	return json.Unmarshal(data, (*MessageActionItemAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Title string `json:"title"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // The log message parameters.
@@ -2173,9 +2478,13 @@ func (s *LogMessageParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'message' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type LogMessageParamsAlias LogMessageParams
-	return json.Unmarshal(data, (*LogMessageParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Type    MessageType `json:"type"`
+		Message string      `json:"message"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // The parameters sent in an open text document notification
@@ -2195,9 +2504,12 @@ func (s *DidOpenTextDocumentParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DidOpenTextDocumentParamsAlias DidOpenTextDocumentParams
-	return json.Unmarshal(data, (*DidOpenTextDocumentParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		TextDocument *TextDocumentItem `json:"textDocument"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // The change text document notification's parameters.
@@ -2235,9 +2547,13 @@ func (s *DidChangeTextDocumentParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'contentChanges' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DidChangeTextDocumentParamsAlias DidChangeTextDocumentParams
-	return json.Unmarshal(data, (*DidChangeTextDocumentParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		TextDocument   VersionedTextDocumentIdentifier  `json:"textDocument"`
+		ContentChanges []TextDocumentContentChangeEvent `json:"contentChanges"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Describe options to be used when registered for text document change events.
@@ -2259,9 +2575,14 @@ func (s *TextDocumentChangeRegistrationOptions) UnmarshalJSON(data []byte) error
 		return fmt.Errorf("required key 'syncKind' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type TextDocumentChangeRegistrationOptionsAlias TextDocumentChangeRegistrationOptions
-	return json.Unmarshal(data, (*TextDocumentChangeRegistrationOptionsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		TextDocumentRegistrationOptions
+
+		SyncKind TextDocumentSyncKind `json:"syncKind"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // The parameters sent in a close text document notification
@@ -2281,9 +2602,12 @@ func (s *DidCloseTextDocumentParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DidCloseTextDocumentParamsAlias DidCloseTextDocumentParams
-	return json.Unmarshal(data, (*DidCloseTextDocumentParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		TextDocument TextDocumentIdentifier `json:"textDocument"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // The parameters sent in a save text document notification
@@ -2307,9 +2631,13 @@ func (s *DidSaveTextDocumentParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DidSaveTextDocumentParamsAlias DidSaveTextDocumentParams
-	return json.Unmarshal(data, (*DidSaveTextDocumentParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		TextDocument TextDocumentIdentifier `json:"textDocument"`
+		Text         *string                `json:"text,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Save registration options.
@@ -2341,9 +2669,13 @@ func (s *WillSaveTextDocumentParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'reason' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type WillSaveTextDocumentParamsAlias WillSaveTextDocumentParams
-	return json.Unmarshal(data, (*WillSaveTextDocumentParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		TextDocument TextDocumentIdentifier `json:"textDocument"`
+		Reason       TextDocumentSaveReason `json:"reason"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A text edit applicable to a text document.
@@ -2371,9 +2703,13 @@ func (s *TextEdit) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'newText' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type TextEditAlias TextEdit
-	return json.Unmarshal(data, (*TextEditAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Range   Range  `json:"range"`
+		NewText string `json:"newText"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // The watched files change notification's parameters.
@@ -2393,9 +2729,12 @@ func (s *DidChangeWatchedFilesParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'changes' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DidChangeWatchedFilesParamsAlias DidChangeWatchedFilesParams
-	return json.Unmarshal(data, (*DidChangeWatchedFilesParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Changes []*FileEvent `json:"changes"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Describe options to be used when registered for text document change events.
@@ -2415,9 +2754,12 @@ func (s *DidChangeWatchedFilesRegistrationOptions) UnmarshalJSON(data []byte) er
 		return fmt.Errorf("required key 'watchers' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DidChangeWatchedFilesRegistrationOptionsAlias DidChangeWatchedFilesRegistrationOptions
-	return json.Unmarshal(data, (*DidChangeWatchedFilesRegistrationOptionsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Watchers []*FileSystemWatcher `json:"watchers"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // The publish diagnostic notification's parameters.
@@ -2448,9 +2790,14 @@ func (s *PublishDiagnosticsParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'diagnostics' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type PublishDiagnosticsParamsAlias PublishDiagnosticsParams
-	return json.Unmarshal(data, (*PublishDiagnosticsParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Uri         DocumentUri   `json:"uri"`
+		Version     *int32        `json:"version,omitempty"`
+		Diagnostics []*Diagnostic `json:"diagnostics"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Completion parameters
@@ -2616,9 +2963,30 @@ func (s *CompletionItem) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'label' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type CompletionItemAlias CompletionItem
-	return json.Unmarshal(data, (*CompletionItemAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Label               string                       `json:"label"`
+		LabelDetails        *CompletionItemLabelDetails  `json:"labelDetails,omitempty"`
+		Kind                *CompletionItemKind          `json:"kind,omitempty"`
+		Tags                *[]CompletionItemTag         `json:"tags,omitempty"`
+		Detail              *string                      `json:"detail,omitempty"`
+		Documentation       *StringOrMarkupContent       `json:"documentation,omitempty"`
+		Deprecated          *bool                        `json:"deprecated,omitempty"`
+		Preselect           *bool                        `json:"preselect,omitempty"`
+		SortText            *string                      `json:"sortText,omitempty"`
+		FilterText          *string                      `json:"filterText,omitempty"`
+		InsertText          *string                      `json:"insertText,omitempty"`
+		InsertTextFormat    *InsertTextFormat            `json:"insertTextFormat,omitempty"`
+		InsertTextMode      *InsertTextMode              `json:"insertTextMode,omitempty"`
+		TextEdit            *TextEditOrInsertReplaceEdit `json:"textEdit,omitempty"`
+		TextEditText        *string                      `json:"textEditText,omitempty"`
+		AdditionalTextEdits *[]*TextEdit                 `json:"additionalTextEdits,omitempty"`
+		CommitCharacters    *[]string                    `json:"commitCharacters,omitempty"`
+		Command             *Command                     `json:"command,omitempty"`
+		Data                *any                         `json:"data,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Represents a collection of items to be presented
@@ -2684,9 +3052,15 @@ func (s *CompletionList) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'items' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type CompletionListAlias CompletionList
-	return json.Unmarshal(data, (*CompletionListAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		IsIncomplete bool                      `json:"isIncomplete"`
+		ItemDefaults *CompletionItemDefaults   `json:"itemDefaults,omitempty"`
+		ApplyKind    *CompletionItemApplyKinds `json:"applyKind,omitempty"`
+		Items        []*CompletionItem         `json:"items"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Registration options for a CompletionRequest.
@@ -2722,9 +3096,13 @@ func (s *Hover) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'contents' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type HoverAlias Hover
-	return json.Unmarshal(data, (*HoverAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Contents MarkupContentOrMarkedStringOrMarkedStrings `json:"contents"`
+		Range    *Range                                     `json:"range,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Registration options for a HoverRequest.
@@ -2793,9 +3171,14 @@ func (s *SignatureHelp) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'signatures' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type SignatureHelpAlias SignatureHelp
-	return json.Unmarshal(data, (*SignatureHelpAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Signatures      []*SignatureInformation `json:"signatures"`
+		ActiveSignature *uint32                 `json:"activeSignature,omitempty"`
+		ActiveParameter *Nullable[uint32]       `json:"activeParameter,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Registration options for a SignatureHelpRequest.
@@ -2837,9 +3220,16 @@ func (s *ReferenceParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'context' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ReferenceParamsAlias ReferenceParams
-	return json.Unmarshal(data, (*ReferenceParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		TextDocumentPositionParams
+		WorkDoneProgressParams
+		PartialResultParams
+
+		Context *ReferenceContext `json:"context"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Registration options for a ReferencesRequest.
@@ -2877,9 +3267,13 @@ func (s *DocumentHighlight) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'range' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DocumentHighlightAlias DocumentHighlight
-	return json.Unmarshal(data, (*DocumentHighlightAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Range Range                  `json:"range"`
+		Kind  *DocumentHighlightKind `json:"kind,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Registration options for a DocumentHighlightRequest.
@@ -2908,9 +3302,15 @@ func (s *DocumentSymbolParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DocumentSymbolParamsAlias DocumentSymbolParams
-	return json.Unmarshal(data, (*DocumentSymbolParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressParams
+		PartialResultParams
+
+		TextDocument TextDocumentIdentifier `json:"textDocument"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Represents information about programming constructs like variables, classes,
@@ -2946,9 +3346,15 @@ func (s *SymbolInformation) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'location' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type SymbolInformationAlias SymbolInformation
-	return json.Unmarshal(data, (*SymbolInformationAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		BaseSymbolInformation
+
+		Deprecated *bool    `json:"deprecated,omitempty"`
+		Location   Location `json:"location"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Represents programming constructs like variables, classes, interfaces etc.
@@ -3009,9 +3415,19 @@ func (s *DocumentSymbol) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'selectionRange' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DocumentSymbolAlias DocumentSymbol
-	return json.Unmarshal(data, (*DocumentSymbolAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Name           string             `json:"name"`
+		Detail         *string            `json:"detail,omitempty"`
+		Kind           SymbolKind         `json:"kind"`
+		Tags           *[]SymbolTag       `json:"tags,omitempty"`
+		Deprecated     *bool              `json:"deprecated,omitempty"`
+		Range          Range              `json:"range"`
+		SelectionRange Range              `json:"selectionRange"`
+		Children       *[]*DocumentSymbol `json:"children,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Registration options for a DocumentSymbolRequest.
@@ -3052,9 +3468,17 @@ func (s *CodeActionParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'context' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type CodeActionParamsAlias CodeActionParams
-	return json.Unmarshal(data, (*CodeActionParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressParams
+		PartialResultParams
+
+		TextDocument TextDocumentIdentifier `json:"textDocument"`
+		Range        Range                  `json:"range"`
+		Context      *CodeActionContext     `json:"context"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Represents a reference to a command. Provides a title which
@@ -3094,9 +3518,15 @@ func (s *Command) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'command' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type CommandAlias Command
-	return json.Unmarshal(data, (*CommandAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Title     string  `json:"title"`
+		Tooltip   *string `json:"tooltip,omitempty"`
+		Command   string  `json:"command"`
+		Arguments *[]any  `json:"arguments,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A code action represents a change that can be performed in code, e.g. to fix a problem or
@@ -3172,9 +3602,20 @@ func (s *CodeAction) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'title' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type CodeActionAlias CodeAction
-	return json.Unmarshal(data, (*CodeActionAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Title       string              `json:"title"`
+		Kind        *CodeActionKind     `json:"kind,omitempty"`
+		Diagnostics *[]*Diagnostic      `json:"diagnostics,omitempty"`
+		IsPreferred *bool               `json:"isPreferred,omitempty"`
+		Disabled    *CodeActionDisabled `json:"disabled,omitempty"`
+		Edit        *WorkspaceEdit      `json:"edit,omitempty"`
+		Command     *Command            `json:"command,omitempty"`
+		Data        *any                `json:"data,omitempty"`
+		Tags        *[]CodeActionTag    `json:"tags,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Registration options for a CodeActionRequest.
@@ -3210,9 +3651,15 @@ func (s *WorkspaceSymbolParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'query' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type WorkspaceSymbolParamsAlias WorkspaceSymbolParams
-	return json.Unmarshal(data, (*WorkspaceSymbolParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressParams
+		PartialResultParams
+
+		Query string `json:"query"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A special workspace symbol that supports locations without a range.
@@ -3246,9 +3693,15 @@ func (s *WorkspaceSymbol) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'location' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type WorkspaceSymbolAlias WorkspaceSymbol
-	return json.Unmarshal(data, (*WorkspaceSymbolAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		BaseSymbolInformation
+
+		Location LocationOrLocationUriOnly `json:"location"`
+		Data     *any                      `json:"data,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Registration options for a WorkspaceSymbolRequest.
@@ -3276,9 +3729,15 @@ func (s *CodeLensParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type CodeLensParamsAlias CodeLensParams
-	return json.Unmarshal(data, (*CodeLensParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressParams
+		PartialResultParams
+
+		TextDocument TextDocumentIdentifier `json:"textDocument"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A code lens represents a command that should be shown along with
@@ -3309,9 +3768,14 @@ func (s *CodeLens) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'range' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type CodeLensAlias CodeLens
-	return json.Unmarshal(data, (*CodeLensAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Range   Range    `json:"range"`
+		Command *Command `json:"command,omitempty"`
+		Data    *any     `json:"data,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Registration options for a CodeLensRequest.
@@ -3340,9 +3804,15 @@ func (s *DocumentLinkParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DocumentLinkParamsAlias DocumentLinkParams
-	return json.Unmarshal(data, (*DocumentLinkParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressParams
+		PartialResultParams
+
+		TextDocument TextDocumentIdentifier `json:"textDocument"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A document link is a range in a text document that links to an internal or external resource, like another
@@ -3379,9 +3849,15 @@ func (s *DocumentLink) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'range' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DocumentLinkAlias DocumentLink
-	return json.Unmarshal(data, (*DocumentLinkAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Range   Range   `json:"range"`
+		Target  *URI    `json:"target,omitempty"`
+		Tooltip *string `json:"tooltip,omitempty"`
+		Data    *any    `json:"data,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Registration options for a DocumentLinkRequest.
@@ -3415,9 +3891,15 @@ func (s *DocumentFormattingParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'options' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DocumentFormattingParamsAlias DocumentFormattingParams
-	return json.Unmarshal(data, (*DocumentFormattingParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressParams
+
+		TextDocument TextDocumentIdentifier `json:"textDocument"`
+		Options      *FormattingOptions     `json:"options"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Registration options for a DocumentFormattingRequest.
@@ -3457,9 +3939,16 @@ func (s *DocumentRangeFormattingParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'options' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DocumentRangeFormattingParamsAlias DocumentRangeFormattingParams
-	return json.Unmarshal(data, (*DocumentRangeFormattingParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressParams
+
+		TextDocument TextDocumentIdentifier `json:"textDocument"`
+		Range        Range                  `json:"range"`
+		Options      *FormattingOptions     `json:"options"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Registration options for a DocumentRangeFormattingRequest.
@@ -3503,9 +3992,16 @@ func (s *DocumentRangesFormattingParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'options' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DocumentRangesFormattingParamsAlias DocumentRangesFormattingParams
-	return json.Unmarshal(data, (*DocumentRangesFormattingParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressParams
+
+		TextDocument TextDocumentIdentifier `json:"textDocument"`
+		Ranges       []Range                `json:"ranges"`
+		Options      *FormattingOptions     `json:"options"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // The parameters of a DocumentOnTypeFormattingRequest.
@@ -3548,9 +4044,15 @@ func (s *DocumentOnTypeFormattingParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'options' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DocumentOnTypeFormattingParamsAlias DocumentOnTypeFormattingParams
-	return json.Unmarshal(data, (*DocumentOnTypeFormattingParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		TextDocument TextDocumentIdentifier `json:"textDocument"`
+		Position     Position               `json:"position"`
+		Ch           string                 `json:"ch"`
+		Options      *FormattingOptions     `json:"options"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Registration options for a DocumentOnTypeFormattingRequest.
@@ -3592,9 +4094,16 @@ func (s *RenameParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'newName' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type RenameParamsAlias RenameParams
-	return json.Unmarshal(data, (*RenameParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressParams
+
+		TextDocument TextDocumentIdentifier `json:"textDocument"`
+		Position     Position               `json:"position"`
+		NewName      string                 `json:"newName"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Registration options for a RenameRequest.
@@ -3630,9 +4139,15 @@ func (s *ExecuteCommandParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'command' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ExecuteCommandParamsAlias ExecuteCommandParams
-	return json.Unmarshal(data, (*ExecuteCommandParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressParams
+
+		Command   string `json:"command"`
+		Arguments *[]any `json:"arguments,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Registration options for a ExecuteCommandRequest.
@@ -3669,9 +4184,14 @@ func (s *ApplyWorkspaceEditParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'edit' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ApplyWorkspaceEditParamsAlias ApplyWorkspaceEditParams
-	return json.Unmarshal(data, (*ApplyWorkspaceEditParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Label    *string                `json:"label,omitempty"`
+		Edit     *WorkspaceEdit         `json:"edit"`
+		Metadata *WorkspaceEditMetadata `json:"metadata,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // The result returned from the apply workspace edit request.
@@ -3703,9 +4223,14 @@ func (s *ApplyWorkspaceEditResult) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'applied' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ApplyWorkspaceEditResultAlias ApplyWorkspaceEditResult
-	return json.Unmarshal(data, (*ApplyWorkspaceEditResultAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Applied       bool    `json:"applied"`
+		FailureReason *string `json:"failureReason,omitempty"`
+		FailedChange  *uint32 `json:"failedChange,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type WorkDoneProgressBegin struct {
@@ -3752,9 +4277,16 @@ func (s *WorkDoneProgressBegin) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'title' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type WorkDoneProgressBeginAlias WorkDoneProgressBegin
-	return json.Unmarshal(data, (*WorkDoneProgressBeginAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Kind        StringLiteralBegin `json:"kind"`
+		Title       string             `json:"title"`
+		Cancellable *bool              `json:"cancellable,omitempty"`
+		Message     *string            `json:"message,omitempty"`
+		Percentage  *uint32            `json:"percentage,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type WorkDoneProgressReport struct {
@@ -3793,9 +4325,15 @@ func (s *WorkDoneProgressReport) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type WorkDoneProgressReportAlias WorkDoneProgressReport
-	return json.Unmarshal(data, (*WorkDoneProgressReportAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Kind        StringLiteralReport `json:"kind"`
+		Cancellable *bool               `json:"cancellable,omitempty"`
+		Message     *string             `json:"message,omitempty"`
+		Percentage  *uint32             `json:"percentage,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type WorkDoneProgressEnd struct {
@@ -3817,9 +4355,13 @@ func (s *WorkDoneProgressEnd) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type WorkDoneProgressEndAlias WorkDoneProgressEnd
-	return json.Unmarshal(data, (*WorkDoneProgressEndAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Kind    StringLiteralEnd `json:"kind"`
+		Message *string          `json:"message,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type SetTraceParams struct {
@@ -3837,9 +4379,12 @@ func (s *SetTraceParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'value' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type SetTraceParamsAlias SetTraceParams
-	return json.Unmarshal(data, (*SetTraceParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Value TraceValue `json:"value"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type LogTraceParams struct {
@@ -3859,9 +4404,13 @@ func (s *LogTraceParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'message' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type LogTraceParamsAlias LogTraceParams
-	return json.Unmarshal(data, (*LogTraceParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Message string  `json:"message"`
+		Verbose *string `json:"verbose,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type CancelParams struct {
@@ -3880,9 +4429,12 @@ func (s *CancelParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'id' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type CancelParamsAlias CancelParams
-	return json.Unmarshal(data, (*CancelParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Id IntegerOrString `json:"id"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type ProgressParams struct {
@@ -3907,9 +4459,13 @@ func (s *ProgressParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'value' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ProgressParamsAlias ProgressParams
-	return json.Unmarshal(data, (*ProgressParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Token ProgressToken `json:"token"`
+		Value any           `json:"value"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A parameter literal used in requests to pass a text document and a position inside that
@@ -3936,9 +4492,13 @@ func (s *TextDocumentPositionParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'position' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type TextDocumentPositionParamsAlias TextDocumentPositionParams
-	return json.Unmarshal(data, (*TextDocumentPositionParamsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		TextDocument TextDocumentIdentifier `json:"textDocument"`
+		Position     Position               `json:"position"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type WorkDoneProgressParams struct {
@@ -3991,9 +4551,15 @@ func (s *LocationLink) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'targetSelectionRange' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type LocationLinkAlias LocationLink
-	return json.Unmarshal(data, (*LocationLinkAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		OriginSelectionRange *Range      `json:"originSelectionRange,omitempty"`
+		TargetUri            DocumentUri `json:"targetUri"`
+		TargetRange          Range       `json:"targetRange"`
+		TargetSelectionRange Range       `json:"targetSelectionRange"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A range in a text document expressed as (zero-based) start and end positions.
@@ -4031,9 +4597,13 @@ func (s *Range) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'end' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type RangeAlias Range
-	return json.Unmarshal(data, (*RangeAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Start Position `json:"start"`
+		End   Position `json:"end"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type ImplementationOptions struct {
@@ -4075,9 +4645,13 @@ func (s *WorkspaceFoldersChangeEvent) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'removed' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type WorkspaceFoldersChangeEventAlias WorkspaceFoldersChangeEvent
-	return json.Unmarshal(data, (*WorkspaceFoldersChangeEventAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Added   []*WorkspaceFolder `json:"added"`
+		Removed []*WorkspaceFolder `json:"removed"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type ConfigurationItem struct {
@@ -4105,9 +4679,12 @@ func (s *TextDocumentIdentifier) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type TextDocumentIdentifierAlias TextDocumentIdentifier
-	return json.Unmarshal(data, (*TextDocumentIdentifierAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Uri DocumentUri `json:"uri"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Represents a color in RGBA space.
@@ -4145,9 +4722,15 @@ func (s *Color) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'alpha' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ColorAlias Color
-	return json.Unmarshal(data, (*ColorAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Red   float64 `json:"red"`
+		Green float64 `json:"green"`
+		Blue  float64 `json:"blue"`
+		Alpha float64 `json:"alpha"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type DocumentColorOptions struct {
@@ -4214,9 +4797,13 @@ func (s *Position) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'character' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type PositionAlias Position
-	return json.Unmarshal(data, (*PositionAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Line      uint32 `json:"line"`
+		Character uint32 `json:"character"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type SelectionRangeOptions struct {
@@ -4256,9 +4843,16 @@ func (s *SemanticTokensOptions) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'legend' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type SemanticTokensOptionsAlias SemanticTokensOptions
-	return json.Unmarshal(data, (*SemanticTokensOptionsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressOptions
+
+		Legend *SemanticTokensLegend             `json:"legend"`
+		Range  *BooleanOrEmptyObject             `json:"range,omitempty"`
+		Full   *BooleanOrSemanticTokensFullDelta `json:"full,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Since: 3.16.0
@@ -4287,9 +4881,14 @@ func (s *SemanticTokensEdit) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'deleteCount' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type SemanticTokensEditAlias SemanticTokensEdit
-	return json.Unmarshal(data, (*SemanticTokensEditAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Start       uint32    `json:"start"`
+		DeleteCount uint32    `json:"deleteCount"`
+		Data        *[]uint32 `json:"data,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type LinkedEditingRangeOptions struct {
@@ -4315,9 +4914,12 @@ func (s *FileCreate) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type FileCreateAlias FileCreate
-	return json.Unmarshal(data, (*FileCreateAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Uri string `json:"uri"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Describes textual changes on a text document. A TextDocumentEdit describes all changes
@@ -4352,9 +4954,13 @@ func (s *TextDocumentEdit) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'edits' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type TextDocumentEditAlias TextDocumentEdit
-	return json.Unmarshal(data, (*TextDocumentEditAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		TextDocument OptionalVersionedTextDocumentIdentifier        `json:"textDocument"`
+		Edits        []TextEditOrAnnotatedTextEditOrSnippetTextEdit `json:"edits"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Create file operation.
@@ -4385,9 +4991,16 @@ func (s *CreateFile) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type CreateFileAlias CreateFile
-	return json.Unmarshal(data, (*CreateFileAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		ResourceOperation
+
+		Kind    StringLiteralCreate `json:"kind"`
+		Uri     DocumentUri         `json:"uri"`
+		Options *CreateFileOptions  `json:"options,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Rename file operation
@@ -4424,9 +5037,17 @@ func (s *RenameFile) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'newUri' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type RenameFileAlias RenameFile
-	return json.Unmarshal(data, (*RenameFileAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		ResourceOperation
+
+		Kind    StringLiteralRename `json:"kind"`
+		OldUri  DocumentUri         `json:"oldUri"`
+		NewUri  DocumentUri         `json:"newUri"`
+		Options *RenameFileOptions  `json:"options,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Delete file operation
@@ -4457,9 +5078,16 @@ func (s *DeleteFile) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DeleteFileAlias DeleteFile
-	return json.Unmarshal(data, (*DeleteFileAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		ResourceOperation
+
+		Kind    StringLiteralDelete `json:"kind"`
+		Uri     DocumentUri         `json:"uri"`
+		Options *DeleteFileOptions  `json:"options,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Additional information that describes document changes.
@@ -4490,9 +5118,14 @@ func (s *ChangeAnnotation) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'label' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ChangeAnnotationAlias ChangeAnnotation
-	return json.Unmarshal(data, (*ChangeAnnotationAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Label             string  `json:"label"`
+		NeedsConfirmation *bool   `json:"needsConfirmation,omitempty"`
+		Description       *string `json:"description,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A filter to describe in which file operation requests or notifications
@@ -4518,9 +5151,13 @@ func (s *FileOperationFilter) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'pattern' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type FileOperationFilterAlias FileOperationFilter
-	return json.Unmarshal(data, (*FileOperationFilterAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Scheme  *string               `json:"scheme,omitempty"`
+		Pattern *FileOperationPattern `json:"pattern"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Represents information on a file/folder rename.
@@ -4548,9 +5185,13 @@ func (s *FileRename) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'newUri' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type FileRenameAlias FileRename
-	return json.Unmarshal(data, (*FileRenameAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		OldUri string `json:"oldUri"`
+		NewUri string `json:"newUri"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Represents information on a file/folder delete.
@@ -4572,9 +5213,12 @@ func (s *FileDelete) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type FileDeleteAlias FileDelete
-	return json.Unmarshal(data, (*FileDeleteAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Uri string `json:"uri"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type MonikerOptions struct {
@@ -4612,9 +5256,13 @@ func (s *InlineValueContext) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'stoppedLocation' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type InlineValueContextAlias InlineValueContext
-	return json.Unmarshal(data, (*InlineValueContextAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		FrameId         int32 `json:"frameId"`
+		StoppedLocation Range `json:"stoppedLocation"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Provide inline value as text.
@@ -4642,9 +5290,13 @@ func (s *InlineValueText) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'text' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type InlineValueTextAlias InlineValueText
-	return json.Unmarshal(data, (*InlineValueTextAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Range Range  `json:"range"`
+		Text  string `json:"text"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Provide inline value through a variable lookup.
@@ -4678,9 +5330,14 @@ func (s *InlineValueVariableLookup) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'caseSensitiveLookup' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type InlineValueVariableLookupAlias InlineValueVariableLookup
-	return json.Unmarshal(data, (*InlineValueVariableLookupAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Range               Range   `json:"range"`
+		VariableName        *string `json:"variableName,omitempty"`
+		CaseSensitiveLookup bool    `json:"caseSensitiveLookup"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Provide an inline value through an expression evaluation.
@@ -4708,9 +5365,13 @@ func (s *InlineValueEvaluatableExpression) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'range' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type InlineValueEvaluatableExpressionAlias InlineValueEvaluatableExpression
-	return json.Unmarshal(data, (*InlineValueEvaluatableExpressionAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Range      Range   `json:"range"`
+		Expression *string `json:"expression,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Inline value options used during static registration.
@@ -4764,9 +5425,15 @@ func (s *InlayHintLabelPart) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'value' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type InlayHintLabelPartAlias InlayHintLabelPart
-	return json.Unmarshal(data, (*InlayHintLabelPartAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Value    string                 `json:"value"`
+		Tooltip  *StringOrMarkupContent `json:"tooltip,omitempty"`
+		Location *Location              `json:"location,omitempty"`
+		Command  *Command               `json:"command,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A `MarkupContent` literal represents a string value which content is interpreted base on its
@@ -4815,9 +5482,13 @@ func (s *MarkupContent) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'value' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type MarkupContentAlias MarkupContent
-	return json.Unmarshal(data, (*MarkupContentAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Kind  MarkupKind `json:"kind"`
+		Value string     `json:"value"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Inlay hint options used during static registration.
@@ -4893,9 +5564,14 @@ func (s *FullDocumentDiagnosticReport) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'items' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type FullDocumentDiagnosticReportAlias FullDocumentDiagnosticReport
-	return json.Unmarshal(data, (*FullDocumentDiagnosticReportAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Kind     StringLiteralFull `json:"kind"`
+		ResultId *string           `json:"resultId,omitempty"`
+		Items    []*Diagnostic     `json:"items"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A diagnostic report indicating that the last returned
@@ -4928,9 +5604,13 @@ func (s *UnchangedDocumentDiagnosticReport) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'resultId' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type UnchangedDocumentDiagnosticReportAlias UnchangedDocumentDiagnosticReport
-	return json.Unmarshal(data, (*UnchangedDocumentDiagnosticReportAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Kind     StringLiteralUnchanged `json:"kind"`
+		ResultId string                 `json:"resultId"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Diagnostic options.
@@ -4967,9 +5647,16 @@ func (s *DiagnosticOptions) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'workspaceDiagnostics' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DiagnosticOptionsAlias DiagnosticOptions
-	return json.Unmarshal(data, (*DiagnosticOptionsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressOptions
+
+		Identifier            *string `json:"identifier,omitempty"`
+		InterFileDependencies bool    `json:"interFileDependencies"`
+		WorkspaceDiagnostics  bool    `json:"workspaceDiagnostics"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A previous result id in a workspace pull request.
@@ -4998,9 +5685,13 @@ func (s *PreviousResultId) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'value' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type PreviousResultIdAlias PreviousResultId
-	return json.Unmarshal(data, (*PreviousResultIdAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Uri   DocumentUri `json:"uri"`
+		Value string      `json:"value"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A notebook document.
@@ -5047,9 +5738,16 @@ func (s *NotebookDocument) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'cells' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type NotebookDocumentAlias NotebookDocument
-	return json.Unmarshal(data, (*NotebookDocumentAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Uri          URI             `json:"uri"`
+		NotebookType string          `json:"notebookType"`
+		Version      int32           `json:"version"`
+		Metadata     *map[string]any `json:"metadata,omitempty"`
+		Cells        []*NotebookCell `json:"cells"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // An item to transfer a text document from the client to the
@@ -5089,9 +5787,15 @@ func (s *TextDocumentItem) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'text' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type TextDocumentItemAlias TextDocumentItem
-	return json.Unmarshal(data, (*TextDocumentItemAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Uri        DocumentUri  `json:"uri"`
+		LanguageId LanguageKind `json:"languageId"`
+		Version    int32        `json:"version"`
+		Text       string       `json:"text"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Options specific to a notebook plus its cells
@@ -5127,9 +5831,13 @@ func (s *NotebookDocumentSyncOptions) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'notebookSelector' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type NotebookDocumentSyncOptionsAlias NotebookDocumentSyncOptions
-	return json.Unmarshal(data, (*NotebookDocumentSyncOptionsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		NotebookSelector []NotebookDocumentFilterWithNotebookOrNotebookDocumentFilterWithCells `json:"notebookSelector"`
+		Save             *bool                                                                 `json:"save,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A versioned notebook document identifier.
@@ -5157,9 +5865,13 @@ func (s *VersionedNotebookDocumentIdentifier) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type VersionedNotebookDocumentIdentifierAlias VersionedNotebookDocumentIdentifier
-	return json.Unmarshal(data, (*VersionedNotebookDocumentIdentifierAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Version int32 `json:"version"`
+		Uri     URI   `json:"uri"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A change event for a notebook document.
@@ -5194,9 +5906,12 @@ func (s *NotebookDocumentIdentifier) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type NotebookDocumentIdentifierAlias NotebookDocumentIdentifier
-	return json.Unmarshal(data, (*NotebookDocumentIdentifierAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Uri URI `json:"uri"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Provides information about the context in which an inline completion was requested.
@@ -5223,9 +5938,13 @@ func (s *InlineCompletionContext) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'triggerKind' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type InlineCompletionContextAlias InlineCompletionContext
-	return json.Unmarshal(data, (*InlineCompletionContextAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		TriggerKind            InlineCompletionTriggerKind `json:"triggerKind"`
+		SelectedCompletionInfo *SelectedCompletionInfo     `json:"selectedCompletionInfo,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A string value used as a snippet is a template which allows to insert text
@@ -5261,9 +5980,13 @@ func (s *StringValue) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'value' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type StringValueAlias StringValue
-	return json.Unmarshal(data, (*StringValueAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Kind  StringLiteralSnippet `json:"kind"`
+		Value string               `json:"value"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Inline completion options used during static registration.
@@ -5296,9 +6019,12 @@ func (s *TextDocumentContentOptions) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'schemes' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type TextDocumentContentOptionsAlias TextDocumentContentOptions
-	return json.Unmarshal(data, (*TextDocumentContentOptionsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Schemes []string `json:"schemes"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // General parameters to register for a notification or to register a provider.
@@ -5328,9 +6054,14 @@ func (s *Registration) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'method' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type RegistrationAlias Registration
-	return json.Unmarshal(data, (*RegistrationAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Id              string `json:"id"`
+		Method          string `json:"method"`
+		RegisterOptions *any   `json:"registerOptions,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // General parameters to unregister a request or notification.
@@ -5357,9 +6088,13 @@ func (s *Unregistration) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'method' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type UnregistrationAlias Unregistration
-	return json.Unmarshal(data, (*UnregistrationAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Id     string `json:"id"`
+		Method string `json:"method"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // The initialize parameters
@@ -5428,9 +6163,21 @@ func (s *InitializeParamsBase) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'capabilities' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type InitializeParamsBaseAlias InitializeParamsBase
-	return json.Unmarshal(data, (*InitializeParamsBaseAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressParams
+
+		ProcessId             Nullable[int32]       `json:"processId"`
+		ClientInfo            *ClientInfo           `json:"clientInfo,omitempty"`
+		Locale                *string               `json:"locale,omitempty"`
+		RootPath              *Nullable[string]     `json:"rootPath,omitempty"`
+		RootUri               Nullable[DocumentUri] `json:"rootUri"`
+		Capabilities          *ClientCapabilities   `json:"capabilities"`
+		InitializationOptions *any                  `json:"initializationOptions,omitempty"`
+		Trace                 *TraceValue           `json:"trace,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type WorkspaceFoldersInitializeParams struct {
@@ -5616,9 +6363,13 @@ func (s *ServerInfo) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'name' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ServerInfoAlias ServerInfo
-	return json.Unmarshal(data, (*ServerInfoAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Name    string  `json:"name"`
+		Version *string `json:"version,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A text document identifier to denote a specific version of a text document.
@@ -5640,9 +6391,14 @@ func (s *VersionedTextDocumentIdentifier) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'version' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type VersionedTextDocumentIdentifierAlias VersionedTextDocumentIdentifier
-	return json.Unmarshal(data, (*VersionedTextDocumentIdentifierAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		TextDocumentIdentifier
+
+		Version int32 `json:"version"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Save options.
@@ -5674,9 +6430,13 @@ func (s *FileEvent) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'type' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type FileEventAlias FileEvent
-	return json.Unmarshal(data, (*FileEventAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Uri  DocumentUri    `json:"uri"`
+		Type FileChangeType `json:"type"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type FileSystemWatcher struct {
@@ -5702,9 +6462,13 @@ func (s *FileSystemWatcher) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'globPattern' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type FileSystemWatcherAlias FileSystemWatcher
-	return json.Unmarshal(data, (*FileSystemWatcherAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		GlobPattern GlobPattern `json:"globPattern"`
+		Kind        *WatchKind  `json:"kind,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Represents a diagnostic, such as a compiler error or warning. Diagnostic objects
@@ -5765,9 +6529,20 @@ func (s *Diagnostic) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'message' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DiagnosticAlias Diagnostic
-	return json.Unmarshal(data, (*DiagnosticAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Range              Range                            `json:"range"`
+		Severity           *DiagnosticSeverity              `json:"severity,omitempty"`
+		Code               *IntegerOrString                 `json:"code,omitempty"`
+		CodeDescription    *CodeDescription                 `json:"codeDescription,omitempty"`
+		Source             *string                          `json:"source,omitempty"`
+		Message            string                           `json:"message"`
+		Tags               *[]DiagnosticTag                 `json:"tags,omitempty"`
+		RelatedInformation *[]*DiagnosticRelatedInformation `json:"relatedInformation,omitempty"`
+		Data               *any                             `json:"data,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Contains additional information about the context in which a completion request is triggered.
@@ -5791,9 +6566,13 @@ func (s *CompletionContext) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'triggerKind' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type CompletionContextAlias CompletionContext
-	return json.Unmarshal(data, (*CompletionContextAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		TriggerKind      CompletionTriggerKind `json:"triggerKind"`
+		TriggerCharacter *string               `json:"triggerCharacter,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Additional details for a completion item label.
@@ -5840,9 +6619,14 @@ func (s *InsertReplaceEdit) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'replace' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type InsertReplaceEditAlias InsertReplaceEdit
-	return json.Unmarshal(data, (*InsertReplaceEditAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		NewText string `json:"newText"`
+		Insert  Range  `json:"insert"`
+		Replace Range  `json:"replace"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // In many cases the items of an actual completion result share the same
@@ -6026,9 +6810,15 @@ func (s *SignatureHelpContext) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'isRetrigger' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type SignatureHelpContextAlias SignatureHelpContext
-	return json.Unmarshal(data, (*SignatureHelpContextAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		TriggerKind         SignatureHelpTriggerKind `json:"triggerKind"`
+		TriggerCharacter    *string                  `json:"triggerCharacter,omitempty"`
+		IsRetrigger         bool                     `json:"isRetrigger"`
+		ActiveSignatureHelp *SignatureHelp           `json:"activeSignatureHelp,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Represents the signature of something callable. A signature
@@ -6071,9 +6861,15 @@ func (s *SignatureInformation) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'label' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type SignatureInformationAlias SignatureInformation
-	return json.Unmarshal(data, (*SignatureInformationAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Label           string                   `json:"label"`
+		Documentation   *StringOrMarkupContent   `json:"documentation,omitempty"`
+		Parameters      *[]*ParameterInformation `json:"parameters,omitempty"`
+		ActiveParameter *Nullable[uint32]        `json:"activeParameter,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Server Capabilities for a SignatureHelpRequest.
@@ -6115,9 +6911,12 @@ func (s *ReferenceContext) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'includeDeclaration' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ReferenceContextAlias ReferenceContext
-	return json.Unmarshal(data, (*ReferenceContextAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		IncludeDeclaration bool `json:"includeDeclaration"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Reference options.
@@ -6164,9 +6963,15 @@ func (s *BaseSymbolInformation) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type BaseSymbolInformationAlias BaseSymbolInformation
-	return json.Unmarshal(data, (*BaseSymbolInformationAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Name          string       `json:"name"`
+		Kind          SymbolKind   `json:"kind"`
+		Tags          *[]SymbolTag `json:"tags,omitempty"`
+		ContainerName *string      `json:"containerName,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Provider options for a DocumentSymbolRequest.
@@ -6213,9 +7018,14 @@ func (s *CodeActionContext) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'diagnostics' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type CodeActionContextAlias CodeActionContext
-	return json.Unmarshal(data, (*CodeActionContextAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Diagnostics []*Diagnostic          `json:"diagnostics"`
+		Only        *[]CodeActionKind      `json:"only,omitempty"`
+		TriggerKind *CodeActionTriggerKind `json:"triggerKind,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Captures why the code action is currently disabled.
@@ -6239,9 +7049,12 @@ func (s *CodeActionDisabled) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'reason' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type CodeActionDisabledAlias CodeActionDisabled
-	return json.Unmarshal(data, (*CodeActionDisabledAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Reason string `json:"reason"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Provider options for a CodeActionRequest.
@@ -6297,9 +7110,12 @@ func (s *LocationUriOnly) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type LocationUriOnlyAlias LocationUriOnly
-	return json.Unmarshal(data, (*LocationUriOnlyAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Uri DocumentUri `json:"uri"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Server capabilities for a WorkspaceSymbolRequest.
@@ -6367,9 +7183,16 @@ func (s *FormattingOptions) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'insertSpaces' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type FormattingOptionsAlias FormattingOptions
-	return json.Unmarshal(data, (*FormattingOptionsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		TabSize                uint32 `json:"tabSize"`
+		InsertSpaces           bool   `json:"insertSpaces"`
+		TrimTrailingWhitespace *bool  `json:"trimTrailingWhitespace,omitempty"`
+		InsertFinalNewline     *bool  `json:"insertFinalNewline,omitempty"`
+		TrimFinalNewlines      *bool  `json:"trimFinalNewlines,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Provider options for a DocumentFormattingRequest.
@@ -6409,9 +7232,13 @@ func (s *DocumentOnTypeFormattingOptions) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'firstTriggerCharacter' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DocumentOnTypeFormattingOptionsAlias DocumentOnTypeFormattingOptions
-	return json.Unmarshal(data, (*DocumentOnTypeFormattingOptionsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		FirstTriggerCharacter string    `json:"firstTriggerCharacter"`
+		MoreTriggerCharacter  *[]string `json:"moreTriggerCharacter,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Provider options for a RenameRequest.
@@ -6445,9 +7272,13 @@ func (s *PrepareRenamePlaceholder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'placeholder' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type PrepareRenamePlaceholderAlias PrepareRenamePlaceholder
-	return json.Unmarshal(data, (*PrepareRenamePlaceholderAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Range       Range  `json:"range"`
+		Placeholder string `json:"placeholder"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Since: 3.18.0
@@ -6466,9 +7297,12 @@ func (s *PrepareRenameDefaultBehavior) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'defaultBehavior' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type PrepareRenameDefaultBehaviorAlias PrepareRenameDefaultBehavior
-	return json.Unmarshal(data, (*PrepareRenameDefaultBehaviorAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		DefaultBehavior bool `json:"defaultBehavior"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // The server capabilities of a ExecuteCommandRequest.
@@ -6490,9 +7324,14 @@ func (s *ExecuteCommandOptions) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'commands' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ExecuteCommandOptionsAlias ExecuteCommandOptions
-	return json.Unmarshal(data, (*ExecuteCommandOptionsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		WorkDoneProgressOptions
+
+		Commands []string `json:"commands"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Additional data about a workspace edit.
@@ -6528,9 +7367,13 @@ func (s *SemanticTokensLegend) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'tokenModifiers' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type SemanticTokensLegendAlias SemanticTokensLegend
-	return json.Unmarshal(data, (*SemanticTokensLegendAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		TokenTypes     []string `json:"tokenTypes"`
+		TokenModifiers []string `json:"tokenModifiers"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Semantic tokens options to support deltas for full documents
@@ -6564,9 +7407,14 @@ func (s *OptionalVersionedTextDocumentIdentifier) UnmarshalJSON(data []byte) err
 		return fmt.Errorf("required key 'version' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type OptionalVersionedTextDocumentIdentifierAlias OptionalVersionedTextDocumentIdentifier
-	return json.Unmarshal(data, (*OptionalVersionedTextDocumentIdentifierAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		TextDocumentIdentifier
+
+		Version Nullable[int32] `json:"version"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A special text edit with an additional change annotation.
@@ -6590,9 +7438,14 @@ func (s *AnnotatedTextEdit) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'annotationId' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type AnnotatedTextEditAlias AnnotatedTextEdit
-	return json.Unmarshal(data, (*AnnotatedTextEditAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		TextEdit
+
+		AnnotationId ChangeAnnotationIdentifier `json:"annotationId"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // An interactive text edit.
@@ -6625,9 +7478,14 @@ func (s *SnippetTextEdit) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'snippet' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type SnippetTextEditAlias SnippetTextEdit
-	return json.Unmarshal(data, (*SnippetTextEditAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Range        Range                       `json:"range"`
+		Snippet      *StringValue                `json:"snippet"`
+		AnnotationId *ChangeAnnotationIdentifier `json:"annotationId,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A generic resource operation.
@@ -6652,9 +7510,13 @@ func (s *ResourceOperation) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ResourceOperationAlias ResourceOperation
-	return json.Unmarshal(data, (*ResourceOperationAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Kind         string                      `json:"kind"`
+		AnnotationId *ChangeAnnotationIdentifier `json:"annotationId,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Options to create a file.
@@ -6718,9 +7580,14 @@ func (s *FileOperationPattern) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'glob' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type FileOperationPatternAlias FileOperationPattern
-	return json.Unmarshal(data, (*FileOperationPatternAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Glob    string                       `json:"glob"`
+		Matches *FileOperationPatternKind    `json:"matches,omitempty"`
+		Options *FileOperationPatternOptions `json:"options,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A full document diagnostic report for a workspace diagnostic result.
@@ -6751,9 +7618,15 @@ func (s *WorkspaceFullDocumentDiagnosticReport) UnmarshalJSON(data []byte) error
 		return fmt.Errorf("required key 'version' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type WorkspaceFullDocumentDiagnosticReportAlias WorkspaceFullDocumentDiagnosticReport
-	return json.Unmarshal(data, (*WorkspaceFullDocumentDiagnosticReportAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		FullDocumentDiagnosticReport
+
+		Uri     DocumentUri     `json:"uri"`
+		Version Nullable[int32] `json:"version"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // An unchanged document diagnostic report for a workspace diagnostic result.
@@ -6784,9 +7657,15 @@ func (s *WorkspaceUnchangedDocumentDiagnosticReport) UnmarshalJSON(data []byte) 
 		return fmt.Errorf("required key 'version' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type WorkspaceUnchangedDocumentDiagnosticReportAlias WorkspaceUnchangedDocumentDiagnosticReport
-	return json.Unmarshal(data, (*WorkspaceUnchangedDocumentDiagnosticReportAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		UnchangedDocumentDiagnosticReport
+
+		Uri     DocumentUri     `json:"uri"`
+		Version Nullable[int32] `json:"version"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A notebook cell.
@@ -6828,9 +7707,15 @@ func (s *NotebookCell) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'document' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type NotebookCellAlias NotebookCell
-	return json.Unmarshal(data, (*NotebookCellAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Kind             NotebookCellKind  `json:"kind"`
+		Document         DocumentUri       `json:"document"`
+		Metadata         *map[string]any   `json:"metadata,omitempty"`
+		ExecutionSummary *ExecutionSummary `json:"executionSummary,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Since: 3.18.0
@@ -6855,9 +7740,13 @@ func (s *NotebookDocumentFilterWithNotebook) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'notebook' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type NotebookDocumentFilterWithNotebookAlias NotebookDocumentFilterWithNotebook
-	return json.Unmarshal(data, (*NotebookDocumentFilterWithNotebookAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Notebook StringOrNotebookDocumentFilter `json:"notebook"`
+		Cells    *[]*NotebookCellLanguage       `json:"cells,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Since: 3.18.0
@@ -6882,9 +7771,13 @@ func (s *NotebookDocumentFilterWithCells) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'cells' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type NotebookDocumentFilterWithCellsAlias NotebookDocumentFilterWithCells
-	return json.Unmarshal(data, (*NotebookDocumentFilterWithCellsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Notebook *StringOrNotebookDocumentFilter `json:"notebook,omitempty"`
+		Cells    []*NotebookCellLanguage         `json:"cells"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Cell changes to a notebook document.
@@ -6930,9 +7823,13 @@ func (s *SelectedCompletionInfo) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'text' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type SelectedCompletionInfoAlias SelectedCompletionInfo
-	return json.Unmarshal(data, (*SelectedCompletionInfoAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Range Range  `json:"range"`
+		Text  string `json:"text"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Information about the client
@@ -6959,9 +7856,13 @@ func (s *ClientInfo) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'name' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ClientInfoAlias ClientInfo
-	return json.Unmarshal(data, (*ClientInfoAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Name    string  `json:"name"`
+		Version *string `json:"version,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Defines the capabilities provided by the client.
@@ -7061,9 +7962,14 @@ func (s *TextDocumentContentChangePartial) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'text' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type TextDocumentContentChangePartialAlias TextDocumentContentChangePartial
-	return json.Unmarshal(data, (*TextDocumentContentChangePartialAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Range       Range   `json:"range"`
+		RangeLength *uint32 `json:"rangeLength,omitempty"`
+		Text        string  `json:"text"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Since: 3.18.0
@@ -7083,9 +7989,12 @@ func (s *TextDocumentContentChangeWholeDocument) UnmarshalJSON(data []byte) erro
 		return fmt.Errorf("required key 'text' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type TextDocumentContentChangeWholeDocumentAlias TextDocumentContentChangeWholeDocument
-	return json.Unmarshal(data, (*TextDocumentContentChangeWholeDocumentAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Text string `json:"text"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Structure to capture a description for an error code.
@@ -7107,9 +8016,12 @@ func (s *CodeDescription) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'href' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type CodeDescriptionAlias CodeDescription
-	return json.Unmarshal(data, (*CodeDescriptionAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Href URI `json:"href"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Represents a related message and source code location for a diagnostic. This should be
@@ -7137,9 +8049,13 @@ func (s *DiagnosticRelatedInformation) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'message' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type DiagnosticRelatedInformationAlias DiagnosticRelatedInformation
-	return json.Unmarshal(data, (*DiagnosticRelatedInformationAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Location Location `json:"location"`
+		Message  string   `json:"message"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Edit range variant that includes ranges for insert and replace operations.
@@ -7165,9 +8081,13 @@ func (s *EditRangeWithInsertReplace) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'replace' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type EditRangeWithInsertReplaceAlias EditRangeWithInsertReplace
-	return json.Unmarshal(data, (*EditRangeWithInsertReplaceAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Insert  Range `json:"insert"`
+		Replace Range `json:"replace"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Since: 3.18.0
@@ -7203,9 +8123,13 @@ func (s *MarkedStringWithLanguage) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'value' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type MarkedStringWithLanguageAlias MarkedStringWithLanguage
-	return json.Unmarshal(data, (*MarkedStringWithLanguageAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Language string `json:"language"`
+		Value    string `json:"value"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Represents a parameter of a callable-signature. A parameter can
@@ -7241,9 +8165,13 @@ func (s *ParameterInformation) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'label' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ParameterInformationAlias ParameterInformation
-	return json.Unmarshal(data, (*ParameterInformationAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Label         StringOrTuple          `json:"label"`
+		Documentation *StringOrMarkupContent `json:"documentation,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Documentation for a class of code actions.
@@ -7279,9 +8207,13 @@ func (s *CodeActionKindDocumentation) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'command' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type CodeActionKindDocumentationAlias CodeActionKindDocumentation
-	return json.Unmarshal(data, (*CodeActionKindDocumentationAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Kind    CodeActionKind `json:"kind"`
+		Command *Command       `json:"command"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A notebook cell text document filter denotes a cell text
@@ -7313,9 +8245,13 @@ func (s *NotebookCellTextDocumentFilter) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'notebook' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type NotebookCellTextDocumentFilterAlias NotebookCellTextDocumentFilter
-	return json.Unmarshal(data, (*NotebookCellTextDocumentFilterAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Notebook StringOrNotebookDocumentFilter `json:"notebook"`
+		Language *string                        `json:"language,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Matching options for the file operation pattern.
@@ -7348,9 +8284,13 @@ func (s *ExecutionSummary) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'executionOrder' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ExecutionSummaryAlias ExecutionSummary
-	return json.Unmarshal(data, (*ExecutionSummaryAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		ExecutionOrder uint32 `json:"executionOrder"`
+		Success        *bool  `json:"success,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Since: 3.18.0
@@ -7369,9 +8309,12 @@ func (s *NotebookCellLanguage) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'language' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type NotebookCellLanguageAlias NotebookCellLanguage
-	return json.Unmarshal(data, (*NotebookCellLanguageAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Language string `json:"language"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Structural changes to cells in a notebook document.
@@ -7399,9 +8342,14 @@ func (s *NotebookDocumentCellChangeStructure) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'array' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type NotebookDocumentCellChangeStructureAlias NotebookDocumentCellChangeStructure
-	return json.Unmarshal(data, (*NotebookDocumentCellChangeStructureAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Array    *NotebookCellArrayChange  `json:"array"`
+		DidOpen  *[]*TextDocumentItem      `json:"didOpen,omitempty"`
+		DidClose *[]TextDocumentIdentifier `json:"didClose,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Content changes to a cell in a notebook document.
@@ -7427,9 +8375,13 @@ func (s *NotebookDocumentCellContentChanges) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'changes' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type NotebookDocumentCellContentChangesAlias NotebookDocumentCellContentChanges
-	return json.Unmarshal(data, (*NotebookDocumentCellContentChangesAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Document VersionedTextDocumentIdentifier  `json:"document"`
+		Changes  []TextDocumentContentChangeEvent `json:"changes"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Workspace specific client capabilities.
@@ -7669,9 +8621,12 @@ func (s *NotebookDocumentClientCapabilities) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'synchronization' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type NotebookDocumentClientCapabilitiesAlias NotebookDocumentClientCapabilities
-	return json.Unmarshal(data, (*NotebookDocumentClientCapabilitiesAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Synchronization *NotebookDocumentSyncClientCapabilities `json:"synchronization"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type WindowClientCapabilities struct {
@@ -7805,9 +8760,13 @@ func (s *RelativePattern) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'pattern' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type RelativePatternAlias RelativePattern
-	return json.Unmarshal(data, (*RelativePatternAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		BaseUri WorkspaceFolderOrURI `json:"baseUri"`
+		Pattern Pattern              `json:"pattern"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A document filter where `language` is required field.
@@ -7839,9 +8798,14 @@ func (s *TextDocumentFilterLanguage) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'language' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type TextDocumentFilterLanguageAlias TextDocumentFilterLanguage
-	return json.Unmarshal(data, (*TextDocumentFilterLanguageAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Language string       `json:"language"`
+		Scheme   *string      `json:"scheme,omitempty"`
+		Pattern  *GlobPattern `json:"pattern,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A document filter where `scheme` is required field.
@@ -7873,9 +8837,14 @@ func (s *TextDocumentFilterScheme) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'scheme' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type TextDocumentFilterSchemeAlias TextDocumentFilterScheme
-	return json.Unmarshal(data, (*TextDocumentFilterSchemeAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Language *string      `json:"language,omitempty"`
+		Scheme   string       `json:"scheme"`
+		Pattern  *GlobPattern `json:"pattern,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A document filter where `pattern` is required field.
@@ -7907,9 +8876,14 @@ func (s *TextDocumentFilterPattern) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'pattern' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type TextDocumentFilterPatternAlias TextDocumentFilterPattern
-	return json.Unmarshal(data, (*TextDocumentFilterPatternAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Language *string     `json:"language,omitempty"`
+		Scheme   *string     `json:"scheme,omitempty"`
+		Pattern  GlobPattern `json:"pattern"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A notebook document filter where `notebookType` is required field.
@@ -7937,9 +8911,14 @@ func (s *NotebookDocumentFilterNotebookType) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'notebookType' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type NotebookDocumentFilterNotebookTypeAlias NotebookDocumentFilterNotebookType
-	return json.Unmarshal(data, (*NotebookDocumentFilterNotebookTypeAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		NotebookType string       `json:"notebookType"`
+		Scheme       *string      `json:"scheme,omitempty"`
+		Pattern      *GlobPattern `json:"pattern,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A notebook document filter where `scheme` is required field.
@@ -7967,9 +8946,14 @@ func (s *NotebookDocumentFilterScheme) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'scheme' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type NotebookDocumentFilterSchemeAlias NotebookDocumentFilterScheme
-	return json.Unmarshal(data, (*NotebookDocumentFilterSchemeAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		NotebookType *string      `json:"notebookType,omitempty"`
+		Scheme       string       `json:"scheme"`
+		Pattern      *GlobPattern `json:"pattern,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A notebook document filter where `pattern` is required field.
@@ -7997,9 +8981,14 @@ func (s *NotebookDocumentFilterPattern) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'pattern' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type NotebookDocumentFilterPatternAlias NotebookDocumentFilterPattern
-	return json.Unmarshal(data, (*NotebookDocumentFilterPatternAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		NotebookType *string     `json:"notebookType,omitempty"`
+		Scheme       *string     `json:"scheme,omitempty"`
+		Pattern      GlobPattern `json:"pattern"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // A change describing how to move a `NotebookCell`
@@ -8031,9 +9020,14 @@ func (s *NotebookCellArrayChange) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'deleteCount' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type NotebookCellArrayChangeAlias NotebookCellArrayChange
-	return json.Unmarshal(data, (*NotebookCellArrayChangeAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Start       uint32           `json:"start"`
+		DeleteCount uint32           `json:"deleteCount"`
+		Cells       *[]*NotebookCell `json:"cells,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 type WorkspaceEditClientCapabilities struct {
@@ -8687,9 +9681,20 @@ func (s *SemanticTokensClientCapabilities) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'formats' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type SemanticTokensClientCapabilitiesAlias SemanticTokensClientCapabilities
-	return json.Unmarshal(data, (*SemanticTokensClientCapabilitiesAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		DynamicRegistration     *bool                               `json:"dynamicRegistration,omitempty"`
+		Requests                *ClientSemanticTokensRequestOptions `json:"requests"`
+		TokenTypes              []string                            `json:"tokenTypes"`
+		TokenModifiers          []string                            `json:"tokenModifiers"`
+		Formats                 []TokenFormat                       `json:"formats"`
+		OverlappingTokenSupport *bool                               `json:"overlappingTokenSupport,omitempty"`
+		MultilineTokenSupport   *bool                               `json:"multilineTokenSupport,omitempty"`
+		ServerCancelSupport     *bool                               `json:"serverCancelSupport,omitempty"`
+		AugmentsSyntaxTokens    *bool                               `json:"augmentsSyntaxTokens,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Client capabilities for the linked editing range request.
@@ -8805,9 +9810,12 @@ func (s *ShowDocumentClientCapabilities) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'support' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ShowDocumentClientCapabilitiesAlias ShowDocumentClientCapabilities
-	return json.Unmarshal(data, (*ShowDocumentClientCapabilitiesAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Support bool `json:"support"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Since: 3.18.0
@@ -8835,9 +9843,13 @@ func (s *StaleRequestSupportOptions) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'retryOnContentModified' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type StaleRequestSupportOptionsAlias StaleRequestSupportOptions
-	return json.Unmarshal(data, (*StaleRequestSupportOptionsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Cancel                 bool     `json:"cancel"`
+		RetryOnContentModified []string `json:"retryOnContentModified"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Client capabilities specific to regular expressions.
@@ -8862,9 +9874,13 @@ func (s *RegularExpressionsClientCapabilities) UnmarshalJSON(data []byte) error 
 		return fmt.Errorf("required key 'engine' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type RegularExpressionsClientCapabilitiesAlias RegularExpressionsClientCapabilities
-	return json.Unmarshal(data, (*RegularExpressionsClientCapabilitiesAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Engine  RegularExpressionEngineKind `json:"engine"`
+		Version *string                     `json:"version,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Client capabilities specific to the used markdown parser.
@@ -8895,9 +9911,14 @@ func (s *MarkdownClientCapabilities) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'parser' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type MarkdownClientCapabilitiesAlias MarkdownClientCapabilities
-	return json.Unmarshal(data, (*MarkdownClientCapabilitiesAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Parser      string    `json:"parser"`
+		Version     *string   `json:"version,omitempty"`
+		AllowedTags *[]string `json:"allowedTags,omitempty"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Since: 3.18.0
@@ -8938,9 +9959,12 @@ func (s *ClientSymbolTagOptions) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'valueSet' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ClientSymbolTagOptionsAlias ClientSymbolTagOptions
-	return json.Unmarshal(data, (*ClientSymbolTagOptionsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		ValueSet []SymbolTag `json:"valueSet"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Since: 3.18.0
@@ -8961,9 +9985,12 @@ func (s *ClientSymbolResolveOptions) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'properties' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ClientSymbolResolveOptionsAlias ClientSymbolResolveOptions
-	return json.Unmarshal(data, (*ClientSymbolResolveOptionsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Properties []string `json:"properties"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Since: 3.18.0
@@ -9109,9 +10136,12 @@ func (s *ClientCodeActionLiteralOptions) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'codeActionKind' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ClientCodeActionLiteralOptionsAlias ClientCodeActionLiteralOptions
-	return json.Unmarshal(data, (*ClientCodeActionLiteralOptionsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		CodeActionKind *ClientCodeActionKindOptions `json:"codeActionKind"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Since: 3.18.0
@@ -9131,9 +10161,12 @@ func (s *ClientCodeActionResolveOptions) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'properties' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ClientCodeActionResolveOptionsAlias ClientCodeActionResolveOptions
-	return json.Unmarshal(data, (*ClientCodeActionResolveOptionsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Properties []string `json:"properties"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Since: 3.18.0 - proposed
@@ -9153,9 +10186,12 @@ func (s *CodeActionTagOptions) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'valueSet' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type CodeActionTagOptionsAlias CodeActionTagOptions
-	return json.Unmarshal(data, (*CodeActionTagOptionsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		ValueSet []CodeActionTag `json:"valueSet"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Since: 3.18.0
@@ -9175,9 +10211,12 @@ func (s *ClientCodeLensResolveOptions) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'properties' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ClientCodeLensResolveOptionsAlias ClientCodeLensResolveOptions
-	return json.Unmarshal(data, (*ClientCodeLensResolveOptionsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Properties []string `json:"properties"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Since: 3.18.0
@@ -9250,9 +10289,12 @@ func (s *ClientInlayHintResolveOptions) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'properties' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ClientInlayHintResolveOptionsAlias ClientInlayHintResolveOptions
-	return json.Unmarshal(data, (*ClientInlayHintResolveOptionsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Properties []string `json:"properties"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Since: 3.18.0
@@ -9280,9 +10322,12 @@ func (s *CompletionItemTagOptions) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'valueSet' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type CompletionItemTagOptionsAlias CompletionItemTagOptions
-	return json.Unmarshal(data, (*CompletionItemTagOptionsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		ValueSet []CompletionItemTag `json:"valueSet"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Since: 3.18.0
@@ -9302,9 +10347,12 @@ func (s *ClientCompletionItemResolveOptions) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'properties' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ClientCompletionItemResolveOptionsAlias ClientCompletionItemResolveOptions
-	return json.Unmarshal(data, (*ClientCompletionItemResolveOptionsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		Properties []string `json:"properties"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Since: 3.18.0
@@ -9323,9 +10371,12 @@ func (s *ClientCompletionItemInsertTextModeOptions) UnmarshalJSON(data []byte) e
 		return fmt.Errorf("required key 'valueSet' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ClientCompletionItemInsertTextModeOptionsAlias ClientCompletionItemInsertTextModeOptions
-	return json.Unmarshal(data, (*ClientCompletionItemInsertTextModeOptionsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		ValueSet []InsertTextMode `json:"valueSet"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Since: 3.18.0
@@ -9357,9 +10408,12 @@ func (s *ClientCodeActionKindOptions) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'valueSet' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ClientCodeActionKindOptionsAlias ClientCodeActionKindOptions
-	return json.Unmarshal(data, (*ClientCodeActionKindOptionsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		ValueSet []CodeActionKind `json:"valueSet"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Since: 3.18.0
@@ -9379,9 +10433,12 @@ func (s *ClientDiagnosticsTagOptions) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("required key 'valueSet' is missing")
 	}
 
-	// Use type alias to avoid infinite recursion
-	type ClientDiagnosticsTagOptionsAlias ClientDiagnosticsTagOptions
-	return json.Unmarshal(data, (*ClientDiagnosticsTagOptionsAlias)(s))
+	// Redeclare the struct to prevent infinite recursion
+	type temp struct {
+		ValueSet []DiagnosticTag `json:"valueSet"`
+	}
+
+	return json.Unmarshal(data, (*temp)(s))
 }
 
 // Since: 3.18.0

--- a/internal/lsp/lsproto/lsp_test.go
+++ b/internal/lsp/lsproto/lsp_test.go
@@ -1,0 +1,82 @@
+package lsproto
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestUnmarshalCompletionItem(t *testing.T) {
+	const message = `{
+    "label": "pageXOffset",
+    "insertTextFormat": 1,
+    "textEdit": {
+        "newText": "pageXOffset",
+        "insert": {
+            "start": {
+                "line": 4,
+                "character": 0
+            },
+            "end": {
+                "line": 4,
+                "character": 4
+            }
+        },
+        "replace": {
+            "start": {
+                "line": 4,
+                "character": 0
+            },
+            "end": {
+                "line": 4,
+                "character": 4
+            }
+        }
+    },
+    "kind": 6,
+    "sortText": "15",
+    "commitCharacters": [
+        ".",
+        ",",
+        ";"
+    ]
+}`
+
+	var result CompletionItem
+	err := json.Unmarshal([]byte(message), &result)
+	assert.NilError(t, err)
+
+	assert.DeepEqual(t, result, CompletionItem{
+		Label:            "pageXOffset",
+		InsertTextFormat: ptrTo(InsertTextFormatPlainText),
+		TextEdit: &TextEditOrInsertReplaceEdit{
+			InsertReplaceEdit: &InsertReplaceEdit{
+				NewText: "pageXOffset",
+				Insert: Range{
+					Start: Position{
+						Line:      4,
+						Character: 0,
+					},
+					End: Position{
+						Line:      4,
+						Character: 4,
+					},
+				},
+				Replace: Range{
+					Start: Position{
+						Line:      4,
+						Character: 0,
+					},
+					End: Position{
+						Line:      4,
+						Character: 4,
+					},
+				},
+			},
+		},
+		Kind:             ptrTo(CompletionItemKindVariable),
+		SortText:         ptrTo("15"),
+		CommitCharacters: ptrTo([]string{".", ",", ";"}),
+	})
+}

--- a/internal/lsp/lsproto/lsp_test.go
+++ b/internal/lsp/lsproto/lsp_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestUnmarshalCompletionItem(t *testing.T) {
+	t.Parallel()
+
 	const message = `{
     "label": "pageXOffset",
     "insertTextFormat": 1,


### PR DESCRIPTION
Fixes #1425

Our union type decoding is broken because Go's JSON parsing has no mechanism to verify required properties. This meant that decoding into a union of structs is almost always guaranteed to succeed at choosing the first choice, except in the case where the types are incompatible.

This PR adds an unmarshal function to each structure that verifies that all required properties have been provided. This is not particularly efficient, but it does get the job done.