### PR TITLE
Ignore empty params, fix cancellation errors

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -374,6 +374,8 @@ func (s *Server) dispatchLoop(ctx context.Context) error {
 				if err := s.handleRequestOrNotification(requestCtx, req); err != nil {
 					if errors.Is(err, io.EOF) {
 						lspExit()
+					} else if errors.Is(err, context.Canceled) {
+						s.sendError(req.ID, lsproto.ErrRequestCancelled)
 					} else {
 						s.sendError(req.ID, err)
 					}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -509,7 +509,11 @@ var handlers = sync.OnceValue(func() handlerMap {
 
 func registerNotificationHandler[Req any](handlers handlerMap, info lsproto.NotificationInfo[Req], fn func(*Server, context.Context, Req) error) {
 	handlers[info.Method] = func(s *Server, ctx context.Context, req *lsproto.RequestMessage) error {
-		params := req.Params.(Req)
+		var params Req
+		// Ignore empty params.
+		if req.Params != nil {
+			params = req.Params.(Req)
+		}
 		if err := fn(s, ctx, params); err != nil {
 			return err
 		}
@@ -519,7 +523,11 @@ func registerNotificationHandler[Req any](handlers handlerMap, info lsproto.Noti
 
 func registerRequestHandler[Req, Resp any](handlers handlerMap, info lsproto.RequestInfo[Req, Resp], fn func(*Server, context.Context, Req) (Resp, error)) {
 	handlers[info.Method] = func(s *Server, ctx context.Context, req *lsproto.RequestMessage) error {
-		params := req.Params.(Req)
+		var params Req
+		// Ignore empty params.
+		if req.Params != nil {
+			params = req.Params.(Req)
+		}
 		resp, err := fn(s, ctx, params)
 		if err != nil {
 			return err

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -372,11 +372,11 @@ func (s *Server) dispatchLoop(ctx context.Context) error {
 					}
 				}()
 				if err := s.handleRequestOrNotification(requestCtx, req); err != nil {
-					if errors.Is(err, io.EOF) {
-						lspExit()
-					} else if errors.Is(err, context.Canceled) {
+					if errors.Is(err, context.Canceled) {
 						s.sendError(req.ID, lsproto.ErrRequestCancelled)
-					} else {
+					} else if errors.Is(err, io.EOF) {
+						lspExit()
+					} else  {
 						s.sendError(req.ID, err)
 					}
 				}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -512,7 +512,7 @@ var handlers = sync.OnceValue(func() handlerMap {
 func registerNotificationHandler[Req any](handlers handlerMap, info lsproto.NotificationInfo[Req], fn func(*Server, context.Context, Req) error) {
 	handlers[info.Method] = func(s *Server, ctx context.Context, req *lsproto.RequestMessage) error {
 		var params Req
-		// Ignore empty params.
+		// Ignore empty params; all generated params are either pointers or any.
 		if req.Params != nil {
 			params = req.Params.(Req)
 		}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -376,7 +376,7 @@ func (s *Server) dispatchLoop(ctx context.Context) error {
 						s.sendError(req.ID, lsproto.ErrRequestCancelled)
 					} else if errors.Is(err, io.EOF) {
 						lspExit()
-					} else  {
+					} else {
 						s.sendError(req.ID, err)
 					}
 				}


### PR DESCRIPTION
Fixes #1458.

Problem is twofold:

- When the param is truly empty, it will be `any(nil)`. But, you can't do `any(nil).(any)` without crashing (I still get things wrong as a 10 year Go veteran). If the params are `nil`, just ignore it. All params are either pointers or `any` anyway and types are checked before the handlers even run.
- I added code to make sure we returned an error for context cancellation. Except, I forgot to actually add in the code that actually sends the right LSP error back. So, they were getting sent as regular errors. Bad.