### PR TITLE
fix: emit end of file comments

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -345,7 +345,6 @@ func (p *Parser) parseSourceFileWorker() *ast.SourceFile {
 	if len(p.reparseList) > 0 {
 		statements = append(statements, p.reparseList...)
 		p.reparseList = nil
-		end = p.nodePos()
 	}
 	node := p.factory.NewSourceFile(p.opts, p.sourceText, p.newNodeList(core.NewTextRange(pos, end), statements), eof)
 	p.finishNode(node, pos)

--- a/testdata/baselines/reference/compiler/emitEndOfFileJSDocComments.js
+++ b/testdata/baselines/reference/compiler/emitEndOfFileJSDocComments.js
@@ -1,0 +1,13 @@
+//// [tests/cases/compiler/emitEndOfFileJSDocComments.ts] ////
+
+//// [emitEndOfFileJSDocComments.js]
+/** @typedef {number} A */
+var unrelated;
+/** @typedef {number} B */
+
+//// [emitEndOfFileJSDocComments.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/** @typedef {number} A */
+var unrelated;
+/** @typedef {number} B */ 

--- a/testdata/baselines/reference/compiler/emitEndOfFileJSDocComments.symbols
+++ b/testdata/baselines/reference/compiler/emitEndOfFileJSDocComments.symbols
@@ -1,0 +1,8 @@
+//// [tests/cases/compiler/emitEndOfFileJSDocComments.ts] ////
+
+=== emitEndOfFileJSDocComments.js ===
+/** @typedef {number} A */
+var unrelated;
+>unrelated : Symbol(unrelated, Decl(emitEndOfFileJSDocComments.js, 1, 3))
+
+/** @typedef {number} B */

--- a/testdata/baselines/reference/compiler/emitEndOfFileJSDocComments.types
+++ b/testdata/baselines/reference/compiler/emitEndOfFileJSDocComments.types
@@ -1,0 +1,8 @@
+//// [tests/cases/compiler/emitEndOfFileJSDocComments.ts] ////
+
+=== emitEndOfFileJSDocComments.js ===
+/** @typedef {number} A */
+var unrelated;
+>unrelated : any
+
+/** @typedef {number} B */

--- a/testdata/baselines/reference/compiler/emitEndOfFileJSDocComments2.js
+++ b/testdata/baselines/reference/compiler/emitEndOfFileJSDocComments2.js
@@ -1,0 +1,42 @@
+//// [tests/cases/compiler/emitEndOfFileJSDocComments2.ts] ////
+
+//// [emitEndOfFileJSDocComments2.js]
+/** @typedef {number} A */
+
+/**
+ * JSDoc comment for function
+ * @param {string} param - A string parameter
+ * @returns {number} The length of the string
+ */
+function test(param) {
+	// Comment inside function
+	return param.length;
+	/** @typedef {number} B2 */
+}
+
+// Single line comment
+/** @typedef {number} C */
+/**
+ * Multiple line comment
+ */
+
+
+//// [emitEndOfFileJSDocComments2.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/** @typedef {number} A */
+/**
+ * JSDoc comment for function
+ * @param {string} param - A string parameter
+ * @returns {number} The length of the string
+ */
+function test(param) {
+    // Comment inside function
+    return param.length;
+    /** @typedef {number} B2 */
+}
+// Single line comment
+/** @typedef {number} C */
+/**
+ * Multiple line comment
+ */

--- a/testdata/baselines/reference/compiler/emitEndOfFileJSDocComments2.symbols
+++ b/testdata/baselines/reference/compiler/emitEndOfFileJSDocComments2.symbols
@@ -1,0 +1,29 @@
+//// [tests/cases/compiler/emitEndOfFileJSDocComments2.ts] ////
+
+=== emitEndOfFileJSDocComments2.js ===
+/** @typedef {number} A */
+
+/**
+ * JSDoc comment for function
+ * @param {string} param - A string parameter
+ * @returns {number} The length of the string
+ */
+function test(param) {
+>test : Symbol(test, Decl(emitEndOfFileJSDocComments2.js, 0, 0))
+>param : Symbol(param, Decl(emitEndOfFileJSDocComments2.js, 7, 14))
+
+	// Comment inside function
+	return param.length;
+>param.length : Symbol(length, Decl(lib.es5.d.ts, --, --))
+>param : Symbol(param, Decl(emitEndOfFileJSDocComments2.js, 7, 14))
+>length : Symbol(length, Decl(lib.es5.d.ts, --, --))
+
+	/** @typedef {number} B2 */
+}
+
+// Single line comment
+/** @typedef {number} C */
+/**
+ * Multiple line comment
+ */
+

--- a/testdata/baselines/reference/compiler/emitEndOfFileJSDocComments2.types
+++ b/testdata/baselines/reference/compiler/emitEndOfFileJSDocComments2.types
@@ -1,0 +1,29 @@
+//// [tests/cases/compiler/emitEndOfFileJSDocComments2.ts] ////
+
+=== emitEndOfFileJSDocComments2.js ===
+/** @typedef {number} A */
+
+/**
+ * JSDoc comment for function
+ * @param {string} param - A string parameter
+ * @returns {number} The length of the string
+ */
+function test(param) {
+>test : (param: string) => number
+>param : string
+
+	// Comment inside function
+	return param.length;
+>param.length : number
+>param : string
+>length : number
+
+	/** @typedef {number} B2 */
+}
+
+// Single line comment
+/** @typedef {number} C */
+/**
+ * Multiple line comment
+ */
+

--- a/testdata/tests/cases/compiler/emitEndOfFileJSDocComments.ts
+++ b/testdata/tests/cases/compiler/emitEndOfFileJSDocComments.ts
@@ -1,0 +1,8 @@
+// @allowJs: true
+// @checkJs: true
+// @outDir: ./out
+// @filename: emitEndOfFileJSDocComments.js
+
+/** @typedef {number} A */
+var unrelated;
+/** @typedef {number} B */

--- a/testdata/tests/cases/compiler/emitEndOfFileJSDocComments2.ts
+++ b/testdata/tests/cases/compiler/emitEndOfFileJSDocComments2.ts
@@ -1,0 +1,23 @@
+// @allowJs: true
+// @checkJs: true
+// @outDir: ./out
+// @filename: emitEndOfFileJSDocComments2.js
+
+/** @typedef {number} A */
+
+/**
+ * JSDoc comment for function
+ * @param {string} param - A string parameter
+ * @returns {number} The length of the string
+ */
+function test(param) {
+	// Comment inside function
+	return param.length;
+	/** @typedef {number} B2 */
+}
+
+// Single line comment
+/** @typedef {number} C */
+/**
+ * Multiple line comment
+ */


### PR DESCRIPTION
### Summary

Fixes https://github.com/microsoft/typescript-go/issues/774

### Detail

The end of file comments won't be emitted correctly now. In this PR, excludes the length of the additional rephrased list from the end position of statements. This behavior now aligns with the TypeScript implementation in the TS version.

### Test

Added two test cases 

