### PR TITLE
remove JS exception for constructor type parameter arity match

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -18364,9 +18364,8 @@ func (c *Checker) getInstantiatedConstructorsForTypeArguments(t *Type, typeArgum
 
 func (c *Checker) getConstructorsForTypeArguments(t *Type, typeArgumentNodes []*ast.Node, location *ast.Node) []*Signature {
 	typeArgCount := len(typeArgumentNodes)
-	isJavaScript := ast.IsInJSFile(location)
 	return core.Filter(c.getSignaturesOfType(t, SignatureKindConstruct), func(sig *Signature) bool {
-		return isJavaScript || typeArgCount >= c.getMinTypeArgumentCount(sig.typeParameters) && typeArgCount <= len(sig.typeParameters)
+		return typeArgCount >= c.getMinTypeArgumentCount(sig.typeParameters) && typeArgCount <= len(sig.typeParameters)
 	})
 }
 

--- a/testdata/baselines/reference/conformance/jsOverrideMap.symbols
+++ b/testdata/baselines/reference/conformance/jsOverrideMap.symbols
@@ -1,0 +1,13 @@
+//// [tests/cases/conformance/salsa/jsOverrideMap.ts] ////
+
+=== index.js ===
+/**
+ * @template K
+ * @template V
+ * @extends {Map<K, V>}
+ */
+export class TestMap extends Map {
+>TestMap : Symbol(TestMap, Decl(index.js, 0, 0))
+>Map : Symbol(Map, Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+}
+

--- a/testdata/baselines/reference/conformance/jsOverrideMap.types
+++ b/testdata/baselines/reference/conformance/jsOverrideMap.types
@@ -1,0 +1,13 @@
+//// [tests/cases/conformance/salsa/jsOverrideMap.ts] ////
+
+=== index.js ===
+/**
+ * @template K
+ * @template V
+ * @extends {Map<K, V>}
+ */
+export class TestMap extends Map {
+>TestMap : TestMap<K, V>
+>Map : Map<K, V>
+}
+

--- a/testdata/tests/cases/conformance/salsa/jsOverrideMap.ts
+++ b/testdata/tests/cases/conformance/salsa/jsOverrideMap.ts
@@ -1,0 +1,12 @@
+// @allowJs: true
+// @noEmit: true
+// @checkJs: true
+// @lib: esnext,dom,dom.iterable
+// @filename: index.js
+/**
+ * @template K
+ * @template V
+ * @extends {Map<K, V>}
+ */
+export class TestMap extends Map {
+}


### PR DESCRIPTION
Javascript isn't supposed to have exemptions for arity anymore, for both value and type arguments. We mistakenly ported a little bit of it, though, and the check here mistakenly allows too many constructors to stay in the list, leading to a bogus "Base constructors must all have the same type" because the base constructors with no type parameters were not removed.