### PR TITLE
Optimize LSP marshalling via jsonv2 methods

### DIFF
--- a/internal/api/proto.go
+++ b/internal/api/proto.go
@@ -200,7 +200,7 @@ type GetSourceFileParams struct {
 	FileName string                  `json:"fileName"`
 }
 
-func unmarshalPayload(method string, payload json.RawMessage) (any, error) {
+func unmarshalPayload(method string, payload json.Value) (any, error) {
 	unmarshaler, ok := unmarshalers[Method(method)]
 	if !ok {
 		return nil, fmt.Errorf("unknown API method %q", method)

--- a/internal/incremental/buildInfo.go
+++ b/internal/incremental/buildInfo.go
@@ -213,7 +213,7 @@ func (b *BuildInfoDiagnosticsOfFile) MarshalJSON() ([]byte, error) {
 }
 
 func (b *BuildInfoDiagnosticsOfFile) UnmarshalJSON(data []byte) error {
-	var fileIdAndDiagnostics []json.RawMessage
+	var fileIdAndDiagnostics []json.Value
 	if err := json.Unmarshal(data, &fileIdAndDiagnostics); err != nil {
 		return fmt.Errorf("invalid BuildInfoDiagnosticsOfFile: %s", data)
 	}

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -5,7 +5,6 @@ import (
 
 	jsonv2 "github.com/go-json-experiment/json"
 	"github.com/go-json-experiment/json/jsontext"
-	jsonv1 "github.com/go-json-experiment/json/v1"
 )
 
 func Marshal(in any, opts ...jsonv2.Options) (out []byte, err error) {
@@ -47,7 +46,7 @@ func UnmarshalRead(in io.Reader, out any, opts ...jsonv2.Options) (err error) {
 }
 
 type (
-	RawMessage      = jsonv1.RawMessage
+	Value           = jsontext.Value
 	UnmarshalerFrom = jsonv2.UnmarshalerFrom
 	MarshalerTo     = jsonv2.MarshalerTo
 )

--- a/internal/lsp/lsproto/_generate/generate.mts
+++ b/internal/lsp/lsproto/_generate/generate.mts
@@ -831,9 +831,13 @@ function generateCode() {
         writeLine(`}`);
         writeLine("");
 
-        writeLine(`func (o *${name}) UnmarshalJSON(data []byte) error {`);
-        writeLine(`\tif string(data) != \`${jsonValue}\` {`);
-        writeLine(`\t\treturn fmt.Errorf("invalid ${name}: %s", data)`);
+        writeLine(`func (o *${name}) UnmarshalJSONFrom(dec *jsontext.Decoder) error {`);
+        writeLine(`\tv, err := dec.ReadValue();`);
+        writeLine(`\tif err != nil {`);
+        writeLine(`\t\treturn err`);
+        writeLine(`\t}`);
+        writeLine(`\tif string(v) != \`${jsonValue}\` {`);
+        writeLine(`\t\treturn fmt.Errorf("expected ${name} value %s, got %s", \`${jsonValue}\`, v)`);
         writeLine(`\t}`);
         writeLine(`\treturn nil`);
         writeLine(`}`);

--- a/internal/lsp/lsproto/_generate/generate.mts
+++ b/internal/lsp/lsproto/_generate/generate.mts
@@ -754,10 +754,14 @@ function generateCode() {
 
         // Determine if this union contained null (check if any member has containedNull = true)
         const unionContainedNull = members.some(member => member.containedNull);
-        const assertionFunc = unionContainedNull ? "assertAtMostOne" : "assertOnlyOne";
+        if (unionContainedNull) {
+            write(`\tassertAtMostOne("more than one element of ${name} is set", `);
+        }
+        else {
+            write(`\tassertOnlyOne("exactly one element of ${name} should be set", `);
+        }
 
         // Create assertion to ensure at most one field is set at a time
-        write(`\t${assertionFunc}("more than one element of ${name} is set", `);
 
         // Write the assertion conditions
         for (let i = 0; i < fieldEntries.length; i++) {

--- a/internal/lsp/lsproto/_generate/generate.mts
+++ b/internal/lsp/lsproto/_generate/generate.mts
@@ -631,17 +631,6 @@ function generateCode() {
 
         writeLine(")");
         writeLine("");
-
-        // Add custom JSON unmarshaling
-        writeLine(`func (e *${enumeration.name}) UnmarshalJSON(data []byte) error {`);
-        writeLine(`\tvar v ${baseType}`);
-        writeLine(`\tif err := json.Unmarshal(data, &v); err != nil {`);
-        writeLine(`\t\treturn err`);
-        writeLine(`\t}`);
-        writeLine(`\t*e = ${enumeration.name}(v)`);
-        writeLine(`\treturn nil`);
-        writeLine(`}`);
-        writeLine("");
     }
 
     const requestsAndNotifications: (Request | Notification)[] = [...model.requests, ...model.notifications];

--- a/internal/lsp/lsproto/_generate/generate.mts
+++ b/internal/lsp/lsproto/_generate/generate.mts
@@ -559,6 +559,8 @@ function generateCode() {
                 writeLine(`\t\t\t}`);
             }
 
+            writeLine(`\t\tdefault:`);
+            writeLine(`\t\t// Ignore unknown properties.`);
             writeLine(`\t\t}`);
             writeLine(`\t}`);
             writeLine("");

--- a/internal/lsp/lsproto/_generate/generate.mts
+++ b/internal/lsp/lsproto/_generate/generate.mts
@@ -785,7 +785,6 @@ function generateCode() {
 
         // If all fields are nil, marshal as null (only for unions that can contain null)
         if (unionContainedNull) {
-            writeLine(`\t// All fields are nil, represent as null`);
             writeLine(`\treturn enc.WriteToken(jsontext.Null)`);
         }
         else {

--- a/internal/lsp/lsproto/_generate/generate.mts
+++ b/internal/lsp/lsproto/_generate/generate.mts
@@ -795,12 +795,17 @@ function generateCode() {
         writeLine("");
 
         // Unmarshal method
-        writeLine(`var _ json.Unmarshaler = (*${name})(nil)`);
+        writeLine(`var _ json.UnmarshalerFrom = (*${name})(nil)`);
         writeLine("");
 
-        writeLine(`func (o *${name}) UnmarshalJSON(data []byte) error {`);
+        writeLine(`func (o *${name}) UnmarshalJSONFrom(dec *jsontext.Decoder) error {`);
         writeLine(`\t*o = ${name}{}`);
         writeLine("");
+
+        writeLine("\tdata, err := dec.ReadValue()");
+        writeLine("\tif err != nil {");
+        writeLine("\t\treturn err");
+        writeLine("\t}");
 
         // Handle null case only for unions that can contain null
         if (unionContainedNull) {

--- a/internal/lsp/lsproto/_generate/generate.mts
+++ b/internal/lsp/lsproto/_generate/generate.mts
@@ -755,10 +755,10 @@ function generateCode() {
         const fieldEntries = Array.from(uniqueTypeFields.entries()).map(([typeName, fieldName]) => ({ fieldName, typeName }));
 
         // Marshal method
-        writeLine(`var _ json.MarshalerTo = ${name}{}`);
+        writeLine(`var _ json.MarshalerTo = (*${name})(nil)`);
         writeLine("");
 
-        writeLine(`func (o ${name}) MarshalJSONTo(enc *jsontext.Encoder) error {`);
+        writeLine(`func (o *${name}) MarshalJSONTo(enc *jsontext.Encoder) error {`);
 
         // Determine if this union contained null (check if any member has containedNull = true)
         const unionContainedNull = members.some(member => member.containedNull);
@@ -781,7 +781,7 @@ function generateCode() {
 
         for (const entry of fieldEntries) {
             writeLine(`\tif o.${entry.fieldName} != nil {`);
-            writeLine(`\t\treturn json.MarshalEncode(enc, *o.${entry.fieldName})`);
+            writeLine(`\t\treturn json.MarshalEncode(enc, o.${entry.fieldName})`);
             writeLine(`\t}`);
         }
 

--- a/internal/lsp/lsproto/_generate/generate.mts
+++ b/internal/lsp/lsproto/_generate/generate.mts
@@ -826,8 +826,8 @@ function generateCode() {
         writeLine(`type ${name} struct{}`);
         writeLine("");
 
-        writeLine(`func (o ${name}) MarshalJSON() ([]byte, error) {`);
-        writeLine(`\treturn []byte(\`${jsonValue}\`), nil`);
+        writeLine(`func (o ${name}) MarshalerTo(enc *jsontext.Encoder) error {`);
+        writeLine(`\treturn enc.WriteValue(jsontext.Value(\`${jsonValue}\`))`);
         writeLine(`}`);
         writeLine("");
 

--- a/internal/lsp/lsproto/_generate/generate.mts
+++ b/internal/lsp/lsproto/_generate/generate.mts
@@ -543,14 +543,14 @@ function generateCode() {
             writeLine("");
 
             writeLine(`\tfor dec.PeekKind() != '}' {`);
-            writeLine(`\t\tvar name string`);
-            writeLine(`\t\tif err := json.UnmarshalDecode(dec, &name); err != nil {`);
+            writeLine("name, err := dec.ReadValue()");
+            writeLine(`\t\tif err != nil {`);
             writeLine(`\t\t\treturn err`);
             writeLine(`\t\t}`);
-            writeLine(`\t\tswitch name {`);
+            writeLine(`\t\tswitch string(name) {`);
 
             for (const prop of structure.properties) {
-                writeLine(`\t\tcase "${prop.name}":`);
+                writeLine(`\t\tcase \`"${prop.name}"\`:`);
                 if (!prop.optional) {
                     writeLine(`\t\t\tseen${titleCase(prop.name)} = true`);
                 }

--- a/internal/lsp/lsproto/_generate/generate.mts
+++ b/internal/lsp/lsproto/_generate/generate.mts
@@ -523,6 +523,9 @@ function generateCode() {
         // Generate UnmarshalJSONFrom method for structure validation
         const requiredProps = structure.properties?.filter(p => !p.optional) || [];
         if (requiredProps.length > 0) {
+            writeLine(`\tvar _ json.UnmarshalerFrom = (*${structure.name})(nil)`);
+            writeLine("");
+
             writeLine(`func (s *${structure.name}) UnmarshalJSONFrom(dec *jsontext.Decoder) error {`);
             writeLine(`\tvar (`);
             for (const prop of requiredProps) {
@@ -750,7 +753,10 @@ function generateCode() {
         const fieldEntries = Array.from(uniqueTypeFields.entries()).map(([typeName, fieldName]) => ({ fieldName, typeName }));
 
         // Marshal method
-        writeLine(`func (o ${name}) MarshalerTo(enc *jsontext.Encoder) error {`);
+        writeLine(`var _ json.MarshalerTo = ${name}{}`);
+        writeLine("");
+
+        writeLine(`func (o ${name}) MarshalJSONTo(enc *jsontext.Encoder) error {`);
 
         // Determine if this union contained null (check if any member has containedNull = true)
         const unionContainedNull = members.some(member => member.containedNull);
@@ -789,6 +795,9 @@ function generateCode() {
         writeLine("");
 
         // Unmarshal method
+        writeLine(`var _ json.Unmarshaler = (*${name})(nil)`);
+        writeLine("");
+
         writeLine(`func (o *${name}) UnmarshalJSON(data []byte) error {`);
         writeLine(`\t*o = ${name}{}`);
         writeLine("");
@@ -826,9 +835,15 @@ function generateCode() {
         writeLine(`type ${name} struct{}`);
         writeLine("");
 
-        writeLine(`func (o ${name}) MarshalerTo(enc *jsontext.Encoder) error {`);
+        writeLine(`var _ json.MarshalerTo = ${name}{}`);
+        writeLine("");
+
+        writeLine(`func (o ${name}) MarshalJSONTo(enc *jsontext.Encoder) error {`);
         writeLine(`\treturn enc.WriteValue(jsontext.Value(\`${jsonValue}\`))`);
         writeLine(`}`);
+        writeLine("");
+
+        writeLine(`var _ json.UnmarshalerFrom = &${name}{}`);
         writeLine("");
 
         writeLine(`func (o *${name}) UnmarshalJSONFrom(dec *jsontext.Decoder) error {`);

--- a/internal/lsp/lsproto/_generate/generate.mts
+++ b/internal/lsp/lsproto/_generate/generate.mts
@@ -572,7 +572,7 @@ function generateCode() {
 
             for (const prop of requiredProps) {
                 writeLine(`\tif !seen${titleCase(prop.name)} {`);
-                writeLine(`\t\treturn fmt.Errorf("required key '${prop.name}' is missing")`);
+                writeLine(`\t\treturn fmt.Errorf("required property '${prop.name}' is missing")`);
                 writeLine(`\t}`);
             }
 

--- a/internal/lsp/lsproto/_generate/generate.mts
+++ b/internal/lsp/lsproto/_generate/generate.mts
@@ -750,7 +750,7 @@ function generateCode() {
         const fieldEntries = Array.from(uniqueTypeFields.entries()).map(([typeName, fieldName]) => ({ fieldName, typeName }));
 
         // Marshal method
-        writeLine(`func (o ${name}) MarshalJSON() ([]byte, error) {`);
+        writeLine(`func (o ${name}) MarshalerTo(enc *jsontext.Encoder) error {`);
 
         // Determine if this union contained null (check if any member has containedNull = true)
         const unionContainedNull = members.some(member => member.containedNull);
@@ -769,14 +769,14 @@ function generateCode() {
 
         for (const entry of fieldEntries) {
             writeLine(`\tif o.${entry.fieldName} != nil {`);
-            writeLine(`\t\treturn json.Marshal(*o.${entry.fieldName})`);
+            writeLine(`\t\treturn json.MarshalEncode(enc, *o.${entry.fieldName})`);
             writeLine(`\t}`);
         }
 
         // If all fields are nil, marshal as null (only for unions that can contain null)
         if (unionContainedNull) {
             writeLine(`\t// All fields are nil, represent as null`);
-            writeLine(`\treturn []byte("null"), nil`);
+            writeLine(`\treturn enc.WriteToken(jsontext.Null)`);
         }
         else {
             writeLine(`\tpanic("unreachable")`);

--- a/internal/lsp/lsproto/_generate/generate.mts
+++ b/internal/lsp/lsproto/_generate/generate.mts
@@ -806,9 +806,7 @@ function generateCode() {
         writeLine("\t\treturn err");
         writeLine("\t}");
 
-        // Handle null case only for unions that can contain null
         if (unionContainedNull) {
-            writeLine(`\t// Handle null case`);
             writeLine(`\tif string(data) == "null" {`);
             writeLine(`\t\treturn nil`);
             writeLine(`\t}`);

--- a/internal/lsp/lsproto/jsonrpc.go
+++ b/internal/lsp/lsproto/jsonrpc.go
@@ -100,12 +100,12 @@ func (m *Message) AsResponse() *ResponseMessage {
 
 func (m *Message) UnmarshalJSON(data []byte) error {
 	var raw struct {
-		JSONRPC JSONRPCVersion  `json:"jsonrpc"`
-		Method  Method          `json:"method"`
-		ID      *ID             `json:"id,omitzero"`
-		Params  json.RawMessage `json:"params"`
-		Result  any             `json:"result,omitzero"`
-		Error   *ResponseError  `json:"error,omitzero"`
+		JSONRPC JSONRPCVersion `json:"jsonrpc"`
+		Method  Method         `json:"method"`
+		ID      *ID            `json:"id,omitzero"`
+		Params  json.Value     `json:"params"`
+		Result  any            `json:"result,omitzero"`
+		Error   *ResponseError `json:"error,omitzero"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return fmt.Errorf("%w: %w", ErrInvalidRequest, err)
@@ -182,10 +182,10 @@ func (r *RequestMessage) Message() *Message {
 
 func (r *RequestMessage) UnmarshalJSON(data []byte) error {
 	var raw struct {
-		JSONRPC JSONRPCVersion  `json:"jsonrpc"`
-		ID      *ID             `json:"id"`
-		Method  Method          `json:"method"`
-		Params  json.RawMessage `json:"params"`
+		JSONRPC JSONRPCVersion `json:"jsonrpc"`
+		ID      *ID            `json:"id"`
+		Method  Method         `json:"method"`
+		Params  json.Value     `json:"params"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return fmt.Errorf("%w: %w", ErrInvalidRequest, err)

--- a/internal/lsp/lsproto/lsp_generated.go
+++ b/internal/lsp/lsproto/lsp_generated.go
@@ -18563,15 +18563,6 @@ const (
 	SemanticTokenTypeslabel SemanticTokenTypes = "label"
 )
 
-func (e *SemanticTokenTypes) UnmarshalJSON(data []byte) error {
-	var v string
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = SemanticTokenTypes(v)
-	return nil
-}
-
 // A set of predefined token modifiers. This set is not fixed
 // an clients can specify additional token types via the
 // corresponding client capabilities.
@@ -18592,15 +18583,6 @@ const (
 	SemanticTokenModifiersdefaultLibrary SemanticTokenModifiers = "defaultLibrary"
 )
 
-func (e *SemanticTokenModifiers) UnmarshalJSON(data []byte) error {
-	var v string
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = SemanticTokenModifiers(v)
-	return nil
-}
-
 // The document diagnostic report kinds.
 //
 // Since: 3.17.0
@@ -18614,15 +18596,6 @@ const (
 	// returned report is still accurate.
 	DocumentDiagnosticReportKindUnchanged DocumentDiagnosticReportKind = "unchanged"
 )
-
-func (e *DocumentDiagnosticReportKind) UnmarshalJSON(data []byte) error {
-	var v string
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = DocumentDiagnosticReportKind(v)
-	return nil
-}
 
 // Predefined error codes.
 type ErrorCodes int32
@@ -18638,15 +18611,6 @@ const (
 	ErrorCodesServerNotInitialized ErrorCodes = -32002
 	ErrorCodesUnknownErrorCode     ErrorCodes = -32001
 )
-
-func (e *ErrorCodes) UnmarshalJSON(data []byte) error {
-	var v int32
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = ErrorCodes(v)
-	return nil
-}
 
 type LSPErrorCodes int32
 
@@ -18678,15 +18642,6 @@ const (
 	LSPErrorCodesRequestCancelled LSPErrorCodes = -32800
 )
 
-func (e *LSPErrorCodes) UnmarshalJSON(data []byte) error {
-	var v int32
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = LSPErrorCodes(v)
-	return nil
-}
-
 // A set of predefined range kinds.
 type FoldingRangeKind string
 
@@ -18698,15 +18653,6 @@ const (
 	// Folding range for a region (e.g. `#region`)
 	FoldingRangeKindRegion FoldingRangeKind = "region"
 )
-
-func (e *FoldingRangeKind) UnmarshalJSON(data []byte) error {
-	var v string
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = FoldingRangeKind(v)
-	return nil
-}
 
 // A symbol kind.
 type SymbolKind uint32
@@ -18740,15 +18686,6 @@ const (
 	SymbolKindTypeParameter SymbolKind = 26
 )
 
-func (e *SymbolKind) UnmarshalJSON(data []byte) error {
-	var v uint32
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = SymbolKind(v)
-	return nil
-}
-
 // Symbol tags are extra annotations that tweak the rendering of a symbol.
 //
 // Since: 3.16
@@ -18758,15 +18695,6 @@ const (
 	// Render a symbol as obsolete, usually using a strike-out.
 	SymbolTagDeprecated SymbolTag = 1
 )
-
-func (e *SymbolTag) UnmarshalJSON(data []byte) error {
-	var v uint32
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = SymbolTag(v)
-	return nil
-}
 
 // Moniker uniqueness level to define scope of the moniker.
 //
@@ -18786,15 +18714,6 @@ const (
 	UniquenessLevelglobal UniquenessLevel = "global"
 )
 
-func (e *UniquenessLevel) UnmarshalJSON(data []byte) error {
-	var v string
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = UniquenessLevel(v)
-	return nil
-}
-
 // The moniker kind.
 //
 // Since: 3.16.0
@@ -18810,15 +18729,6 @@ const (
 	MonikerKindlocal MonikerKind = "local"
 )
 
-func (e *MonikerKind) UnmarshalJSON(data []byte) error {
-	var v string
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = MonikerKind(v)
-	return nil
-}
-
 // Inlay hint kinds.
 //
 // Since: 3.17.0
@@ -18830,15 +18740,6 @@ const (
 	// An inlay hint that is for a parameter.
 	InlayHintKindParameter InlayHintKind = 2
 )
-
-func (e *InlayHintKind) UnmarshalJSON(data []byte) error {
-	var v uint32
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = InlayHintKind(v)
-	return nil
-}
 
 // The message type
 type MessageType uint32
@@ -18860,15 +18761,6 @@ const (
 	MessageTypeDebug MessageType = 5
 )
 
-func (e *MessageType) UnmarshalJSON(data []byte) error {
-	var v uint32
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = MessageType(v)
-	return nil
-}
-
 // Defines how the host (editor) should sync
 // document changes to the language server.
 type TextDocumentSyncKind uint32
@@ -18885,15 +18777,6 @@ const (
 	TextDocumentSyncKindIncremental TextDocumentSyncKind = 2
 )
 
-func (e *TextDocumentSyncKind) UnmarshalJSON(data []byte) error {
-	var v uint32
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = TextDocumentSyncKind(v)
-	return nil
-}
-
 // Represents reasons why a text document is saved.
 type TextDocumentSaveReason uint32
 
@@ -18906,15 +18789,6 @@ const (
 	// When the editor lost focus.
 	TextDocumentSaveReasonFocusOut TextDocumentSaveReason = 3
 )
-
-func (e *TextDocumentSaveReason) UnmarshalJSON(data []byte) error {
-	var v uint32
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = TextDocumentSaveReason(v)
-	return nil
-}
 
 // The kind of a completion entry.
 type CompletionItemKind uint32
@@ -18947,15 +18821,6 @@ const (
 	CompletionItemKindTypeParameter CompletionItemKind = 25
 )
 
-func (e *CompletionItemKind) UnmarshalJSON(data []byte) error {
-	var v uint32
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = CompletionItemKind(v)
-	return nil
-}
-
 // Completion item tags are extra annotations that tweak the rendering of a completion
 // item.
 //
@@ -18966,15 +18831,6 @@ const (
 	// Render a completion as obsolete, usually using a strike-out.
 	CompletionItemTagDeprecated CompletionItemTag = 1
 )
-
-func (e *CompletionItemTag) UnmarshalJSON(data []byte) error {
-	var v uint32
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = CompletionItemTag(v)
-	return nil
-}
 
 // Defines whether the insert text in a completion item should be interpreted as
 // plain text or a snippet.
@@ -18993,15 +18849,6 @@ const (
 	// See also: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#snippet_syntax
 	InsertTextFormatSnippet InsertTextFormat = 2
 )
-
-func (e *InsertTextFormat) UnmarshalJSON(data []byte) error {
-	var v uint32
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = InsertTextFormat(v)
-	return nil
-}
 
 // How whitespace and indentation is handled during completion
 // item insertion.
@@ -19026,15 +18873,6 @@ const (
 	InsertTextModeadjustIndentation InsertTextMode = 2
 )
 
-func (e *InsertTextMode) UnmarshalJSON(data []byte) error {
-	var v uint32
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = InsertTextMode(v)
-	return nil
-}
-
 // A document highlight kind.
 type DocumentHighlightKind uint32
 
@@ -19046,15 +18884,6 @@ const (
 	// Write-access of a symbol, like writing to a variable.
 	DocumentHighlightKindWrite DocumentHighlightKind = 3
 )
-
-func (e *DocumentHighlightKind) UnmarshalJSON(data []byte) error {
-	var v uint32
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = DocumentHighlightKind(v)
-	return nil
-}
 
 // A set of predefined code action kinds
 type CodeActionKind string
@@ -19129,15 +18958,6 @@ const (
 	CodeActionKindNotebook CodeActionKind = "notebook"
 )
 
-func (e *CodeActionKind) UnmarshalJSON(data []byte) error {
-	var v string
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = CodeActionKind(v)
-	return nil
-}
-
 // Code action tags are extra annotations that tweak the behavior of a code action.
 //
 // Since: 3.18.0 - proposed
@@ -19147,15 +18967,6 @@ const (
 	// Marks the code action as LLM-generated.
 	CodeActionTagLLMGenerated CodeActionTag = 1
 )
-
-func (e *CodeActionTag) UnmarshalJSON(data []byte) error {
-	var v uint32
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = CodeActionTag(v)
-	return nil
-}
 
 type TraceValue string
 
@@ -19167,15 +18978,6 @@ const (
 	// Verbose message tracing.
 	TraceValueVerbose TraceValue = "verbose"
 )
-
-func (e *TraceValue) UnmarshalJSON(data []byte) error {
-	var v string
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = TraceValue(v)
-	return nil
-}
 
 // Describes the content type that a client supports in various
 // result literals like `Hover`, `ParameterInfo` or `CompletionItem`.
@@ -19190,15 +18992,6 @@ const (
 	// Markdown is supported as a content format
 	MarkupKindMarkdown MarkupKind = "markdown"
 )
-
-func (e *MarkupKind) UnmarshalJSON(data []byte) error {
-	var v string
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = MarkupKind(v)
-	return nil
-}
 
 // Predefined Language kinds
 //
@@ -19278,15 +19071,6 @@ const (
 	LanguageKindYAML            LanguageKind = "yaml"
 )
 
-func (e *LanguageKind) UnmarshalJSON(data []byte) error {
-	var v string
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = LanguageKind(v)
-	return nil
-}
-
 // Describes how an provider was triggered.
 //
 // Since: 3.18.0
@@ -19300,15 +19084,6 @@ const (
 	// Completion was triggered automatically while editing.
 	InlineCompletionTriggerKindAutomatic InlineCompletionTriggerKind = 2
 )
-
-func (e *InlineCompletionTriggerKind) UnmarshalJSON(data []byte) error {
-	var v uint32
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = InlineCompletionTriggerKind(v)
-	return nil
-}
 
 // A set of predefined position encoding kinds.
 //
@@ -19331,15 +19106,6 @@ const (
 	PositionEncodingKindUTF32 PositionEncodingKind = "utf-32"
 )
 
-func (e *PositionEncodingKind) UnmarshalJSON(data []byte) error {
-	var v string
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = PositionEncodingKind(v)
-	return nil
-}
-
 // The file event type
 type FileChangeType uint32
 
@@ -19352,15 +19118,6 @@ const (
 	FileChangeTypeDeleted FileChangeType = 3
 )
 
-func (e *FileChangeType) UnmarshalJSON(data []byte) error {
-	var v uint32
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = FileChangeType(v)
-	return nil
-}
-
 type WatchKind uint32
 
 const (
@@ -19371,15 +19128,6 @@ const (
 	// Interested in delete events
 	WatchKindDelete WatchKind = 4
 )
-
-func (e *WatchKind) UnmarshalJSON(data []byte) error {
-	var v uint32
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = WatchKind(v)
-	return nil
-}
 
 // The diagnostic's severity.
 type DiagnosticSeverity uint32
@@ -19394,15 +19142,6 @@ const (
 	// Reports a hint.
 	DiagnosticSeverityHint DiagnosticSeverity = 4
 )
-
-func (e *DiagnosticSeverity) UnmarshalJSON(data []byte) error {
-	var v uint32
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = DiagnosticSeverity(v)
-	return nil
-}
 
 // The diagnostic tags.
 //
@@ -19421,15 +19160,6 @@ const (
 	DiagnosticTagDeprecated DiagnosticTag = 2
 )
 
-func (e *DiagnosticTag) UnmarshalJSON(data []byte) error {
-	var v uint32
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = DiagnosticTag(v)
-	return nil
-}
-
 // How a completion was triggered
 type CompletionTriggerKind uint32
 
@@ -19443,15 +19173,6 @@ const (
 	// Completion was re-triggered as current completion list is incomplete
 	CompletionTriggerKindTriggerForIncompleteCompletions CompletionTriggerKind = 3
 )
-
-func (e *CompletionTriggerKind) UnmarshalJSON(data []byte) error {
-	var v uint32
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = CompletionTriggerKind(v)
-	return nil
-}
 
 // Defines how values from a set of defaults and an individual item will be
 // merged.
@@ -19470,15 +19191,6 @@ const (
 	ApplyKindMerge ApplyKind = 2
 )
 
-func (e *ApplyKind) UnmarshalJSON(data []byte) error {
-	var v uint32
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = ApplyKind(v)
-	return nil
-}
-
 // How a signature help was triggered.
 //
 // Since: 3.15.0
@@ -19492,15 +19204,6 @@ const (
 	// Signature help was triggered by the cursor moving or by the document content changing.
 	SignatureHelpTriggerKindContentChange SignatureHelpTriggerKind = 3
 )
-
-func (e *SignatureHelpTriggerKind) UnmarshalJSON(data []byte) error {
-	var v uint32
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = SignatureHelpTriggerKind(v)
-	return nil
-}
 
 // The reason why code actions were requested.
 //
@@ -19517,15 +19220,6 @@ const (
 	CodeActionTriggerKindAutomatic CodeActionTriggerKind = 2
 )
 
-func (e *CodeActionTriggerKind) UnmarshalJSON(data []byte) error {
-	var v uint32
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = CodeActionTriggerKind(v)
-	return nil
-}
-
 // A pattern kind describing if a glob pattern matches a file a folder or
 // both.
 //
@@ -19539,15 +19233,6 @@ const (
 	FileOperationPatternKindfolder FileOperationPatternKind = "folder"
 )
 
-func (e *FileOperationPatternKind) UnmarshalJSON(data []byte) error {
-	var v string
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = FileOperationPatternKind(v)
-	return nil
-}
-
 // A notebook cell kind.
 //
 // Since: 3.17.0
@@ -19560,15 +19245,6 @@ const (
 	NotebookCellKindCode NotebookCellKind = 2
 )
 
-func (e *NotebookCellKind) UnmarshalJSON(data []byte) error {
-	var v uint32
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = NotebookCellKind(v)
-	return nil
-}
-
 type ResourceOperationKind string
 
 const (
@@ -19579,15 +19255,6 @@ const (
 	// Supports deleting existing files and folders.
 	ResourceOperationKindDelete ResourceOperationKind = "delete"
 )
-
-func (e *ResourceOperationKind) UnmarshalJSON(data []byte) error {
-	var v string
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = ResourceOperationKind(v)
-	return nil
-}
 
 type FailureHandlingKind string
 
@@ -19607,15 +19274,6 @@ const (
 	FailureHandlingKindUndo FailureHandlingKind = "undo"
 )
 
-func (e *FailureHandlingKind) UnmarshalJSON(data []byte) error {
-	var v string
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = FailureHandlingKind(v)
-	return nil
-}
-
 type PrepareSupportDefaultBehavior uint32
 
 const (
@@ -19624,29 +19282,11 @@ const (
 	PrepareSupportDefaultBehaviorIdentifier PrepareSupportDefaultBehavior = 1
 )
 
-func (e *PrepareSupportDefaultBehavior) UnmarshalJSON(data []byte) error {
-	var v uint32
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = PrepareSupportDefaultBehavior(v)
-	return nil
-}
-
 type TokenFormat string
 
 const (
 	TokenFormatRelative TokenFormat = "relative"
 )
-
-func (e *TokenFormat) UnmarshalJSON(data []byte) error {
-	var v string
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*e = TokenFormat(v)
-	return nil
-}
 
 func unmarshalParams(method Method, data []byte) (any, error) {
 	switch method {

--- a/internal/lsp/lsproto/lsp_generated.go
+++ b/internal/lsp/lsproto/lsp_generated.go
@@ -20378,7 +20378,7 @@ type IntegerOrString struct {
 }
 
 func (o IntegerOrString) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of IntegerOrString is set", o.Integer != nil, o.String != nil)
+	assertOnlyOne("exactly one element of IntegerOrString should be set", o.Integer != nil, o.String != nil)
 
 	if o.Integer != nil {
 		return json.MarshalEncode(enc, *o.Integer)
@@ -20441,7 +20441,7 @@ type BooleanOrEmptyObject struct {
 }
 
 func (o BooleanOrEmptyObject) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of BooleanOrEmptyObject is set", o.Boolean != nil, o.EmptyObject != nil)
+	assertOnlyOne("exactly one element of BooleanOrEmptyObject should be set", o.Boolean != nil, o.EmptyObject != nil)
 
 	if o.Boolean != nil {
 		return json.MarshalEncode(enc, *o.Boolean)
@@ -20474,7 +20474,7 @@ type BooleanOrSemanticTokensFullDelta struct {
 }
 
 func (o BooleanOrSemanticTokensFullDelta) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of BooleanOrSemanticTokensFullDelta is set", o.Boolean != nil, o.SemanticTokensFullDelta != nil)
+	assertOnlyOne("exactly one element of BooleanOrSemanticTokensFullDelta should be set", o.Boolean != nil, o.SemanticTokensFullDelta != nil)
 
 	if o.Boolean != nil {
 		return json.MarshalEncode(enc, *o.Boolean)
@@ -20509,7 +20509,7 @@ type TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile struct {
 }
 
 func (o TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile is set", o.TextDocumentEdit != nil, o.CreateFile != nil, o.RenameFile != nil, o.DeleteFile != nil)
+	assertOnlyOne("exactly one element of TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile should be set", o.TextDocumentEdit != nil, o.CreateFile != nil, o.RenameFile != nil, o.DeleteFile != nil)
 
 	if o.TextDocumentEdit != nil {
 		return json.MarshalEncode(enc, *o.TextDocumentEdit)
@@ -20558,7 +20558,7 @@ type StringOrInlayHintLabelParts struct {
 }
 
 func (o StringOrInlayHintLabelParts) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of StringOrInlayHintLabelParts is set", o.String != nil, o.InlayHintLabelParts != nil)
+	assertOnlyOne("exactly one element of StringOrInlayHintLabelParts should be set", o.String != nil, o.InlayHintLabelParts != nil)
 
 	if o.String != nil {
 		return json.MarshalEncode(enc, *o.String)
@@ -20591,7 +20591,7 @@ type StringOrMarkupContent struct {
 }
 
 func (o StringOrMarkupContent) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of StringOrMarkupContent is set", o.String != nil, o.MarkupContent != nil)
+	assertOnlyOne("exactly one element of StringOrMarkupContent should be set", o.String != nil, o.MarkupContent != nil)
 
 	if o.String != nil {
 		return json.MarshalEncode(enc, *o.String)
@@ -20624,7 +20624,7 @@ type FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport struct {
 }
 
 func (o FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport is set", o.FullDocumentDiagnosticReport != nil, o.UnchangedDocumentDiagnosticReport != nil)
+	assertOnlyOne("exactly one element of FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport should be set", o.FullDocumentDiagnosticReport != nil, o.UnchangedDocumentDiagnosticReport != nil)
 
 	if o.FullDocumentDiagnosticReport != nil {
 		return json.MarshalEncode(enc, *o.FullDocumentDiagnosticReport)
@@ -20657,7 +20657,7 @@ type WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport st
 }
 
 func (o WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport is set", o.FullDocumentDiagnosticReport != nil, o.UnchangedDocumentDiagnosticReport != nil)
+	assertOnlyOne("exactly one element of WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport should be set", o.FullDocumentDiagnosticReport != nil, o.UnchangedDocumentDiagnosticReport != nil)
 
 	if o.FullDocumentDiagnosticReport != nil {
 		return json.MarshalEncode(enc, *o.FullDocumentDiagnosticReport)
@@ -20690,7 +20690,7 @@ type NotebookDocumentFilterWithNotebookOrCells struct {
 }
 
 func (o NotebookDocumentFilterWithNotebookOrCells) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of NotebookDocumentFilterWithNotebookOrCells is set", o.Notebook != nil, o.Cells != nil)
+	assertOnlyOne("exactly one element of NotebookDocumentFilterWithNotebookOrCells should be set", o.Notebook != nil, o.Cells != nil)
 
 	if o.Notebook != nil {
 		return json.MarshalEncode(enc, *o.Notebook)
@@ -20723,7 +20723,7 @@ type StringOrStringValue struct {
 }
 
 func (o StringOrStringValue) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of StringOrStringValue is set", o.String != nil, o.StringValue != nil)
+	assertOnlyOne("exactly one element of StringOrStringValue should be set", o.String != nil, o.StringValue != nil)
 
 	if o.String != nil {
 		return json.MarshalEncode(enc, *o.String)
@@ -20876,7 +20876,7 @@ type StringOrStrings struct {
 }
 
 func (o StringOrStrings) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of StringOrStrings is set", o.String != nil, o.Strings != nil)
+	assertOnlyOne("exactly one element of StringOrStrings should be set", o.String != nil, o.Strings != nil)
 
 	if o.String != nil {
 		return json.MarshalEncode(enc, *o.String)
@@ -20909,7 +20909,7 @@ type TextDocumentContentChangePartialOrWholeDocument struct {
 }
 
 func (o TextDocumentContentChangePartialOrWholeDocument) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of TextDocumentContentChangePartialOrWholeDocument is set", o.Partial != nil, o.WholeDocument != nil)
+	assertOnlyOne("exactly one element of TextDocumentContentChangePartialOrWholeDocument should be set", o.Partial != nil, o.WholeDocument != nil)
 
 	if o.Partial != nil {
 		return json.MarshalEncode(enc, *o.Partial)
@@ -20942,7 +20942,7 @@ type TextEditOrInsertReplaceEdit struct {
 }
 
 func (o TextEditOrInsertReplaceEdit) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of TextEditOrInsertReplaceEdit is set", o.TextEdit != nil, o.InsertReplaceEdit != nil)
+	assertOnlyOne("exactly one element of TextEditOrInsertReplaceEdit should be set", o.TextEdit != nil, o.InsertReplaceEdit != nil)
 
 	if o.TextEdit != nil {
 		return json.MarshalEncode(enc, *o.TextEdit)
@@ -20977,7 +20977,7 @@ type MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings struct {
 }
 
 func (o MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings is set", o.MarkupContent != nil, o.String != nil, o.MarkedStringWithLanguage != nil, o.MarkedStrings != nil)
+	assertOnlyOne("exactly one element of MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings should be set", o.MarkupContent != nil, o.String != nil, o.MarkedStringWithLanguage != nil, o.MarkedStrings != nil)
 
 	if o.MarkupContent != nil {
 		return json.MarshalEncode(enc, *o.MarkupContent)
@@ -21056,7 +21056,7 @@ type LocationOrLocationUriOnly struct {
 }
 
 func (o LocationOrLocationUriOnly) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of LocationOrLocationUriOnly is set", o.Location != nil, o.LocationUriOnly != nil)
+	assertOnlyOne("exactly one element of LocationOrLocationUriOnly should be set", o.Location != nil, o.LocationUriOnly != nil)
 
 	if o.Location != nil {
 		return json.MarshalEncode(enc, *o.Location)
@@ -21090,7 +21090,7 @@ type TextEditOrAnnotatedTextEditOrSnippetTextEdit struct {
 }
 
 func (o TextEditOrAnnotatedTextEditOrSnippetTextEdit) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of TextEditOrAnnotatedTextEditOrSnippetTextEdit is set", o.TextEdit != nil, o.AnnotatedTextEdit != nil, o.SnippetTextEdit != nil)
+	assertOnlyOne("exactly one element of TextEditOrAnnotatedTextEditOrSnippetTextEdit should be set", o.TextEdit != nil, o.AnnotatedTextEdit != nil, o.SnippetTextEdit != nil)
 
 	if o.TextEdit != nil {
 		return json.MarshalEncode(enc, *o.TextEdit)
@@ -21131,7 +21131,7 @@ type TextDocumentSyncOptionsOrKind struct {
 }
 
 func (o TextDocumentSyncOptionsOrKind) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of TextDocumentSyncOptionsOrKind is set", o.Options != nil, o.Kind != nil)
+	assertOnlyOne("exactly one element of TextDocumentSyncOptionsOrKind should be set", o.Options != nil, o.Kind != nil)
 
 	if o.Options != nil {
 		return json.MarshalEncode(enc, *o.Options)
@@ -21164,7 +21164,7 @@ type NotebookDocumentSyncOptionsOrRegistrationOptions struct {
 }
 
 func (o NotebookDocumentSyncOptionsOrRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of NotebookDocumentSyncOptionsOrRegistrationOptions is set", o.Options != nil, o.RegistrationOptions != nil)
+	assertOnlyOne("exactly one element of NotebookDocumentSyncOptionsOrRegistrationOptions should be set", o.Options != nil, o.RegistrationOptions != nil)
 
 	if o.Options != nil {
 		return json.MarshalEncode(enc, *o.Options)
@@ -21197,7 +21197,7 @@ type BooleanOrHoverOptions struct {
 }
 
 func (o BooleanOrHoverOptions) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of BooleanOrHoverOptions is set", o.Boolean != nil, o.HoverOptions != nil)
+	assertOnlyOne("exactly one element of BooleanOrHoverOptions should be set", o.Boolean != nil, o.HoverOptions != nil)
 
 	if o.Boolean != nil {
 		return json.MarshalEncode(enc, *o.Boolean)
@@ -21231,7 +21231,7 @@ type BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions struct {
 }
 
 func (o BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions is set", o.Boolean != nil, o.DeclarationOptions != nil, o.DeclarationRegistrationOptions != nil)
+	assertOnlyOne("exactly one element of BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions should be set", o.Boolean != nil, o.DeclarationOptions != nil, o.DeclarationRegistrationOptions != nil)
 
 	if o.Boolean != nil {
 		return json.MarshalEncode(enc, *o.Boolean)
@@ -21272,7 +21272,7 @@ type BooleanOrDefinitionOptions struct {
 }
 
 func (o BooleanOrDefinitionOptions) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of BooleanOrDefinitionOptions is set", o.Boolean != nil, o.DefinitionOptions != nil)
+	assertOnlyOne("exactly one element of BooleanOrDefinitionOptions should be set", o.Boolean != nil, o.DefinitionOptions != nil)
 
 	if o.Boolean != nil {
 		return json.MarshalEncode(enc, *o.Boolean)
@@ -21306,7 +21306,7 @@ type BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions struct {
 }
 
 func (o BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions is set", o.Boolean != nil, o.TypeDefinitionOptions != nil, o.TypeDefinitionRegistrationOptions != nil)
+	assertOnlyOne("exactly one element of BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions should be set", o.Boolean != nil, o.TypeDefinitionOptions != nil, o.TypeDefinitionRegistrationOptions != nil)
 
 	if o.Boolean != nil {
 		return json.MarshalEncode(enc, *o.Boolean)
@@ -21348,7 +21348,7 @@ type BooleanOrImplementationOptionsOrImplementationRegistrationOptions struct {
 }
 
 func (o BooleanOrImplementationOptionsOrImplementationRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of BooleanOrImplementationOptionsOrImplementationRegistrationOptions is set", o.Boolean != nil, o.ImplementationOptions != nil, o.ImplementationRegistrationOptions != nil)
+	assertOnlyOne("exactly one element of BooleanOrImplementationOptionsOrImplementationRegistrationOptions should be set", o.Boolean != nil, o.ImplementationOptions != nil, o.ImplementationRegistrationOptions != nil)
 
 	if o.Boolean != nil {
 		return json.MarshalEncode(enc, *o.Boolean)
@@ -21389,7 +21389,7 @@ type BooleanOrReferenceOptions struct {
 }
 
 func (o BooleanOrReferenceOptions) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of BooleanOrReferenceOptions is set", o.Boolean != nil, o.ReferenceOptions != nil)
+	assertOnlyOne("exactly one element of BooleanOrReferenceOptions should be set", o.Boolean != nil, o.ReferenceOptions != nil)
 
 	if o.Boolean != nil {
 		return json.MarshalEncode(enc, *o.Boolean)
@@ -21422,7 +21422,7 @@ type BooleanOrDocumentHighlightOptions struct {
 }
 
 func (o BooleanOrDocumentHighlightOptions) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of BooleanOrDocumentHighlightOptions is set", o.Boolean != nil, o.DocumentHighlightOptions != nil)
+	assertOnlyOne("exactly one element of BooleanOrDocumentHighlightOptions should be set", o.Boolean != nil, o.DocumentHighlightOptions != nil)
 
 	if o.Boolean != nil {
 		return json.MarshalEncode(enc, *o.Boolean)
@@ -21455,7 +21455,7 @@ type BooleanOrDocumentSymbolOptions struct {
 }
 
 func (o BooleanOrDocumentSymbolOptions) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of BooleanOrDocumentSymbolOptions is set", o.Boolean != nil, o.DocumentSymbolOptions != nil)
+	assertOnlyOne("exactly one element of BooleanOrDocumentSymbolOptions should be set", o.Boolean != nil, o.DocumentSymbolOptions != nil)
 
 	if o.Boolean != nil {
 		return json.MarshalEncode(enc, *o.Boolean)
@@ -21488,7 +21488,7 @@ type BooleanOrCodeActionOptions struct {
 }
 
 func (o BooleanOrCodeActionOptions) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of BooleanOrCodeActionOptions is set", o.Boolean != nil, o.CodeActionOptions != nil)
+	assertOnlyOne("exactly one element of BooleanOrCodeActionOptions should be set", o.Boolean != nil, o.CodeActionOptions != nil)
 
 	if o.Boolean != nil {
 		return json.MarshalEncode(enc, *o.Boolean)
@@ -21522,7 +21522,7 @@ type BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions struct {
 }
 
 func (o BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions is set", o.Boolean != nil, o.DocumentColorOptions != nil, o.DocumentColorRegistrationOptions != nil)
+	assertOnlyOne("exactly one element of BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions should be set", o.Boolean != nil, o.DocumentColorOptions != nil, o.DocumentColorRegistrationOptions != nil)
 
 	if o.Boolean != nil {
 		return json.MarshalEncode(enc, *o.Boolean)
@@ -21563,7 +21563,7 @@ type BooleanOrWorkspaceSymbolOptions struct {
 }
 
 func (o BooleanOrWorkspaceSymbolOptions) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of BooleanOrWorkspaceSymbolOptions is set", o.Boolean != nil, o.WorkspaceSymbolOptions != nil)
+	assertOnlyOne("exactly one element of BooleanOrWorkspaceSymbolOptions should be set", o.Boolean != nil, o.WorkspaceSymbolOptions != nil)
 
 	if o.Boolean != nil {
 		return json.MarshalEncode(enc, *o.Boolean)
@@ -21596,7 +21596,7 @@ type BooleanOrDocumentFormattingOptions struct {
 }
 
 func (o BooleanOrDocumentFormattingOptions) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of BooleanOrDocumentFormattingOptions is set", o.Boolean != nil, o.DocumentFormattingOptions != nil)
+	assertOnlyOne("exactly one element of BooleanOrDocumentFormattingOptions should be set", o.Boolean != nil, o.DocumentFormattingOptions != nil)
 
 	if o.Boolean != nil {
 		return json.MarshalEncode(enc, *o.Boolean)
@@ -21629,7 +21629,7 @@ type BooleanOrDocumentRangeFormattingOptions struct {
 }
 
 func (o BooleanOrDocumentRangeFormattingOptions) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of BooleanOrDocumentRangeFormattingOptions is set", o.Boolean != nil, o.DocumentRangeFormattingOptions != nil)
+	assertOnlyOne("exactly one element of BooleanOrDocumentRangeFormattingOptions should be set", o.Boolean != nil, o.DocumentRangeFormattingOptions != nil)
 
 	if o.Boolean != nil {
 		return json.MarshalEncode(enc, *o.Boolean)
@@ -21662,7 +21662,7 @@ type BooleanOrRenameOptions struct {
 }
 
 func (o BooleanOrRenameOptions) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of BooleanOrRenameOptions is set", o.Boolean != nil, o.RenameOptions != nil)
+	assertOnlyOne("exactly one element of BooleanOrRenameOptions should be set", o.Boolean != nil, o.RenameOptions != nil)
 
 	if o.Boolean != nil {
 		return json.MarshalEncode(enc, *o.Boolean)
@@ -21696,7 +21696,7 @@ type BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions struct {
 }
 
 func (o BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions is set", o.Boolean != nil, o.FoldingRangeOptions != nil, o.FoldingRangeRegistrationOptions != nil)
+	assertOnlyOne("exactly one element of BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions should be set", o.Boolean != nil, o.FoldingRangeOptions != nil, o.FoldingRangeRegistrationOptions != nil)
 
 	if o.Boolean != nil {
 		return json.MarshalEncode(enc, *o.Boolean)
@@ -21738,7 +21738,7 @@ type BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions struct {
 }
 
 func (o BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions is set", o.Boolean != nil, o.SelectionRangeOptions != nil, o.SelectionRangeRegistrationOptions != nil)
+	assertOnlyOne("exactly one element of BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions should be set", o.Boolean != nil, o.SelectionRangeOptions != nil, o.SelectionRangeRegistrationOptions != nil)
 
 	if o.Boolean != nil {
 		return json.MarshalEncode(enc, *o.Boolean)
@@ -21780,7 +21780,7 @@ type BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions struct {
 }
 
 func (o BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions is set", o.Boolean != nil, o.CallHierarchyOptions != nil, o.CallHierarchyRegistrationOptions != nil)
+	assertOnlyOne("exactly one element of BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions should be set", o.Boolean != nil, o.CallHierarchyOptions != nil, o.CallHierarchyRegistrationOptions != nil)
 
 	if o.Boolean != nil {
 		return json.MarshalEncode(enc, *o.Boolean)
@@ -21822,7 +21822,7 @@ type BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOptions s
 }
 
 func (o BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOptions is set", o.Boolean != nil, o.LinkedEditingRangeOptions != nil, o.LinkedEditingRangeRegistrationOptions != nil)
+	assertOnlyOne("exactly one element of BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOptions should be set", o.Boolean != nil, o.LinkedEditingRangeOptions != nil, o.LinkedEditingRangeRegistrationOptions != nil)
 
 	if o.Boolean != nil {
 		return json.MarshalEncode(enc, *o.Boolean)
@@ -21863,7 +21863,7 @@ type SemanticTokensOptionsOrRegistrationOptions struct {
 }
 
 func (o SemanticTokensOptionsOrRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of SemanticTokensOptionsOrRegistrationOptions is set", o.Options != nil, o.RegistrationOptions != nil)
+	assertOnlyOne("exactly one element of SemanticTokensOptionsOrRegistrationOptions should be set", o.Options != nil, o.RegistrationOptions != nil)
 
 	if o.Options != nil {
 		return json.MarshalEncode(enc, *o.Options)
@@ -21897,7 +21897,7 @@ type BooleanOrMonikerOptionsOrMonikerRegistrationOptions struct {
 }
 
 func (o BooleanOrMonikerOptionsOrMonikerRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of BooleanOrMonikerOptionsOrMonikerRegistrationOptions is set", o.Boolean != nil, o.MonikerOptions != nil, o.MonikerRegistrationOptions != nil)
+	assertOnlyOne("exactly one element of BooleanOrMonikerOptionsOrMonikerRegistrationOptions should be set", o.Boolean != nil, o.MonikerOptions != nil, o.MonikerRegistrationOptions != nil)
 
 	if o.Boolean != nil {
 		return json.MarshalEncode(enc, *o.Boolean)
@@ -21939,7 +21939,7 @@ type BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions struct {
 }
 
 func (o BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions is set", o.Boolean != nil, o.TypeHierarchyOptions != nil, o.TypeHierarchyRegistrationOptions != nil)
+	assertOnlyOne("exactly one element of BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions should be set", o.Boolean != nil, o.TypeHierarchyOptions != nil, o.TypeHierarchyRegistrationOptions != nil)
 
 	if o.Boolean != nil {
 		return json.MarshalEncode(enc, *o.Boolean)
@@ -21981,7 +21981,7 @@ type BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions struct {
 }
 
 func (o BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions is set", o.Boolean != nil, o.InlineValueOptions != nil, o.InlineValueRegistrationOptions != nil)
+	assertOnlyOne("exactly one element of BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions should be set", o.Boolean != nil, o.InlineValueOptions != nil, o.InlineValueRegistrationOptions != nil)
 
 	if o.Boolean != nil {
 		return json.MarshalEncode(enc, *o.Boolean)
@@ -22023,7 +22023,7 @@ type BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions struct {
 }
 
 func (o BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions is set", o.Boolean != nil, o.InlayHintOptions != nil, o.InlayHintRegistrationOptions != nil)
+	assertOnlyOne("exactly one element of BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions should be set", o.Boolean != nil, o.InlayHintOptions != nil, o.InlayHintRegistrationOptions != nil)
 
 	if o.Boolean != nil {
 		return json.MarshalEncode(enc, *o.Boolean)
@@ -22064,7 +22064,7 @@ type DiagnosticOptionsOrRegistrationOptions struct {
 }
 
 func (o DiagnosticOptionsOrRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of DiagnosticOptionsOrRegistrationOptions is set", o.Options != nil, o.RegistrationOptions != nil)
+	assertOnlyOne("exactly one element of DiagnosticOptionsOrRegistrationOptions should be set", o.Options != nil, o.RegistrationOptions != nil)
 
 	if o.Options != nil {
 		return json.MarshalEncode(enc, *o.Options)
@@ -22097,7 +22097,7 @@ type BooleanOrInlineCompletionOptions struct {
 }
 
 func (o BooleanOrInlineCompletionOptions) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of BooleanOrInlineCompletionOptions is set", o.Boolean != nil, o.InlineCompletionOptions != nil)
+	assertOnlyOne("exactly one element of BooleanOrInlineCompletionOptions should be set", o.Boolean != nil, o.InlineCompletionOptions != nil)
 
 	if o.Boolean != nil {
 		return json.MarshalEncode(enc, *o.Boolean)
@@ -22130,7 +22130,7 @@ type PatternOrRelativePattern struct {
 }
 
 func (o PatternOrRelativePattern) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of PatternOrRelativePattern is set", o.Pattern != nil, o.RelativePattern != nil)
+	assertOnlyOne("exactly one element of PatternOrRelativePattern should be set", o.Pattern != nil, o.RelativePattern != nil)
 
 	if o.Pattern != nil {
 		return json.MarshalEncode(enc, *o.Pattern)
@@ -22163,7 +22163,7 @@ type RangeOrEditRangeWithInsertReplace struct {
 }
 
 func (o RangeOrEditRangeWithInsertReplace) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of RangeOrEditRangeWithInsertReplace is set", o.Range != nil, o.EditRangeWithInsertReplace != nil)
+	assertOnlyOne("exactly one element of RangeOrEditRangeWithInsertReplace should be set", o.Range != nil, o.EditRangeWithInsertReplace != nil)
 
 	if o.Range != nil {
 		return json.MarshalEncode(enc, *o.Range)
@@ -22198,7 +22198,7 @@ type StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrN
 }
 
 func (o StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrNotebookDocumentFilterPattern) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrNotebookDocumentFilterPattern is set", o.String != nil, o.NotebookDocumentFilterNotebookType != nil, o.NotebookDocumentFilterScheme != nil, o.NotebookDocumentFilterPattern != nil)
+	assertOnlyOne("exactly one element of StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrNotebookDocumentFilterPattern should be set", o.String != nil, o.NotebookDocumentFilterNotebookType != nil, o.NotebookDocumentFilterScheme != nil, o.NotebookDocumentFilterPattern != nil)
 
 	if o.String != nil {
 		return json.MarshalEncode(enc, *o.String)
@@ -22247,7 +22247,7 @@ type BooleanOrSaveOptions struct {
 }
 
 func (o BooleanOrSaveOptions) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of BooleanOrSaveOptions is set", o.Boolean != nil, o.SaveOptions != nil)
+	assertOnlyOne("exactly one element of BooleanOrSaveOptions should be set", o.Boolean != nil, o.SaveOptions != nil)
 
 	if o.Boolean != nil {
 		return json.MarshalEncode(enc, *o.Boolean)
@@ -22280,7 +22280,7 @@ type TextDocumentContentOptionsOrRegistrationOptions struct {
 }
 
 func (o TextDocumentContentOptionsOrRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of TextDocumentContentOptionsOrRegistrationOptions is set", o.Options != nil, o.RegistrationOptions != nil)
+	assertOnlyOne("exactly one element of TextDocumentContentOptionsOrRegistrationOptions should be set", o.Options != nil, o.RegistrationOptions != nil)
 
 	if o.Options != nil {
 		return json.MarshalEncode(enc, *o.Options)
@@ -22313,7 +22313,7 @@ type StringOrTuple struct {
 }
 
 func (o StringOrTuple) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of StringOrTuple is set", o.String != nil, o.Tuple != nil)
+	assertOnlyOne("exactly one element of StringOrTuple should be set", o.String != nil, o.Tuple != nil)
 
 	if o.String != nil {
 		return json.MarshalEncode(enc, *o.String)
@@ -22346,7 +22346,7 @@ type StringOrBoolean struct {
 }
 
 func (o StringOrBoolean) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of StringOrBoolean is set", o.String != nil, o.Boolean != nil)
+	assertOnlyOne("exactly one element of StringOrBoolean should be set", o.String != nil, o.Boolean != nil)
 
 	if o.String != nil {
 		return json.MarshalEncode(enc, *o.String)
@@ -22379,7 +22379,7 @@ type WorkspaceFolderOrURI struct {
 }
 
 func (o WorkspaceFolderOrURI) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of WorkspaceFolderOrURI is set", o.WorkspaceFolder != nil, o.URI != nil)
+	assertOnlyOne("exactly one element of WorkspaceFolderOrURI should be set", o.WorkspaceFolder != nil, o.URI != nil)
 
 	if o.WorkspaceFolder != nil {
 		return json.MarshalEncode(enc, *o.WorkspaceFolder)
@@ -22412,7 +22412,7 @@ type BooleanOrClientSemanticTokensRequestFullDelta struct {
 }
 
 func (o BooleanOrClientSemanticTokensRequestFullDelta) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of BooleanOrClientSemanticTokensRequestFullDelta is set", o.Boolean != nil, o.ClientSemanticTokensRequestFullDelta != nil)
+	assertOnlyOne("exactly one element of BooleanOrClientSemanticTokensRequestFullDelta should be set", o.Boolean != nil, o.ClientSemanticTokensRequestFullDelta != nil)
 
 	if o.Boolean != nil {
 		return json.MarshalEncode(enc, *o.Boolean)
@@ -22940,7 +22940,7 @@ type RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport stru
 }
 
 func (o RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport is set", o.FullDocumentDiagnosticReport != nil, o.UnchangedDocumentDiagnosticReport != nil)
+	assertOnlyOne("exactly one element of RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport should be set", o.FullDocumentDiagnosticReport != nil, o.UnchangedDocumentDiagnosticReport != nil)
 
 	if o.FullDocumentDiagnosticReport != nil {
 		return json.MarshalEncode(enc, *o.FullDocumentDiagnosticReport)
@@ -23270,7 +23270,7 @@ type CommandOrCodeAction struct {
 }
 
 func (o CommandOrCodeAction) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of CommandOrCodeAction is set", o.Command != nil, o.CodeAction != nil)
+	assertOnlyOne("exactly one element of CommandOrCodeAction should be set", o.Command != nil, o.CodeAction != nil)
 
 	if o.Command != nil {
 		return json.MarshalEncode(enc, *o.Command)
@@ -23512,7 +23512,7 @@ type TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPat
 }
 
 func (o TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPatternOrNotebookCellTextDocumentFilter) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPatternOrNotebookCellTextDocumentFilter is set", o.TextDocumentFilterLanguage != nil, o.TextDocumentFilterScheme != nil, o.TextDocumentFilterPattern != nil, o.NotebookCellTextDocumentFilter != nil)
+	assertOnlyOne("exactly one element of TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPatternOrNotebookCellTextDocumentFilter should be set", o.TextDocumentFilterLanguage != nil, o.TextDocumentFilterScheme != nil, o.TextDocumentFilterPattern != nil, o.NotebookCellTextDocumentFilter != nil)
 
 	if o.TextDocumentFilterLanguage != nil {
 		return json.MarshalEncode(enc, *o.TextDocumentFilterLanguage)
@@ -23561,7 +23561,7 @@ type StringOrMarkedStringWithLanguage struct {
 }
 
 func (o StringOrMarkedStringWithLanguage) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of StringOrMarkedStringWithLanguage is set", o.String != nil, o.MarkedStringWithLanguage != nil)
+	assertOnlyOne("exactly one element of StringOrMarkedStringWithLanguage should be set", o.String != nil, o.MarkedStringWithLanguage != nil)
 
 	if o.String != nil {
 		return json.MarshalEncode(enc, *o.String)
@@ -23595,7 +23595,7 @@ type InlineValueTextOrVariableLookupOrEvaluatableExpression struct {
 }
 
 func (o InlineValueTextOrVariableLookupOrEvaluatableExpression) MarshalerTo(enc *jsontext.Encoder) error {
-	assertOnlyOne("more than one element of InlineValueTextOrVariableLookupOrEvaluatableExpression is set", o.Text != nil, o.VariableLookup != nil, o.EvaluatableExpression != nil)
+	assertOnlyOne("exactly one element of InlineValueTextOrVariableLookupOrEvaluatableExpression should be set", o.Text != nil, o.VariableLookup != nil, o.EvaluatableExpression != nil)
 
 	if o.Text != nil {
 		return json.MarshalEncode(enc, *o.Text)

--- a/internal/lsp/lsproto/lsp_generated.go
+++ b/internal/lsp/lsproto/lsp_generated.go
@@ -67,6 +67,8 @@ func (s *ImplementationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -123,6 +125,8 @@ func (s *Location) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -183,6 +187,8 @@ func (s *ImplementationRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Deco
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -251,6 +257,8 @@ func (s *TypeDefinitionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -311,6 +319,8 @@ func (s *TypeDefinitionRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Deco
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -366,6 +376,8 @@ func (s *WorkspaceFolder) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Name); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -412,6 +424,8 @@ func (s *DidChangeWorkspaceFoldersParams) UnmarshalJSONFrom(dec *jsontext.Decode
 			if err := json.UnmarshalDecode(dec, &s.Event); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -454,6 +468,8 @@ func (s *ConfigurationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Items); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -512,6 +528,8 @@ func (s *DocumentColorParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -566,6 +584,8 @@ func (s *ColorInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Color); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -626,6 +646,8 @@ func (s *DocumentColorRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decod
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -704,6 +726,8 @@ func (s *ColorPresentationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -771,6 +795,8 @@ func (s *ColorPresentation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.AdditionalTextEdits); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -819,6 +845,8 @@ func (s *TextDocumentRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decode
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -877,6 +905,8 @@ func (s *FoldingRangeParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -968,6 +998,8 @@ func (s *FoldingRange) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.CollapsedText); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -1028,6 +1060,8 @@ func (s *FoldingRangeRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decode
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -1096,6 +1130,8 @@ func (s *DeclarationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -1156,6 +1192,8 @@ func (s *DeclarationRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -1225,6 +1263,8 @@ func (s *SelectionRangeParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Positions); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -1279,6 +1319,8 @@ func (s *SelectionRange) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Parent); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -1336,6 +1378,8 @@ func (s *SelectionRangeRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Deco
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -1378,6 +1422,8 @@ func (s *WorkDoneProgressCreateParams) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 			if err := json.UnmarshalDecode(dec, &s.Token); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -1420,6 +1466,8 @@ func (s *WorkDoneProgressCancelParams) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 			if err := json.UnmarshalDecode(dec, &s.Token); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -1483,6 +1531,8 @@ func (s *CallHierarchyPrepareParams) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -1593,6 +1643,8 @@ func (s *CallHierarchyItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -1665,6 +1717,8 @@ func (s *CallHierarchyRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decod
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -1724,6 +1778,8 @@ func (s *CallHierarchyIncomingCallsParams) UnmarshalJSONFrom(dec *jsontext.Decod
 			if err := json.UnmarshalDecode(dec, &s.Item); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -1781,6 +1837,8 @@ func (s *CallHierarchyIncomingCall) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 			if err := json.UnmarshalDecode(dec, &s.FromRanges); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -1843,6 +1901,8 @@ func (s *CallHierarchyOutgoingCallsParams) UnmarshalJSONFrom(dec *jsontext.Decod
 			if err := json.UnmarshalDecode(dec, &s.Item); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -1901,6 +1961,8 @@ func (s *CallHierarchyOutgoingCall) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 			if err := json.UnmarshalDecode(dec, &s.FromRanges); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -1962,6 +2024,8 @@ func (s *SemanticTokensParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -2015,6 +2079,8 @@ func (s *SemanticTokens) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -2057,6 +2123,8 @@ func (s *SemanticTokensPartialResult) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -2141,6 +2209,8 @@ func (s *SemanticTokensRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Deco
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -2214,6 +2284,8 @@ func (s *SemanticTokensDeltaParams) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 			if err := json.UnmarshalDecode(dec, &s.PreviousResultId); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -2266,6 +2338,8 @@ func (s *SemanticTokensDelta) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Edits); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -2308,6 +2382,8 @@ func (s *SemanticTokensDeltaPartialResult) UnmarshalJSONFrom(dec *jsontext.Decod
 			if err := json.UnmarshalDecode(dec, &s.Edits); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -2377,6 +2453,8 @@ func (s *SemanticTokensRangeParams) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -2454,6 +2532,8 @@ func (s *ShowDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Selection); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -2499,6 +2579,8 @@ func (s *ShowDocumentResult) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Success); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -2559,6 +2641,8 @@ func (s *LinkedEditingRangeParams) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -2617,6 +2701,8 @@ func (s *LinkedEditingRanges) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.WordPattern); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -2674,6 +2760,8 @@ func (s *LinkedEditingRangeRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -2720,6 +2808,8 @@ func (s *CreateFilesParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Files); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -2802,6 +2892,8 @@ func (s *FileOperationRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decod
 			if err := json.UnmarshalDecode(dec, &s.Filters); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -2849,6 +2941,8 @@ func (s *RenameFilesParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Files); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -2895,6 +2989,8 @@ func (s *DeleteFilesParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Files); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -2963,6 +3059,8 @@ func (s *MonikerParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -3039,6 +3137,8 @@ func (s *Moniker) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -3094,6 +3194,8 @@ func (s *MonikerRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -3157,6 +3259,8 @@ func (s *TypeHierarchyPrepareParams) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -3268,6 +3372,8 @@ func (s *TypeHierarchyItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -3340,6 +3446,8 @@ func (s *TypeHierarchyRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decod
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -3399,6 +3507,8 @@ func (s *TypeHierarchySupertypesParams) UnmarshalJSONFrom(dec *jsontext.Decoder)
 			if err := json.UnmarshalDecode(dec, &s.Item); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -3458,6 +3568,8 @@ func (s *TypeHierarchySubtypesParams) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 			if err := json.UnmarshalDecode(dec, &s.Item); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -3531,6 +3643,8 @@ func (s *InlineValueParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Context); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -3597,6 +3711,8 @@ func (s *InlineValueRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -3660,6 +3776,8 @@ func (s *InlayHintParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -3781,6 +3899,8 @@ func (s *InlayHint) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -3852,6 +3972,8 @@ func (s *InlayHintRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -3926,6 +4048,8 @@ func (s *DocumentDiagnosticParams) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 			if err := json.UnmarshalDecode(dec, &s.PreviousResultId); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -3970,6 +4094,8 @@ func (s *DocumentDiagnosticReportPartialResult) UnmarshalJSONFrom(dec *jsontext.
 			if err := json.UnmarshalDecode(dec, &s.RelatedDocuments); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -4014,6 +4140,8 @@ func (s *DiagnosticServerCancellationData) UnmarshalJSONFrom(dec *jsontext.Decod
 			if err := json.UnmarshalDecode(dec, &s.RetriggerRequest); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -4105,6 +4233,8 @@ func (s *DiagnosticRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder)
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -4179,6 +4309,8 @@ func (s *WorkspaceDiagnosticParams) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 			if err := json.UnmarshalDecode(dec, &s.PreviousResultIds); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -4223,6 +4355,8 @@ func (s *WorkspaceDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 			if err := json.UnmarshalDecode(dec, &s.Items); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -4267,6 +4401,8 @@ func (s *WorkspaceDiagnosticReportPartialResult) UnmarshalJSONFrom(dec *jsontext
 			if err := json.UnmarshalDecode(dec, &s.Items); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -4324,6 +4460,8 @@ func (s *DidOpenNotebookDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder)
 			if err := json.UnmarshalDecode(dec, &s.CellTextDocuments); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -4388,6 +4526,8 @@ func (s *NotebookDocumentSyncRegistrationOptions) UnmarshalJSONFrom(dec *jsontex
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -4459,6 +4599,8 @@ func (s *DidChangeNotebookDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decode
 			if err := json.UnmarshalDecode(dec, &s.Change); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -4507,6 +4649,8 @@ func (s *DidSaveNotebookDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder)
 			if err := json.UnmarshalDecode(dec, &s.NotebookDocument); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -4564,6 +4708,8 @@ func (s *DidCloseNotebookDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder
 			if err := json.UnmarshalDecode(dec, &s.CellTextDocuments); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -4642,6 +4788,8 @@ func (s *InlineCompletionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error 
 			if err := json.UnmarshalDecode(dec, &s.Context); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -4695,6 +4843,8 @@ func (s *InlineCompletionList) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Items); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -4763,6 +4913,8 @@ func (s *InlineCompletionItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Command); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -4825,6 +4977,8 @@ func (s *InlineCompletionRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.De
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -4872,6 +5026,8 @@ func (s *TextDocumentContentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -4922,6 +5078,8 @@ func (s *TextDocumentContentResult) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 			if err := json.UnmarshalDecode(dec, &s.Text); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -4977,6 +5135,8 @@ func (s *TextDocumentContentRegistrationOptions) UnmarshalJSONFrom(dec *jsontext
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -5024,6 +5184,8 @@ func (s *TextDocumentContentRefreshParams) UnmarshalJSONFrom(dec *jsontext.Decod
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -5065,6 +5227,8 @@ func (s *RegistrationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Registrations); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -5106,6 +5270,8 @@ func (s *UnregistrationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Unregisterations); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -5243,6 +5409,8 @@ func (s *InitializeParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.WorkspaceFolders); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -5301,6 +5469,8 @@ func (s *InitializeResult) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.ServerInfo); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -5348,6 +5518,8 @@ func (s *InitializeError) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Retry); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -5393,6 +5565,8 @@ func (s *DidChangeConfigurationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 			if err := json.UnmarshalDecode(dec, &s.Settings); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -5451,6 +5625,8 @@ func (s *ShowMessageParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Message); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -5514,6 +5690,8 @@ func (s *ShowMessageRequestParams) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 			if err := json.UnmarshalDecode(dec, &s.Actions); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -5559,6 +5737,8 @@ func (s *MessageActionItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Title); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -5613,6 +5793,8 @@ func (s *LogMessageParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Message); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -5659,6 +5841,8 @@ func (s *DidOpenTextDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -5725,6 +5909,8 @@ func (s *DidChangeTextDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 			if err := json.UnmarshalDecode(dec, &s.ContentChanges); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -5783,6 +5969,8 @@ func (s *TextDocumentChangeRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.
 			if err := json.UnmarshalDecode(dec, &s.SyncKind); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -5829,6 +6017,8 @@ func (s *DidCloseTextDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -5880,6 +6070,8 @@ func (s *DidSaveTextDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 			if err := json.UnmarshalDecode(dec, &s.Text); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -5931,6 +6123,8 @@ func (s *TextDocumentSaveRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.De
 			if err := json.UnmarshalDecode(dec, &s.IncludeText); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -5985,6 +6179,8 @@ func (s *WillSaveTextDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 			if err := json.UnmarshalDecode(dec, &s.Reason); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -6044,6 +6240,8 @@ func (s *TextEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.NewText); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -6090,6 +6288,8 @@ func (s *DidChangeWatchedFilesParams) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 			if err := json.UnmarshalDecode(dec, &s.Changes); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -6133,6 +6333,8 @@ func (s *DidChangeWatchedFilesRegistrationOptions) UnmarshalJSONFrom(dec *jsonte
 			if err := json.UnmarshalDecode(dec, &s.Watchers); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -6196,6 +6398,8 @@ func (s *PublishDiagnosticsParams) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 			if err := json.UnmarshalDecode(dec, &s.Diagnostics); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -6276,6 +6480,8 @@ func (s *CompletionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Context); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -6529,6 +6735,8 @@ func (s *CompletionItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -6631,6 +6839,8 @@ func (s *CompletionList) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Items); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -6730,6 +6940,8 @@ func (s *CompletionRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder)
 			if err := json.UnmarshalDecode(dec, &s.CompletionItem); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -6791,6 +7003,8 @@ func (s *HoverParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -6845,6 +7059,8 @@ func (s *Hover) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -6895,6 +7111,8 @@ func (s *HoverRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -6966,6 +7184,8 @@ func (s *SignatureHelpParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Context); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -7051,6 +7271,8 @@ func (s *SignatureHelp) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.ActiveParameter); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -7120,6 +7342,8 @@ func (s *SignatureHelpRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decod
 			if err := json.UnmarshalDecode(dec, &s.RetriggerCharacters); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -7189,6 +7413,8 @@ func (s *DefinitionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -7242,6 +7468,8 @@ func (s *DefinitionRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder)
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -7319,6 +7547,8 @@ func (s *ReferenceParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Context); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -7375,6 +7605,8 @@ func (s *ReferenceRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -7444,6 +7676,8 @@ func (s *DocumentHighlightParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -7499,6 +7733,8 @@ func (s *DocumentHighlight) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -7549,6 +7785,8 @@ func (s *DocumentHighlightRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.D
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -7607,6 +7845,8 @@ func (s *DocumentSymbolParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -7707,6 +7947,8 @@ func (s *SymbolInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Location); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -7824,6 +8066,8 @@ func (s *DocumentSymbol) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Children); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -7893,6 +8137,8 @@ func (s *DocumentSymbolRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Deco
 			if err := json.UnmarshalDecode(dec, &s.Label); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -7971,6 +8217,8 @@ func (s *CodeActionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Context); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -8053,6 +8301,8 @@ func (s *Command) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Arguments); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -8187,6 +8437,8 @@ func (s *CodeAction) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Tags); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -8279,6 +8531,8 @@ func (s *CodeActionRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder)
 			if err := json.UnmarshalDecode(dec, &s.ResolveProvider); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -8344,6 +8598,8 @@ func (s *WorkspaceSymbolParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Query); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -8442,6 +8698,8 @@ func (s *WorkspaceSymbol) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -8517,6 +8775,8 @@ func (s *CodeLensParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -8579,6 +8839,8 @@ func (s *CodeLens) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -8636,6 +8898,8 @@ func (s *CodeLensRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 			if err := json.UnmarshalDecode(dec, &s.ResolveProvider); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -8694,6 +8958,8 @@ func (s *DocumentLinkParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -8766,6 +9032,8 @@ func (s *DocumentLink) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -8823,6 +9091,8 @@ func (s *DocumentLinkRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decode
 			if err := json.UnmarshalDecode(dec, &s.ResolveProvider); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -8884,6 +9154,8 @@ func (s *DocumentFormattingParams) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 			if err := json.UnmarshalDecode(dec, &s.Options); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -8937,6 +9209,8 @@ func (s *DocumentFormattingRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -9007,6 +9281,8 @@ func (s *DocumentRangeFormattingParams) UnmarshalJSONFrom(dec *jsontext.Decoder)
 			if err := json.UnmarshalDecode(dec, &s.Options); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -9074,6 +9350,8 @@ func (s *DocumentRangeFormattingRegistrationOptions) UnmarshalJSONFrom(dec *json
 			if err := json.UnmarshalDecode(dec, &s.RangesSupport); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -9148,6 +9426,8 @@ func (s *DocumentRangesFormattingParams) UnmarshalJSONFrom(dec *jsontext.Decoder
 			if err := json.UnmarshalDecode(dec, &s.Options); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -9231,6 +9511,8 @@ func (s *DocumentOnTypeFormattingParams) UnmarshalJSONFrom(dec *jsontext.Decoder
 			if err := json.UnmarshalDecode(dec, &s.Options); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -9302,6 +9584,8 @@ func (s *DocumentOnTypeFormattingRegistrationOptions) UnmarshalJSONFrom(dec *jso
 			if err := json.UnmarshalDecode(dec, &s.MoreTriggerCharacter); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -9377,6 +9661,8 @@ func (s *RenameParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.NewName); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -9442,6 +9728,8 @@ func (s *RenameRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 			if err := json.UnmarshalDecode(dec, &s.PrepareProvider); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -9502,6 +9790,8 @@ func (s *PrepareRenameParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -9562,6 +9852,8 @@ func (s *ExecuteCommandParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Arguments); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -9611,6 +9903,8 @@ func (s *ExecuteCommandRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Deco
 			if err := json.UnmarshalDecode(dec, &s.Commands); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -9674,6 +9968,8 @@ func (s *ApplyWorkspaceEditParams) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 			if err := json.UnmarshalDecode(dec, &s.Metadata); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -9737,6 +10033,8 @@ func (s *ApplyWorkspaceEditResult) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 			if err := json.UnmarshalDecode(dec, &s.FailedChange); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -9824,6 +10122,8 @@ func (s *WorkDoneProgressBegin) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Percentage); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -9901,6 +10201,8 @@ func (s *WorkDoneProgressReport) UnmarshalJSONFrom(dec *jsontext.Decoder) error 
 			if err := json.UnmarshalDecode(dec, &s.Percentage); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -9950,6 +10252,8 @@ func (s *WorkDoneProgressEnd) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Message); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -9991,6 +10295,8 @@ func (s *SetTraceParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Value); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -10038,6 +10344,8 @@ func (s *LogTraceParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Verbose); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -10080,6 +10388,8 @@ func (s *CancelParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -10133,6 +10443,8 @@ func (s *ProgressParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Value); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -10191,6 +10503,8 @@ func (s *TextDocumentPositionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -10282,6 +10596,8 @@ func (s *LocationLink) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.TargetSelectionRange); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -10354,6 +10670,8 @@ func (s *Range) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.End); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -10427,6 +10745,8 @@ func (s *WorkspaceFoldersChangeEvent) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 			if err := json.UnmarshalDecode(dec, &s.Removed); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -10481,6 +10801,8 @@ func (s *TextDocumentIdentifier) UnmarshalJSONFrom(dec *jsontext.Decoder) error 
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -10553,6 +10875,8 @@ func (s *Color) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Alpha); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -10657,6 +10981,8 @@ func (s *Position) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Character); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -10735,6 +11061,8 @@ func (s *SemanticTokensOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Full); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -10796,6 +11124,8 @@ func (s *SemanticTokensEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -10848,6 +11178,8 @@ func (s *FileCreate) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -10911,6 +11243,8 @@ func (s *TextDocumentEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Edits); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -10984,6 +11318,8 @@ func (s *CreateFile) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Options); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -11066,6 +11402,8 @@ func (s *RenameFile) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Options); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -11142,6 +11480,8 @@ func (s *DeleteFile) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Options); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -11207,6 +11547,8 @@ func (s *ChangeAnnotation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Description); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -11260,6 +11602,8 @@ func (s *FileOperationFilter) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Pattern); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -11316,6 +11660,8 @@ func (s *FileRename) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.NewUri); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -11364,6 +11710,8 @@ func (s *FileDelete) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -11430,6 +11778,8 @@ func (s *InlineValueContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.StoppedLocation); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -11489,6 +11839,8 @@ func (s *InlineValueText) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Text); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -11558,6 +11910,8 @@ func (s *InlineValueVariableLookup) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 			if err := json.UnmarshalDecode(dec, &s.CaseSensitiveLookup); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -11616,6 +11970,8 @@ func (s *InlineValueEvaluatableExpression) UnmarshalJSONFrom(dec *jsontext.Decod
 			if err := json.UnmarshalDecode(dec, &s.Expression); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -11705,6 +12061,8 @@ func (s *InlayHintLabelPart) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Command); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -11782,6 +12140,8 @@ func (s *MarkupContent) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Value); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -11874,6 +12234,8 @@ func (s *RelatedFullDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.De
 			if err := json.UnmarshalDecode(dec, &s.RelatedDocuments); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -11950,6 +12312,8 @@ func (s *RelatedUnchangedDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsonte
 			if err := json.UnmarshalDecode(dec, &s.RelatedDocuments); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -12018,6 +12382,8 @@ func (s *FullDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 			if err := json.UnmarshalDecode(dec, &s.Items); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -12082,6 +12448,8 @@ func (s *UnchangedDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.Deco
 			if err := json.UnmarshalDecode(dec, &s.ResultId); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -12158,6 +12526,8 @@ func (s *DiagnosticOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.WorkspaceDiagnostics); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -12218,6 +12588,8 @@ func (s *PreviousResultId) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Value); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -12306,6 +12678,8 @@ func (s *NotebookDocument) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Cells); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -12389,6 +12763,8 @@ func (s *TextDocumentItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Text); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -12461,6 +12837,8 @@ func (s *NotebookDocumentSyncOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 			if err := json.UnmarshalDecode(dec, &s.Save); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -12517,6 +12895,8 @@ func (s *VersionedNotebookDocumentIdentifier) UnmarshalJSONFrom(dec *jsontext.De
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -12578,6 +12958,8 @@ func (s *NotebookDocumentIdentifier) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -12632,6 +13014,8 @@ func (s *InlineCompletionContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error
 			if err := json.UnmarshalDecode(dec, &s.SelectedCompletionInfo); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -12696,6 +13080,8 @@ func (s *StringValue) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Value); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -12755,6 +13141,8 @@ func (s *TextDocumentContentOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 			if err := json.UnmarshalDecode(dec, &s.Schemes); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -12817,6 +13205,8 @@ func (s *Registration) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.RegisterOptions); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -12875,6 +13265,8 @@ func (s *Unregistration) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Method); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -13003,6 +13395,8 @@ func (s *InitializeParamsBase) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Trace); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -13222,6 +13616,8 @@ func (s *ServerInfo) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -13276,6 +13672,8 @@ func (s *VersionedTextDocumentIdentifier) UnmarshalJSONFrom(dec *jsontext.Decode
 			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -13339,6 +13737,8 @@ func (s *FileEvent) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Type); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -13395,6 +13795,8 @@ func (s *FileSystemWatcher) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -13512,6 +13914,8 @@ func (s *Diagnostic) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -13566,6 +13970,8 @@ func (s *CompletionContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.TriggerCharacter); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -13644,6 +14050,8 @@ func (s *InsertReplaceEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Replace); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -13870,6 +14278,8 @@ func (s *SignatureHelpContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.ActiveSignatureHelp); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -13951,6 +14361,8 @@ func (s *SignatureInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.ActiveParameter); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -14016,6 +14428,8 @@ func (s *ReferenceContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.IncludeDeclaration); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -14099,6 +14513,8 @@ func (s *BaseSymbolInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.ContainerName); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -14180,6 +14596,8 @@ func (s *CodeActionContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.TriggerKind); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -14227,6 +14645,8 @@ func (s *CodeActionDisabled) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Reason); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -14306,6 +14726,8 @@ func (s *LocationUriOnly) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -14414,6 +14836,8 @@ func (s *FormattingOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.TrimFinalNewlines); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -14484,6 +14908,8 @@ func (s *DocumentOnTypeFormattingOptions) UnmarshalJSONFrom(dec *jsontext.Decode
 			if err := json.UnmarshalDecode(dec, &s.MoreTriggerCharacter); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -14546,6 +14972,8 @@ func (s *PrepareRenamePlaceholder) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 			if err := json.UnmarshalDecode(dec, &s.Placeholder); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -14591,6 +15019,8 @@ func (s *PrepareRenameDefaultBehavior) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 			if err := json.UnmarshalDecode(dec, &s.DefaultBehavior); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -14640,6 +15070,8 @@ func (s *ExecuteCommandOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Commands); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -14704,6 +15136,8 @@ func (s *SemanticTokensLegend) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.TokenModifiers); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -14773,6 +15207,8 @@ func (s *OptionalVersionedTextDocumentIdentifier) UnmarshalJSONFrom(dec *jsontex
 			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -14843,6 +15279,8 @@ func (s *AnnotatedTextEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.AnnotationId); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -14914,6 +15352,8 @@ func (s *SnippetTextEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.AnnotationId); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -14969,6 +15409,8 @@ func (s *ResourceOperation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.AnnotationId); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -15064,6 +15506,8 @@ func (s *FileOperationPattern) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Options); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -15148,6 +15592,8 @@ func (s *WorkspaceFullDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.
 			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -15236,6 +15682,8 @@ func (s *WorkspaceUnchangedDocumentDiagnosticReport) UnmarshalJSONFrom(dec *json
 			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -15323,6 +15771,8 @@ func (s *NotebookCell) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.ExecutionSummary); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -15378,6 +15828,8 @@ func (s *NotebookDocumentFilterWithNotebook) UnmarshalJSONFrom(dec *jsontext.Dec
 			if err := json.UnmarshalDecode(dec, &s.Cells); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -15430,6 +15882,8 @@ func (s *NotebookDocumentFilterWithCells) UnmarshalJSONFrom(dec *jsontext.Decode
 			if err := json.UnmarshalDecode(dec, &s.Cells); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -15504,6 +15958,8 @@ func (s *SelectedCompletionInfo) UnmarshalJSONFrom(dec *jsontext.Decoder) error 
 			if err := json.UnmarshalDecode(dec, &s.Text); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -15561,6 +16017,8 @@ func (s *ClientInfo) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -15693,6 +16151,8 @@ func (s *TextDocumentContentChangePartial) UnmarshalJSONFrom(dec *jsontext.Decod
 			if err := json.UnmarshalDecode(dec, &s.Text); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -15739,6 +16199,8 @@ func (s *TextDocumentContentChangeWholeDocument) UnmarshalJSONFrom(dec *jsontext
 			if err := json.UnmarshalDecode(dec, &s.Text); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -15784,6 +16246,8 @@ func (s *CodeDescription) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Href); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -15840,6 +16304,8 @@ func (s *DiagnosticRelatedInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 			if err := json.UnmarshalDecode(dec, &s.Message); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -15897,6 +16363,8 @@ func (s *EditRangeWithInsertReplace) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 			if err := json.UnmarshalDecode(dec, &s.Replace); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -15964,6 +16432,8 @@ func (s *MarkedStringWithLanguage) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 			if err := json.UnmarshalDecode(dec, &s.Value); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -16030,6 +16500,8 @@ func (s *ParameterInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Documentation); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -16094,6 +16566,8 @@ func (s *CodeActionKindDocumentation) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 			if err := json.UnmarshalDecode(dec, &s.Command); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -16156,6 +16630,8 @@ func (s *NotebookCellTextDocumentFilter) UnmarshalJSONFrom(dec *jsontext.Decoder
 			if err := json.UnmarshalDecode(dec, &s.Language); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -16216,6 +16692,8 @@ func (s *ExecutionSummary) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Success); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -16258,6 +16736,8 @@ func (s *NotebookCellLanguage) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Language); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -16317,6 +16797,8 @@ func (s *NotebookDocumentCellChangeStructure) UnmarshalJSONFrom(dec *jsontext.De
 			if err := json.UnmarshalDecode(dec, &s.DidClose); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -16371,6 +16853,8 @@ func (s *NotebookDocumentCellContentChanges) UnmarshalJSONFrom(dec *jsontext.Dec
 			if err := json.UnmarshalDecode(dec, &s.Changes); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -16637,6 +17121,8 @@ func (s *NotebookDocumentClientCapabilities) UnmarshalJSONFrom(dec *jsontext.Dec
 			if err := json.UnmarshalDecode(dec, &s.Synchronization); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -16799,6 +17285,8 @@ func (s *RelativePattern) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Pattern); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -16865,6 +17353,8 @@ func (s *TextDocumentFilterLanguage) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 			if err := json.UnmarshalDecode(dec, &s.Pattern); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -16928,6 +17418,8 @@ func (s *TextDocumentFilterScheme) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 			if err := json.UnmarshalDecode(dec, &s.Pattern); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -16991,6 +17483,8 @@ func (s *TextDocumentFilterPattern) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 			if err := json.UnmarshalDecode(dec, &s.Pattern); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -17050,6 +17544,8 @@ func (s *NotebookDocumentFilterNotebookType) UnmarshalJSONFrom(dec *jsontext.Dec
 			if err := json.UnmarshalDecode(dec, &s.Pattern); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -17109,6 +17605,8 @@ func (s *NotebookDocumentFilterScheme) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 			if err := json.UnmarshalDecode(dec, &s.Pattern); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -17168,6 +17666,8 @@ func (s *NotebookDocumentFilterPattern) UnmarshalJSONFrom(dec *jsontext.Decoder)
 			if err := json.UnmarshalDecode(dec, &s.Pattern); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -17232,6 +17732,8 @@ func (s *NotebookCellArrayChange) UnmarshalJSONFrom(dec *jsontext.Decoder) error
 			if err := json.UnmarshalDecode(dec, &s.Cells); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -17962,6 +18464,8 @@ func (s *SemanticTokensClientCapabilities) UnmarshalJSONFrom(dec *jsontext.Decod
 			if err := json.UnmarshalDecode(dec, &s.AugmentsSyntaxTokens); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -18129,6 +18633,8 @@ func (s *ShowDocumentClientCapabilities) UnmarshalJSONFrom(dec *jsontext.Decoder
 			if err := json.UnmarshalDecode(dec, &s.Support); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -18185,6 +18691,8 @@ func (s *StaleRequestSupportOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 			if err := json.UnmarshalDecode(dec, &s.RetryOnContentModified); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -18240,6 +18748,8 @@ func (s *RegularExpressionsClientCapabilities) UnmarshalJSONFrom(dec *jsontext.D
 			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -18302,6 +18812,8 @@ func (s *MarkdownClientCapabilities) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 			if err := json.UnmarshalDecode(dec, &s.AllowedTags); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -18366,6 +18878,8 @@ func (s *ClientSymbolTagOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error 
 			if err := json.UnmarshalDecode(dec, &s.ValueSet); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -18410,6 +18924,8 @@ func (s *ClientSymbolResolveOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 			if err := json.UnmarshalDecode(dec, &s.Properties); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -18579,6 +19095,8 @@ func (s *ClientCodeActionLiteralOptions) UnmarshalJSONFrom(dec *jsontext.Decoder
 			if err := json.UnmarshalDecode(dec, &s.CodeActionKind); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -18622,6 +19140,8 @@ func (s *ClientCodeActionResolveOptions) UnmarshalJSONFrom(dec *jsontext.Decoder
 			if err := json.UnmarshalDecode(dec, &s.Properties); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -18665,6 +19185,8 @@ func (s *CodeActionTagOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.ValueSet); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -18708,6 +19230,8 @@ func (s *ClientCodeLensResolveOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 			if err := json.UnmarshalDecode(dec, &s.Properties); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -18804,6 +19328,8 @@ func (s *ClientInlayHintResolveOptions) UnmarshalJSONFrom(dec *jsontext.Decoder)
 			if err := json.UnmarshalDecode(dec, &s.Properties); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -18855,6 +19381,8 @@ func (s *CompletionItemTagOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 			if err := json.UnmarshalDecode(dec, &s.ValueSet); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -18898,6 +19426,8 @@ func (s *ClientCompletionItemResolveOptions) UnmarshalJSONFrom(dec *jsontext.Dec
 			if err := json.UnmarshalDecode(dec, &s.Properties); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -18940,6 +19470,8 @@ func (s *ClientCompletionItemInsertTextModeOptions) UnmarshalJSONFrom(dec *jsont
 			if err := json.UnmarshalDecode(dec, &s.ValueSet); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -18995,6 +19527,8 @@ func (s *ClientCodeActionKindOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 			if err := json.UnmarshalDecode(dec, &s.ValueSet); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 
@@ -19038,6 +19572,8 @@ func (s *ClientDiagnosticsTagOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 			if err := json.UnmarshalDecode(dec, &s.ValueSet); err != nil {
 				return err
 			}
+		default:
+			// Ignore unknown properties.
 		}
 	}
 

--- a/internal/lsp/lsproto/lsp_generated.go
+++ b/internal/lsp/lsproto/lsp_generated.go
@@ -77,10 +77,10 @@ func (s *ImplementationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenPosition {
-		return fmt.Errorf("required key 'position' is missing")
+		return fmt.Errorf("required property 'position' is missing")
 	}
 
 	return nil
@@ -135,10 +135,10 @@ func (s *Location) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenUri {
-		return fmt.Errorf("required key 'uri' is missing")
+		return fmt.Errorf("required property 'uri' is missing")
 	}
 	if !seenRange {
-		return fmt.Errorf("required key 'range' is missing")
+		return fmt.Errorf("required property 'range' is missing")
 	}
 
 	return nil
@@ -197,7 +197,7 @@ func (s *ImplementationRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Deco
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 
 	return nil
@@ -267,10 +267,10 @@ func (s *TypeDefinitionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenPosition {
-		return fmt.Errorf("required key 'position' is missing")
+		return fmt.Errorf("required property 'position' is missing")
 	}
 
 	return nil
@@ -329,7 +329,7 @@ func (s *TypeDefinitionRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Deco
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 
 	return nil
@@ -386,10 +386,10 @@ func (s *WorkspaceFolder) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenUri {
-		return fmt.Errorf("required key 'uri' is missing")
+		return fmt.Errorf("required property 'uri' is missing")
 	}
 	if !seenName {
-		return fmt.Errorf("required key 'name' is missing")
+		return fmt.Errorf("required property 'name' is missing")
 	}
 
 	return nil
@@ -434,7 +434,7 @@ func (s *DidChangeWorkspaceFoldersParams) UnmarshalJSONFrom(dec *jsontext.Decode
 	}
 
 	if !seenEvent {
-		return fmt.Errorf("required key 'event' is missing")
+		return fmt.Errorf("required property 'event' is missing")
 	}
 
 	return nil
@@ -478,7 +478,7 @@ func (s *ConfigurationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenItems {
-		return fmt.Errorf("required key 'items' is missing")
+		return fmt.Errorf("required property 'items' is missing")
 	}
 
 	return nil
@@ -538,7 +538,7 @@ func (s *DocumentColorParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 
 	return nil
@@ -594,10 +594,10 @@ func (s *ColorInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenRange {
-		return fmt.Errorf("required key 'range' is missing")
+		return fmt.Errorf("required property 'range' is missing")
 	}
 	if !seenColor {
-		return fmt.Errorf("required key 'color' is missing")
+		return fmt.Errorf("required property 'color' is missing")
 	}
 
 	return nil
@@ -656,7 +656,7 @@ func (s *DocumentColorRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decod
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 
 	return nil
@@ -736,13 +736,13 @@ func (s *ColorPresentationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenColor {
-		return fmt.Errorf("required key 'color' is missing")
+		return fmt.Errorf("required property 'color' is missing")
 	}
 	if !seenRange {
-		return fmt.Errorf("required key 'range' is missing")
+		return fmt.Errorf("required property 'range' is missing")
 	}
 
 	return nil
@@ -805,7 +805,7 @@ func (s *ColorPresentation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenLabel {
-		return fmt.Errorf("required key 'label' is missing")
+		return fmt.Errorf("required property 'label' is missing")
 	}
 
 	return nil
@@ -855,7 +855,7 @@ func (s *TextDocumentRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decode
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 
 	return nil
@@ -915,7 +915,7 @@ func (s *FoldingRangeParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 
 	return nil
@@ -1008,10 +1008,10 @@ func (s *FoldingRange) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenStartLine {
-		return fmt.Errorf("required key 'startLine' is missing")
+		return fmt.Errorf("required property 'startLine' is missing")
 	}
 	if !seenEndLine {
-		return fmt.Errorf("required key 'endLine' is missing")
+		return fmt.Errorf("required property 'endLine' is missing")
 	}
 
 	return nil
@@ -1070,7 +1070,7 @@ func (s *FoldingRangeRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decode
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 
 	return nil
@@ -1140,10 +1140,10 @@ func (s *DeclarationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenPosition {
-		return fmt.Errorf("required key 'position' is missing")
+		return fmt.Errorf("required property 'position' is missing")
 	}
 
 	return nil
@@ -1202,7 +1202,7 @@ func (s *DeclarationRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 
 	return nil
@@ -1273,10 +1273,10 @@ func (s *SelectionRangeParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenPositions {
-		return fmt.Errorf("required key 'positions' is missing")
+		return fmt.Errorf("required property 'positions' is missing")
 	}
 
 	return nil
@@ -1329,7 +1329,7 @@ func (s *SelectionRange) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenRange {
-		return fmt.Errorf("required key 'range' is missing")
+		return fmt.Errorf("required property 'range' is missing")
 	}
 
 	return nil
@@ -1388,7 +1388,7 @@ func (s *SelectionRangeRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Deco
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 
 	return nil
@@ -1432,7 +1432,7 @@ func (s *WorkDoneProgressCreateParams) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 	}
 
 	if !seenToken {
-		return fmt.Errorf("required key 'token' is missing")
+		return fmt.Errorf("required property 'token' is missing")
 	}
 
 	return nil
@@ -1476,7 +1476,7 @@ func (s *WorkDoneProgressCancelParams) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 	}
 
 	if !seenToken {
-		return fmt.Errorf("required key 'token' is missing")
+		return fmt.Errorf("required property 'token' is missing")
 	}
 
 	return nil
@@ -1541,10 +1541,10 @@ func (s *CallHierarchyPrepareParams) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenPosition {
-		return fmt.Errorf("required key 'position' is missing")
+		return fmt.Errorf("required property 'position' is missing")
 	}
 
 	return nil
@@ -1653,19 +1653,19 @@ func (s *CallHierarchyItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenName {
-		return fmt.Errorf("required key 'name' is missing")
+		return fmt.Errorf("required property 'name' is missing")
 	}
 	if !seenKind {
-		return fmt.Errorf("required key 'kind' is missing")
+		return fmt.Errorf("required property 'kind' is missing")
 	}
 	if !seenUri {
-		return fmt.Errorf("required key 'uri' is missing")
+		return fmt.Errorf("required property 'uri' is missing")
 	}
 	if !seenRange {
-		return fmt.Errorf("required key 'range' is missing")
+		return fmt.Errorf("required property 'range' is missing")
 	}
 	if !seenSelectionRange {
-		return fmt.Errorf("required key 'selectionRange' is missing")
+		return fmt.Errorf("required property 'selectionRange' is missing")
 	}
 
 	return nil
@@ -1727,7 +1727,7 @@ func (s *CallHierarchyRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decod
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 
 	return nil
@@ -1788,7 +1788,7 @@ func (s *CallHierarchyIncomingCallsParams) UnmarshalJSONFrom(dec *jsontext.Decod
 	}
 
 	if !seenItem {
-		return fmt.Errorf("required key 'item' is missing")
+		return fmt.Errorf("required property 'item' is missing")
 	}
 
 	return nil
@@ -1847,10 +1847,10 @@ func (s *CallHierarchyIncomingCall) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 	}
 
 	if !seenFrom {
-		return fmt.Errorf("required key 'from' is missing")
+		return fmt.Errorf("required property 'from' is missing")
 	}
 	if !seenFromRanges {
-		return fmt.Errorf("required key 'fromRanges' is missing")
+		return fmt.Errorf("required property 'fromRanges' is missing")
 	}
 
 	return nil
@@ -1911,7 +1911,7 @@ func (s *CallHierarchyOutgoingCallsParams) UnmarshalJSONFrom(dec *jsontext.Decod
 	}
 
 	if !seenItem {
-		return fmt.Errorf("required key 'item' is missing")
+		return fmt.Errorf("required property 'item' is missing")
 	}
 
 	return nil
@@ -1971,10 +1971,10 @@ func (s *CallHierarchyOutgoingCall) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 	}
 
 	if !seenTo {
-		return fmt.Errorf("required key 'to' is missing")
+		return fmt.Errorf("required property 'to' is missing")
 	}
 	if !seenFromRanges {
-		return fmt.Errorf("required key 'fromRanges' is missing")
+		return fmt.Errorf("required property 'fromRanges' is missing")
 	}
 
 	return nil
@@ -2034,7 +2034,7 @@ func (s *SemanticTokensParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 
 	return nil
@@ -2089,7 +2089,7 @@ func (s *SemanticTokens) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenData {
-		return fmt.Errorf("required key 'data' is missing")
+		return fmt.Errorf("required property 'data' is missing")
 	}
 
 	return nil
@@ -2133,7 +2133,7 @@ func (s *SemanticTokensPartialResult) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 	}
 
 	if !seenData {
-		return fmt.Errorf("required key 'data' is missing")
+		return fmt.Errorf("required property 'data' is missing")
 	}
 
 	return nil
@@ -2219,10 +2219,10 @@ func (s *SemanticTokensRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Deco
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 	if !seenLegend {
-		return fmt.Errorf("required key 'legend' is missing")
+		return fmt.Errorf("required property 'legend' is missing")
 	}
 
 	return nil
@@ -2294,10 +2294,10 @@ func (s *SemanticTokensDeltaParams) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenPreviousResultId {
-		return fmt.Errorf("required key 'previousResultId' is missing")
+		return fmt.Errorf("required property 'previousResultId' is missing")
 	}
 
 	return nil
@@ -2348,7 +2348,7 @@ func (s *SemanticTokensDelta) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenEdits {
-		return fmt.Errorf("required key 'edits' is missing")
+		return fmt.Errorf("required property 'edits' is missing")
 	}
 
 	return nil
@@ -2392,7 +2392,7 @@ func (s *SemanticTokensDeltaPartialResult) UnmarshalJSONFrom(dec *jsontext.Decod
 	}
 
 	if !seenEdits {
-		return fmt.Errorf("required key 'edits' is missing")
+		return fmt.Errorf("required property 'edits' is missing")
 	}
 
 	return nil
@@ -2463,10 +2463,10 @@ func (s *SemanticTokensRangeParams) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenRange {
-		return fmt.Errorf("required key 'range' is missing")
+		return fmt.Errorf("required property 'range' is missing")
 	}
 
 	return nil
@@ -2542,7 +2542,7 @@ func (s *ShowDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenUri {
-		return fmt.Errorf("required key 'uri' is missing")
+		return fmt.Errorf("required property 'uri' is missing")
 	}
 
 	return nil
@@ -2589,7 +2589,7 @@ func (s *ShowDocumentResult) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenSuccess {
-		return fmt.Errorf("required key 'success' is missing")
+		return fmt.Errorf("required property 'success' is missing")
 	}
 
 	return nil
@@ -2651,10 +2651,10 @@ func (s *LinkedEditingRangeParams) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenPosition {
-		return fmt.Errorf("required key 'position' is missing")
+		return fmt.Errorf("required property 'position' is missing")
 	}
 
 	return nil
@@ -2711,7 +2711,7 @@ func (s *LinkedEditingRanges) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenRanges {
-		return fmt.Errorf("required key 'ranges' is missing")
+		return fmt.Errorf("required property 'ranges' is missing")
 	}
 
 	return nil
@@ -2770,7 +2770,7 @@ func (s *LinkedEditingRangeRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 
 	return nil
@@ -2818,7 +2818,7 @@ func (s *CreateFilesParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenFiles {
-		return fmt.Errorf("required key 'files' is missing")
+		return fmt.Errorf("required property 'files' is missing")
 	}
 
 	return nil
@@ -2902,7 +2902,7 @@ func (s *FileOperationRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decod
 	}
 
 	if !seenFilters {
-		return fmt.Errorf("required key 'filters' is missing")
+		return fmt.Errorf("required property 'filters' is missing")
 	}
 
 	return nil
@@ -2951,7 +2951,7 @@ func (s *RenameFilesParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenFiles {
-		return fmt.Errorf("required key 'files' is missing")
+		return fmt.Errorf("required property 'files' is missing")
 	}
 
 	return nil
@@ -2999,7 +2999,7 @@ func (s *DeleteFilesParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenFiles {
-		return fmt.Errorf("required key 'files' is missing")
+		return fmt.Errorf("required property 'files' is missing")
 	}
 
 	return nil
@@ -3069,10 +3069,10 @@ func (s *MonikerParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenPosition {
-		return fmt.Errorf("required key 'position' is missing")
+		return fmt.Errorf("required property 'position' is missing")
 	}
 
 	return nil
@@ -3147,13 +3147,13 @@ func (s *Moniker) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenScheme {
-		return fmt.Errorf("required key 'scheme' is missing")
+		return fmt.Errorf("required property 'scheme' is missing")
 	}
 	if !seenIdentifier {
-		return fmt.Errorf("required key 'identifier' is missing")
+		return fmt.Errorf("required property 'identifier' is missing")
 	}
 	if !seenUnique {
-		return fmt.Errorf("required key 'unique' is missing")
+		return fmt.Errorf("required property 'unique' is missing")
 	}
 
 	return nil
@@ -3204,7 +3204,7 @@ func (s *MonikerRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 
 	return nil
@@ -3269,10 +3269,10 @@ func (s *TypeHierarchyPrepareParams) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenPosition {
-		return fmt.Errorf("required key 'position' is missing")
+		return fmt.Errorf("required property 'position' is missing")
 	}
 
 	return nil
@@ -3382,19 +3382,19 @@ func (s *TypeHierarchyItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenName {
-		return fmt.Errorf("required key 'name' is missing")
+		return fmt.Errorf("required property 'name' is missing")
 	}
 	if !seenKind {
-		return fmt.Errorf("required key 'kind' is missing")
+		return fmt.Errorf("required property 'kind' is missing")
 	}
 	if !seenUri {
-		return fmt.Errorf("required key 'uri' is missing")
+		return fmt.Errorf("required property 'uri' is missing")
 	}
 	if !seenRange {
-		return fmt.Errorf("required key 'range' is missing")
+		return fmt.Errorf("required property 'range' is missing")
 	}
 	if !seenSelectionRange {
-		return fmt.Errorf("required key 'selectionRange' is missing")
+		return fmt.Errorf("required property 'selectionRange' is missing")
 	}
 
 	return nil
@@ -3456,7 +3456,7 @@ func (s *TypeHierarchyRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decod
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 
 	return nil
@@ -3517,7 +3517,7 @@ func (s *TypeHierarchySupertypesParams) UnmarshalJSONFrom(dec *jsontext.Decoder)
 	}
 
 	if !seenItem {
-		return fmt.Errorf("required key 'item' is missing")
+		return fmt.Errorf("required property 'item' is missing")
 	}
 
 	return nil
@@ -3578,7 +3578,7 @@ func (s *TypeHierarchySubtypesParams) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 	}
 
 	if !seenItem {
-		return fmt.Errorf("required key 'item' is missing")
+		return fmt.Errorf("required property 'item' is missing")
 	}
 
 	return nil
@@ -3653,13 +3653,13 @@ func (s *InlineValueParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenRange {
-		return fmt.Errorf("required key 'range' is missing")
+		return fmt.Errorf("required property 'range' is missing")
 	}
 	if !seenContext {
-		return fmt.Errorf("required key 'context' is missing")
+		return fmt.Errorf("required property 'context' is missing")
 	}
 
 	return nil
@@ -3721,7 +3721,7 @@ func (s *InlineValueRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 
 	return nil
@@ -3786,10 +3786,10 @@ func (s *InlayHintParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenRange {
-		return fmt.Errorf("required key 'range' is missing")
+		return fmt.Errorf("required property 'range' is missing")
 	}
 
 	return nil
@@ -3909,10 +3909,10 @@ func (s *InlayHint) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenPosition {
-		return fmt.Errorf("required key 'position' is missing")
+		return fmt.Errorf("required property 'position' is missing")
 	}
 	if !seenLabel {
-		return fmt.Errorf("required key 'label' is missing")
+		return fmt.Errorf("required property 'label' is missing")
 	}
 
 	return nil
@@ -3982,7 +3982,7 @@ func (s *InlayHintRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 
 	return nil
@@ -4058,7 +4058,7 @@ func (s *DocumentDiagnosticParams) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 
 	return nil
@@ -4104,7 +4104,7 @@ func (s *DocumentDiagnosticReportPartialResult) UnmarshalJSONFrom(dec *jsontext.
 	}
 
 	if !seenRelatedDocuments {
-		return fmt.Errorf("required key 'relatedDocuments' is missing")
+		return fmt.Errorf("required property 'relatedDocuments' is missing")
 	}
 
 	return nil
@@ -4150,7 +4150,7 @@ func (s *DiagnosticServerCancellationData) UnmarshalJSONFrom(dec *jsontext.Decod
 	}
 
 	if !seenRetriggerRequest {
-		return fmt.Errorf("required key 'retriggerRequest' is missing")
+		return fmt.Errorf("required property 'retriggerRequest' is missing")
 	}
 
 	return nil
@@ -4243,13 +4243,13 @@ func (s *DiagnosticRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder)
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 	if !seenInterFileDependencies {
-		return fmt.Errorf("required key 'interFileDependencies' is missing")
+		return fmt.Errorf("required property 'interFileDependencies' is missing")
 	}
 	if !seenWorkspaceDiagnostics {
-		return fmt.Errorf("required key 'workspaceDiagnostics' is missing")
+		return fmt.Errorf("required property 'workspaceDiagnostics' is missing")
 	}
 
 	return nil
@@ -4319,7 +4319,7 @@ func (s *WorkspaceDiagnosticParams) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 	}
 
 	if !seenPreviousResultIds {
-		return fmt.Errorf("required key 'previousResultIds' is missing")
+		return fmt.Errorf("required property 'previousResultIds' is missing")
 	}
 
 	return nil
@@ -4365,7 +4365,7 @@ func (s *WorkspaceDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 	}
 
 	if !seenItems {
-		return fmt.Errorf("required key 'items' is missing")
+		return fmt.Errorf("required property 'items' is missing")
 	}
 
 	return nil
@@ -4411,7 +4411,7 @@ func (s *WorkspaceDiagnosticReportPartialResult) UnmarshalJSONFrom(dec *jsontext
 	}
 
 	if !seenItems {
-		return fmt.Errorf("required key 'items' is missing")
+		return fmt.Errorf("required property 'items' is missing")
 	}
 
 	return nil
@@ -4470,10 +4470,10 @@ func (s *DidOpenNotebookDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder)
 	}
 
 	if !seenNotebookDocument {
-		return fmt.Errorf("required key 'notebookDocument' is missing")
+		return fmt.Errorf("required property 'notebookDocument' is missing")
 	}
 	if !seenCellTextDocuments {
-		return fmt.Errorf("required key 'cellTextDocuments' is missing")
+		return fmt.Errorf("required property 'cellTextDocuments' is missing")
 	}
 
 	return nil
@@ -4536,7 +4536,7 @@ func (s *NotebookDocumentSyncRegistrationOptions) UnmarshalJSONFrom(dec *jsontex
 	}
 
 	if !seenNotebookSelector {
-		return fmt.Errorf("required key 'notebookSelector' is missing")
+		return fmt.Errorf("required property 'notebookSelector' is missing")
 	}
 
 	return nil
@@ -4609,10 +4609,10 @@ func (s *DidChangeNotebookDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decode
 	}
 
 	if !seenNotebookDocument {
-		return fmt.Errorf("required key 'notebookDocument' is missing")
+		return fmt.Errorf("required property 'notebookDocument' is missing")
 	}
 	if !seenChange {
-		return fmt.Errorf("required key 'change' is missing")
+		return fmt.Errorf("required property 'change' is missing")
 	}
 
 	return nil
@@ -4659,7 +4659,7 @@ func (s *DidSaveNotebookDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder)
 	}
 
 	if !seenNotebookDocument {
-		return fmt.Errorf("required key 'notebookDocument' is missing")
+		return fmt.Errorf("required property 'notebookDocument' is missing")
 	}
 
 	return nil
@@ -4718,10 +4718,10 @@ func (s *DidCloseNotebookDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder
 	}
 
 	if !seenNotebookDocument {
-		return fmt.Errorf("required key 'notebookDocument' is missing")
+		return fmt.Errorf("required property 'notebookDocument' is missing")
 	}
 	if !seenCellTextDocuments {
-		return fmt.Errorf("required key 'cellTextDocuments' is missing")
+		return fmt.Errorf("required property 'cellTextDocuments' is missing")
 	}
 
 	return nil
@@ -4798,13 +4798,13 @@ func (s *InlineCompletionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error 
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenPosition {
-		return fmt.Errorf("required key 'position' is missing")
+		return fmt.Errorf("required property 'position' is missing")
 	}
 	if !seenContext {
-		return fmt.Errorf("required key 'context' is missing")
+		return fmt.Errorf("required property 'context' is missing")
 	}
 
 	return nil
@@ -4853,7 +4853,7 @@ func (s *InlineCompletionList) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenItems {
-		return fmt.Errorf("required key 'items' is missing")
+		return fmt.Errorf("required property 'items' is missing")
 	}
 
 	return nil
@@ -4923,7 +4923,7 @@ func (s *InlineCompletionItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenInsertText {
-		return fmt.Errorf("required key 'insertText' is missing")
+		return fmt.Errorf("required property 'insertText' is missing")
 	}
 
 	return nil
@@ -4987,7 +4987,7 @@ func (s *InlineCompletionRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.De
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 
 	return nil
@@ -5036,7 +5036,7 @@ func (s *TextDocumentContentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 	}
 
 	if !seenUri {
-		return fmt.Errorf("required key 'uri' is missing")
+		return fmt.Errorf("required property 'uri' is missing")
 	}
 
 	return nil
@@ -5088,7 +5088,7 @@ func (s *TextDocumentContentResult) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 	}
 
 	if !seenText {
-		return fmt.Errorf("required key 'text' is missing")
+		return fmt.Errorf("required property 'text' is missing")
 	}
 
 	return nil
@@ -5145,7 +5145,7 @@ func (s *TextDocumentContentRegistrationOptions) UnmarshalJSONFrom(dec *jsontext
 	}
 
 	if !seenSchemes {
-		return fmt.Errorf("required key 'schemes' is missing")
+		return fmt.Errorf("required property 'schemes' is missing")
 	}
 
 	return nil
@@ -5194,7 +5194,7 @@ func (s *TextDocumentContentRefreshParams) UnmarshalJSONFrom(dec *jsontext.Decod
 	}
 
 	if !seenUri {
-		return fmt.Errorf("required key 'uri' is missing")
+		return fmt.Errorf("required property 'uri' is missing")
 	}
 
 	return nil
@@ -5237,7 +5237,7 @@ func (s *RegistrationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenRegistrations {
-		return fmt.Errorf("required key 'registrations' is missing")
+		return fmt.Errorf("required property 'registrations' is missing")
 	}
 
 	return nil
@@ -5280,7 +5280,7 @@ func (s *UnregistrationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenUnregisterations {
-		return fmt.Errorf("required key 'unregisterations' is missing")
+		return fmt.Errorf("required property 'unregisterations' is missing")
 	}
 
 	return nil
@@ -5419,13 +5419,13 @@ func (s *InitializeParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenProcessId {
-		return fmt.Errorf("required key 'processId' is missing")
+		return fmt.Errorf("required property 'processId' is missing")
 	}
 	if !seenRootUri {
-		return fmt.Errorf("required key 'rootUri' is missing")
+		return fmt.Errorf("required property 'rootUri' is missing")
 	}
 	if !seenCapabilities {
-		return fmt.Errorf("required key 'capabilities' is missing")
+		return fmt.Errorf("required property 'capabilities' is missing")
 	}
 
 	return nil
@@ -5479,7 +5479,7 @@ func (s *InitializeResult) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenCapabilities {
-		return fmt.Errorf("required key 'capabilities' is missing")
+		return fmt.Errorf("required property 'capabilities' is missing")
 	}
 
 	return nil
@@ -5528,7 +5528,7 @@ func (s *InitializeError) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenRetry {
-		return fmt.Errorf("required key 'retry' is missing")
+		return fmt.Errorf("required property 'retry' is missing")
 	}
 
 	return nil
@@ -5575,7 +5575,7 @@ func (s *DidChangeConfigurationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 	}
 
 	if !seenSettings {
-		return fmt.Errorf("required key 'settings' is missing")
+		return fmt.Errorf("required property 'settings' is missing")
 	}
 
 	return nil
@@ -5635,10 +5635,10 @@ func (s *ShowMessageParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenType {
-		return fmt.Errorf("required key 'type' is missing")
+		return fmt.Errorf("required property 'type' is missing")
 	}
 	if !seenMessage {
-		return fmt.Errorf("required key 'message' is missing")
+		return fmt.Errorf("required property 'message' is missing")
 	}
 
 	return nil
@@ -5700,10 +5700,10 @@ func (s *ShowMessageRequestParams) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 	}
 
 	if !seenType {
-		return fmt.Errorf("required key 'type' is missing")
+		return fmt.Errorf("required property 'type' is missing")
 	}
 	if !seenMessage {
-		return fmt.Errorf("required key 'message' is missing")
+		return fmt.Errorf("required property 'message' is missing")
 	}
 
 	return nil
@@ -5747,7 +5747,7 @@ func (s *MessageActionItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTitle {
-		return fmt.Errorf("required key 'title' is missing")
+		return fmt.Errorf("required property 'title' is missing")
 	}
 
 	return nil
@@ -5803,10 +5803,10 @@ func (s *LogMessageParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenType {
-		return fmt.Errorf("required key 'type' is missing")
+		return fmt.Errorf("required property 'type' is missing")
 	}
 	if !seenMessage {
-		return fmt.Errorf("required key 'message' is missing")
+		return fmt.Errorf("required property 'message' is missing")
 	}
 
 	return nil
@@ -5851,7 +5851,7 @@ func (s *DidOpenTextDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 
 	return nil
@@ -5919,10 +5919,10 @@ func (s *DidChangeTextDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenContentChanges {
-		return fmt.Errorf("required key 'contentChanges' is missing")
+		return fmt.Errorf("required property 'contentChanges' is missing")
 	}
 
 	return nil
@@ -5979,10 +5979,10 @@ func (s *TextDocumentChangeRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 	if !seenSyncKind {
-		return fmt.Errorf("required key 'syncKind' is missing")
+		return fmt.Errorf("required property 'syncKind' is missing")
 	}
 
 	return nil
@@ -6027,7 +6027,7 @@ func (s *DidCloseTextDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 
 	return nil
@@ -6080,7 +6080,7 @@ func (s *DidSaveTextDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 
 	return nil
@@ -6133,7 +6133,7 @@ func (s *TextDocumentSaveRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.De
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 
 	return nil
@@ -6189,10 +6189,10 @@ func (s *WillSaveTextDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenReason {
-		return fmt.Errorf("required key 'reason' is missing")
+		return fmt.Errorf("required property 'reason' is missing")
 	}
 
 	return nil
@@ -6250,10 +6250,10 @@ func (s *TextEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenRange {
-		return fmt.Errorf("required key 'range' is missing")
+		return fmt.Errorf("required property 'range' is missing")
 	}
 	if !seenNewText {
-		return fmt.Errorf("required key 'newText' is missing")
+		return fmt.Errorf("required property 'newText' is missing")
 	}
 
 	return nil
@@ -6298,7 +6298,7 @@ func (s *DidChangeWatchedFilesParams) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 	}
 
 	if !seenChanges {
-		return fmt.Errorf("required key 'changes' is missing")
+		return fmt.Errorf("required property 'changes' is missing")
 	}
 
 	return nil
@@ -6343,7 +6343,7 @@ func (s *DidChangeWatchedFilesRegistrationOptions) UnmarshalJSONFrom(dec *jsonte
 	}
 
 	if !seenWatchers {
-		return fmt.Errorf("required key 'watchers' is missing")
+		return fmt.Errorf("required property 'watchers' is missing")
 	}
 
 	return nil
@@ -6408,10 +6408,10 @@ func (s *PublishDiagnosticsParams) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 	}
 
 	if !seenUri {
-		return fmt.Errorf("required key 'uri' is missing")
+		return fmt.Errorf("required property 'uri' is missing")
 	}
 	if !seenDiagnostics {
-		return fmt.Errorf("required key 'diagnostics' is missing")
+		return fmt.Errorf("required property 'diagnostics' is missing")
 	}
 
 	return nil
@@ -6490,10 +6490,10 @@ func (s *CompletionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenPosition {
-		return fmt.Errorf("required key 'position' is missing")
+		return fmt.Errorf("required property 'position' is missing")
 	}
 
 	return nil
@@ -6745,7 +6745,7 @@ func (s *CompletionItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenLabel {
-		return fmt.Errorf("required key 'label' is missing")
+		return fmt.Errorf("required property 'label' is missing")
 	}
 
 	return nil
@@ -6849,10 +6849,10 @@ func (s *CompletionList) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenIsIncomplete {
-		return fmt.Errorf("required key 'isIncomplete' is missing")
+		return fmt.Errorf("required property 'isIncomplete' is missing")
 	}
 	if !seenItems {
-		return fmt.Errorf("required key 'items' is missing")
+		return fmt.Errorf("required property 'items' is missing")
 	}
 
 	return nil
@@ -6950,7 +6950,7 @@ func (s *CompletionRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder)
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 
 	return nil
@@ -7013,10 +7013,10 @@ func (s *HoverParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenPosition {
-		return fmt.Errorf("required key 'position' is missing")
+		return fmt.Errorf("required property 'position' is missing")
 	}
 
 	return nil
@@ -7069,7 +7069,7 @@ func (s *Hover) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenContents {
-		return fmt.Errorf("required key 'contents' is missing")
+		return fmt.Errorf("required property 'contents' is missing")
 	}
 
 	return nil
@@ -7121,7 +7121,7 @@ func (s *HoverRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 
 	return nil
@@ -7194,10 +7194,10 @@ func (s *SignatureHelpParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenPosition {
-		return fmt.Errorf("required key 'position' is missing")
+		return fmt.Errorf("required property 'position' is missing")
 	}
 
 	return nil
@@ -7281,7 +7281,7 @@ func (s *SignatureHelp) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenSignatures {
-		return fmt.Errorf("required key 'signatures' is missing")
+		return fmt.Errorf("required property 'signatures' is missing")
 	}
 
 	return nil
@@ -7352,7 +7352,7 @@ func (s *SignatureHelpRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decod
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 
 	return nil
@@ -7423,10 +7423,10 @@ func (s *DefinitionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenPosition {
-		return fmt.Errorf("required key 'position' is missing")
+		return fmt.Errorf("required property 'position' is missing")
 	}
 
 	return nil
@@ -7478,7 +7478,7 @@ func (s *DefinitionRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder)
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 
 	return nil
@@ -7557,13 +7557,13 @@ func (s *ReferenceParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenPosition {
-		return fmt.Errorf("required key 'position' is missing")
+		return fmt.Errorf("required property 'position' is missing")
 	}
 	if !seenContext {
-		return fmt.Errorf("required key 'context' is missing")
+		return fmt.Errorf("required property 'context' is missing")
 	}
 
 	return nil
@@ -7615,7 +7615,7 @@ func (s *ReferenceRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 
 	return nil
@@ -7686,10 +7686,10 @@ func (s *DocumentHighlightParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenPosition {
-		return fmt.Errorf("required key 'position' is missing")
+		return fmt.Errorf("required property 'position' is missing")
 	}
 
 	return nil
@@ -7743,7 +7743,7 @@ func (s *DocumentHighlight) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenRange {
-		return fmt.Errorf("required key 'range' is missing")
+		return fmt.Errorf("required property 'range' is missing")
 	}
 
 	return nil
@@ -7795,7 +7795,7 @@ func (s *DocumentHighlightRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.D
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 
 	return nil
@@ -7855,7 +7855,7 @@ func (s *DocumentSymbolParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 
 	return nil
@@ -7957,13 +7957,13 @@ func (s *SymbolInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenName {
-		return fmt.Errorf("required key 'name' is missing")
+		return fmt.Errorf("required property 'name' is missing")
 	}
 	if !seenKind {
-		return fmt.Errorf("required key 'kind' is missing")
+		return fmt.Errorf("required property 'kind' is missing")
 	}
 	if !seenLocation {
-		return fmt.Errorf("required key 'location' is missing")
+		return fmt.Errorf("required property 'location' is missing")
 	}
 
 	return nil
@@ -8076,16 +8076,16 @@ func (s *DocumentSymbol) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenName {
-		return fmt.Errorf("required key 'name' is missing")
+		return fmt.Errorf("required property 'name' is missing")
 	}
 	if !seenKind {
-		return fmt.Errorf("required key 'kind' is missing")
+		return fmt.Errorf("required property 'kind' is missing")
 	}
 	if !seenRange {
-		return fmt.Errorf("required key 'range' is missing")
+		return fmt.Errorf("required property 'range' is missing")
 	}
 	if !seenSelectionRange {
-		return fmt.Errorf("required key 'selectionRange' is missing")
+		return fmt.Errorf("required property 'selectionRange' is missing")
 	}
 
 	return nil
@@ -8147,7 +8147,7 @@ func (s *DocumentSymbolRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Deco
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 
 	return nil
@@ -8227,13 +8227,13 @@ func (s *CodeActionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenRange {
-		return fmt.Errorf("required key 'range' is missing")
+		return fmt.Errorf("required property 'range' is missing")
 	}
 	if !seenContext {
-		return fmt.Errorf("required key 'context' is missing")
+		return fmt.Errorf("required property 'context' is missing")
 	}
 
 	return nil
@@ -8311,10 +8311,10 @@ func (s *Command) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTitle {
-		return fmt.Errorf("required key 'title' is missing")
+		return fmt.Errorf("required property 'title' is missing")
 	}
 	if !seenCommand {
-		return fmt.Errorf("required key 'command' is missing")
+		return fmt.Errorf("required property 'command' is missing")
 	}
 
 	return nil
@@ -8447,7 +8447,7 @@ func (s *CodeAction) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTitle {
-		return fmt.Errorf("required key 'title' is missing")
+		return fmt.Errorf("required property 'title' is missing")
 	}
 
 	return nil
@@ -8541,7 +8541,7 @@ func (s *CodeActionRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder)
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 
 	return nil
@@ -8608,7 +8608,7 @@ func (s *WorkspaceSymbolParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenQuery {
-		return fmt.Errorf("required key 'query' is missing")
+		return fmt.Errorf("required property 'query' is missing")
 	}
 
 	return nil
@@ -8708,13 +8708,13 @@ func (s *WorkspaceSymbol) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenName {
-		return fmt.Errorf("required key 'name' is missing")
+		return fmt.Errorf("required property 'name' is missing")
 	}
 	if !seenKind {
-		return fmt.Errorf("required key 'kind' is missing")
+		return fmt.Errorf("required property 'kind' is missing")
 	}
 	if !seenLocation {
-		return fmt.Errorf("required key 'location' is missing")
+		return fmt.Errorf("required property 'location' is missing")
 	}
 
 	return nil
@@ -8785,7 +8785,7 @@ func (s *CodeLensParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 
 	return nil
@@ -8849,7 +8849,7 @@ func (s *CodeLens) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenRange {
-		return fmt.Errorf("required key 'range' is missing")
+		return fmt.Errorf("required property 'range' is missing")
 	}
 
 	return nil
@@ -8908,7 +8908,7 @@ func (s *CodeLensRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 
 	return nil
@@ -8968,7 +8968,7 @@ func (s *DocumentLinkParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 
 	return nil
@@ -9042,7 +9042,7 @@ func (s *DocumentLink) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenRange {
-		return fmt.Errorf("required key 'range' is missing")
+		return fmt.Errorf("required property 'range' is missing")
 	}
 
 	return nil
@@ -9101,7 +9101,7 @@ func (s *DocumentLinkRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decode
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 
 	return nil
@@ -9164,10 +9164,10 @@ func (s *DocumentFormattingParams) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenOptions {
-		return fmt.Errorf("required key 'options' is missing")
+		return fmt.Errorf("required property 'options' is missing")
 	}
 
 	return nil
@@ -9219,7 +9219,7 @@ func (s *DocumentFormattingRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 
 	return nil
@@ -9291,13 +9291,13 @@ func (s *DocumentRangeFormattingParams) UnmarshalJSONFrom(dec *jsontext.Decoder)
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenRange {
-		return fmt.Errorf("required key 'range' is missing")
+		return fmt.Errorf("required property 'range' is missing")
 	}
 	if !seenOptions {
-		return fmt.Errorf("required key 'options' is missing")
+		return fmt.Errorf("required property 'options' is missing")
 	}
 
 	return nil
@@ -9360,7 +9360,7 @@ func (s *DocumentRangeFormattingRegistrationOptions) UnmarshalJSONFrom(dec *json
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 
 	return nil
@@ -9436,13 +9436,13 @@ func (s *DocumentRangesFormattingParams) UnmarshalJSONFrom(dec *jsontext.Decoder
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenRanges {
-		return fmt.Errorf("required key 'ranges' is missing")
+		return fmt.Errorf("required property 'ranges' is missing")
 	}
 	if !seenOptions {
-		return fmt.Errorf("required key 'options' is missing")
+		return fmt.Errorf("required property 'options' is missing")
 	}
 
 	return nil
@@ -9521,16 +9521,16 @@ func (s *DocumentOnTypeFormattingParams) UnmarshalJSONFrom(dec *jsontext.Decoder
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenPosition {
-		return fmt.Errorf("required key 'position' is missing")
+		return fmt.Errorf("required property 'position' is missing")
 	}
 	if !seenCh {
-		return fmt.Errorf("required key 'ch' is missing")
+		return fmt.Errorf("required property 'ch' is missing")
 	}
 	if !seenOptions {
-		return fmt.Errorf("required key 'options' is missing")
+		return fmt.Errorf("required property 'options' is missing")
 	}
 
 	return nil
@@ -9594,10 +9594,10 @@ func (s *DocumentOnTypeFormattingRegistrationOptions) UnmarshalJSONFrom(dec *jso
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 	if !seenFirstTriggerCharacter {
-		return fmt.Errorf("required key 'firstTriggerCharacter' is missing")
+		return fmt.Errorf("required property 'firstTriggerCharacter' is missing")
 	}
 
 	return nil
@@ -9671,13 +9671,13 @@ func (s *RenameParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenPosition {
-		return fmt.Errorf("required key 'position' is missing")
+		return fmt.Errorf("required property 'position' is missing")
 	}
 	if !seenNewName {
-		return fmt.Errorf("required key 'newName' is missing")
+		return fmt.Errorf("required property 'newName' is missing")
 	}
 
 	return nil
@@ -9738,7 +9738,7 @@ func (s *RenameRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 	}
 
 	if !seenDocumentSelector {
-		return fmt.Errorf("required key 'documentSelector' is missing")
+		return fmt.Errorf("required property 'documentSelector' is missing")
 	}
 
 	return nil
@@ -9800,10 +9800,10 @@ func (s *PrepareRenameParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenPosition {
-		return fmt.Errorf("required key 'position' is missing")
+		return fmt.Errorf("required property 'position' is missing")
 	}
 
 	return nil
@@ -9862,7 +9862,7 @@ func (s *ExecuteCommandParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenCommand {
-		return fmt.Errorf("required key 'command' is missing")
+		return fmt.Errorf("required property 'command' is missing")
 	}
 
 	return nil
@@ -9913,7 +9913,7 @@ func (s *ExecuteCommandRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Deco
 	}
 
 	if !seenCommands {
-		return fmt.Errorf("required key 'commands' is missing")
+		return fmt.Errorf("required property 'commands' is missing")
 	}
 
 	return nil
@@ -9978,7 +9978,7 @@ func (s *ApplyWorkspaceEditParams) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 	}
 
 	if !seenEdit {
-		return fmt.Errorf("required key 'edit' is missing")
+		return fmt.Errorf("required property 'edit' is missing")
 	}
 
 	return nil
@@ -10043,7 +10043,7 @@ func (s *ApplyWorkspaceEditResult) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 	}
 
 	if !seenApplied {
-		return fmt.Errorf("required key 'applied' is missing")
+		return fmt.Errorf("required property 'applied' is missing")
 	}
 
 	return nil
@@ -10132,10 +10132,10 @@ func (s *WorkDoneProgressBegin) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenKind {
-		return fmt.Errorf("required key 'kind' is missing")
+		return fmt.Errorf("required property 'kind' is missing")
 	}
 	if !seenTitle {
-		return fmt.Errorf("required key 'title' is missing")
+		return fmt.Errorf("required property 'title' is missing")
 	}
 
 	return nil
@@ -10211,7 +10211,7 @@ func (s *WorkDoneProgressReport) UnmarshalJSONFrom(dec *jsontext.Decoder) error 
 	}
 
 	if !seenKind {
-		return fmt.Errorf("required key 'kind' is missing")
+		return fmt.Errorf("required property 'kind' is missing")
 	}
 
 	return nil
@@ -10262,7 +10262,7 @@ func (s *WorkDoneProgressEnd) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenKind {
-		return fmt.Errorf("required key 'kind' is missing")
+		return fmt.Errorf("required property 'kind' is missing")
 	}
 
 	return nil
@@ -10305,7 +10305,7 @@ func (s *SetTraceParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenValue {
-		return fmt.Errorf("required key 'value' is missing")
+		return fmt.Errorf("required property 'value' is missing")
 	}
 
 	return nil
@@ -10354,7 +10354,7 @@ func (s *LogTraceParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenMessage {
-		return fmt.Errorf("required key 'message' is missing")
+		return fmt.Errorf("required property 'message' is missing")
 	}
 
 	return nil
@@ -10398,7 +10398,7 @@ func (s *CancelParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenId {
-		return fmt.Errorf("required key 'id' is missing")
+		return fmt.Errorf("required property 'id' is missing")
 	}
 
 	return nil
@@ -10453,10 +10453,10 @@ func (s *ProgressParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenToken {
-		return fmt.Errorf("required key 'token' is missing")
+		return fmt.Errorf("required property 'token' is missing")
 	}
 	if !seenValue {
-		return fmt.Errorf("required key 'value' is missing")
+		return fmt.Errorf("required property 'value' is missing")
 	}
 
 	return nil
@@ -10513,10 +10513,10 @@ func (s *TextDocumentPositionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenPosition {
-		return fmt.Errorf("required key 'position' is missing")
+		return fmt.Errorf("required property 'position' is missing")
 	}
 
 	return nil
@@ -10606,13 +10606,13 @@ func (s *LocationLink) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTargetUri {
-		return fmt.Errorf("required key 'targetUri' is missing")
+		return fmt.Errorf("required property 'targetUri' is missing")
 	}
 	if !seenTargetRange {
-		return fmt.Errorf("required key 'targetRange' is missing")
+		return fmt.Errorf("required property 'targetRange' is missing")
 	}
 	if !seenTargetSelectionRange {
-		return fmt.Errorf("required key 'targetSelectionRange' is missing")
+		return fmt.Errorf("required property 'targetSelectionRange' is missing")
 	}
 
 	return nil
@@ -10680,10 +10680,10 @@ func (s *Range) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenStart {
-		return fmt.Errorf("required key 'start' is missing")
+		return fmt.Errorf("required property 'start' is missing")
 	}
 	if !seenEnd {
-		return fmt.Errorf("required key 'end' is missing")
+		return fmt.Errorf("required property 'end' is missing")
 	}
 
 	return nil
@@ -10755,10 +10755,10 @@ func (s *WorkspaceFoldersChangeEvent) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 	}
 
 	if !seenAdded {
-		return fmt.Errorf("required key 'added' is missing")
+		return fmt.Errorf("required property 'added' is missing")
 	}
 	if !seenRemoved {
-		return fmt.Errorf("required key 'removed' is missing")
+		return fmt.Errorf("required property 'removed' is missing")
 	}
 
 	return nil
@@ -10811,7 +10811,7 @@ func (s *TextDocumentIdentifier) UnmarshalJSONFrom(dec *jsontext.Decoder) error 
 	}
 
 	if !seenUri {
-		return fmt.Errorf("required key 'uri' is missing")
+		return fmt.Errorf("required property 'uri' is missing")
 	}
 
 	return nil
@@ -10885,16 +10885,16 @@ func (s *Color) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenRed {
-		return fmt.Errorf("required key 'red' is missing")
+		return fmt.Errorf("required property 'red' is missing")
 	}
 	if !seenGreen {
-		return fmt.Errorf("required key 'green' is missing")
+		return fmt.Errorf("required property 'green' is missing")
 	}
 	if !seenBlue {
-		return fmt.Errorf("required key 'blue' is missing")
+		return fmt.Errorf("required property 'blue' is missing")
 	}
 	if !seenAlpha {
-		return fmt.Errorf("required key 'alpha' is missing")
+		return fmt.Errorf("required property 'alpha' is missing")
 	}
 
 	return nil
@@ -10991,10 +10991,10 @@ func (s *Position) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenLine {
-		return fmt.Errorf("required key 'line' is missing")
+		return fmt.Errorf("required property 'line' is missing")
 	}
 	if !seenCharacter {
-		return fmt.Errorf("required key 'character' is missing")
+		return fmt.Errorf("required property 'character' is missing")
 	}
 
 	return nil
@@ -11071,7 +11071,7 @@ func (s *SemanticTokensOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenLegend {
-		return fmt.Errorf("required key 'legend' is missing")
+		return fmt.Errorf("required property 'legend' is missing")
 	}
 
 	return nil
@@ -11134,10 +11134,10 @@ func (s *SemanticTokensEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenStart {
-		return fmt.Errorf("required key 'start' is missing")
+		return fmt.Errorf("required property 'start' is missing")
 	}
 	if !seenDeleteCount {
-		return fmt.Errorf("required key 'deleteCount' is missing")
+		return fmt.Errorf("required property 'deleteCount' is missing")
 	}
 
 	return nil
@@ -11188,7 +11188,7 @@ func (s *FileCreate) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenUri {
-		return fmt.Errorf("required key 'uri' is missing")
+		return fmt.Errorf("required property 'uri' is missing")
 	}
 
 	return nil
@@ -11253,10 +11253,10 @@ func (s *TextDocumentEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTextDocument {
-		return fmt.Errorf("required key 'textDocument' is missing")
+		return fmt.Errorf("required property 'textDocument' is missing")
 	}
 	if !seenEdits {
-		return fmt.Errorf("required key 'edits' is missing")
+		return fmt.Errorf("required property 'edits' is missing")
 	}
 
 	return nil
@@ -11328,10 +11328,10 @@ func (s *CreateFile) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenKind {
-		return fmt.Errorf("required key 'kind' is missing")
+		return fmt.Errorf("required property 'kind' is missing")
 	}
 	if !seenUri {
-		return fmt.Errorf("required key 'uri' is missing")
+		return fmt.Errorf("required property 'uri' is missing")
 	}
 
 	return nil
@@ -11412,13 +11412,13 @@ func (s *RenameFile) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenKind {
-		return fmt.Errorf("required key 'kind' is missing")
+		return fmt.Errorf("required property 'kind' is missing")
 	}
 	if !seenOldUri {
-		return fmt.Errorf("required key 'oldUri' is missing")
+		return fmt.Errorf("required property 'oldUri' is missing")
 	}
 	if !seenNewUri {
-		return fmt.Errorf("required key 'newUri' is missing")
+		return fmt.Errorf("required property 'newUri' is missing")
 	}
 
 	return nil
@@ -11490,10 +11490,10 @@ func (s *DeleteFile) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenKind {
-		return fmt.Errorf("required key 'kind' is missing")
+		return fmt.Errorf("required property 'kind' is missing")
 	}
 	if !seenUri {
-		return fmt.Errorf("required key 'uri' is missing")
+		return fmt.Errorf("required property 'uri' is missing")
 	}
 
 	return nil
@@ -11557,7 +11557,7 @@ func (s *ChangeAnnotation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenLabel {
-		return fmt.Errorf("required key 'label' is missing")
+		return fmt.Errorf("required property 'label' is missing")
 	}
 
 	return nil
@@ -11612,7 +11612,7 @@ func (s *FileOperationFilter) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenPattern {
-		return fmt.Errorf("required key 'pattern' is missing")
+		return fmt.Errorf("required property 'pattern' is missing")
 	}
 
 	return nil
@@ -11670,10 +11670,10 @@ func (s *FileRename) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenOldUri {
-		return fmt.Errorf("required key 'oldUri' is missing")
+		return fmt.Errorf("required property 'oldUri' is missing")
 	}
 	if !seenNewUri {
-		return fmt.Errorf("required key 'newUri' is missing")
+		return fmt.Errorf("required property 'newUri' is missing")
 	}
 
 	return nil
@@ -11720,7 +11720,7 @@ func (s *FileDelete) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenUri {
-		return fmt.Errorf("required key 'uri' is missing")
+		return fmt.Errorf("required property 'uri' is missing")
 	}
 
 	return nil
@@ -11788,10 +11788,10 @@ func (s *InlineValueContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenFrameId {
-		return fmt.Errorf("required key 'frameId' is missing")
+		return fmt.Errorf("required property 'frameId' is missing")
 	}
 	if !seenStoppedLocation {
-		return fmt.Errorf("required key 'stoppedLocation' is missing")
+		return fmt.Errorf("required property 'stoppedLocation' is missing")
 	}
 
 	return nil
@@ -11849,10 +11849,10 @@ func (s *InlineValueText) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenRange {
-		return fmt.Errorf("required key 'range' is missing")
+		return fmt.Errorf("required property 'range' is missing")
 	}
 	if !seenText {
-		return fmt.Errorf("required key 'text' is missing")
+		return fmt.Errorf("required property 'text' is missing")
 	}
 
 	return nil
@@ -11920,10 +11920,10 @@ func (s *InlineValueVariableLookup) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 	}
 
 	if !seenRange {
-		return fmt.Errorf("required key 'range' is missing")
+		return fmt.Errorf("required property 'range' is missing")
 	}
 	if !seenCaseSensitiveLookup {
-		return fmt.Errorf("required key 'caseSensitiveLookup' is missing")
+		return fmt.Errorf("required property 'caseSensitiveLookup' is missing")
 	}
 
 	return nil
@@ -11980,7 +11980,7 @@ func (s *InlineValueEvaluatableExpression) UnmarshalJSONFrom(dec *jsontext.Decod
 	}
 
 	if !seenRange {
-		return fmt.Errorf("required key 'range' is missing")
+		return fmt.Errorf("required property 'range' is missing")
 	}
 
 	return nil
@@ -12071,7 +12071,7 @@ func (s *InlayHintLabelPart) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenValue {
-		return fmt.Errorf("required key 'value' is missing")
+		return fmt.Errorf("required property 'value' is missing")
 	}
 
 	return nil
@@ -12150,10 +12150,10 @@ func (s *MarkupContent) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenKind {
-		return fmt.Errorf("required key 'kind' is missing")
+		return fmt.Errorf("required property 'kind' is missing")
 	}
 	if !seenValue {
-		return fmt.Errorf("required key 'value' is missing")
+		return fmt.Errorf("required property 'value' is missing")
 	}
 
 	return nil
@@ -12244,10 +12244,10 @@ func (s *RelatedFullDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.De
 	}
 
 	if !seenKind {
-		return fmt.Errorf("required key 'kind' is missing")
+		return fmt.Errorf("required property 'kind' is missing")
 	}
 	if !seenItems {
-		return fmt.Errorf("required key 'items' is missing")
+		return fmt.Errorf("required property 'items' is missing")
 	}
 
 	return nil
@@ -12322,10 +12322,10 @@ func (s *RelatedUnchangedDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsonte
 	}
 
 	if !seenKind {
-		return fmt.Errorf("required key 'kind' is missing")
+		return fmt.Errorf("required property 'kind' is missing")
 	}
 	if !seenResultId {
-		return fmt.Errorf("required key 'resultId' is missing")
+		return fmt.Errorf("required property 'resultId' is missing")
 	}
 
 	return nil
@@ -12392,10 +12392,10 @@ func (s *FullDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 	}
 
 	if !seenKind {
-		return fmt.Errorf("required key 'kind' is missing")
+		return fmt.Errorf("required property 'kind' is missing")
 	}
 	if !seenItems {
-		return fmt.Errorf("required key 'items' is missing")
+		return fmt.Errorf("required property 'items' is missing")
 	}
 
 	return nil
@@ -12458,10 +12458,10 @@ func (s *UnchangedDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.Deco
 	}
 
 	if !seenKind {
-		return fmt.Errorf("required key 'kind' is missing")
+		return fmt.Errorf("required property 'kind' is missing")
 	}
 	if !seenResultId {
-		return fmt.Errorf("required key 'resultId' is missing")
+		return fmt.Errorf("required property 'resultId' is missing")
 	}
 
 	return nil
@@ -12536,10 +12536,10 @@ func (s *DiagnosticOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenInterFileDependencies {
-		return fmt.Errorf("required key 'interFileDependencies' is missing")
+		return fmt.Errorf("required property 'interFileDependencies' is missing")
 	}
 	if !seenWorkspaceDiagnostics {
-		return fmt.Errorf("required key 'workspaceDiagnostics' is missing")
+		return fmt.Errorf("required property 'workspaceDiagnostics' is missing")
 	}
 
 	return nil
@@ -12598,10 +12598,10 @@ func (s *PreviousResultId) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenUri {
-		return fmt.Errorf("required key 'uri' is missing")
+		return fmt.Errorf("required property 'uri' is missing")
 	}
 	if !seenValue {
-		return fmt.Errorf("required key 'value' is missing")
+		return fmt.Errorf("required property 'value' is missing")
 	}
 
 	return nil
@@ -12688,16 +12688,16 @@ func (s *NotebookDocument) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenUri {
-		return fmt.Errorf("required key 'uri' is missing")
+		return fmt.Errorf("required property 'uri' is missing")
 	}
 	if !seenNotebookType {
-		return fmt.Errorf("required key 'notebookType' is missing")
+		return fmt.Errorf("required property 'notebookType' is missing")
 	}
 	if !seenVersion {
-		return fmt.Errorf("required key 'version' is missing")
+		return fmt.Errorf("required property 'version' is missing")
 	}
 	if !seenCells {
-		return fmt.Errorf("required key 'cells' is missing")
+		return fmt.Errorf("required property 'cells' is missing")
 	}
 
 	return nil
@@ -12773,16 +12773,16 @@ func (s *TextDocumentItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenUri {
-		return fmt.Errorf("required key 'uri' is missing")
+		return fmt.Errorf("required property 'uri' is missing")
 	}
 	if !seenLanguageId {
-		return fmt.Errorf("required key 'languageId' is missing")
+		return fmt.Errorf("required property 'languageId' is missing")
 	}
 	if !seenVersion {
-		return fmt.Errorf("required key 'version' is missing")
+		return fmt.Errorf("required property 'version' is missing")
 	}
 	if !seenText {
-		return fmt.Errorf("required key 'text' is missing")
+		return fmt.Errorf("required property 'text' is missing")
 	}
 
 	return nil
@@ -12847,7 +12847,7 @@ func (s *NotebookDocumentSyncOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 	}
 
 	if !seenNotebookSelector {
-		return fmt.Errorf("required key 'notebookSelector' is missing")
+		return fmt.Errorf("required property 'notebookSelector' is missing")
 	}
 
 	return nil
@@ -12905,10 +12905,10 @@ func (s *VersionedNotebookDocumentIdentifier) UnmarshalJSONFrom(dec *jsontext.De
 	}
 
 	if !seenVersion {
-		return fmt.Errorf("required key 'version' is missing")
+		return fmt.Errorf("required property 'version' is missing")
 	}
 	if !seenUri {
-		return fmt.Errorf("required key 'uri' is missing")
+		return fmt.Errorf("required property 'uri' is missing")
 	}
 
 	return nil
@@ -12968,7 +12968,7 @@ func (s *NotebookDocumentIdentifier) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 	}
 
 	if !seenUri {
-		return fmt.Errorf("required key 'uri' is missing")
+		return fmt.Errorf("required property 'uri' is missing")
 	}
 
 	return nil
@@ -13024,7 +13024,7 @@ func (s *InlineCompletionContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error
 	}
 
 	if !seenTriggerKind {
-		return fmt.Errorf("required key 'triggerKind' is missing")
+		return fmt.Errorf("required property 'triggerKind' is missing")
 	}
 
 	return nil
@@ -13090,10 +13090,10 @@ func (s *StringValue) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenKind {
-		return fmt.Errorf("required key 'kind' is missing")
+		return fmt.Errorf("required property 'kind' is missing")
 	}
 	if !seenValue {
-		return fmt.Errorf("required key 'value' is missing")
+		return fmt.Errorf("required property 'value' is missing")
 	}
 
 	return nil
@@ -13151,7 +13151,7 @@ func (s *TextDocumentContentOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 	}
 
 	if !seenSchemes {
-		return fmt.Errorf("required key 'schemes' is missing")
+		return fmt.Errorf("required property 'schemes' is missing")
 	}
 
 	return nil
@@ -13215,10 +13215,10 @@ func (s *Registration) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenId {
-		return fmt.Errorf("required key 'id' is missing")
+		return fmt.Errorf("required property 'id' is missing")
 	}
 	if !seenMethod {
-		return fmt.Errorf("required key 'method' is missing")
+		return fmt.Errorf("required property 'method' is missing")
 	}
 
 	return nil
@@ -13275,10 +13275,10 @@ func (s *Unregistration) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenId {
-		return fmt.Errorf("required key 'id' is missing")
+		return fmt.Errorf("required property 'id' is missing")
 	}
 	if !seenMethod {
-		return fmt.Errorf("required key 'method' is missing")
+		return fmt.Errorf("required property 'method' is missing")
 	}
 
 	return nil
@@ -13405,13 +13405,13 @@ func (s *InitializeParamsBase) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenProcessId {
-		return fmt.Errorf("required key 'processId' is missing")
+		return fmt.Errorf("required property 'processId' is missing")
 	}
 	if !seenRootUri {
-		return fmt.Errorf("required key 'rootUri' is missing")
+		return fmt.Errorf("required property 'rootUri' is missing")
 	}
 	if !seenCapabilities {
-		return fmt.Errorf("required key 'capabilities' is missing")
+		return fmt.Errorf("required property 'capabilities' is missing")
 	}
 
 	return nil
@@ -13626,7 +13626,7 @@ func (s *ServerInfo) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenName {
-		return fmt.Errorf("required key 'name' is missing")
+		return fmt.Errorf("required property 'name' is missing")
 	}
 
 	return nil
@@ -13682,10 +13682,10 @@ func (s *VersionedTextDocumentIdentifier) UnmarshalJSONFrom(dec *jsontext.Decode
 	}
 
 	if !seenUri {
-		return fmt.Errorf("required key 'uri' is missing")
+		return fmt.Errorf("required property 'uri' is missing")
 	}
 	if !seenVersion {
-		return fmt.Errorf("required key 'version' is missing")
+		return fmt.Errorf("required property 'version' is missing")
 	}
 
 	return nil
@@ -13747,10 +13747,10 @@ func (s *FileEvent) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenUri {
-		return fmt.Errorf("required key 'uri' is missing")
+		return fmt.Errorf("required property 'uri' is missing")
 	}
 	if !seenType {
-		return fmt.Errorf("required key 'type' is missing")
+		return fmt.Errorf("required property 'type' is missing")
 	}
 
 	return nil
@@ -13805,7 +13805,7 @@ func (s *FileSystemWatcher) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenGlobPattern {
-		return fmt.Errorf("required key 'globPattern' is missing")
+		return fmt.Errorf("required property 'globPattern' is missing")
 	}
 
 	return nil
@@ -13924,10 +13924,10 @@ func (s *Diagnostic) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenRange {
-		return fmt.Errorf("required key 'range' is missing")
+		return fmt.Errorf("required property 'range' is missing")
 	}
 	if !seenMessage {
-		return fmt.Errorf("required key 'message' is missing")
+		return fmt.Errorf("required property 'message' is missing")
 	}
 
 	return nil
@@ -13980,7 +13980,7 @@ func (s *CompletionContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTriggerKind {
-		return fmt.Errorf("required key 'triggerKind' is missing")
+		return fmt.Errorf("required property 'triggerKind' is missing")
 	}
 
 	return nil
@@ -14060,13 +14060,13 @@ func (s *InsertReplaceEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenNewText {
-		return fmt.Errorf("required key 'newText' is missing")
+		return fmt.Errorf("required property 'newText' is missing")
 	}
 	if !seenInsert {
-		return fmt.Errorf("required key 'insert' is missing")
+		return fmt.Errorf("required property 'insert' is missing")
 	}
 	if !seenReplace {
-		return fmt.Errorf("required key 'replace' is missing")
+		return fmt.Errorf("required property 'replace' is missing")
 	}
 
 	return nil
@@ -14288,10 +14288,10 @@ func (s *SignatureHelpContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTriggerKind {
-		return fmt.Errorf("required key 'triggerKind' is missing")
+		return fmt.Errorf("required property 'triggerKind' is missing")
 	}
 	if !seenIsRetrigger {
-		return fmt.Errorf("required key 'isRetrigger' is missing")
+		return fmt.Errorf("required property 'isRetrigger' is missing")
 	}
 
 	return nil
@@ -14371,7 +14371,7 @@ func (s *SignatureInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenLabel {
-		return fmt.Errorf("required key 'label' is missing")
+		return fmt.Errorf("required property 'label' is missing")
 	}
 
 	return nil
@@ -14438,7 +14438,7 @@ func (s *ReferenceContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenIncludeDeclaration {
-		return fmt.Errorf("required key 'includeDeclaration' is missing")
+		return fmt.Errorf("required property 'includeDeclaration' is missing")
 	}
 
 	return nil
@@ -14523,10 +14523,10 @@ func (s *BaseSymbolInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenName {
-		return fmt.Errorf("required key 'name' is missing")
+		return fmt.Errorf("required property 'name' is missing")
 	}
 	if !seenKind {
-		return fmt.Errorf("required key 'kind' is missing")
+		return fmt.Errorf("required property 'kind' is missing")
 	}
 
 	return nil
@@ -14606,7 +14606,7 @@ func (s *CodeActionContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenDiagnostics {
-		return fmt.Errorf("required key 'diagnostics' is missing")
+		return fmt.Errorf("required property 'diagnostics' is missing")
 	}
 
 	return nil
@@ -14655,7 +14655,7 @@ func (s *CodeActionDisabled) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenReason {
-		return fmt.Errorf("required key 'reason' is missing")
+		return fmt.Errorf("required property 'reason' is missing")
 	}
 
 	return nil
@@ -14736,7 +14736,7 @@ func (s *LocationUriOnly) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenUri {
-		return fmt.Errorf("required key 'uri' is missing")
+		return fmt.Errorf("required property 'uri' is missing")
 	}
 
 	return nil
@@ -14846,10 +14846,10 @@ func (s *FormattingOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTabSize {
-		return fmt.Errorf("required key 'tabSize' is missing")
+		return fmt.Errorf("required property 'tabSize' is missing")
 	}
 	if !seenInsertSpaces {
-		return fmt.Errorf("required key 'insertSpaces' is missing")
+		return fmt.Errorf("required property 'insertSpaces' is missing")
 	}
 
 	return nil
@@ -14918,7 +14918,7 @@ func (s *DocumentOnTypeFormattingOptions) UnmarshalJSONFrom(dec *jsontext.Decode
 	}
 
 	if !seenFirstTriggerCharacter {
-		return fmt.Errorf("required key 'firstTriggerCharacter' is missing")
+		return fmt.Errorf("required property 'firstTriggerCharacter' is missing")
 	}
 
 	return nil
@@ -14982,10 +14982,10 @@ func (s *PrepareRenamePlaceholder) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 	}
 
 	if !seenRange {
-		return fmt.Errorf("required key 'range' is missing")
+		return fmt.Errorf("required property 'range' is missing")
 	}
 	if !seenPlaceholder {
-		return fmt.Errorf("required key 'placeholder' is missing")
+		return fmt.Errorf("required property 'placeholder' is missing")
 	}
 
 	return nil
@@ -15029,7 +15029,7 @@ func (s *PrepareRenameDefaultBehavior) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 	}
 
 	if !seenDefaultBehavior {
-		return fmt.Errorf("required key 'defaultBehavior' is missing")
+		return fmt.Errorf("required property 'defaultBehavior' is missing")
 	}
 
 	return nil
@@ -15080,7 +15080,7 @@ func (s *ExecuteCommandOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenCommands {
-		return fmt.Errorf("required key 'commands' is missing")
+		return fmt.Errorf("required property 'commands' is missing")
 	}
 
 	return nil
@@ -15146,10 +15146,10 @@ func (s *SemanticTokensLegend) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenTokenTypes {
-		return fmt.Errorf("required key 'tokenTypes' is missing")
+		return fmt.Errorf("required property 'tokenTypes' is missing")
 	}
 	if !seenTokenModifiers {
-		return fmt.Errorf("required key 'tokenModifiers' is missing")
+		return fmt.Errorf("required property 'tokenModifiers' is missing")
 	}
 
 	return nil
@@ -15217,10 +15217,10 @@ func (s *OptionalVersionedTextDocumentIdentifier) UnmarshalJSONFrom(dec *jsontex
 	}
 
 	if !seenUri {
-		return fmt.Errorf("required key 'uri' is missing")
+		return fmt.Errorf("required property 'uri' is missing")
 	}
 	if !seenVersion {
-		return fmt.Errorf("required key 'version' is missing")
+		return fmt.Errorf("required property 'version' is missing")
 	}
 
 	return nil
@@ -15289,13 +15289,13 @@ func (s *AnnotatedTextEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenRange {
-		return fmt.Errorf("required key 'range' is missing")
+		return fmt.Errorf("required property 'range' is missing")
 	}
 	if !seenNewText {
-		return fmt.Errorf("required key 'newText' is missing")
+		return fmt.Errorf("required property 'newText' is missing")
 	}
 	if !seenAnnotationId {
-		return fmt.Errorf("required key 'annotationId' is missing")
+		return fmt.Errorf("required property 'annotationId' is missing")
 	}
 
 	return nil
@@ -15362,10 +15362,10 @@ func (s *SnippetTextEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenRange {
-		return fmt.Errorf("required key 'range' is missing")
+		return fmt.Errorf("required property 'range' is missing")
 	}
 	if !seenSnippet {
-		return fmt.Errorf("required key 'snippet' is missing")
+		return fmt.Errorf("required property 'snippet' is missing")
 	}
 
 	return nil
@@ -15419,7 +15419,7 @@ func (s *ResourceOperation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenKind {
-		return fmt.Errorf("required key 'kind' is missing")
+		return fmt.Errorf("required property 'kind' is missing")
 	}
 
 	return nil
@@ -15516,7 +15516,7 @@ func (s *FileOperationPattern) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenGlob {
-		return fmt.Errorf("required key 'glob' is missing")
+		return fmt.Errorf("required property 'glob' is missing")
 	}
 
 	return nil
@@ -15602,16 +15602,16 @@ func (s *WorkspaceFullDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.
 	}
 
 	if !seenKind {
-		return fmt.Errorf("required key 'kind' is missing")
+		return fmt.Errorf("required property 'kind' is missing")
 	}
 	if !seenItems {
-		return fmt.Errorf("required key 'items' is missing")
+		return fmt.Errorf("required property 'items' is missing")
 	}
 	if !seenUri {
-		return fmt.Errorf("required key 'uri' is missing")
+		return fmt.Errorf("required property 'uri' is missing")
 	}
 	if !seenVersion {
-		return fmt.Errorf("required key 'version' is missing")
+		return fmt.Errorf("required property 'version' is missing")
 	}
 
 	return nil
@@ -15692,16 +15692,16 @@ func (s *WorkspaceUnchangedDocumentDiagnosticReport) UnmarshalJSONFrom(dec *json
 	}
 
 	if !seenKind {
-		return fmt.Errorf("required key 'kind' is missing")
+		return fmt.Errorf("required property 'kind' is missing")
 	}
 	if !seenResultId {
-		return fmt.Errorf("required key 'resultId' is missing")
+		return fmt.Errorf("required property 'resultId' is missing")
 	}
 	if !seenUri {
-		return fmt.Errorf("required key 'uri' is missing")
+		return fmt.Errorf("required property 'uri' is missing")
 	}
 	if !seenVersion {
-		return fmt.Errorf("required key 'version' is missing")
+		return fmt.Errorf("required property 'version' is missing")
 	}
 
 	return nil
@@ -15781,10 +15781,10 @@ func (s *NotebookCell) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenKind {
-		return fmt.Errorf("required key 'kind' is missing")
+		return fmt.Errorf("required property 'kind' is missing")
 	}
 	if !seenDocument {
-		return fmt.Errorf("required key 'document' is missing")
+		return fmt.Errorf("required property 'document' is missing")
 	}
 
 	return nil
@@ -15838,7 +15838,7 @@ func (s *NotebookDocumentFilterWithNotebook) UnmarshalJSONFrom(dec *jsontext.Dec
 	}
 
 	if !seenNotebook {
-		return fmt.Errorf("required key 'notebook' is missing")
+		return fmt.Errorf("required property 'notebook' is missing")
 	}
 
 	return nil
@@ -15892,7 +15892,7 @@ func (s *NotebookDocumentFilterWithCells) UnmarshalJSONFrom(dec *jsontext.Decode
 	}
 
 	if !seenCells {
-		return fmt.Errorf("required key 'cells' is missing")
+		return fmt.Errorf("required property 'cells' is missing")
 	}
 
 	return nil
@@ -15968,10 +15968,10 @@ func (s *SelectedCompletionInfo) UnmarshalJSONFrom(dec *jsontext.Decoder) error 
 	}
 
 	if !seenRange {
-		return fmt.Errorf("required key 'range' is missing")
+		return fmt.Errorf("required property 'range' is missing")
 	}
 	if !seenText {
-		return fmt.Errorf("required key 'text' is missing")
+		return fmt.Errorf("required property 'text' is missing")
 	}
 
 	return nil
@@ -16027,7 +16027,7 @@ func (s *ClientInfo) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenName {
-		return fmt.Errorf("required key 'name' is missing")
+		return fmt.Errorf("required property 'name' is missing")
 	}
 
 	return nil
@@ -16161,10 +16161,10 @@ func (s *TextDocumentContentChangePartial) UnmarshalJSONFrom(dec *jsontext.Decod
 	}
 
 	if !seenRange {
-		return fmt.Errorf("required key 'range' is missing")
+		return fmt.Errorf("required property 'range' is missing")
 	}
 	if !seenText {
-		return fmt.Errorf("required key 'text' is missing")
+		return fmt.Errorf("required property 'text' is missing")
 	}
 
 	return nil
@@ -16209,7 +16209,7 @@ func (s *TextDocumentContentChangeWholeDocument) UnmarshalJSONFrom(dec *jsontext
 	}
 
 	if !seenText {
-		return fmt.Errorf("required key 'text' is missing")
+		return fmt.Errorf("required property 'text' is missing")
 	}
 
 	return nil
@@ -16256,7 +16256,7 @@ func (s *CodeDescription) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenHref {
-		return fmt.Errorf("required key 'href' is missing")
+		return fmt.Errorf("required property 'href' is missing")
 	}
 
 	return nil
@@ -16314,10 +16314,10 @@ func (s *DiagnosticRelatedInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 	}
 
 	if !seenLocation {
-		return fmt.Errorf("required key 'location' is missing")
+		return fmt.Errorf("required property 'location' is missing")
 	}
 	if !seenMessage {
-		return fmt.Errorf("required key 'message' is missing")
+		return fmt.Errorf("required property 'message' is missing")
 	}
 
 	return nil
@@ -16373,10 +16373,10 @@ func (s *EditRangeWithInsertReplace) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 	}
 
 	if !seenInsert {
-		return fmt.Errorf("required key 'insert' is missing")
+		return fmt.Errorf("required property 'insert' is missing")
 	}
 	if !seenReplace {
-		return fmt.Errorf("required key 'replace' is missing")
+		return fmt.Errorf("required property 'replace' is missing")
 	}
 
 	return nil
@@ -16442,10 +16442,10 @@ func (s *MarkedStringWithLanguage) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 	}
 
 	if !seenLanguage {
-		return fmt.Errorf("required key 'language' is missing")
+		return fmt.Errorf("required property 'language' is missing")
 	}
 	if !seenValue {
-		return fmt.Errorf("required key 'value' is missing")
+		return fmt.Errorf("required property 'value' is missing")
 	}
 
 	return nil
@@ -16510,7 +16510,7 @@ func (s *ParameterInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenLabel {
-		return fmt.Errorf("required key 'label' is missing")
+		return fmt.Errorf("required property 'label' is missing")
 	}
 
 	return nil
@@ -16576,10 +16576,10 @@ func (s *CodeActionKindDocumentation) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 	}
 
 	if !seenKind {
-		return fmt.Errorf("required key 'kind' is missing")
+		return fmt.Errorf("required property 'kind' is missing")
 	}
 	if !seenCommand {
-		return fmt.Errorf("required key 'command' is missing")
+		return fmt.Errorf("required property 'command' is missing")
 	}
 
 	return nil
@@ -16640,7 +16640,7 @@ func (s *NotebookCellTextDocumentFilter) UnmarshalJSONFrom(dec *jsontext.Decoder
 	}
 
 	if !seenNotebook {
-		return fmt.Errorf("required key 'notebook' is missing")
+		return fmt.Errorf("required property 'notebook' is missing")
 	}
 
 	return nil
@@ -16702,7 +16702,7 @@ func (s *ExecutionSummary) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenExecutionOrder {
-		return fmt.Errorf("required key 'executionOrder' is missing")
+		return fmt.Errorf("required property 'executionOrder' is missing")
 	}
 
 	return nil
@@ -16746,7 +16746,7 @@ func (s *NotebookCellLanguage) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenLanguage {
-		return fmt.Errorf("required key 'language' is missing")
+		return fmt.Errorf("required property 'language' is missing")
 	}
 
 	return nil
@@ -16807,7 +16807,7 @@ func (s *NotebookDocumentCellChangeStructure) UnmarshalJSONFrom(dec *jsontext.De
 	}
 
 	if !seenArray {
-		return fmt.Errorf("required key 'array' is missing")
+		return fmt.Errorf("required property 'array' is missing")
 	}
 
 	return nil
@@ -16863,10 +16863,10 @@ func (s *NotebookDocumentCellContentChanges) UnmarshalJSONFrom(dec *jsontext.Dec
 	}
 
 	if !seenDocument {
-		return fmt.Errorf("required key 'document' is missing")
+		return fmt.Errorf("required property 'document' is missing")
 	}
 	if !seenChanges {
-		return fmt.Errorf("required key 'changes' is missing")
+		return fmt.Errorf("required property 'changes' is missing")
 	}
 
 	return nil
@@ -17131,7 +17131,7 @@ func (s *NotebookDocumentClientCapabilities) UnmarshalJSONFrom(dec *jsontext.Dec
 	}
 
 	if !seenSynchronization {
-		return fmt.Errorf("required key 'synchronization' is missing")
+		return fmt.Errorf("required property 'synchronization' is missing")
 	}
 
 	return nil
@@ -17295,10 +17295,10 @@ func (s *RelativePattern) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenBaseUri {
-		return fmt.Errorf("required key 'baseUri' is missing")
+		return fmt.Errorf("required property 'baseUri' is missing")
 	}
 	if !seenPattern {
-		return fmt.Errorf("required key 'pattern' is missing")
+		return fmt.Errorf("required property 'pattern' is missing")
 	}
 
 	return nil
@@ -17363,7 +17363,7 @@ func (s *TextDocumentFilterLanguage) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 	}
 
 	if !seenLanguage {
-		return fmt.Errorf("required key 'language' is missing")
+		return fmt.Errorf("required property 'language' is missing")
 	}
 
 	return nil
@@ -17428,7 +17428,7 @@ func (s *TextDocumentFilterScheme) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 	}
 
 	if !seenScheme {
-		return fmt.Errorf("required key 'scheme' is missing")
+		return fmt.Errorf("required property 'scheme' is missing")
 	}
 
 	return nil
@@ -17493,7 +17493,7 @@ func (s *TextDocumentFilterPattern) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 	}
 
 	if !seenPattern {
-		return fmt.Errorf("required key 'pattern' is missing")
+		return fmt.Errorf("required property 'pattern' is missing")
 	}
 
 	return nil
@@ -17554,7 +17554,7 @@ func (s *NotebookDocumentFilterNotebookType) UnmarshalJSONFrom(dec *jsontext.Dec
 	}
 
 	if !seenNotebookType {
-		return fmt.Errorf("required key 'notebookType' is missing")
+		return fmt.Errorf("required property 'notebookType' is missing")
 	}
 
 	return nil
@@ -17615,7 +17615,7 @@ func (s *NotebookDocumentFilterScheme) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 	}
 
 	if !seenScheme {
-		return fmt.Errorf("required key 'scheme' is missing")
+		return fmt.Errorf("required property 'scheme' is missing")
 	}
 
 	return nil
@@ -17676,7 +17676,7 @@ func (s *NotebookDocumentFilterPattern) UnmarshalJSONFrom(dec *jsontext.Decoder)
 	}
 
 	if !seenPattern {
-		return fmt.Errorf("required key 'pattern' is missing")
+		return fmt.Errorf("required property 'pattern' is missing")
 	}
 
 	return nil
@@ -17742,10 +17742,10 @@ func (s *NotebookCellArrayChange) UnmarshalJSONFrom(dec *jsontext.Decoder) error
 	}
 
 	if !seenStart {
-		return fmt.Errorf("required key 'start' is missing")
+		return fmt.Errorf("required property 'start' is missing")
 	}
 	if !seenDeleteCount {
-		return fmt.Errorf("required key 'deleteCount' is missing")
+		return fmt.Errorf("required property 'deleteCount' is missing")
 	}
 
 	return nil
@@ -18474,16 +18474,16 @@ func (s *SemanticTokensClientCapabilities) UnmarshalJSONFrom(dec *jsontext.Decod
 	}
 
 	if !seenRequests {
-		return fmt.Errorf("required key 'requests' is missing")
+		return fmt.Errorf("required property 'requests' is missing")
 	}
 	if !seenTokenTypes {
-		return fmt.Errorf("required key 'tokenTypes' is missing")
+		return fmt.Errorf("required property 'tokenTypes' is missing")
 	}
 	if !seenTokenModifiers {
-		return fmt.Errorf("required key 'tokenModifiers' is missing")
+		return fmt.Errorf("required property 'tokenModifiers' is missing")
 	}
 	if !seenFormats {
-		return fmt.Errorf("required key 'formats' is missing")
+		return fmt.Errorf("required property 'formats' is missing")
 	}
 
 	return nil
@@ -18643,7 +18643,7 @@ func (s *ShowDocumentClientCapabilities) UnmarshalJSONFrom(dec *jsontext.Decoder
 	}
 
 	if !seenSupport {
-		return fmt.Errorf("required key 'support' is missing")
+		return fmt.Errorf("required property 'support' is missing")
 	}
 
 	return nil
@@ -18701,10 +18701,10 @@ func (s *StaleRequestSupportOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 	}
 
 	if !seenCancel {
-		return fmt.Errorf("required key 'cancel' is missing")
+		return fmt.Errorf("required property 'cancel' is missing")
 	}
 	if !seenRetryOnContentModified {
-		return fmt.Errorf("required key 'retryOnContentModified' is missing")
+		return fmt.Errorf("required property 'retryOnContentModified' is missing")
 	}
 
 	return nil
@@ -18758,7 +18758,7 @@ func (s *RegularExpressionsClientCapabilities) UnmarshalJSONFrom(dec *jsontext.D
 	}
 
 	if !seenEngine {
-		return fmt.Errorf("required key 'engine' is missing")
+		return fmt.Errorf("required property 'engine' is missing")
 	}
 
 	return nil
@@ -18822,7 +18822,7 @@ func (s *MarkdownClientCapabilities) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 	}
 
 	if !seenParser {
-		return fmt.Errorf("required key 'parser' is missing")
+		return fmt.Errorf("required property 'parser' is missing")
 	}
 
 	return nil
@@ -18888,7 +18888,7 @@ func (s *ClientSymbolTagOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error 
 	}
 
 	if !seenValueSet {
-		return fmt.Errorf("required key 'valueSet' is missing")
+		return fmt.Errorf("required property 'valueSet' is missing")
 	}
 
 	return nil
@@ -18934,7 +18934,7 @@ func (s *ClientSymbolResolveOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 	}
 
 	if !seenProperties {
-		return fmt.Errorf("required key 'properties' is missing")
+		return fmt.Errorf("required property 'properties' is missing")
 	}
 
 	return nil
@@ -19105,7 +19105,7 @@ func (s *ClientCodeActionLiteralOptions) UnmarshalJSONFrom(dec *jsontext.Decoder
 	}
 
 	if !seenCodeActionKind {
-		return fmt.Errorf("required key 'codeActionKind' is missing")
+		return fmt.Errorf("required property 'codeActionKind' is missing")
 	}
 
 	return nil
@@ -19150,7 +19150,7 @@ func (s *ClientCodeActionResolveOptions) UnmarshalJSONFrom(dec *jsontext.Decoder
 	}
 
 	if !seenProperties {
-		return fmt.Errorf("required key 'properties' is missing")
+		return fmt.Errorf("required property 'properties' is missing")
 	}
 
 	return nil
@@ -19195,7 +19195,7 @@ func (s *CodeActionTagOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	if !seenValueSet {
-		return fmt.Errorf("required key 'valueSet' is missing")
+		return fmt.Errorf("required property 'valueSet' is missing")
 	}
 
 	return nil
@@ -19240,7 +19240,7 @@ func (s *ClientCodeLensResolveOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 	}
 
 	if !seenProperties {
-		return fmt.Errorf("required key 'properties' is missing")
+		return fmt.Errorf("required property 'properties' is missing")
 	}
 
 	return nil
@@ -19338,7 +19338,7 @@ func (s *ClientInlayHintResolveOptions) UnmarshalJSONFrom(dec *jsontext.Decoder)
 	}
 
 	if !seenProperties {
-		return fmt.Errorf("required key 'properties' is missing")
+		return fmt.Errorf("required property 'properties' is missing")
 	}
 
 	return nil
@@ -19391,7 +19391,7 @@ func (s *CompletionItemTagOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 	}
 
 	if !seenValueSet {
-		return fmt.Errorf("required key 'valueSet' is missing")
+		return fmt.Errorf("required property 'valueSet' is missing")
 	}
 
 	return nil
@@ -19436,7 +19436,7 @@ func (s *ClientCompletionItemResolveOptions) UnmarshalJSONFrom(dec *jsontext.Dec
 	}
 
 	if !seenProperties {
-		return fmt.Errorf("required key 'properties' is missing")
+		return fmt.Errorf("required property 'properties' is missing")
 	}
 
 	return nil
@@ -19480,7 +19480,7 @@ func (s *ClientCompletionItemInsertTextModeOptions) UnmarshalJSONFrom(dec *jsont
 	}
 
 	if !seenValueSet {
-		return fmt.Errorf("required key 'valueSet' is missing")
+		return fmt.Errorf("required property 'valueSet' is missing")
 	}
 
 	return nil
@@ -19537,7 +19537,7 @@ func (s *ClientCodeActionKindOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 	}
 
 	if !seenValueSet {
-		return fmt.Errorf("required key 'valueSet' is missing")
+		return fmt.Errorf("required property 'valueSet' is missing")
 	}
 
 	return nil
@@ -19582,7 +19582,7 @@ func (s *ClientDiagnosticsTagOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 	}
 
 	if !seenValueSet {
-		return fmt.Errorf("required key 'valueSet' is missing")
+		return fmt.Errorf("required property 'valueSet' is missing")
 	}
 
 	return nil

--- a/internal/lsp/lsproto/lsp_generated.go
+++ b/internal/lsp/lsproto/lsp_generated.go
@@ -20927,11 +20927,15 @@ func (o IntegerOrString) MarshalJSONTo(enc *jsontext.Encoder) error {
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*IntegerOrString)(nil)
+var _ json.UnmarshalerFrom = (*IntegerOrString)(nil)
 
-func (o *IntegerOrString) UnmarshalJSON(data []byte) error {
+func (o *IntegerOrString) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = IntegerOrString{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vInteger int32
 	if err := json.Unmarshal(data, &vInteger); err == nil {
 		o.Integer = &vInteger
@@ -20961,11 +20965,15 @@ func (o DocumentSelectorOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*DocumentSelectorOrNull)(nil)
+var _ json.UnmarshalerFrom = (*DocumentSelectorOrNull)(nil)
 
-func (o *DocumentSelectorOrNull) UnmarshalJSON(data []byte) error {
+func (o *DocumentSelectorOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = DocumentSelectorOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -20998,11 +21006,15 @@ func (o BooleanOrEmptyObject) MarshalJSONTo(enc *jsontext.Encoder) error {
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*BooleanOrEmptyObject)(nil)
+var _ json.UnmarshalerFrom = (*BooleanOrEmptyObject)(nil)
 
-func (o *BooleanOrEmptyObject) UnmarshalJSON(data []byte) error {
+func (o *BooleanOrEmptyObject) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = BooleanOrEmptyObject{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vBoolean bool
 	if err := json.Unmarshal(data, &vBoolean); err == nil {
 		o.Boolean = &vBoolean
@@ -21035,11 +21047,15 @@ func (o BooleanOrSemanticTokensFullDelta) MarshalJSONTo(enc *jsontext.Encoder) e
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*BooleanOrSemanticTokensFullDelta)(nil)
+var _ json.UnmarshalerFrom = (*BooleanOrSemanticTokensFullDelta)(nil)
 
-func (o *BooleanOrSemanticTokensFullDelta) UnmarshalJSON(data []byte) error {
+func (o *BooleanOrSemanticTokensFullDelta) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = BooleanOrSemanticTokensFullDelta{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vBoolean bool
 	if err := json.Unmarshal(data, &vBoolean); err == nil {
 		o.Boolean = &vBoolean
@@ -21080,11 +21096,15 @@ func (o TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile) MarshalJSONTo(enc 
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile)(nil)
+var _ json.UnmarshalerFrom = (*TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile)(nil)
 
-func (o *TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile) UnmarshalJSON(data []byte) error {
+func (o *TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vTextDocumentEdit TextDocumentEdit
 	if err := json.Unmarshal(data, &vTextDocumentEdit); err == nil {
 		o.TextDocumentEdit = &vTextDocumentEdit
@@ -21127,11 +21147,15 @@ func (o StringOrInlayHintLabelParts) MarshalJSONTo(enc *jsontext.Encoder) error 
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*StringOrInlayHintLabelParts)(nil)
+var _ json.UnmarshalerFrom = (*StringOrInlayHintLabelParts)(nil)
 
-func (o *StringOrInlayHintLabelParts) UnmarshalJSON(data []byte) error {
+func (o *StringOrInlayHintLabelParts) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = StringOrInlayHintLabelParts{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vString string
 	if err := json.Unmarshal(data, &vString); err == nil {
 		o.String = &vString
@@ -21164,11 +21188,15 @@ func (o StringOrMarkupContent) MarshalJSONTo(enc *jsontext.Encoder) error {
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*StringOrMarkupContent)(nil)
+var _ json.UnmarshalerFrom = (*StringOrMarkupContent)(nil)
 
-func (o *StringOrMarkupContent) UnmarshalJSON(data []byte) error {
+func (o *StringOrMarkupContent) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = StringOrMarkupContent{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vString string
 	if err := json.Unmarshal(data, &vString); err == nil {
 		o.String = &vString
@@ -21201,11 +21229,15 @@ func (o FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) Marshal
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport)(nil)
+var _ json.UnmarshalerFrom = (*FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport)(nil)
 
-func (o *FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) UnmarshalJSON(data []byte) error {
+func (o *FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vFullDocumentDiagnosticReport FullDocumentDiagnosticReport
 	if err := json.Unmarshal(data, &vFullDocumentDiagnosticReport); err == nil {
 		o.FullDocumentDiagnosticReport = &vFullDocumentDiagnosticReport
@@ -21238,11 +21270,15 @@ func (o WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport)(nil)
+var _ json.UnmarshalerFrom = (*WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport)(nil)
 
-func (o *WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) UnmarshalJSON(data []byte) error {
+func (o *WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vFullDocumentDiagnosticReport WorkspaceFullDocumentDiagnosticReport
 	if err := json.Unmarshal(data, &vFullDocumentDiagnosticReport); err == nil {
 		o.FullDocumentDiagnosticReport = &vFullDocumentDiagnosticReport
@@ -21275,11 +21311,15 @@ func (o NotebookDocumentFilterWithNotebookOrCells) MarshalJSONTo(enc *jsontext.E
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*NotebookDocumentFilterWithNotebookOrCells)(nil)
+var _ json.UnmarshalerFrom = (*NotebookDocumentFilterWithNotebookOrCells)(nil)
 
-func (o *NotebookDocumentFilterWithNotebookOrCells) UnmarshalJSON(data []byte) error {
+func (o *NotebookDocumentFilterWithNotebookOrCells) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = NotebookDocumentFilterWithNotebookOrCells{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vNotebook NotebookDocumentFilterWithNotebook
 	if err := json.Unmarshal(data, &vNotebook); err == nil {
 		o.Notebook = &vNotebook
@@ -21312,11 +21352,15 @@ func (o StringOrStringValue) MarshalJSONTo(enc *jsontext.Encoder) error {
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*StringOrStringValue)(nil)
+var _ json.UnmarshalerFrom = (*StringOrStringValue)(nil)
 
-func (o *StringOrStringValue) UnmarshalJSON(data []byte) error {
+func (o *StringOrStringValue) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = StringOrStringValue{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vString string
 	if err := json.Unmarshal(data, &vString); err == nil {
 		o.String = &vString
@@ -21346,11 +21390,15 @@ func (o IntegerOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*IntegerOrNull)(nil)
+var _ json.UnmarshalerFrom = (*IntegerOrNull)(nil)
 
-func (o *IntegerOrNull) UnmarshalJSON(data []byte) error {
+func (o *IntegerOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = IntegerOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -21380,11 +21428,15 @@ func (o StringOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*StringOrNull)(nil)
+var _ json.UnmarshalerFrom = (*StringOrNull)(nil)
 
-func (o *StringOrNull) UnmarshalJSON(data []byte) error {
+func (o *StringOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = StringOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -21414,11 +21466,15 @@ func (o DocumentUriOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*DocumentUriOrNull)(nil)
+var _ json.UnmarshalerFrom = (*DocumentUriOrNull)(nil)
 
-func (o *DocumentUriOrNull) UnmarshalJSON(data []byte) error {
+func (o *DocumentUriOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = DocumentUriOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -21448,11 +21504,15 @@ func (o WorkspaceFoldersOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*WorkspaceFoldersOrNull)(nil)
+var _ json.UnmarshalerFrom = (*WorkspaceFoldersOrNull)(nil)
 
-func (o *WorkspaceFoldersOrNull) UnmarshalJSON(data []byte) error {
+func (o *WorkspaceFoldersOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = WorkspaceFoldersOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -21485,11 +21545,15 @@ func (o StringOrStrings) MarshalJSONTo(enc *jsontext.Encoder) error {
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*StringOrStrings)(nil)
+var _ json.UnmarshalerFrom = (*StringOrStrings)(nil)
 
-func (o *StringOrStrings) UnmarshalJSON(data []byte) error {
+func (o *StringOrStrings) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = StringOrStrings{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vString string
 	if err := json.Unmarshal(data, &vString); err == nil {
 		o.String = &vString
@@ -21522,11 +21586,15 @@ func (o TextDocumentContentChangePartialOrWholeDocument) MarshalJSONTo(enc *json
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*TextDocumentContentChangePartialOrWholeDocument)(nil)
+var _ json.UnmarshalerFrom = (*TextDocumentContentChangePartialOrWholeDocument)(nil)
 
-func (o *TextDocumentContentChangePartialOrWholeDocument) UnmarshalJSON(data []byte) error {
+func (o *TextDocumentContentChangePartialOrWholeDocument) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = TextDocumentContentChangePartialOrWholeDocument{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vPartial TextDocumentContentChangePartial
 	if err := json.Unmarshal(data, &vPartial); err == nil {
 		o.Partial = &vPartial
@@ -21559,11 +21627,15 @@ func (o TextEditOrInsertReplaceEdit) MarshalJSONTo(enc *jsontext.Encoder) error 
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*TextEditOrInsertReplaceEdit)(nil)
+var _ json.UnmarshalerFrom = (*TextEditOrInsertReplaceEdit)(nil)
 
-func (o *TextEditOrInsertReplaceEdit) UnmarshalJSON(data []byte) error {
+func (o *TextEditOrInsertReplaceEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = TextEditOrInsertReplaceEdit{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vTextEdit TextEdit
 	if err := json.Unmarshal(data, &vTextEdit); err == nil {
 		o.TextEdit = &vTextEdit
@@ -21604,11 +21676,15 @@ func (o MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings) MarshalJ
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings)(nil)
+var _ json.UnmarshalerFrom = (*MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings)(nil)
 
-func (o *MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings) UnmarshalJSON(data []byte) error {
+func (o *MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vMarkupContent MarkupContent
 	if err := json.Unmarshal(data, &vMarkupContent); err == nil {
 		o.MarkupContent = &vMarkupContent
@@ -21648,11 +21724,15 @@ func (o UintegerOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*UintegerOrNull)(nil)
+var _ json.UnmarshalerFrom = (*UintegerOrNull)(nil)
 
-func (o *UintegerOrNull) UnmarshalJSON(data []byte) error {
+func (o *UintegerOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = UintegerOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -21685,11 +21765,15 @@ func (o LocationOrLocationUriOnly) MarshalJSONTo(enc *jsontext.Encoder) error {
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*LocationOrLocationUriOnly)(nil)
+var _ json.UnmarshalerFrom = (*LocationOrLocationUriOnly)(nil)
 
-func (o *LocationOrLocationUriOnly) UnmarshalJSON(data []byte) error {
+func (o *LocationOrLocationUriOnly) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = LocationOrLocationUriOnly{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vLocation Location
 	if err := json.Unmarshal(data, &vLocation); err == nil {
 		o.Location = &vLocation
@@ -21726,11 +21810,15 @@ func (o TextEditOrAnnotatedTextEditOrSnippetTextEdit) MarshalJSONTo(enc *jsontex
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*TextEditOrAnnotatedTextEditOrSnippetTextEdit)(nil)
+var _ json.UnmarshalerFrom = (*TextEditOrAnnotatedTextEditOrSnippetTextEdit)(nil)
 
-func (o *TextEditOrAnnotatedTextEditOrSnippetTextEdit) UnmarshalJSON(data []byte) error {
+func (o *TextEditOrAnnotatedTextEditOrSnippetTextEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = TextEditOrAnnotatedTextEditOrSnippetTextEdit{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vTextEdit TextEdit
 	if err := json.Unmarshal(data, &vTextEdit); err == nil {
 		o.TextEdit = &vTextEdit
@@ -21768,11 +21856,15 @@ func (o TextDocumentSyncOptionsOrKind) MarshalJSONTo(enc *jsontext.Encoder) erro
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*TextDocumentSyncOptionsOrKind)(nil)
+var _ json.UnmarshalerFrom = (*TextDocumentSyncOptionsOrKind)(nil)
 
-func (o *TextDocumentSyncOptionsOrKind) UnmarshalJSON(data []byte) error {
+func (o *TextDocumentSyncOptionsOrKind) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = TextDocumentSyncOptionsOrKind{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vOptions TextDocumentSyncOptions
 	if err := json.Unmarshal(data, &vOptions); err == nil {
 		o.Options = &vOptions
@@ -21805,11 +21897,15 @@ func (o NotebookDocumentSyncOptionsOrRegistrationOptions) MarshalJSONTo(enc *jso
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*NotebookDocumentSyncOptionsOrRegistrationOptions)(nil)
+var _ json.UnmarshalerFrom = (*NotebookDocumentSyncOptionsOrRegistrationOptions)(nil)
 
-func (o *NotebookDocumentSyncOptionsOrRegistrationOptions) UnmarshalJSON(data []byte) error {
+func (o *NotebookDocumentSyncOptionsOrRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = NotebookDocumentSyncOptionsOrRegistrationOptions{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vOptions NotebookDocumentSyncOptions
 	if err := json.Unmarshal(data, &vOptions); err == nil {
 		o.Options = &vOptions
@@ -21842,11 +21938,15 @@ func (o BooleanOrHoverOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*BooleanOrHoverOptions)(nil)
+var _ json.UnmarshalerFrom = (*BooleanOrHoverOptions)(nil)
 
-func (o *BooleanOrHoverOptions) UnmarshalJSON(data []byte) error {
+func (o *BooleanOrHoverOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = BooleanOrHoverOptions{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vBoolean bool
 	if err := json.Unmarshal(data, &vBoolean); err == nil {
 		o.Boolean = &vBoolean
@@ -21883,11 +21983,15 @@ func (o BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions) MarshalJSON
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions)(nil)
+var _ json.UnmarshalerFrom = (*BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions)(nil)
 
-func (o *BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions) UnmarshalJSON(data []byte) error {
+func (o *BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vBoolean bool
 	if err := json.Unmarshal(data, &vBoolean); err == nil {
 		o.Boolean = &vBoolean
@@ -21925,11 +22029,15 @@ func (o BooleanOrDefinitionOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*BooleanOrDefinitionOptions)(nil)
+var _ json.UnmarshalerFrom = (*BooleanOrDefinitionOptions)(nil)
 
-func (o *BooleanOrDefinitionOptions) UnmarshalJSON(data []byte) error {
+func (o *BooleanOrDefinitionOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = BooleanOrDefinitionOptions{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vBoolean bool
 	if err := json.Unmarshal(data, &vBoolean); err == nil {
 		o.Boolean = &vBoolean
@@ -21966,11 +22074,15 @@ func (o BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions) Marsh
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions)(nil)
+var _ json.UnmarshalerFrom = (*BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions)(nil)
 
-func (o *BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions) UnmarshalJSON(data []byte) error {
+func (o *BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vBoolean bool
 	if err := json.Unmarshal(data, &vBoolean); err == nil {
 		o.Boolean = &vBoolean
@@ -22012,11 +22124,15 @@ func (o BooleanOrImplementationOptionsOrImplementationRegistrationOptions) Marsh
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*BooleanOrImplementationOptionsOrImplementationRegistrationOptions)(nil)
+var _ json.UnmarshalerFrom = (*BooleanOrImplementationOptionsOrImplementationRegistrationOptions)(nil)
 
-func (o *BooleanOrImplementationOptionsOrImplementationRegistrationOptions) UnmarshalJSON(data []byte) error {
+func (o *BooleanOrImplementationOptionsOrImplementationRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = BooleanOrImplementationOptionsOrImplementationRegistrationOptions{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vBoolean bool
 	if err := json.Unmarshal(data, &vBoolean); err == nil {
 		o.Boolean = &vBoolean
@@ -22054,11 +22170,15 @@ func (o BooleanOrReferenceOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*BooleanOrReferenceOptions)(nil)
+var _ json.UnmarshalerFrom = (*BooleanOrReferenceOptions)(nil)
 
-func (o *BooleanOrReferenceOptions) UnmarshalJSON(data []byte) error {
+func (o *BooleanOrReferenceOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = BooleanOrReferenceOptions{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vBoolean bool
 	if err := json.Unmarshal(data, &vBoolean); err == nil {
 		o.Boolean = &vBoolean
@@ -22091,11 +22211,15 @@ func (o BooleanOrDocumentHighlightOptions) MarshalJSONTo(enc *jsontext.Encoder) 
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*BooleanOrDocumentHighlightOptions)(nil)
+var _ json.UnmarshalerFrom = (*BooleanOrDocumentHighlightOptions)(nil)
 
-func (o *BooleanOrDocumentHighlightOptions) UnmarshalJSON(data []byte) error {
+func (o *BooleanOrDocumentHighlightOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = BooleanOrDocumentHighlightOptions{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vBoolean bool
 	if err := json.Unmarshal(data, &vBoolean); err == nil {
 		o.Boolean = &vBoolean
@@ -22128,11 +22252,15 @@ func (o BooleanOrDocumentSymbolOptions) MarshalJSONTo(enc *jsontext.Encoder) err
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*BooleanOrDocumentSymbolOptions)(nil)
+var _ json.UnmarshalerFrom = (*BooleanOrDocumentSymbolOptions)(nil)
 
-func (o *BooleanOrDocumentSymbolOptions) UnmarshalJSON(data []byte) error {
+func (o *BooleanOrDocumentSymbolOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = BooleanOrDocumentSymbolOptions{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vBoolean bool
 	if err := json.Unmarshal(data, &vBoolean); err == nil {
 		o.Boolean = &vBoolean
@@ -22165,11 +22293,15 @@ func (o BooleanOrCodeActionOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*BooleanOrCodeActionOptions)(nil)
+var _ json.UnmarshalerFrom = (*BooleanOrCodeActionOptions)(nil)
 
-func (o *BooleanOrCodeActionOptions) UnmarshalJSON(data []byte) error {
+func (o *BooleanOrCodeActionOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = BooleanOrCodeActionOptions{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vBoolean bool
 	if err := json.Unmarshal(data, &vBoolean); err == nil {
 		o.Boolean = &vBoolean
@@ -22206,11 +22338,15 @@ func (o BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions) Marshal
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions)(nil)
+var _ json.UnmarshalerFrom = (*BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions)(nil)
 
-func (o *BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions) UnmarshalJSON(data []byte) error {
+func (o *BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vBoolean bool
 	if err := json.Unmarshal(data, &vBoolean); err == nil {
 		o.Boolean = &vBoolean
@@ -22248,11 +22384,15 @@ func (o BooleanOrWorkspaceSymbolOptions) MarshalJSONTo(enc *jsontext.Encoder) er
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*BooleanOrWorkspaceSymbolOptions)(nil)
+var _ json.UnmarshalerFrom = (*BooleanOrWorkspaceSymbolOptions)(nil)
 
-func (o *BooleanOrWorkspaceSymbolOptions) UnmarshalJSON(data []byte) error {
+func (o *BooleanOrWorkspaceSymbolOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = BooleanOrWorkspaceSymbolOptions{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vBoolean bool
 	if err := json.Unmarshal(data, &vBoolean); err == nil {
 		o.Boolean = &vBoolean
@@ -22285,11 +22425,15 @@ func (o BooleanOrDocumentFormattingOptions) MarshalJSONTo(enc *jsontext.Encoder)
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*BooleanOrDocumentFormattingOptions)(nil)
+var _ json.UnmarshalerFrom = (*BooleanOrDocumentFormattingOptions)(nil)
 
-func (o *BooleanOrDocumentFormattingOptions) UnmarshalJSON(data []byte) error {
+func (o *BooleanOrDocumentFormattingOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = BooleanOrDocumentFormattingOptions{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vBoolean bool
 	if err := json.Unmarshal(data, &vBoolean); err == nil {
 		o.Boolean = &vBoolean
@@ -22322,11 +22466,15 @@ func (o BooleanOrDocumentRangeFormattingOptions) MarshalJSONTo(enc *jsontext.Enc
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*BooleanOrDocumentRangeFormattingOptions)(nil)
+var _ json.UnmarshalerFrom = (*BooleanOrDocumentRangeFormattingOptions)(nil)
 
-func (o *BooleanOrDocumentRangeFormattingOptions) UnmarshalJSON(data []byte) error {
+func (o *BooleanOrDocumentRangeFormattingOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = BooleanOrDocumentRangeFormattingOptions{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vBoolean bool
 	if err := json.Unmarshal(data, &vBoolean); err == nil {
 		o.Boolean = &vBoolean
@@ -22359,11 +22507,15 @@ func (o BooleanOrRenameOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*BooleanOrRenameOptions)(nil)
+var _ json.UnmarshalerFrom = (*BooleanOrRenameOptions)(nil)
 
-func (o *BooleanOrRenameOptions) UnmarshalJSON(data []byte) error {
+func (o *BooleanOrRenameOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = BooleanOrRenameOptions{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vBoolean bool
 	if err := json.Unmarshal(data, &vBoolean); err == nil {
 		o.Boolean = &vBoolean
@@ -22400,11 +22552,15 @@ func (o BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions) MarshalJS
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions)(nil)
+var _ json.UnmarshalerFrom = (*BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions)(nil)
 
-func (o *BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions) UnmarshalJSON(data []byte) error {
+func (o *BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vBoolean bool
 	if err := json.Unmarshal(data, &vBoolean); err == nil {
 		o.Boolean = &vBoolean
@@ -22446,11 +22602,15 @@ func (o BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions) Marsh
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions)(nil)
+var _ json.UnmarshalerFrom = (*BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions)(nil)
 
-func (o *BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions) UnmarshalJSON(data []byte) error {
+func (o *BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vBoolean bool
 	if err := json.Unmarshal(data, &vBoolean); err == nil {
 		o.Boolean = &vBoolean
@@ -22492,11 +22652,15 @@ func (o BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions) Marshal
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions)(nil)
+var _ json.UnmarshalerFrom = (*BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions)(nil)
 
-func (o *BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions) UnmarshalJSON(data []byte) error {
+func (o *BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vBoolean bool
 	if err := json.Unmarshal(data, &vBoolean); err == nil {
 		o.Boolean = &vBoolean
@@ -22538,11 +22702,15 @@ func (o BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOption
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOptions)(nil)
+var _ json.UnmarshalerFrom = (*BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOptions)(nil)
 
-func (o *BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOptions) UnmarshalJSON(data []byte) error {
+func (o *BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOptions{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vBoolean bool
 	if err := json.Unmarshal(data, &vBoolean); err == nil {
 		o.Boolean = &vBoolean
@@ -22580,11 +22748,15 @@ func (o SemanticTokensOptionsOrRegistrationOptions) MarshalJSONTo(enc *jsontext.
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*SemanticTokensOptionsOrRegistrationOptions)(nil)
+var _ json.UnmarshalerFrom = (*SemanticTokensOptionsOrRegistrationOptions)(nil)
 
-func (o *SemanticTokensOptionsOrRegistrationOptions) UnmarshalJSON(data []byte) error {
+func (o *SemanticTokensOptionsOrRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = SemanticTokensOptionsOrRegistrationOptions{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vOptions SemanticTokensOptions
 	if err := json.Unmarshal(data, &vOptions); err == nil {
 		o.Options = &vOptions
@@ -22621,11 +22793,15 @@ func (o BooleanOrMonikerOptionsOrMonikerRegistrationOptions) MarshalJSONTo(enc *
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*BooleanOrMonikerOptionsOrMonikerRegistrationOptions)(nil)
+var _ json.UnmarshalerFrom = (*BooleanOrMonikerOptionsOrMonikerRegistrationOptions)(nil)
 
-func (o *BooleanOrMonikerOptionsOrMonikerRegistrationOptions) UnmarshalJSON(data []byte) error {
+func (o *BooleanOrMonikerOptionsOrMonikerRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = BooleanOrMonikerOptionsOrMonikerRegistrationOptions{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vBoolean bool
 	if err := json.Unmarshal(data, &vBoolean); err == nil {
 		o.Boolean = &vBoolean
@@ -22667,11 +22843,15 @@ func (o BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions) Marshal
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions)(nil)
+var _ json.UnmarshalerFrom = (*BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions)(nil)
 
-func (o *BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions) UnmarshalJSON(data []byte) error {
+func (o *BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vBoolean bool
 	if err := json.Unmarshal(data, &vBoolean); err == nil {
 		o.Boolean = &vBoolean
@@ -22713,11 +22893,15 @@ func (o BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions) MarshalJSON
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions)(nil)
+var _ json.UnmarshalerFrom = (*BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions)(nil)
 
-func (o *BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions) UnmarshalJSON(data []byte) error {
+func (o *BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vBoolean bool
 	if err := json.Unmarshal(data, &vBoolean); err == nil {
 		o.Boolean = &vBoolean
@@ -22759,11 +22943,15 @@ func (o BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions) MarshalJSONTo(e
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions)(nil)
+var _ json.UnmarshalerFrom = (*BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions)(nil)
 
-func (o *BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions) UnmarshalJSON(data []byte) error {
+func (o *BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vBoolean bool
 	if err := json.Unmarshal(data, &vBoolean); err == nil {
 		o.Boolean = &vBoolean
@@ -22801,11 +22989,15 @@ func (o DiagnosticOptionsOrRegistrationOptions) MarshalJSONTo(enc *jsontext.Enco
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*DiagnosticOptionsOrRegistrationOptions)(nil)
+var _ json.UnmarshalerFrom = (*DiagnosticOptionsOrRegistrationOptions)(nil)
 
-func (o *DiagnosticOptionsOrRegistrationOptions) UnmarshalJSON(data []byte) error {
+func (o *DiagnosticOptionsOrRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = DiagnosticOptionsOrRegistrationOptions{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vOptions DiagnosticOptions
 	if err := json.Unmarshal(data, &vOptions); err == nil {
 		o.Options = &vOptions
@@ -22838,11 +23030,15 @@ func (o BooleanOrInlineCompletionOptions) MarshalJSONTo(enc *jsontext.Encoder) e
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*BooleanOrInlineCompletionOptions)(nil)
+var _ json.UnmarshalerFrom = (*BooleanOrInlineCompletionOptions)(nil)
 
-func (o *BooleanOrInlineCompletionOptions) UnmarshalJSON(data []byte) error {
+func (o *BooleanOrInlineCompletionOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = BooleanOrInlineCompletionOptions{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vBoolean bool
 	if err := json.Unmarshal(data, &vBoolean); err == nil {
 		o.Boolean = &vBoolean
@@ -22875,11 +23071,15 @@ func (o PatternOrRelativePattern) MarshalJSONTo(enc *jsontext.Encoder) error {
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*PatternOrRelativePattern)(nil)
+var _ json.UnmarshalerFrom = (*PatternOrRelativePattern)(nil)
 
-func (o *PatternOrRelativePattern) UnmarshalJSON(data []byte) error {
+func (o *PatternOrRelativePattern) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = PatternOrRelativePattern{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vPattern string
 	if err := json.Unmarshal(data, &vPattern); err == nil {
 		o.Pattern = &vPattern
@@ -22912,11 +23112,15 @@ func (o RangeOrEditRangeWithInsertReplace) MarshalJSONTo(enc *jsontext.Encoder) 
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*RangeOrEditRangeWithInsertReplace)(nil)
+var _ json.UnmarshalerFrom = (*RangeOrEditRangeWithInsertReplace)(nil)
 
-func (o *RangeOrEditRangeWithInsertReplace) UnmarshalJSON(data []byte) error {
+func (o *RangeOrEditRangeWithInsertReplace) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = RangeOrEditRangeWithInsertReplace{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vRange Range
 	if err := json.Unmarshal(data, &vRange); err == nil {
 		o.Range = &vRange
@@ -22957,11 +23161,15 @@ func (o StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterScheme
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrNotebookDocumentFilterPattern)(nil)
+var _ json.UnmarshalerFrom = (*StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrNotebookDocumentFilterPattern)(nil)
 
-func (o *StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrNotebookDocumentFilterPattern) UnmarshalJSON(data []byte) error {
+func (o *StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrNotebookDocumentFilterPattern) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrNotebookDocumentFilterPattern{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vString string
 	if err := json.Unmarshal(data, &vString); err == nil {
 		o.String = &vString
@@ -23004,11 +23212,15 @@ func (o BooleanOrSaveOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*BooleanOrSaveOptions)(nil)
+var _ json.UnmarshalerFrom = (*BooleanOrSaveOptions)(nil)
 
-func (o *BooleanOrSaveOptions) UnmarshalJSON(data []byte) error {
+func (o *BooleanOrSaveOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = BooleanOrSaveOptions{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vBoolean bool
 	if err := json.Unmarshal(data, &vBoolean); err == nil {
 		o.Boolean = &vBoolean
@@ -23041,11 +23253,15 @@ func (o TextDocumentContentOptionsOrRegistrationOptions) MarshalJSONTo(enc *json
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*TextDocumentContentOptionsOrRegistrationOptions)(nil)
+var _ json.UnmarshalerFrom = (*TextDocumentContentOptionsOrRegistrationOptions)(nil)
 
-func (o *TextDocumentContentOptionsOrRegistrationOptions) UnmarshalJSON(data []byte) error {
+func (o *TextDocumentContentOptionsOrRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = TextDocumentContentOptionsOrRegistrationOptions{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vOptions TextDocumentContentOptions
 	if err := json.Unmarshal(data, &vOptions); err == nil {
 		o.Options = &vOptions
@@ -23078,11 +23294,15 @@ func (o StringOrTuple) MarshalJSONTo(enc *jsontext.Encoder) error {
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*StringOrTuple)(nil)
+var _ json.UnmarshalerFrom = (*StringOrTuple)(nil)
 
-func (o *StringOrTuple) UnmarshalJSON(data []byte) error {
+func (o *StringOrTuple) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = StringOrTuple{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vString string
 	if err := json.Unmarshal(data, &vString); err == nil {
 		o.String = &vString
@@ -23115,11 +23335,15 @@ func (o StringOrBoolean) MarshalJSONTo(enc *jsontext.Encoder) error {
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*StringOrBoolean)(nil)
+var _ json.UnmarshalerFrom = (*StringOrBoolean)(nil)
 
-func (o *StringOrBoolean) UnmarshalJSON(data []byte) error {
+func (o *StringOrBoolean) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = StringOrBoolean{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vString string
 	if err := json.Unmarshal(data, &vString); err == nil {
 		o.String = &vString
@@ -23152,11 +23376,15 @@ func (o WorkspaceFolderOrURI) MarshalJSONTo(enc *jsontext.Encoder) error {
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*WorkspaceFolderOrURI)(nil)
+var _ json.UnmarshalerFrom = (*WorkspaceFolderOrURI)(nil)
 
-func (o *WorkspaceFolderOrURI) UnmarshalJSON(data []byte) error {
+func (o *WorkspaceFolderOrURI) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = WorkspaceFolderOrURI{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vWorkspaceFolder WorkspaceFolder
 	if err := json.Unmarshal(data, &vWorkspaceFolder); err == nil {
 		o.WorkspaceFolder = &vWorkspaceFolder
@@ -23189,11 +23417,15 @@ func (o BooleanOrClientSemanticTokensRequestFullDelta) MarshalJSONTo(enc *jsonte
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*BooleanOrClientSemanticTokensRequestFullDelta)(nil)
+var _ json.UnmarshalerFrom = (*BooleanOrClientSemanticTokensRequestFullDelta)(nil)
 
-func (o *BooleanOrClientSemanticTokensRequestFullDelta) UnmarshalJSON(data []byte) error {
+func (o *BooleanOrClientSemanticTokensRequestFullDelta) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = BooleanOrClientSemanticTokensRequestFullDelta{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vBoolean bool
 	if err := json.Unmarshal(data, &vBoolean); err == nil {
 		o.Boolean = &vBoolean
@@ -23231,11 +23463,15 @@ func (o LocationOrLocationsOrDefinitionLinksOrNull) MarshalJSONTo(enc *jsontext.
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*LocationOrLocationsOrDefinitionLinksOrNull)(nil)
+var _ json.UnmarshalerFrom = (*LocationOrLocationsOrDefinitionLinksOrNull)(nil)
 
-func (o *LocationOrLocationsOrDefinitionLinksOrNull) UnmarshalJSON(data []byte) error {
+func (o *LocationOrLocationsOrDefinitionLinksOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = LocationOrLocationsOrDefinitionLinksOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -23275,11 +23511,15 @@ func (o FoldingRangesOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*FoldingRangesOrNull)(nil)
+var _ json.UnmarshalerFrom = (*FoldingRangesOrNull)(nil)
 
-func (o *FoldingRangesOrNull) UnmarshalJSON(data []byte) error {
+func (o *FoldingRangesOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = FoldingRangesOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -23317,11 +23557,15 @@ func (o LocationOrLocationsOrDeclarationLinksOrNull) MarshalJSONTo(enc *jsontext
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*LocationOrLocationsOrDeclarationLinksOrNull)(nil)
+var _ json.UnmarshalerFrom = (*LocationOrLocationsOrDeclarationLinksOrNull)(nil)
 
-func (o *LocationOrLocationsOrDeclarationLinksOrNull) UnmarshalJSON(data []byte) error {
+func (o *LocationOrLocationsOrDeclarationLinksOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = LocationOrLocationsOrDeclarationLinksOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -23361,11 +23605,15 @@ func (o SelectionRangesOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*SelectionRangesOrNull)(nil)
+var _ json.UnmarshalerFrom = (*SelectionRangesOrNull)(nil)
 
-func (o *SelectionRangesOrNull) UnmarshalJSON(data []byte) error {
+func (o *SelectionRangesOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = SelectionRangesOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -23395,11 +23643,15 @@ func (o CallHierarchyItemsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*CallHierarchyItemsOrNull)(nil)
+var _ json.UnmarshalerFrom = (*CallHierarchyItemsOrNull)(nil)
 
-func (o *CallHierarchyItemsOrNull) UnmarshalJSON(data []byte) error {
+func (o *CallHierarchyItemsOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = CallHierarchyItemsOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -23429,11 +23681,15 @@ func (o CallHierarchyIncomingCallsOrNull) MarshalJSONTo(enc *jsontext.Encoder) e
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*CallHierarchyIncomingCallsOrNull)(nil)
+var _ json.UnmarshalerFrom = (*CallHierarchyIncomingCallsOrNull)(nil)
 
-func (o *CallHierarchyIncomingCallsOrNull) UnmarshalJSON(data []byte) error {
+func (o *CallHierarchyIncomingCallsOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = CallHierarchyIncomingCallsOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -23463,11 +23719,15 @@ func (o CallHierarchyOutgoingCallsOrNull) MarshalJSONTo(enc *jsontext.Encoder) e
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*CallHierarchyOutgoingCallsOrNull)(nil)
+var _ json.UnmarshalerFrom = (*CallHierarchyOutgoingCallsOrNull)(nil)
 
-func (o *CallHierarchyOutgoingCallsOrNull) UnmarshalJSON(data []byte) error {
+func (o *CallHierarchyOutgoingCallsOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = CallHierarchyOutgoingCallsOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -23497,11 +23757,15 @@ func (o SemanticTokensOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*SemanticTokensOrNull)(nil)
+var _ json.UnmarshalerFrom = (*SemanticTokensOrNull)(nil)
 
-func (o *SemanticTokensOrNull) UnmarshalJSON(data []byte) error {
+func (o *SemanticTokensOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = SemanticTokensOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -23535,11 +23799,15 @@ func (o SemanticTokensOrSemanticTokensDeltaOrNull) MarshalJSONTo(enc *jsontext.E
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*SemanticTokensOrSemanticTokensDeltaOrNull)(nil)
+var _ json.UnmarshalerFrom = (*SemanticTokensOrSemanticTokensDeltaOrNull)(nil)
 
-func (o *SemanticTokensOrSemanticTokensDeltaOrNull) UnmarshalJSON(data []byte) error {
+func (o *SemanticTokensOrSemanticTokensDeltaOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = SemanticTokensOrSemanticTokensDeltaOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -23574,11 +23842,15 @@ func (o LinkedEditingRangesOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*LinkedEditingRangesOrNull)(nil)
+var _ json.UnmarshalerFrom = (*LinkedEditingRangesOrNull)(nil)
 
-func (o *LinkedEditingRangesOrNull) UnmarshalJSON(data []byte) error {
+func (o *LinkedEditingRangesOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = LinkedEditingRangesOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -23608,11 +23880,15 @@ func (o WorkspaceEditOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*WorkspaceEditOrNull)(nil)
+var _ json.UnmarshalerFrom = (*WorkspaceEditOrNull)(nil)
 
-func (o *WorkspaceEditOrNull) UnmarshalJSON(data []byte) error {
+func (o *WorkspaceEditOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = WorkspaceEditOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -23642,11 +23918,15 @@ func (o MonikersOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*MonikersOrNull)(nil)
+var _ json.UnmarshalerFrom = (*MonikersOrNull)(nil)
 
-func (o *MonikersOrNull) UnmarshalJSON(data []byte) error {
+func (o *MonikersOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = MonikersOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -23676,11 +23956,15 @@ func (o TypeHierarchyItemsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*TypeHierarchyItemsOrNull)(nil)
+var _ json.UnmarshalerFrom = (*TypeHierarchyItemsOrNull)(nil)
 
-func (o *TypeHierarchyItemsOrNull) UnmarshalJSON(data []byte) error {
+func (o *TypeHierarchyItemsOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = TypeHierarchyItemsOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -23710,11 +23994,15 @@ func (o InlineValuesOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*InlineValuesOrNull)(nil)
+var _ json.UnmarshalerFrom = (*InlineValuesOrNull)(nil)
 
-func (o *InlineValuesOrNull) UnmarshalJSON(data []byte) error {
+func (o *InlineValuesOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = InlineValuesOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -23744,11 +24032,15 @@ func (o InlayHintsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*InlayHintsOrNull)(nil)
+var _ json.UnmarshalerFrom = (*InlayHintsOrNull)(nil)
 
-func (o *InlayHintsOrNull) UnmarshalJSON(data []byte) error {
+func (o *InlayHintsOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = InlayHintsOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -23781,11 +24073,15 @@ func (o RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) 
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport)(nil)
+var _ json.UnmarshalerFrom = (*RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport)(nil)
 
-func (o *RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) UnmarshalJSON(data []byte) error {
+func (o *RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vFullDocumentDiagnosticReport RelatedFullDocumentDiagnosticReport
 	if err := json.Unmarshal(data, &vFullDocumentDiagnosticReport); err == nil {
 		o.FullDocumentDiagnosticReport = &vFullDocumentDiagnosticReport
@@ -23819,11 +24115,15 @@ func (o InlineCompletionListOrItemsOrNull) MarshalJSONTo(enc *jsontext.Encoder) 
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*InlineCompletionListOrItemsOrNull)(nil)
+var _ json.UnmarshalerFrom = (*InlineCompletionListOrItemsOrNull)(nil)
 
-func (o *InlineCompletionListOrItemsOrNull) UnmarshalJSON(data []byte) error {
+func (o *InlineCompletionListOrItemsOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = InlineCompletionListOrItemsOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -23858,11 +24158,15 @@ func (o MessageActionItemOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*MessageActionItemOrNull)(nil)
+var _ json.UnmarshalerFrom = (*MessageActionItemOrNull)(nil)
 
-func (o *MessageActionItemOrNull) UnmarshalJSON(data []byte) error {
+func (o *MessageActionItemOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = MessageActionItemOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -23892,11 +24196,15 @@ func (o TextEditsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*TextEditsOrNull)(nil)
+var _ json.UnmarshalerFrom = (*TextEditsOrNull)(nil)
 
-func (o *TextEditsOrNull) UnmarshalJSON(data []byte) error {
+func (o *TextEditsOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = TextEditsOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -23930,11 +24238,15 @@ func (o CompletionItemsOrListOrNull) MarshalJSONTo(enc *jsontext.Encoder) error 
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*CompletionItemsOrListOrNull)(nil)
+var _ json.UnmarshalerFrom = (*CompletionItemsOrListOrNull)(nil)
 
-func (o *CompletionItemsOrListOrNull) UnmarshalJSON(data []byte) error {
+func (o *CompletionItemsOrListOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = CompletionItemsOrListOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -23969,11 +24281,15 @@ func (o HoverOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*HoverOrNull)(nil)
+var _ json.UnmarshalerFrom = (*HoverOrNull)(nil)
 
-func (o *HoverOrNull) UnmarshalJSON(data []byte) error {
+func (o *HoverOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = HoverOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -24003,11 +24319,15 @@ func (o SignatureHelpOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*SignatureHelpOrNull)(nil)
+var _ json.UnmarshalerFrom = (*SignatureHelpOrNull)(nil)
 
-func (o *SignatureHelpOrNull) UnmarshalJSON(data []byte) error {
+func (o *SignatureHelpOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = SignatureHelpOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -24037,11 +24357,15 @@ func (o LocationsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*LocationsOrNull)(nil)
+var _ json.UnmarshalerFrom = (*LocationsOrNull)(nil)
 
-func (o *LocationsOrNull) UnmarshalJSON(data []byte) error {
+func (o *LocationsOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = LocationsOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -24071,11 +24395,15 @@ func (o DocumentHighlightsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*DocumentHighlightsOrNull)(nil)
+var _ json.UnmarshalerFrom = (*DocumentHighlightsOrNull)(nil)
 
-func (o *DocumentHighlightsOrNull) UnmarshalJSON(data []byte) error {
+func (o *DocumentHighlightsOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = DocumentHighlightsOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -24109,11 +24437,15 @@ func (o SymbolInformationsOrDocumentSymbolsOrNull) MarshalJSONTo(enc *jsontext.E
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*SymbolInformationsOrDocumentSymbolsOrNull)(nil)
+var _ json.UnmarshalerFrom = (*SymbolInformationsOrDocumentSymbolsOrNull)(nil)
 
-func (o *SymbolInformationsOrDocumentSymbolsOrNull) UnmarshalJSON(data []byte) error {
+func (o *SymbolInformationsOrDocumentSymbolsOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = SymbolInformationsOrDocumentSymbolsOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -24151,11 +24483,15 @@ func (o CommandOrCodeAction) MarshalJSONTo(enc *jsontext.Encoder) error {
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*CommandOrCodeAction)(nil)
+var _ json.UnmarshalerFrom = (*CommandOrCodeAction)(nil)
 
-func (o *CommandOrCodeAction) UnmarshalJSON(data []byte) error {
+func (o *CommandOrCodeAction) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = CommandOrCodeAction{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vCommand Command
 	if err := json.Unmarshal(data, &vCommand); err == nil {
 		o.Command = &vCommand
@@ -24185,11 +24521,15 @@ func (o CommandOrCodeActionArrayOrNull) MarshalJSONTo(enc *jsontext.Encoder) err
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*CommandOrCodeActionArrayOrNull)(nil)
+var _ json.UnmarshalerFrom = (*CommandOrCodeActionArrayOrNull)(nil)
 
-func (o *CommandOrCodeActionArrayOrNull) UnmarshalJSON(data []byte) error {
+func (o *CommandOrCodeActionArrayOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = CommandOrCodeActionArrayOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -24223,11 +24563,15 @@ func (o SymbolInformationsOrWorkspaceSymbolsOrNull) MarshalJSONTo(enc *jsontext.
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*SymbolInformationsOrWorkspaceSymbolsOrNull)(nil)
+var _ json.UnmarshalerFrom = (*SymbolInformationsOrWorkspaceSymbolsOrNull)(nil)
 
-func (o *SymbolInformationsOrWorkspaceSymbolsOrNull) UnmarshalJSON(data []byte) error {
+func (o *SymbolInformationsOrWorkspaceSymbolsOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = SymbolInformationsOrWorkspaceSymbolsOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -24262,11 +24606,15 @@ func (o CodeLenssOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*CodeLenssOrNull)(nil)
+var _ json.UnmarshalerFrom = (*CodeLenssOrNull)(nil)
 
-func (o *CodeLenssOrNull) UnmarshalJSON(data []byte) error {
+func (o *CodeLenssOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = CodeLenssOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -24296,11 +24644,15 @@ func (o DocumentLinksOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*DocumentLinksOrNull)(nil)
+var _ json.UnmarshalerFrom = (*DocumentLinksOrNull)(nil)
 
-func (o *DocumentLinksOrNull) UnmarshalJSON(data []byte) error {
+func (o *DocumentLinksOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = DocumentLinksOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -24338,11 +24690,15 @@ func (o RangeOrPrepareRenamePlaceholderOrPrepareRenameDefaultBehaviorOrNull) Mar
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*RangeOrPrepareRenamePlaceholderOrPrepareRenameDefaultBehaviorOrNull)(nil)
+var _ json.UnmarshalerFrom = (*RangeOrPrepareRenamePlaceholderOrPrepareRenameDefaultBehaviorOrNull)(nil)
 
-func (o *RangeOrPrepareRenamePlaceholderOrPrepareRenameDefaultBehaviorOrNull) UnmarshalJSON(data []byte) error {
+func (o *RangeOrPrepareRenamePlaceholderOrPrepareRenameDefaultBehaviorOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = RangeOrPrepareRenamePlaceholderOrPrepareRenameDefaultBehaviorOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -24382,11 +24738,15 @@ func (o LSPAnyOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteToken(jsontext.Null)
 }
 
-var _ json.Unmarshaler = (*LSPAnyOrNull)(nil)
+var _ json.UnmarshalerFrom = (*LSPAnyOrNull)(nil)
 
-func (o *LSPAnyOrNull) UnmarshalJSON(data []byte) error {
+func (o *LSPAnyOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = LSPAnyOrNull{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	// Handle null case
 	if string(data) == "null" {
 		return nil
@@ -24427,11 +24787,15 @@ func (o TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilter
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPatternOrNotebookCellTextDocumentFilter)(nil)
+var _ json.UnmarshalerFrom = (*TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPatternOrNotebookCellTextDocumentFilter)(nil)
 
-func (o *TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPatternOrNotebookCellTextDocumentFilter) UnmarshalJSON(data []byte) error {
+func (o *TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPatternOrNotebookCellTextDocumentFilter) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPatternOrNotebookCellTextDocumentFilter{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vTextDocumentFilterLanguage TextDocumentFilterLanguage
 	if err := json.Unmarshal(data, &vTextDocumentFilterLanguage); err == nil {
 		o.TextDocumentFilterLanguage = &vTextDocumentFilterLanguage
@@ -24474,11 +24838,15 @@ func (o StringOrMarkedStringWithLanguage) MarshalJSONTo(enc *jsontext.Encoder) e
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*StringOrMarkedStringWithLanguage)(nil)
+var _ json.UnmarshalerFrom = (*StringOrMarkedStringWithLanguage)(nil)
 
-func (o *StringOrMarkedStringWithLanguage) UnmarshalJSON(data []byte) error {
+func (o *StringOrMarkedStringWithLanguage) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = StringOrMarkedStringWithLanguage{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vString string
 	if err := json.Unmarshal(data, &vString); err == nil {
 		o.String = &vString
@@ -24515,11 +24883,15 @@ func (o InlineValueTextOrVariableLookupOrEvaluatableExpression) MarshalJSONTo(en
 	panic("unreachable")
 }
 
-var _ json.Unmarshaler = (*InlineValueTextOrVariableLookupOrEvaluatableExpression)(nil)
+var _ json.UnmarshalerFrom = (*InlineValueTextOrVariableLookupOrEvaluatableExpression)(nil)
 
-func (o *InlineValueTextOrVariableLookupOrEvaluatableExpression) UnmarshalJSON(data []byte) error {
+func (o *InlineValueTextOrVariableLookupOrEvaluatableExpression) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	*o = InlineValueTextOrVariableLookupOrEvaluatableExpression{}
 
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
 	var vText InlineValueText
 	if err := json.Unmarshal(data, &vText); err == nil {
 		o.Text = &vText

--- a/internal/lsp/lsproto/lsp_generated.go
+++ b/internal/lsp/lsproto/lsp_generated.go
@@ -23639,9 +23639,13 @@ func (o StringLiteralBegin) MarshalerTo(enc *jsontext.Encoder) error {
 	return enc.WriteValue(jsontext.Value(`"begin"`))
 }
 
-func (o *StringLiteralBegin) UnmarshalJSON(data []byte) error {
-	if string(data) != `"begin"` {
-		return fmt.Errorf("invalid StringLiteralBegin: %s", data)
+func (o *StringLiteralBegin) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	v, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
+	if string(v) != `"begin"` {
+		return fmt.Errorf("expected StringLiteralBegin value %s, got %s", `"begin"`, v)
 	}
 	return nil
 }
@@ -23653,9 +23657,13 @@ func (o StringLiteralReport) MarshalerTo(enc *jsontext.Encoder) error {
 	return enc.WriteValue(jsontext.Value(`"report"`))
 }
 
-func (o *StringLiteralReport) UnmarshalJSON(data []byte) error {
-	if string(data) != `"report"` {
-		return fmt.Errorf("invalid StringLiteralReport: %s", data)
+func (o *StringLiteralReport) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	v, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
+	if string(v) != `"report"` {
+		return fmt.Errorf("expected StringLiteralReport value %s, got %s", `"report"`, v)
 	}
 	return nil
 }
@@ -23667,9 +23675,13 @@ func (o StringLiteralEnd) MarshalerTo(enc *jsontext.Encoder) error {
 	return enc.WriteValue(jsontext.Value(`"end"`))
 }
 
-func (o *StringLiteralEnd) UnmarshalJSON(data []byte) error {
-	if string(data) != `"end"` {
-		return fmt.Errorf("invalid StringLiteralEnd: %s", data)
+func (o *StringLiteralEnd) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	v, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
+	if string(v) != `"end"` {
+		return fmt.Errorf("expected StringLiteralEnd value %s, got %s", `"end"`, v)
 	}
 	return nil
 }
@@ -23681,9 +23693,13 @@ func (o StringLiteralCreate) MarshalerTo(enc *jsontext.Encoder) error {
 	return enc.WriteValue(jsontext.Value(`"create"`))
 }
 
-func (o *StringLiteralCreate) UnmarshalJSON(data []byte) error {
-	if string(data) != `"create"` {
-		return fmt.Errorf("invalid StringLiteralCreate: %s", data)
+func (o *StringLiteralCreate) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	v, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
+	if string(v) != `"create"` {
+		return fmt.Errorf("expected StringLiteralCreate value %s, got %s", `"create"`, v)
 	}
 	return nil
 }
@@ -23695,9 +23711,13 @@ func (o StringLiteralRename) MarshalerTo(enc *jsontext.Encoder) error {
 	return enc.WriteValue(jsontext.Value(`"rename"`))
 }
 
-func (o *StringLiteralRename) UnmarshalJSON(data []byte) error {
-	if string(data) != `"rename"` {
-		return fmt.Errorf("invalid StringLiteralRename: %s", data)
+func (o *StringLiteralRename) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	v, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
+	if string(v) != `"rename"` {
+		return fmt.Errorf("expected StringLiteralRename value %s, got %s", `"rename"`, v)
 	}
 	return nil
 }
@@ -23709,9 +23729,13 @@ func (o StringLiteralDelete) MarshalerTo(enc *jsontext.Encoder) error {
 	return enc.WriteValue(jsontext.Value(`"delete"`))
 }
 
-func (o *StringLiteralDelete) UnmarshalJSON(data []byte) error {
-	if string(data) != `"delete"` {
-		return fmt.Errorf("invalid StringLiteralDelete: %s", data)
+func (o *StringLiteralDelete) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	v, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
+	if string(v) != `"delete"` {
+		return fmt.Errorf("expected StringLiteralDelete value %s, got %s", `"delete"`, v)
 	}
 	return nil
 }
@@ -23723,9 +23747,13 @@ func (o StringLiteralFull) MarshalerTo(enc *jsontext.Encoder) error {
 	return enc.WriteValue(jsontext.Value(`"full"`))
 }
 
-func (o *StringLiteralFull) UnmarshalJSON(data []byte) error {
-	if string(data) != `"full"` {
-		return fmt.Errorf("invalid StringLiteralFull: %s", data)
+func (o *StringLiteralFull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	v, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
+	if string(v) != `"full"` {
+		return fmt.Errorf("expected StringLiteralFull value %s, got %s", `"full"`, v)
 	}
 	return nil
 }
@@ -23737,9 +23765,13 @@ func (o StringLiteralUnchanged) MarshalerTo(enc *jsontext.Encoder) error {
 	return enc.WriteValue(jsontext.Value(`"unchanged"`))
 }
 
-func (o *StringLiteralUnchanged) UnmarshalJSON(data []byte) error {
-	if string(data) != `"unchanged"` {
-		return fmt.Errorf("invalid StringLiteralUnchanged: %s", data)
+func (o *StringLiteralUnchanged) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	v, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
+	if string(v) != `"unchanged"` {
+		return fmt.Errorf("expected StringLiteralUnchanged value %s, got %s", `"unchanged"`, v)
 	}
 	return nil
 }
@@ -23751,9 +23783,13 @@ func (o StringLiteralSnippet) MarshalerTo(enc *jsontext.Encoder) error {
 	return enc.WriteValue(jsontext.Value(`"snippet"`))
 }
 
-func (o *StringLiteralSnippet) UnmarshalJSON(data []byte) error {
-	if string(data) != `"snippet"` {
-		return fmt.Errorf("invalid StringLiteralSnippet: %s", data)
+func (o *StringLiteralSnippet) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	v, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
+	if string(v) != `"snippet"` {
+		return fmt.Errorf("expected StringLiteralSnippet value %s, got %s", `"snippet"`, v)
 	}
 	return nil
 }

--- a/internal/lsp/lsproto/lsp_generated.go
+++ b/internal/lsp/lsproto/lsp_generated.go
@@ -21449,16 +21449,16 @@ type IntegerOrString struct {
 	String  *string
 }
 
-var _ json.MarshalerTo = IntegerOrString{}
+var _ json.MarshalerTo = (*IntegerOrString)(nil)
 
-func (o IntegerOrString) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *IntegerOrString) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of IntegerOrString should be set", o.Integer != nil, o.String != nil)
 
 	if o.Integer != nil {
-		return json.MarshalEncode(enc, *o.Integer)
+		return json.MarshalEncode(enc, o.Integer)
 	}
 	if o.String != nil {
-		return json.MarshalEncode(enc, *o.String)
+		return json.MarshalEncode(enc, o.String)
 	}
 	panic("unreachable")
 }
@@ -21489,13 +21489,13 @@ type DocumentSelectorOrNull struct {
 	DocumentSelector *[]TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPatternOrNotebookCellTextDocumentFilter
 }
 
-var _ json.MarshalerTo = DocumentSelectorOrNull{}
+var _ json.MarshalerTo = (*DocumentSelectorOrNull)(nil)
 
-func (o DocumentSelectorOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *DocumentSelectorOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of DocumentSelectorOrNull is set", o.DocumentSelector != nil)
 
 	if o.DocumentSelector != nil {
-		return json.MarshalEncode(enc, *o.DocumentSelector)
+		return json.MarshalEncode(enc, o.DocumentSelector)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -21526,16 +21526,16 @@ type BooleanOrEmptyObject struct {
 	EmptyObject *struct{}
 }
 
-var _ json.MarshalerTo = BooleanOrEmptyObject{}
+var _ json.MarshalerTo = (*BooleanOrEmptyObject)(nil)
 
-func (o BooleanOrEmptyObject) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *BooleanOrEmptyObject) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrEmptyObject should be set", o.Boolean != nil, o.EmptyObject != nil)
 
 	if o.Boolean != nil {
-		return json.MarshalEncode(enc, *o.Boolean)
+		return json.MarshalEncode(enc, o.Boolean)
 	}
 	if o.EmptyObject != nil {
-		return json.MarshalEncode(enc, *o.EmptyObject)
+		return json.MarshalEncode(enc, o.EmptyObject)
 	}
 	panic("unreachable")
 }
@@ -21567,16 +21567,16 @@ type BooleanOrSemanticTokensFullDelta struct {
 	SemanticTokensFullDelta *SemanticTokensFullDelta
 }
 
-var _ json.MarshalerTo = BooleanOrSemanticTokensFullDelta{}
+var _ json.MarshalerTo = (*BooleanOrSemanticTokensFullDelta)(nil)
 
-func (o BooleanOrSemanticTokensFullDelta) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *BooleanOrSemanticTokensFullDelta) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrSemanticTokensFullDelta should be set", o.Boolean != nil, o.SemanticTokensFullDelta != nil)
 
 	if o.Boolean != nil {
-		return json.MarshalEncode(enc, *o.Boolean)
+		return json.MarshalEncode(enc, o.Boolean)
 	}
 	if o.SemanticTokensFullDelta != nil {
-		return json.MarshalEncode(enc, *o.SemanticTokensFullDelta)
+		return json.MarshalEncode(enc, o.SemanticTokensFullDelta)
 	}
 	panic("unreachable")
 }
@@ -21610,22 +21610,22 @@ type TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile struct {
 	DeleteFile       *DeleteFile
 }
 
-var _ json.MarshalerTo = TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile{}
+var _ json.MarshalerTo = (*TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile)(nil)
 
-func (o TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile should be set", o.TextDocumentEdit != nil, o.CreateFile != nil, o.RenameFile != nil, o.DeleteFile != nil)
 
 	if o.TextDocumentEdit != nil {
-		return json.MarshalEncode(enc, *o.TextDocumentEdit)
+		return json.MarshalEncode(enc, o.TextDocumentEdit)
 	}
 	if o.CreateFile != nil {
-		return json.MarshalEncode(enc, *o.CreateFile)
+		return json.MarshalEncode(enc, o.CreateFile)
 	}
 	if o.RenameFile != nil {
-		return json.MarshalEncode(enc, *o.RenameFile)
+		return json.MarshalEncode(enc, o.RenameFile)
 	}
 	if o.DeleteFile != nil {
-		return json.MarshalEncode(enc, *o.DeleteFile)
+		return json.MarshalEncode(enc, o.DeleteFile)
 	}
 	panic("unreachable")
 }
@@ -21667,16 +21667,16 @@ type StringOrInlayHintLabelParts struct {
 	InlayHintLabelParts *[]*InlayHintLabelPart
 }
 
-var _ json.MarshalerTo = StringOrInlayHintLabelParts{}
+var _ json.MarshalerTo = (*StringOrInlayHintLabelParts)(nil)
 
-func (o StringOrInlayHintLabelParts) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *StringOrInlayHintLabelParts) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of StringOrInlayHintLabelParts should be set", o.String != nil, o.InlayHintLabelParts != nil)
 
 	if o.String != nil {
-		return json.MarshalEncode(enc, *o.String)
+		return json.MarshalEncode(enc, o.String)
 	}
 	if o.InlayHintLabelParts != nil {
-		return json.MarshalEncode(enc, *o.InlayHintLabelParts)
+		return json.MarshalEncode(enc, o.InlayHintLabelParts)
 	}
 	panic("unreachable")
 }
@@ -21708,16 +21708,16 @@ type StringOrMarkupContent struct {
 	MarkupContent *MarkupContent
 }
 
-var _ json.MarshalerTo = StringOrMarkupContent{}
+var _ json.MarshalerTo = (*StringOrMarkupContent)(nil)
 
-func (o StringOrMarkupContent) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *StringOrMarkupContent) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of StringOrMarkupContent should be set", o.String != nil, o.MarkupContent != nil)
 
 	if o.String != nil {
-		return json.MarshalEncode(enc, *o.String)
+		return json.MarshalEncode(enc, o.String)
 	}
 	if o.MarkupContent != nil {
-		return json.MarshalEncode(enc, *o.MarkupContent)
+		return json.MarshalEncode(enc, o.MarkupContent)
 	}
 	panic("unreachable")
 }
@@ -21749,16 +21749,16 @@ type FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport struct {
 	UnchangedDocumentDiagnosticReport *UnchangedDocumentDiagnosticReport
 }
 
-var _ json.MarshalerTo = FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport{}
+var _ json.MarshalerTo = (*FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport)(nil)
 
-func (o FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport should be set", o.FullDocumentDiagnosticReport != nil, o.UnchangedDocumentDiagnosticReport != nil)
 
 	if o.FullDocumentDiagnosticReport != nil {
-		return json.MarshalEncode(enc, *o.FullDocumentDiagnosticReport)
+		return json.MarshalEncode(enc, o.FullDocumentDiagnosticReport)
 	}
 	if o.UnchangedDocumentDiagnosticReport != nil {
-		return json.MarshalEncode(enc, *o.UnchangedDocumentDiagnosticReport)
+		return json.MarshalEncode(enc, o.UnchangedDocumentDiagnosticReport)
 	}
 	panic("unreachable")
 }
@@ -21790,16 +21790,16 @@ type WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport st
 	UnchangedDocumentDiagnosticReport *WorkspaceUnchangedDocumentDiagnosticReport
 }
 
-var _ json.MarshalerTo = WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport{}
+var _ json.MarshalerTo = (*WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport)(nil)
 
-func (o WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport should be set", o.FullDocumentDiagnosticReport != nil, o.UnchangedDocumentDiagnosticReport != nil)
 
 	if o.FullDocumentDiagnosticReport != nil {
-		return json.MarshalEncode(enc, *o.FullDocumentDiagnosticReport)
+		return json.MarshalEncode(enc, o.FullDocumentDiagnosticReport)
 	}
 	if o.UnchangedDocumentDiagnosticReport != nil {
-		return json.MarshalEncode(enc, *o.UnchangedDocumentDiagnosticReport)
+		return json.MarshalEncode(enc, o.UnchangedDocumentDiagnosticReport)
 	}
 	panic("unreachable")
 }
@@ -21831,16 +21831,16 @@ type NotebookDocumentFilterWithNotebookOrCells struct {
 	Cells    *NotebookDocumentFilterWithCells
 }
 
-var _ json.MarshalerTo = NotebookDocumentFilterWithNotebookOrCells{}
+var _ json.MarshalerTo = (*NotebookDocumentFilterWithNotebookOrCells)(nil)
 
-func (o NotebookDocumentFilterWithNotebookOrCells) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *NotebookDocumentFilterWithNotebookOrCells) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of NotebookDocumentFilterWithNotebookOrCells should be set", o.Notebook != nil, o.Cells != nil)
 
 	if o.Notebook != nil {
-		return json.MarshalEncode(enc, *o.Notebook)
+		return json.MarshalEncode(enc, o.Notebook)
 	}
 	if o.Cells != nil {
-		return json.MarshalEncode(enc, *o.Cells)
+		return json.MarshalEncode(enc, o.Cells)
 	}
 	panic("unreachable")
 }
@@ -21872,16 +21872,16 @@ type StringOrStringValue struct {
 	StringValue *StringValue
 }
 
-var _ json.MarshalerTo = StringOrStringValue{}
+var _ json.MarshalerTo = (*StringOrStringValue)(nil)
 
-func (o StringOrStringValue) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *StringOrStringValue) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of StringOrStringValue should be set", o.String != nil, o.StringValue != nil)
 
 	if o.String != nil {
-		return json.MarshalEncode(enc, *o.String)
+		return json.MarshalEncode(enc, o.String)
 	}
 	if o.StringValue != nil {
-		return json.MarshalEncode(enc, *o.StringValue)
+		return json.MarshalEncode(enc, o.StringValue)
 	}
 	panic("unreachable")
 }
@@ -21912,13 +21912,13 @@ type IntegerOrNull struct {
 	Integer *int32
 }
 
-var _ json.MarshalerTo = IntegerOrNull{}
+var _ json.MarshalerTo = (*IntegerOrNull)(nil)
 
-func (o IntegerOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *IntegerOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of IntegerOrNull is set", o.Integer != nil)
 
 	if o.Integer != nil {
-		return json.MarshalEncode(enc, *o.Integer)
+		return json.MarshalEncode(enc, o.Integer)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -21948,13 +21948,13 @@ type StringOrNull struct {
 	String *string
 }
 
-var _ json.MarshalerTo = StringOrNull{}
+var _ json.MarshalerTo = (*StringOrNull)(nil)
 
-func (o StringOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *StringOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of StringOrNull is set", o.String != nil)
 
 	if o.String != nil {
-		return json.MarshalEncode(enc, *o.String)
+		return json.MarshalEncode(enc, o.String)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -21984,13 +21984,13 @@ type DocumentUriOrNull struct {
 	DocumentUri *DocumentUri
 }
 
-var _ json.MarshalerTo = DocumentUriOrNull{}
+var _ json.MarshalerTo = (*DocumentUriOrNull)(nil)
 
-func (o DocumentUriOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *DocumentUriOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of DocumentUriOrNull is set", o.DocumentUri != nil)
 
 	if o.DocumentUri != nil {
-		return json.MarshalEncode(enc, *o.DocumentUri)
+		return json.MarshalEncode(enc, o.DocumentUri)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -22020,13 +22020,13 @@ type WorkspaceFoldersOrNull struct {
 	WorkspaceFolders *[]*WorkspaceFolder
 }
 
-var _ json.MarshalerTo = WorkspaceFoldersOrNull{}
+var _ json.MarshalerTo = (*WorkspaceFoldersOrNull)(nil)
 
-func (o WorkspaceFoldersOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *WorkspaceFoldersOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of WorkspaceFoldersOrNull is set", o.WorkspaceFolders != nil)
 
 	if o.WorkspaceFolders != nil {
-		return json.MarshalEncode(enc, *o.WorkspaceFolders)
+		return json.MarshalEncode(enc, o.WorkspaceFolders)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -22057,16 +22057,16 @@ type StringOrStrings struct {
 	Strings *[]string
 }
 
-var _ json.MarshalerTo = StringOrStrings{}
+var _ json.MarshalerTo = (*StringOrStrings)(nil)
 
-func (o StringOrStrings) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *StringOrStrings) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of StringOrStrings should be set", o.String != nil, o.Strings != nil)
 
 	if o.String != nil {
-		return json.MarshalEncode(enc, *o.String)
+		return json.MarshalEncode(enc, o.String)
 	}
 	if o.Strings != nil {
-		return json.MarshalEncode(enc, *o.Strings)
+		return json.MarshalEncode(enc, o.Strings)
 	}
 	panic("unreachable")
 }
@@ -22098,16 +22098,16 @@ type TextDocumentContentChangePartialOrWholeDocument struct {
 	WholeDocument *TextDocumentContentChangeWholeDocument
 }
 
-var _ json.MarshalerTo = TextDocumentContentChangePartialOrWholeDocument{}
+var _ json.MarshalerTo = (*TextDocumentContentChangePartialOrWholeDocument)(nil)
 
-func (o TextDocumentContentChangePartialOrWholeDocument) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *TextDocumentContentChangePartialOrWholeDocument) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of TextDocumentContentChangePartialOrWholeDocument should be set", o.Partial != nil, o.WholeDocument != nil)
 
 	if o.Partial != nil {
-		return json.MarshalEncode(enc, *o.Partial)
+		return json.MarshalEncode(enc, o.Partial)
 	}
 	if o.WholeDocument != nil {
-		return json.MarshalEncode(enc, *o.WholeDocument)
+		return json.MarshalEncode(enc, o.WholeDocument)
 	}
 	panic("unreachable")
 }
@@ -22139,16 +22139,16 @@ type TextEditOrInsertReplaceEdit struct {
 	InsertReplaceEdit *InsertReplaceEdit
 }
 
-var _ json.MarshalerTo = TextEditOrInsertReplaceEdit{}
+var _ json.MarshalerTo = (*TextEditOrInsertReplaceEdit)(nil)
 
-func (o TextEditOrInsertReplaceEdit) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *TextEditOrInsertReplaceEdit) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of TextEditOrInsertReplaceEdit should be set", o.TextEdit != nil, o.InsertReplaceEdit != nil)
 
 	if o.TextEdit != nil {
-		return json.MarshalEncode(enc, *o.TextEdit)
+		return json.MarshalEncode(enc, o.TextEdit)
 	}
 	if o.InsertReplaceEdit != nil {
-		return json.MarshalEncode(enc, *o.InsertReplaceEdit)
+		return json.MarshalEncode(enc, o.InsertReplaceEdit)
 	}
 	panic("unreachable")
 }
@@ -22182,22 +22182,22 @@ type MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings struct {
 	MarkedStrings            *[]StringOrMarkedStringWithLanguage
 }
 
-var _ json.MarshalerTo = MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings{}
+var _ json.MarshalerTo = (*MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings)(nil)
 
-func (o MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings should be set", o.MarkupContent != nil, o.String != nil, o.MarkedStringWithLanguage != nil, o.MarkedStrings != nil)
 
 	if o.MarkupContent != nil {
-		return json.MarshalEncode(enc, *o.MarkupContent)
+		return json.MarshalEncode(enc, o.MarkupContent)
 	}
 	if o.String != nil {
-		return json.MarshalEncode(enc, *o.String)
+		return json.MarshalEncode(enc, o.String)
 	}
 	if o.MarkedStringWithLanguage != nil {
-		return json.MarshalEncode(enc, *o.MarkedStringWithLanguage)
+		return json.MarshalEncode(enc, o.MarkedStringWithLanguage)
 	}
 	if o.MarkedStrings != nil {
-		return json.MarshalEncode(enc, *o.MarkedStrings)
+		return json.MarshalEncode(enc, o.MarkedStrings)
 	}
 	panic("unreachable")
 }
@@ -22238,13 +22238,13 @@ type UintegerOrNull struct {
 	Uinteger *uint32
 }
 
-var _ json.MarshalerTo = UintegerOrNull{}
+var _ json.MarshalerTo = (*UintegerOrNull)(nil)
 
-func (o UintegerOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *UintegerOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of UintegerOrNull is set", o.Uinteger != nil)
 
 	if o.Uinteger != nil {
-		return json.MarshalEncode(enc, *o.Uinteger)
+		return json.MarshalEncode(enc, o.Uinteger)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -22275,16 +22275,16 @@ type LocationOrLocationUriOnly struct {
 	LocationUriOnly *LocationUriOnly
 }
 
-var _ json.MarshalerTo = LocationOrLocationUriOnly{}
+var _ json.MarshalerTo = (*LocationOrLocationUriOnly)(nil)
 
-func (o LocationOrLocationUriOnly) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *LocationOrLocationUriOnly) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of LocationOrLocationUriOnly should be set", o.Location != nil, o.LocationUriOnly != nil)
 
 	if o.Location != nil {
-		return json.MarshalEncode(enc, *o.Location)
+		return json.MarshalEncode(enc, o.Location)
 	}
 	if o.LocationUriOnly != nil {
-		return json.MarshalEncode(enc, *o.LocationUriOnly)
+		return json.MarshalEncode(enc, o.LocationUriOnly)
 	}
 	panic("unreachable")
 }
@@ -22317,19 +22317,19 @@ type TextEditOrAnnotatedTextEditOrSnippetTextEdit struct {
 	SnippetTextEdit   *SnippetTextEdit
 }
 
-var _ json.MarshalerTo = TextEditOrAnnotatedTextEditOrSnippetTextEdit{}
+var _ json.MarshalerTo = (*TextEditOrAnnotatedTextEditOrSnippetTextEdit)(nil)
 
-func (o TextEditOrAnnotatedTextEditOrSnippetTextEdit) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *TextEditOrAnnotatedTextEditOrSnippetTextEdit) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of TextEditOrAnnotatedTextEditOrSnippetTextEdit should be set", o.TextEdit != nil, o.AnnotatedTextEdit != nil, o.SnippetTextEdit != nil)
 
 	if o.TextEdit != nil {
-		return json.MarshalEncode(enc, *o.TextEdit)
+		return json.MarshalEncode(enc, o.TextEdit)
 	}
 	if o.AnnotatedTextEdit != nil {
-		return json.MarshalEncode(enc, *o.AnnotatedTextEdit)
+		return json.MarshalEncode(enc, o.AnnotatedTextEdit)
 	}
 	if o.SnippetTextEdit != nil {
-		return json.MarshalEncode(enc, *o.SnippetTextEdit)
+		return json.MarshalEncode(enc, o.SnippetTextEdit)
 	}
 	panic("unreachable")
 }
@@ -22366,16 +22366,16 @@ type TextDocumentSyncOptionsOrKind struct {
 	Kind    *TextDocumentSyncKind
 }
 
-var _ json.MarshalerTo = TextDocumentSyncOptionsOrKind{}
+var _ json.MarshalerTo = (*TextDocumentSyncOptionsOrKind)(nil)
 
-func (o TextDocumentSyncOptionsOrKind) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *TextDocumentSyncOptionsOrKind) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of TextDocumentSyncOptionsOrKind should be set", o.Options != nil, o.Kind != nil)
 
 	if o.Options != nil {
-		return json.MarshalEncode(enc, *o.Options)
+		return json.MarshalEncode(enc, o.Options)
 	}
 	if o.Kind != nil {
-		return json.MarshalEncode(enc, *o.Kind)
+		return json.MarshalEncode(enc, o.Kind)
 	}
 	panic("unreachable")
 }
@@ -22407,16 +22407,16 @@ type NotebookDocumentSyncOptionsOrRegistrationOptions struct {
 	RegistrationOptions *NotebookDocumentSyncRegistrationOptions
 }
 
-var _ json.MarshalerTo = NotebookDocumentSyncOptionsOrRegistrationOptions{}
+var _ json.MarshalerTo = (*NotebookDocumentSyncOptionsOrRegistrationOptions)(nil)
 
-func (o NotebookDocumentSyncOptionsOrRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *NotebookDocumentSyncOptionsOrRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of NotebookDocumentSyncOptionsOrRegistrationOptions should be set", o.Options != nil, o.RegistrationOptions != nil)
 
 	if o.Options != nil {
-		return json.MarshalEncode(enc, *o.Options)
+		return json.MarshalEncode(enc, o.Options)
 	}
 	if o.RegistrationOptions != nil {
-		return json.MarshalEncode(enc, *o.RegistrationOptions)
+		return json.MarshalEncode(enc, o.RegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -22448,16 +22448,16 @@ type BooleanOrHoverOptions struct {
 	HoverOptions *HoverOptions
 }
 
-var _ json.MarshalerTo = BooleanOrHoverOptions{}
+var _ json.MarshalerTo = (*BooleanOrHoverOptions)(nil)
 
-func (o BooleanOrHoverOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *BooleanOrHoverOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrHoverOptions should be set", o.Boolean != nil, o.HoverOptions != nil)
 
 	if o.Boolean != nil {
-		return json.MarshalEncode(enc, *o.Boolean)
+		return json.MarshalEncode(enc, o.Boolean)
 	}
 	if o.HoverOptions != nil {
-		return json.MarshalEncode(enc, *o.HoverOptions)
+		return json.MarshalEncode(enc, o.HoverOptions)
 	}
 	panic("unreachable")
 }
@@ -22490,19 +22490,19 @@ type BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions struct {
 	DeclarationRegistrationOptions *DeclarationRegistrationOptions
 }
 
-var _ json.MarshalerTo = BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions{}
+var _ json.MarshalerTo = (*BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions)(nil)
 
-func (o BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions should be set", o.Boolean != nil, o.DeclarationOptions != nil, o.DeclarationRegistrationOptions != nil)
 
 	if o.Boolean != nil {
-		return json.MarshalEncode(enc, *o.Boolean)
+		return json.MarshalEncode(enc, o.Boolean)
 	}
 	if o.DeclarationOptions != nil {
-		return json.MarshalEncode(enc, *o.DeclarationOptions)
+		return json.MarshalEncode(enc, o.DeclarationOptions)
 	}
 	if o.DeclarationRegistrationOptions != nil {
-		return json.MarshalEncode(enc, *o.DeclarationRegistrationOptions)
+		return json.MarshalEncode(enc, o.DeclarationRegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -22539,16 +22539,16 @@ type BooleanOrDefinitionOptions struct {
 	DefinitionOptions *DefinitionOptions
 }
 
-var _ json.MarshalerTo = BooleanOrDefinitionOptions{}
+var _ json.MarshalerTo = (*BooleanOrDefinitionOptions)(nil)
 
-func (o BooleanOrDefinitionOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *BooleanOrDefinitionOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrDefinitionOptions should be set", o.Boolean != nil, o.DefinitionOptions != nil)
 
 	if o.Boolean != nil {
-		return json.MarshalEncode(enc, *o.Boolean)
+		return json.MarshalEncode(enc, o.Boolean)
 	}
 	if o.DefinitionOptions != nil {
-		return json.MarshalEncode(enc, *o.DefinitionOptions)
+		return json.MarshalEncode(enc, o.DefinitionOptions)
 	}
 	panic("unreachable")
 }
@@ -22581,19 +22581,19 @@ type BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions struct {
 	TypeDefinitionRegistrationOptions *TypeDefinitionRegistrationOptions
 }
 
-var _ json.MarshalerTo = BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions{}
+var _ json.MarshalerTo = (*BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions)(nil)
 
-func (o BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions should be set", o.Boolean != nil, o.TypeDefinitionOptions != nil, o.TypeDefinitionRegistrationOptions != nil)
 
 	if o.Boolean != nil {
-		return json.MarshalEncode(enc, *o.Boolean)
+		return json.MarshalEncode(enc, o.Boolean)
 	}
 	if o.TypeDefinitionOptions != nil {
-		return json.MarshalEncode(enc, *o.TypeDefinitionOptions)
+		return json.MarshalEncode(enc, o.TypeDefinitionOptions)
 	}
 	if o.TypeDefinitionRegistrationOptions != nil {
-		return json.MarshalEncode(enc, *o.TypeDefinitionRegistrationOptions)
+		return json.MarshalEncode(enc, o.TypeDefinitionRegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -22631,19 +22631,19 @@ type BooleanOrImplementationOptionsOrImplementationRegistrationOptions struct {
 	ImplementationRegistrationOptions *ImplementationRegistrationOptions
 }
 
-var _ json.MarshalerTo = BooleanOrImplementationOptionsOrImplementationRegistrationOptions{}
+var _ json.MarshalerTo = (*BooleanOrImplementationOptionsOrImplementationRegistrationOptions)(nil)
 
-func (o BooleanOrImplementationOptionsOrImplementationRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *BooleanOrImplementationOptionsOrImplementationRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrImplementationOptionsOrImplementationRegistrationOptions should be set", o.Boolean != nil, o.ImplementationOptions != nil, o.ImplementationRegistrationOptions != nil)
 
 	if o.Boolean != nil {
-		return json.MarshalEncode(enc, *o.Boolean)
+		return json.MarshalEncode(enc, o.Boolean)
 	}
 	if o.ImplementationOptions != nil {
-		return json.MarshalEncode(enc, *o.ImplementationOptions)
+		return json.MarshalEncode(enc, o.ImplementationOptions)
 	}
 	if o.ImplementationRegistrationOptions != nil {
-		return json.MarshalEncode(enc, *o.ImplementationRegistrationOptions)
+		return json.MarshalEncode(enc, o.ImplementationRegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -22680,16 +22680,16 @@ type BooleanOrReferenceOptions struct {
 	ReferenceOptions *ReferenceOptions
 }
 
-var _ json.MarshalerTo = BooleanOrReferenceOptions{}
+var _ json.MarshalerTo = (*BooleanOrReferenceOptions)(nil)
 
-func (o BooleanOrReferenceOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *BooleanOrReferenceOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrReferenceOptions should be set", o.Boolean != nil, o.ReferenceOptions != nil)
 
 	if o.Boolean != nil {
-		return json.MarshalEncode(enc, *o.Boolean)
+		return json.MarshalEncode(enc, o.Boolean)
 	}
 	if o.ReferenceOptions != nil {
-		return json.MarshalEncode(enc, *o.ReferenceOptions)
+		return json.MarshalEncode(enc, o.ReferenceOptions)
 	}
 	panic("unreachable")
 }
@@ -22721,16 +22721,16 @@ type BooleanOrDocumentHighlightOptions struct {
 	DocumentHighlightOptions *DocumentHighlightOptions
 }
 
-var _ json.MarshalerTo = BooleanOrDocumentHighlightOptions{}
+var _ json.MarshalerTo = (*BooleanOrDocumentHighlightOptions)(nil)
 
-func (o BooleanOrDocumentHighlightOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *BooleanOrDocumentHighlightOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrDocumentHighlightOptions should be set", o.Boolean != nil, o.DocumentHighlightOptions != nil)
 
 	if o.Boolean != nil {
-		return json.MarshalEncode(enc, *o.Boolean)
+		return json.MarshalEncode(enc, o.Boolean)
 	}
 	if o.DocumentHighlightOptions != nil {
-		return json.MarshalEncode(enc, *o.DocumentHighlightOptions)
+		return json.MarshalEncode(enc, o.DocumentHighlightOptions)
 	}
 	panic("unreachable")
 }
@@ -22762,16 +22762,16 @@ type BooleanOrDocumentSymbolOptions struct {
 	DocumentSymbolOptions *DocumentSymbolOptions
 }
 
-var _ json.MarshalerTo = BooleanOrDocumentSymbolOptions{}
+var _ json.MarshalerTo = (*BooleanOrDocumentSymbolOptions)(nil)
 
-func (o BooleanOrDocumentSymbolOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *BooleanOrDocumentSymbolOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrDocumentSymbolOptions should be set", o.Boolean != nil, o.DocumentSymbolOptions != nil)
 
 	if o.Boolean != nil {
-		return json.MarshalEncode(enc, *o.Boolean)
+		return json.MarshalEncode(enc, o.Boolean)
 	}
 	if o.DocumentSymbolOptions != nil {
-		return json.MarshalEncode(enc, *o.DocumentSymbolOptions)
+		return json.MarshalEncode(enc, o.DocumentSymbolOptions)
 	}
 	panic("unreachable")
 }
@@ -22803,16 +22803,16 @@ type BooleanOrCodeActionOptions struct {
 	CodeActionOptions *CodeActionOptions
 }
 
-var _ json.MarshalerTo = BooleanOrCodeActionOptions{}
+var _ json.MarshalerTo = (*BooleanOrCodeActionOptions)(nil)
 
-func (o BooleanOrCodeActionOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *BooleanOrCodeActionOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrCodeActionOptions should be set", o.Boolean != nil, o.CodeActionOptions != nil)
 
 	if o.Boolean != nil {
-		return json.MarshalEncode(enc, *o.Boolean)
+		return json.MarshalEncode(enc, o.Boolean)
 	}
 	if o.CodeActionOptions != nil {
-		return json.MarshalEncode(enc, *o.CodeActionOptions)
+		return json.MarshalEncode(enc, o.CodeActionOptions)
 	}
 	panic("unreachable")
 }
@@ -22845,19 +22845,19 @@ type BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions struct {
 	DocumentColorRegistrationOptions *DocumentColorRegistrationOptions
 }
 
-var _ json.MarshalerTo = BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions{}
+var _ json.MarshalerTo = (*BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions)(nil)
 
-func (o BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions should be set", o.Boolean != nil, o.DocumentColorOptions != nil, o.DocumentColorRegistrationOptions != nil)
 
 	if o.Boolean != nil {
-		return json.MarshalEncode(enc, *o.Boolean)
+		return json.MarshalEncode(enc, o.Boolean)
 	}
 	if o.DocumentColorOptions != nil {
-		return json.MarshalEncode(enc, *o.DocumentColorOptions)
+		return json.MarshalEncode(enc, o.DocumentColorOptions)
 	}
 	if o.DocumentColorRegistrationOptions != nil {
-		return json.MarshalEncode(enc, *o.DocumentColorRegistrationOptions)
+		return json.MarshalEncode(enc, o.DocumentColorRegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -22894,16 +22894,16 @@ type BooleanOrWorkspaceSymbolOptions struct {
 	WorkspaceSymbolOptions *WorkspaceSymbolOptions
 }
 
-var _ json.MarshalerTo = BooleanOrWorkspaceSymbolOptions{}
+var _ json.MarshalerTo = (*BooleanOrWorkspaceSymbolOptions)(nil)
 
-func (o BooleanOrWorkspaceSymbolOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *BooleanOrWorkspaceSymbolOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrWorkspaceSymbolOptions should be set", o.Boolean != nil, o.WorkspaceSymbolOptions != nil)
 
 	if o.Boolean != nil {
-		return json.MarshalEncode(enc, *o.Boolean)
+		return json.MarshalEncode(enc, o.Boolean)
 	}
 	if o.WorkspaceSymbolOptions != nil {
-		return json.MarshalEncode(enc, *o.WorkspaceSymbolOptions)
+		return json.MarshalEncode(enc, o.WorkspaceSymbolOptions)
 	}
 	panic("unreachable")
 }
@@ -22935,16 +22935,16 @@ type BooleanOrDocumentFormattingOptions struct {
 	DocumentFormattingOptions *DocumentFormattingOptions
 }
 
-var _ json.MarshalerTo = BooleanOrDocumentFormattingOptions{}
+var _ json.MarshalerTo = (*BooleanOrDocumentFormattingOptions)(nil)
 
-func (o BooleanOrDocumentFormattingOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *BooleanOrDocumentFormattingOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrDocumentFormattingOptions should be set", o.Boolean != nil, o.DocumentFormattingOptions != nil)
 
 	if o.Boolean != nil {
-		return json.MarshalEncode(enc, *o.Boolean)
+		return json.MarshalEncode(enc, o.Boolean)
 	}
 	if o.DocumentFormattingOptions != nil {
-		return json.MarshalEncode(enc, *o.DocumentFormattingOptions)
+		return json.MarshalEncode(enc, o.DocumentFormattingOptions)
 	}
 	panic("unreachable")
 }
@@ -22976,16 +22976,16 @@ type BooleanOrDocumentRangeFormattingOptions struct {
 	DocumentRangeFormattingOptions *DocumentRangeFormattingOptions
 }
 
-var _ json.MarshalerTo = BooleanOrDocumentRangeFormattingOptions{}
+var _ json.MarshalerTo = (*BooleanOrDocumentRangeFormattingOptions)(nil)
 
-func (o BooleanOrDocumentRangeFormattingOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *BooleanOrDocumentRangeFormattingOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrDocumentRangeFormattingOptions should be set", o.Boolean != nil, o.DocumentRangeFormattingOptions != nil)
 
 	if o.Boolean != nil {
-		return json.MarshalEncode(enc, *o.Boolean)
+		return json.MarshalEncode(enc, o.Boolean)
 	}
 	if o.DocumentRangeFormattingOptions != nil {
-		return json.MarshalEncode(enc, *o.DocumentRangeFormattingOptions)
+		return json.MarshalEncode(enc, o.DocumentRangeFormattingOptions)
 	}
 	panic("unreachable")
 }
@@ -23017,16 +23017,16 @@ type BooleanOrRenameOptions struct {
 	RenameOptions *RenameOptions
 }
 
-var _ json.MarshalerTo = BooleanOrRenameOptions{}
+var _ json.MarshalerTo = (*BooleanOrRenameOptions)(nil)
 
-func (o BooleanOrRenameOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *BooleanOrRenameOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrRenameOptions should be set", o.Boolean != nil, o.RenameOptions != nil)
 
 	if o.Boolean != nil {
-		return json.MarshalEncode(enc, *o.Boolean)
+		return json.MarshalEncode(enc, o.Boolean)
 	}
 	if o.RenameOptions != nil {
-		return json.MarshalEncode(enc, *o.RenameOptions)
+		return json.MarshalEncode(enc, o.RenameOptions)
 	}
 	panic("unreachable")
 }
@@ -23059,19 +23059,19 @@ type BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions struct {
 	FoldingRangeRegistrationOptions *FoldingRangeRegistrationOptions
 }
 
-var _ json.MarshalerTo = BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions{}
+var _ json.MarshalerTo = (*BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions)(nil)
 
-func (o BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions should be set", o.Boolean != nil, o.FoldingRangeOptions != nil, o.FoldingRangeRegistrationOptions != nil)
 
 	if o.Boolean != nil {
-		return json.MarshalEncode(enc, *o.Boolean)
+		return json.MarshalEncode(enc, o.Boolean)
 	}
 	if o.FoldingRangeOptions != nil {
-		return json.MarshalEncode(enc, *o.FoldingRangeOptions)
+		return json.MarshalEncode(enc, o.FoldingRangeOptions)
 	}
 	if o.FoldingRangeRegistrationOptions != nil {
-		return json.MarshalEncode(enc, *o.FoldingRangeRegistrationOptions)
+		return json.MarshalEncode(enc, o.FoldingRangeRegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -23109,19 +23109,19 @@ type BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions struct {
 	SelectionRangeRegistrationOptions *SelectionRangeRegistrationOptions
 }
 
-var _ json.MarshalerTo = BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions{}
+var _ json.MarshalerTo = (*BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions)(nil)
 
-func (o BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions should be set", o.Boolean != nil, o.SelectionRangeOptions != nil, o.SelectionRangeRegistrationOptions != nil)
 
 	if o.Boolean != nil {
-		return json.MarshalEncode(enc, *o.Boolean)
+		return json.MarshalEncode(enc, o.Boolean)
 	}
 	if o.SelectionRangeOptions != nil {
-		return json.MarshalEncode(enc, *o.SelectionRangeOptions)
+		return json.MarshalEncode(enc, o.SelectionRangeOptions)
 	}
 	if o.SelectionRangeRegistrationOptions != nil {
-		return json.MarshalEncode(enc, *o.SelectionRangeRegistrationOptions)
+		return json.MarshalEncode(enc, o.SelectionRangeRegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -23159,19 +23159,19 @@ type BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions struct {
 	CallHierarchyRegistrationOptions *CallHierarchyRegistrationOptions
 }
 
-var _ json.MarshalerTo = BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions{}
+var _ json.MarshalerTo = (*BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions)(nil)
 
-func (o BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions should be set", o.Boolean != nil, o.CallHierarchyOptions != nil, o.CallHierarchyRegistrationOptions != nil)
 
 	if o.Boolean != nil {
-		return json.MarshalEncode(enc, *o.Boolean)
+		return json.MarshalEncode(enc, o.Boolean)
 	}
 	if o.CallHierarchyOptions != nil {
-		return json.MarshalEncode(enc, *o.CallHierarchyOptions)
+		return json.MarshalEncode(enc, o.CallHierarchyOptions)
 	}
 	if o.CallHierarchyRegistrationOptions != nil {
-		return json.MarshalEncode(enc, *o.CallHierarchyRegistrationOptions)
+		return json.MarshalEncode(enc, o.CallHierarchyRegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -23209,19 +23209,19 @@ type BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOptions s
 	LinkedEditingRangeRegistrationOptions *LinkedEditingRangeRegistrationOptions
 }
 
-var _ json.MarshalerTo = BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOptions{}
+var _ json.MarshalerTo = (*BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOptions)(nil)
 
-func (o BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOptions should be set", o.Boolean != nil, o.LinkedEditingRangeOptions != nil, o.LinkedEditingRangeRegistrationOptions != nil)
 
 	if o.Boolean != nil {
-		return json.MarshalEncode(enc, *o.Boolean)
+		return json.MarshalEncode(enc, o.Boolean)
 	}
 	if o.LinkedEditingRangeOptions != nil {
-		return json.MarshalEncode(enc, *o.LinkedEditingRangeOptions)
+		return json.MarshalEncode(enc, o.LinkedEditingRangeOptions)
 	}
 	if o.LinkedEditingRangeRegistrationOptions != nil {
-		return json.MarshalEncode(enc, *o.LinkedEditingRangeRegistrationOptions)
+		return json.MarshalEncode(enc, o.LinkedEditingRangeRegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -23258,16 +23258,16 @@ type SemanticTokensOptionsOrRegistrationOptions struct {
 	RegistrationOptions *SemanticTokensRegistrationOptions
 }
 
-var _ json.MarshalerTo = SemanticTokensOptionsOrRegistrationOptions{}
+var _ json.MarshalerTo = (*SemanticTokensOptionsOrRegistrationOptions)(nil)
 
-func (o SemanticTokensOptionsOrRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *SemanticTokensOptionsOrRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of SemanticTokensOptionsOrRegistrationOptions should be set", o.Options != nil, o.RegistrationOptions != nil)
 
 	if o.Options != nil {
-		return json.MarshalEncode(enc, *o.Options)
+		return json.MarshalEncode(enc, o.Options)
 	}
 	if o.RegistrationOptions != nil {
-		return json.MarshalEncode(enc, *o.RegistrationOptions)
+		return json.MarshalEncode(enc, o.RegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -23300,19 +23300,19 @@ type BooleanOrMonikerOptionsOrMonikerRegistrationOptions struct {
 	MonikerRegistrationOptions *MonikerRegistrationOptions
 }
 
-var _ json.MarshalerTo = BooleanOrMonikerOptionsOrMonikerRegistrationOptions{}
+var _ json.MarshalerTo = (*BooleanOrMonikerOptionsOrMonikerRegistrationOptions)(nil)
 
-func (o BooleanOrMonikerOptionsOrMonikerRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *BooleanOrMonikerOptionsOrMonikerRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrMonikerOptionsOrMonikerRegistrationOptions should be set", o.Boolean != nil, o.MonikerOptions != nil, o.MonikerRegistrationOptions != nil)
 
 	if o.Boolean != nil {
-		return json.MarshalEncode(enc, *o.Boolean)
+		return json.MarshalEncode(enc, o.Boolean)
 	}
 	if o.MonikerOptions != nil {
-		return json.MarshalEncode(enc, *o.MonikerOptions)
+		return json.MarshalEncode(enc, o.MonikerOptions)
 	}
 	if o.MonikerRegistrationOptions != nil {
-		return json.MarshalEncode(enc, *o.MonikerRegistrationOptions)
+		return json.MarshalEncode(enc, o.MonikerRegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -23350,19 +23350,19 @@ type BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions struct {
 	TypeHierarchyRegistrationOptions *TypeHierarchyRegistrationOptions
 }
 
-var _ json.MarshalerTo = BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions{}
+var _ json.MarshalerTo = (*BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions)(nil)
 
-func (o BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions should be set", o.Boolean != nil, o.TypeHierarchyOptions != nil, o.TypeHierarchyRegistrationOptions != nil)
 
 	if o.Boolean != nil {
-		return json.MarshalEncode(enc, *o.Boolean)
+		return json.MarshalEncode(enc, o.Boolean)
 	}
 	if o.TypeHierarchyOptions != nil {
-		return json.MarshalEncode(enc, *o.TypeHierarchyOptions)
+		return json.MarshalEncode(enc, o.TypeHierarchyOptions)
 	}
 	if o.TypeHierarchyRegistrationOptions != nil {
-		return json.MarshalEncode(enc, *o.TypeHierarchyRegistrationOptions)
+		return json.MarshalEncode(enc, o.TypeHierarchyRegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -23400,19 +23400,19 @@ type BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions struct {
 	InlineValueRegistrationOptions *InlineValueRegistrationOptions
 }
 
-var _ json.MarshalerTo = BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions{}
+var _ json.MarshalerTo = (*BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions)(nil)
 
-func (o BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions should be set", o.Boolean != nil, o.InlineValueOptions != nil, o.InlineValueRegistrationOptions != nil)
 
 	if o.Boolean != nil {
-		return json.MarshalEncode(enc, *o.Boolean)
+		return json.MarshalEncode(enc, o.Boolean)
 	}
 	if o.InlineValueOptions != nil {
-		return json.MarshalEncode(enc, *o.InlineValueOptions)
+		return json.MarshalEncode(enc, o.InlineValueOptions)
 	}
 	if o.InlineValueRegistrationOptions != nil {
-		return json.MarshalEncode(enc, *o.InlineValueRegistrationOptions)
+		return json.MarshalEncode(enc, o.InlineValueRegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -23450,19 +23450,19 @@ type BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions struct {
 	InlayHintRegistrationOptions *InlayHintRegistrationOptions
 }
 
-var _ json.MarshalerTo = BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions{}
+var _ json.MarshalerTo = (*BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions)(nil)
 
-func (o BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions should be set", o.Boolean != nil, o.InlayHintOptions != nil, o.InlayHintRegistrationOptions != nil)
 
 	if o.Boolean != nil {
-		return json.MarshalEncode(enc, *o.Boolean)
+		return json.MarshalEncode(enc, o.Boolean)
 	}
 	if o.InlayHintOptions != nil {
-		return json.MarshalEncode(enc, *o.InlayHintOptions)
+		return json.MarshalEncode(enc, o.InlayHintOptions)
 	}
 	if o.InlayHintRegistrationOptions != nil {
-		return json.MarshalEncode(enc, *o.InlayHintRegistrationOptions)
+		return json.MarshalEncode(enc, o.InlayHintRegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -23499,16 +23499,16 @@ type DiagnosticOptionsOrRegistrationOptions struct {
 	RegistrationOptions *DiagnosticRegistrationOptions
 }
 
-var _ json.MarshalerTo = DiagnosticOptionsOrRegistrationOptions{}
+var _ json.MarshalerTo = (*DiagnosticOptionsOrRegistrationOptions)(nil)
 
-func (o DiagnosticOptionsOrRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *DiagnosticOptionsOrRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of DiagnosticOptionsOrRegistrationOptions should be set", o.Options != nil, o.RegistrationOptions != nil)
 
 	if o.Options != nil {
-		return json.MarshalEncode(enc, *o.Options)
+		return json.MarshalEncode(enc, o.Options)
 	}
 	if o.RegistrationOptions != nil {
-		return json.MarshalEncode(enc, *o.RegistrationOptions)
+		return json.MarshalEncode(enc, o.RegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -23540,16 +23540,16 @@ type BooleanOrInlineCompletionOptions struct {
 	InlineCompletionOptions *InlineCompletionOptions
 }
 
-var _ json.MarshalerTo = BooleanOrInlineCompletionOptions{}
+var _ json.MarshalerTo = (*BooleanOrInlineCompletionOptions)(nil)
 
-func (o BooleanOrInlineCompletionOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *BooleanOrInlineCompletionOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrInlineCompletionOptions should be set", o.Boolean != nil, o.InlineCompletionOptions != nil)
 
 	if o.Boolean != nil {
-		return json.MarshalEncode(enc, *o.Boolean)
+		return json.MarshalEncode(enc, o.Boolean)
 	}
 	if o.InlineCompletionOptions != nil {
-		return json.MarshalEncode(enc, *o.InlineCompletionOptions)
+		return json.MarshalEncode(enc, o.InlineCompletionOptions)
 	}
 	panic("unreachable")
 }
@@ -23581,16 +23581,16 @@ type PatternOrRelativePattern struct {
 	RelativePattern *RelativePattern
 }
 
-var _ json.MarshalerTo = PatternOrRelativePattern{}
+var _ json.MarshalerTo = (*PatternOrRelativePattern)(nil)
 
-func (o PatternOrRelativePattern) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *PatternOrRelativePattern) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of PatternOrRelativePattern should be set", o.Pattern != nil, o.RelativePattern != nil)
 
 	if o.Pattern != nil {
-		return json.MarshalEncode(enc, *o.Pattern)
+		return json.MarshalEncode(enc, o.Pattern)
 	}
 	if o.RelativePattern != nil {
-		return json.MarshalEncode(enc, *o.RelativePattern)
+		return json.MarshalEncode(enc, o.RelativePattern)
 	}
 	panic("unreachable")
 }
@@ -23622,16 +23622,16 @@ type RangeOrEditRangeWithInsertReplace struct {
 	EditRangeWithInsertReplace *EditRangeWithInsertReplace
 }
 
-var _ json.MarshalerTo = RangeOrEditRangeWithInsertReplace{}
+var _ json.MarshalerTo = (*RangeOrEditRangeWithInsertReplace)(nil)
 
-func (o RangeOrEditRangeWithInsertReplace) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *RangeOrEditRangeWithInsertReplace) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of RangeOrEditRangeWithInsertReplace should be set", o.Range != nil, o.EditRangeWithInsertReplace != nil)
 
 	if o.Range != nil {
-		return json.MarshalEncode(enc, *o.Range)
+		return json.MarshalEncode(enc, o.Range)
 	}
 	if o.EditRangeWithInsertReplace != nil {
-		return json.MarshalEncode(enc, *o.EditRangeWithInsertReplace)
+		return json.MarshalEncode(enc, o.EditRangeWithInsertReplace)
 	}
 	panic("unreachable")
 }
@@ -23665,22 +23665,22 @@ type StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrN
 	NotebookDocumentFilterPattern      *NotebookDocumentFilterPattern
 }
 
-var _ json.MarshalerTo = StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrNotebookDocumentFilterPattern{}
+var _ json.MarshalerTo = (*StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrNotebookDocumentFilterPattern)(nil)
 
-func (o StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrNotebookDocumentFilterPattern) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrNotebookDocumentFilterPattern) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrNotebookDocumentFilterPattern should be set", o.String != nil, o.NotebookDocumentFilterNotebookType != nil, o.NotebookDocumentFilterScheme != nil, o.NotebookDocumentFilterPattern != nil)
 
 	if o.String != nil {
-		return json.MarshalEncode(enc, *o.String)
+		return json.MarshalEncode(enc, o.String)
 	}
 	if o.NotebookDocumentFilterNotebookType != nil {
-		return json.MarshalEncode(enc, *o.NotebookDocumentFilterNotebookType)
+		return json.MarshalEncode(enc, o.NotebookDocumentFilterNotebookType)
 	}
 	if o.NotebookDocumentFilterScheme != nil {
-		return json.MarshalEncode(enc, *o.NotebookDocumentFilterScheme)
+		return json.MarshalEncode(enc, o.NotebookDocumentFilterScheme)
 	}
 	if o.NotebookDocumentFilterPattern != nil {
-		return json.MarshalEncode(enc, *o.NotebookDocumentFilterPattern)
+		return json.MarshalEncode(enc, o.NotebookDocumentFilterPattern)
 	}
 	panic("unreachable")
 }
@@ -23722,16 +23722,16 @@ type BooleanOrSaveOptions struct {
 	SaveOptions *SaveOptions
 }
 
-var _ json.MarshalerTo = BooleanOrSaveOptions{}
+var _ json.MarshalerTo = (*BooleanOrSaveOptions)(nil)
 
-func (o BooleanOrSaveOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *BooleanOrSaveOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrSaveOptions should be set", o.Boolean != nil, o.SaveOptions != nil)
 
 	if o.Boolean != nil {
-		return json.MarshalEncode(enc, *o.Boolean)
+		return json.MarshalEncode(enc, o.Boolean)
 	}
 	if o.SaveOptions != nil {
-		return json.MarshalEncode(enc, *o.SaveOptions)
+		return json.MarshalEncode(enc, o.SaveOptions)
 	}
 	panic("unreachable")
 }
@@ -23763,16 +23763,16 @@ type TextDocumentContentOptionsOrRegistrationOptions struct {
 	RegistrationOptions *TextDocumentContentRegistrationOptions
 }
 
-var _ json.MarshalerTo = TextDocumentContentOptionsOrRegistrationOptions{}
+var _ json.MarshalerTo = (*TextDocumentContentOptionsOrRegistrationOptions)(nil)
 
-func (o TextDocumentContentOptionsOrRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *TextDocumentContentOptionsOrRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of TextDocumentContentOptionsOrRegistrationOptions should be set", o.Options != nil, o.RegistrationOptions != nil)
 
 	if o.Options != nil {
-		return json.MarshalEncode(enc, *o.Options)
+		return json.MarshalEncode(enc, o.Options)
 	}
 	if o.RegistrationOptions != nil {
-		return json.MarshalEncode(enc, *o.RegistrationOptions)
+		return json.MarshalEncode(enc, o.RegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -23804,16 +23804,16 @@ type StringOrTuple struct {
 	Tuple  *[2]uint32
 }
 
-var _ json.MarshalerTo = StringOrTuple{}
+var _ json.MarshalerTo = (*StringOrTuple)(nil)
 
-func (o StringOrTuple) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *StringOrTuple) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of StringOrTuple should be set", o.String != nil, o.Tuple != nil)
 
 	if o.String != nil {
-		return json.MarshalEncode(enc, *o.String)
+		return json.MarshalEncode(enc, o.String)
 	}
 	if o.Tuple != nil {
-		return json.MarshalEncode(enc, *o.Tuple)
+		return json.MarshalEncode(enc, o.Tuple)
 	}
 	panic("unreachable")
 }
@@ -23845,16 +23845,16 @@ type StringOrBoolean struct {
 	Boolean *bool
 }
 
-var _ json.MarshalerTo = StringOrBoolean{}
+var _ json.MarshalerTo = (*StringOrBoolean)(nil)
 
-func (o StringOrBoolean) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *StringOrBoolean) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of StringOrBoolean should be set", o.String != nil, o.Boolean != nil)
 
 	if o.String != nil {
-		return json.MarshalEncode(enc, *o.String)
+		return json.MarshalEncode(enc, o.String)
 	}
 	if o.Boolean != nil {
-		return json.MarshalEncode(enc, *o.Boolean)
+		return json.MarshalEncode(enc, o.Boolean)
 	}
 	panic("unreachable")
 }
@@ -23886,16 +23886,16 @@ type WorkspaceFolderOrURI struct {
 	URI             *URI
 }
 
-var _ json.MarshalerTo = WorkspaceFolderOrURI{}
+var _ json.MarshalerTo = (*WorkspaceFolderOrURI)(nil)
 
-func (o WorkspaceFolderOrURI) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *WorkspaceFolderOrURI) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of WorkspaceFolderOrURI should be set", o.WorkspaceFolder != nil, o.URI != nil)
 
 	if o.WorkspaceFolder != nil {
-		return json.MarshalEncode(enc, *o.WorkspaceFolder)
+		return json.MarshalEncode(enc, o.WorkspaceFolder)
 	}
 	if o.URI != nil {
-		return json.MarshalEncode(enc, *o.URI)
+		return json.MarshalEncode(enc, o.URI)
 	}
 	panic("unreachable")
 }
@@ -23927,16 +23927,16 @@ type BooleanOrClientSemanticTokensRequestFullDelta struct {
 	ClientSemanticTokensRequestFullDelta *ClientSemanticTokensRequestFullDelta
 }
 
-var _ json.MarshalerTo = BooleanOrClientSemanticTokensRequestFullDelta{}
+var _ json.MarshalerTo = (*BooleanOrClientSemanticTokensRequestFullDelta)(nil)
 
-func (o BooleanOrClientSemanticTokensRequestFullDelta) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *BooleanOrClientSemanticTokensRequestFullDelta) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrClientSemanticTokensRequestFullDelta should be set", o.Boolean != nil, o.ClientSemanticTokensRequestFullDelta != nil)
 
 	if o.Boolean != nil {
-		return json.MarshalEncode(enc, *o.Boolean)
+		return json.MarshalEncode(enc, o.Boolean)
 	}
 	if o.ClientSemanticTokensRequestFullDelta != nil {
-		return json.MarshalEncode(enc, *o.ClientSemanticTokensRequestFullDelta)
+		return json.MarshalEncode(enc, o.ClientSemanticTokensRequestFullDelta)
 	}
 	panic("unreachable")
 }
@@ -23969,19 +23969,19 @@ type LocationOrLocationsOrDefinitionLinksOrNull struct {
 	DefinitionLinks *[]*LocationLink
 }
 
-var _ json.MarshalerTo = LocationOrLocationsOrDefinitionLinksOrNull{}
+var _ json.MarshalerTo = (*LocationOrLocationsOrDefinitionLinksOrNull)(nil)
 
-func (o LocationOrLocationsOrDefinitionLinksOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *LocationOrLocationsOrDefinitionLinksOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of LocationOrLocationsOrDefinitionLinksOrNull is set", o.Location != nil, o.Locations != nil, o.DefinitionLinks != nil)
 
 	if o.Location != nil {
-		return json.MarshalEncode(enc, *o.Location)
+		return json.MarshalEncode(enc, o.Location)
 	}
 	if o.Locations != nil {
-		return json.MarshalEncode(enc, *o.Locations)
+		return json.MarshalEncode(enc, o.Locations)
 	}
 	if o.DefinitionLinks != nil {
-		return json.MarshalEncode(enc, *o.DefinitionLinks)
+		return json.MarshalEncode(enc, o.DefinitionLinks)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -24021,13 +24021,13 @@ type FoldingRangesOrNull struct {
 	FoldingRanges *[]*FoldingRange
 }
 
-var _ json.MarshalerTo = FoldingRangesOrNull{}
+var _ json.MarshalerTo = (*FoldingRangesOrNull)(nil)
 
-func (o FoldingRangesOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *FoldingRangesOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of FoldingRangesOrNull is set", o.FoldingRanges != nil)
 
 	if o.FoldingRanges != nil {
-		return json.MarshalEncode(enc, *o.FoldingRanges)
+		return json.MarshalEncode(enc, o.FoldingRanges)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -24059,19 +24059,19 @@ type LocationOrLocationsOrDeclarationLinksOrNull struct {
 	DeclarationLinks *[]*LocationLink
 }
 
-var _ json.MarshalerTo = LocationOrLocationsOrDeclarationLinksOrNull{}
+var _ json.MarshalerTo = (*LocationOrLocationsOrDeclarationLinksOrNull)(nil)
 
-func (o LocationOrLocationsOrDeclarationLinksOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *LocationOrLocationsOrDeclarationLinksOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of LocationOrLocationsOrDeclarationLinksOrNull is set", o.Location != nil, o.Locations != nil, o.DeclarationLinks != nil)
 
 	if o.Location != nil {
-		return json.MarshalEncode(enc, *o.Location)
+		return json.MarshalEncode(enc, o.Location)
 	}
 	if o.Locations != nil {
-		return json.MarshalEncode(enc, *o.Locations)
+		return json.MarshalEncode(enc, o.Locations)
 	}
 	if o.DeclarationLinks != nil {
-		return json.MarshalEncode(enc, *o.DeclarationLinks)
+		return json.MarshalEncode(enc, o.DeclarationLinks)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -24111,13 +24111,13 @@ type SelectionRangesOrNull struct {
 	SelectionRanges *[]*SelectionRange
 }
 
-var _ json.MarshalerTo = SelectionRangesOrNull{}
+var _ json.MarshalerTo = (*SelectionRangesOrNull)(nil)
 
-func (o SelectionRangesOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *SelectionRangesOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of SelectionRangesOrNull is set", o.SelectionRanges != nil)
 
 	if o.SelectionRanges != nil {
-		return json.MarshalEncode(enc, *o.SelectionRanges)
+		return json.MarshalEncode(enc, o.SelectionRanges)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -24147,13 +24147,13 @@ type CallHierarchyItemsOrNull struct {
 	CallHierarchyItems *[]*CallHierarchyItem
 }
 
-var _ json.MarshalerTo = CallHierarchyItemsOrNull{}
+var _ json.MarshalerTo = (*CallHierarchyItemsOrNull)(nil)
 
-func (o CallHierarchyItemsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *CallHierarchyItemsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of CallHierarchyItemsOrNull is set", o.CallHierarchyItems != nil)
 
 	if o.CallHierarchyItems != nil {
-		return json.MarshalEncode(enc, *o.CallHierarchyItems)
+		return json.MarshalEncode(enc, o.CallHierarchyItems)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -24183,13 +24183,13 @@ type CallHierarchyIncomingCallsOrNull struct {
 	CallHierarchyIncomingCalls *[]*CallHierarchyIncomingCall
 }
 
-var _ json.MarshalerTo = CallHierarchyIncomingCallsOrNull{}
+var _ json.MarshalerTo = (*CallHierarchyIncomingCallsOrNull)(nil)
 
-func (o CallHierarchyIncomingCallsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *CallHierarchyIncomingCallsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of CallHierarchyIncomingCallsOrNull is set", o.CallHierarchyIncomingCalls != nil)
 
 	if o.CallHierarchyIncomingCalls != nil {
-		return json.MarshalEncode(enc, *o.CallHierarchyIncomingCalls)
+		return json.MarshalEncode(enc, o.CallHierarchyIncomingCalls)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -24219,13 +24219,13 @@ type CallHierarchyOutgoingCallsOrNull struct {
 	CallHierarchyOutgoingCalls *[]*CallHierarchyOutgoingCall
 }
 
-var _ json.MarshalerTo = CallHierarchyOutgoingCallsOrNull{}
+var _ json.MarshalerTo = (*CallHierarchyOutgoingCallsOrNull)(nil)
 
-func (o CallHierarchyOutgoingCallsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *CallHierarchyOutgoingCallsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of CallHierarchyOutgoingCallsOrNull is set", o.CallHierarchyOutgoingCalls != nil)
 
 	if o.CallHierarchyOutgoingCalls != nil {
-		return json.MarshalEncode(enc, *o.CallHierarchyOutgoingCalls)
+		return json.MarshalEncode(enc, o.CallHierarchyOutgoingCalls)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -24255,13 +24255,13 @@ type SemanticTokensOrNull struct {
 	SemanticTokens *SemanticTokens
 }
 
-var _ json.MarshalerTo = SemanticTokensOrNull{}
+var _ json.MarshalerTo = (*SemanticTokensOrNull)(nil)
 
-func (o SemanticTokensOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *SemanticTokensOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of SemanticTokensOrNull is set", o.SemanticTokens != nil)
 
 	if o.SemanticTokens != nil {
-		return json.MarshalEncode(enc, *o.SemanticTokens)
+		return json.MarshalEncode(enc, o.SemanticTokens)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -24292,16 +24292,16 @@ type SemanticTokensOrSemanticTokensDeltaOrNull struct {
 	SemanticTokensDelta *SemanticTokensDelta
 }
 
-var _ json.MarshalerTo = SemanticTokensOrSemanticTokensDeltaOrNull{}
+var _ json.MarshalerTo = (*SemanticTokensOrSemanticTokensDeltaOrNull)(nil)
 
-func (o SemanticTokensOrSemanticTokensDeltaOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *SemanticTokensOrSemanticTokensDeltaOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of SemanticTokensOrSemanticTokensDeltaOrNull is set", o.SemanticTokens != nil, o.SemanticTokensDelta != nil)
 
 	if o.SemanticTokens != nil {
-		return json.MarshalEncode(enc, *o.SemanticTokens)
+		return json.MarshalEncode(enc, o.SemanticTokens)
 	}
 	if o.SemanticTokensDelta != nil {
-		return json.MarshalEncode(enc, *o.SemanticTokensDelta)
+		return json.MarshalEncode(enc, o.SemanticTokensDelta)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -24336,13 +24336,13 @@ type LinkedEditingRangesOrNull struct {
 	LinkedEditingRanges *LinkedEditingRanges
 }
 
-var _ json.MarshalerTo = LinkedEditingRangesOrNull{}
+var _ json.MarshalerTo = (*LinkedEditingRangesOrNull)(nil)
 
-func (o LinkedEditingRangesOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *LinkedEditingRangesOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of LinkedEditingRangesOrNull is set", o.LinkedEditingRanges != nil)
 
 	if o.LinkedEditingRanges != nil {
-		return json.MarshalEncode(enc, *o.LinkedEditingRanges)
+		return json.MarshalEncode(enc, o.LinkedEditingRanges)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -24372,13 +24372,13 @@ type WorkspaceEditOrNull struct {
 	WorkspaceEdit *WorkspaceEdit
 }
 
-var _ json.MarshalerTo = WorkspaceEditOrNull{}
+var _ json.MarshalerTo = (*WorkspaceEditOrNull)(nil)
 
-func (o WorkspaceEditOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *WorkspaceEditOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of WorkspaceEditOrNull is set", o.WorkspaceEdit != nil)
 
 	if o.WorkspaceEdit != nil {
-		return json.MarshalEncode(enc, *o.WorkspaceEdit)
+		return json.MarshalEncode(enc, o.WorkspaceEdit)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -24408,13 +24408,13 @@ type MonikersOrNull struct {
 	Monikers *[]*Moniker
 }
 
-var _ json.MarshalerTo = MonikersOrNull{}
+var _ json.MarshalerTo = (*MonikersOrNull)(nil)
 
-func (o MonikersOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *MonikersOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of MonikersOrNull is set", o.Monikers != nil)
 
 	if o.Monikers != nil {
-		return json.MarshalEncode(enc, *o.Monikers)
+		return json.MarshalEncode(enc, o.Monikers)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -24444,13 +24444,13 @@ type TypeHierarchyItemsOrNull struct {
 	TypeHierarchyItems *[]*TypeHierarchyItem
 }
 
-var _ json.MarshalerTo = TypeHierarchyItemsOrNull{}
+var _ json.MarshalerTo = (*TypeHierarchyItemsOrNull)(nil)
 
-func (o TypeHierarchyItemsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *TypeHierarchyItemsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of TypeHierarchyItemsOrNull is set", o.TypeHierarchyItems != nil)
 
 	if o.TypeHierarchyItems != nil {
-		return json.MarshalEncode(enc, *o.TypeHierarchyItems)
+		return json.MarshalEncode(enc, o.TypeHierarchyItems)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -24480,13 +24480,13 @@ type InlineValuesOrNull struct {
 	InlineValues *[]InlineValueTextOrVariableLookupOrEvaluatableExpression
 }
 
-var _ json.MarshalerTo = InlineValuesOrNull{}
+var _ json.MarshalerTo = (*InlineValuesOrNull)(nil)
 
-func (o InlineValuesOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *InlineValuesOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of InlineValuesOrNull is set", o.InlineValues != nil)
 
 	if o.InlineValues != nil {
-		return json.MarshalEncode(enc, *o.InlineValues)
+		return json.MarshalEncode(enc, o.InlineValues)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -24516,13 +24516,13 @@ type InlayHintsOrNull struct {
 	InlayHints *[]*InlayHint
 }
 
-var _ json.MarshalerTo = InlayHintsOrNull{}
+var _ json.MarshalerTo = (*InlayHintsOrNull)(nil)
 
-func (o InlayHintsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *InlayHintsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of InlayHintsOrNull is set", o.InlayHints != nil)
 
 	if o.InlayHints != nil {
-		return json.MarshalEncode(enc, *o.InlayHints)
+		return json.MarshalEncode(enc, o.InlayHints)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -24553,16 +24553,16 @@ type RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport stru
 	UnchangedDocumentDiagnosticReport *RelatedUnchangedDocumentDiagnosticReport
 }
 
-var _ json.MarshalerTo = RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport{}
+var _ json.MarshalerTo = (*RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport)(nil)
 
-func (o RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport should be set", o.FullDocumentDiagnosticReport != nil, o.UnchangedDocumentDiagnosticReport != nil)
 
 	if o.FullDocumentDiagnosticReport != nil {
-		return json.MarshalEncode(enc, *o.FullDocumentDiagnosticReport)
+		return json.MarshalEncode(enc, o.FullDocumentDiagnosticReport)
 	}
 	if o.UnchangedDocumentDiagnosticReport != nil {
-		return json.MarshalEncode(enc, *o.UnchangedDocumentDiagnosticReport)
+		return json.MarshalEncode(enc, o.UnchangedDocumentDiagnosticReport)
 	}
 	panic("unreachable")
 }
@@ -24594,16 +24594,16 @@ type InlineCompletionListOrItemsOrNull struct {
 	Items *[]*InlineCompletionItem
 }
 
-var _ json.MarshalerTo = InlineCompletionListOrItemsOrNull{}
+var _ json.MarshalerTo = (*InlineCompletionListOrItemsOrNull)(nil)
 
-func (o InlineCompletionListOrItemsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *InlineCompletionListOrItemsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of InlineCompletionListOrItemsOrNull is set", o.List != nil, o.Items != nil)
 
 	if o.List != nil {
-		return json.MarshalEncode(enc, *o.List)
+		return json.MarshalEncode(enc, o.List)
 	}
 	if o.Items != nil {
-		return json.MarshalEncode(enc, *o.Items)
+		return json.MarshalEncode(enc, o.Items)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -24638,13 +24638,13 @@ type MessageActionItemOrNull struct {
 	MessageActionItem *MessageActionItem
 }
 
-var _ json.MarshalerTo = MessageActionItemOrNull{}
+var _ json.MarshalerTo = (*MessageActionItemOrNull)(nil)
 
-func (o MessageActionItemOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *MessageActionItemOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of MessageActionItemOrNull is set", o.MessageActionItem != nil)
 
 	if o.MessageActionItem != nil {
-		return json.MarshalEncode(enc, *o.MessageActionItem)
+		return json.MarshalEncode(enc, o.MessageActionItem)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -24674,13 +24674,13 @@ type TextEditsOrNull struct {
 	TextEdits *[]*TextEdit
 }
 
-var _ json.MarshalerTo = TextEditsOrNull{}
+var _ json.MarshalerTo = (*TextEditsOrNull)(nil)
 
-func (o TextEditsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *TextEditsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of TextEditsOrNull is set", o.TextEdits != nil)
 
 	if o.TextEdits != nil {
-		return json.MarshalEncode(enc, *o.TextEdits)
+		return json.MarshalEncode(enc, o.TextEdits)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -24711,16 +24711,16 @@ type CompletionItemsOrListOrNull struct {
 	List  *CompletionList
 }
 
-var _ json.MarshalerTo = CompletionItemsOrListOrNull{}
+var _ json.MarshalerTo = (*CompletionItemsOrListOrNull)(nil)
 
-func (o CompletionItemsOrListOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *CompletionItemsOrListOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of CompletionItemsOrListOrNull is set", o.Items != nil, o.List != nil)
 
 	if o.Items != nil {
-		return json.MarshalEncode(enc, *o.Items)
+		return json.MarshalEncode(enc, o.Items)
 	}
 	if o.List != nil {
-		return json.MarshalEncode(enc, *o.List)
+		return json.MarshalEncode(enc, o.List)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -24755,13 +24755,13 @@ type HoverOrNull struct {
 	Hover *Hover
 }
 
-var _ json.MarshalerTo = HoverOrNull{}
+var _ json.MarshalerTo = (*HoverOrNull)(nil)
 
-func (o HoverOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *HoverOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of HoverOrNull is set", o.Hover != nil)
 
 	if o.Hover != nil {
-		return json.MarshalEncode(enc, *o.Hover)
+		return json.MarshalEncode(enc, o.Hover)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -24791,13 +24791,13 @@ type SignatureHelpOrNull struct {
 	SignatureHelp *SignatureHelp
 }
 
-var _ json.MarshalerTo = SignatureHelpOrNull{}
+var _ json.MarshalerTo = (*SignatureHelpOrNull)(nil)
 
-func (o SignatureHelpOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *SignatureHelpOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of SignatureHelpOrNull is set", o.SignatureHelp != nil)
 
 	if o.SignatureHelp != nil {
-		return json.MarshalEncode(enc, *o.SignatureHelp)
+		return json.MarshalEncode(enc, o.SignatureHelp)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -24827,13 +24827,13 @@ type LocationsOrNull struct {
 	Locations *[]Location
 }
 
-var _ json.MarshalerTo = LocationsOrNull{}
+var _ json.MarshalerTo = (*LocationsOrNull)(nil)
 
-func (o LocationsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *LocationsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of LocationsOrNull is set", o.Locations != nil)
 
 	if o.Locations != nil {
-		return json.MarshalEncode(enc, *o.Locations)
+		return json.MarshalEncode(enc, o.Locations)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -24863,13 +24863,13 @@ type DocumentHighlightsOrNull struct {
 	DocumentHighlights *[]*DocumentHighlight
 }
 
-var _ json.MarshalerTo = DocumentHighlightsOrNull{}
+var _ json.MarshalerTo = (*DocumentHighlightsOrNull)(nil)
 
-func (o DocumentHighlightsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *DocumentHighlightsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of DocumentHighlightsOrNull is set", o.DocumentHighlights != nil)
 
 	if o.DocumentHighlights != nil {
-		return json.MarshalEncode(enc, *o.DocumentHighlights)
+		return json.MarshalEncode(enc, o.DocumentHighlights)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -24900,16 +24900,16 @@ type SymbolInformationsOrDocumentSymbolsOrNull struct {
 	DocumentSymbols    *[]*DocumentSymbol
 }
 
-var _ json.MarshalerTo = SymbolInformationsOrDocumentSymbolsOrNull{}
+var _ json.MarshalerTo = (*SymbolInformationsOrDocumentSymbolsOrNull)(nil)
 
-func (o SymbolInformationsOrDocumentSymbolsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *SymbolInformationsOrDocumentSymbolsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of SymbolInformationsOrDocumentSymbolsOrNull is set", o.SymbolInformations != nil, o.DocumentSymbols != nil)
 
 	if o.SymbolInformations != nil {
-		return json.MarshalEncode(enc, *o.SymbolInformations)
+		return json.MarshalEncode(enc, o.SymbolInformations)
 	}
 	if o.DocumentSymbols != nil {
-		return json.MarshalEncode(enc, *o.DocumentSymbols)
+		return json.MarshalEncode(enc, o.DocumentSymbols)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -24945,16 +24945,16 @@ type CommandOrCodeAction struct {
 	CodeAction *CodeAction
 }
 
-var _ json.MarshalerTo = CommandOrCodeAction{}
+var _ json.MarshalerTo = (*CommandOrCodeAction)(nil)
 
-func (o CommandOrCodeAction) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *CommandOrCodeAction) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of CommandOrCodeAction should be set", o.Command != nil, o.CodeAction != nil)
 
 	if o.Command != nil {
-		return json.MarshalEncode(enc, *o.Command)
+		return json.MarshalEncode(enc, o.Command)
 	}
 	if o.CodeAction != nil {
-		return json.MarshalEncode(enc, *o.CodeAction)
+		return json.MarshalEncode(enc, o.CodeAction)
 	}
 	panic("unreachable")
 }
@@ -24985,13 +24985,13 @@ type CommandOrCodeActionArrayOrNull struct {
 	CommandOrCodeActionArray *[]CommandOrCodeAction
 }
 
-var _ json.MarshalerTo = CommandOrCodeActionArrayOrNull{}
+var _ json.MarshalerTo = (*CommandOrCodeActionArrayOrNull)(nil)
 
-func (o CommandOrCodeActionArrayOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *CommandOrCodeActionArrayOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of CommandOrCodeActionArrayOrNull is set", o.CommandOrCodeActionArray != nil)
 
 	if o.CommandOrCodeActionArray != nil {
-		return json.MarshalEncode(enc, *o.CommandOrCodeActionArray)
+		return json.MarshalEncode(enc, o.CommandOrCodeActionArray)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -25022,16 +25022,16 @@ type SymbolInformationsOrWorkspaceSymbolsOrNull struct {
 	WorkspaceSymbols   *[]*WorkspaceSymbol
 }
 
-var _ json.MarshalerTo = SymbolInformationsOrWorkspaceSymbolsOrNull{}
+var _ json.MarshalerTo = (*SymbolInformationsOrWorkspaceSymbolsOrNull)(nil)
 
-func (o SymbolInformationsOrWorkspaceSymbolsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *SymbolInformationsOrWorkspaceSymbolsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of SymbolInformationsOrWorkspaceSymbolsOrNull is set", o.SymbolInformations != nil, o.WorkspaceSymbols != nil)
 
 	if o.SymbolInformations != nil {
-		return json.MarshalEncode(enc, *o.SymbolInformations)
+		return json.MarshalEncode(enc, o.SymbolInformations)
 	}
 	if o.WorkspaceSymbols != nil {
-		return json.MarshalEncode(enc, *o.WorkspaceSymbols)
+		return json.MarshalEncode(enc, o.WorkspaceSymbols)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -25066,13 +25066,13 @@ type CodeLenssOrNull struct {
 	CodeLenss *[]*CodeLens
 }
 
-var _ json.MarshalerTo = CodeLenssOrNull{}
+var _ json.MarshalerTo = (*CodeLenssOrNull)(nil)
 
-func (o CodeLenssOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *CodeLenssOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of CodeLenssOrNull is set", o.CodeLenss != nil)
 
 	if o.CodeLenss != nil {
-		return json.MarshalEncode(enc, *o.CodeLenss)
+		return json.MarshalEncode(enc, o.CodeLenss)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -25102,13 +25102,13 @@ type DocumentLinksOrNull struct {
 	DocumentLinks *[]*DocumentLink
 }
 
-var _ json.MarshalerTo = DocumentLinksOrNull{}
+var _ json.MarshalerTo = (*DocumentLinksOrNull)(nil)
 
-func (o DocumentLinksOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *DocumentLinksOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of DocumentLinksOrNull is set", o.DocumentLinks != nil)
 
 	if o.DocumentLinks != nil {
-		return json.MarshalEncode(enc, *o.DocumentLinks)
+		return json.MarshalEncode(enc, o.DocumentLinks)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -25140,19 +25140,19 @@ type RangeOrPrepareRenamePlaceholderOrPrepareRenameDefaultBehaviorOrNull struct 
 	PrepareRenameDefaultBehavior *PrepareRenameDefaultBehavior
 }
 
-var _ json.MarshalerTo = RangeOrPrepareRenamePlaceholderOrPrepareRenameDefaultBehaviorOrNull{}
+var _ json.MarshalerTo = (*RangeOrPrepareRenamePlaceholderOrPrepareRenameDefaultBehaviorOrNull)(nil)
 
-func (o RangeOrPrepareRenamePlaceholderOrPrepareRenameDefaultBehaviorOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *RangeOrPrepareRenamePlaceholderOrPrepareRenameDefaultBehaviorOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of RangeOrPrepareRenamePlaceholderOrPrepareRenameDefaultBehaviorOrNull is set", o.Range != nil, o.PrepareRenamePlaceholder != nil, o.PrepareRenameDefaultBehavior != nil)
 
 	if o.Range != nil {
-		return json.MarshalEncode(enc, *o.Range)
+		return json.MarshalEncode(enc, o.Range)
 	}
 	if o.PrepareRenamePlaceholder != nil {
-		return json.MarshalEncode(enc, *o.PrepareRenamePlaceholder)
+		return json.MarshalEncode(enc, o.PrepareRenamePlaceholder)
 	}
 	if o.PrepareRenameDefaultBehavior != nil {
-		return json.MarshalEncode(enc, *o.PrepareRenameDefaultBehavior)
+		return json.MarshalEncode(enc, o.PrepareRenameDefaultBehavior)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -25192,13 +25192,13 @@ type LSPAnyOrNull struct {
 	LSPAny *any
 }
 
-var _ json.MarshalerTo = LSPAnyOrNull{}
+var _ json.MarshalerTo = (*LSPAnyOrNull)(nil)
 
-func (o LSPAnyOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *LSPAnyOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of LSPAnyOrNull is set", o.LSPAny != nil)
 
 	if o.LSPAny != nil {
-		return json.MarshalEncode(enc, *o.LSPAny)
+		return json.MarshalEncode(enc, o.LSPAny)
 	}
 	return enc.WriteToken(jsontext.Null)
 }
@@ -25231,22 +25231,22 @@ type TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPat
 	NotebookCellTextDocumentFilter *NotebookCellTextDocumentFilter
 }
 
-var _ json.MarshalerTo = TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPatternOrNotebookCellTextDocumentFilter{}
+var _ json.MarshalerTo = (*TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPatternOrNotebookCellTextDocumentFilter)(nil)
 
-func (o TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPatternOrNotebookCellTextDocumentFilter) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPatternOrNotebookCellTextDocumentFilter) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPatternOrNotebookCellTextDocumentFilter should be set", o.TextDocumentFilterLanguage != nil, o.TextDocumentFilterScheme != nil, o.TextDocumentFilterPattern != nil, o.NotebookCellTextDocumentFilter != nil)
 
 	if o.TextDocumentFilterLanguage != nil {
-		return json.MarshalEncode(enc, *o.TextDocumentFilterLanguage)
+		return json.MarshalEncode(enc, o.TextDocumentFilterLanguage)
 	}
 	if o.TextDocumentFilterScheme != nil {
-		return json.MarshalEncode(enc, *o.TextDocumentFilterScheme)
+		return json.MarshalEncode(enc, o.TextDocumentFilterScheme)
 	}
 	if o.TextDocumentFilterPattern != nil {
-		return json.MarshalEncode(enc, *o.TextDocumentFilterPattern)
+		return json.MarshalEncode(enc, o.TextDocumentFilterPattern)
 	}
 	if o.NotebookCellTextDocumentFilter != nil {
-		return json.MarshalEncode(enc, *o.NotebookCellTextDocumentFilter)
+		return json.MarshalEncode(enc, o.NotebookCellTextDocumentFilter)
 	}
 	panic("unreachable")
 }
@@ -25288,16 +25288,16 @@ type StringOrMarkedStringWithLanguage struct {
 	MarkedStringWithLanguage *MarkedStringWithLanguage
 }
 
-var _ json.MarshalerTo = StringOrMarkedStringWithLanguage{}
+var _ json.MarshalerTo = (*StringOrMarkedStringWithLanguage)(nil)
 
-func (o StringOrMarkedStringWithLanguage) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *StringOrMarkedStringWithLanguage) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of StringOrMarkedStringWithLanguage should be set", o.String != nil, o.MarkedStringWithLanguage != nil)
 
 	if o.String != nil {
-		return json.MarshalEncode(enc, *o.String)
+		return json.MarshalEncode(enc, o.String)
 	}
 	if o.MarkedStringWithLanguage != nil {
-		return json.MarshalEncode(enc, *o.MarkedStringWithLanguage)
+		return json.MarshalEncode(enc, o.MarkedStringWithLanguage)
 	}
 	panic("unreachable")
 }
@@ -25330,19 +25330,19 @@ type InlineValueTextOrVariableLookupOrEvaluatableExpression struct {
 	EvaluatableExpression *InlineValueEvaluatableExpression
 }
 
-var _ json.MarshalerTo = InlineValueTextOrVariableLookupOrEvaluatableExpression{}
+var _ json.MarshalerTo = (*InlineValueTextOrVariableLookupOrEvaluatableExpression)(nil)
 
-func (o InlineValueTextOrVariableLookupOrEvaluatableExpression) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (o *InlineValueTextOrVariableLookupOrEvaluatableExpression) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of InlineValueTextOrVariableLookupOrEvaluatableExpression should be set", o.Text != nil, o.VariableLookup != nil, o.EvaluatableExpression != nil)
 
 	if o.Text != nil {
-		return json.MarshalEncode(enc, *o.Text)
+		return json.MarshalEncode(enc, o.Text)
 	}
 	if o.VariableLookup != nil {
-		return json.MarshalEncode(enc, *o.VariableLookup)
+		return json.MarshalEncode(enc, o.VariableLookup)
 	}
 	if o.EvaluatableExpression != nil {
-		return json.MarshalEncode(enc, *o.EvaluatableExpression)
+		return json.MarshalEncode(enc, o.EvaluatableExpression)
 	}
 	panic("unreachable")
 }

--- a/internal/lsp/lsproto/lsp_generated.go
+++ b/internal/lsp/lsproto/lsp_generated.go
@@ -20377,14 +20377,14 @@ type IntegerOrString struct {
 	String  *string
 }
 
-func (o IntegerOrString) MarshalJSON() ([]byte, error) {
+func (o IntegerOrString) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of IntegerOrString is set", o.Integer != nil, o.String != nil)
 
 	if o.Integer != nil {
-		return json.Marshal(*o.Integer)
+		return json.MarshalEncode(enc, *o.Integer)
 	}
 	if o.String != nil {
-		return json.Marshal(*o.String)
+		return json.MarshalEncode(enc, *o.String)
 	}
 	panic("unreachable")
 }
@@ -20409,14 +20409,14 @@ type DocumentSelectorOrNull struct {
 	DocumentSelector *[]TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPatternOrNotebookCellTextDocumentFilter
 }
 
-func (o DocumentSelectorOrNull) MarshalJSON() ([]byte, error) {
+func (o DocumentSelectorOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of DocumentSelectorOrNull is set", o.DocumentSelector != nil)
 
 	if o.DocumentSelector != nil {
-		return json.Marshal(*o.DocumentSelector)
+		return json.MarshalEncode(enc, *o.DocumentSelector)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *DocumentSelectorOrNull) UnmarshalJSON(data []byte) error {
@@ -20440,14 +20440,14 @@ type BooleanOrEmptyObject struct {
 	EmptyObject *struct{}
 }
 
-func (o BooleanOrEmptyObject) MarshalJSON() ([]byte, error) {
+func (o BooleanOrEmptyObject) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of BooleanOrEmptyObject is set", o.Boolean != nil, o.EmptyObject != nil)
 
 	if o.Boolean != nil {
-		return json.Marshal(*o.Boolean)
+		return json.MarshalEncode(enc, *o.Boolean)
 	}
 	if o.EmptyObject != nil {
-		return json.Marshal(*o.EmptyObject)
+		return json.MarshalEncode(enc, *o.EmptyObject)
 	}
 	panic("unreachable")
 }
@@ -20473,14 +20473,14 @@ type BooleanOrSemanticTokensFullDelta struct {
 	SemanticTokensFullDelta *SemanticTokensFullDelta
 }
 
-func (o BooleanOrSemanticTokensFullDelta) MarshalJSON() ([]byte, error) {
+func (o BooleanOrSemanticTokensFullDelta) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of BooleanOrSemanticTokensFullDelta is set", o.Boolean != nil, o.SemanticTokensFullDelta != nil)
 
 	if o.Boolean != nil {
-		return json.Marshal(*o.Boolean)
+		return json.MarshalEncode(enc, *o.Boolean)
 	}
 	if o.SemanticTokensFullDelta != nil {
-		return json.Marshal(*o.SemanticTokensFullDelta)
+		return json.MarshalEncode(enc, *o.SemanticTokensFullDelta)
 	}
 	panic("unreachable")
 }
@@ -20508,20 +20508,20 @@ type TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile struct {
 	DeleteFile       *DeleteFile
 }
 
-func (o TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile) MarshalJSON() ([]byte, error) {
+func (o TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile is set", o.TextDocumentEdit != nil, o.CreateFile != nil, o.RenameFile != nil, o.DeleteFile != nil)
 
 	if o.TextDocumentEdit != nil {
-		return json.Marshal(*o.TextDocumentEdit)
+		return json.MarshalEncode(enc, *o.TextDocumentEdit)
 	}
 	if o.CreateFile != nil {
-		return json.Marshal(*o.CreateFile)
+		return json.MarshalEncode(enc, *o.CreateFile)
 	}
 	if o.RenameFile != nil {
-		return json.Marshal(*o.RenameFile)
+		return json.MarshalEncode(enc, *o.RenameFile)
 	}
 	if o.DeleteFile != nil {
-		return json.Marshal(*o.DeleteFile)
+		return json.MarshalEncode(enc, *o.DeleteFile)
 	}
 	panic("unreachable")
 }
@@ -20557,14 +20557,14 @@ type StringOrInlayHintLabelParts struct {
 	InlayHintLabelParts *[]*InlayHintLabelPart
 }
 
-func (o StringOrInlayHintLabelParts) MarshalJSON() ([]byte, error) {
+func (o StringOrInlayHintLabelParts) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of StringOrInlayHintLabelParts is set", o.String != nil, o.InlayHintLabelParts != nil)
 
 	if o.String != nil {
-		return json.Marshal(*o.String)
+		return json.MarshalEncode(enc, *o.String)
 	}
 	if o.InlayHintLabelParts != nil {
-		return json.Marshal(*o.InlayHintLabelParts)
+		return json.MarshalEncode(enc, *o.InlayHintLabelParts)
 	}
 	panic("unreachable")
 }
@@ -20590,14 +20590,14 @@ type StringOrMarkupContent struct {
 	MarkupContent *MarkupContent
 }
 
-func (o StringOrMarkupContent) MarshalJSON() ([]byte, error) {
+func (o StringOrMarkupContent) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of StringOrMarkupContent is set", o.String != nil, o.MarkupContent != nil)
 
 	if o.String != nil {
-		return json.Marshal(*o.String)
+		return json.MarshalEncode(enc, *o.String)
 	}
 	if o.MarkupContent != nil {
-		return json.Marshal(*o.MarkupContent)
+		return json.MarshalEncode(enc, *o.MarkupContent)
 	}
 	panic("unreachable")
 }
@@ -20623,14 +20623,14 @@ type FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport struct {
 	UnchangedDocumentDiagnosticReport *UnchangedDocumentDiagnosticReport
 }
 
-func (o FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) MarshalJSON() ([]byte, error) {
+func (o FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport is set", o.FullDocumentDiagnosticReport != nil, o.UnchangedDocumentDiagnosticReport != nil)
 
 	if o.FullDocumentDiagnosticReport != nil {
-		return json.Marshal(*o.FullDocumentDiagnosticReport)
+		return json.MarshalEncode(enc, *o.FullDocumentDiagnosticReport)
 	}
 	if o.UnchangedDocumentDiagnosticReport != nil {
-		return json.Marshal(*o.UnchangedDocumentDiagnosticReport)
+		return json.MarshalEncode(enc, *o.UnchangedDocumentDiagnosticReport)
 	}
 	panic("unreachable")
 }
@@ -20656,14 +20656,14 @@ type WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport st
 	UnchangedDocumentDiagnosticReport *WorkspaceUnchangedDocumentDiagnosticReport
 }
 
-func (o WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) MarshalJSON() ([]byte, error) {
+func (o WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport is set", o.FullDocumentDiagnosticReport != nil, o.UnchangedDocumentDiagnosticReport != nil)
 
 	if o.FullDocumentDiagnosticReport != nil {
-		return json.Marshal(*o.FullDocumentDiagnosticReport)
+		return json.MarshalEncode(enc, *o.FullDocumentDiagnosticReport)
 	}
 	if o.UnchangedDocumentDiagnosticReport != nil {
-		return json.Marshal(*o.UnchangedDocumentDiagnosticReport)
+		return json.MarshalEncode(enc, *o.UnchangedDocumentDiagnosticReport)
 	}
 	panic("unreachable")
 }
@@ -20689,14 +20689,14 @@ type NotebookDocumentFilterWithNotebookOrCells struct {
 	Cells    *NotebookDocumentFilterWithCells
 }
 
-func (o NotebookDocumentFilterWithNotebookOrCells) MarshalJSON() ([]byte, error) {
+func (o NotebookDocumentFilterWithNotebookOrCells) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of NotebookDocumentFilterWithNotebookOrCells is set", o.Notebook != nil, o.Cells != nil)
 
 	if o.Notebook != nil {
-		return json.Marshal(*o.Notebook)
+		return json.MarshalEncode(enc, *o.Notebook)
 	}
 	if o.Cells != nil {
-		return json.Marshal(*o.Cells)
+		return json.MarshalEncode(enc, *o.Cells)
 	}
 	panic("unreachable")
 }
@@ -20722,14 +20722,14 @@ type StringOrStringValue struct {
 	StringValue *StringValue
 }
 
-func (o StringOrStringValue) MarshalJSON() ([]byte, error) {
+func (o StringOrStringValue) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of StringOrStringValue is set", o.String != nil, o.StringValue != nil)
 
 	if o.String != nil {
-		return json.Marshal(*o.String)
+		return json.MarshalEncode(enc, *o.String)
 	}
 	if o.StringValue != nil {
-		return json.Marshal(*o.StringValue)
+		return json.MarshalEncode(enc, *o.StringValue)
 	}
 	panic("unreachable")
 }
@@ -20754,14 +20754,14 @@ type IntegerOrNull struct {
 	Integer *int32
 }
 
-func (o IntegerOrNull) MarshalJSON() ([]byte, error) {
+func (o IntegerOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of IntegerOrNull is set", o.Integer != nil)
 
 	if o.Integer != nil {
-		return json.Marshal(*o.Integer)
+		return json.MarshalEncode(enc, *o.Integer)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *IntegerOrNull) UnmarshalJSON(data []byte) error {
@@ -20784,14 +20784,14 @@ type StringOrNull struct {
 	String *string
 }
 
-func (o StringOrNull) MarshalJSON() ([]byte, error) {
+func (o StringOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of StringOrNull is set", o.String != nil)
 
 	if o.String != nil {
-		return json.Marshal(*o.String)
+		return json.MarshalEncode(enc, *o.String)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *StringOrNull) UnmarshalJSON(data []byte) error {
@@ -20814,14 +20814,14 @@ type DocumentUriOrNull struct {
 	DocumentUri *DocumentUri
 }
 
-func (o DocumentUriOrNull) MarshalJSON() ([]byte, error) {
+func (o DocumentUriOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of DocumentUriOrNull is set", o.DocumentUri != nil)
 
 	if o.DocumentUri != nil {
-		return json.Marshal(*o.DocumentUri)
+		return json.MarshalEncode(enc, *o.DocumentUri)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *DocumentUriOrNull) UnmarshalJSON(data []byte) error {
@@ -20844,14 +20844,14 @@ type WorkspaceFoldersOrNull struct {
 	WorkspaceFolders *[]*WorkspaceFolder
 }
 
-func (o WorkspaceFoldersOrNull) MarshalJSON() ([]byte, error) {
+func (o WorkspaceFoldersOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of WorkspaceFoldersOrNull is set", o.WorkspaceFolders != nil)
 
 	if o.WorkspaceFolders != nil {
-		return json.Marshal(*o.WorkspaceFolders)
+		return json.MarshalEncode(enc, *o.WorkspaceFolders)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *WorkspaceFoldersOrNull) UnmarshalJSON(data []byte) error {
@@ -20875,14 +20875,14 @@ type StringOrStrings struct {
 	Strings *[]string
 }
 
-func (o StringOrStrings) MarshalJSON() ([]byte, error) {
+func (o StringOrStrings) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of StringOrStrings is set", o.String != nil, o.Strings != nil)
 
 	if o.String != nil {
-		return json.Marshal(*o.String)
+		return json.MarshalEncode(enc, *o.String)
 	}
 	if o.Strings != nil {
-		return json.Marshal(*o.Strings)
+		return json.MarshalEncode(enc, *o.Strings)
 	}
 	panic("unreachable")
 }
@@ -20908,14 +20908,14 @@ type TextDocumentContentChangePartialOrWholeDocument struct {
 	WholeDocument *TextDocumentContentChangeWholeDocument
 }
 
-func (o TextDocumentContentChangePartialOrWholeDocument) MarshalJSON() ([]byte, error) {
+func (o TextDocumentContentChangePartialOrWholeDocument) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of TextDocumentContentChangePartialOrWholeDocument is set", o.Partial != nil, o.WholeDocument != nil)
 
 	if o.Partial != nil {
-		return json.Marshal(*o.Partial)
+		return json.MarshalEncode(enc, *o.Partial)
 	}
 	if o.WholeDocument != nil {
-		return json.Marshal(*o.WholeDocument)
+		return json.MarshalEncode(enc, *o.WholeDocument)
 	}
 	panic("unreachable")
 }
@@ -20941,14 +20941,14 @@ type TextEditOrInsertReplaceEdit struct {
 	InsertReplaceEdit *InsertReplaceEdit
 }
 
-func (o TextEditOrInsertReplaceEdit) MarshalJSON() ([]byte, error) {
+func (o TextEditOrInsertReplaceEdit) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of TextEditOrInsertReplaceEdit is set", o.TextEdit != nil, o.InsertReplaceEdit != nil)
 
 	if o.TextEdit != nil {
-		return json.Marshal(*o.TextEdit)
+		return json.MarshalEncode(enc, *o.TextEdit)
 	}
 	if o.InsertReplaceEdit != nil {
-		return json.Marshal(*o.InsertReplaceEdit)
+		return json.MarshalEncode(enc, *o.InsertReplaceEdit)
 	}
 	panic("unreachable")
 }
@@ -20976,20 +20976,20 @@ type MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings struct {
 	MarkedStrings            *[]StringOrMarkedStringWithLanguage
 }
 
-func (o MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings) MarshalJSON() ([]byte, error) {
+func (o MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings is set", o.MarkupContent != nil, o.String != nil, o.MarkedStringWithLanguage != nil, o.MarkedStrings != nil)
 
 	if o.MarkupContent != nil {
-		return json.Marshal(*o.MarkupContent)
+		return json.MarshalEncode(enc, *o.MarkupContent)
 	}
 	if o.String != nil {
-		return json.Marshal(*o.String)
+		return json.MarshalEncode(enc, *o.String)
 	}
 	if o.MarkedStringWithLanguage != nil {
-		return json.Marshal(*o.MarkedStringWithLanguage)
+		return json.MarshalEncode(enc, *o.MarkedStringWithLanguage)
 	}
 	if o.MarkedStrings != nil {
-		return json.Marshal(*o.MarkedStrings)
+		return json.MarshalEncode(enc, *o.MarkedStrings)
 	}
 	panic("unreachable")
 }
@@ -21024,14 +21024,14 @@ type UintegerOrNull struct {
 	Uinteger *uint32
 }
 
-func (o UintegerOrNull) MarshalJSON() ([]byte, error) {
+func (o UintegerOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of UintegerOrNull is set", o.Uinteger != nil)
 
 	if o.Uinteger != nil {
-		return json.Marshal(*o.Uinteger)
+		return json.MarshalEncode(enc, *o.Uinteger)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *UintegerOrNull) UnmarshalJSON(data []byte) error {
@@ -21055,14 +21055,14 @@ type LocationOrLocationUriOnly struct {
 	LocationUriOnly *LocationUriOnly
 }
 
-func (o LocationOrLocationUriOnly) MarshalJSON() ([]byte, error) {
+func (o LocationOrLocationUriOnly) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of LocationOrLocationUriOnly is set", o.Location != nil, o.LocationUriOnly != nil)
 
 	if o.Location != nil {
-		return json.Marshal(*o.Location)
+		return json.MarshalEncode(enc, *o.Location)
 	}
 	if o.LocationUriOnly != nil {
-		return json.Marshal(*o.LocationUriOnly)
+		return json.MarshalEncode(enc, *o.LocationUriOnly)
 	}
 	panic("unreachable")
 }
@@ -21089,17 +21089,17 @@ type TextEditOrAnnotatedTextEditOrSnippetTextEdit struct {
 	SnippetTextEdit   *SnippetTextEdit
 }
 
-func (o TextEditOrAnnotatedTextEditOrSnippetTextEdit) MarshalJSON() ([]byte, error) {
+func (o TextEditOrAnnotatedTextEditOrSnippetTextEdit) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of TextEditOrAnnotatedTextEditOrSnippetTextEdit is set", o.TextEdit != nil, o.AnnotatedTextEdit != nil, o.SnippetTextEdit != nil)
 
 	if o.TextEdit != nil {
-		return json.Marshal(*o.TextEdit)
+		return json.MarshalEncode(enc, *o.TextEdit)
 	}
 	if o.AnnotatedTextEdit != nil {
-		return json.Marshal(*o.AnnotatedTextEdit)
+		return json.MarshalEncode(enc, *o.AnnotatedTextEdit)
 	}
 	if o.SnippetTextEdit != nil {
-		return json.Marshal(*o.SnippetTextEdit)
+		return json.MarshalEncode(enc, *o.SnippetTextEdit)
 	}
 	panic("unreachable")
 }
@@ -21130,14 +21130,14 @@ type TextDocumentSyncOptionsOrKind struct {
 	Kind    *TextDocumentSyncKind
 }
 
-func (o TextDocumentSyncOptionsOrKind) MarshalJSON() ([]byte, error) {
+func (o TextDocumentSyncOptionsOrKind) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of TextDocumentSyncOptionsOrKind is set", o.Options != nil, o.Kind != nil)
 
 	if o.Options != nil {
-		return json.Marshal(*o.Options)
+		return json.MarshalEncode(enc, *o.Options)
 	}
 	if o.Kind != nil {
-		return json.Marshal(*o.Kind)
+		return json.MarshalEncode(enc, *o.Kind)
 	}
 	panic("unreachable")
 }
@@ -21163,14 +21163,14 @@ type NotebookDocumentSyncOptionsOrRegistrationOptions struct {
 	RegistrationOptions *NotebookDocumentSyncRegistrationOptions
 }
 
-func (o NotebookDocumentSyncOptionsOrRegistrationOptions) MarshalJSON() ([]byte, error) {
+func (o NotebookDocumentSyncOptionsOrRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of NotebookDocumentSyncOptionsOrRegistrationOptions is set", o.Options != nil, o.RegistrationOptions != nil)
 
 	if o.Options != nil {
-		return json.Marshal(*o.Options)
+		return json.MarshalEncode(enc, *o.Options)
 	}
 	if o.RegistrationOptions != nil {
-		return json.Marshal(*o.RegistrationOptions)
+		return json.MarshalEncode(enc, *o.RegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -21196,14 +21196,14 @@ type BooleanOrHoverOptions struct {
 	HoverOptions *HoverOptions
 }
 
-func (o BooleanOrHoverOptions) MarshalJSON() ([]byte, error) {
+func (o BooleanOrHoverOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of BooleanOrHoverOptions is set", o.Boolean != nil, o.HoverOptions != nil)
 
 	if o.Boolean != nil {
-		return json.Marshal(*o.Boolean)
+		return json.MarshalEncode(enc, *o.Boolean)
 	}
 	if o.HoverOptions != nil {
-		return json.Marshal(*o.HoverOptions)
+		return json.MarshalEncode(enc, *o.HoverOptions)
 	}
 	panic("unreachable")
 }
@@ -21230,17 +21230,17 @@ type BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions struct {
 	DeclarationRegistrationOptions *DeclarationRegistrationOptions
 }
 
-func (o BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions) MarshalJSON() ([]byte, error) {
+func (o BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions is set", o.Boolean != nil, o.DeclarationOptions != nil, o.DeclarationRegistrationOptions != nil)
 
 	if o.Boolean != nil {
-		return json.Marshal(*o.Boolean)
+		return json.MarshalEncode(enc, *o.Boolean)
 	}
 	if o.DeclarationOptions != nil {
-		return json.Marshal(*o.DeclarationOptions)
+		return json.MarshalEncode(enc, *o.DeclarationOptions)
 	}
 	if o.DeclarationRegistrationOptions != nil {
-		return json.Marshal(*o.DeclarationRegistrationOptions)
+		return json.MarshalEncode(enc, *o.DeclarationRegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -21271,14 +21271,14 @@ type BooleanOrDefinitionOptions struct {
 	DefinitionOptions *DefinitionOptions
 }
 
-func (o BooleanOrDefinitionOptions) MarshalJSON() ([]byte, error) {
+func (o BooleanOrDefinitionOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of BooleanOrDefinitionOptions is set", o.Boolean != nil, o.DefinitionOptions != nil)
 
 	if o.Boolean != nil {
-		return json.Marshal(*o.Boolean)
+		return json.MarshalEncode(enc, *o.Boolean)
 	}
 	if o.DefinitionOptions != nil {
-		return json.Marshal(*o.DefinitionOptions)
+		return json.MarshalEncode(enc, *o.DefinitionOptions)
 	}
 	panic("unreachable")
 }
@@ -21305,17 +21305,17 @@ type BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions struct {
 	TypeDefinitionRegistrationOptions *TypeDefinitionRegistrationOptions
 }
 
-func (o BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions) MarshalJSON() ([]byte, error) {
+func (o BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions is set", o.Boolean != nil, o.TypeDefinitionOptions != nil, o.TypeDefinitionRegistrationOptions != nil)
 
 	if o.Boolean != nil {
-		return json.Marshal(*o.Boolean)
+		return json.MarshalEncode(enc, *o.Boolean)
 	}
 	if o.TypeDefinitionOptions != nil {
-		return json.Marshal(*o.TypeDefinitionOptions)
+		return json.MarshalEncode(enc, *o.TypeDefinitionOptions)
 	}
 	if o.TypeDefinitionRegistrationOptions != nil {
-		return json.Marshal(*o.TypeDefinitionRegistrationOptions)
+		return json.MarshalEncode(enc, *o.TypeDefinitionRegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -21347,17 +21347,17 @@ type BooleanOrImplementationOptionsOrImplementationRegistrationOptions struct {
 	ImplementationRegistrationOptions *ImplementationRegistrationOptions
 }
 
-func (o BooleanOrImplementationOptionsOrImplementationRegistrationOptions) MarshalJSON() ([]byte, error) {
+func (o BooleanOrImplementationOptionsOrImplementationRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of BooleanOrImplementationOptionsOrImplementationRegistrationOptions is set", o.Boolean != nil, o.ImplementationOptions != nil, o.ImplementationRegistrationOptions != nil)
 
 	if o.Boolean != nil {
-		return json.Marshal(*o.Boolean)
+		return json.MarshalEncode(enc, *o.Boolean)
 	}
 	if o.ImplementationOptions != nil {
-		return json.Marshal(*o.ImplementationOptions)
+		return json.MarshalEncode(enc, *o.ImplementationOptions)
 	}
 	if o.ImplementationRegistrationOptions != nil {
-		return json.Marshal(*o.ImplementationRegistrationOptions)
+		return json.MarshalEncode(enc, *o.ImplementationRegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -21388,14 +21388,14 @@ type BooleanOrReferenceOptions struct {
 	ReferenceOptions *ReferenceOptions
 }
 
-func (o BooleanOrReferenceOptions) MarshalJSON() ([]byte, error) {
+func (o BooleanOrReferenceOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of BooleanOrReferenceOptions is set", o.Boolean != nil, o.ReferenceOptions != nil)
 
 	if o.Boolean != nil {
-		return json.Marshal(*o.Boolean)
+		return json.MarshalEncode(enc, *o.Boolean)
 	}
 	if o.ReferenceOptions != nil {
-		return json.Marshal(*o.ReferenceOptions)
+		return json.MarshalEncode(enc, *o.ReferenceOptions)
 	}
 	panic("unreachable")
 }
@@ -21421,14 +21421,14 @@ type BooleanOrDocumentHighlightOptions struct {
 	DocumentHighlightOptions *DocumentHighlightOptions
 }
 
-func (o BooleanOrDocumentHighlightOptions) MarshalJSON() ([]byte, error) {
+func (o BooleanOrDocumentHighlightOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of BooleanOrDocumentHighlightOptions is set", o.Boolean != nil, o.DocumentHighlightOptions != nil)
 
 	if o.Boolean != nil {
-		return json.Marshal(*o.Boolean)
+		return json.MarshalEncode(enc, *o.Boolean)
 	}
 	if o.DocumentHighlightOptions != nil {
-		return json.Marshal(*o.DocumentHighlightOptions)
+		return json.MarshalEncode(enc, *o.DocumentHighlightOptions)
 	}
 	panic("unreachable")
 }
@@ -21454,14 +21454,14 @@ type BooleanOrDocumentSymbolOptions struct {
 	DocumentSymbolOptions *DocumentSymbolOptions
 }
 
-func (o BooleanOrDocumentSymbolOptions) MarshalJSON() ([]byte, error) {
+func (o BooleanOrDocumentSymbolOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of BooleanOrDocumentSymbolOptions is set", o.Boolean != nil, o.DocumentSymbolOptions != nil)
 
 	if o.Boolean != nil {
-		return json.Marshal(*o.Boolean)
+		return json.MarshalEncode(enc, *o.Boolean)
 	}
 	if o.DocumentSymbolOptions != nil {
-		return json.Marshal(*o.DocumentSymbolOptions)
+		return json.MarshalEncode(enc, *o.DocumentSymbolOptions)
 	}
 	panic("unreachable")
 }
@@ -21487,14 +21487,14 @@ type BooleanOrCodeActionOptions struct {
 	CodeActionOptions *CodeActionOptions
 }
 
-func (o BooleanOrCodeActionOptions) MarshalJSON() ([]byte, error) {
+func (o BooleanOrCodeActionOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of BooleanOrCodeActionOptions is set", o.Boolean != nil, o.CodeActionOptions != nil)
 
 	if o.Boolean != nil {
-		return json.Marshal(*o.Boolean)
+		return json.MarshalEncode(enc, *o.Boolean)
 	}
 	if o.CodeActionOptions != nil {
-		return json.Marshal(*o.CodeActionOptions)
+		return json.MarshalEncode(enc, *o.CodeActionOptions)
 	}
 	panic("unreachable")
 }
@@ -21521,17 +21521,17 @@ type BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions struct {
 	DocumentColorRegistrationOptions *DocumentColorRegistrationOptions
 }
 
-func (o BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions) MarshalJSON() ([]byte, error) {
+func (o BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions is set", o.Boolean != nil, o.DocumentColorOptions != nil, o.DocumentColorRegistrationOptions != nil)
 
 	if o.Boolean != nil {
-		return json.Marshal(*o.Boolean)
+		return json.MarshalEncode(enc, *o.Boolean)
 	}
 	if o.DocumentColorOptions != nil {
-		return json.Marshal(*o.DocumentColorOptions)
+		return json.MarshalEncode(enc, *o.DocumentColorOptions)
 	}
 	if o.DocumentColorRegistrationOptions != nil {
-		return json.Marshal(*o.DocumentColorRegistrationOptions)
+		return json.MarshalEncode(enc, *o.DocumentColorRegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -21562,14 +21562,14 @@ type BooleanOrWorkspaceSymbolOptions struct {
 	WorkspaceSymbolOptions *WorkspaceSymbolOptions
 }
 
-func (o BooleanOrWorkspaceSymbolOptions) MarshalJSON() ([]byte, error) {
+func (o BooleanOrWorkspaceSymbolOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of BooleanOrWorkspaceSymbolOptions is set", o.Boolean != nil, o.WorkspaceSymbolOptions != nil)
 
 	if o.Boolean != nil {
-		return json.Marshal(*o.Boolean)
+		return json.MarshalEncode(enc, *o.Boolean)
 	}
 	if o.WorkspaceSymbolOptions != nil {
-		return json.Marshal(*o.WorkspaceSymbolOptions)
+		return json.MarshalEncode(enc, *o.WorkspaceSymbolOptions)
 	}
 	panic("unreachable")
 }
@@ -21595,14 +21595,14 @@ type BooleanOrDocumentFormattingOptions struct {
 	DocumentFormattingOptions *DocumentFormattingOptions
 }
 
-func (o BooleanOrDocumentFormattingOptions) MarshalJSON() ([]byte, error) {
+func (o BooleanOrDocumentFormattingOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of BooleanOrDocumentFormattingOptions is set", o.Boolean != nil, o.DocumentFormattingOptions != nil)
 
 	if o.Boolean != nil {
-		return json.Marshal(*o.Boolean)
+		return json.MarshalEncode(enc, *o.Boolean)
 	}
 	if o.DocumentFormattingOptions != nil {
-		return json.Marshal(*o.DocumentFormattingOptions)
+		return json.MarshalEncode(enc, *o.DocumentFormattingOptions)
 	}
 	panic("unreachable")
 }
@@ -21628,14 +21628,14 @@ type BooleanOrDocumentRangeFormattingOptions struct {
 	DocumentRangeFormattingOptions *DocumentRangeFormattingOptions
 }
 
-func (o BooleanOrDocumentRangeFormattingOptions) MarshalJSON() ([]byte, error) {
+func (o BooleanOrDocumentRangeFormattingOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of BooleanOrDocumentRangeFormattingOptions is set", o.Boolean != nil, o.DocumentRangeFormattingOptions != nil)
 
 	if o.Boolean != nil {
-		return json.Marshal(*o.Boolean)
+		return json.MarshalEncode(enc, *o.Boolean)
 	}
 	if o.DocumentRangeFormattingOptions != nil {
-		return json.Marshal(*o.DocumentRangeFormattingOptions)
+		return json.MarshalEncode(enc, *o.DocumentRangeFormattingOptions)
 	}
 	panic("unreachable")
 }
@@ -21661,14 +21661,14 @@ type BooleanOrRenameOptions struct {
 	RenameOptions *RenameOptions
 }
 
-func (o BooleanOrRenameOptions) MarshalJSON() ([]byte, error) {
+func (o BooleanOrRenameOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of BooleanOrRenameOptions is set", o.Boolean != nil, o.RenameOptions != nil)
 
 	if o.Boolean != nil {
-		return json.Marshal(*o.Boolean)
+		return json.MarshalEncode(enc, *o.Boolean)
 	}
 	if o.RenameOptions != nil {
-		return json.Marshal(*o.RenameOptions)
+		return json.MarshalEncode(enc, *o.RenameOptions)
 	}
 	panic("unreachable")
 }
@@ -21695,17 +21695,17 @@ type BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions struct {
 	FoldingRangeRegistrationOptions *FoldingRangeRegistrationOptions
 }
 
-func (o BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions) MarshalJSON() ([]byte, error) {
+func (o BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions is set", o.Boolean != nil, o.FoldingRangeOptions != nil, o.FoldingRangeRegistrationOptions != nil)
 
 	if o.Boolean != nil {
-		return json.Marshal(*o.Boolean)
+		return json.MarshalEncode(enc, *o.Boolean)
 	}
 	if o.FoldingRangeOptions != nil {
-		return json.Marshal(*o.FoldingRangeOptions)
+		return json.MarshalEncode(enc, *o.FoldingRangeOptions)
 	}
 	if o.FoldingRangeRegistrationOptions != nil {
-		return json.Marshal(*o.FoldingRangeRegistrationOptions)
+		return json.MarshalEncode(enc, *o.FoldingRangeRegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -21737,17 +21737,17 @@ type BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions struct {
 	SelectionRangeRegistrationOptions *SelectionRangeRegistrationOptions
 }
 
-func (o BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions) MarshalJSON() ([]byte, error) {
+func (o BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions is set", o.Boolean != nil, o.SelectionRangeOptions != nil, o.SelectionRangeRegistrationOptions != nil)
 
 	if o.Boolean != nil {
-		return json.Marshal(*o.Boolean)
+		return json.MarshalEncode(enc, *o.Boolean)
 	}
 	if o.SelectionRangeOptions != nil {
-		return json.Marshal(*o.SelectionRangeOptions)
+		return json.MarshalEncode(enc, *o.SelectionRangeOptions)
 	}
 	if o.SelectionRangeRegistrationOptions != nil {
-		return json.Marshal(*o.SelectionRangeRegistrationOptions)
+		return json.MarshalEncode(enc, *o.SelectionRangeRegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -21779,17 +21779,17 @@ type BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions struct {
 	CallHierarchyRegistrationOptions *CallHierarchyRegistrationOptions
 }
 
-func (o BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions) MarshalJSON() ([]byte, error) {
+func (o BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions is set", o.Boolean != nil, o.CallHierarchyOptions != nil, o.CallHierarchyRegistrationOptions != nil)
 
 	if o.Boolean != nil {
-		return json.Marshal(*o.Boolean)
+		return json.MarshalEncode(enc, *o.Boolean)
 	}
 	if o.CallHierarchyOptions != nil {
-		return json.Marshal(*o.CallHierarchyOptions)
+		return json.MarshalEncode(enc, *o.CallHierarchyOptions)
 	}
 	if o.CallHierarchyRegistrationOptions != nil {
-		return json.Marshal(*o.CallHierarchyRegistrationOptions)
+		return json.MarshalEncode(enc, *o.CallHierarchyRegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -21821,17 +21821,17 @@ type BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOptions s
 	LinkedEditingRangeRegistrationOptions *LinkedEditingRangeRegistrationOptions
 }
 
-func (o BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOptions) MarshalJSON() ([]byte, error) {
+func (o BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOptions is set", o.Boolean != nil, o.LinkedEditingRangeOptions != nil, o.LinkedEditingRangeRegistrationOptions != nil)
 
 	if o.Boolean != nil {
-		return json.Marshal(*o.Boolean)
+		return json.MarshalEncode(enc, *o.Boolean)
 	}
 	if o.LinkedEditingRangeOptions != nil {
-		return json.Marshal(*o.LinkedEditingRangeOptions)
+		return json.MarshalEncode(enc, *o.LinkedEditingRangeOptions)
 	}
 	if o.LinkedEditingRangeRegistrationOptions != nil {
-		return json.Marshal(*o.LinkedEditingRangeRegistrationOptions)
+		return json.MarshalEncode(enc, *o.LinkedEditingRangeRegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -21862,14 +21862,14 @@ type SemanticTokensOptionsOrRegistrationOptions struct {
 	RegistrationOptions *SemanticTokensRegistrationOptions
 }
 
-func (o SemanticTokensOptionsOrRegistrationOptions) MarshalJSON() ([]byte, error) {
+func (o SemanticTokensOptionsOrRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of SemanticTokensOptionsOrRegistrationOptions is set", o.Options != nil, o.RegistrationOptions != nil)
 
 	if o.Options != nil {
-		return json.Marshal(*o.Options)
+		return json.MarshalEncode(enc, *o.Options)
 	}
 	if o.RegistrationOptions != nil {
-		return json.Marshal(*o.RegistrationOptions)
+		return json.MarshalEncode(enc, *o.RegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -21896,17 +21896,17 @@ type BooleanOrMonikerOptionsOrMonikerRegistrationOptions struct {
 	MonikerRegistrationOptions *MonikerRegistrationOptions
 }
 
-func (o BooleanOrMonikerOptionsOrMonikerRegistrationOptions) MarshalJSON() ([]byte, error) {
+func (o BooleanOrMonikerOptionsOrMonikerRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of BooleanOrMonikerOptionsOrMonikerRegistrationOptions is set", o.Boolean != nil, o.MonikerOptions != nil, o.MonikerRegistrationOptions != nil)
 
 	if o.Boolean != nil {
-		return json.Marshal(*o.Boolean)
+		return json.MarshalEncode(enc, *o.Boolean)
 	}
 	if o.MonikerOptions != nil {
-		return json.Marshal(*o.MonikerOptions)
+		return json.MarshalEncode(enc, *o.MonikerOptions)
 	}
 	if o.MonikerRegistrationOptions != nil {
-		return json.Marshal(*o.MonikerRegistrationOptions)
+		return json.MarshalEncode(enc, *o.MonikerRegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -21938,17 +21938,17 @@ type BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions struct {
 	TypeHierarchyRegistrationOptions *TypeHierarchyRegistrationOptions
 }
 
-func (o BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions) MarshalJSON() ([]byte, error) {
+func (o BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions is set", o.Boolean != nil, o.TypeHierarchyOptions != nil, o.TypeHierarchyRegistrationOptions != nil)
 
 	if o.Boolean != nil {
-		return json.Marshal(*o.Boolean)
+		return json.MarshalEncode(enc, *o.Boolean)
 	}
 	if o.TypeHierarchyOptions != nil {
-		return json.Marshal(*o.TypeHierarchyOptions)
+		return json.MarshalEncode(enc, *o.TypeHierarchyOptions)
 	}
 	if o.TypeHierarchyRegistrationOptions != nil {
-		return json.Marshal(*o.TypeHierarchyRegistrationOptions)
+		return json.MarshalEncode(enc, *o.TypeHierarchyRegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -21980,17 +21980,17 @@ type BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions struct {
 	InlineValueRegistrationOptions *InlineValueRegistrationOptions
 }
 
-func (o BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions) MarshalJSON() ([]byte, error) {
+func (o BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions is set", o.Boolean != nil, o.InlineValueOptions != nil, o.InlineValueRegistrationOptions != nil)
 
 	if o.Boolean != nil {
-		return json.Marshal(*o.Boolean)
+		return json.MarshalEncode(enc, *o.Boolean)
 	}
 	if o.InlineValueOptions != nil {
-		return json.Marshal(*o.InlineValueOptions)
+		return json.MarshalEncode(enc, *o.InlineValueOptions)
 	}
 	if o.InlineValueRegistrationOptions != nil {
-		return json.Marshal(*o.InlineValueRegistrationOptions)
+		return json.MarshalEncode(enc, *o.InlineValueRegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -22022,17 +22022,17 @@ type BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions struct {
 	InlayHintRegistrationOptions *InlayHintRegistrationOptions
 }
 
-func (o BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions) MarshalJSON() ([]byte, error) {
+func (o BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions is set", o.Boolean != nil, o.InlayHintOptions != nil, o.InlayHintRegistrationOptions != nil)
 
 	if o.Boolean != nil {
-		return json.Marshal(*o.Boolean)
+		return json.MarshalEncode(enc, *o.Boolean)
 	}
 	if o.InlayHintOptions != nil {
-		return json.Marshal(*o.InlayHintOptions)
+		return json.MarshalEncode(enc, *o.InlayHintOptions)
 	}
 	if o.InlayHintRegistrationOptions != nil {
-		return json.Marshal(*o.InlayHintRegistrationOptions)
+		return json.MarshalEncode(enc, *o.InlayHintRegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -22063,14 +22063,14 @@ type DiagnosticOptionsOrRegistrationOptions struct {
 	RegistrationOptions *DiagnosticRegistrationOptions
 }
 
-func (o DiagnosticOptionsOrRegistrationOptions) MarshalJSON() ([]byte, error) {
+func (o DiagnosticOptionsOrRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of DiagnosticOptionsOrRegistrationOptions is set", o.Options != nil, o.RegistrationOptions != nil)
 
 	if o.Options != nil {
-		return json.Marshal(*o.Options)
+		return json.MarshalEncode(enc, *o.Options)
 	}
 	if o.RegistrationOptions != nil {
-		return json.Marshal(*o.RegistrationOptions)
+		return json.MarshalEncode(enc, *o.RegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -22096,14 +22096,14 @@ type BooleanOrInlineCompletionOptions struct {
 	InlineCompletionOptions *InlineCompletionOptions
 }
 
-func (o BooleanOrInlineCompletionOptions) MarshalJSON() ([]byte, error) {
+func (o BooleanOrInlineCompletionOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of BooleanOrInlineCompletionOptions is set", o.Boolean != nil, o.InlineCompletionOptions != nil)
 
 	if o.Boolean != nil {
-		return json.Marshal(*o.Boolean)
+		return json.MarshalEncode(enc, *o.Boolean)
 	}
 	if o.InlineCompletionOptions != nil {
-		return json.Marshal(*o.InlineCompletionOptions)
+		return json.MarshalEncode(enc, *o.InlineCompletionOptions)
 	}
 	panic("unreachable")
 }
@@ -22129,14 +22129,14 @@ type PatternOrRelativePattern struct {
 	RelativePattern *RelativePattern
 }
 
-func (o PatternOrRelativePattern) MarshalJSON() ([]byte, error) {
+func (o PatternOrRelativePattern) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of PatternOrRelativePattern is set", o.Pattern != nil, o.RelativePattern != nil)
 
 	if o.Pattern != nil {
-		return json.Marshal(*o.Pattern)
+		return json.MarshalEncode(enc, *o.Pattern)
 	}
 	if o.RelativePattern != nil {
-		return json.Marshal(*o.RelativePattern)
+		return json.MarshalEncode(enc, *o.RelativePattern)
 	}
 	panic("unreachable")
 }
@@ -22162,14 +22162,14 @@ type RangeOrEditRangeWithInsertReplace struct {
 	EditRangeWithInsertReplace *EditRangeWithInsertReplace
 }
 
-func (o RangeOrEditRangeWithInsertReplace) MarshalJSON() ([]byte, error) {
+func (o RangeOrEditRangeWithInsertReplace) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of RangeOrEditRangeWithInsertReplace is set", o.Range != nil, o.EditRangeWithInsertReplace != nil)
 
 	if o.Range != nil {
-		return json.Marshal(*o.Range)
+		return json.MarshalEncode(enc, *o.Range)
 	}
 	if o.EditRangeWithInsertReplace != nil {
-		return json.Marshal(*o.EditRangeWithInsertReplace)
+		return json.MarshalEncode(enc, *o.EditRangeWithInsertReplace)
 	}
 	panic("unreachable")
 }
@@ -22197,20 +22197,20 @@ type StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrN
 	NotebookDocumentFilterPattern      *NotebookDocumentFilterPattern
 }
 
-func (o StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrNotebookDocumentFilterPattern) MarshalJSON() ([]byte, error) {
+func (o StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrNotebookDocumentFilterPattern) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrNotebookDocumentFilterPattern is set", o.String != nil, o.NotebookDocumentFilterNotebookType != nil, o.NotebookDocumentFilterScheme != nil, o.NotebookDocumentFilterPattern != nil)
 
 	if o.String != nil {
-		return json.Marshal(*o.String)
+		return json.MarshalEncode(enc, *o.String)
 	}
 	if o.NotebookDocumentFilterNotebookType != nil {
-		return json.Marshal(*o.NotebookDocumentFilterNotebookType)
+		return json.MarshalEncode(enc, *o.NotebookDocumentFilterNotebookType)
 	}
 	if o.NotebookDocumentFilterScheme != nil {
-		return json.Marshal(*o.NotebookDocumentFilterScheme)
+		return json.MarshalEncode(enc, *o.NotebookDocumentFilterScheme)
 	}
 	if o.NotebookDocumentFilterPattern != nil {
-		return json.Marshal(*o.NotebookDocumentFilterPattern)
+		return json.MarshalEncode(enc, *o.NotebookDocumentFilterPattern)
 	}
 	panic("unreachable")
 }
@@ -22246,14 +22246,14 @@ type BooleanOrSaveOptions struct {
 	SaveOptions *SaveOptions
 }
 
-func (o BooleanOrSaveOptions) MarshalJSON() ([]byte, error) {
+func (o BooleanOrSaveOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of BooleanOrSaveOptions is set", o.Boolean != nil, o.SaveOptions != nil)
 
 	if o.Boolean != nil {
-		return json.Marshal(*o.Boolean)
+		return json.MarshalEncode(enc, *o.Boolean)
 	}
 	if o.SaveOptions != nil {
-		return json.Marshal(*o.SaveOptions)
+		return json.MarshalEncode(enc, *o.SaveOptions)
 	}
 	panic("unreachable")
 }
@@ -22279,14 +22279,14 @@ type TextDocumentContentOptionsOrRegistrationOptions struct {
 	RegistrationOptions *TextDocumentContentRegistrationOptions
 }
 
-func (o TextDocumentContentOptionsOrRegistrationOptions) MarshalJSON() ([]byte, error) {
+func (o TextDocumentContentOptionsOrRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of TextDocumentContentOptionsOrRegistrationOptions is set", o.Options != nil, o.RegistrationOptions != nil)
 
 	if o.Options != nil {
-		return json.Marshal(*o.Options)
+		return json.MarshalEncode(enc, *o.Options)
 	}
 	if o.RegistrationOptions != nil {
-		return json.Marshal(*o.RegistrationOptions)
+		return json.MarshalEncode(enc, *o.RegistrationOptions)
 	}
 	panic("unreachable")
 }
@@ -22312,14 +22312,14 @@ type StringOrTuple struct {
 	Tuple  *[2]uint32
 }
 
-func (o StringOrTuple) MarshalJSON() ([]byte, error) {
+func (o StringOrTuple) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of StringOrTuple is set", o.String != nil, o.Tuple != nil)
 
 	if o.String != nil {
-		return json.Marshal(*o.String)
+		return json.MarshalEncode(enc, *o.String)
 	}
 	if o.Tuple != nil {
-		return json.Marshal(*o.Tuple)
+		return json.MarshalEncode(enc, *o.Tuple)
 	}
 	panic("unreachable")
 }
@@ -22345,14 +22345,14 @@ type StringOrBoolean struct {
 	Boolean *bool
 }
 
-func (o StringOrBoolean) MarshalJSON() ([]byte, error) {
+func (o StringOrBoolean) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of StringOrBoolean is set", o.String != nil, o.Boolean != nil)
 
 	if o.String != nil {
-		return json.Marshal(*o.String)
+		return json.MarshalEncode(enc, *o.String)
 	}
 	if o.Boolean != nil {
-		return json.Marshal(*o.Boolean)
+		return json.MarshalEncode(enc, *o.Boolean)
 	}
 	panic("unreachable")
 }
@@ -22378,14 +22378,14 @@ type WorkspaceFolderOrURI struct {
 	URI             *URI
 }
 
-func (o WorkspaceFolderOrURI) MarshalJSON() ([]byte, error) {
+func (o WorkspaceFolderOrURI) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of WorkspaceFolderOrURI is set", o.WorkspaceFolder != nil, o.URI != nil)
 
 	if o.WorkspaceFolder != nil {
-		return json.Marshal(*o.WorkspaceFolder)
+		return json.MarshalEncode(enc, *o.WorkspaceFolder)
 	}
 	if o.URI != nil {
-		return json.Marshal(*o.URI)
+		return json.MarshalEncode(enc, *o.URI)
 	}
 	panic("unreachable")
 }
@@ -22411,14 +22411,14 @@ type BooleanOrClientSemanticTokensRequestFullDelta struct {
 	ClientSemanticTokensRequestFullDelta *ClientSemanticTokensRequestFullDelta
 }
 
-func (o BooleanOrClientSemanticTokensRequestFullDelta) MarshalJSON() ([]byte, error) {
+func (o BooleanOrClientSemanticTokensRequestFullDelta) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of BooleanOrClientSemanticTokensRequestFullDelta is set", o.Boolean != nil, o.ClientSemanticTokensRequestFullDelta != nil)
 
 	if o.Boolean != nil {
-		return json.Marshal(*o.Boolean)
+		return json.MarshalEncode(enc, *o.Boolean)
 	}
 	if o.ClientSemanticTokensRequestFullDelta != nil {
-		return json.Marshal(*o.ClientSemanticTokensRequestFullDelta)
+		return json.MarshalEncode(enc, *o.ClientSemanticTokensRequestFullDelta)
 	}
 	panic("unreachable")
 }
@@ -22445,20 +22445,20 @@ type LocationOrLocationsOrDefinitionLinksOrNull struct {
 	DefinitionLinks *[]*LocationLink
 }
 
-func (o LocationOrLocationsOrDefinitionLinksOrNull) MarshalJSON() ([]byte, error) {
+func (o LocationOrLocationsOrDefinitionLinksOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of LocationOrLocationsOrDefinitionLinksOrNull is set", o.Location != nil, o.Locations != nil, o.DefinitionLinks != nil)
 
 	if o.Location != nil {
-		return json.Marshal(*o.Location)
+		return json.MarshalEncode(enc, *o.Location)
 	}
 	if o.Locations != nil {
-		return json.Marshal(*o.Locations)
+		return json.MarshalEncode(enc, *o.Locations)
 	}
 	if o.DefinitionLinks != nil {
-		return json.Marshal(*o.DefinitionLinks)
+		return json.MarshalEncode(enc, *o.DefinitionLinks)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *LocationOrLocationsOrDefinitionLinksOrNull) UnmarshalJSON(data []byte) error {
@@ -22491,14 +22491,14 @@ type FoldingRangesOrNull struct {
 	FoldingRanges *[]*FoldingRange
 }
 
-func (o FoldingRangesOrNull) MarshalJSON() ([]byte, error) {
+func (o FoldingRangesOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of FoldingRangesOrNull is set", o.FoldingRanges != nil)
 
 	if o.FoldingRanges != nil {
-		return json.Marshal(*o.FoldingRanges)
+		return json.MarshalEncode(enc, *o.FoldingRanges)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *FoldingRangesOrNull) UnmarshalJSON(data []byte) error {
@@ -22523,20 +22523,20 @@ type LocationOrLocationsOrDeclarationLinksOrNull struct {
 	DeclarationLinks *[]*LocationLink
 }
 
-func (o LocationOrLocationsOrDeclarationLinksOrNull) MarshalJSON() ([]byte, error) {
+func (o LocationOrLocationsOrDeclarationLinksOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of LocationOrLocationsOrDeclarationLinksOrNull is set", o.Location != nil, o.Locations != nil, o.DeclarationLinks != nil)
 
 	if o.Location != nil {
-		return json.Marshal(*o.Location)
+		return json.MarshalEncode(enc, *o.Location)
 	}
 	if o.Locations != nil {
-		return json.Marshal(*o.Locations)
+		return json.MarshalEncode(enc, *o.Locations)
 	}
 	if o.DeclarationLinks != nil {
-		return json.Marshal(*o.DeclarationLinks)
+		return json.MarshalEncode(enc, *o.DeclarationLinks)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *LocationOrLocationsOrDeclarationLinksOrNull) UnmarshalJSON(data []byte) error {
@@ -22569,14 +22569,14 @@ type SelectionRangesOrNull struct {
 	SelectionRanges *[]*SelectionRange
 }
 
-func (o SelectionRangesOrNull) MarshalJSON() ([]byte, error) {
+func (o SelectionRangesOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of SelectionRangesOrNull is set", o.SelectionRanges != nil)
 
 	if o.SelectionRanges != nil {
-		return json.Marshal(*o.SelectionRanges)
+		return json.MarshalEncode(enc, *o.SelectionRanges)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *SelectionRangesOrNull) UnmarshalJSON(data []byte) error {
@@ -22599,14 +22599,14 @@ type CallHierarchyItemsOrNull struct {
 	CallHierarchyItems *[]*CallHierarchyItem
 }
 
-func (o CallHierarchyItemsOrNull) MarshalJSON() ([]byte, error) {
+func (o CallHierarchyItemsOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of CallHierarchyItemsOrNull is set", o.CallHierarchyItems != nil)
 
 	if o.CallHierarchyItems != nil {
-		return json.Marshal(*o.CallHierarchyItems)
+		return json.MarshalEncode(enc, *o.CallHierarchyItems)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *CallHierarchyItemsOrNull) UnmarshalJSON(data []byte) error {
@@ -22629,14 +22629,14 @@ type CallHierarchyIncomingCallsOrNull struct {
 	CallHierarchyIncomingCalls *[]*CallHierarchyIncomingCall
 }
 
-func (o CallHierarchyIncomingCallsOrNull) MarshalJSON() ([]byte, error) {
+func (o CallHierarchyIncomingCallsOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of CallHierarchyIncomingCallsOrNull is set", o.CallHierarchyIncomingCalls != nil)
 
 	if o.CallHierarchyIncomingCalls != nil {
-		return json.Marshal(*o.CallHierarchyIncomingCalls)
+		return json.MarshalEncode(enc, *o.CallHierarchyIncomingCalls)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *CallHierarchyIncomingCallsOrNull) UnmarshalJSON(data []byte) error {
@@ -22659,14 +22659,14 @@ type CallHierarchyOutgoingCallsOrNull struct {
 	CallHierarchyOutgoingCalls *[]*CallHierarchyOutgoingCall
 }
 
-func (o CallHierarchyOutgoingCallsOrNull) MarshalJSON() ([]byte, error) {
+func (o CallHierarchyOutgoingCallsOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of CallHierarchyOutgoingCallsOrNull is set", o.CallHierarchyOutgoingCalls != nil)
 
 	if o.CallHierarchyOutgoingCalls != nil {
-		return json.Marshal(*o.CallHierarchyOutgoingCalls)
+		return json.MarshalEncode(enc, *o.CallHierarchyOutgoingCalls)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *CallHierarchyOutgoingCallsOrNull) UnmarshalJSON(data []byte) error {
@@ -22689,14 +22689,14 @@ type SemanticTokensOrNull struct {
 	SemanticTokens *SemanticTokens
 }
 
-func (o SemanticTokensOrNull) MarshalJSON() ([]byte, error) {
+func (o SemanticTokensOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of SemanticTokensOrNull is set", o.SemanticTokens != nil)
 
 	if o.SemanticTokens != nil {
-		return json.Marshal(*o.SemanticTokens)
+		return json.MarshalEncode(enc, *o.SemanticTokens)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *SemanticTokensOrNull) UnmarshalJSON(data []byte) error {
@@ -22720,17 +22720,17 @@ type SemanticTokensOrSemanticTokensDeltaOrNull struct {
 	SemanticTokensDelta *SemanticTokensDelta
 }
 
-func (o SemanticTokensOrSemanticTokensDeltaOrNull) MarshalJSON() ([]byte, error) {
+func (o SemanticTokensOrSemanticTokensDeltaOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of SemanticTokensOrSemanticTokensDeltaOrNull is set", o.SemanticTokens != nil, o.SemanticTokensDelta != nil)
 
 	if o.SemanticTokens != nil {
-		return json.Marshal(*o.SemanticTokens)
+		return json.MarshalEncode(enc, *o.SemanticTokens)
 	}
 	if o.SemanticTokensDelta != nil {
-		return json.Marshal(*o.SemanticTokensDelta)
+		return json.MarshalEncode(enc, *o.SemanticTokensDelta)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *SemanticTokensOrSemanticTokensDeltaOrNull) UnmarshalJSON(data []byte) error {
@@ -22758,14 +22758,14 @@ type LinkedEditingRangesOrNull struct {
 	LinkedEditingRanges *LinkedEditingRanges
 }
 
-func (o LinkedEditingRangesOrNull) MarshalJSON() ([]byte, error) {
+func (o LinkedEditingRangesOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of LinkedEditingRangesOrNull is set", o.LinkedEditingRanges != nil)
 
 	if o.LinkedEditingRanges != nil {
-		return json.Marshal(*o.LinkedEditingRanges)
+		return json.MarshalEncode(enc, *o.LinkedEditingRanges)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *LinkedEditingRangesOrNull) UnmarshalJSON(data []byte) error {
@@ -22788,14 +22788,14 @@ type WorkspaceEditOrNull struct {
 	WorkspaceEdit *WorkspaceEdit
 }
 
-func (o WorkspaceEditOrNull) MarshalJSON() ([]byte, error) {
+func (o WorkspaceEditOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of WorkspaceEditOrNull is set", o.WorkspaceEdit != nil)
 
 	if o.WorkspaceEdit != nil {
-		return json.Marshal(*o.WorkspaceEdit)
+		return json.MarshalEncode(enc, *o.WorkspaceEdit)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *WorkspaceEditOrNull) UnmarshalJSON(data []byte) error {
@@ -22818,14 +22818,14 @@ type MonikersOrNull struct {
 	Monikers *[]*Moniker
 }
 
-func (o MonikersOrNull) MarshalJSON() ([]byte, error) {
+func (o MonikersOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of MonikersOrNull is set", o.Monikers != nil)
 
 	if o.Monikers != nil {
-		return json.Marshal(*o.Monikers)
+		return json.MarshalEncode(enc, *o.Monikers)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *MonikersOrNull) UnmarshalJSON(data []byte) error {
@@ -22848,14 +22848,14 @@ type TypeHierarchyItemsOrNull struct {
 	TypeHierarchyItems *[]*TypeHierarchyItem
 }
 
-func (o TypeHierarchyItemsOrNull) MarshalJSON() ([]byte, error) {
+func (o TypeHierarchyItemsOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of TypeHierarchyItemsOrNull is set", o.TypeHierarchyItems != nil)
 
 	if o.TypeHierarchyItems != nil {
-		return json.Marshal(*o.TypeHierarchyItems)
+		return json.MarshalEncode(enc, *o.TypeHierarchyItems)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *TypeHierarchyItemsOrNull) UnmarshalJSON(data []byte) error {
@@ -22878,14 +22878,14 @@ type InlineValuesOrNull struct {
 	InlineValues *[]InlineValueTextOrVariableLookupOrEvaluatableExpression
 }
 
-func (o InlineValuesOrNull) MarshalJSON() ([]byte, error) {
+func (o InlineValuesOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of InlineValuesOrNull is set", o.InlineValues != nil)
 
 	if o.InlineValues != nil {
-		return json.Marshal(*o.InlineValues)
+		return json.MarshalEncode(enc, *o.InlineValues)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *InlineValuesOrNull) UnmarshalJSON(data []byte) error {
@@ -22908,14 +22908,14 @@ type InlayHintsOrNull struct {
 	InlayHints *[]*InlayHint
 }
 
-func (o InlayHintsOrNull) MarshalJSON() ([]byte, error) {
+func (o InlayHintsOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of InlayHintsOrNull is set", o.InlayHints != nil)
 
 	if o.InlayHints != nil {
-		return json.Marshal(*o.InlayHints)
+		return json.MarshalEncode(enc, *o.InlayHints)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *InlayHintsOrNull) UnmarshalJSON(data []byte) error {
@@ -22939,14 +22939,14 @@ type RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport stru
 	UnchangedDocumentDiagnosticReport *RelatedUnchangedDocumentDiagnosticReport
 }
 
-func (o RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) MarshalJSON() ([]byte, error) {
+func (o RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport is set", o.FullDocumentDiagnosticReport != nil, o.UnchangedDocumentDiagnosticReport != nil)
 
 	if o.FullDocumentDiagnosticReport != nil {
-		return json.Marshal(*o.FullDocumentDiagnosticReport)
+		return json.MarshalEncode(enc, *o.FullDocumentDiagnosticReport)
 	}
 	if o.UnchangedDocumentDiagnosticReport != nil {
-		return json.Marshal(*o.UnchangedDocumentDiagnosticReport)
+		return json.MarshalEncode(enc, *o.UnchangedDocumentDiagnosticReport)
 	}
 	panic("unreachable")
 }
@@ -22972,17 +22972,17 @@ type InlineCompletionListOrItemsOrNull struct {
 	Items *[]*InlineCompletionItem
 }
 
-func (o InlineCompletionListOrItemsOrNull) MarshalJSON() ([]byte, error) {
+func (o InlineCompletionListOrItemsOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of InlineCompletionListOrItemsOrNull is set", o.List != nil, o.Items != nil)
 
 	if o.List != nil {
-		return json.Marshal(*o.List)
+		return json.MarshalEncode(enc, *o.List)
 	}
 	if o.Items != nil {
-		return json.Marshal(*o.Items)
+		return json.MarshalEncode(enc, *o.Items)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *InlineCompletionListOrItemsOrNull) UnmarshalJSON(data []byte) error {
@@ -23010,14 +23010,14 @@ type MessageActionItemOrNull struct {
 	MessageActionItem *MessageActionItem
 }
 
-func (o MessageActionItemOrNull) MarshalJSON() ([]byte, error) {
+func (o MessageActionItemOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of MessageActionItemOrNull is set", o.MessageActionItem != nil)
 
 	if o.MessageActionItem != nil {
-		return json.Marshal(*o.MessageActionItem)
+		return json.MarshalEncode(enc, *o.MessageActionItem)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *MessageActionItemOrNull) UnmarshalJSON(data []byte) error {
@@ -23040,14 +23040,14 @@ type TextEditsOrNull struct {
 	TextEdits *[]*TextEdit
 }
 
-func (o TextEditsOrNull) MarshalJSON() ([]byte, error) {
+func (o TextEditsOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of TextEditsOrNull is set", o.TextEdits != nil)
 
 	if o.TextEdits != nil {
-		return json.Marshal(*o.TextEdits)
+		return json.MarshalEncode(enc, *o.TextEdits)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *TextEditsOrNull) UnmarshalJSON(data []byte) error {
@@ -23071,17 +23071,17 @@ type CompletionItemsOrListOrNull struct {
 	List  *CompletionList
 }
 
-func (o CompletionItemsOrListOrNull) MarshalJSON() ([]byte, error) {
+func (o CompletionItemsOrListOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of CompletionItemsOrListOrNull is set", o.Items != nil, o.List != nil)
 
 	if o.Items != nil {
-		return json.Marshal(*o.Items)
+		return json.MarshalEncode(enc, *o.Items)
 	}
 	if o.List != nil {
-		return json.Marshal(*o.List)
+		return json.MarshalEncode(enc, *o.List)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *CompletionItemsOrListOrNull) UnmarshalJSON(data []byte) error {
@@ -23109,14 +23109,14 @@ type HoverOrNull struct {
 	Hover *Hover
 }
 
-func (o HoverOrNull) MarshalJSON() ([]byte, error) {
+func (o HoverOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of HoverOrNull is set", o.Hover != nil)
 
 	if o.Hover != nil {
-		return json.Marshal(*o.Hover)
+		return json.MarshalEncode(enc, *o.Hover)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *HoverOrNull) UnmarshalJSON(data []byte) error {
@@ -23139,14 +23139,14 @@ type SignatureHelpOrNull struct {
 	SignatureHelp *SignatureHelp
 }
 
-func (o SignatureHelpOrNull) MarshalJSON() ([]byte, error) {
+func (o SignatureHelpOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of SignatureHelpOrNull is set", o.SignatureHelp != nil)
 
 	if o.SignatureHelp != nil {
-		return json.Marshal(*o.SignatureHelp)
+		return json.MarshalEncode(enc, *o.SignatureHelp)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *SignatureHelpOrNull) UnmarshalJSON(data []byte) error {
@@ -23169,14 +23169,14 @@ type LocationsOrNull struct {
 	Locations *[]Location
 }
 
-func (o LocationsOrNull) MarshalJSON() ([]byte, error) {
+func (o LocationsOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of LocationsOrNull is set", o.Locations != nil)
 
 	if o.Locations != nil {
-		return json.Marshal(*o.Locations)
+		return json.MarshalEncode(enc, *o.Locations)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *LocationsOrNull) UnmarshalJSON(data []byte) error {
@@ -23199,14 +23199,14 @@ type DocumentHighlightsOrNull struct {
 	DocumentHighlights *[]*DocumentHighlight
 }
 
-func (o DocumentHighlightsOrNull) MarshalJSON() ([]byte, error) {
+func (o DocumentHighlightsOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of DocumentHighlightsOrNull is set", o.DocumentHighlights != nil)
 
 	if o.DocumentHighlights != nil {
-		return json.Marshal(*o.DocumentHighlights)
+		return json.MarshalEncode(enc, *o.DocumentHighlights)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *DocumentHighlightsOrNull) UnmarshalJSON(data []byte) error {
@@ -23230,17 +23230,17 @@ type SymbolInformationsOrDocumentSymbolsOrNull struct {
 	DocumentSymbols    *[]*DocumentSymbol
 }
 
-func (o SymbolInformationsOrDocumentSymbolsOrNull) MarshalJSON() ([]byte, error) {
+func (o SymbolInformationsOrDocumentSymbolsOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of SymbolInformationsOrDocumentSymbolsOrNull is set", o.SymbolInformations != nil, o.DocumentSymbols != nil)
 
 	if o.SymbolInformations != nil {
-		return json.Marshal(*o.SymbolInformations)
+		return json.MarshalEncode(enc, *o.SymbolInformations)
 	}
 	if o.DocumentSymbols != nil {
-		return json.Marshal(*o.DocumentSymbols)
+		return json.MarshalEncode(enc, *o.DocumentSymbols)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *SymbolInformationsOrDocumentSymbolsOrNull) UnmarshalJSON(data []byte) error {
@@ -23269,14 +23269,14 @@ type CommandOrCodeAction struct {
 	CodeAction *CodeAction
 }
 
-func (o CommandOrCodeAction) MarshalJSON() ([]byte, error) {
+func (o CommandOrCodeAction) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of CommandOrCodeAction is set", o.Command != nil, o.CodeAction != nil)
 
 	if o.Command != nil {
-		return json.Marshal(*o.Command)
+		return json.MarshalEncode(enc, *o.Command)
 	}
 	if o.CodeAction != nil {
-		return json.Marshal(*o.CodeAction)
+		return json.MarshalEncode(enc, *o.CodeAction)
 	}
 	panic("unreachable")
 }
@@ -23301,14 +23301,14 @@ type CommandOrCodeActionArrayOrNull struct {
 	CommandOrCodeActionArray *[]CommandOrCodeAction
 }
 
-func (o CommandOrCodeActionArrayOrNull) MarshalJSON() ([]byte, error) {
+func (o CommandOrCodeActionArrayOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of CommandOrCodeActionArrayOrNull is set", o.CommandOrCodeActionArray != nil)
 
 	if o.CommandOrCodeActionArray != nil {
-		return json.Marshal(*o.CommandOrCodeActionArray)
+		return json.MarshalEncode(enc, *o.CommandOrCodeActionArray)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *CommandOrCodeActionArrayOrNull) UnmarshalJSON(data []byte) error {
@@ -23332,17 +23332,17 @@ type SymbolInformationsOrWorkspaceSymbolsOrNull struct {
 	WorkspaceSymbols   *[]*WorkspaceSymbol
 }
 
-func (o SymbolInformationsOrWorkspaceSymbolsOrNull) MarshalJSON() ([]byte, error) {
+func (o SymbolInformationsOrWorkspaceSymbolsOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of SymbolInformationsOrWorkspaceSymbolsOrNull is set", o.SymbolInformations != nil, o.WorkspaceSymbols != nil)
 
 	if o.SymbolInformations != nil {
-		return json.Marshal(*o.SymbolInformations)
+		return json.MarshalEncode(enc, *o.SymbolInformations)
 	}
 	if o.WorkspaceSymbols != nil {
-		return json.Marshal(*o.WorkspaceSymbols)
+		return json.MarshalEncode(enc, *o.WorkspaceSymbols)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *SymbolInformationsOrWorkspaceSymbolsOrNull) UnmarshalJSON(data []byte) error {
@@ -23370,14 +23370,14 @@ type CodeLenssOrNull struct {
 	CodeLenss *[]*CodeLens
 }
 
-func (o CodeLenssOrNull) MarshalJSON() ([]byte, error) {
+func (o CodeLenssOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of CodeLenssOrNull is set", o.CodeLenss != nil)
 
 	if o.CodeLenss != nil {
-		return json.Marshal(*o.CodeLenss)
+		return json.MarshalEncode(enc, *o.CodeLenss)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *CodeLenssOrNull) UnmarshalJSON(data []byte) error {
@@ -23400,14 +23400,14 @@ type DocumentLinksOrNull struct {
 	DocumentLinks *[]*DocumentLink
 }
 
-func (o DocumentLinksOrNull) MarshalJSON() ([]byte, error) {
+func (o DocumentLinksOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of DocumentLinksOrNull is set", o.DocumentLinks != nil)
 
 	if o.DocumentLinks != nil {
-		return json.Marshal(*o.DocumentLinks)
+		return json.MarshalEncode(enc, *o.DocumentLinks)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *DocumentLinksOrNull) UnmarshalJSON(data []byte) error {
@@ -23432,20 +23432,20 @@ type RangeOrPrepareRenamePlaceholderOrPrepareRenameDefaultBehaviorOrNull struct 
 	PrepareRenameDefaultBehavior *PrepareRenameDefaultBehavior
 }
 
-func (o RangeOrPrepareRenamePlaceholderOrPrepareRenameDefaultBehaviorOrNull) MarshalJSON() ([]byte, error) {
+func (o RangeOrPrepareRenamePlaceholderOrPrepareRenameDefaultBehaviorOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of RangeOrPrepareRenamePlaceholderOrPrepareRenameDefaultBehaviorOrNull is set", o.Range != nil, o.PrepareRenamePlaceholder != nil, o.PrepareRenameDefaultBehavior != nil)
 
 	if o.Range != nil {
-		return json.Marshal(*o.Range)
+		return json.MarshalEncode(enc, *o.Range)
 	}
 	if o.PrepareRenamePlaceholder != nil {
-		return json.Marshal(*o.PrepareRenamePlaceholder)
+		return json.MarshalEncode(enc, *o.PrepareRenamePlaceholder)
 	}
 	if o.PrepareRenameDefaultBehavior != nil {
-		return json.Marshal(*o.PrepareRenameDefaultBehavior)
+		return json.MarshalEncode(enc, *o.PrepareRenameDefaultBehavior)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *RangeOrPrepareRenamePlaceholderOrPrepareRenameDefaultBehaviorOrNull) UnmarshalJSON(data []byte) error {
@@ -23478,14 +23478,14 @@ type LSPAnyOrNull struct {
 	LSPAny *any
 }
 
-func (o LSPAnyOrNull) MarshalJSON() ([]byte, error) {
+func (o LSPAnyOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of LSPAnyOrNull is set", o.LSPAny != nil)
 
 	if o.LSPAny != nil {
-		return json.Marshal(*o.LSPAny)
+		return json.MarshalEncode(enc, *o.LSPAny)
 	}
 	// All fields are nil, represent as null
-	return []byte("null"), nil
+	return enc.WriteToken(jsontext.Null)
 }
 
 func (o *LSPAnyOrNull) UnmarshalJSON(data []byte) error {
@@ -23511,20 +23511,20 @@ type TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPat
 	NotebookCellTextDocumentFilter *NotebookCellTextDocumentFilter
 }
 
-func (o TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPatternOrNotebookCellTextDocumentFilter) MarshalJSON() ([]byte, error) {
+func (o TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPatternOrNotebookCellTextDocumentFilter) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPatternOrNotebookCellTextDocumentFilter is set", o.TextDocumentFilterLanguage != nil, o.TextDocumentFilterScheme != nil, o.TextDocumentFilterPattern != nil, o.NotebookCellTextDocumentFilter != nil)
 
 	if o.TextDocumentFilterLanguage != nil {
-		return json.Marshal(*o.TextDocumentFilterLanguage)
+		return json.MarshalEncode(enc, *o.TextDocumentFilterLanguage)
 	}
 	if o.TextDocumentFilterScheme != nil {
-		return json.Marshal(*o.TextDocumentFilterScheme)
+		return json.MarshalEncode(enc, *o.TextDocumentFilterScheme)
 	}
 	if o.TextDocumentFilterPattern != nil {
-		return json.Marshal(*o.TextDocumentFilterPattern)
+		return json.MarshalEncode(enc, *o.TextDocumentFilterPattern)
 	}
 	if o.NotebookCellTextDocumentFilter != nil {
-		return json.Marshal(*o.NotebookCellTextDocumentFilter)
+		return json.MarshalEncode(enc, *o.NotebookCellTextDocumentFilter)
 	}
 	panic("unreachable")
 }
@@ -23560,14 +23560,14 @@ type StringOrMarkedStringWithLanguage struct {
 	MarkedStringWithLanguage *MarkedStringWithLanguage
 }
 
-func (o StringOrMarkedStringWithLanguage) MarshalJSON() ([]byte, error) {
+func (o StringOrMarkedStringWithLanguage) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of StringOrMarkedStringWithLanguage is set", o.String != nil, o.MarkedStringWithLanguage != nil)
 
 	if o.String != nil {
-		return json.Marshal(*o.String)
+		return json.MarshalEncode(enc, *o.String)
 	}
 	if o.MarkedStringWithLanguage != nil {
-		return json.Marshal(*o.MarkedStringWithLanguage)
+		return json.MarshalEncode(enc, *o.MarkedStringWithLanguage)
 	}
 	panic("unreachable")
 }
@@ -23594,17 +23594,17 @@ type InlineValueTextOrVariableLookupOrEvaluatableExpression struct {
 	EvaluatableExpression *InlineValueEvaluatableExpression
 }
 
-func (o InlineValueTextOrVariableLookupOrEvaluatableExpression) MarshalJSON() ([]byte, error) {
+func (o InlineValueTextOrVariableLookupOrEvaluatableExpression) MarshalerTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("more than one element of InlineValueTextOrVariableLookupOrEvaluatableExpression is set", o.Text != nil, o.VariableLookup != nil, o.EvaluatableExpression != nil)
 
 	if o.Text != nil {
-		return json.Marshal(*o.Text)
+		return json.MarshalEncode(enc, *o.Text)
 	}
 	if o.VariableLookup != nil {
-		return json.Marshal(*o.VariableLookup)
+		return json.MarshalEncode(enc, *o.VariableLookup)
 	}
 	if o.EvaluatableExpression != nil {
-		return json.Marshal(*o.EvaluatableExpression)
+		return json.MarshalEncode(enc, *o.EvaluatableExpression)
 	}
 	panic("unreachable")
 }

--- a/internal/lsp/lsproto/lsp_generated.go
+++ b/internal/lsp/lsproto/lsp_generated.go
@@ -23635,8 +23635,8 @@ func (o *InlineValueTextOrVariableLookupOrEvaluatableExpression) UnmarshalJSON(d
 // StringLiteralBegin is a literal type for "begin"
 type StringLiteralBegin struct{}
 
-func (o StringLiteralBegin) MarshalJSON() ([]byte, error) {
-	return []byte(`"begin"`), nil
+func (o StringLiteralBegin) MarshalerTo(enc *jsontext.Encoder) error {
+	return enc.WriteValue(jsontext.Value(`"begin"`))
 }
 
 func (o *StringLiteralBegin) UnmarshalJSON(data []byte) error {
@@ -23649,8 +23649,8 @@ func (o *StringLiteralBegin) UnmarshalJSON(data []byte) error {
 // StringLiteralReport is a literal type for "report"
 type StringLiteralReport struct{}
 
-func (o StringLiteralReport) MarshalJSON() ([]byte, error) {
-	return []byte(`"report"`), nil
+func (o StringLiteralReport) MarshalerTo(enc *jsontext.Encoder) error {
+	return enc.WriteValue(jsontext.Value(`"report"`))
 }
 
 func (o *StringLiteralReport) UnmarshalJSON(data []byte) error {
@@ -23663,8 +23663,8 @@ func (o *StringLiteralReport) UnmarshalJSON(data []byte) error {
 // StringLiteralEnd is a literal type for "end"
 type StringLiteralEnd struct{}
 
-func (o StringLiteralEnd) MarshalJSON() ([]byte, error) {
-	return []byte(`"end"`), nil
+func (o StringLiteralEnd) MarshalerTo(enc *jsontext.Encoder) error {
+	return enc.WriteValue(jsontext.Value(`"end"`))
 }
 
 func (o *StringLiteralEnd) UnmarshalJSON(data []byte) error {
@@ -23677,8 +23677,8 @@ func (o *StringLiteralEnd) UnmarshalJSON(data []byte) error {
 // StringLiteralCreate is a literal type for "create"
 type StringLiteralCreate struct{}
 
-func (o StringLiteralCreate) MarshalJSON() ([]byte, error) {
-	return []byte(`"create"`), nil
+func (o StringLiteralCreate) MarshalerTo(enc *jsontext.Encoder) error {
+	return enc.WriteValue(jsontext.Value(`"create"`))
 }
 
 func (o *StringLiteralCreate) UnmarshalJSON(data []byte) error {
@@ -23691,8 +23691,8 @@ func (o *StringLiteralCreate) UnmarshalJSON(data []byte) error {
 // StringLiteralRename is a literal type for "rename"
 type StringLiteralRename struct{}
 
-func (o StringLiteralRename) MarshalJSON() ([]byte, error) {
-	return []byte(`"rename"`), nil
+func (o StringLiteralRename) MarshalerTo(enc *jsontext.Encoder) error {
+	return enc.WriteValue(jsontext.Value(`"rename"`))
 }
 
 func (o *StringLiteralRename) UnmarshalJSON(data []byte) error {
@@ -23705,8 +23705,8 @@ func (o *StringLiteralRename) UnmarshalJSON(data []byte) error {
 // StringLiteralDelete is a literal type for "delete"
 type StringLiteralDelete struct{}
 
-func (o StringLiteralDelete) MarshalJSON() ([]byte, error) {
-	return []byte(`"delete"`), nil
+func (o StringLiteralDelete) MarshalerTo(enc *jsontext.Encoder) error {
+	return enc.WriteValue(jsontext.Value(`"delete"`))
 }
 
 func (o *StringLiteralDelete) UnmarshalJSON(data []byte) error {
@@ -23719,8 +23719,8 @@ func (o *StringLiteralDelete) UnmarshalJSON(data []byte) error {
 // StringLiteralFull is a literal type for "full"
 type StringLiteralFull struct{}
 
-func (o StringLiteralFull) MarshalJSON() ([]byte, error) {
-	return []byte(`"full"`), nil
+func (o StringLiteralFull) MarshalerTo(enc *jsontext.Encoder) error {
+	return enc.WriteValue(jsontext.Value(`"full"`))
 }
 
 func (o *StringLiteralFull) UnmarshalJSON(data []byte) error {
@@ -23733,8 +23733,8 @@ func (o *StringLiteralFull) UnmarshalJSON(data []byte) error {
 // StringLiteralUnchanged is a literal type for "unchanged"
 type StringLiteralUnchanged struct{}
 
-func (o StringLiteralUnchanged) MarshalJSON() ([]byte, error) {
-	return []byte(`"unchanged"`), nil
+func (o StringLiteralUnchanged) MarshalerTo(enc *jsontext.Encoder) error {
+	return enc.WriteValue(jsontext.Value(`"unchanged"`))
 }
 
 func (o *StringLiteralUnchanged) UnmarshalJSON(data []byte) error {
@@ -23747,8 +23747,8 @@ func (o *StringLiteralUnchanged) UnmarshalJSON(data []byte) error {
 // StringLiteralSnippet is a literal type for "snippet"
 type StringLiteralSnippet struct{}
 
-func (o StringLiteralSnippet) MarshalJSON() ([]byte, error) {
-	return []byte(`"snippet"`), nil
+func (o StringLiteralSnippet) MarshalerTo(enc *jsontext.Encoder) error {
+	return enc.WriteValue(jsontext.Value(`"snippet"`))
 }
 
 func (o *StringLiteralSnippet) UnmarshalJSON(data []byte) error {

--- a/internal/lsp/lsproto/lsp_generated.go
+++ b/internal/lsp/lsproto/lsp_generated.go
@@ -20973,7 +20973,6 @@ func (o *DocumentSelectorOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error 
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -21397,7 +21396,6 @@ func (o *IntegerOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -21434,7 +21432,6 @@ func (o *StringOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -21471,7 +21468,6 @@ func (o *DocumentUriOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -21508,7 +21504,6 @@ func (o *WorkspaceFoldersOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error 
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -21727,7 +21722,6 @@ func (o *UintegerOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -23465,7 +23459,6 @@ func (o *LocationOrLocationsOrDefinitionLinksOrNull) UnmarshalJSONFrom(dec *json
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -23512,7 +23505,6 @@ func (o *FoldingRangesOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -23557,7 +23549,6 @@ func (o *LocationOrLocationsOrDeclarationLinksOrNull) UnmarshalJSONFrom(dec *jso
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -23604,7 +23595,6 @@ func (o *SelectionRangesOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -23641,7 +23631,6 @@ func (o *CallHierarchyItemsOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -23678,7 +23667,6 @@ func (o *CallHierarchyIncomingCallsOrNull) UnmarshalJSONFrom(dec *jsontext.Decod
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -23715,7 +23703,6 @@ func (o *CallHierarchyOutgoingCallsOrNull) UnmarshalJSONFrom(dec *jsontext.Decod
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -23752,7 +23739,6 @@ func (o *SemanticTokensOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -23793,7 +23779,6 @@ func (o *SemanticTokensOrSemanticTokensDeltaOrNull) UnmarshalJSONFrom(dec *jsont
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -23835,7 +23820,6 @@ func (o *LinkedEditingRangesOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -23872,7 +23856,6 @@ func (o *WorkspaceEditOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -23909,7 +23892,6 @@ func (o *MonikersOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -23946,7 +23928,6 @@ func (o *TypeHierarchyItemsOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -23983,7 +23964,6 @@ func (o *InlineValuesOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -24020,7 +24000,6 @@ func (o *InlayHintsOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -24102,7 +24081,6 @@ func (o *InlineCompletionListOrItemsOrNull) UnmarshalJSONFrom(dec *jsontext.Deco
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -24144,7 +24122,6 @@ func (o *MessageActionItemOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -24181,7 +24158,6 @@ func (o *TextEditsOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -24222,7 +24198,6 @@ func (o *CompletionItemsOrListOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -24264,7 +24239,6 @@ func (o *HoverOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -24301,7 +24275,6 @@ func (o *SignatureHelpOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -24338,7 +24311,6 @@ func (o *LocationsOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -24375,7 +24347,6 @@ func (o *DocumentHighlightsOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -24416,7 +24387,6 @@ func (o *SymbolInformationsOrDocumentSymbolsOrNull) UnmarshalJSONFrom(dec *jsont
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -24499,7 +24469,6 @@ func (o *CommandOrCodeActionArrayOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -24540,7 +24509,6 @@ func (o *SymbolInformationsOrWorkspaceSymbolsOrNull) UnmarshalJSONFrom(dec *json
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -24582,7 +24550,6 @@ func (o *CodeLenssOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -24619,7 +24586,6 @@ func (o *DocumentLinksOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -24664,7 +24630,6 @@ func (o *RangeOrPrepareRenamePlaceholderOrPrepareRenameDefaultBehaviorOrNull) Un
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}
@@ -24711,7 +24676,6 @@ func (o *LSPAnyOrNull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	if err != nil {
 		return err
 	}
-	// Handle null case
 	if string(data) == "null" {
 		return nil
 	}

--- a/internal/lsp/lsproto/lsp_generated.go
+++ b/internal/lsp/lsproto/lsp_generated.go
@@ -28,6 +28,8 @@ type ImplementationParams struct {
 	PartialResultToken *IntegerOrString `json:"partialResultToken,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*ImplementationParams)(nil)
+
 func (s *ImplementationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenTextDocument bool
@@ -90,6 +92,8 @@ type Location struct {
 	Range Range `json:"range"`
 }
 
+var _ json.UnmarshalerFrom = (*Location)(nil)
+
 func (s *Location) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenUri   bool
@@ -148,6 +152,8 @@ type ImplementationRegistrationOptions struct {
 	Id *string `json:"id,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*ImplementationRegistrationOptions)(nil)
+
 func (s *ImplementationRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDocumentSelector bool
 
@@ -205,6 +211,8 @@ type TypeDefinitionParams struct {
 	// the client.
 	PartialResultToken *IntegerOrString `json:"partialResultToken,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*TypeDefinitionParams)(nil)
 
 func (s *TypeDefinitionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -272,6 +280,8 @@ type TypeDefinitionRegistrationOptions struct {
 	Id *string `json:"id,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*TypeDefinitionRegistrationOptions)(nil)
+
 func (s *TypeDefinitionRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDocumentSelector bool
 
@@ -325,6 +335,8 @@ type WorkspaceFolder struct {
 	Name string `json:"name"`
 }
 
+var _ json.UnmarshalerFrom = (*WorkspaceFolder)(nil)
+
 func (s *WorkspaceFolder) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenUri  bool
@@ -377,6 +389,8 @@ type DidChangeWorkspaceFoldersParams struct {
 	Event *WorkspaceFoldersChangeEvent `json:"event"`
 }
 
+var _ json.UnmarshalerFrom = (*DidChangeWorkspaceFoldersParams)(nil)
+
 func (s *DidChangeWorkspaceFoldersParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenEvent bool
 
@@ -416,6 +430,8 @@ func (s *DidChangeWorkspaceFoldersParams) UnmarshalJSONFrom(dec *jsontext.Decode
 type ConfigurationParams struct {
 	Items []*ConfigurationItem `json:"items"`
 }
+
+var _ json.UnmarshalerFrom = (*ConfigurationParams)(nil)
 
 func (s *ConfigurationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenItems bool
@@ -464,6 +480,8 @@ type DocumentColorParams struct {
 	// The text document.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 }
+
+var _ json.UnmarshalerFrom = (*DocumentColorParams)(nil)
 
 func (s *DocumentColorParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenTextDocument bool
@@ -516,6 +534,8 @@ type ColorInformation struct {
 	// The actual color value for this color range.
 	Color Color `json:"color"`
 }
+
+var _ json.UnmarshalerFrom = (*ColorInformation)(nil)
 
 func (s *ColorInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -574,6 +594,8 @@ type DocumentColorRegistrationOptions struct {
 	// the request again. See also Registration#id.
 	Id *string `json:"id,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*DocumentColorRegistrationOptions)(nil)
 
 func (s *DocumentColorRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDocumentSelector bool
@@ -636,6 +658,8 @@ type ColorPresentationParams struct {
 	// The range where the color would be inserted. Serves as a context.
 	Range Range `json:"range"`
 }
+
+var _ json.UnmarshalerFrom = (*ColorPresentationParams)(nil)
 
 func (s *ColorPresentationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -716,6 +740,8 @@ type ColorPresentation struct {
 	AdditionalTextEdits *[]*TextEdit `json:"additionalTextEdits,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*ColorPresentation)(nil)
+
 func (s *ColorPresentation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenLabel bool
 
@@ -770,6 +796,8 @@ type TextDocumentRegistrationOptions struct {
 	DocumentSelector DocumentSelectorOrNull `json:"documentSelector"`
 }
 
+var _ json.UnmarshalerFrom = (*TextDocumentRegistrationOptions)(nil)
+
 func (s *TextDocumentRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDocumentSelector bool
 
@@ -817,6 +845,8 @@ type FoldingRangeParams struct {
 	// The text document.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 }
+
+var _ json.UnmarshalerFrom = (*FoldingRangeParams)(nil)
 
 func (s *FoldingRangeParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenTextDocument bool
@@ -890,6 +920,8 @@ type FoldingRange struct {
 	// Since: 3.17.0
 	CollapsedText *string `json:"collapsedText,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*FoldingRange)(nil)
 
 func (s *FoldingRange) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -965,6 +997,8 @@ type FoldingRangeRegistrationOptions struct {
 	Id *string `json:"id,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*FoldingRangeRegistrationOptions)(nil)
+
 func (s *FoldingRangeRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDocumentSelector bool
 
@@ -1022,6 +1056,8 @@ type DeclarationParams struct {
 	// the client.
 	PartialResultToken *IntegerOrString `json:"partialResultToken,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*DeclarationParams)(nil)
 
 func (s *DeclarationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -1089,6 +1125,8 @@ type DeclarationRegistrationOptions struct {
 	Id *string `json:"id,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*DeclarationRegistrationOptions)(nil)
+
 func (s *DeclarationRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDocumentSelector bool
 
@@ -1147,6 +1185,8 @@ type SelectionRangeParams struct {
 	// The positions inside the text document.
 	Positions []Position `json:"positions"`
 }
+
+var _ json.UnmarshalerFrom = (*SelectionRangeParams)(nil)
 
 func (s *SelectionRangeParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -1212,6 +1252,8 @@ type SelectionRange struct {
 	Parent *SelectionRange `json:"parent,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*SelectionRange)(nil)
+
 func (s *SelectionRange) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenRange bool
 
@@ -1263,6 +1305,8 @@ type SelectionRangeRegistrationOptions struct {
 	Id *string `json:"id,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*SelectionRangeRegistrationOptions)(nil)
+
 func (s *SelectionRangeRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDocumentSelector bool
 
@@ -1311,6 +1355,8 @@ type WorkDoneProgressCreateParams struct {
 	Token IntegerOrString `json:"token"`
 }
 
+var _ json.UnmarshalerFrom = (*WorkDoneProgressCreateParams)(nil)
+
 func (s *WorkDoneProgressCreateParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenToken bool
 
@@ -1350,6 +1396,8 @@ type WorkDoneProgressCancelParams struct {
 	// The token to be used to report progress.
 	Token IntegerOrString `json:"token"`
 }
+
+var _ json.UnmarshalerFrom = (*WorkDoneProgressCancelParams)(nil)
 
 func (s *WorkDoneProgressCancelParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenToken bool
@@ -1399,6 +1447,8 @@ type CallHierarchyPrepareParams struct {
 	// An optional token that a server can use to report work done progress.
 	WorkDoneToken *IntegerOrString `json:"workDoneToken,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*CallHierarchyPrepareParams)(nil)
 
 func (s *CallHierarchyPrepareParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -1481,6 +1531,8 @@ type CallHierarchyItem struct {
 	// incoming calls or outgoing calls requests.
 	Data *any `json:"data,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*CallHierarchyItem)(nil)
 
 func (s *CallHierarchyItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -1582,6 +1634,8 @@ type CallHierarchyRegistrationOptions struct {
 	Id *string `json:"id,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*CallHierarchyRegistrationOptions)(nil)
+
 func (s *CallHierarchyRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDocumentSelector bool
 
@@ -1639,6 +1693,8 @@ type CallHierarchyIncomingCallsParams struct {
 	Item *CallHierarchyItem `json:"item"`
 }
 
+var _ json.UnmarshalerFrom = (*CallHierarchyIncomingCallsParams)(nil)
+
 func (s *CallHierarchyIncomingCallsParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenItem bool
 
@@ -1693,6 +1749,8 @@ type CallHierarchyIncomingCall struct {
 	// denoted by `this.from`.
 	FromRanges []Range `json:"fromRanges"`
 }
+
+var _ json.UnmarshalerFrom = (*CallHierarchyIncomingCall)(nil)
 
 func (s *CallHierarchyIncomingCall) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -1754,6 +1812,8 @@ type CallHierarchyOutgoingCallsParams struct {
 	Item *CallHierarchyItem `json:"item"`
 }
 
+var _ json.UnmarshalerFrom = (*CallHierarchyOutgoingCallsParams)(nil)
+
 func (s *CallHierarchyOutgoingCallsParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenItem bool
 
@@ -1809,6 +1869,8 @@ type CallHierarchyOutgoingCall struct {
 	// and not `this.to`.
 	FromRanges []Range `json:"fromRanges"`
 }
+
+var _ json.UnmarshalerFrom = (*CallHierarchyOutgoingCall)(nil)
 
 func (s *CallHierarchyOutgoingCall) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -1869,6 +1931,8 @@ type SemanticTokensParams struct {
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 }
 
+var _ json.UnmarshalerFrom = (*SemanticTokensParams)(nil)
+
 func (s *SemanticTokensParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenTextDocument bool
 
@@ -1924,6 +1988,8 @@ type SemanticTokens struct {
 	Data []uint32 `json:"data"`
 }
 
+var _ json.UnmarshalerFrom = (*SemanticTokens)(nil)
+
 func (s *SemanticTokens) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenData bool
 
@@ -1967,6 +2033,8 @@ func (s *SemanticTokens) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 type SemanticTokensPartialResult struct {
 	Data []uint32 `json:"data"`
 }
+
+var _ json.UnmarshalerFrom = (*SemanticTokensPartialResult)(nil)
 
 func (s *SemanticTokensPartialResult) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenData bool
@@ -2025,6 +2093,8 @@ type SemanticTokensRegistrationOptions struct {
 	// the request again. See also Registration#id.
 	Id *string `json:"id,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*SemanticTokensRegistrationOptions)(nil)
 
 func (s *SemanticTokensRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -2105,6 +2175,8 @@ type SemanticTokensDeltaParams struct {
 	PreviousResultId string `json:"previousResultId"`
 }
 
+var _ json.UnmarshalerFrom = (*SemanticTokensDeltaParams)(nil)
+
 func (s *SemanticTokensDeltaParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenTextDocument     bool
@@ -2167,6 +2239,8 @@ type SemanticTokensDelta struct {
 	Edits []*SemanticTokensEdit `json:"edits"`
 }
 
+var _ json.UnmarshalerFrom = (*SemanticTokensDelta)(nil)
+
 func (s *SemanticTokensDelta) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenEdits bool
 
@@ -2210,6 +2284,8 @@ func (s *SemanticTokensDelta) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 type SemanticTokensDeltaPartialResult struct {
 	Edits []*SemanticTokensEdit `json:"edits"`
 }
+
+var _ json.UnmarshalerFrom = (*SemanticTokensDeltaPartialResult)(nil)
 
 func (s *SemanticTokensDeltaPartialResult) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenEdits bool
@@ -2261,6 +2337,8 @@ type SemanticTokensRangeParams struct {
 	// The range the semantic tokens are requested for.
 	Range Range `json:"range"`
 }
+
+var _ json.UnmarshalerFrom = (*SemanticTokensRangeParams)(nil)
 
 func (s *SemanticTokensRangeParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -2341,6 +2419,8 @@ type ShowDocumentParams struct {
 	Selection *Range `json:"selection,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*ShowDocumentParams)(nil)
+
 func (s *ShowDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenUri bool
 
@@ -2396,6 +2476,8 @@ type ShowDocumentResult struct {
 	Success bool `json:"success"`
 }
 
+var _ json.UnmarshalerFrom = (*ShowDocumentResult)(nil)
+
 func (s *ShowDocumentResult) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenSuccess bool
 
@@ -2441,6 +2523,8 @@ type LinkedEditingRangeParams struct {
 	// An optional token that a server can use to report work done progress.
 	WorkDoneToken *IntegerOrString `json:"workDoneToken,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*LinkedEditingRangeParams)(nil)
 
 func (s *LinkedEditingRangeParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -2506,6 +2590,8 @@ type LinkedEditingRanges struct {
 	WordPattern *string `json:"wordPattern,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*LinkedEditingRanges)(nil)
+
 func (s *LinkedEditingRanges) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenRanges bool
 
@@ -2556,6 +2642,8 @@ type LinkedEditingRangeRegistrationOptions struct {
 	// the request again. See also Registration#id.
 	Id *string `json:"id,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*LinkedEditingRangeRegistrationOptions)(nil)
 
 func (s *LinkedEditingRangeRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDocumentSelector bool
@@ -2608,6 +2696,8 @@ type CreateFilesParams struct {
 	// An array of all files/folders created in this operation.
 	Files []*FileCreate `json:"files"`
 }
+
+var _ json.UnmarshalerFrom = (*CreateFilesParams)(nil)
 
 func (s *CreateFilesParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenFiles bool
@@ -2689,6 +2779,8 @@ type FileOperationRegistrationOptions struct {
 	Filters []*FileOperationFilter `json:"filters"`
 }
 
+var _ json.UnmarshalerFrom = (*FileOperationRegistrationOptions)(nil)
+
 func (s *FileOperationRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenFilters bool
 
@@ -2734,6 +2826,8 @@ type RenameFilesParams struct {
 	Files []*FileRename `json:"files"`
 }
 
+var _ json.UnmarshalerFrom = (*RenameFilesParams)(nil)
+
 func (s *RenameFilesParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenFiles bool
 
@@ -2777,6 +2871,8 @@ type DeleteFilesParams struct {
 	// An array of all files/folders deleted in this operation.
 	Files []*FileDelete `json:"files"`
 }
+
+var _ json.UnmarshalerFrom = (*DeleteFilesParams)(nil)
 
 func (s *DeleteFilesParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenFiles bool
@@ -2827,6 +2923,8 @@ type MonikerParams struct {
 	// the client.
 	PartialResultToken *IntegerOrString `json:"partialResultToken,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*MonikerParams)(nil)
 
 func (s *MonikerParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -2900,6 +2998,8 @@ type Moniker struct {
 	Kind *MonikerKind `json:"kind,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*Moniker)(nil)
+
 func (s *Moniker) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenScheme     bool
@@ -2967,6 +3067,8 @@ type MonikerRegistrationOptions struct {
 	WorkDoneProgress *bool `json:"workDoneProgress,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*MonikerRegistrationOptions)(nil)
+
 func (s *MonikerRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDocumentSelector bool
 
@@ -3019,6 +3121,8 @@ type TypeHierarchyPrepareParams struct {
 	// An optional token that a server can use to report work done progress.
 	WorkDoneToken *IntegerOrString `json:"workDoneToken,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*TypeHierarchyPrepareParams)(nil)
 
 func (s *TypeHierarchyPrepareParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -3102,6 +3206,8 @@ type TypeHierarchyItem struct {
 	// resolving supertypes and subtypes.
 	Data *any `json:"data,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*TypeHierarchyItem)(nil)
 
 func (s *TypeHierarchyItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -3203,6 +3309,8 @@ type TypeHierarchyRegistrationOptions struct {
 	Id *string `json:"id,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*TypeHierarchyRegistrationOptions)(nil)
+
 func (s *TypeHierarchyRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDocumentSelector bool
 
@@ -3260,6 +3368,8 @@ type TypeHierarchySupertypesParams struct {
 	Item *TypeHierarchyItem `json:"item"`
 }
 
+var _ json.UnmarshalerFrom = (*TypeHierarchySupertypesParams)(nil)
+
 func (s *TypeHierarchySupertypesParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenItem bool
 
@@ -3316,6 +3426,8 @@ type TypeHierarchySubtypesParams struct {
 
 	Item *TypeHierarchyItem `json:"item"`
 }
+
+var _ json.UnmarshalerFrom = (*TypeHierarchySubtypesParams)(nil)
 
 func (s *TypeHierarchySubtypesParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenItem bool
@@ -3377,6 +3489,8 @@ type InlineValueParams struct {
 	// requested.
 	Context *InlineValueContext `json:"context"`
 }
+
+var _ json.UnmarshalerFrom = (*InlineValueParams)(nil)
 
 func (s *InlineValueParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -3452,6 +3566,8 @@ type InlineValueRegistrationOptions struct {
 	Id *string `json:"id,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*InlineValueRegistrationOptions)(nil)
+
 func (s *InlineValueRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDocumentSelector bool
 
@@ -3508,6 +3624,8 @@ type InlayHintParams struct {
 	// The document range for which inlay hints should be computed.
 	Range Range `json:"range"`
 }
+
+var _ json.UnmarshalerFrom = (*InlayHintParams)(nil)
 
 func (s *InlayHintParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -3608,6 +3726,8 @@ type InlayHint struct {
 	Data *any `json:"data,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*InlayHint)(nil)
+
 func (s *InlayHint) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenPosition bool
@@ -3697,6 +3817,8 @@ type InlayHintRegistrationOptions struct {
 	Id *string `json:"id,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*InlayHintRegistrationOptions)(nil)
+
 func (s *InlayHintRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDocumentSelector bool
 
@@ -3765,6 +3887,8 @@ type DocumentDiagnosticParams struct {
 	PreviousResultId *string `json:"previousResultId,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*DocumentDiagnosticParams)(nil)
+
 func (s *DocumentDiagnosticParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenTextDocument bool
 
@@ -3823,6 +3947,8 @@ type DocumentDiagnosticReportPartialResult struct {
 	RelatedDocuments map[DocumentUri]FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport `json:"relatedDocuments"`
 }
 
+var _ json.UnmarshalerFrom = (*DocumentDiagnosticReportPartialResult)(nil)
+
 func (s *DocumentDiagnosticReportPartialResult) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenRelatedDocuments bool
 
@@ -3864,6 +3990,8 @@ func (s *DocumentDiagnosticReportPartialResult) UnmarshalJSONFrom(dec *jsontext.
 type DiagnosticServerCancellationData struct {
 	RetriggerRequest bool `json:"retriggerRequest"`
 }
+
+var _ json.UnmarshalerFrom = (*DiagnosticServerCancellationData)(nil)
 
 func (s *DiagnosticServerCancellationData) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenRetriggerRequest bool
@@ -3927,6 +4055,8 @@ type DiagnosticRegistrationOptions struct {
 	// the request again. See also Registration#id.
 	Id *string `json:"id,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*DiagnosticRegistrationOptions)(nil)
 
 func (s *DiagnosticRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -4014,6 +4144,8 @@ type WorkspaceDiagnosticParams struct {
 	PreviousResultIds []PreviousResultId `json:"previousResultIds"`
 }
 
+var _ json.UnmarshalerFrom = (*WorkspaceDiagnosticParams)(nil)
+
 func (s *WorkspaceDiagnosticParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenPreviousResultIds bool
 
@@ -4068,6 +4200,8 @@ type WorkspaceDiagnosticReport struct {
 	Items []WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport `json:"items"`
 }
 
+var _ json.UnmarshalerFrom = (*WorkspaceDiagnosticReport)(nil)
+
 func (s *WorkspaceDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenItems bool
 
@@ -4109,6 +4243,8 @@ func (s *WorkspaceDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 type WorkspaceDiagnosticReportPartialResult struct {
 	Items []WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport `json:"items"`
 }
+
+var _ json.UnmarshalerFrom = (*WorkspaceDiagnosticReportPartialResult)(nil)
 
 func (s *WorkspaceDiagnosticReportPartialResult) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenItems bool
@@ -4156,6 +4292,8 @@ type DidOpenNotebookDocumentParams struct {
 	// of a notebook cell.
 	CellTextDocuments []*TextDocumentItem `json:"cellTextDocuments"`
 }
+
+var _ json.UnmarshalerFrom = (*DidOpenNotebookDocumentParams)(nil)
 
 func (s *DidOpenNotebookDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -4218,6 +4356,8 @@ type NotebookDocumentSyncRegistrationOptions struct {
 	// the request again. See also Registration#id.
 	Id *string `json:"id,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*NotebookDocumentSyncRegistrationOptions)(nil)
 
 func (s *NotebookDocumentSyncRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenNotebookSelector bool
@@ -4288,6 +4428,8 @@ type DidChangeNotebookDocumentParams struct {
 	Change *NotebookDocumentChangeEvent `json:"change"`
 }
 
+var _ json.UnmarshalerFrom = (*DidChangeNotebookDocumentParams)(nil)
+
 func (s *DidChangeNotebookDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenNotebookDocument bool
@@ -4342,6 +4484,8 @@ type DidSaveNotebookDocumentParams struct {
 	NotebookDocument NotebookDocumentIdentifier `json:"notebookDocument"`
 }
 
+var _ json.UnmarshalerFrom = (*DidSaveNotebookDocumentParams)(nil)
+
 func (s *DidSaveNotebookDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenNotebookDocument bool
 
@@ -4388,6 +4532,8 @@ type DidCloseNotebookDocumentParams struct {
 	// of a notebook cell that got closed.
 	CellTextDocuments []TextDocumentIdentifier `json:"cellTextDocuments"`
 }
+
+var _ json.UnmarshalerFrom = (*DidCloseNotebookDocumentParams)(nil)
 
 func (s *DidCloseNotebookDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -4454,6 +4600,8 @@ type InlineCompletionParams struct {
 	// requested.
 	Context *InlineCompletionContext `json:"context"`
 }
+
+var _ json.UnmarshalerFrom = (*InlineCompletionParams)(nil)
 
 func (s *InlineCompletionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -4524,6 +4672,8 @@ type InlineCompletionList struct {
 	Items []*InlineCompletionItem `json:"items"`
 }
 
+var _ json.UnmarshalerFrom = (*InlineCompletionList)(nil)
+
 func (s *InlineCompletionList) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenItems bool
 
@@ -4577,6 +4727,8 @@ type InlineCompletionItem struct {
 	// An optional Command that is executed *after* inserting this completion.
 	Command *Command `json:"command,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*InlineCompletionItem)(nil)
 
 func (s *InlineCompletionItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenInsertText bool
@@ -4642,6 +4794,8 @@ type InlineCompletionRegistrationOptions struct {
 	Id *string `json:"id,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*InlineCompletionRegistrationOptions)(nil)
+
 func (s *InlineCompletionRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDocumentSelector bool
 
@@ -4695,6 +4849,8 @@ type TextDocumentContentParams struct {
 	Uri DocumentUri `json:"uri"`
 }
 
+var _ json.UnmarshalerFrom = (*TextDocumentContentParams)(nil)
+
 func (s *TextDocumentContentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenUri bool
 
@@ -4742,6 +4898,8 @@ type TextDocumentContentResult struct {
 	// normalizations done on the client
 	Text string `json:"text"`
 }
+
+var _ json.UnmarshalerFrom = (*TextDocumentContentResult)(nil)
 
 func (s *TextDocumentContentResult) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenText bool
@@ -4792,6 +4950,8 @@ type TextDocumentContentRegistrationOptions struct {
 	Id *string `json:"id,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*TextDocumentContentRegistrationOptions)(nil)
+
 func (s *TextDocumentContentRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenSchemes bool
 
@@ -4841,6 +5001,8 @@ type TextDocumentContentRefreshParams struct {
 	Uri DocumentUri `json:"uri"`
 }
 
+var _ json.UnmarshalerFrom = (*TextDocumentContentRefreshParams)(nil)
+
 func (s *TextDocumentContentRefreshParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenUri bool
 
@@ -4880,6 +5042,8 @@ type RegistrationParams struct {
 	Registrations []*Registration `json:"registrations"`
 }
 
+var _ json.UnmarshalerFrom = (*RegistrationParams)(nil)
+
 func (s *RegistrationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenRegistrations bool
 
@@ -4918,6 +5082,8 @@ func (s *RegistrationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 type UnregistrationParams struct {
 	Unregisterations []*Unregistration `json:"unregisterations"`
 }
+
+var _ json.UnmarshalerFrom = (*UnregistrationParams)(nil)
 
 func (s *UnregistrationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenUnregisterations bool
@@ -5011,6 +5177,8 @@ type InitializeParams struct {
 	// Since: 3.6.0
 	WorkspaceFolders *WorkspaceFoldersOrNull `json:"workspaceFolders,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*InitializeParams)(nil)
 
 func (s *InitializeParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -5106,6 +5274,8 @@ type InitializeResult struct {
 	ServerInfo *ServerInfo `json:"serverInfo,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*InitializeResult)(nil)
+
 func (s *InitializeResult) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenCapabilities bool
 
@@ -5155,6 +5325,8 @@ type InitializeError struct {
 	Retry bool `json:"retry"`
 }
 
+var _ json.UnmarshalerFrom = (*InitializeError)(nil)
+
 func (s *InitializeError) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenRetry bool
 
@@ -5197,6 +5369,8 @@ type DidChangeConfigurationParams struct {
 	// The actual changed settings
 	Settings any `json:"settings"`
 }
+
+var _ json.UnmarshalerFrom = (*DidChangeConfigurationParams)(nil)
 
 func (s *DidChangeConfigurationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenSettings bool
@@ -5245,6 +5419,8 @@ type ShowMessageParams struct {
 	// The actual message.
 	Message string `json:"message"`
 }
+
+var _ json.UnmarshalerFrom = (*ShowMessageParams)(nil)
 
 func (s *ShowMessageParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -5303,6 +5479,8 @@ type ShowMessageRequestParams struct {
 	Actions *[]*MessageActionItem `json:"actions,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*ShowMessageRequestParams)(nil)
+
 func (s *ShowMessageRequestParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenType    bool
@@ -5358,6 +5536,8 @@ type MessageActionItem struct {
 	Title string `json:"title"`
 }
 
+var _ json.UnmarshalerFrom = (*MessageActionItem)(nil)
+
 func (s *MessageActionItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenTitle bool
 
@@ -5401,6 +5581,8 @@ type LogMessageParams struct {
 	// The actual message.
 	Message string `json:"message"`
 }
+
+var _ json.UnmarshalerFrom = (*LogMessageParams)(nil)
 
 func (s *LogMessageParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -5453,6 +5635,8 @@ type DidOpenTextDocumentParams struct {
 	// The document that was opened.
 	TextDocument *TextDocumentItem `json:"textDocument"`
 }
+
+var _ json.UnmarshalerFrom = (*DidOpenTextDocumentParams)(nil)
 
 func (s *DidOpenTextDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenTextDocument bool
@@ -5510,6 +5694,8 @@ type DidChangeTextDocumentParams struct {
 	ContentChanges []TextDocumentContentChangePartialOrWholeDocument `json:"contentChanges"`
 }
 
+var _ json.UnmarshalerFrom = (*DidChangeTextDocumentParams)(nil)
+
 func (s *DidChangeTextDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenTextDocument   bool
@@ -5566,6 +5752,8 @@ type TextDocumentChangeRegistrationOptions struct {
 	SyncKind TextDocumentSyncKind `json:"syncKind"`
 }
 
+var _ json.UnmarshalerFrom = (*TextDocumentChangeRegistrationOptions)(nil)
+
 func (s *TextDocumentChangeRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenDocumentSelector bool
@@ -5618,6 +5806,8 @@ type DidCloseTextDocumentParams struct {
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 }
 
+var _ json.UnmarshalerFrom = (*DidCloseTextDocumentParams)(nil)
+
 func (s *DidCloseTextDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenTextDocument bool
 
@@ -5662,6 +5852,8 @@ type DidSaveTextDocumentParams struct {
 	// when the save notification was requested.
 	Text *string `json:"text,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*DidSaveTextDocumentParams)(nil)
 
 func (s *DidSaveTextDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenTextDocument bool
@@ -5712,6 +5904,8 @@ type TextDocumentSaveRegistrationOptions struct {
 	IncludeText *bool `json:"includeText,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*TextDocumentSaveRegistrationOptions)(nil)
+
 func (s *TextDocumentSaveRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDocumentSelector bool
 
@@ -5759,6 +5953,8 @@ type WillSaveTextDocumentParams struct {
 	// The 'TextDocumentSaveReason'.
 	Reason TextDocumentSaveReason `json:"reason"`
 }
+
+var _ json.UnmarshalerFrom = (*WillSaveTextDocumentParams)(nil)
 
 func (s *WillSaveTextDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -5817,6 +6013,8 @@ type TextEdit struct {
 	NewText string `json:"newText"`
 }
 
+var _ json.UnmarshalerFrom = (*TextEdit)(nil)
+
 func (s *TextEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenRange   bool
@@ -5869,6 +6067,8 @@ type DidChangeWatchedFilesParams struct {
 	Changes []*FileEvent `json:"changes"`
 }
 
+var _ json.UnmarshalerFrom = (*DidChangeWatchedFilesParams)(nil)
+
 func (s *DidChangeWatchedFilesParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenChanges bool
 
@@ -5909,6 +6109,8 @@ type DidChangeWatchedFilesRegistrationOptions struct {
 	// The watchers to register.
 	Watchers []*FileSystemWatcher `json:"watchers"`
 }
+
+var _ json.UnmarshalerFrom = (*DidChangeWatchedFilesRegistrationOptions)(nil)
 
 func (s *DidChangeWatchedFilesRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenWatchers bool
@@ -5958,6 +6160,8 @@ type PublishDiagnosticsParams struct {
 	// An array of diagnostic information items.
 	Diagnostics []*Diagnostic `json:"diagnostics"`
 }
+
+var _ json.UnmarshalerFrom = (*PublishDiagnosticsParams)(nil)
 
 func (s *PublishDiagnosticsParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -6028,6 +6232,8 @@ type CompletionParams struct {
 	// to send this using the client capability `textDocument.completion.contextSupport === true`
 	Context *CompletionContext `json:"context,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*CompletionParams)(nil)
 
 func (s *CompletionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -6228,6 +6434,8 @@ type CompletionItem struct {
 	Data *any `json:"data,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*CompletionItem)(nil)
+
 func (s *CompletionItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenLabel bool
 
@@ -6384,6 +6592,8 @@ type CompletionList struct {
 	Items []*CompletionItem `json:"items"`
 }
 
+var _ json.UnmarshalerFrom = (*CompletionList)(nil)
+
 func (s *CompletionList) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenIsIncomplete bool
@@ -6477,6 +6687,8 @@ type CompletionRegistrationOptions struct {
 	CompletionItem *ServerCompletionItemOptions `json:"completionItem,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*CompletionRegistrationOptions)(nil)
+
 func (s *CompletionRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDocumentSelector bool
 
@@ -6544,6 +6756,8 @@ type HoverParams struct {
 	WorkDoneToken *IntegerOrString `json:"workDoneToken,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*HoverParams)(nil)
+
 func (s *HoverParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenTextDocument bool
@@ -6604,6 +6818,8 @@ type Hover struct {
 	Range *Range `json:"range,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*Hover)(nil)
+
 func (s *Hover) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenContents bool
 
@@ -6651,6 +6867,8 @@ type HoverRegistrationOptions struct {
 
 	WorkDoneProgress *bool `json:"workDoneProgress,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*HoverRegistrationOptions)(nil)
 
 func (s *HoverRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDocumentSelector bool
@@ -6708,6 +6926,8 @@ type SignatureHelpParams struct {
 	// Since: 3.15.0
 	Context *SignatureHelpContext `json:"context,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*SignatureHelpParams)(nil)
 
 func (s *SignatureHelpParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -6800,6 +7020,8 @@ type SignatureHelp struct {
 	ActiveParameter *UintegerOrNull `json:"activeParameter,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*SignatureHelp)(nil)
+
 func (s *SignatureHelp) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenSignatures bool
 
@@ -6862,6 +7084,8 @@ type SignatureHelpRegistrationOptions struct {
 	// Since: 3.15.0
 	RetriggerCharacters *[]string `json:"retriggerCharacters,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*SignatureHelpRegistrationOptions)(nil)
 
 func (s *SignatureHelpRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDocumentSelector bool
@@ -6926,6 +7150,8 @@ type DefinitionParams struct {
 	PartialResultToken *IntegerOrString `json:"partialResultToken,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*DefinitionParams)(nil)
+
 func (s *DefinitionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenTextDocument bool
@@ -6989,6 +7215,8 @@ type DefinitionRegistrationOptions struct {
 	WorkDoneProgress *bool `json:"workDoneProgress,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*DefinitionRegistrationOptions)(nil)
+
 func (s *DefinitionRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDocumentSelector bool
 
@@ -7045,6 +7273,8 @@ type ReferenceParams struct {
 
 	Context *ReferenceContext `json:"context"`
 }
+
+var _ json.UnmarshalerFrom = (*ReferenceParams)(nil)
 
 func (s *ReferenceParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -7118,6 +7348,8 @@ type ReferenceRegistrationOptions struct {
 	WorkDoneProgress *bool `json:"workDoneProgress,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*ReferenceRegistrationOptions)(nil)
+
 func (s *ReferenceRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDocumentSelector bool
 
@@ -7172,6 +7404,8 @@ type DocumentHighlightParams struct {
 	// the client.
 	PartialResultToken *IntegerOrString `json:"partialResultToken,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*DocumentHighlightParams)(nil)
 
 func (s *DocumentHighlightParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -7238,6 +7472,8 @@ type DocumentHighlight struct {
 	Kind *DocumentHighlightKind `json:"kind,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*DocumentHighlight)(nil)
+
 func (s *DocumentHighlight) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenRange bool
 
@@ -7285,6 +7521,8 @@ type DocumentHighlightRegistrationOptions struct {
 
 	WorkDoneProgress *bool `json:"workDoneProgress,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*DocumentHighlightRegistrationOptions)(nil)
 
 func (s *DocumentHighlightRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDocumentSelector bool
@@ -7337,6 +7575,8 @@ type DocumentSymbolParams struct {
 	// The text document.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 }
+
+var _ json.UnmarshalerFrom = (*DocumentSymbolParams)(nil)
 
 func (s *DocumentSymbolParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenTextDocument bool
@@ -7417,6 +7657,8 @@ type SymbolInformation struct {
 	// the symbols.
 	Location Location `json:"location"`
 }
+
+var _ json.UnmarshalerFrom = (*SymbolInformation)(nil)
 
 func (s *SymbolInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -7523,6 +7765,8 @@ type DocumentSymbol struct {
 	Children *[]*DocumentSymbol `json:"children,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*DocumentSymbol)(nil)
+
 func (s *DocumentSymbol) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenName           bool
@@ -7618,6 +7862,8 @@ type DocumentSymbolRegistrationOptions struct {
 	Label *string `json:"label,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*DocumentSymbolRegistrationOptions)(nil)
+
 func (s *DocumentSymbolRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDocumentSelector bool
 
@@ -7679,6 +7925,8 @@ type CodeActionParams struct {
 	// Context carrying additional information.
 	Context *CodeActionContext `json:"context"`
 }
+
+var _ json.UnmarshalerFrom = (*CodeActionParams)(nil)
 
 func (s *CodeActionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -7765,6 +8013,8 @@ type Command struct {
 	// invoked with.
 	Arguments *[]any `json:"arguments,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*Command)(nil)
 
 func (s *Command) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -7882,6 +8132,8 @@ type CodeAction struct {
 	Tags *[]CodeActionTag `json:"tags,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*CodeAction)(nil)
+
 func (s *CodeAction) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenTitle bool
 
@@ -7988,6 +8240,8 @@ type CodeActionRegistrationOptions struct {
 	ResolveProvider *bool `json:"resolveProvider,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*CodeActionRegistrationOptions)(nil)
+
 func (s *CodeActionRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDocumentSelector bool
 
@@ -8058,6 +8312,8 @@ type WorkspaceSymbolParams struct {
 	// Servers shouldn't use prefix, substring, or similar strict matching.
 	Query string `json:"query"`
 }
+
+var _ json.UnmarshalerFrom = (*WorkspaceSymbolParams)(nil)
 
 func (s *WorkspaceSymbolParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenQuery bool
@@ -8136,6 +8392,8 @@ type WorkspaceSymbol struct {
 	// workspace symbol request and a workspace symbol resolve request.
 	Data *any `json:"data,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*WorkspaceSymbol)(nil)
 
 func (s *WorkspaceSymbol) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -8228,6 +8486,8 @@ type CodeLensParams struct {
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 }
 
+var _ json.UnmarshalerFrom = (*CodeLensParams)(nil)
+
 func (s *CodeLensParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenTextDocument bool
 
@@ -8288,6 +8548,8 @@ type CodeLens struct {
 	Data *any `json:"data,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*CodeLens)(nil)
+
 func (s *CodeLens) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenRange bool
 
@@ -8342,6 +8604,8 @@ type CodeLensRegistrationOptions struct {
 	// Code lens has a resolve provider as well.
 	ResolveProvider *bool `json:"resolveProvider,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*CodeLensRegistrationOptions)(nil)
 
 func (s *CodeLensRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDocumentSelector bool
@@ -8398,6 +8662,8 @@ type DocumentLinkParams struct {
 	// The document to provide document links for.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 }
+
+var _ json.UnmarshalerFrom = (*DocumentLinkParams)(nil)
 
 func (s *DocumentLinkParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenTextDocument bool
@@ -8465,6 +8731,8 @@ type DocumentLink struct {
 	Data *any `json:"data,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*DocumentLink)(nil)
+
 func (s *DocumentLink) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenRange bool
 
@@ -8524,6 +8792,8 @@ type DocumentLinkRegistrationOptions struct {
 	ResolveProvider *bool `json:"resolveProvider,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*DocumentLinkRegistrationOptions)(nil)
+
 func (s *DocumentLinkRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDocumentSelector bool
 
@@ -8578,6 +8848,8 @@ type DocumentFormattingParams struct {
 	// The format options.
 	Options *FormattingOptions `json:"options"`
 }
+
+var _ json.UnmarshalerFrom = (*DocumentFormattingParams)(nil)
 
 func (s *DocumentFormattingParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -8638,6 +8910,8 @@ type DocumentFormattingRegistrationOptions struct {
 	WorkDoneProgress *bool `json:"workDoneProgress,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*DocumentFormattingRegistrationOptions)(nil)
+
 func (s *DocumentFormattingRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDocumentSelector bool
 
@@ -8691,6 +8965,8 @@ type DocumentRangeFormattingParams struct {
 	// The format options
 	Options *FormattingOptions `json:"options"`
 }
+
+var _ json.UnmarshalerFrom = (*DocumentRangeFormattingParams)(nil)
 
 func (s *DocumentRangeFormattingParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -8767,6 +9043,8 @@ type DocumentRangeFormattingRegistrationOptions struct {
 	RangesSupport *bool `json:"rangesSupport,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*DocumentRangeFormattingRegistrationOptions)(nil)
+
 func (s *DocumentRangeFormattingRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDocumentSelector bool
 
@@ -8828,6 +9106,8 @@ type DocumentRangesFormattingParams struct {
 	// The format options
 	Options *FormattingOptions `json:"options"`
 }
+
+var _ json.UnmarshalerFrom = (*DocumentRangesFormattingParams)(nil)
 
 func (s *DocumentRangesFormattingParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -8908,6 +9188,8 @@ type DocumentOnTypeFormattingParams struct {
 	Options *FormattingOptions `json:"options"`
 }
 
+var _ json.UnmarshalerFrom = (*DocumentOnTypeFormattingParams)(nil)
+
 func (s *DocumentOnTypeFormattingParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenTextDocument bool
@@ -8985,6 +9267,8 @@ type DocumentOnTypeFormattingRegistrationOptions struct {
 	MoreTriggerCharacter *[]string `json:"moreTriggerCharacter,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*DocumentOnTypeFormattingRegistrationOptions)(nil)
+
 func (s *DocumentOnTypeFormattingRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenDocumentSelector      bool
@@ -9051,6 +9335,8 @@ type RenameParams struct {
 	// appropriate message set.
 	NewName string `json:"newName"`
 }
+
+var _ json.UnmarshalerFrom = (*RenameParams)(nil)
 
 func (s *RenameParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -9125,6 +9411,8 @@ type RenameRegistrationOptions struct {
 	PrepareProvider *bool `json:"prepareProvider,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*RenameRegistrationOptions)(nil)
+
 func (s *RenameRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDocumentSelector bool
 
@@ -9178,6 +9466,8 @@ type PrepareRenameParams struct {
 	// An optional token that a server can use to report work done progress.
 	WorkDoneToken *IntegerOrString `json:"workDoneToken,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*PrepareRenameParams)(nil)
 
 func (s *PrepareRenameParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -9241,6 +9531,8 @@ type ExecuteCommandParams struct {
 	Arguments *[]any `json:"arguments,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*ExecuteCommandParams)(nil)
+
 func (s *ExecuteCommandParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenCommand bool
 
@@ -9291,6 +9583,8 @@ type ExecuteCommandRegistrationOptions struct {
 	// The commands to be executed on the server
 	Commands []string `json:"commands"`
 }
+
+var _ json.UnmarshalerFrom = (*ExecuteCommandRegistrationOptions)(nil)
 
 func (s *ExecuteCommandRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenCommands bool
@@ -9348,6 +9642,8 @@ type ApplyWorkspaceEditParams struct {
 	// Proposed.
 	Metadata *WorkspaceEditMetadata `json:"metadata,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*ApplyWorkspaceEditParams)(nil)
 
 func (s *ApplyWorkspaceEditParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenEdit bool
@@ -9409,6 +9705,8 @@ type ApplyWorkspaceEditResult struct {
 	// if the client signals a `failureHandlingStrategy` in its client capabilities.
 	FailedChange *uint32 `json:"failedChange,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*ApplyWorkspaceEditResult)(nil)
 
 func (s *ApplyWorkspaceEditResult) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenApplied bool
@@ -9482,6 +9780,8 @@ type WorkDoneProgressBegin struct {
 	// that are not following this rule. The value range is [0, 100].
 	Percentage *uint32 `json:"percentage,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*WorkDoneProgressBegin)(nil)
 
 func (s *WorkDoneProgressBegin) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -9566,6 +9866,8 @@ type WorkDoneProgressReport struct {
 	Percentage *uint32 `json:"percentage,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*WorkDoneProgressReport)(nil)
+
 func (s *WorkDoneProgressReport) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenKind bool
 
@@ -9621,6 +9923,8 @@ type WorkDoneProgressEnd struct {
 	Message *string `json:"message,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*WorkDoneProgressEnd)(nil)
+
 func (s *WorkDoneProgressEnd) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenKind bool
 
@@ -9664,6 +9968,8 @@ type SetTraceParams struct {
 	Value TraceValue `json:"value"`
 }
 
+var _ json.UnmarshalerFrom = (*SetTraceParams)(nil)
+
 func (s *SetTraceParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenValue bool
 
@@ -9704,6 +10010,8 @@ type LogTraceParams struct {
 
 	Verbose *string `json:"verbose,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*LogTraceParams)(nil)
 
 func (s *LogTraceParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenMessage bool
@@ -9749,6 +10057,8 @@ type CancelParams struct {
 	Id IntegerOrString `json:"id"`
 }
 
+var _ json.UnmarshalerFrom = (*CancelParams)(nil)
+
 func (s *CancelParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenId bool
 
@@ -9791,6 +10101,8 @@ type ProgressParams struct {
 	// The progress data.
 	Value any `json:"value"`
 }
+
+var _ json.UnmarshalerFrom = (*ProgressParams)(nil)
 
 func (s *ProgressParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -9847,6 +10159,8 @@ type TextDocumentPositionParams struct {
 	// The position inside the text document.
 	Position Position `json:"position"`
 }
+
+var _ json.UnmarshalerFrom = (*TextDocumentPositionParams)(nil)
 
 func (s *TextDocumentPositionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -9926,6 +10240,8 @@ type LocationLink struct {
 	// Must be contained by the `targetRange`. See also `DocumentSymbol#range`
 	TargetSelectionRange Range `json:"targetSelectionRange"`
 }
+
+var _ json.UnmarshalerFrom = (*LocationLink)(nil)
 
 func (s *LocationLink) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -10007,6 +10323,8 @@ type Range struct {
 	End Position `json:"end"`
 }
 
+var _ json.UnmarshalerFrom = (*Range)(nil)
+
 func (s *Range) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenStart bool
@@ -10078,6 +10396,8 @@ type WorkspaceFoldersChangeEvent struct {
 	Removed []*WorkspaceFolder `json:"removed"`
 }
 
+var _ json.UnmarshalerFrom = (*WorkspaceFoldersChangeEvent)(nil)
+
 func (s *WorkspaceFoldersChangeEvent) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenAdded   bool
@@ -10138,6 +10458,8 @@ type TextDocumentIdentifier struct {
 	Uri DocumentUri `json:"uri"`
 }
 
+var _ json.UnmarshalerFrom = (*TextDocumentIdentifier)(nil)
+
 func (s *TextDocumentIdentifier) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenUri bool
 
@@ -10187,6 +10509,8 @@ type Color struct {
 	// The alpha component of this color in the range [0-1].
 	Alpha float64 `json:"alpha"`
 }
+
+var _ json.UnmarshalerFrom = (*Color)(nil)
 
 func (s *Color) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -10302,6 +10626,8 @@ type Position struct {
 	Character uint32 `json:"character"`
 }
 
+var _ json.UnmarshalerFrom = (*Position)(nil)
+
 func (s *Position) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenLine      bool
@@ -10374,6 +10700,8 @@ type SemanticTokensOptions struct {
 	Full *BooleanOrSemanticTokensFullDelta `json:"full,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*SemanticTokensOptions)(nil)
+
 func (s *SemanticTokensOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenLegend bool
 
@@ -10432,6 +10760,8 @@ type SemanticTokensEdit struct {
 	// The elements to insert.
 	Data *[]uint32 `json:"data,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*SemanticTokensEdit)(nil)
 
 func (s *SemanticTokensEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -10495,6 +10825,8 @@ type FileCreate struct {
 	Uri string `json:"uri"`
 }
 
+var _ json.UnmarshalerFrom = (*FileCreate)(nil)
+
 func (s *FileCreate) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenUri bool
 
@@ -10547,6 +10879,8 @@ type TextDocumentEdit struct {
 	// client capability.
 	Edits []TextEditOrAnnotatedTextEditOrSnippetTextEdit `json:"edits"`
 }
+
+var _ json.UnmarshalerFrom = (*TextDocumentEdit)(nil)
 
 func (s *TextDocumentEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -10610,6 +10944,8 @@ type CreateFile struct {
 	// Additional options
 	Options *CreateFileOptions `json:"options,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*CreateFile)(nil)
 
 func (s *CreateFile) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -10684,6 +11020,8 @@ type RenameFile struct {
 	// Rename options.
 	Options *RenameFileOptions `json:"options,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*RenameFile)(nil)
 
 func (s *RenameFile) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -10765,6 +11103,8 @@ type DeleteFile struct {
 	Options *DeleteFileOptions `json:"options,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*DeleteFile)(nil)
+
 func (s *DeleteFile) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenKind bool
@@ -10836,6 +11176,8 @@ type ChangeAnnotation struct {
 	Description *string `json:"description,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*ChangeAnnotation)(nil)
+
 func (s *ChangeAnnotation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenLabel bool
 
@@ -10891,6 +11233,8 @@ type FileOperationFilter struct {
 	Pattern *FileOperationPattern `json:"pattern"`
 }
 
+var _ json.UnmarshalerFrom = (*FileOperationFilter)(nil)
+
 func (s *FileOperationFilter) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenPattern bool
 
@@ -10940,6 +11284,8 @@ type FileRename struct {
 	// A file:// URI for the new location of the file/folder being renamed.
 	NewUri string `json:"newUri"`
 }
+
+var _ json.UnmarshalerFrom = (*FileRename)(nil)
 
 func (s *FileRename) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -10994,6 +11340,8 @@ type FileDelete struct {
 	// A file:// URI for the location of the file/folder being deleted.
 	Uri string `json:"uri"`
 }
+
+var _ json.UnmarshalerFrom = (*FileDelete)(nil)
 
 func (s *FileDelete) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenUri bool
@@ -11051,6 +11399,8 @@ type InlineValueContext struct {
 	StoppedLocation Range `json:"stoppedLocation"`
 }
 
+var _ json.UnmarshalerFrom = (*InlineValueContext)(nil)
+
 func (s *InlineValueContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenFrameId         bool
@@ -11107,6 +11457,8 @@ type InlineValueText struct {
 	// The text of the inline value.
 	Text string `json:"text"`
 }
+
+var _ json.UnmarshalerFrom = (*InlineValueText)(nil)
 
 func (s *InlineValueText) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -11171,6 +11523,8 @@ type InlineValueVariableLookup struct {
 	CaseSensitiveLookup bool `json:"caseSensitiveLookup"`
 }
 
+var _ json.UnmarshalerFrom = (*InlineValueVariableLookup)(nil)
+
 func (s *InlineValueVariableLookup) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenRange               bool
@@ -11234,6 +11588,8 @@ type InlineValueEvaluatableExpression struct {
 	// If specified the expression overrides the extracted expression.
 	Expression *string `json:"expression,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*InlineValueEvaluatableExpression)(nil)
 
 func (s *InlineValueEvaluatableExpression) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenRange bool
@@ -11314,6 +11670,8 @@ type InlayHintLabelPart struct {
 	Command *Command `json:"command,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*InlayHintLabelPart)(nil)
+
 func (s *InlayHintLabelPart) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenValue bool
 
@@ -11392,6 +11750,8 @@ type MarkupContent struct {
 	// The content itself
 	Value string `json:"value"`
 }
+
+var _ json.UnmarshalerFrom = (*MarkupContent)(nil)
 
 func (s *MarkupContent) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -11475,6 +11835,8 @@ type RelatedFullDocumentDiagnosticReport struct {
 	RelatedDocuments *map[DocumentUri]FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport `json:"relatedDocuments,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*RelatedFullDocumentDiagnosticReport)(nil)
+
 func (s *RelatedFullDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenKind  bool
@@ -11553,6 +11915,8 @@ type RelatedUnchangedDocumentDiagnosticReport struct {
 	RelatedDocuments *map[DocumentUri]FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport `json:"relatedDocuments,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*RelatedUnchangedDocumentDiagnosticReport)(nil)
+
 func (s *RelatedUnchangedDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenKind     bool
@@ -11618,6 +11982,8 @@ type FullDocumentDiagnosticReport struct {
 	// The actual items.
 	Items []*Diagnostic `json:"items"`
 }
+
+var _ json.UnmarshalerFrom = (*FullDocumentDiagnosticReport)(nil)
 
 func (s *FullDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -11685,6 +12051,8 @@ type UnchangedDocumentDiagnosticReport struct {
 	ResultId string `json:"resultId"`
 }
 
+var _ json.UnmarshalerFrom = (*UnchangedDocumentDiagnosticReport)(nil)
+
 func (s *UnchangedDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenKind     bool
@@ -11751,6 +12119,8 @@ type DiagnosticOptions struct {
 	WorkspaceDiagnostics bool `json:"workspaceDiagnostics"`
 }
 
+var _ json.UnmarshalerFrom = (*DiagnosticOptions)(nil)
+
 func (s *DiagnosticOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenInterFileDependencies bool
@@ -11816,6 +12186,8 @@ type PreviousResultId struct {
 	// The value of the previous result id.
 	Value string `json:"value"`
 }
+
+var _ json.UnmarshalerFrom = (*PreviousResultId)(nil)
 
 func (s *PreviousResultId) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -11886,6 +12258,8 @@ type NotebookDocument struct {
 	// The cells of a notebook.
 	Cells []*NotebookCell `json:"cells"`
 }
+
+var _ json.UnmarshalerFrom = (*NotebookDocument)(nil)
 
 func (s *NotebookDocument) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -11971,6 +12345,8 @@ type TextDocumentItem struct {
 	// The content of the opened text document.
 	Text string `json:"text"`
 }
+
+var _ json.UnmarshalerFrom = (*TextDocumentItem)(nil)
 
 func (s *TextDocumentItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -12058,6 +12434,8 @@ type NotebookDocumentSyncOptions struct {
 	Save *bool `json:"save,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*NotebookDocumentSyncOptions)(nil)
+
 func (s *NotebookDocumentSyncOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenNotebookSelector bool
 
@@ -12107,6 +12485,8 @@ type VersionedNotebookDocumentIdentifier struct {
 	// The notebook document's uri.
 	Uri URI `json:"uri"`
 }
+
+var _ json.UnmarshalerFrom = (*VersionedNotebookDocumentIdentifier)(nil)
 
 func (s *VersionedNotebookDocumentIdentifier) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -12175,6 +12555,8 @@ type NotebookDocumentIdentifier struct {
 	Uri URI `json:"uri"`
 }
 
+var _ json.UnmarshalerFrom = (*NotebookDocumentIdentifier)(nil)
+
 func (s *NotebookDocumentIdentifier) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenUri bool
 
@@ -12222,6 +12604,8 @@ type InlineCompletionContext struct {
 	// Provides information about the currently selected item in the autocomplete widget if it is visible.
 	SelectedCompletionInfo *SelectedCompletionInfo `json:"selectedCompletionInfo,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*InlineCompletionContext)(nil)
 
 func (s *InlineCompletionContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenTriggerKind bool
@@ -12280,6 +12664,8 @@ type StringValue struct {
 	// The snippet string.
 	Value string `json:"value"`
 }
+
+var _ json.UnmarshalerFrom = (*StringValue)(nil)
 
 func (s *StringValue) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -12346,6 +12732,8 @@ type TextDocumentContentOptions struct {
 	Schemes []string `json:"schemes"`
 }
 
+var _ json.UnmarshalerFrom = (*TextDocumentContentOptions)(nil)
+
 func (s *TextDocumentContentOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenSchemes bool
 
@@ -12393,6 +12781,8 @@ type Registration struct {
 	// Options necessary for the registration.
 	RegisterOptions *any `json:"registerOptions,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*Registration)(nil)
 
 func (s *Registration) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -12453,6 +12843,8 @@ type Unregistration struct {
 	// The method to unregister for.
 	Method string `json:"method"`
 }
+
+var _ json.UnmarshalerFrom = (*Unregistration)(nil)
 
 func (s *Unregistration) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -12549,6 +12941,8 @@ type InitializeParamsBase struct {
 	// The initial trace setting. If omitted trace is disabled ('off').
 	Trace *TraceValue `json:"trace,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*InitializeParamsBase)(nil)
 
 func (s *InitializeParamsBase) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -12801,6 +13195,8 @@ type ServerInfo struct {
 	Version *string `json:"version,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*ServerInfo)(nil)
+
 func (s *ServerInfo) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenName bool
 
@@ -12848,6 +13244,8 @@ type VersionedTextDocumentIdentifier struct {
 	// The version number of this document.
 	Version int32 `json:"version"`
 }
+
+var _ json.UnmarshalerFrom = (*VersionedTextDocumentIdentifier)(nil)
 
 func (s *VersionedTextDocumentIdentifier) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -12910,6 +13308,8 @@ type FileEvent struct {
 	Type FileChangeType `json:"type"`
 }
 
+var _ json.UnmarshalerFrom = (*FileEvent)(nil)
+
 func (s *FileEvent) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenUri  bool
@@ -12967,6 +13367,8 @@ type FileSystemWatcher struct {
 	// which is 7.
 	Kind *WatchKind `json:"kind,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*FileSystemWatcher)(nil)
 
 func (s *FileSystemWatcher) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenGlobPattern bool
@@ -13050,6 +13452,8 @@ type Diagnostic struct {
 	// Since: 3.16.0
 	Data *any `json:"data,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*Diagnostic)(nil)
 
 func (s *Diagnostic) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -13135,6 +13539,8 @@ type CompletionContext struct {
 	TriggerCharacter *string `json:"triggerCharacter,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*CompletionContext)(nil)
+
 func (s *CompletionContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenTriggerKind bool
 
@@ -13200,6 +13606,8 @@ type InsertReplaceEdit struct {
 	// The range if the replace is requested.
 	Replace Range `json:"replace"`
 }
+
+var _ json.UnmarshalerFrom = (*InsertReplaceEdit)(nil)
 
 func (s *InsertReplaceEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -13423,6 +13831,8 @@ type SignatureHelpContext struct {
 	ActiveSignatureHelp *SignatureHelp `json:"activeSignatureHelp,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*SignatureHelpContext)(nil)
+
 func (s *SignatureHelpContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenTriggerKind bool
@@ -13506,6 +13916,8 @@ type SignatureInformation struct {
 	ActiveParameter *UintegerOrNull `json:"activeParameter,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*SignatureInformation)(nil)
+
 func (s *SignatureInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenLabel bool
 
@@ -13581,6 +13993,8 @@ type ReferenceContext struct {
 	IncludeDeclaration bool `json:"includeDeclaration"`
 }
 
+var _ json.UnmarshalerFrom = (*ReferenceContext)(nil)
+
 func (s *ReferenceContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenIncludeDeclaration bool
 
@@ -13645,6 +14059,8 @@ type BaseSymbolInformation struct {
 	// symbols.
 	ContainerName *string `json:"containerName,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*BaseSymbolInformation)(nil)
 
 func (s *BaseSymbolInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -13733,6 +14149,8 @@ type CodeActionContext struct {
 	TriggerKind *CodeActionTriggerKind `json:"triggerKind,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*CodeActionContext)(nil)
+
 func (s *CodeActionContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDiagnostics bool
 
@@ -13785,6 +14203,8 @@ type CodeActionDisabled struct {
 	// This is displayed in the code actions UI.
 	Reason string `json:"reason"`
 }
+
+var _ json.UnmarshalerFrom = (*CodeActionDisabled)(nil)
 
 func (s *CodeActionDisabled) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenReason bool
@@ -13862,6 +14282,8 @@ type CodeActionOptions struct {
 type LocationUriOnly struct {
 	Uri DocumentUri `json:"uri"`
 }
+
+var _ json.UnmarshalerFrom = (*LocationUriOnly)(nil)
 
 func (s *LocationUriOnly) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenUri bool
@@ -13949,6 +14371,8 @@ type FormattingOptions struct {
 	TrimFinalNewlines *bool `json:"trimFinalNewlines,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*FormattingOptions)(nil)
+
 func (s *FormattingOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenTabSize      bool
@@ -14033,6 +14457,8 @@ type DocumentOnTypeFormattingOptions struct {
 	MoreTriggerCharacter *[]string `json:"moreTriggerCharacter,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*DocumentOnTypeFormattingOptions)(nil)
+
 func (s *DocumentOnTypeFormattingOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenFirstTriggerCharacter bool
 
@@ -14089,6 +14515,8 @@ type PrepareRenamePlaceholder struct {
 	Placeholder string `json:"placeholder"`
 }
 
+var _ json.UnmarshalerFrom = (*PrepareRenamePlaceholder)(nil)
+
 func (s *PrepareRenamePlaceholder) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenRange       bool
@@ -14140,6 +14568,8 @@ type PrepareRenameDefaultBehavior struct {
 	DefaultBehavior bool `json:"defaultBehavior"`
 }
 
+var _ json.UnmarshalerFrom = (*PrepareRenameDefaultBehavior)(nil)
+
 func (s *PrepareRenameDefaultBehavior) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenDefaultBehavior bool
 
@@ -14182,6 +14612,8 @@ type ExecuteCommandOptions struct {
 	// The commands to be executed on the server
 	Commands []string `json:"commands"`
 }
+
+var _ json.UnmarshalerFrom = (*ExecuteCommandOptions)(nil)
 
 func (s *ExecuteCommandOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenCommands bool
@@ -14240,6 +14672,8 @@ type SemanticTokensLegend struct {
 	// The token modifiers a server uses.
 	TokenModifiers []string `json:"tokenModifiers"`
 }
+
+var _ json.UnmarshalerFrom = (*SemanticTokensLegend)(nil)
 
 func (s *SemanticTokensLegend) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -14308,6 +14742,8 @@ type OptionalVersionedTextDocumentIdentifier struct {
 	Version IntegerOrNull `json:"version"`
 }
 
+var _ json.UnmarshalerFrom = (*OptionalVersionedTextDocumentIdentifier)(nil)
+
 func (s *OptionalVersionedTextDocumentIdentifier) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenUri     bool
@@ -14369,6 +14805,8 @@ type AnnotatedTextEdit struct {
 	// The actual identifier of the change annotation
 	AnnotationId string `json:"annotationId"`
 }
+
+var _ json.UnmarshalerFrom = (*AnnotatedTextEdit)(nil)
 
 func (s *AnnotatedTextEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -14441,6 +14879,8 @@ type SnippetTextEdit struct {
 	AnnotationId *string `json:"annotationId,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*SnippetTextEdit)(nil)
+
 func (s *SnippetTextEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenRange   bool
@@ -14501,6 +14941,8 @@ type ResourceOperation struct {
 	// Since: 3.16.0
 	AnnotationId *string `json:"annotationId,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*ResourceOperation)(nil)
 
 func (s *ResourceOperation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenKind bool
@@ -14591,6 +15033,8 @@ type FileOperationPattern struct {
 	Options *FileOperationPatternOptions `json:"options,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*FileOperationPattern)(nil)
+
 func (s *FileOperationPattern) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenGlob bool
 
@@ -14656,6 +15100,8 @@ type WorkspaceFullDocumentDiagnosticReport struct {
 	// If the document is not marked as open `null` can be provided.
 	Version IntegerOrNull `json:"version"`
 }
+
+var _ json.UnmarshalerFrom = (*WorkspaceFullDocumentDiagnosticReport)(nil)
 
 func (s *WorkspaceFullDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -14747,6 +15193,8 @@ type WorkspaceUnchangedDocumentDiagnosticReport struct {
 	Version IntegerOrNull `json:"version"`
 }
 
+var _ json.UnmarshalerFrom = (*WorkspaceUnchangedDocumentDiagnosticReport)(nil)
+
 func (s *WorkspaceUnchangedDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenKind     bool
@@ -14836,6 +15284,8 @@ type NotebookCell struct {
 	ExecutionSummary *ExecutionSummary `json:"executionSummary,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*NotebookCell)(nil)
+
 func (s *NotebookCell) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenKind     bool
@@ -14901,6 +15351,8 @@ type NotebookDocumentFilterWithNotebook struct {
 	Cells *[]*NotebookCellLanguage `json:"cells,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*NotebookDocumentFilterWithNotebook)(nil)
+
 func (s *NotebookDocumentFilterWithNotebook) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenNotebook bool
 
@@ -14950,6 +15402,8 @@ type NotebookDocumentFilterWithCells struct {
 	// The cells of the matching notebook to be synced.
 	Cells []*NotebookCellLanguage `json:"cells"`
 }
+
+var _ json.UnmarshalerFrom = (*NotebookDocumentFilterWithCells)(nil)
 
 func (s *NotebookDocumentFilterWithCells) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenCells bool
@@ -15019,6 +15473,8 @@ type SelectedCompletionInfo struct {
 	Text string `json:"text"`
 }
 
+var _ json.UnmarshalerFrom = (*SelectedCompletionInfo)(nil)
+
 func (s *SelectedCompletionInfo) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenRange bool
@@ -15077,6 +15533,8 @@ type ClientInfo struct {
 	// The client's version as defined by the client.
 	Version *string `json:"version,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*ClientInfo)(nil)
 
 func (s *ClientInfo) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenName bool
@@ -15200,6 +15658,8 @@ type TextDocumentContentChangePartial struct {
 	Text string `json:"text"`
 }
 
+var _ json.UnmarshalerFrom = (*TextDocumentContentChangePartial)(nil)
+
 func (s *TextDocumentContentChangePartial) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenRange bool
@@ -15256,6 +15716,8 @@ type TextDocumentContentChangeWholeDocument struct {
 	Text string `json:"text"`
 }
 
+var _ json.UnmarshalerFrom = (*TextDocumentContentChangeWholeDocument)(nil)
+
 func (s *TextDocumentContentChangeWholeDocument) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenText bool
 
@@ -15298,6 +15760,8 @@ type CodeDescription struct {
 	// An URI to open with more information about the diagnostic error.
 	Href URI `json:"href"`
 }
+
+var _ json.UnmarshalerFrom = (*CodeDescription)(nil)
 
 func (s *CodeDescription) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenHref bool
@@ -15344,6 +15808,8 @@ type DiagnosticRelatedInformation struct {
 	// The message of this related diagnostic information.
 	Message string `json:"message"`
 }
+
+var _ json.UnmarshalerFrom = (*DiagnosticRelatedInformation)(nil)
 
 func (s *DiagnosticRelatedInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -15399,6 +15865,8 @@ type EditRangeWithInsertReplace struct {
 
 	Replace Range `json:"replace"`
 }
+
+var _ json.UnmarshalerFrom = (*EditRangeWithInsertReplace)(nil)
 
 func (s *EditRangeWithInsertReplace) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -15464,6 +15932,8 @@ type MarkedStringWithLanguage struct {
 
 	Value string `json:"value"`
 }
+
+var _ json.UnmarshalerFrom = (*MarkedStringWithLanguage)(nil)
 
 func (s *MarkedStringWithLanguage) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -15533,6 +16003,8 @@ type ParameterInformation struct {
 	Documentation *StringOrMarkupContent `json:"documentation,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*ParameterInformation)(nil)
+
 func (s *ParameterInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenLabel bool
 
@@ -15590,6 +16062,8 @@ type CodeActionKindDocumentation struct {
 	// The title of this documentation code action is taken from Command.title
 	Command *Command `json:"command"`
 }
+
+var _ json.UnmarshalerFrom = (*CodeActionKindDocumentation)(nil)
 
 func (s *CodeActionKindDocumentation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -15655,6 +16129,8 @@ type NotebookCellTextDocumentFilter struct {
 	Language *string `json:"language,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*NotebookCellTextDocumentFilter)(nil)
+
 func (s *NotebookCellTextDocumentFilter) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenNotebook bool
 
@@ -15713,6 +16189,8 @@ type ExecutionSummary struct {
 	Success *bool `json:"success,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*ExecutionSummary)(nil)
+
 func (s *ExecutionSummary) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenExecutionOrder bool
 
@@ -15756,6 +16234,8 @@ func (s *ExecutionSummary) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 type NotebookCellLanguage struct {
 	Language string `json:"language"`
 }
+
+var _ json.UnmarshalerFrom = (*NotebookCellLanguage)(nil)
 
 func (s *NotebookCellLanguage) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenLanguage bool
@@ -15805,6 +16285,8 @@ type NotebookDocumentCellChangeStructure struct {
 	// Additional closed cell text documents.
 	DidClose *[]TextDocumentIdentifier `json:"didClose,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*NotebookDocumentCellChangeStructure)(nil)
 
 func (s *NotebookDocumentCellChangeStructure) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenArray bool
@@ -15857,6 +16339,8 @@ type NotebookDocumentCellContentChanges struct {
 
 	Changes []TextDocumentContentChangePartialOrWholeDocument `json:"changes"`
 }
+
+var _ json.UnmarshalerFrom = (*NotebookDocumentCellContentChanges)(nil)
 
 func (s *NotebookDocumentCellContentChanges) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -16130,6 +16614,8 @@ type NotebookDocumentClientCapabilities struct {
 	Synchronization *NotebookDocumentSyncClientCapabilities `json:"synchronization"`
 }
 
+var _ json.UnmarshalerFrom = (*NotebookDocumentClientCapabilities)(nil)
+
 func (s *NotebookDocumentClientCapabilities) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenSynchronization bool
 
@@ -16282,6 +16768,8 @@ type RelativePattern struct {
 	Pattern string `json:"pattern"`
 }
 
+var _ json.UnmarshalerFrom = (*RelativePattern)(nil)
+
 func (s *RelativePattern) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenBaseUri bool
@@ -16346,6 +16834,8 @@ type TextDocumentFilterLanguage struct {
 	Pattern *PatternOrRelativePattern `json:"pattern,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*TextDocumentFilterLanguage)(nil)
+
 func (s *TextDocumentFilterLanguage) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenLanguage bool
 
@@ -16406,6 +16896,8 @@ type TextDocumentFilterScheme struct {
 	// `textDocuments.filters.relativePatternSupport`.
 	Pattern *PatternOrRelativePattern `json:"pattern,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*TextDocumentFilterScheme)(nil)
 
 func (s *TextDocumentFilterScheme) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenScheme bool
@@ -16468,6 +16960,8 @@ type TextDocumentFilterPattern struct {
 	Pattern PatternOrRelativePattern `json:"pattern"`
 }
 
+var _ json.UnmarshalerFrom = (*TextDocumentFilterPattern)(nil)
+
 func (s *TextDocumentFilterPattern) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenPattern bool
 
@@ -16524,6 +17018,8 @@ type NotebookDocumentFilterNotebookType struct {
 	// A glob pattern.
 	Pattern *PatternOrRelativePattern `json:"pattern,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*NotebookDocumentFilterNotebookType)(nil)
 
 func (s *NotebookDocumentFilterNotebookType) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenNotebookType bool
@@ -16582,6 +17078,8 @@ type NotebookDocumentFilterScheme struct {
 	Pattern *PatternOrRelativePattern `json:"pattern,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*NotebookDocumentFilterScheme)(nil)
+
 func (s *NotebookDocumentFilterScheme) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenScheme bool
 
@@ -16638,6 +17136,8 @@ type NotebookDocumentFilterPattern struct {
 	// A glob pattern.
 	Pattern PatternOrRelativePattern `json:"pattern"`
 }
+
+var _ json.UnmarshalerFrom = (*NotebookDocumentFilterPattern)(nil)
 
 func (s *NotebookDocumentFilterPattern) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenPattern bool
@@ -16696,6 +17196,8 @@ type NotebookCellArrayChange struct {
 	// The new cells, if any
 	Cells *[]*NotebookCell `json:"cells,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*NotebookCellArrayChange)(nil)
 
 func (s *NotebookCellArrayChange) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -17397,6 +17899,8 @@ type SemanticTokensClientCapabilities struct {
 	AugmentsSyntaxTokens *bool `json:"augmentsSyntaxTokens,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*SemanticTokensClientCapabilities)(nil)
+
 func (s *SemanticTokensClientCapabilities) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
 		seenRequests       bool
@@ -17602,6 +18106,8 @@ type ShowDocumentClientCapabilities struct {
 	Support bool `json:"support"`
 }
 
+var _ json.UnmarshalerFrom = (*ShowDocumentClientCapabilities)(nil)
+
 func (s *ShowDocumentClientCapabilities) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenSupport bool
 
@@ -17647,6 +18153,8 @@ type StaleRequestSupportOptions struct {
 	// response with error code `ContentModified`
 	RetryOnContentModified []string `json:"retryOnContentModified"`
 }
+
+var _ json.UnmarshalerFrom = (*StaleRequestSupportOptions)(nil)
 
 func (s *StaleRequestSupportOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var (
@@ -17705,6 +18213,8 @@ type RegularExpressionsClientCapabilities struct {
 	Version *string `json:"version,omitzero"`
 }
 
+var _ json.UnmarshalerFrom = (*RegularExpressionsClientCapabilities)(nil)
+
 func (s *RegularExpressionsClientCapabilities) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenEngine bool
 
@@ -17760,6 +18270,8 @@ type MarkdownClientCapabilities struct {
 	// Since: 3.17.0
 	AllowedTags *[]string `json:"allowedTags,omitzero"`
 }
+
+var _ json.UnmarshalerFrom = (*MarkdownClientCapabilities)(nil)
 
 func (s *MarkdownClientCapabilities) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenParser bool
@@ -17831,6 +18343,8 @@ type ClientSymbolTagOptions struct {
 	ValueSet []SymbolTag `json:"valueSet"`
 }
 
+var _ json.UnmarshalerFrom = (*ClientSymbolTagOptions)(nil)
+
 func (s *ClientSymbolTagOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenValueSet bool
 
@@ -17872,6 +18386,8 @@ type ClientSymbolResolveOptions struct {
 	// `location.range`
 	Properties []string `json:"properties"`
 }
+
+var _ json.UnmarshalerFrom = (*ClientSymbolResolveOptions)(nil)
 
 func (s *ClientSymbolResolveOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenProperties bool
@@ -18040,6 +18556,8 @@ type ClientCodeActionLiteralOptions struct {
 	CodeActionKind *ClientCodeActionKindOptions `json:"codeActionKind"`
 }
 
+var _ json.UnmarshalerFrom = (*ClientCodeActionLiteralOptions)(nil)
+
 func (s *ClientCodeActionLiteralOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenCodeActionKind bool
 
@@ -18080,6 +18598,8 @@ type ClientCodeActionResolveOptions struct {
 	// The properties that a client can resolve lazily.
 	Properties []string `json:"properties"`
 }
+
+var _ json.UnmarshalerFrom = (*ClientCodeActionResolveOptions)(nil)
 
 func (s *ClientCodeActionResolveOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenProperties bool
@@ -18122,6 +18642,8 @@ type CodeActionTagOptions struct {
 	ValueSet []CodeActionTag `json:"valueSet"`
 }
 
+var _ json.UnmarshalerFrom = (*CodeActionTagOptions)(nil)
+
 func (s *CodeActionTagOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenValueSet bool
 
@@ -18162,6 +18684,8 @@ type ClientCodeLensResolveOptions struct {
 	// The properties that a client can resolve lazily.
 	Properties []string `json:"properties"`
 }
+
+var _ json.UnmarshalerFrom = (*ClientCodeLensResolveOptions)(nil)
 
 func (s *ClientCodeLensResolveOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenProperties bool
@@ -18257,6 +18781,8 @@ type ClientInlayHintResolveOptions struct {
 	Properties []string `json:"properties"`
 }
 
+var _ json.UnmarshalerFrom = (*ClientInlayHintResolveOptions)(nil)
+
 func (s *ClientInlayHintResolveOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenProperties bool
 
@@ -18306,6 +18832,8 @@ type CompletionItemTagOptions struct {
 	ValueSet []CompletionItemTag `json:"valueSet"`
 }
 
+var _ json.UnmarshalerFrom = (*CompletionItemTagOptions)(nil)
+
 func (s *CompletionItemTagOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenValueSet bool
 
@@ -18347,6 +18875,8 @@ type ClientCompletionItemResolveOptions struct {
 	Properties []string `json:"properties"`
 }
 
+var _ json.UnmarshalerFrom = (*ClientCompletionItemResolveOptions)(nil)
+
 func (s *ClientCompletionItemResolveOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenProperties bool
 
@@ -18386,6 +18916,8 @@ func (s *ClientCompletionItemResolveOptions) UnmarshalJSONFrom(dec *jsontext.Dec
 type ClientCompletionItemInsertTextModeOptions struct {
 	ValueSet []InsertTextMode `json:"valueSet"`
 }
+
+var _ json.UnmarshalerFrom = (*ClientCompletionItemInsertTextModeOptions)(nil)
 
 func (s *ClientCompletionItemInsertTextModeOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenValueSet bool
@@ -18440,6 +18972,8 @@ type ClientCodeActionKindOptions struct {
 	ValueSet []CodeActionKind `json:"valueSet"`
 }
 
+var _ json.UnmarshalerFrom = (*ClientCodeActionKindOptions)(nil)
+
 func (s *ClientCodeActionKindOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenValueSet bool
 
@@ -18480,6 +19014,8 @@ type ClientDiagnosticsTagOptions struct {
 	// The tags supported by the client.
 	ValueSet []DiagnosticTag `json:"valueSet"`
 }
+
+var _ json.UnmarshalerFrom = (*ClientDiagnosticsTagOptions)(nil)
 
 func (s *ClientDiagnosticsTagOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var seenValueSet bool
@@ -20377,7 +20913,9 @@ type IntegerOrString struct {
 	String  *string
 }
 
-func (o IntegerOrString) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = IntegerOrString{}
+
+func (o IntegerOrString) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of IntegerOrString should be set", o.Integer != nil, o.String != nil)
 
 	if o.Integer != nil {
@@ -20388,6 +20926,8 @@ func (o IntegerOrString) MarshalerTo(enc *jsontext.Encoder) error {
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*IntegerOrString)(nil)
 
 func (o *IntegerOrString) UnmarshalJSON(data []byte) error {
 	*o = IntegerOrString{}
@@ -20409,7 +20949,9 @@ type DocumentSelectorOrNull struct {
 	DocumentSelector *[]TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPatternOrNotebookCellTextDocumentFilter
 }
 
-func (o DocumentSelectorOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = DocumentSelectorOrNull{}
+
+func (o DocumentSelectorOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of DocumentSelectorOrNull is set", o.DocumentSelector != nil)
 
 	if o.DocumentSelector != nil {
@@ -20418,6 +20960,8 @@ func (o DocumentSelectorOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*DocumentSelectorOrNull)(nil)
 
 func (o *DocumentSelectorOrNull) UnmarshalJSON(data []byte) error {
 	*o = DocumentSelectorOrNull{}
@@ -20440,7 +20984,9 @@ type BooleanOrEmptyObject struct {
 	EmptyObject *struct{}
 }
 
-func (o BooleanOrEmptyObject) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = BooleanOrEmptyObject{}
+
+func (o BooleanOrEmptyObject) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrEmptyObject should be set", o.Boolean != nil, o.EmptyObject != nil)
 
 	if o.Boolean != nil {
@@ -20451,6 +20997,8 @@ func (o BooleanOrEmptyObject) MarshalerTo(enc *jsontext.Encoder) error {
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*BooleanOrEmptyObject)(nil)
 
 func (o *BooleanOrEmptyObject) UnmarshalJSON(data []byte) error {
 	*o = BooleanOrEmptyObject{}
@@ -20473,7 +21021,9 @@ type BooleanOrSemanticTokensFullDelta struct {
 	SemanticTokensFullDelta *SemanticTokensFullDelta
 }
 
-func (o BooleanOrSemanticTokensFullDelta) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = BooleanOrSemanticTokensFullDelta{}
+
+func (o BooleanOrSemanticTokensFullDelta) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrSemanticTokensFullDelta should be set", o.Boolean != nil, o.SemanticTokensFullDelta != nil)
 
 	if o.Boolean != nil {
@@ -20484,6 +21034,8 @@ func (o BooleanOrSemanticTokensFullDelta) MarshalerTo(enc *jsontext.Encoder) err
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*BooleanOrSemanticTokensFullDelta)(nil)
 
 func (o *BooleanOrSemanticTokensFullDelta) UnmarshalJSON(data []byte) error {
 	*o = BooleanOrSemanticTokensFullDelta{}
@@ -20508,7 +21060,9 @@ type TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile struct {
 	DeleteFile       *DeleteFile
 }
 
-func (o TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile{}
+
+func (o TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile should be set", o.TextDocumentEdit != nil, o.CreateFile != nil, o.RenameFile != nil, o.DeleteFile != nil)
 
 	if o.TextDocumentEdit != nil {
@@ -20525,6 +21079,8 @@ func (o TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile) MarshalerTo(enc *j
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile)(nil)
 
 func (o *TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile) UnmarshalJSON(data []byte) error {
 	*o = TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile{}
@@ -20557,7 +21113,9 @@ type StringOrInlayHintLabelParts struct {
 	InlayHintLabelParts *[]*InlayHintLabelPart
 }
 
-func (o StringOrInlayHintLabelParts) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = StringOrInlayHintLabelParts{}
+
+func (o StringOrInlayHintLabelParts) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of StringOrInlayHintLabelParts should be set", o.String != nil, o.InlayHintLabelParts != nil)
 
 	if o.String != nil {
@@ -20568,6 +21126,8 @@ func (o StringOrInlayHintLabelParts) MarshalerTo(enc *jsontext.Encoder) error {
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*StringOrInlayHintLabelParts)(nil)
 
 func (o *StringOrInlayHintLabelParts) UnmarshalJSON(data []byte) error {
 	*o = StringOrInlayHintLabelParts{}
@@ -20590,7 +21150,9 @@ type StringOrMarkupContent struct {
 	MarkupContent *MarkupContent
 }
 
-func (o StringOrMarkupContent) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = StringOrMarkupContent{}
+
+func (o StringOrMarkupContent) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of StringOrMarkupContent should be set", o.String != nil, o.MarkupContent != nil)
 
 	if o.String != nil {
@@ -20601,6 +21163,8 @@ func (o StringOrMarkupContent) MarshalerTo(enc *jsontext.Encoder) error {
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*StringOrMarkupContent)(nil)
 
 func (o *StringOrMarkupContent) UnmarshalJSON(data []byte) error {
 	*o = StringOrMarkupContent{}
@@ -20623,7 +21187,9 @@ type FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport struct {
 	UnchangedDocumentDiagnosticReport *UnchangedDocumentDiagnosticReport
 }
 
-func (o FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport{}
+
+func (o FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport should be set", o.FullDocumentDiagnosticReport != nil, o.UnchangedDocumentDiagnosticReport != nil)
 
 	if o.FullDocumentDiagnosticReport != nil {
@@ -20634,6 +21200,8 @@ func (o FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) Marshal
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport)(nil)
 
 func (o *FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) UnmarshalJSON(data []byte) error {
 	*o = FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport{}
@@ -20656,7 +21224,9 @@ type WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport st
 	UnchangedDocumentDiagnosticReport *WorkspaceUnchangedDocumentDiagnosticReport
 }
 
-func (o WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport{}
+
+func (o WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport should be set", o.FullDocumentDiagnosticReport != nil, o.UnchangedDocumentDiagnosticReport != nil)
 
 	if o.FullDocumentDiagnosticReport != nil {
@@ -20667,6 +21237,8 @@ func (o WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport)(nil)
 
 func (o *WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) UnmarshalJSON(data []byte) error {
 	*o = WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport{}
@@ -20689,7 +21261,9 @@ type NotebookDocumentFilterWithNotebookOrCells struct {
 	Cells    *NotebookDocumentFilterWithCells
 }
 
-func (o NotebookDocumentFilterWithNotebookOrCells) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = NotebookDocumentFilterWithNotebookOrCells{}
+
+func (o NotebookDocumentFilterWithNotebookOrCells) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of NotebookDocumentFilterWithNotebookOrCells should be set", o.Notebook != nil, o.Cells != nil)
 
 	if o.Notebook != nil {
@@ -20700,6 +21274,8 @@ func (o NotebookDocumentFilterWithNotebookOrCells) MarshalerTo(enc *jsontext.Enc
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*NotebookDocumentFilterWithNotebookOrCells)(nil)
 
 func (o *NotebookDocumentFilterWithNotebookOrCells) UnmarshalJSON(data []byte) error {
 	*o = NotebookDocumentFilterWithNotebookOrCells{}
@@ -20722,7 +21298,9 @@ type StringOrStringValue struct {
 	StringValue *StringValue
 }
 
-func (o StringOrStringValue) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = StringOrStringValue{}
+
+func (o StringOrStringValue) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of StringOrStringValue should be set", o.String != nil, o.StringValue != nil)
 
 	if o.String != nil {
@@ -20733,6 +21311,8 @@ func (o StringOrStringValue) MarshalerTo(enc *jsontext.Encoder) error {
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*StringOrStringValue)(nil)
 
 func (o *StringOrStringValue) UnmarshalJSON(data []byte) error {
 	*o = StringOrStringValue{}
@@ -20754,7 +21334,9 @@ type IntegerOrNull struct {
 	Integer *int32
 }
 
-func (o IntegerOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = IntegerOrNull{}
+
+func (o IntegerOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of IntegerOrNull is set", o.Integer != nil)
 
 	if o.Integer != nil {
@@ -20763,6 +21345,8 @@ func (o IntegerOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*IntegerOrNull)(nil)
 
 func (o *IntegerOrNull) UnmarshalJSON(data []byte) error {
 	*o = IntegerOrNull{}
@@ -20784,7 +21368,9 @@ type StringOrNull struct {
 	String *string
 }
 
-func (o StringOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = StringOrNull{}
+
+func (o StringOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of StringOrNull is set", o.String != nil)
 
 	if o.String != nil {
@@ -20793,6 +21379,8 @@ func (o StringOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*StringOrNull)(nil)
 
 func (o *StringOrNull) UnmarshalJSON(data []byte) error {
 	*o = StringOrNull{}
@@ -20814,7 +21402,9 @@ type DocumentUriOrNull struct {
 	DocumentUri *DocumentUri
 }
 
-func (o DocumentUriOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = DocumentUriOrNull{}
+
+func (o DocumentUriOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of DocumentUriOrNull is set", o.DocumentUri != nil)
 
 	if o.DocumentUri != nil {
@@ -20823,6 +21413,8 @@ func (o DocumentUriOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*DocumentUriOrNull)(nil)
 
 func (o *DocumentUriOrNull) UnmarshalJSON(data []byte) error {
 	*o = DocumentUriOrNull{}
@@ -20844,7 +21436,9 @@ type WorkspaceFoldersOrNull struct {
 	WorkspaceFolders *[]*WorkspaceFolder
 }
 
-func (o WorkspaceFoldersOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = WorkspaceFoldersOrNull{}
+
+func (o WorkspaceFoldersOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of WorkspaceFoldersOrNull is set", o.WorkspaceFolders != nil)
 
 	if o.WorkspaceFolders != nil {
@@ -20853,6 +21447,8 @@ func (o WorkspaceFoldersOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*WorkspaceFoldersOrNull)(nil)
 
 func (o *WorkspaceFoldersOrNull) UnmarshalJSON(data []byte) error {
 	*o = WorkspaceFoldersOrNull{}
@@ -20875,7 +21471,9 @@ type StringOrStrings struct {
 	Strings *[]string
 }
 
-func (o StringOrStrings) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = StringOrStrings{}
+
+func (o StringOrStrings) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of StringOrStrings should be set", o.String != nil, o.Strings != nil)
 
 	if o.String != nil {
@@ -20886,6 +21484,8 @@ func (o StringOrStrings) MarshalerTo(enc *jsontext.Encoder) error {
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*StringOrStrings)(nil)
 
 func (o *StringOrStrings) UnmarshalJSON(data []byte) error {
 	*o = StringOrStrings{}
@@ -20908,7 +21508,9 @@ type TextDocumentContentChangePartialOrWholeDocument struct {
 	WholeDocument *TextDocumentContentChangeWholeDocument
 }
 
-func (o TextDocumentContentChangePartialOrWholeDocument) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = TextDocumentContentChangePartialOrWholeDocument{}
+
+func (o TextDocumentContentChangePartialOrWholeDocument) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of TextDocumentContentChangePartialOrWholeDocument should be set", o.Partial != nil, o.WholeDocument != nil)
 
 	if o.Partial != nil {
@@ -20919,6 +21521,8 @@ func (o TextDocumentContentChangePartialOrWholeDocument) MarshalerTo(enc *jsonte
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*TextDocumentContentChangePartialOrWholeDocument)(nil)
 
 func (o *TextDocumentContentChangePartialOrWholeDocument) UnmarshalJSON(data []byte) error {
 	*o = TextDocumentContentChangePartialOrWholeDocument{}
@@ -20941,7 +21545,9 @@ type TextEditOrInsertReplaceEdit struct {
 	InsertReplaceEdit *InsertReplaceEdit
 }
 
-func (o TextEditOrInsertReplaceEdit) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = TextEditOrInsertReplaceEdit{}
+
+func (o TextEditOrInsertReplaceEdit) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of TextEditOrInsertReplaceEdit should be set", o.TextEdit != nil, o.InsertReplaceEdit != nil)
 
 	if o.TextEdit != nil {
@@ -20952,6 +21558,8 @@ func (o TextEditOrInsertReplaceEdit) MarshalerTo(enc *jsontext.Encoder) error {
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*TextEditOrInsertReplaceEdit)(nil)
 
 func (o *TextEditOrInsertReplaceEdit) UnmarshalJSON(data []byte) error {
 	*o = TextEditOrInsertReplaceEdit{}
@@ -20976,7 +21584,9 @@ type MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings struct {
 	MarkedStrings            *[]StringOrMarkedStringWithLanguage
 }
 
-func (o MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings{}
+
+func (o MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings should be set", o.MarkupContent != nil, o.String != nil, o.MarkedStringWithLanguage != nil, o.MarkedStrings != nil)
 
 	if o.MarkupContent != nil {
@@ -20993,6 +21603,8 @@ func (o MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings) Marshale
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings)(nil)
 
 func (o *MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings) UnmarshalJSON(data []byte) error {
 	*o = MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings{}
@@ -21024,7 +21636,9 @@ type UintegerOrNull struct {
 	Uinteger *uint32
 }
 
-func (o UintegerOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = UintegerOrNull{}
+
+func (o UintegerOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of UintegerOrNull is set", o.Uinteger != nil)
 
 	if o.Uinteger != nil {
@@ -21033,6 +21647,8 @@ func (o UintegerOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*UintegerOrNull)(nil)
 
 func (o *UintegerOrNull) UnmarshalJSON(data []byte) error {
 	*o = UintegerOrNull{}
@@ -21055,7 +21671,9 @@ type LocationOrLocationUriOnly struct {
 	LocationUriOnly *LocationUriOnly
 }
 
-func (o LocationOrLocationUriOnly) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = LocationOrLocationUriOnly{}
+
+func (o LocationOrLocationUriOnly) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of LocationOrLocationUriOnly should be set", o.Location != nil, o.LocationUriOnly != nil)
 
 	if o.Location != nil {
@@ -21066,6 +21684,8 @@ func (o LocationOrLocationUriOnly) MarshalerTo(enc *jsontext.Encoder) error {
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*LocationOrLocationUriOnly)(nil)
 
 func (o *LocationOrLocationUriOnly) UnmarshalJSON(data []byte) error {
 	*o = LocationOrLocationUriOnly{}
@@ -21089,7 +21709,9 @@ type TextEditOrAnnotatedTextEditOrSnippetTextEdit struct {
 	SnippetTextEdit   *SnippetTextEdit
 }
 
-func (o TextEditOrAnnotatedTextEditOrSnippetTextEdit) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = TextEditOrAnnotatedTextEditOrSnippetTextEdit{}
+
+func (o TextEditOrAnnotatedTextEditOrSnippetTextEdit) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of TextEditOrAnnotatedTextEditOrSnippetTextEdit should be set", o.TextEdit != nil, o.AnnotatedTextEdit != nil, o.SnippetTextEdit != nil)
 
 	if o.TextEdit != nil {
@@ -21103,6 +21725,8 @@ func (o TextEditOrAnnotatedTextEditOrSnippetTextEdit) MarshalerTo(enc *jsontext.
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*TextEditOrAnnotatedTextEditOrSnippetTextEdit)(nil)
 
 func (o *TextEditOrAnnotatedTextEditOrSnippetTextEdit) UnmarshalJSON(data []byte) error {
 	*o = TextEditOrAnnotatedTextEditOrSnippetTextEdit{}
@@ -21130,7 +21754,9 @@ type TextDocumentSyncOptionsOrKind struct {
 	Kind    *TextDocumentSyncKind
 }
 
-func (o TextDocumentSyncOptionsOrKind) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = TextDocumentSyncOptionsOrKind{}
+
+func (o TextDocumentSyncOptionsOrKind) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of TextDocumentSyncOptionsOrKind should be set", o.Options != nil, o.Kind != nil)
 
 	if o.Options != nil {
@@ -21141,6 +21767,8 @@ func (o TextDocumentSyncOptionsOrKind) MarshalerTo(enc *jsontext.Encoder) error 
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*TextDocumentSyncOptionsOrKind)(nil)
 
 func (o *TextDocumentSyncOptionsOrKind) UnmarshalJSON(data []byte) error {
 	*o = TextDocumentSyncOptionsOrKind{}
@@ -21163,7 +21791,9 @@ type NotebookDocumentSyncOptionsOrRegistrationOptions struct {
 	RegistrationOptions *NotebookDocumentSyncRegistrationOptions
 }
 
-func (o NotebookDocumentSyncOptionsOrRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = NotebookDocumentSyncOptionsOrRegistrationOptions{}
+
+func (o NotebookDocumentSyncOptionsOrRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of NotebookDocumentSyncOptionsOrRegistrationOptions should be set", o.Options != nil, o.RegistrationOptions != nil)
 
 	if o.Options != nil {
@@ -21174,6 +21804,8 @@ func (o NotebookDocumentSyncOptionsOrRegistrationOptions) MarshalerTo(enc *jsont
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*NotebookDocumentSyncOptionsOrRegistrationOptions)(nil)
 
 func (o *NotebookDocumentSyncOptionsOrRegistrationOptions) UnmarshalJSON(data []byte) error {
 	*o = NotebookDocumentSyncOptionsOrRegistrationOptions{}
@@ -21196,7 +21828,9 @@ type BooleanOrHoverOptions struct {
 	HoverOptions *HoverOptions
 }
 
-func (o BooleanOrHoverOptions) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = BooleanOrHoverOptions{}
+
+func (o BooleanOrHoverOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrHoverOptions should be set", o.Boolean != nil, o.HoverOptions != nil)
 
 	if o.Boolean != nil {
@@ -21207,6 +21841,8 @@ func (o BooleanOrHoverOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*BooleanOrHoverOptions)(nil)
 
 func (o *BooleanOrHoverOptions) UnmarshalJSON(data []byte) error {
 	*o = BooleanOrHoverOptions{}
@@ -21230,7 +21866,9 @@ type BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions struct {
 	DeclarationRegistrationOptions *DeclarationRegistrationOptions
 }
 
-func (o BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions{}
+
+func (o BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions should be set", o.Boolean != nil, o.DeclarationOptions != nil, o.DeclarationRegistrationOptions != nil)
 
 	if o.Boolean != nil {
@@ -21244,6 +21882,8 @@ func (o BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions) MarshalerTo
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions)(nil)
 
 func (o *BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions) UnmarshalJSON(data []byte) error {
 	*o = BooleanOrDeclarationOptionsOrDeclarationRegistrationOptions{}
@@ -21271,7 +21911,9 @@ type BooleanOrDefinitionOptions struct {
 	DefinitionOptions *DefinitionOptions
 }
 
-func (o BooleanOrDefinitionOptions) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = BooleanOrDefinitionOptions{}
+
+func (o BooleanOrDefinitionOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrDefinitionOptions should be set", o.Boolean != nil, o.DefinitionOptions != nil)
 
 	if o.Boolean != nil {
@@ -21282,6 +21924,8 @@ func (o BooleanOrDefinitionOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*BooleanOrDefinitionOptions)(nil)
 
 func (o *BooleanOrDefinitionOptions) UnmarshalJSON(data []byte) error {
 	*o = BooleanOrDefinitionOptions{}
@@ -21305,7 +21949,9 @@ type BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions struct {
 	TypeDefinitionRegistrationOptions *TypeDefinitionRegistrationOptions
 }
 
-func (o BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions{}
+
+func (o BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions should be set", o.Boolean != nil, o.TypeDefinitionOptions != nil, o.TypeDefinitionRegistrationOptions != nil)
 
 	if o.Boolean != nil {
@@ -21319,6 +21965,8 @@ func (o BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions) Marsh
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions)(nil)
 
 func (o *BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions) UnmarshalJSON(data []byte) error {
 	*o = BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions{}
@@ -21347,7 +21995,9 @@ type BooleanOrImplementationOptionsOrImplementationRegistrationOptions struct {
 	ImplementationRegistrationOptions *ImplementationRegistrationOptions
 }
 
-func (o BooleanOrImplementationOptionsOrImplementationRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = BooleanOrImplementationOptionsOrImplementationRegistrationOptions{}
+
+func (o BooleanOrImplementationOptionsOrImplementationRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrImplementationOptionsOrImplementationRegistrationOptions should be set", o.Boolean != nil, o.ImplementationOptions != nil, o.ImplementationRegistrationOptions != nil)
 
 	if o.Boolean != nil {
@@ -21361,6 +22011,8 @@ func (o BooleanOrImplementationOptionsOrImplementationRegistrationOptions) Marsh
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*BooleanOrImplementationOptionsOrImplementationRegistrationOptions)(nil)
 
 func (o *BooleanOrImplementationOptionsOrImplementationRegistrationOptions) UnmarshalJSON(data []byte) error {
 	*o = BooleanOrImplementationOptionsOrImplementationRegistrationOptions{}
@@ -21388,7 +22040,9 @@ type BooleanOrReferenceOptions struct {
 	ReferenceOptions *ReferenceOptions
 }
 
-func (o BooleanOrReferenceOptions) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = BooleanOrReferenceOptions{}
+
+func (o BooleanOrReferenceOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrReferenceOptions should be set", o.Boolean != nil, o.ReferenceOptions != nil)
 
 	if o.Boolean != nil {
@@ -21399,6 +22053,8 @@ func (o BooleanOrReferenceOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*BooleanOrReferenceOptions)(nil)
 
 func (o *BooleanOrReferenceOptions) UnmarshalJSON(data []byte) error {
 	*o = BooleanOrReferenceOptions{}
@@ -21421,7 +22077,9 @@ type BooleanOrDocumentHighlightOptions struct {
 	DocumentHighlightOptions *DocumentHighlightOptions
 }
 
-func (o BooleanOrDocumentHighlightOptions) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = BooleanOrDocumentHighlightOptions{}
+
+func (o BooleanOrDocumentHighlightOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrDocumentHighlightOptions should be set", o.Boolean != nil, o.DocumentHighlightOptions != nil)
 
 	if o.Boolean != nil {
@@ -21432,6 +22090,8 @@ func (o BooleanOrDocumentHighlightOptions) MarshalerTo(enc *jsontext.Encoder) er
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*BooleanOrDocumentHighlightOptions)(nil)
 
 func (o *BooleanOrDocumentHighlightOptions) UnmarshalJSON(data []byte) error {
 	*o = BooleanOrDocumentHighlightOptions{}
@@ -21454,7 +22114,9 @@ type BooleanOrDocumentSymbolOptions struct {
 	DocumentSymbolOptions *DocumentSymbolOptions
 }
 
-func (o BooleanOrDocumentSymbolOptions) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = BooleanOrDocumentSymbolOptions{}
+
+func (o BooleanOrDocumentSymbolOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrDocumentSymbolOptions should be set", o.Boolean != nil, o.DocumentSymbolOptions != nil)
 
 	if o.Boolean != nil {
@@ -21465,6 +22127,8 @@ func (o BooleanOrDocumentSymbolOptions) MarshalerTo(enc *jsontext.Encoder) error
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*BooleanOrDocumentSymbolOptions)(nil)
 
 func (o *BooleanOrDocumentSymbolOptions) UnmarshalJSON(data []byte) error {
 	*o = BooleanOrDocumentSymbolOptions{}
@@ -21487,7 +22151,9 @@ type BooleanOrCodeActionOptions struct {
 	CodeActionOptions *CodeActionOptions
 }
 
-func (o BooleanOrCodeActionOptions) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = BooleanOrCodeActionOptions{}
+
+func (o BooleanOrCodeActionOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrCodeActionOptions should be set", o.Boolean != nil, o.CodeActionOptions != nil)
 
 	if o.Boolean != nil {
@@ -21498,6 +22164,8 @@ func (o BooleanOrCodeActionOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*BooleanOrCodeActionOptions)(nil)
 
 func (o *BooleanOrCodeActionOptions) UnmarshalJSON(data []byte) error {
 	*o = BooleanOrCodeActionOptions{}
@@ -21521,7 +22189,9 @@ type BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions struct {
 	DocumentColorRegistrationOptions *DocumentColorRegistrationOptions
 }
 
-func (o BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions{}
+
+func (o BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions should be set", o.Boolean != nil, o.DocumentColorOptions != nil, o.DocumentColorRegistrationOptions != nil)
 
 	if o.Boolean != nil {
@@ -21535,6 +22205,8 @@ func (o BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions) Marshal
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions)(nil)
 
 func (o *BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions) UnmarshalJSON(data []byte) error {
 	*o = BooleanOrDocumentColorOptionsOrDocumentColorRegistrationOptions{}
@@ -21562,7 +22234,9 @@ type BooleanOrWorkspaceSymbolOptions struct {
 	WorkspaceSymbolOptions *WorkspaceSymbolOptions
 }
 
-func (o BooleanOrWorkspaceSymbolOptions) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = BooleanOrWorkspaceSymbolOptions{}
+
+func (o BooleanOrWorkspaceSymbolOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrWorkspaceSymbolOptions should be set", o.Boolean != nil, o.WorkspaceSymbolOptions != nil)
 
 	if o.Boolean != nil {
@@ -21573,6 +22247,8 @@ func (o BooleanOrWorkspaceSymbolOptions) MarshalerTo(enc *jsontext.Encoder) erro
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*BooleanOrWorkspaceSymbolOptions)(nil)
 
 func (o *BooleanOrWorkspaceSymbolOptions) UnmarshalJSON(data []byte) error {
 	*o = BooleanOrWorkspaceSymbolOptions{}
@@ -21595,7 +22271,9 @@ type BooleanOrDocumentFormattingOptions struct {
 	DocumentFormattingOptions *DocumentFormattingOptions
 }
 
-func (o BooleanOrDocumentFormattingOptions) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = BooleanOrDocumentFormattingOptions{}
+
+func (o BooleanOrDocumentFormattingOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrDocumentFormattingOptions should be set", o.Boolean != nil, o.DocumentFormattingOptions != nil)
 
 	if o.Boolean != nil {
@@ -21606,6 +22284,8 @@ func (o BooleanOrDocumentFormattingOptions) MarshalerTo(enc *jsontext.Encoder) e
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*BooleanOrDocumentFormattingOptions)(nil)
 
 func (o *BooleanOrDocumentFormattingOptions) UnmarshalJSON(data []byte) error {
 	*o = BooleanOrDocumentFormattingOptions{}
@@ -21628,7 +22308,9 @@ type BooleanOrDocumentRangeFormattingOptions struct {
 	DocumentRangeFormattingOptions *DocumentRangeFormattingOptions
 }
 
-func (o BooleanOrDocumentRangeFormattingOptions) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = BooleanOrDocumentRangeFormattingOptions{}
+
+func (o BooleanOrDocumentRangeFormattingOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrDocumentRangeFormattingOptions should be set", o.Boolean != nil, o.DocumentRangeFormattingOptions != nil)
 
 	if o.Boolean != nil {
@@ -21639,6 +22321,8 @@ func (o BooleanOrDocumentRangeFormattingOptions) MarshalerTo(enc *jsontext.Encod
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*BooleanOrDocumentRangeFormattingOptions)(nil)
 
 func (o *BooleanOrDocumentRangeFormattingOptions) UnmarshalJSON(data []byte) error {
 	*o = BooleanOrDocumentRangeFormattingOptions{}
@@ -21661,7 +22345,9 @@ type BooleanOrRenameOptions struct {
 	RenameOptions *RenameOptions
 }
 
-func (o BooleanOrRenameOptions) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = BooleanOrRenameOptions{}
+
+func (o BooleanOrRenameOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrRenameOptions should be set", o.Boolean != nil, o.RenameOptions != nil)
 
 	if o.Boolean != nil {
@@ -21672,6 +22358,8 @@ func (o BooleanOrRenameOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*BooleanOrRenameOptions)(nil)
 
 func (o *BooleanOrRenameOptions) UnmarshalJSON(data []byte) error {
 	*o = BooleanOrRenameOptions{}
@@ -21695,7 +22383,9 @@ type BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions struct {
 	FoldingRangeRegistrationOptions *FoldingRangeRegistrationOptions
 }
 
-func (o BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions{}
+
+func (o BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions should be set", o.Boolean != nil, o.FoldingRangeOptions != nil, o.FoldingRangeRegistrationOptions != nil)
 
 	if o.Boolean != nil {
@@ -21709,6 +22399,8 @@ func (o BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions) Marshaler
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions)(nil)
 
 func (o *BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions) UnmarshalJSON(data []byte) error {
 	*o = BooleanOrFoldingRangeOptionsOrFoldingRangeRegistrationOptions{}
@@ -21737,7 +22429,9 @@ type BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions struct {
 	SelectionRangeRegistrationOptions *SelectionRangeRegistrationOptions
 }
 
-func (o BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions{}
+
+func (o BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions should be set", o.Boolean != nil, o.SelectionRangeOptions != nil, o.SelectionRangeRegistrationOptions != nil)
 
 	if o.Boolean != nil {
@@ -21751,6 +22445,8 @@ func (o BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions) Marsh
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions)(nil)
 
 func (o *BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions) UnmarshalJSON(data []byte) error {
 	*o = BooleanOrSelectionRangeOptionsOrSelectionRangeRegistrationOptions{}
@@ -21779,7 +22475,9 @@ type BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions struct {
 	CallHierarchyRegistrationOptions *CallHierarchyRegistrationOptions
 }
 
-func (o BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions{}
+
+func (o BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions should be set", o.Boolean != nil, o.CallHierarchyOptions != nil, o.CallHierarchyRegistrationOptions != nil)
 
 	if o.Boolean != nil {
@@ -21793,6 +22491,8 @@ func (o BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions) Marshal
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions)(nil)
 
 func (o *BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions) UnmarshalJSON(data []byte) error {
 	*o = BooleanOrCallHierarchyOptionsOrCallHierarchyRegistrationOptions{}
@@ -21821,7 +22521,9 @@ type BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOptions s
 	LinkedEditingRangeRegistrationOptions *LinkedEditingRangeRegistrationOptions
 }
 
-func (o BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOptions{}
+
+func (o BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOptions should be set", o.Boolean != nil, o.LinkedEditingRangeOptions != nil, o.LinkedEditingRangeRegistrationOptions != nil)
 
 	if o.Boolean != nil {
@@ -21835,6 +22537,8 @@ func (o BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOption
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOptions)(nil)
 
 func (o *BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOptions) UnmarshalJSON(data []byte) error {
 	*o = BooleanOrLinkedEditingRangeOptionsOrLinkedEditingRangeRegistrationOptions{}
@@ -21862,7 +22566,9 @@ type SemanticTokensOptionsOrRegistrationOptions struct {
 	RegistrationOptions *SemanticTokensRegistrationOptions
 }
 
-func (o SemanticTokensOptionsOrRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = SemanticTokensOptionsOrRegistrationOptions{}
+
+func (o SemanticTokensOptionsOrRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of SemanticTokensOptionsOrRegistrationOptions should be set", o.Options != nil, o.RegistrationOptions != nil)
 
 	if o.Options != nil {
@@ -21873,6 +22579,8 @@ func (o SemanticTokensOptionsOrRegistrationOptions) MarshalerTo(enc *jsontext.En
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*SemanticTokensOptionsOrRegistrationOptions)(nil)
 
 func (o *SemanticTokensOptionsOrRegistrationOptions) UnmarshalJSON(data []byte) error {
 	*o = SemanticTokensOptionsOrRegistrationOptions{}
@@ -21896,7 +22604,9 @@ type BooleanOrMonikerOptionsOrMonikerRegistrationOptions struct {
 	MonikerRegistrationOptions *MonikerRegistrationOptions
 }
 
-func (o BooleanOrMonikerOptionsOrMonikerRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = BooleanOrMonikerOptionsOrMonikerRegistrationOptions{}
+
+func (o BooleanOrMonikerOptionsOrMonikerRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrMonikerOptionsOrMonikerRegistrationOptions should be set", o.Boolean != nil, o.MonikerOptions != nil, o.MonikerRegistrationOptions != nil)
 
 	if o.Boolean != nil {
@@ -21910,6 +22620,8 @@ func (o BooleanOrMonikerOptionsOrMonikerRegistrationOptions) MarshalerTo(enc *js
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*BooleanOrMonikerOptionsOrMonikerRegistrationOptions)(nil)
 
 func (o *BooleanOrMonikerOptionsOrMonikerRegistrationOptions) UnmarshalJSON(data []byte) error {
 	*o = BooleanOrMonikerOptionsOrMonikerRegistrationOptions{}
@@ -21938,7 +22650,9 @@ type BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions struct {
 	TypeHierarchyRegistrationOptions *TypeHierarchyRegistrationOptions
 }
 
-func (o BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions{}
+
+func (o BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions should be set", o.Boolean != nil, o.TypeHierarchyOptions != nil, o.TypeHierarchyRegistrationOptions != nil)
 
 	if o.Boolean != nil {
@@ -21952,6 +22666,8 @@ func (o BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions) Marshal
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions)(nil)
 
 func (o *BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions) UnmarshalJSON(data []byte) error {
 	*o = BooleanOrTypeHierarchyOptionsOrTypeHierarchyRegistrationOptions{}
@@ -21980,7 +22696,9 @@ type BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions struct {
 	InlineValueRegistrationOptions *InlineValueRegistrationOptions
 }
 
-func (o BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions{}
+
+func (o BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions should be set", o.Boolean != nil, o.InlineValueOptions != nil, o.InlineValueRegistrationOptions != nil)
 
 	if o.Boolean != nil {
@@ -21994,6 +22712,8 @@ func (o BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions) MarshalerTo
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions)(nil)
 
 func (o *BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions) UnmarshalJSON(data []byte) error {
 	*o = BooleanOrInlineValueOptionsOrInlineValueRegistrationOptions{}
@@ -22022,7 +22742,9 @@ type BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions struct {
 	InlayHintRegistrationOptions *InlayHintRegistrationOptions
 }
 
-func (o BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions{}
+
+func (o BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions should be set", o.Boolean != nil, o.InlayHintOptions != nil, o.InlayHintRegistrationOptions != nil)
 
 	if o.Boolean != nil {
@@ -22036,6 +22758,8 @@ func (o BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions) MarshalerTo(enc
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions)(nil)
 
 func (o *BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions) UnmarshalJSON(data []byte) error {
 	*o = BooleanOrInlayHintOptionsOrInlayHintRegistrationOptions{}
@@ -22063,7 +22787,9 @@ type DiagnosticOptionsOrRegistrationOptions struct {
 	RegistrationOptions *DiagnosticRegistrationOptions
 }
 
-func (o DiagnosticOptionsOrRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = DiagnosticOptionsOrRegistrationOptions{}
+
+func (o DiagnosticOptionsOrRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of DiagnosticOptionsOrRegistrationOptions should be set", o.Options != nil, o.RegistrationOptions != nil)
 
 	if o.Options != nil {
@@ -22074,6 +22800,8 @@ func (o DiagnosticOptionsOrRegistrationOptions) MarshalerTo(enc *jsontext.Encode
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*DiagnosticOptionsOrRegistrationOptions)(nil)
 
 func (o *DiagnosticOptionsOrRegistrationOptions) UnmarshalJSON(data []byte) error {
 	*o = DiagnosticOptionsOrRegistrationOptions{}
@@ -22096,7 +22824,9 @@ type BooleanOrInlineCompletionOptions struct {
 	InlineCompletionOptions *InlineCompletionOptions
 }
 
-func (o BooleanOrInlineCompletionOptions) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = BooleanOrInlineCompletionOptions{}
+
+func (o BooleanOrInlineCompletionOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrInlineCompletionOptions should be set", o.Boolean != nil, o.InlineCompletionOptions != nil)
 
 	if o.Boolean != nil {
@@ -22107,6 +22837,8 @@ func (o BooleanOrInlineCompletionOptions) MarshalerTo(enc *jsontext.Encoder) err
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*BooleanOrInlineCompletionOptions)(nil)
 
 func (o *BooleanOrInlineCompletionOptions) UnmarshalJSON(data []byte) error {
 	*o = BooleanOrInlineCompletionOptions{}
@@ -22129,7 +22861,9 @@ type PatternOrRelativePattern struct {
 	RelativePattern *RelativePattern
 }
 
-func (o PatternOrRelativePattern) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = PatternOrRelativePattern{}
+
+func (o PatternOrRelativePattern) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of PatternOrRelativePattern should be set", o.Pattern != nil, o.RelativePattern != nil)
 
 	if o.Pattern != nil {
@@ -22140,6 +22874,8 @@ func (o PatternOrRelativePattern) MarshalerTo(enc *jsontext.Encoder) error {
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*PatternOrRelativePattern)(nil)
 
 func (o *PatternOrRelativePattern) UnmarshalJSON(data []byte) error {
 	*o = PatternOrRelativePattern{}
@@ -22162,7 +22898,9 @@ type RangeOrEditRangeWithInsertReplace struct {
 	EditRangeWithInsertReplace *EditRangeWithInsertReplace
 }
 
-func (o RangeOrEditRangeWithInsertReplace) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = RangeOrEditRangeWithInsertReplace{}
+
+func (o RangeOrEditRangeWithInsertReplace) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of RangeOrEditRangeWithInsertReplace should be set", o.Range != nil, o.EditRangeWithInsertReplace != nil)
 
 	if o.Range != nil {
@@ -22173,6 +22911,8 @@ func (o RangeOrEditRangeWithInsertReplace) MarshalerTo(enc *jsontext.Encoder) er
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*RangeOrEditRangeWithInsertReplace)(nil)
 
 func (o *RangeOrEditRangeWithInsertReplace) UnmarshalJSON(data []byte) error {
 	*o = RangeOrEditRangeWithInsertReplace{}
@@ -22197,7 +22937,9 @@ type StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrN
 	NotebookDocumentFilterPattern      *NotebookDocumentFilterPattern
 }
 
-func (o StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrNotebookDocumentFilterPattern) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrNotebookDocumentFilterPattern{}
+
+func (o StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrNotebookDocumentFilterPattern) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrNotebookDocumentFilterPattern should be set", o.String != nil, o.NotebookDocumentFilterNotebookType != nil, o.NotebookDocumentFilterScheme != nil, o.NotebookDocumentFilterPattern != nil)
 
 	if o.String != nil {
@@ -22214,6 +22956,8 @@ func (o StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterScheme
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrNotebookDocumentFilterPattern)(nil)
 
 func (o *StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrNotebookDocumentFilterPattern) UnmarshalJSON(data []byte) error {
 	*o = StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrNotebookDocumentFilterPattern{}
@@ -22246,7 +22990,9 @@ type BooleanOrSaveOptions struct {
 	SaveOptions *SaveOptions
 }
 
-func (o BooleanOrSaveOptions) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = BooleanOrSaveOptions{}
+
+func (o BooleanOrSaveOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrSaveOptions should be set", o.Boolean != nil, o.SaveOptions != nil)
 
 	if o.Boolean != nil {
@@ -22257,6 +23003,8 @@ func (o BooleanOrSaveOptions) MarshalerTo(enc *jsontext.Encoder) error {
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*BooleanOrSaveOptions)(nil)
 
 func (o *BooleanOrSaveOptions) UnmarshalJSON(data []byte) error {
 	*o = BooleanOrSaveOptions{}
@@ -22279,7 +23027,9 @@ type TextDocumentContentOptionsOrRegistrationOptions struct {
 	RegistrationOptions *TextDocumentContentRegistrationOptions
 }
 
-func (o TextDocumentContentOptionsOrRegistrationOptions) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = TextDocumentContentOptionsOrRegistrationOptions{}
+
+func (o TextDocumentContentOptionsOrRegistrationOptions) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of TextDocumentContentOptionsOrRegistrationOptions should be set", o.Options != nil, o.RegistrationOptions != nil)
 
 	if o.Options != nil {
@@ -22290,6 +23040,8 @@ func (o TextDocumentContentOptionsOrRegistrationOptions) MarshalerTo(enc *jsonte
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*TextDocumentContentOptionsOrRegistrationOptions)(nil)
 
 func (o *TextDocumentContentOptionsOrRegistrationOptions) UnmarshalJSON(data []byte) error {
 	*o = TextDocumentContentOptionsOrRegistrationOptions{}
@@ -22312,7 +23064,9 @@ type StringOrTuple struct {
 	Tuple  *[2]uint32
 }
 
-func (o StringOrTuple) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = StringOrTuple{}
+
+func (o StringOrTuple) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of StringOrTuple should be set", o.String != nil, o.Tuple != nil)
 
 	if o.String != nil {
@@ -22323,6 +23077,8 @@ func (o StringOrTuple) MarshalerTo(enc *jsontext.Encoder) error {
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*StringOrTuple)(nil)
 
 func (o *StringOrTuple) UnmarshalJSON(data []byte) error {
 	*o = StringOrTuple{}
@@ -22345,7 +23101,9 @@ type StringOrBoolean struct {
 	Boolean *bool
 }
 
-func (o StringOrBoolean) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = StringOrBoolean{}
+
+func (o StringOrBoolean) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of StringOrBoolean should be set", o.String != nil, o.Boolean != nil)
 
 	if o.String != nil {
@@ -22356,6 +23114,8 @@ func (o StringOrBoolean) MarshalerTo(enc *jsontext.Encoder) error {
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*StringOrBoolean)(nil)
 
 func (o *StringOrBoolean) UnmarshalJSON(data []byte) error {
 	*o = StringOrBoolean{}
@@ -22378,7 +23138,9 @@ type WorkspaceFolderOrURI struct {
 	URI             *URI
 }
 
-func (o WorkspaceFolderOrURI) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = WorkspaceFolderOrURI{}
+
+func (o WorkspaceFolderOrURI) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of WorkspaceFolderOrURI should be set", o.WorkspaceFolder != nil, o.URI != nil)
 
 	if o.WorkspaceFolder != nil {
@@ -22389,6 +23151,8 @@ func (o WorkspaceFolderOrURI) MarshalerTo(enc *jsontext.Encoder) error {
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*WorkspaceFolderOrURI)(nil)
 
 func (o *WorkspaceFolderOrURI) UnmarshalJSON(data []byte) error {
 	*o = WorkspaceFolderOrURI{}
@@ -22411,7 +23175,9 @@ type BooleanOrClientSemanticTokensRequestFullDelta struct {
 	ClientSemanticTokensRequestFullDelta *ClientSemanticTokensRequestFullDelta
 }
 
-func (o BooleanOrClientSemanticTokensRequestFullDelta) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = BooleanOrClientSemanticTokensRequestFullDelta{}
+
+func (o BooleanOrClientSemanticTokensRequestFullDelta) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of BooleanOrClientSemanticTokensRequestFullDelta should be set", o.Boolean != nil, o.ClientSemanticTokensRequestFullDelta != nil)
 
 	if o.Boolean != nil {
@@ -22422,6 +23188,8 @@ func (o BooleanOrClientSemanticTokensRequestFullDelta) MarshalerTo(enc *jsontext
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*BooleanOrClientSemanticTokensRequestFullDelta)(nil)
 
 func (o *BooleanOrClientSemanticTokensRequestFullDelta) UnmarshalJSON(data []byte) error {
 	*o = BooleanOrClientSemanticTokensRequestFullDelta{}
@@ -22445,7 +23213,9 @@ type LocationOrLocationsOrDefinitionLinksOrNull struct {
 	DefinitionLinks *[]*LocationLink
 }
 
-func (o LocationOrLocationsOrDefinitionLinksOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = LocationOrLocationsOrDefinitionLinksOrNull{}
+
+func (o LocationOrLocationsOrDefinitionLinksOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of LocationOrLocationsOrDefinitionLinksOrNull is set", o.Location != nil, o.Locations != nil, o.DefinitionLinks != nil)
 
 	if o.Location != nil {
@@ -22460,6 +23230,8 @@ func (o LocationOrLocationsOrDefinitionLinksOrNull) MarshalerTo(enc *jsontext.En
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*LocationOrLocationsOrDefinitionLinksOrNull)(nil)
 
 func (o *LocationOrLocationsOrDefinitionLinksOrNull) UnmarshalJSON(data []byte) error {
 	*o = LocationOrLocationsOrDefinitionLinksOrNull{}
@@ -22491,7 +23263,9 @@ type FoldingRangesOrNull struct {
 	FoldingRanges *[]*FoldingRange
 }
 
-func (o FoldingRangesOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = FoldingRangesOrNull{}
+
+func (o FoldingRangesOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of FoldingRangesOrNull is set", o.FoldingRanges != nil)
 
 	if o.FoldingRanges != nil {
@@ -22500,6 +23274,8 @@ func (o FoldingRangesOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*FoldingRangesOrNull)(nil)
 
 func (o *FoldingRangesOrNull) UnmarshalJSON(data []byte) error {
 	*o = FoldingRangesOrNull{}
@@ -22523,7 +23299,9 @@ type LocationOrLocationsOrDeclarationLinksOrNull struct {
 	DeclarationLinks *[]*LocationLink
 }
 
-func (o LocationOrLocationsOrDeclarationLinksOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = LocationOrLocationsOrDeclarationLinksOrNull{}
+
+func (o LocationOrLocationsOrDeclarationLinksOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of LocationOrLocationsOrDeclarationLinksOrNull is set", o.Location != nil, o.Locations != nil, o.DeclarationLinks != nil)
 
 	if o.Location != nil {
@@ -22538,6 +23316,8 @@ func (o LocationOrLocationsOrDeclarationLinksOrNull) MarshalerTo(enc *jsontext.E
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*LocationOrLocationsOrDeclarationLinksOrNull)(nil)
 
 func (o *LocationOrLocationsOrDeclarationLinksOrNull) UnmarshalJSON(data []byte) error {
 	*o = LocationOrLocationsOrDeclarationLinksOrNull{}
@@ -22569,7 +23349,9 @@ type SelectionRangesOrNull struct {
 	SelectionRanges *[]*SelectionRange
 }
 
-func (o SelectionRangesOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = SelectionRangesOrNull{}
+
+func (o SelectionRangesOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of SelectionRangesOrNull is set", o.SelectionRanges != nil)
 
 	if o.SelectionRanges != nil {
@@ -22578,6 +23360,8 @@ func (o SelectionRangesOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*SelectionRangesOrNull)(nil)
 
 func (o *SelectionRangesOrNull) UnmarshalJSON(data []byte) error {
 	*o = SelectionRangesOrNull{}
@@ -22599,7 +23383,9 @@ type CallHierarchyItemsOrNull struct {
 	CallHierarchyItems *[]*CallHierarchyItem
 }
 
-func (o CallHierarchyItemsOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = CallHierarchyItemsOrNull{}
+
+func (o CallHierarchyItemsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of CallHierarchyItemsOrNull is set", o.CallHierarchyItems != nil)
 
 	if o.CallHierarchyItems != nil {
@@ -22608,6 +23394,8 @@ func (o CallHierarchyItemsOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*CallHierarchyItemsOrNull)(nil)
 
 func (o *CallHierarchyItemsOrNull) UnmarshalJSON(data []byte) error {
 	*o = CallHierarchyItemsOrNull{}
@@ -22629,7 +23417,9 @@ type CallHierarchyIncomingCallsOrNull struct {
 	CallHierarchyIncomingCalls *[]*CallHierarchyIncomingCall
 }
 
-func (o CallHierarchyIncomingCallsOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = CallHierarchyIncomingCallsOrNull{}
+
+func (o CallHierarchyIncomingCallsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of CallHierarchyIncomingCallsOrNull is set", o.CallHierarchyIncomingCalls != nil)
 
 	if o.CallHierarchyIncomingCalls != nil {
@@ -22638,6 +23428,8 @@ func (o CallHierarchyIncomingCallsOrNull) MarshalerTo(enc *jsontext.Encoder) err
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*CallHierarchyIncomingCallsOrNull)(nil)
 
 func (o *CallHierarchyIncomingCallsOrNull) UnmarshalJSON(data []byte) error {
 	*o = CallHierarchyIncomingCallsOrNull{}
@@ -22659,7 +23451,9 @@ type CallHierarchyOutgoingCallsOrNull struct {
 	CallHierarchyOutgoingCalls *[]*CallHierarchyOutgoingCall
 }
 
-func (o CallHierarchyOutgoingCallsOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = CallHierarchyOutgoingCallsOrNull{}
+
+func (o CallHierarchyOutgoingCallsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of CallHierarchyOutgoingCallsOrNull is set", o.CallHierarchyOutgoingCalls != nil)
 
 	if o.CallHierarchyOutgoingCalls != nil {
@@ -22668,6 +23462,8 @@ func (o CallHierarchyOutgoingCallsOrNull) MarshalerTo(enc *jsontext.Encoder) err
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*CallHierarchyOutgoingCallsOrNull)(nil)
 
 func (o *CallHierarchyOutgoingCallsOrNull) UnmarshalJSON(data []byte) error {
 	*o = CallHierarchyOutgoingCallsOrNull{}
@@ -22689,7 +23485,9 @@ type SemanticTokensOrNull struct {
 	SemanticTokens *SemanticTokens
 }
 
-func (o SemanticTokensOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = SemanticTokensOrNull{}
+
+func (o SemanticTokensOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of SemanticTokensOrNull is set", o.SemanticTokens != nil)
 
 	if o.SemanticTokens != nil {
@@ -22698,6 +23496,8 @@ func (o SemanticTokensOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*SemanticTokensOrNull)(nil)
 
 func (o *SemanticTokensOrNull) UnmarshalJSON(data []byte) error {
 	*o = SemanticTokensOrNull{}
@@ -22720,7 +23520,9 @@ type SemanticTokensOrSemanticTokensDeltaOrNull struct {
 	SemanticTokensDelta *SemanticTokensDelta
 }
 
-func (o SemanticTokensOrSemanticTokensDeltaOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = SemanticTokensOrSemanticTokensDeltaOrNull{}
+
+func (o SemanticTokensOrSemanticTokensDeltaOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of SemanticTokensOrSemanticTokensDeltaOrNull is set", o.SemanticTokens != nil, o.SemanticTokensDelta != nil)
 
 	if o.SemanticTokens != nil {
@@ -22732,6 +23534,8 @@ func (o SemanticTokensOrSemanticTokensDeltaOrNull) MarshalerTo(enc *jsontext.Enc
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*SemanticTokensOrSemanticTokensDeltaOrNull)(nil)
 
 func (o *SemanticTokensOrSemanticTokensDeltaOrNull) UnmarshalJSON(data []byte) error {
 	*o = SemanticTokensOrSemanticTokensDeltaOrNull{}
@@ -22758,7 +23562,9 @@ type LinkedEditingRangesOrNull struct {
 	LinkedEditingRanges *LinkedEditingRanges
 }
 
-func (o LinkedEditingRangesOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = LinkedEditingRangesOrNull{}
+
+func (o LinkedEditingRangesOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of LinkedEditingRangesOrNull is set", o.LinkedEditingRanges != nil)
 
 	if o.LinkedEditingRanges != nil {
@@ -22767,6 +23573,8 @@ func (o LinkedEditingRangesOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*LinkedEditingRangesOrNull)(nil)
 
 func (o *LinkedEditingRangesOrNull) UnmarshalJSON(data []byte) error {
 	*o = LinkedEditingRangesOrNull{}
@@ -22788,7 +23596,9 @@ type WorkspaceEditOrNull struct {
 	WorkspaceEdit *WorkspaceEdit
 }
 
-func (o WorkspaceEditOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = WorkspaceEditOrNull{}
+
+func (o WorkspaceEditOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of WorkspaceEditOrNull is set", o.WorkspaceEdit != nil)
 
 	if o.WorkspaceEdit != nil {
@@ -22797,6 +23607,8 @@ func (o WorkspaceEditOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*WorkspaceEditOrNull)(nil)
 
 func (o *WorkspaceEditOrNull) UnmarshalJSON(data []byte) error {
 	*o = WorkspaceEditOrNull{}
@@ -22818,7 +23630,9 @@ type MonikersOrNull struct {
 	Monikers *[]*Moniker
 }
 
-func (o MonikersOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = MonikersOrNull{}
+
+func (o MonikersOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of MonikersOrNull is set", o.Monikers != nil)
 
 	if o.Monikers != nil {
@@ -22827,6 +23641,8 @@ func (o MonikersOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*MonikersOrNull)(nil)
 
 func (o *MonikersOrNull) UnmarshalJSON(data []byte) error {
 	*o = MonikersOrNull{}
@@ -22848,7 +23664,9 @@ type TypeHierarchyItemsOrNull struct {
 	TypeHierarchyItems *[]*TypeHierarchyItem
 }
 
-func (o TypeHierarchyItemsOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = TypeHierarchyItemsOrNull{}
+
+func (o TypeHierarchyItemsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of TypeHierarchyItemsOrNull is set", o.TypeHierarchyItems != nil)
 
 	if o.TypeHierarchyItems != nil {
@@ -22857,6 +23675,8 @@ func (o TypeHierarchyItemsOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*TypeHierarchyItemsOrNull)(nil)
 
 func (o *TypeHierarchyItemsOrNull) UnmarshalJSON(data []byte) error {
 	*o = TypeHierarchyItemsOrNull{}
@@ -22878,7 +23698,9 @@ type InlineValuesOrNull struct {
 	InlineValues *[]InlineValueTextOrVariableLookupOrEvaluatableExpression
 }
 
-func (o InlineValuesOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = InlineValuesOrNull{}
+
+func (o InlineValuesOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of InlineValuesOrNull is set", o.InlineValues != nil)
 
 	if o.InlineValues != nil {
@@ -22887,6 +23709,8 @@ func (o InlineValuesOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*InlineValuesOrNull)(nil)
 
 func (o *InlineValuesOrNull) UnmarshalJSON(data []byte) error {
 	*o = InlineValuesOrNull{}
@@ -22908,7 +23732,9 @@ type InlayHintsOrNull struct {
 	InlayHints *[]*InlayHint
 }
 
-func (o InlayHintsOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = InlayHintsOrNull{}
+
+func (o InlayHintsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of InlayHintsOrNull is set", o.InlayHints != nil)
 
 	if o.InlayHints != nil {
@@ -22917,6 +23743,8 @@ func (o InlayHintsOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*InlayHintsOrNull)(nil)
 
 func (o *InlayHintsOrNull) UnmarshalJSON(data []byte) error {
 	*o = InlayHintsOrNull{}
@@ -22939,7 +23767,9 @@ type RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport stru
 	UnchangedDocumentDiagnosticReport *RelatedUnchangedDocumentDiagnosticReport
 }
 
-func (o RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport{}
+
+func (o RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport should be set", o.FullDocumentDiagnosticReport != nil, o.UnchangedDocumentDiagnosticReport != nil)
 
 	if o.FullDocumentDiagnosticReport != nil {
@@ -22950,6 +23780,8 @@ func (o RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) 
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport)(nil)
 
 func (o *RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) UnmarshalJSON(data []byte) error {
 	*o = RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport{}
@@ -22972,7 +23804,9 @@ type InlineCompletionListOrItemsOrNull struct {
 	Items *[]*InlineCompletionItem
 }
 
-func (o InlineCompletionListOrItemsOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = InlineCompletionListOrItemsOrNull{}
+
+func (o InlineCompletionListOrItemsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of InlineCompletionListOrItemsOrNull is set", o.List != nil, o.Items != nil)
 
 	if o.List != nil {
@@ -22984,6 +23818,8 @@ func (o InlineCompletionListOrItemsOrNull) MarshalerTo(enc *jsontext.Encoder) er
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*InlineCompletionListOrItemsOrNull)(nil)
 
 func (o *InlineCompletionListOrItemsOrNull) UnmarshalJSON(data []byte) error {
 	*o = InlineCompletionListOrItemsOrNull{}
@@ -23010,7 +23846,9 @@ type MessageActionItemOrNull struct {
 	MessageActionItem *MessageActionItem
 }
 
-func (o MessageActionItemOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = MessageActionItemOrNull{}
+
+func (o MessageActionItemOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of MessageActionItemOrNull is set", o.MessageActionItem != nil)
 
 	if o.MessageActionItem != nil {
@@ -23019,6 +23857,8 @@ func (o MessageActionItemOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*MessageActionItemOrNull)(nil)
 
 func (o *MessageActionItemOrNull) UnmarshalJSON(data []byte) error {
 	*o = MessageActionItemOrNull{}
@@ -23040,7 +23880,9 @@ type TextEditsOrNull struct {
 	TextEdits *[]*TextEdit
 }
 
-func (o TextEditsOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = TextEditsOrNull{}
+
+func (o TextEditsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of TextEditsOrNull is set", o.TextEdits != nil)
 
 	if o.TextEdits != nil {
@@ -23049,6 +23891,8 @@ func (o TextEditsOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*TextEditsOrNull)(nil)
 
 func (o *TextEditsOrNull) UnmarshalJSON(data []byte) error {
 	*o = TextEditsOrNull{}
@@ -23071,7 +23915,9 @@ type CompletionItemsOrListOrNull struct {
 	List  *CompletionList
 }
 
-func (o CompletionItemsOrListOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = CompletionItemsOrListOrNull{}
+
+func (o CompletionItemsOrListOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of CompletionItemsOrListOrNull is set", o.Items != nil, o.List != nil)
 
 	if o.Items != nil {
@@ -23083,6 +23929,8 @@ func (o CompletionItemsOrListOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*CompletionItemsOrListOrNull)(nil)
 
 func (o *CompletionItemsOrListOrNull) UnmarshalJSON(data []byte) error {
 	*o = CompletionItemsOrListOrNull{}
@@ -23109,7 +23957,9 @@ type HoverOrNull struct {
 	Hover *Hover
 }
 
-func (o HoverOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = HoverOrNull{}
+
+func (o HoverOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of HoverOrNull is set", o.Hover != nil)
 
 	if o.Hover != nil {
@@ -23118,6 +23968,8 @@ func (o HoverOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*HoverOrNull)(nil)
 
 func (o *HoverOrNull) UnmarshalJSON(data []byte) error {
 	*o = HoverOrNull{}
@@ -23139,7 +23991,9 @@ type SignatureHelpOrNull struct {
 	SignatureHelp *SignatureHelp
 }
 
-func (o SignatureHelpOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = SignatureHelpOrNull{}
+
+func (o SignatureHelpOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of SignatureHelpOrNull is set", o.SignatureHelp != nil)
 
 	if o.SignatureHelp != nil {
@@ -23148,6 +24002,8 @@ func (o SignatureHelpOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*SignatureHelpOrNull)(nil)
 
 func (o *SignatureHelpOrNull) UnmarshalJSON(data []byte) error {
 	*o = SignatureHelpOrNull{}
@@ -23169,7 +24025,9 @@ type LocationsOrNull struct {
 	Locations *[]Location
 }
 
-func (o LocationsOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = LocationsOrNull{}
+
+func (o LocationsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of LocationsOrNull is set", o.Locations != nil)
 
 	if o.Locations != nil {
@@ -23178,6 +24036,8 @@ func (o LocationsOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*LocationsOrNull)(nil)
 
 func (o *LocationsOrNull) UnmarshalJSON(data []byte) error {
 	*o = LocationsOrNull{}
@@ -23199,7 +24059,9 @@ type DocumentHighlightsOrNull struct {
 	DocumentHighlights *[]*DocumentHighlight
 }
 
-func (o DocumentHighlightsOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = DocumentHighlightsOrNull{}
+
+func (o DocumentHighlightsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of DocumentHighlightsOrNull is set", o.DocumentHighlights != nil)
 
 	if o.DocumentHighlights != nil {
@@ -23208,6 +24070,8 @@ func (o DocumentHighlightsOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*DocumentHighlightsOrNull)(nil)
 
 func (o *DocumentHighlightsOrNull) UnmarshalJSON(data []byte) error {
 	*o = DocumentHighlightsOrNull{}
@@ -23230,7 +24094,9 @@ type SymbolInformationsOrDocumentSymbolsOrNull struct {
 	DocumentSymbols    *[]*DocumentSymbol
 }
 
-func (o SymbolInformationsOrDocumentSymbolsOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = SymbolInformationsOrDocumentSymbolsOrNull{}
+
+func (o SymbolInformationsOrDocumentSymbolsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of SymbolInformationsOrDocumentSymbolsOrNull is set", o.SymbolInformations != nil, o.DocumentSymbols != nil)
 
 	if o.SymbolInformations != nil {
@@ -23242,6 +24108,8 @@ func (o SymbolInformationsOrDocumentSymbolsOrNull) MarshalerTo(enc *jsontext.Enc
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*SymbolInformationsOrDocumentSymbolsOrNull)(nil)
 
 func (o *SymbolInformationsOrDocumentSymbolsOrNull) UnmarshalJSON(data []byte) error {
 	*o = SymbolInformationsOrDocumentSymbolsOrNull{}
@@ -23269,7 +24137,9 @@ type CommandOrCodeAction struct {
 	CodeAction *CodeAction
 }
 
-func (o CommandOrCodeAction) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = CommandOrCodeAction{}
+
+func (o CommandOrCodeAction) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of CommandOrCodeAction should be set", o.Command != nil, o.CodeAction != nil)
 
 	if o.Command != nil {
@@ -23280,6 +24150,8 @@ func (o CommandOrCodeAction) MarshalerTo(enc *jsontext.Encoder) error {
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*CommandOrCodeAction)(nil)
 
 func (o *CommandOrCodeAction) UnmarshalJSON(data []byte) error {
 	*o = CommandOrCodeAction{}
@@ -23301,7 +24173,9 @@ type CommandOrCodeActionArrayOrNull struct {
 	CommandOrCodeActionArray *[]CommandOrCodeAction
 }
 
-func (o CommandOrCodeActionArrayOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = CommandOrCodeActionArrayOrNull{}
+
+func (o CommandOrCodeActionArrayOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of CommandOrCodeActionArrayOrNull is set", o.CommandOrCodeActionArray != nil)
 
 	if o.CommandOrCodeActionArray != nil {
@@ -23310,6 +24184,8 @@ func (o CommandOrCodeActionArrayOrNull) MarshalerTo(enc *jsontext.Encoder) error
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*CommandOrCodeActionArrayOrNull)(nil)
 
 func (o *CommandOrCodeActionArrayOrNull) UnmarshalJSON(data []byte) error {
 	*o = CommandOrCodeActionArrayOrNull{}
@@ -23332,7 +24208,9 @@ type SymbolInformationsOrWorkspaceSymbolsOrNull struct {
 	WorkspaceSymbols   *[]*WorkspaceSymbol
 }
 
-func (o SymbolInformationsOrWorkspaceSymbolsOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = SymbolInformationsOrWorkspaceSymbolsOrNull{}
+
+func (o SymbolInformationsOrWorkspaceSymbolsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of SymbolInformationsOrWorkspaceSymbolsOrNull is set", o.SymbolInformations != nil, o.WorkspaceSymbols != nil)
 
 	if o.SymbolInformations != nil {
@@ -23344,6 +24222,8 @@ func (o SymbolInformationsOrWorkspaceSymbolsOrNull) MarshalerTo(enc *jsontext.En
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*SymbolInformationsOrWorkspaceSymbolsOrNull)(nil)
 
 func (o *SymbolInformationsOrWorkspaceSymbolsOrNull) UnmarshalJSON(data []byte) error {
 	*o = SymbolInformationsOrWorkspaceSymbolsOrNull{}
@@ -23370,7 +24250,9 @@ type CodeLenssOrNull struct {
 	CodeLenss *[]*CodeLens
 }
 
-func (o CodeLenssOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = CodeLenssOrNull{}
+
+func (o CodeLenssOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of CodeLenssOrNull is set", o.CodeLenss != nil)
 
 	if o.CodeLenss != nil {
@@ -23379,6 +24261,8 @@ func (o CodeLenssOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*CodeLenssOrNull)(nil)
 
 func (o *CodeLenssOrNull) UnmarshalJSON(data []byte) error {
 	*o = CodeLenssOrNull{}
@@ -23400,7 +24284,9 @@ type DocumentLinksOrNull struct {
 	DocumentLinks *[]*DocumentLink
 }
 
-func (o DocumentLinksOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = DocumentLinksOrNull{}
+
+func (o DocumentLinksOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of DocumentLinksOrNull is set", o.DocumentLinks != nil)
 
 	if o.DocumentLinks != nil {
@@ -23409,6 +24295,8 @@ func (o DocumentLinksOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*DocumentLinksOrNull)(nil)
 
 func (o *DocumentLinksOrNull) UnmarshalJSON(data []byte) error {
 	*o = DocumentLinksOrNull{}
@@ -23432,7 +24320,9 @@ type RangeOrPrepareRenamePlaceholderOrPrepareRenameDefaultBehaviorOrNull struct 
 	PrepareRenameDefaultBehavior *PrepareRenameDefaultBehavior
 }
 
-func (o RangeOrPrepareRenamePlaceholderOrPrepareRenameDefaultBehaviorOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = RangeOrPrepareRenamePlaceholderOrPrepareRenameDefaultBehaviorOrNull{}
+
+func (o RangeOrPrepareRenamePlaceholderOrPrepareRenameDefaultBehaviorOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of RangeOrPrepareRenamePlaceholderOrPrepareRenameDefaultBehaviorOrNull is set", o.Range != nil, o.PrepareRenamePlaceholder != nil, o.PrepareRenameDefaultBehavior != nil)
 
 	if o.Range != nil {
@@ -23447,6 +24337,8 @@ func (o RangeOrPrepareRenamePlaceholderOrPrepareRenameDefaultBehaviorOrNull) Mar
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*RangeOrPrepareRenamePlaceholderOrPrepareRenameDefaultBehaviorOrNull)(nil)
 
 func (o *RangeOrPrepareRenamePlaceholderOrPrepareRenameDefaultBehaviorOrNull) UnmarshalJSON(data []byte) error {
 	*o = RangeOrPrepareRenamePlaceholderOrPrepareRenameDefaultBehaviorOrNull{}
@@ -23478,7 +24370,9 @@ type LSPAnyOrNull struct {
 	LSPAny *any
 }
 
-func (o LSPAnyOrNull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = LSPAnyOrNull{}
+
+func (o LSPAnyOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertAtMostOne("more than one element of LSPAnyOrNull is set", o.LSPAny != nil)
 
 	if o.LSPAny != nil {
@@ -23487,6 +24381,8 @@ func (o LSPAnyOrNull) MarshalerTo(enc *jsontext.Encoder) error {
 	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
+
+var _ json.Unmarshaler = (*LSPAnyOrNull)(nil)
 
 func (o *LSPAnyOrNull) UnmarshalJSON(data []byte) error {
 	*o = LSPAnyOrNull{}
@@ -23511,7 +24407,9 @@ type TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPat
 	NotebookCellTextDocumentFilter *NotebookCellTextDocumentFilter
 }
 
-func (o TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPatternOrNotebookCellTextDocumentFilter) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPatternOrNotebookCellTextDocumentFilter{}
+
+func (o TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPatternOrNotebookCellTextDocumentFilter) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPatternOrNotebookCellTextDocumentFilter should be set", o.TextDocumentFilterLanguage != nil, o.TextDocumentFilterScheme != nil, o.TextDocumentFilterPattern != nil, o.NotebookCellTextDocumentFilter != nil)
 
 	if o.TextDocumentFilterLanguage != nil {
@@ -23528,6 +24426,8 @@ func (o TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilter
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPatternOrNotebookCellTextDocumentFilter)(nil)
 
 func (o *TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPatternOrNotebookCellTextDocumentFilter) UnmarshalJSON(data []byte) error {
 	*o = TextDocumentFilterLanguageOrTextDocumentFilterSchemeOrTextDocumentFilterPatternOrNotebookCellTextDocumentFilter{}
@@ -23560,7 +24460,9 @@ type StringOrMarkedStringWithLanguage struct {
 	MarkedStringWithLanguage *MarkedStringWithLanguage
 }
 
-func (o StringOrMarkedStringWithLanguage) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = StringOrMarkedStringWithLanguage{}
+
+func (o StringOrMarkedStringWithLanguage) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of StringOrMarkedStringWithLanguage should be set", o.String != nil, o.MarkedStringWithLanguage != nil)
 
 	if o.String != nil {
@@ -23571,6 +24473,8 @@ func (o StringOrMarkedStringWithLanguage) MarshalerTo(enc *jsontext.Encoder) err
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*StringOrMarkedStringWithLanguage)(nil)
 
 func (o *StringOrMarkedStringWithLanguage) UnmarshalJSON(data []byte) error {
 	*o = StringOrMarkedStringWithLanguage{}
@@ -23594,7 +24498,9 @@ type InlineValueTextOrVariableLookupOrEvaluatableExpression struct {
 	EvaluatableExpression *InlineValueEvaluatableExpression
 }
 
-func (o InlineValueTextOrVariableLookupOrEvaluatableExpression) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = InlineValueTextOrVariableLookupOrEvaluatableExpression{}
+
+func (o InlineValueTextOrVariableLookupOrEvaluatableExpression) MarshalJSONTo(enc *jsontext.Encoder) error {
 	assertOnlyOne("exactly one element of InlineValueTextOrVariableLookupOrEvaluatableExpression should be set", o.Text != nil, o.VariableLookup != nil, o.EvaluatableExpression != nil)
 
 	if o.Text != nil {
@@ -23608,6 +24514,8 @@ func (o InlineValueTextOrVariableLookupOrEvaluatableExpression) MarshalerTo(enc 
 	}
 	panic("unreachable")
 }
+
+var _ json.Unmarshaler = (*InlineValueTextOrVariableLookupOrEvaluatableExpression)(nil)
 
 func (o *InlineValueTextOrVariableLookupOrEvaluatableExpression) UnmarshalJSON(data []byte) error {
 	*o = InlineValueTextOrVariableLookupOrEvaluatableExpression{}
@@ -23635,9 +24543,13 @@ func (o *InlineValueTextOrVariableLookupOrEvaluatableExpression) UnmarshalJSON(d
 // StringLiteralBegin is a literal type for "begin"
 type StringLiteralBegin struct{}
 
-func (o StringLiteralBegin) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = StringLiteralBegin{}
+
+func (o StringLiteralBegin) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteValue(jsontext.Value(`"begin"`))
 }
+
+var _ json.UnmarshalerFrom = &StringLiteralBegin{}
 
 func (o *StringLiteralBegin) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	v, err := dec.ReadValue()
@@ -23653,9 +24565,13 @@ func (o *StringLiteralBegin) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 // StringLiteralReport is a literal type for "report"
 type StringLiteralReport struct{}
 
-func (o StringLiteralReport) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = StringLiteralReport{}
+
+func (o StringLiteralReport) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteValue(jsontext.Value(`"report"`))
 }
+
+var _ json.UnmarshalerFrom = &StringLiteralReport{}
 
 func (o *StringLiteralReport) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	v, err := dec.ReadValue()
@@ -23671,9 +24587,13 @@ func (o *StringLiteralReport) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 // StringLiteralEnd is a literal type for "end"
 type StringLiteralEnd struct{}
 
-func (o StringLiteralEnd) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = StringLiteralEnd{}
+
+func (o StringLiteralEnd) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteValue(jsontext.Value(`"end"`))
 }
+
+var _ json.UnmarshalerFrom = &StringLiteralEnd{}
 
 func (o *StringLiteralEnd) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	v, err := dec.ReadValue()
@@ -23689,9 +24609,13 @@ func (o *StringLiteralEnd) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 // StringLiteralCreate is a literal type for "create"
 type StringLiteralCreate struct{}
 
-func (o StringLiteralCreate) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = StringLiteralCreate{}
+
+func (o StringLiteralCreate) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteValue(jsontext.Value(`"create"`))
 }
+
+var _ json.UnmarshalerFrom = &StringLiteralCreate{}
 
 func (o *StringLiteralCreate) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	v, err := dec.ReadValue()
@@ -23707,9 +24631,13 @@ func (o *StringLiteralCreate) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 // StringLiteralRename is a literal type for "rename"
 type StringLiteralRename struct{}
 
-func (o StringLiteralRename) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = StringLiteralRename{}
+
+func (o StringLiteralRename) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteValue(jsontext.Value(`"rename"`))
 }
+
+var _ json.UnmarshalerFrom = &StringLiteralRename{}
 
 func (o *StringLiteralRename) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	v, err := dec.ReadValue()
@@ -23725,9 +24653,13 @@ func (o *StringLiteralRename) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 // StringLiteralDelete is a literal type for "delete"
 type StringLiteralDelete struct{}
 
-func (o StringLiteralDelete) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = StringLiteralDelete{}
+
+func (o StringLiteralDelete) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteValue(jsontext.Value(`"delete"`))
 }
+
+var _ json.UnmarshalerFrom = &StringLiteralDelete{}
 
 func (o *StringLiteralDelete) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	v, err := dec.ReadValue()
@@ -23743,9 +24675,13 @@ func (o *StringLiteralDelete) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 // StringLiteralFull is a literal type for "full"
 type StringLiteralFull struct{}
 
-func (o StringLiteralFull) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = StringLiteralFull{}
+
+func (o StringLiteralFull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteValue(jsontext.Value(`"full"`))
 }
+
+var _ json.UnmarshalerFrom = &StringLiteralFull{}
 
 func (o *StringLiteralFull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	v, err := dec.ReadValue()
@@ -23761,9 +24697,13 @@ func (o *StringLiteralFull) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 // StringLiteralUnchanged is a literal type for "unchanged"
 type StringLiteralUnchanged struct{}
 
-func (o StringLiteralUnchanged) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = StringLiteralUnchanged{}
+
+func (o StringLiteralUnchanged) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteValue(jsontext.Value(`"unchanged"`))
 }
+
+var _ json.UnmarshalerFrom = &StringLiteralUnchanged{}
 
 func (o *StringLiteralUnchanged) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	v, err := dec.ReadValue()
@@ -23779,9 +24719,13 @@ func (o *StringLiteralUnchanged) UnmarshalJSONFrom(dec *jsontext.Decoder) error 
 // StringLiteralSnippet is a literal type for "snippet"
 type StringLiteralSnippet struct{}
 
-func (o StringLiteralSnippet) MarshalerTo(enc *jsontext.Encoder) error {
+var _ json.MarshalerTo = StringLiteralSnippet{}
+
+func (o StringLiteralSnippet) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteValue(jsontext.Value(`"snippet"`))
 }
+
+var _ json.UnmarshalerFrom = &StringLiteralSnippet{}
 
 func (o *StringLiteralSnippet) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	v, err := dec.ReadValue()

--- a/internal/lsp/lsproto/lsp_generated.go
+++ b/internal/lsp/lsproto/lsp_generated.go
@@ -44,26 +44,26 @@ func (s *ImplementationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "textDocument":
+		switch string(name) {
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "position":
+		case `"position"`:
 			seenPosition = true
 			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
 				return err
 			}
-		case "workDoneToken":
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "partialResultToken":
+		case `"partialResultToken"`:
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
@@ -110,17 +110,17 @@ func (s *Location) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "uri":
+		switch string(name) {
+		case `"uri"`:
 			seenUri = true
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
 			}
-		case "range":
+		case `"range"`:
 			seenRange = true
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
@@ -169,21 +169,21 @@ func (s *ImplementationRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Deco
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "documentSelector":
+		switch string(name) {
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "workDoneProgress":
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
-		case "id":
+		case `"id"`:
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
@@ -234,26 +234,26 @@ func (s *TypeDefinitionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "textDocument":
+		switch string(name) {
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "position":
+		case `"position"`:
 			seenPosition = true
 			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
 				return err
 			}
-		case "workDoneToken":
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "partialResultToken":
+		case `"partialResultToken"`:
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
@@ -301,21 +301,21 @@ func (s *TypeDefinitionRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Deco
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "documentSelector":
+		switch string(name) {
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "workDoneProgress":
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
-		case "id":
+		case `"id"`:
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
@@ -361,17 +361,17 @@ func (s *WorkspaceFolder) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "uri":
+		switch string(name) {
+		case `"uri"`:
 			seenUri = true
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
 			}
-		case "name":
+		case `"name"`:
 			seenName = true
 			if err := json.UnmarshalDecode(dec, &s.Name); err != nil {
 				return err
@@ -414,12 +414,12 @@ func (s *DidChangeWorkspaceFoldersParams) UnmarshalJSONFrom(dec *jsontext.Decode
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "event":
+		switch string(name) {
+		case `"event"`:
 			seenEvent = true
 			if err := json.UnmarshalDecode(dec, &s.Event); err != nil {
 				return err
@@ -458,12 +458,12 @@ func (s *ConfigurationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "items":
+		switch string(name) {
+		case `"items"`:
 			seenItems = true
 			if err := json.UnmarshalDecode(dec, &s.Items); err != nil {
 				return err
@@ -510,20 +510,20 @@ func (s *DocumentColorParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneToken":
+		switch string(name) {
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "partialResultToken":
+		case `"partialResultToken"`:
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
-		case "textDocument":
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
@@ -569,17 +569,17 @@ func (s *ColorInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "range":
+		switch string(name) {
+		case `"range"`:
 			seenRange = true
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
-		case "color":
+		case `"color"`:
 			seenColor = true
 			if err := json.UnmarshalDecode(dec, &s.Color); err != nil {
 				return err
@@ -628,21 +628,21 @@ func (s *DocumentColorRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decod
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "documentSelector":
+		switch string(name) {
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "workDoneProgress":
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
-		case "id":
+		case `"id"`:
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
@@ -698,30 +698,30 @@ func (s *ColorPresentationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneToken":
+		switch string(name) {
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "partialResultToken":
+		case `"partialResultToken"`:
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
-		case "textDocument":
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "color":
+		case `"color"`:
 			seenColor = true
 			if err := json.UnmarshalDecode(dec, &s.Color); err != nil {
 				return err
 			}
-		case "range":
+		case `"range"`:
 			seenRange = true
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
@@ -777,21 +777,21 @@ func (s *ColorPresentation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "label":
+		switch string(name) {
+		case `"label"`:
 			seenLabel = true
 			if err := json.UnmarshalDecode(dec, &s.Label); err != nil {
 				return err
 			}
-		case "textEdit":
+		case `"textEdit"`:
 			if err := json.UnmarshalDecode(dec, &s.TextEdit); err != nil {
 				return err
 			}
-		case "additionalTextEdits":
+		case `"additionalTextEdits"`:
 			if err := json.UnmarshalDecode(dec, &s.AdditionalTextEdits); err != nil {
 				return err
 			}
@@ -835,12 +835,12 @@ func (s *TextDocumentRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decode
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "documentSelector":
+		switch string(name) {
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
@@ -887,20 +887,20 @@ func (s *FoldingRangeParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneToken":
+		switch string(name) {
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "partialResultToken":
+		case `"partialResultToken"`:
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
-		case "textDocument":
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
@@ -967,34 +967,34 @@ func (s *FoldingRange) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "startLine":
+		switch string(name) {
+		case `"startLine"`:
 			seenStartLine = true
 			if err := json.UnmarshalDecode(dec, &s.StartLine); err != nil {
 				return err
 			}
-		case "startCharacter":
+		case `"startCharacter"`:
 			if err := json.UnmarshalDecode(dec, &s.StartCharacter); err != nil {
 				return err
 			}
-		case "endLine":
+		case `"endLine"`:
 			seenEndLine = true
 			if err := json.UnmarshalDecode(dec, &s.EndLine); err != nil {
 				return err
 			}
-		case "endCharacter":
+		case `"endCharacter"`:
 			if err := json.UnmarshalDecode(dec, &s.EndCharacter); err != nil {
 				return err
 			}
-		case "kind":
+		case `"kind"`:
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
-		case "collapsedText":
+		case `"collapsedText"`:
 			if err := json.UnmarshalDecode(dec, &s.CollapsedText); err != nil {
 				return err
 			}
@@ -1042,21 +1042,21 @@ func (s *FoldingRangeRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decode
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "documentSelector":
+		switch string(name) {
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "workDoneProgress":
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
-		case "id":
+		case `"id"`:
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
@@ -1107,26 +1107,26 @@ func (s *DeclarationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "textDocument":
+		switch string(name) {
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "position":
+		case `"position"`:
 			seenPosition = true
 			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
 				return err
 			}
-		case "workDoneToken":
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "partialResultToken":
+		case `"partialResultToken"`:
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
@@ -1174,21 +1174,21 @@ func (s *DeclarationRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneProgress":
+		switch string(name) {
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
-		case "documentSelector":
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "id":
+		case `"id"`:
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
@@ -1240,25 +1240,25 @@ func (s *SelectionRangeParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneToken":
+		switch string(name) {
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "partialResultToken":
+		case `"partialResultToken"`:
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
-		case "textDocument":
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "positions":
+		case `"positions"`:
 			seenPositions = true
 			if err := json.UnmarshalDecode(dec, &s.Positions); err != nil {
 				return err
@@ -1305,17 +1305,17 @@ func (s *SelectionRange) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "range":
+		switch string(name) {
+		case `"range"`:
 			seenRange = true
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
-		case "parent":
+		case `"parent"`:
 			if err := json.UnmarshalDecode(dec, &s.Parent); err != nil {
 				return err
 			}
@@ -1360,21 +1360,21 @@ func (s *SelectionRangeRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Deco
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneProgress":
+		switch string(name) {
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
-		case "documentSelector":
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "id":
+		case `"id"`:
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
@@ -1412,12 +1412,12 @@ func (s *WorkDoneProgressCreateParams) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "token":
+		switch string(name) {
+		case `"token"`:
 			seenToken = true
 			if err := json.UnmarshalDecode(dec, &s.Token); err != nil {
 				return err
@@ -1456,12 +1456,12 @@ func (s *WorkDoneProgressCancelParams) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "token":
+		switch string(name) {
+		case `"token"`:
 			seenToken = true
 			if err := json.UnmarshalDecode(dec, &s.Token); err != nil {
 				return err
@@ -1512,22 +1512,22 @@ func (s *CallHierarchyPrepareParams) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "textDocument":
+		switch string(name) {
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "position":
+		case `"position"`:
 			seenPosition = true
 			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
 				return err
 			}
-		case "workDoneToken":
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
@@ -1601,45 +1601,45 @@ func (s *CallHierarchyItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "name":
+		switch string(name) {
+		case `"name"`:
 			seenName = true
 			if err := json.UnmarshalDecode(dec, &s.Name); err != nil {
 				return err
 			}
-		case "kind":
+		case `"kind"`:
 			seenKind = true
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
-		case "tags":
+		case `"tags"`:
 			if err := json.UnmarshalDecode(dec, &s.Tags); err != nil {
 				return err
 			}
-		case "detail":
+		case `"detail"`:
 			if err := json.UnmarshalDecode(dec, &s.Detail); err != nil {
 				return err
 			}
-		case "uri":
+		case `"uri"`:
 			seenUri = true
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
 			}
-		case "range":
+		case `"range"`:
 			seenRange = true
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
-		case "selectionRange":
+		case `"selectionRange"`:
 			seenSelectionRange = true
 			if err := json.UnmarshalDecode(dec, &s.SelectionRange); err != nil {
 				return err
 			}
-		case "data":
+		case `"data"`:
 			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
 				return err
 			}
@@ -1699,21 +1699,21 @@ func (s *CallHierarchyRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decod
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "documentSelector":
+		switch string(name) {
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "workDoneProgress":
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
-		case "id":
+		case `"id"`:
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
@@ -1760,20 +1760,20 @@ func (s *CallHierarchyIncomingCallsParams) UnmarshalJSONFrom(dec *jsontext.Decod
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneToken":
+		switch string(name) {
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "partialResultToken":
+		case `"partialResultToken"`:
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
-		case "item":
+		case `"item"`:
 			seenItem = true
 			if err := json.UnmarshalDecode(dec, &s.Item); err != nil {
 				return err
@@ -1822,17 +1822,17 @@ func (s *CallHierarchyIncomingCall) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "from":
+		switch string(name) {
+		case `"from"`:
 			seenFrom = true
 			if err := json.UnmarshalDecode(dec, &s.From); err != nil {
 				return err
 			}
-		case "fromRanges":
+		case `"fromRanges"`:
 			seenFromRanges = true
 			if err := json.UnmarshalDecode(dec, &s.FromRanges); err != nil {
 				return err
@@ -1883,20 +1883,20 @@ func (s *CallHierarchyOutgoingCallsParams) UnmarshalJSONFrom(dec *jsontext.Decod
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneToken":
+		switch string(name) {
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "partialResultToken":
+		case `"partialResultToken"`:
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
-		case "item":
+		case `"item"`:
 			seenItem = true
 			if err := json.UnmarshalDecode(dec, &s.Item); err != nil {
 				return err
@@ -1946,17 +1946,17 @@ func (s *CallHierarchyOutgoingCall) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "to":
+		switch string(name) {
+		case `"to"`:
 			seenTo = true
 			if err := json.UnmarshalDecode(dec, &s.To); err != nil {
 				return err
 			}
-		case "fromRanges":
+		case `"fromRanges"`:
 			seenFromRanges = true
 			if err := json.UnmarshalDecode(dec, &s.FromRanges); err != nil {
 				return err
@@ -2006,20 +2006,20 @@ func (s *SemanticTokensParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneToken":
+		switch string(name) {
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "partialResultToken":
+		case `"partialResultToken"`:
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
-		case "textDocument":
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
@@ -2065,16 +2065,16 @@ func (s *SemanticTokens) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "resultId":
+		switch string(name) {
+		case `"resultId"`:
 			if err := json.UnmarshalDecode(dec, &s.ResultId); err != nil {
 				return err
 			}
-		case "data":
+		case `"data"`:
 			seenData = true
 			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
 				return err
@@ -2113,12 +2113,12 @@ func (s *SemanticTokensPartialResult) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "data":
+		switch string(name) {
+		case `"data"`:
 			seenData = true
 			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
 				return err
@@ -2178,34 +2178,34 @@ func (s *SemanticTokensRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Deco
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "documentSelector":
+		switch string(name) {
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "workDoneProgress":
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
-		case "legend":
+		case `"legend"`:
 			seenLegend = true
 			if err := json.UnmarshalDecode(dec, &s.Legend); err != nil {
 				return err
 			}
-		case "range":
+		case `"range"`:
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
-		case "full":
+		case `"full"`:
 			if err := json.UnmarshalDecode(dec, &s.Full); err != nil {
 				return err
 			}
-		case "id":
+		case `"id"`:
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
@@ -2261,25 +2261,25 @@ func (s *SemanticTokensDeltaParams) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneToken":
+		switch string(name) {
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "partialResultToken":
+		case `"partialResultToken"`:
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
-		case "textDocument":
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "previousResultId":
+		case `"previousResultId"`:
 			seenPreviousResultId = true
 			if err := json.UnmarshalDecode(dec, &s.PreviousResultId); err != nil {
 				return err
@@ -2324,16 +2324,16 @@ func (s *SemanticTokensDelta) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "resultId":
+		switch string(name) {
+		case `"resultId"`:
 			if err := json.UnmarshalDecode(dec, &s.ResultId); err != nil {
 				return err
 			}
-		case "edits":
+		case `"edits"`:
 			seenEdits = true
 			if err := json.UnmarshalDecode(dec, &s.Edits); err != nil {
 				return err
@@ -2372,12 +2372,12 @@ func (s *SemanticTokensDeltaPartialResult) UnmarshalJSONFrom(dec *jsontext.Decod
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "edits":
+		switch string(name) {
+		case `"edits"`:
 			seenEdits = true
 			if err := json.UnmarshalDecode(dec, &s.Edits); err != nil {
 				return err
@@ -2430,25 +2430,25 @@ func (s *SemanticTokensRangeParams) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneToken":
+		switch string(name) {
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "partialResultToken":
+		case `"partialResultToken"`:
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
-		case "textDocument":
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "range":
+		case `"range"`:
 			seenRange = true
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
@@ -2510,25 +2510,25 @@ func (s *ShowDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "uri":
+		switch string(name) {
+		case `"uri"`:
 			seenUri = true
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
 			}
-		case "external":
+		case `"external"`:
 			if err := json.UnmarshalDecode(dec, &s.External); err != nil {
 				return err
 			}
-		case "takeFocus":
+		case `"takeFocus"`:
 			if err := json.UnmarshalDecode(dec, &s.TakeFocus); err != nil {
 				return err
 			}
-		case "selection":
+		case `"selection"`:
 			if err := json.UnmarshalDecode(dec, &s.Selection); err != nil {
 				return err
 			}
@@ -2569,12 +2569,12 @@ func (s *ShowDocumentResult) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "success":
+		switch string(name) {
+		case `"success"`:
 			seenSuccess = true
 			if err := json.UnmarshalDecode(dec, &s.Success); err != nil {
 				return err
@@ -2622,22 +2622,22 @@ func (s *LinkedEditingRangeParams) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "textDocument":
+		switch string(name) {
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "position":
+		case `"position"`:
 			seenPosition = true
 			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
 				return err
 			}
-		case "workDoneToken":
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
@@ -2687,17 +2687,17 @@ func (s *LinkedEditingRanges) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "ranges":
+		switch string(name) {
+		case `"ranges"`:
 			seenRanges = true
 			if err := json.UnmarshalDecode(dec, &s.Ranges); err != nil {
 				return err
 			}
-		case "wordPattern":
+		case `"wordPattern"`:
 			if err := json.UnmarshalDecode(dec, &s.WordPattern); err != nil {
 				return err
 			}
@@ -2742,21 +2742,21 @@ func (s *LinkedEditingRangeRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "documentSelector":
+		switch string(name) {
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "workDoneProgress":
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
-		case "id":
+		case `"id"`:
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
@@ -2798,12 +2798,12 @@ func (s *CreateFilesParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "files":
+		switch string(name) {
+		case `"files"`:
 			seenFiles = true
 			if err := json.UnmarshalDecode(dec, &s.Files); err != nil {
 				return err
@@ -2882,12 +2882,12 @@ func (s *FileOperationRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decod
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "filters":
+		switch string(name) {
+		case `"filters"`:
 			seenFilters = true
 			if err := json.UnmarshalDecode(dec, &s.Filters); err != nil {
 				return err
@@ -2931,12 +2931,12 @@ func (s *RenameFilesParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "files":
+		switch string(name) {
+		case `"files"`:
 			seenFiles = true
 			if err := json.UnmarshalDecode(dec, &s.Files); err != nil {
 				return err
@@ -2979,12 +2979,12 @@ func (s *DeleteFilesParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "files":
+		switch string(name) {
+		case `"files"`:
 			seenFiles = true
 			if err := json.UnmarshalDecode(dec, &s.Files); err != nil {
 				return err
@@ -3036,26 +3036,26 @@ func (s *MonikerParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "textDocument":
+		switch string(name) {
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "position":
+		case `"position"`:
 			seenPosition = true
 			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
 				return err
 			}
-		case "workDoneToken":
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "partialResultToken":
+		case `"partialResultToken"`:
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
@@ -3113,27 +3113,27 @@ func (s *Moniker) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "scheme":
+		switch string(name) {
+		case `"scheme"`:
 			seenScheme = true
 			if err := json.UnmarshalDecode(dec, &s.Scheme); err != nil {
 				return err
 			}
-		case "identifier":
+		case `"identifier"`:
 			seenIdentifier = true
 			if err := json.UnmarshalDecode(dec, &s.Identifier); err != nil {
 				return err
 			}
-		case "unique":
+		case `"unique"`:
 			seenUnique = true
 			if err := json.UnmarshalDecode(dec, &s.Unique); err != nil {
 				return err
 			}
-		case "kind":
+		case `"kind"`:
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
@@ -3180,17 +3180,17 @@ func (s *MonikerRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "documentSelector":
+		switch string(name) {
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "workDoneProgress":
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
@@ -3240,22 +3240,22 @@ func (s *TypeHierarchyPrepareParams) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "textDocument":
+		switch string(name) {
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "position":
+		case `"position"`:
 			seenPosition = true
 			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
 				return err
 			}
-		case "workDoneToken":
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
@@ -3330,45 +3330,45 @@ func (s *TypeHierarchyItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "name":
+		switch string(name) {
+		case `"name"`:
 			seenName = true
 			if err := json.UnmarshalDecode(dec, &s.Name); err != nil {
 				return err
 			}
-		case "kind":
+		case `"kind"`:
 			seenKind = true
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
-		case "tags":
+		case `"tags"`:
 			if err := json.UnmarshalDecode(dec, &s.Tags); err != nil {
 				return err
 			}
-		case "detail":
+		case `"detail"`:
 			if err := json.UnmarshalDecode(dec, &s.Detail); err != nil {
 				return err
 			}
-		case "uri":
+		case `"uri"`:
 			seenUri = true
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
 			}
-		case "range":
+		case `"range"`:
 			seenRange = true
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
-		case "selectionRange":
+		case `"selectionRange"`:
 			seenSelectionRange = true
 			if err := json.UnmarshalDecode(dec, &s.SelectionRange); err != nil {
 				return err
 			}
-		case "data":
+		case `"data"`:
 			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
 				return err
 			}
@@ -3428,21 +3428,21 @@ func (s *TypeHierarchyRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decod
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "documentSelector":
+		switch string(name) {
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "workDoneProgress":
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
-		case "id":
+		case `"id"`:
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
@@ -3489,20 +3489,20 @@ func (s *TypeHierarchySupertypesParams) UnmarshalJSONFrom(dec *jsontext.Decoder)
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneToken":
+		switch string(name) {
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "partialResultToken":
+		case `"partialResultToken"`:
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
-		case "item":
+		case `"item"`:
 			seenItem = true
 			if err := json.UnmarshalDecode(dec, &s.Item); err != nil {
 				return err
@@ -3550,20 +3550,20 @@ func (s *TypeHierarchySubtypesParams) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneToken":
+		switch string(name) {
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "partialResultToken":
+		case `"partialResultToken"`:
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
-		case "item":
+		case `"item"`:
 			seenItem = true
 			if err := json.UnmarshalDecode(dec, &s.Item); err != nil {
 				return err
@@ -3619,26 +3619,26 @@ func (s *InlineValueParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneToken":
+		switch string(name) {
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "textDocument":
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "range":
+		case `"range"`:
 			seenRange = true
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
-		case "context":
+		case `"context"`:
 			seenContext = true
 			if err := json.UnmarshalDecode(dec, &s.Context); err != nil {
 				return err
@@ -3693,21 +3693,21 @@ func (s *InlineValueRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneProgress":
+		switch string(name) {
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
-		case "documentSelector":
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "id":
+		case `"id"`:
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
@@ -3757,21 +3757,21 @@ func (s *InlayHintParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneToken":
+		switch string(name) {
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "textDocument":
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "range":
+		case `"range"`:
 			seenRange = true
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
@@ -3860,42 +3860,42 @@ func (s *InlayHint) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "position":
+		switch string(name) {
+		case `"position"`:
 			seenPosition = true
 			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
 				return err
 			}
-		case "label":
+		case `"label"`:
 			seenLabel = true
 			if err := json.UnmarshalDecode(dec, &s.Label); err != nil {
 				return err
 			}
-		case "kind":
+		case `"kind"`:
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
-		case "textEdits":
+		case `"textEdits"`:
 			if err := json.UnmarshalDecode(dec, &s.TextEdits); err != nil {
 				return err
 			}
-		case "tooltip":
+		case `"tooltip"`:
 			if err := json.UnmarshalDecode(dec, &s.Tooltip); err != nil {
 				return err
 			}
-		case "paddingLeft":
+		case `"paddingLeft"`:
 			if err := json.UnmarshalDecode(dec, &s.PaddingLeft); err != nil {
 				return err
 			}
-		case "paddingRight":
+		case `"paddingRight"`:
 			if err := json.UnmarshalDecode(dec, &s.PaddingRight); err != nil {
 				return err
 			}
-		case "data":
+		case `"data"`:
 			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
 				return err
 			}
@@ -3950,25 +3950,25 @@ func (s *InlayHintRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneProgress":
+		switch string(name) {
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
-		case "resolveProvider":
+		case `"resolveProvider"`:
 			if err := json.UnmarshalDecode(dec, &s.ResolveProvider); err != nil {
 				return err
 			}
-		case "documentSelector":
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "id":
+		case `"id"`:
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
@@ -4022,29 +4022,29 @@ func (s *DocumentDiagnosticParams) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneToken":
+		switch string(name) {
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "partialResultToken":
+		case `"partialResultToken"`:
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
-		case "textDocument":
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "identifier":
+		case `"identifier"`:
 			if err := json.UnmarshalDecode(dec, &s.Identifier); err != nil {
 				return err
 			}
-		case "previousResultId":
+		case `"previousResultId"`:
 			if err := json.UnmarshalDecode(dec, &s.PreviousResultId); err != nil {
 				return err
 			}
@@ -4084,12 +4084,12 @@ func (s *DocumentDiagnosticReportPartialResult) UnmarshalJSONFrom(dec *jsontext.
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "relatedDocuments":
+		switch string(name) {
+		case `"relatedDocuments"`:
 			seenRelatedDocuments = true
 			if err := json.UnmarshalDecode(dec, &s.RelatedDocuments); err != nil {
 				return err
@@ -4130,12 +4130,12 @@ func (s *DiagnosticServerCancellationData) UnmarshalJSONFrom(dec *jsontext.Decod
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "retriggerRequest":
+		switch string(name) {
+		case `"retriggerRequest"`:
 			seenRetriggerRequest = true
 			if err := json.UnmarshalDecode(dec, &s.RetriggerRequest); err != nil {
 				return err
@@ -4201,35 +4201,35 @@ func (s *DiagnosticRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder)
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "documentSelector":
+		switch string(name) {
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "workDoneProgress":
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
-		case "identifier":
+		case `"identifier"`:
 			if err := json.UnmarshalDecode(dec, &s.Identifier); err != nil {
 				return err
 			}
-		case "interFileDependencies":
+		case `"interFileDependencies"`:
 			seenInterFileDependencies = true
 			if err := json.UnmarshalDecode(dec, &s.InterFileDependencies); err != nil {
 				return err
 			}
-		case "workspaceDiagnostics":
+		case `"workspaceDiagnostics"`:
 			seenWorkspaceDiagnostics = true
 			if err := json.UnmarshalDecode(dec, &s.WorkspaceDiagnostics); err != nil {
 				return err
 			}
-		case "id":
+		case `"id"`:
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
@@ -4287,24 +4287,24 @@ func (s *WorkspaceDiagnosticParams) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneToken":
+		switch string(name) {
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "partialResultToken":
+		case `"partialResultToken"`:
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
-		case "identifier":
+		case `"identifier"`:
 			if err := json.UnmarshalDecode(dec, &s.Identifier); err != nil {
 				return err
 			}
-		case "previousResultIds":
+		case `"previousResultIds"`:
 			seenPreviousResultIds = true
 			if err := json.UnmarshalDecode(dec, &s.PreviousResultIds); err != nil {
 				return err
@@ -4345,12 +4345,12 @@ func (s *WorkspaceDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "items":
+		switch string(name) {
+		case `"items"`:
 			seenItems = true
 			if err := json.UnmarshalDecode(dec, &s.Items); err != nil {
 				return err
@@ -4391,12 +4391,12 @@ func (s *WorkspaceDiagnosticReportPartialResult) UnmarshalJSONFrom(dec *jsontext
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "items":
+		switch string(name) {
+		case `"items"`:
 			seenItems = true
 			if err := json.UnmarshalDecode(dec, &s.Items); err != nil {
 				return err
@@ -4445,17 +4445,17 @@ func (s *DidOpenNotebookDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder)
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "notebookDocument":
+		switch string(name) {
+		case `"notebookDocument"`:
 			seenNotebookDocument = true
 			if err := json.UnmarshalDecode(dec, &s.NotebookDocument); err != nil {
 				return err
 			}
-		case "cellTextDocuments":
+		case `"cellTextDocuments"`:
 			seenCellTextDocuments = true
 			if err := json.UnmarshalDecode(dec, &s.CellTextDocuments); err != nil {
 				return err
@@ -4508,21 +4508,21 @@ func (s *NotebookDocumentSyncRegistrationOptions) UnmarshalJSONFrom(dec *jsontex
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "notebookSelector":
+		switch string(name) {
+		case `"notebookSelector"`:
 			seenNotebookSelector = true
 			if err := json.UnmarshalDecode(dec, &s.NotebookSelector); err != nil {
 				return err
 			}
-		case "save":
+		case `"save"`:
 			if err := json.UnmarshalDecode(dec, &s.Save); err != nil {
 				return err
 			}
-		case "id":
+		case `"id"`:
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
@@ -4584,17 +4584,17 @@ func (s *DidChangeNotebookDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decode
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "notebookDocument":
+		switch string(name) {
+		case `"notebookDocument"`:
 			seenNotebookDocument = true
 			if err := json.UnmarshalDecode(dec, &s.NotebookDocument); err != nil {
 				return err
 			}
-		case "change":
+		case `"change"`:
 			seenChange = true
 			if err := json.UnmarshalDecode(dec, &s.Change); err != nil {
 				return err
@@ -4639,12 +4639,12 @@ func (s *DidSaveNotebookDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder)
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "notebookDocument":
+		switch string(name) {
+		case `"notebookDocument"`:
 			seenNotebookDocument = true
 			if err := json.UnmarshalDecode(dec, &s.NotebookDocument); err != nil {
 				return err
@@ -4693,17 +4693,17 @@ func (s *DidCloseNotebookDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "notebookDocument":
+		switch string(name) {
+		case `"notebookDocument"`:
 			seenNotebookDocument = true
 			if err := json.UnmarshalDecode(dec, &s.NotebookDocument); err != nil {
 				return err
 			}
-		case "cellTextDocuments":
+		case `"cellTextDocuments"`:
 			seenCellTextDocuments = true
 			if err := json.UnmarshalDecode(dec, &s.CellTextDocuments); err != nil {
 				return err
@@ -4764,26 +4764,26 @@ func (s *InlineCompletionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error 
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "textDocument":
+		switch string(name) {
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "position":
+		case `"position"`:
 			seenPosition = true
 			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
 				return err
 			}
-		case "workDoneToken":
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "context":
+		case `"context"`:
 			seenContext = true
 			if err := json.UnmarshalDecode(dec, &s.Context); err != nil {
 				return err
@@ -4833,12 +4833,12 @@ func (s *InlineCompletionList) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "items":
+		switch string(name) {
+		case `"items"`:
 			seenItems = true
 			if err := json.UnmarshalDecode(dec, &s.Items); err != nil {
 				return err
@@ -4891,25 +4891,25 @@ func (s *InlineCompletionItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "insertText":
+		switch string(name) {
+		case `"insertText"`:
 			seenInsertText = true
 			if err := json.UnmarshalDecode(dec, &s.InsertText); err != nil {
 				return err
 			}
-		case "filterText":
+		case `"filterText"`:
 			if err := json.UnmarshalDecode(dec, &s.FilterText); err != nil {
 				return err
 			}
-		case "range":
+		case `"range"`:
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
-		case "command":
+		case `"command"`:
 			if err := json.UnmarshalDecode(dec, &s.Command); err != nil {
 				return err
 			}
@@ -4959,21 +4959,21 @@ func (s *InlineCompletionRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.De
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneProgress":
+		switch string(name) {
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
-		case "documentSelector":
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "id":
+		case `"id"`:
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
@@ -5016,12 +5016,12 @@ func (s *TextDocumentContentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "uri":
+		switch string(name) {
+		case `"uri"`:
 			seenUri = true
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
@@ -5068,12 +5068,12 @@ func (s *TextDocumentContentResult) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "text":
+		switch string(name) {
+		case `"text"`:
 			seenText = true
 			if err := json.UnmarshalDecode(dec, &s.Text); err != nil {
 				return err
@@ -5121,17 +5121,17 @@ func (s *TextDocumentContentRegistrationOptions) UnmarshalJSONFrom(dec *jsontext
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "schemes":
+		switch string(name) {
+		case `"schemes"`:
 			seenSchemes = true
 			if err := json.UnmarshalDecode(dec, &s.Schemes); err != nil {
 				return err
 			}
-		case "id":
+		case `"id"`:
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
@@ -5174,12 +5174,12 @@ func (s *TextDocumentContentRefreshParams) UnmarshalJSONFrom(dec *jsontext.Decod
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "uri":
+		switch string(name) {
+		case `"uri"`:
 			seenUri = true
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
@@ -5217,12 +5217,12 @@ func (s *RegistrationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "registrations":
+		switch string(name) {
+		case `"registrations"`:
 			seenRegistrations = true
 			if err := json.UnmarshalDecode(dec, &s.Registrations); err != nil {
 				return err
@@ -5260,12 +5260,12 @@ func (s *UnregistrationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "unregisterations":
+		switch string(name) {
+		case `"unregisterations"`:
 			seenUnregisterations = true
 			if err := json.UnmarshalDecode(dec, &s.Unregisterations); err != nil {
 				return err
@@ -5361,51 +5361,51 @@ func (s *InitializeParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneToken":
+		switch string(name) {
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "processId":
+		case `"processId"`:
 			seenProcessId = true
 			if err := json.UnmarshalDecode(dec, &s.ProcessId); err != nil {
 				return err
 			}
-		case "clientInfo":
+		case `"clientInfo"`:
 			if err := json.UnmarshalDecode(dec, &s.ClientInfo); err != nil {
 				return err
 			}
-		case "locale":
+		case `"locale"`:
 			if err := json.UnmarshalDecode(dec, &s.Locale); err != nil {
 				return err
 			}
-		case "rootPath":
+		case `"rootPath"`:
 			if err := json.UnmarshalDecode(dec, &s.RootPath); err != nil {
 				return err
 			}
-		case "rootUri":
+		case `"rootUri"`:
 			seenRootUri = true
 			if err := json.UnmarshalDecode(dec, &s.RootUri); err != nil {
 				return err
 			}
-		case "capabilities":
+		case `"capabilities"`:
 			seenCapabilities = true
 			if err := json.UnmarshalDecode(dec, &s.Capabilities); err != nil {
 				return err
 			}
-		case "initializationOptions":
+		case `"initializationOptions"`:
 			if err := json.UnmarshalDecode(dec, &s.InitializationOptions); err != nil {
 				return err
 			}
-		case "trace":
+		case `"trace"`:
 			if err := json.UnmarshalDecode(dec, &s.Trace); err != nil {
 				return err
 			}
-		case "workspaceFolders":
+		case `"workspaceFolders"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkspaceFolders); err != nil {
 				return err
 			}
@@ -5455,17 +5455,17 @@ func (s *InitializeResult) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "capabilities":
+		switch string(name) {
+		case `"capabilities"`:
 			seenCapabilities = true
 			if err := json.UnmarshalDecode(dec, &s.Capabilities); err != nil {
 				return err
 			}
-		case "serverInfo":
+		case `"serverInfo"`:
 			if err := json.UnmarshalDecode(dec, &s.ServerInfo); err != nil {
 				return err
 			}
@@ -5508,12 +5508,12 @@ func (s *InitializeError) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "retry":
+		switch string(name) {
+		case `"retry"`:
 			seenRetry = true
 			if err := json.UnmarshalDecode(dec, &s.Retry); err != nil {
 				return err
@@ -5555,12 +5555,12 @@ func (s *DidChangeConfigurationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "settings":
+		switch string(name) {
+		case `"settings"`:
 			seenSettings = true
 			if err := json.UnmarshalDecode(dec, &s.Settings); err != nil {
 				return err
@@ -5610,17 +5610,17 @@ func (s *ShowMessageParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "type":
+		switch string(name) {
+		case `"type"`:
 			seenType = true
 			if err := json.UnmarshalDecode(dec, &s.Type); err != nil {
 				return err
 			}
-		case "message":
+		case `"message"`:
 			seenMessage = true
 			if err := json.UnmarshalDecode(dec, &s.Message); err != nil {
 				return err
@@ -5671,22 +5671,22 @@ func (s *ShowMessageRequestParams) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "type":
+		switch string(name) {
+		case `"type"`:
 			seenType = true
 			if err := json.UnmarshalDecode(dec, &s.Type); err != nil {
 				return err
 			}
-		case "message":
+		case `"message"`:
 			seenMessage = true
 			if err := json.UnmarshalDecode(dec, &s.Message); err != nil {
 				return err
 			}
-		case "actions":
+		case `"actions"`:
 			if err := json.UnmarshalDecode(dec, &s.Actions); err != nil {
 				return err
 			}
@@ -5727,12 +5727,12 @@ func (s *MessageActionItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "title":
+		switch string(name) {
+		case `"title"`:
 			seenTitle = true
 			if err := json.UnmarshalDecode(dec, &s.Title); err != nil {
 				return err
@@ -5778,17 +5778,17 @@ func (s *LogMessageParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "type":
+		switch string(name) {
+		case `"type"`:
 			seenType = true
 			if err := json.UnmarshalDecode(dec, &s.Type); err != nil {
 				return err
 			}
-		case "message":
+		case `"message"`:
 			seenMessage = true
 			if err := json.UnmarshalDecode(dec, &s.Message); err != nil {
 				return err
@@ -5831,12 +5831,12 @@ func (s *DidOpenTextDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "textDocument":
+		switch string(name) {
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
@@ -5894,17 +5894,17 @@ func (s *DidChangeTextDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "textDocument":
+		switch string(name) {
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "contentChanges":
+		case `"contentChanges"`:
 			seenContentChanges = true
 			if err := json.UnmarshalDecode(dec, &s.ContentChanges); err != nil {
 				return err
@@ -5954,17 +5954,17 @@ func (s *TextDocumentChangeRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "documentSelector":
+		switch string(name) {
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "syncKind":
+		case `"syncKind"`:
 			seenSyncKind = true
 			if err := json.UnmarshalDecode(dec, &s.SyncKind); err != nil {
 				return err
@@ -6007,12 +6007,12 @@ func (s *DidCloseTextDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "textDocument":
+		switch string(name) {
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
@@ -6056,17 +6056,17 @@ func (s *DidSaveTextDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "textDocument":
+		switch string(name) {
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "text":
+		case `"text"`:
 			if err := json.UnmarshalDecode(dec, &s.Text); err != nil {
 				return err
 			}
@@ -6109,17 +6109,17 @@ func (s *TextDocumentSaveRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.De
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "documentSelector":
+		switch string(name) {
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "includeText":
+		case `"includeText"`:
 			if err := json.UnmarshalDecode(dec, &s.IncludeText); err != nil {
 				return err
 			}
@@ -6164,17 +6164,17 @@ func (s *WillSaveTextDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "textDocument":
+		switch string(name) {
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "reason":
+		case `"reason"`:
 			seenReason = true
 			if err := json.UnmarshalDecode(dec, &s.Reason); err != nil {
 				return err
@@ -6225,17 +6225,17 @@ func (s *TextEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "range":
+		switch string(name) {
+		case `"range"`:
 			seenRange = true
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
-		case "newText":
+		case `"newText"`:
 			seenNewText = true
 			if err := json.UnmarshalDecode(dec, &s.NewText); err != nil {
 				return err
@@ -6278,12 +6278,12 @@ func (s *DidChangeWatchedFilesParams) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "changes":
+		switch string(name) {
+		case `"changes"`:
 			seenChanges = true
 			if err := json.UnmarshalDecode(dec, &s.Changes); err != nil {
 				return err
@@ -6323,12 +6323,12 @@ func (s *DidChangeWatchedFilesRegistrationOptions) UnmarshalJSONFrom(dec *jsonte
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "watchers":
+		switch string(name) {
+		case `"watchers"`:
 			seenWatchers = true
 			if err := json.UnmarshalDecode(dec, &s.Watchers); err != nil {
 				return err
@@ -6379,21 +6379,21 @@ func (s *PublishDiagnosticsParams) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "uri":
+		switch string(name) {
+		case `"uri"`:
 			seenUri = true
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
 			}
-		case "version":
+		case `"version"`:
 			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
 				return err
 			}
-		case "diagnostics":
+		case `"diagnostics"`:
 			seenDiagnostics = true
 			if err := json.UnmarshalDecode(dec, &s.Diagnostics); err != nil {
 				return err
@@ -6453,30 +6453,30 @@ func (s *CompletionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "textDocument":
+		switch string(name) {
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "position":
+		case `"position"`:
 			seenPosition = true
 			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
 				return err
 			}
-		case "workDoneToken":
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "partialResultToken":
+		case `"partialResultToken"`:
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
-		case "context":
+		case `"context"`:
 			if err := json.UnmarshalDecode(dec, &s.Context); err != nil {
 				return err
 			}
@@ -6653,85 +6653,85 @@ func (s *CompletionItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "label":
+		switch string(name) {
+		case `"label"`:
 			seenLabel = true
 			if err := json.UnmarshalDecode(dec, &s.Label); err != nil {
 				return err
 			}
-		case "labelDetails":
+		case `"labelDetails"`:
 			if err := json.UnmarshalDecode(dec, &s.LabelDetails); err != nil {
 				return err
 			}
-		case "kind":
+		case `"kind"`:
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
-		case "tags":
+		case `"tags"`:
 			if err := json.UnmarshalDecode(dec, &s.Tags); err != nil {
 				return err
 			}
-		case "detail":
+		case `"detail"`:
 			if err := json.UnmarshalDecode(dec, &s.Detail); err != nil {
 				return err
 			}
-		case "documentation":
+		case `"documentation"`:
 			if err := json.UnmarshalDecode(dec, &s.Documentation); err != nil {
 				return err
 			}
-		case "deprecated":
+		case `"deprecated"`:
 			if err := json.UnmarshalDecode(dec, &s.Deprecated); err != nil {
 				return err
 			}
-		case "preselect":
+		case `"preselect"`:
 			if err := json.UnmarshalDecode(dec, &s.Preselect); err != nil {
 				return err
 			}
-		case "sortText":
+		case `"sortText"`:
 			if err := json.UnmarshalDecode(dec, &s.SortText); err != nil {
 				return err
 			}
-		case "filterText":
+		case `"filterText"`:
 			if err := json.UnmarshalDecode(dec, &s.FilterText); err != nil {
 				return err
 			}
-		case "insertText":
+		case `"insertText"`:
 			if err := json.UnmarshalDecode(dec, &s.InsertText); err != nil {
 				return err
 			}
-		case "insertTextFormat":
+		case `"insertTextFormat"`:
 			if err := json.UnmarshalDecode(dec, &s.InsertTextFormat); err != nil {
 				return err
 			}
-		case "insertTextMode":
+		case `"insertTextMode"`:
 			if err := json.UnmarshalDecode(dec, &s.InsertTextMode); err != nil {
 				return err
 			}
-		case "textEdit":
+		case `"textEdit"`:
 			if err := json.UnmarshalDecode(dec, &s.TextEdit); err != nil {
 				return err
 			}
-		case "textEditText":
+		case `"textEditText"`:
 			if err := json.UnmarshalDecode(dec, &s.TextEditText); err != nil {
 				return err
 			}
-		case "additionalTextEdits":
+		case `"additionalTextEdits"`:
 			if err := json.UnmarshalDecode(dec, &s.AdditionalTextEdits); err != nil {
 				return err
 			}
-		case "commitCharacters":
+		case `"commitCharacters"`:
 			if err := json.UnmarshalDecode(dec, &s.CommitCharacters); err != nil {
 				return err
 			}
-		case "command":
+		case `"command"`:
 			if err := json.UnmarshalDecode(dec, &s.Command); err != nil {
 				return err
 			}
-		case "data":
+		case `"data"`:
 			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
 				return err
 			}
@@ -6816,25 +6816,25 @@ func (s *CompletionList) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "isIncomplete":
+		switch string(name) {
+		case `"isIncomplete"`:
 			seenIsIncomplete = true
 			if err := json.UnmarshalDecode(dec, &s.IsIncomplete); err != nil {
 				return err
 			}
-		case "itemDefaults":
+		case `"itemDefaults"`:
 			if err := json.UnmarshalDecode(dec, &s.ItemDefaults); err != nil {
 				return err
 			}
-		case "applyKind":
+		case `"applyKind"`:
 			if err := json.UnmarshalDecode(dec, &s.ApplyKind); err != nil {
 				return err
 			}
-		case "items":
+		case `"items"`:
 			seenItems = true
 			if err := json.UnmarshalDecode(dec, &s.Items); err != nil {
 				return err
@@ -6910,33 +6910,33 @@ func (s *CompletionRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder)
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "documentSelector":
+		switch string(name) {
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "workDoneProgress":
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
-		case "triggerCharacters":
+		case `"triggerCharacters"`:
 			if err := json.UnmarshalDecode(dec, &s.TriggerCharacters); err != nil {
 				return err
 			}
-		case "allCommitCharacters":
+		case `"allCommitCharacters"`:
 			if err := json.UnmarshalDecode(dec, &s.AllCommitCharacters); err != nil {
 				return err
 			}
-		case "resolveProvider":
+		case `"resolveProvider"`:
 			if err := json.UnmarshalDecode(dec, &s.ResolveProvider); err != nil {
 				return err
 			}
-		case "completionItem":
+		case `"completionItem"`:
 			if err := json.UnmarshalDecode(dec, &s.CompletionItem); err != nil {
 				return err
 			}
@@ -6984,22 +6984,22 @@ func (s *HoverParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "textDocument":
+		switch string(name) {
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "position":
+		case `"position"`:
 			seenPosition = true
 			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
 				return err
 			}
-		case "workDoneToken":
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
@@ -7045,17 +7045,17 @@ func (s *Hover) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "contents":
+		switch string(name) {
+		case `"contents"`:
 			seenContents = true
 			if err := json.UnmarshalDecode(dec, &s.Contents); err != nil {
 				return err
 			}
-		case "range":
+		case `"range"`:
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
@@ -7097,17 +7097,17 @@ func (s *HoverRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "documentSelector":
+		switch string(name) {
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "workDoneProgress":
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
@@ -7161,26 +7161,26 @@ func (s *SignatureHelpParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "textDocument":
+		switch string(name) {
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "position":
+		case `"position"`:
 			seenPosition = true
 			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
 				return err
 			}
-		case "workDoneToken":
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "context":
+		case `"context"`:
 			if err := json.UnmarshalDecode(dec, &s.Context); err != nil {
 				return err
 			}
@@ -7253,21 +7253,21 @@ func (s *SignatureHelp) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "signatures":
+		switch string(name) {
+		case `"signatures"`:
 			seenSignatures = true
 			if err := json.UnmarshalDecode(dec, &s.Signatures); err != nil {
 				return err
 			}
-		case "activeSignature":
+		case `"activeSignature"`:
 			if err := json.UnmarshalDecode(dec, &s.ActiveSignature); err != nil {
 				return err
 			}
-		case "activeParameter":
+		case `"activeParameter"`:
 			if err := json.UnmarshalDecode(dec, &s.ActiveParameter); err != nil {
 				return err
 			}
@@ -7320,25 +7320,25 @@ func (s *SignatureHelpRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decod
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "documentSelector":
+		switch string(name) {
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "workDoneProgress":
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
-		case "triggerCharacters":
+		case `"triggerCharacters"`:
 			if err := json.UnmarshalDecode(dec, &s.TriggerCharacters); err != nil {
 				return err
 			}
-		case "retriggerCharacters":
+		case `"retriggerCharacters"`:
 			if err := json.UnmarshalDecode(dec, &s.RetriggerCharacters); err != nil {
 				return err
 			}
@@ -7390,26 +7390,26 @@ func (s *DefinitionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "textDocument":
+		switch string(name) {
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "position":
+		case `"position"`:
 			seenPosition = true
 			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
 				return err
 			}
-		case "workDoneToken":
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "partialResultToken":
+		case `"partialResultToken"`:
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
@@ -7454,17 +7454,17 @@ func (s *DefinitionRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder)
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "documentSelector":
+		switch string(name) {
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "workDoneProgress":
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
@@ -7519,30 +7519,30 @@ func (s *ReferenceParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "textDocument":
+		switch string(name) {
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "position":
+		case `"position"`:
 			seenPosition = true
 			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
 				return err
 			}
-		case "workDoneToken":
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "partialResultToken":
+		case `"partialResultToken"`:
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
-		case "context":
+		case `"context"`:
 			seenContext = true
 			if err := json.UnmarshalDecode(dec, &s.Context); err != nil {
 				return err
@@ -7591,17 +7591,17 @@ func (s *ReferenceRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "documentSelector":
+		switch string(name) {
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "workDoneProgress":
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
@@ -7653,26 +7653,26 @@ func (s *DocumentHighlightParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "textDocument":
+		switch string(name) {
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "position":
+		case `"position"`:
 			seenPosition = true
 			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
 				return err
 			}
-		case "workDoneToken":
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "partialResultToken":
+		case `"partialResultToken"`:
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
@@ -7719,17 +7719,17 @@ func (s *DocumentHighlight) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "range":
+		switch string(name) {
+		case `"range"`:
 			seenRange = true
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
-		case "kind":
+		case `"kind"`:
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
@@ -7771,17 +7771,17 @@ func (s *DocumentHighlightRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.D
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "documentSelector":
+		switch string(name) {
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "workDoneProgress":
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
@@ -7827,20 +7827,20 @@ func (s *DocumentSymbolParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneToken":
+		switch string(name) {
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "partialResultToken":
+		case `"partialResultToken"`:
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
-		case "textDocument":
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
@@ -7915,34 +7915,34 @@ func (s *SymbolInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "name":
+		switch string(name) {
+		case `"name"`:
 			seenName = true
 			if err := json.UnmarshalDecode(dec, &s.Name); err != nil {
 				return err
 			}
-		case "kind":
+		case `"kind"`:
 			seenKind = true
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
-		case "tags":
+		case `"tags"`:
 			if err := json.UnmarshalDecode(dec, &s.Tags); err != nil {
 				return err
 			}
-		case "containerName":
+		case `"containerName"`:
 			if err := json.UnmarshalDecode(dec, &s.ContainerName); err != nil {
 				return err
 			}
-		case "deprecated":
+		case `"deprecated"`:
 			if err := json.UnmarshalDecode(dec, &s.Deprecated); err != nil {
 				return err
 			}
-		case "location":
+		case `"location"`:
 			seenLocation = true
 			if err := json.UnmarshalDecode(dec, &s.Location); err != nil {
 				return err
@@ -8025,44 +8025,44 @@ func (s *DocumentSymbol) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "name":
+		switch string(name) {
+		case `"name"`:
 			seenName = true
 			if err := json.UnmarshalDecode(dec, &s.Name); err != nil {
 				return err
 			}
-		case "detail":
+		case `"detail"`:
 			if err := json.UnmarshalDecode(dec, &s.Detail); err != nil {
 				return err
 			}
-		case "kind":
+		case `"kind"`:
 			seenKind = true
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
-		case "tags":
+		case `"tags"`:
 			if err := json.UnmarshalDecode(dec, &s.Tags); err != nil {
 				return err
 			}
-		case "deprecated":
+		case `"deprecated"`:
 			if err := json.UnmarshalDecode(dec, &s.Deprecated); err != nil {
 				return err
 			}
-		case "range":
+		case `"range"`:
 			seenRange = true
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
-		case "selectionRange":
+		case `"selectionRange"`:
 			seenSelectionRange = true
 			if err := json.UnmarshalDecode(dec, &s.SelectionRange); err != nil {
 				return err
 			}
-		case "children":
+		case `"children"`:
 			if err := json.UnmarshalDecode(dec, &s.Children); err != nil {
 				return err
 			}
@@ -8119,21 +8119,21 @@ func (s *DocumentSymbolRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Deco
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "documentSelector":
+		switch string(name) {
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "workDoneProgress":
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
-		case "label":
+		case `"label"`:
 			if err := json.UnmarshalDecode(dec, &s.Label); err != nil {
 				return err
 			}
@@ -8189,30 +8189,30 @@ func (s *CodeActionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneToken":
+		switch string(name) {
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "partialResultToken":
+		case `"partialResultToken"`:
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
-		case "textDocument":
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "range":
+		case `"range"`:
 			seenRange = true
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
-		case "context":
+		case `"context"`:
 			seenContext = true
 			if err := json.UnmarshalDecode(dec, &s.Context); err != nil {
 				return err
@@ -8278,26 +8278,26 @@ func (s *Command) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "title":
+		switch string(name) {
+		case `"title"`:
 			seenTitle = true
 			if err := json.UnmarshalDecode(dec, &s.Title); err != nil {
 				return err
 			}
-		case "tooltip":
+		case `"tooltip"`:
 			if err := json.UnmarshalDecode(dec, &s.Tooltip); err != nil {
 				return err
 			}
-		case "command":
+		case `"command"`:
 			seenCommand = true
 			if err := json.UnmarshalDecode(dec, &s.Command); err != nil {
 				return err
 			}
-		case "arguments":
+		case `"arguments"`:
 			if err := json.UnmarshalDecode(dec, &s.Arguments); err != nil {
 				return err
 			}
@@ -8395,45 +8395,45 @@ func (s *CodeAction) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "title":
+		switch string(name) {
+		case `"title"`:
 			seenTitle = true
 			if err := json.UnmarshalDecode(dec, &s.Title); err != nil {
 				return err
 			}
-		case "kind":
+		case `"kind"`:
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
-		case "diagnostics":
+		case `"diagnostics"`:
 			if err := json.UnmarshalDecode(dec, &s.Diagnostics); err != nil {
 				return err
 			}
-		case "isPreferred":
+		case `"isPreferred"`:
 			if err := json.UnmarshalDecode(dec, &s.IsPreferred); err != nil {
 				return err
 			}
-		case "disabled":
+		case `"disabled"`:
 			if err := json.UnmarshalDecode(dec, &s.Disabled); err != nil {
 				return err
 			}
-		case "edit":
+		case `"edit"`:
 			if err := json.UnmarshalDecode(dec, &s.Edit); err != nil {
 				return err
 			}
-		case "command":
+		case `"command"`:
 			if err := json.UnmarshalDecode(dec, &s.Command); err != nil {
 				return err
 			}
-		case "data":
+		case `"data"`:
 			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
 				return err
 			}
-		case "tags":
+		case `"tags"`:
 			if err := json.UnmarshalDecode(dec, &s.Tags); err != nil {
 				return err
 			}
@@ -8505,29 +8505,29 @@ func (s *CodeActionRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder)
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "documentSelector":
+		switch string(name) {
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "workDoneProgress":
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
-		case "codeActionKinds":
+		case `"codeActionKinds"`:
 			if err := json.UnmarshalDecode(dec, &s.CodeActionKinds); err != nil {
 				return err
 			}
-		case "documentation":
+		case `"documentation"`:
 			if err := json.UnmarshalDecode(dec, &s.Documentation); err != nil {
 				return err
 			}
-		case "resolveProvider":
+		case `"resolveProvider"`:
 			if err := json.UnmarshalDecode(dec, &s.ResolveProvider); err != nil {
 				return err
 			}
@@ -8580,20 +8580,20 @@ func (s *WorkspaceSymbolParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneToken":
+		switch string(name) {
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "partialResultToken":
+		case `"partialResultToken"`:
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
-		case "query":
+		case `"query"`:
 			seenQuery = true
 			if err := json.UnmarshalDecode(dec, &s.Query); err != nil {
 				return err
@@ -8666,35 +8666,35 @@ func (s *WorkspaceSymbol) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "name":
+		switch string(name) {
+		case `"name"`:
 			seenName = true
 			if err := json.UnmarshalDecode(dec, &s.Name); err != nil {
 				return err
 			}
-		case "kind":
+		case `"kind"`:
 			seenKind = true
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
-		case "tags":
+		case `"tags"`:
 			if err := json.UnmarshalDecode(dec, &s.Tags); err != nil {
 				return err
 			}
-		case "containerName":
+		case `"containerName"`:
 			if err := json.UnmarshalDecode(dec, &s.ContainerName); err != nil {
 				return err
 			}
-		case "location":
+		case `"location"`:
 			seenLocation = true
 			if err := json.UnmarshalDecode(dec, &s.Location); err != nil {
 				return err
 			}
-		case "data":
+		case `"data"`:
 			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
 				return err
 			}
@@ -8757,20 +8757,20 @@ func (s *CodeLensParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneToken":
+		switch string(name) {
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "partialResultToken":
+		case `"partialResultToken"`:
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
-		case "textDocument":
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
@@ -8821,21 +8821,21 @@ func (s *CodeLens) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "range":
+		switch string(name) {
+		case `"range"`:
 			seenRange = true
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
-		case "command":
+		case `"command"`:
 			if err := json.UnmarshalDecode(dec, &s.Command); err != nil {
 				return err
 			}
-		case "data":
+		case `"data"`:
 			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
 				return err
 			}
@@ -8880,21 +8880,21 @@ func (s *CodeLensRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "documentSelector":
+		switch string(name) {
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "workDoneProgress":
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
-		case "resolveProvider":
+		case `"resolveProvider"`:
 			if err := json.UnmarshalDecode(dec, &s.ResolveProvider); err != nil {
 				return err
 			}
@@ -8940,20 +8940,20 @@ func (s *DocumentLinkParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneToken":
+		switch string(name) {
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "partialResultToken":
+		case `"partialResultToken"`:
 			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
 				return err
 			}
-		case "textDocument":
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
@@ -9010,25 +9010,25 @@ func (s *DocumentLink) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "range":
+		switch string(name) {
+		case `"range"`:
 			seenRange = true
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
-		case "target":
+		case `"target"`:
 			if err := json.UnmarshalDecode(dec, &s.Target); err != nil {
 				return err
 			}
-		case "tooltip":
+		case `"tooltip"`:
 			if err := json.UnmarshalDecode(dec, &s.Tooltip); err != nil {
 				return err
 			}
-		case "data":
+		case `"data"`:
 			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
 				return err
 			}
@@ -9073,21 +9073,21 @@ func (s *DocumentLinkRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decode
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "documentSelector":
+		switch string(name) {
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "workDoneProgress":
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
-		case "resolveProvider":
+		case `"resolveProvider"`:
 			if err := json.UnmarshalDecode(dec, &s.ResolveProvider); err != nil {
 				return err
 			}
@@ -9135,21 +9135,21 @@ func (s *DocumentFormattingParams) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneToken":
+		switch string(name) {
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "textDocument":
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "options":
+		case `"options"`:
 			seenOptions = true
 			if err := json.UnmarshalDecode(dec, &s.Options); err != nil {
 				return err
@@ -9195,17 +9195,17 @@ func (s *DocumentFormattingRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "documentSelector":
+		switch string(name) {
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "workDoneProgress":
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
@@ -9257,26 +9257,26 @@ func (s *DocumentRangeFormattingParams) UnmarshalJSONFrom(dec *jsontext.Decoder)
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneToken":
+		switch string(name) {
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "textDocument":
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "range":
+		case `"range"`:
 			seenRange = true
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
-		case "options":
+		case `"options"`:
 			seenOptions = true
 			if err := json.UnmarshalDecode(dec, &s.Options); err != nil {
 				return err
@@ -9332,21 +9332,21 @@ func (s *DocumentRangeFormattingRegistrationOptions) UnmarshalJSONFrom(dec *json
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "documentSelector":
+		switch string(name) {
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "workDoneProgress":
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
-		case "rangesSupport":
+		case `"rangesSupport"`:
 			if err := json.UnmarshalDecode(dec, &s.RangesSupport); err != nil {
 				return err
 			}
@@ -9402,26 +9402,26 @@ func (s *DocumentRangesFormattingParams) UnmarshalJSONFrom(dec *jsontext.Decoder
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneToken":
+		switch string(name) {
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "textDocument":
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "ranges":
+		case `"ranges"`:
 			seenRanges = true
 			if err := json.UnmarshalDecode(dec, &s.Ranges); err != nil {
 				return err
 			}
-		case "options":
+		case `"options"`:
 			seenOptions = true
 			if err := json.UnmarshalDecode(dec, &s.Options); err != nil {
 				return err
@@ -9486,27 +9486,27 @@ func (s *DocumentOnTypeFormattingParams) UnmarshalJSONFrom(dec *jsontext.Decoder
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "textDocument":
+		switch string(name) {
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "position":
+		case `"position"`:
 			seenPosition = true
 			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
 				return err
 			}
-		case "ch":
+		case `"ch"`:
 			seenCh = true
 			if err := json.UnmarshalDecode(dec, &s.Ch); err != nil {
 				return err
 			}
-		case "options":
+		case `"options"`:
 			seenOptions = true
 			if err := json.UnmarshalDecode(dec, &s.Options); err != nil {
 				return err
@@ -9565,22 +9565,22 @@ func (s *DocumentOnTypeFormattingRegistrationOptions) UnmarshalJSONFrom(dec *jso
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "documentSelector":
+		switch string(name) {
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "firstTriggerCharacter":
+		case `"firstTriggerCharacter"`:
 			seenFirstTriggerCharacter = true
 			if err := json.UnmarshalDecode(dec, &s.FirstTriggerCharacter); err != nil {
 				return err
 			}
-		case "moreTriggerCharacter":
+		case `"moreTriggerCharacter"`:
 			if err := json.UnmarshalDecode(dec, &s.MoreTriggerCharacter); err != nil {
 				return err
 			}
@@ -9637,26 +9637,26 @@ func (s *RenameParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneToken":
+		switch string(name) {
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "textDocument":
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "position":
+		case `"position"`:
 			seenPosition = true
 			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
 				return err
 			}
-		case "newName":
+		case `"newName"`:
 			seenNewName = true
 			if err := json.UnmarshalDecode(dec, &s.NewName); err != nil {
 				return err
@@ -9710,21 +9710,21 @@ func (s *RenameRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "documentSelector":
+		switch string(name) {
+		case `"documentSelector"`:
 			seenDocumentSelector = true
 			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
 				return err
 			}
-		case "workDoneProgress":
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
-		case "prepareProvider":
+		case `"prepareProvider"`:
 			if err := json.UnmarshalDecode(dec, &s.PrepareProvider); err != nil {
 				return err
 			}
@@ -9771,22 +9771,22 @@ func (s *PrepareRenameParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "textDocument":
+		switch string(name) {
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "position":
+		case `"position"`:
 			seenPosition = true
 			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
 				return err
 			}
-		case "workDoneToken":
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
@@ -9834,21 +9834,21 @@ func (s *ExecuteCommandParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneToken":
+		switch string(name) {
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "command":
+		case `"command"`:
 			seenCommand = true
 			if err := json.UnmarshalDecode(dec, &s.Command); err != nil {
 				return err
 			}
-		case "arguments":
+		case `"arguments"`:
 			if err := json.UnmarshalDecode(dec, &s.Arguments); err != nil {
 				return err
 			}
@@ -9889,16 +9889,16 @@ func (s *ExecuteCommandRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Deco
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneProgress":
+		switch string(name) {
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
-		case "commands":
+		case `"commands"`:
 			seenCommands = true
 			if err := json.UnmarshalDecode(dec, &s.Commands); err != nil {
 				return err
@@ -9950,21 +9950,21 @@ func (s *ApplyWorkspaceEditParams) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "label":
+		switch string(name) {
+		case `"label"`:
 			if err := json.UnmarshalDecode(dec, &s.Label); err != nil {
 				return err
 			}
-		case "edit":
+		case `"edit"`:
 			seenEdit = true
 			if err := json.UnmarshalDecode(dec, &s.Edit); err != nil {
 				return err
 			}
-		case "metadata":
+		case `"metadata"`:
 			if err := json.UnmarshalDecode(dec, &s.Metadata); err != nil {
 				return err
 			}
@@ -10015,21 +10015,21 @@ func (s *ApplyWorkspaceEditResult) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "applied":
+		switch string(name) {
+		case `"applied"`:
 			seenApplied = true
 			if err := json.UnmarshalDecode(dec, &s.Applied); err != nil {
 				return err
 			}
-		case "failureReason":
+		case `"failureReason"`:
 			if err := json.UnmarshalDecode(dec, &s.FailureReason); err != nil {
 				return err
 			}
-		case "failedChange":
+		case `"failedChange"`:
 			if err := json.UnmarshalDecode(dec, &s.FailedChange); err != nil {
 				return err
 			}
@@ -10095,30 +10095,30 @@ func (s *WorkDoneProgressBegin) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "kind":
+		switch string(name) {
+		case `"kind"`:
 			seenKind = true
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
-		case "title":
+		case `"title"`:
 			seenTitle = true
 			if err := json.UnmarshalDecode(dec, &s.Title); err != nil {
 				return err
 			}
-		case "cancellable":
+		case `"cancellable"`:
 			if err := json.UnmarshalDecode(dec, &s.Cancellable); err != nil {
 				return err
 			}
-		case "message":
+		case `"message"`:
 			if err := json.UnmarshalDecode(dec, &s.Message); err != nil {
 				return err
 			}
-		case "percentage":
+		case `"percentage"`:
 			if err := json.UnmarshalDecode(dec, &s.Percentage); err != nil {
 				return err
 			}
@@ -10179,25 +10179,25 @@ func (s *WorkDoneProgressReport) UnmarshalJSONFrom(dec *jsontext.Decoder) error 
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "kind":
+		switch string(name) {
+		case `"kind"`:
 			seenKind = true
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
-		case "cancellable":
+		case `"cancellable"`:
 			if err := json.UnmarshalDecode(dec, &s.Cancellable); err != nil {
 				return err
 			}
-		case "message":
+		case `"message"`:
 			if err := json.UnmarshalDecode(dec, &s.Message); err != nil {
 				return err
 			}
-		case "percentage":
+		case `"percentage"`:
 			if err := json.UnmarshalDecode(dec, &s.Percentage); err != nil {
 				return err
 			}
@@ -10238,17 +10238,17 @@ func (s *WorkDoneProgressEnd) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "kind":
+		switch string(name) {
+		case `"kind"`:
 			seenKind = true
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
-		case "message":
+		case `"message"`:
 			if err := json.UnmarshalDecode(dec, &s.Message); err != nil {
 				return err
 			}
@@ -10285,12 +10285,12 @@ func (s *SetTraceParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "value":
+		switch string(name) {
+		case `"value"`:
 			seenValue = true
 			if err := json.UnmarshalDecode(dec, &s.Value); err != nil {
 				return err
@@ -10330,17 +10330,17 @@ func (s *LogTraceParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "message":
+		switch string(name) {
+		case `"message"`:
 			seenMessage = true
 			if err := json.UnmarshalDecode(dec, &s.Message); err != nil {
 				return err
 			}
-		case "verbose":
+		case `"verbose"`:
 			if err := json.UnmarshalDecode(dec, &s.Verbose); err != nil {
 				return err
 			}
@@ -10378,12 +10378,12 @@ func (s *CancelParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "id":
+		switch string(name) {
+		case `"id"`:
 			seenId = true
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
@@ -10428,17 +10428,17 @@ func (s *ProgressParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "token":
+		switch string(name) {
+		case `"token"`:
 			seenToken = true
 			if err := json.UnmarshalDecode(dec, &s.Token); err != nil {
 				return err
 			}
-		case "value":
+		case `"value"`:
 			seenValue = true
 			if err := json.UnmarshalDecode(dec, &s.Value); err != nil {
 				return err
@@ -10488,17 +10488,17 @@ func (s *TextDocumentPositionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "textDocument":
+		switch string(name) {
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "position":
+		case `"position"`:
 			seenPosition = true
 			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
 				return err
@@ -10572,26 +10572,26 @@ func (s *LocationLink) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "originSelectionRange":
+		switch string(name) {
+		case `"originSelectionRange"`:
 			if err := json.UnmarshalDecode(dec, &s.OriginSelectionRange); err != nil {
 				return err
 			}
-		case "targetUri":
+		case `"targetUri"`:
 			seenTargetUri = true
 			if err := json.UnmarshalDecode(dec, &s.TargetUri); err != nil {
 				return err
 			}
-		case "targetRange":
+		case `"targetRange"`:
 			seenTargetRange = true
 			if err := json.UnmarshalDecode(dec, &s.TargetRange); err != nil {
 				return err
 			}
-		case "targetSelectionRange":
+		case `"targetSelectionRange"`:
 			seenTargetSelectionRange = true
 			if err := json.UnmarshalDecode(dec, &s.TargetSelectionRange); err != nil {
 				return err
@@ -10655,17 +10655,17 @@ func (s *Range) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "start":
+		switch string(name) {
+		case `"start"`:
 			seenStart = true
 			if err := json.UnmarshalDecode(dec, &s.Start); err != nil {
 				return err
 			}
-		case "end":
+		case `"end"`:
 			seenEnd = true
 			if err := json.UnmarshalDecode(dec, &s.End); err != nil {
 				return err
@@ -10730,17 +10730,17 @@ func (s *WorkspaceFoldersChangeEvent) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "added":
+		switch string(name) {
+		case `"added"`:
 			seenAdded = true
 			if err := json.UnmarshalDecode(dec, &s.Added); err != nil {
 				return err
 			}
-		case "removed":
+		case `"removed"`:
 			seenRemoved = true
 			if err := json.UnmarshalDecode(dec, &s.Removed); err != nil {
 				return err
@@ -10791,12 +10791,12 @@ func (s *TextDocumentIdentifier) UnmarshalJSONFrom(dec *jsontext.Decoder) error 
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "uri":
+		switch string(name) {
+		case `"uri"`:
 			seenUri = true
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
@@ -10850,27 +10850,27 @@ func (s *Color) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "red":
+		switch string(name) {
+		case `"red"`:
 			seenRed = true
 			if err := json.UnmarshalDecode(dec, &s.Red); err != nil {
 				return err
 			}
-		case "green":
+		case `"green"`:
 			seenGreen = true
 			if err := json.UnmarshalDecode(dec, &s.Green); err != nil {
 				return err
 			}
-		case "blue":
+		case `"blue"`:
 			seenBlue = true
 			if err := json.UnmarshalDecode(dec, &s.Blue); err != nil {
 				return err
 			}
-		case "alpha":
+		case `"alpha"`:
 			seenAlpha = true
 			if err := json.UnmarshalDecode(dec, &s.Alpha); err != nil {
 				return err
@@ -10966,17 +10966,17 @@ func (s *Position) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "line":
+		switch string(name) {
+		case `"line"`:
 			seenLine = true
 			if err := json.UnmarshalDecode(dec, &s.Line); err != nil {
 				return err
 			}
-		case "character":
+		case `"character"`:
 			seenCharacter = true
 			if err := json.UnmarshalDecode(dec, &s.Character); err != nil {
 				return err
@@ -11039,25 +11039,25 @@ func (s *SemanticTokensOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneProgress":
+		switch string(name) {
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
-		case "legend":
+		case `"legend"`:
 			seenLegend = true
 			if err := json.UnmarshalDecode(dec, &s.Legend); err != nil {
 				return err
 			}
-		case "range":
+		case `"range"`:
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
-		case "full":
+		case `"full"`:
 			if err := json.UnmarshalDecode(dec, &s.Full); err != nil {
 				return err
 			}
@@ -11105,22 +11105,22 @@ func (s *SemanticTokensEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "start":
+		switch string(name) {
+		case `"start"`:
 			seenStart = true
 			if err := json.UnmarshalDecode(dec, &s.Start); err != nil {
 				return err
 			}
-		case "deleteCount":
+		case `"deleteCount"`:
 			seenDeleteCount = true
 			if err := json.UnmarshalDecode(dec, &s.DeleteCount); err != nil {
 				return err
 			}
-		case "data":
+		case `"data"`:
 			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
 				return err
 			}
@@ -11168,12 +11168,12 @@ func (s *FileCreate) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "uri":
+		switch string(name) {
+		case `"uri"`:
 			seenUri = true
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
@@ -11228,17 +11228,17 @@ func (s *TextDocumentEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "textDocument":
+		switch string(name) {
+		case `"textDocument"`:
 			seenTextDocument = true
 			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
 				return err
 			}
-		case "edits":
+		case `"edits"`:
 			seenEdits = true
 			if err := json.UnmarshalDecode(dec, &s.Edits); err != nil {
 				return err
@@ -11295,26 +11295,26 @@ func (s *CreateFile) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "kind":
+		switch string(name) {
+		case `"kind"`:
 			seenKind = true
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
-		case "annotationId":
+		case `"annotationId"`:
 			if err := json.UnmarshalDecode(dec, &s.AnnotationId); err != nil {
 				return err
 			}
-		case "uri":
+		case `"uri"`:
 			seenUri = true
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
 			}
-		case "options":
+		case `"options"`:
 			if err := json.UnmarshalDecode(dec, &s.Options); err != nil {
 				return err
 			}
@@ -11374,31 +11374,31 @@ func (s *RenameFile) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "kind":
+		switch string(name) {
+		case `"kind"`:
 			seenKind = true
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
-		case "annotationId":
+		case `"annotationId"`:
 			if err := json.UnmarshalDecode(dec, &s.AnnotationId); err != nil {
 				return err
 			}
-		case "oldUri":
+		case `"oldUri"`:
 			seenOldUri = true
 			if err := json.UnmarshalDecode(dec, &s.OldUri); err != nil {
 				return err
 			}
-		case "newUri":
+		case `"newUri"`:
 			seenNewUri = true
 			if err := json.UnmarshalDecode(dec, &s.NewUri); err != nil {
 				return err
 			}
-		case "options":
+		case `"options"`:
 			if err := json.UnmarshalDecode(dec, &s.Options); err != nil {
 				return err
 			}
@@ -11457,26 +11457,26 @@ func (s *DeleteFile) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "kind":
+		switch string(name) {
+		case `"kind"`:
 			seenKind = true
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
-		case "annotationId":
+		case `"annotationId"`:
 			if err := json.UnmarshalDecode(dec, &s.AnnotationId); err != nil {
 				return err
 			}
-		case "uri":
+		case `"uri"`:
 			seenUri = true
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
 			}
-		case "options":
+		case `"options"`:
 			if err := json.UnmarshalDecode(dec, &s.Options); err != nil {
 				return err
 			}
@@ -11529,21 +11529,21 @@ func (s *ChangeAnnotation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "label":
+		switch string(name) {
+		case `"label"`:
 			seenLabel = true
 			if err := json.UnmarshalDecode(dec, &s.Label); err != nil {
 				return err
 			}
-		case "needsConfirmation":
+		case `"needsConfirmation"`:
 			if err := json.UnmarshalDecode(dec, &s.NeedsConfirmation); err != nil {
 				return err
 			}
-		case "description":
+		case `"description"`:
 			if err := json.UnmarshalDecode(dec, &s.Description); err != nil {
 				return err
 			}
@@ -11588,16 +11588,16 @@ func (s *FileOperationFilter) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "scheme":
+		switch string(name) {
+		case `"scheme"`:
 			if err := json.UnmarshalDecode(dec, &s.Scheme); err != nil {
 				return err
 			}
-		case "pattern":
+		case `"pattern"`:
 			seenPattern = true
 			if err := json.UnmarshalDecode(dec, &s.Pattern); err != nil {
 				return err
@@ -11645,17 +11645,17 @@ func (s *FileRename) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "oldUri":
+		switch string(name) {
+		case `"oldUri"`:
 			seenOldUri = true
 			if err := json.UnmarshalDecode(dec, &s.OldUri); err != nil {
 				return err
 			}
-		case "newUri":
+		case `"newUri"`:
 			seenNewUri = true
 			if err := json.UnmarshalDecode(dec, &s.NewUri); err != nil {
 				return err
@@ -11700,12 +11700,12 @@ func (s *FileDelete) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "uri":
+		switch string(name) {
+		case `"uri"`:
 			seenUri = true
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
@@ -11763,17 +11763,17 @@ func (s *InlineValueContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "frameId":
+		switch string(name) {
+		case `"frameId"`:
 			seenFrameId = true
 			if err := json.UnmarshalDecode(dec, &s.FrameId); err != nil {
 				return err
 			}
-		case "stoppedLocation":
+		case `"stoppedLocation"`:
 			seenStoppedLocation = true
 			if err := json.UnmarshalDecode(dec, &s.StoppedLocation); err != nil {
 				return err
@@ -11824,17 +11824,17 @@ func (s *InlineValueText) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "range":
+		switch string(name) {
+		case `"range"`:
 			seenRange = true
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
-		case "text":
+		case `"text"`:
 			seenText = true
 			if err := json.UnmarshalDecode(dec, &s.Text); err != nil {
 				return err
@@ -11891,21 +11891,21 @@ func (s *InlineValueVariableLookup) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "range":
+		switch string(name) {
+		case `"range"`:
 			seenRange = true
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
-		case "variableName":
+		case `"variableName"`:
 			if err := json.UnmarshalDecode(dec, &s.VariableName); err != nil {
 				return err
 			}
-		case "caseSensitiveLookup":
+		case `"caseSensitiveLookup"`:
 			seenCaseSensitiveLookup = true
 			if err := json.UnmarshalDecode(dec, &s.CaseSensitiveLookup); err != nil {
 				return err
@@ -11956,17 +11956,17 @@ func (s *InlineValueEvaluatableExpression) UnmarshalJSONFrom(dec *jsontext.Decod
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "range":
+		switch string(name) {
+		case `"range"`:
 			seenRange = true
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
-		case "expression":
+		case `"expression"`:
 			if err := json.UnmarshalDecode(dec, &s.Expression); err != nil {
 				return err
 			}
@@ -12039,25 +12039,25 @@ func (s *InlayHintLabelPart) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "value":
+		switch string(name) {
+		case `"value"`:
 			seenValue = true
 			if err := json.UnmarshalDecode(dec, &s.Value); err != nil {
 				return err
 			}
-		case "tooltip":
+		case `"tooltip"`:
 			if err := json.UnmarshalDecode(dec, &s.Tooltip); err != nil {
 				return err
 			}
-		case "location":
+		case `"location"`:
 			if err := json.UnmarshalDecode(dec, &s.Location); err != nil {
 				return err
 			}
-		case "command":
+		case `"command"`:
 			if err := json.UnmarshalDecode(dec, &s.Command); err != nil {
 				return err
 			}
@@ -12125,17 +12125,17 @@ func (s *MarkupContent) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "kind":
+		switch string(name) {
+		case `"kind"`:
 			seenKind = true
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
-		case "value":
+		case `"value"`:
 			seenValue = true
 			if err := json.UnmarshalDecode(dec, &s.Value); err != nil {
 				return err
@@ -12211,26 +12211,26 @@ func (s *RelatedFullDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.De
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "kind":
+		switch string(name) {
+		case `"kind"`:
 			seenKind = true
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
-		case "resultId":
+		case `"resultId"`:
 			if err := json.UnmarshalDecode(dec, &s.ResultId); err != nil {
 				return err
 			}
-		case "items":
+		case `"items"`:
 			seenItems = true
 			if err := json.UnmarshalDecode(dec, &s.Items); err != nil {
 				return err
 			}
-		case "relatedDocuments":
+		case `"relatedDocuments"`:
 			if err := json.UnmarshalDecode(dec, &s.RelatedDocuments); err != nil {
 				return err
 			}
@@ -12293,22 +12293,22 @@ func (s *RelatedUnchangedDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsonte
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "kind":
+		switch string(name) {
+		case `"kind"`:
 			seenKind = true
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
-		case "resultId":
+		case `"resultId"`:
 			seenResultId = true
 			if err := json.UnmarshalDecode(dec, &s.ResultId); err != nil {
 				return err
 			}
-		case "relatedDocuments":
+		case `"relatedDocuments"`:
 			if err := json.UnmarshalDecode(dec, &s.RelatedDocuments); err != nil {
 				return err
 			}
@@ -12363,21 +12363,21 @@ func (s *FullDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "kind":
+		switch string(name) {
+		case `"kind"`:
 			seenKind = true
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
-		case "resultId":
+		case `"resultId"`:
 			if err := json.UnmarshalDecode(dec, &s.ResultId); err != nil {
 				return err
 			}
-		case "items":
+		case `"items"`:
 			seenItems = true
 			if err := json.UnmarshalDecode(dec, &s.Items); err != nil {
 				return err
@@ -12433,17 +12433,17 @@ func (s *UnchangedDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.Deco
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "kind":
+		switch string(name) {
+		case `"kind"`:
 			seenKind = true
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
-		case "resultId":
+		case `"resultId"`:
 			seenResultId = true
 			if err := json.UnmarshalDecode(dec, &s.ResultId); err != nil {
 				return err
@@ -12503,25 +12503,25 @@ func (s *DiagnosticOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneProgress":
+		switch string(name) {
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
-		case "identifier":
+		case `"identifier"`:
 			if err := json.UnmarshalDecode(dec, &s.Identifier); err != nil {
 				return err
 			}
-		case "interFileDependencies":
+		case `"interFileDependencies"`:
 			seenInterFileDependencies = true
 			if err := json.UnmarshalDecode(dec, &s.InterFileDependencies); err != nil {
 				return err
 			}
-		case "workspaceDiagnostics":
+		case `"workspaceDiagnostics"`:
 			seenWorkspaceDiagnostics = true
 			if err := json.UnmarshalDecode(dec, &s.WorkspaceDiagnostics); err != nil {
 				return err
@@ -12573,17 +12573,17 @@ func (s *PreviousResultId) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "uri":
+		switch string(name) {
+		case `"uri"`:
 			seenUri = true
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
 			}
-		case "value":
+		case `"value"`:
 			seenValue = true
 			if err := json.UnmarshalDecode(dec, &s.Value); err != nil {
 				return err
@@ -12649,31 +12649,31 @@ func (s *NotebookDocument) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "uri":
+		switch string(name) {
+		case `"uri"`:
 			seenUri = true
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
 			}
-		case "notebookType":
+		case `"notebookType"`:
 			seenNotebookType = true
 			if err := json.UnmarshalDecode(dec, &s.NotebookType); err != nil {
 				return err
 			}
-		case "version":
+		case `"version"`:
 			seenVersion = true
 			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
 				return err
 			}
-		case "metadata":
+		case `"metadata"`:
 			if err := json.UnmarshalDecode(dec, &s.Metadata); err != nil {
 				return err
 			}
-		case "cells":
+		case `"cells"`:
 			seenCells = true
 			if err := json.UnmarshalDecode(dec, &s.Cells); err != nil {
 				return err
@@ -12738,27 +12738,27 @@ func (s *TextDocumentItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "uri":
+		switch string(name) {
+		case `"uri"`:
 			seenUri = true
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
 			}
-		case "languageId":
+		case `"languageId"`:
 			seenLanguageId = true
 			if err := json.UnmarshalDecode(dec, &s.LanguageId); err != nil {
 				return err
 			}
-		case "version":
+		case `"version"`:
 			seenVersion = true
 			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
 				return err
 			}
-		case "text":
+		case `"text"`:
 			seenText = true
 			if err := json.UnmarshalDecode(dec, &s.Text); err != nil {
 				return err
@@ -12823,17 +12823,17 @@ func (s *NotebookDocumentSyncOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "notebookSelector":
+		switch string(name) {
+		case `"notebookSelector"`:
 			seenNotebookSelector = true
 			if err := json.UnmarshalDecode(dec, &s.NotebookSelector); err != nil {
 				return err
 			}
-		case "save":
+		case `"save"`:
 			if err := json.UnmarshalDecode(dec, &s.Save); err != nil {
 				return err
 			}
@@ -12880,17 +12880,17 @@ func (s *VersionedNotebookDocumentIdentifier) UnmarshalJSONFrom(dec *jsontext.De
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "version":
+		switch string(name) {
+		case `"version"`:
 			seenVersion = true
 			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
 				return err
 			}
-		case "uri":
+		case `"uri"`:
 			seenUri = true
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
@@ -12948,12 +12948,12 @@ func (s *NotebookDocumentIdentifier) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "uri":
+		switch string(name) {
+		case `"uri"`:
 			seenUri = true
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
@@ -13000,17 +13000,17 @@ func (s *InlineCompletionContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "triggerKind":
+		switch string(name) {
+		case `"triggerKind"`:
 			seenTriggerKind = true
 			if err := json.UnmarshalDecode(dec, &s.TriggerKind); err != nil {
 				return err
 			}
-		case "selectedCompletionInfo":
+		case `"selectedCompletionInfo"`:
 			if err := json.UnmarshalDecode(dec, &s.SelectedCompletionInfo); err != nil {
 				return err
 			}
@@ -13065,17 +13065,17 @@ func (s *StringValue) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "kind":
+		switch string(name) {
+		case `"kind"`:
 			seenKind = true
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
-		case "value":
+		case `"value"`:
 			seenValue = true
 			if err := json.UnmarshalDecode(dec, &s.Value); err != nil {
 				return err
@@ -13131,12 +13131,12 @@ func (s *TextDocumentContentOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "schemes":
+		switch string(name) {
+		case `"schemes"`:
 			seenSchemes = true
 			if err := json.UnmarshalDecode(dec, &s.Schemes); err != nil {
 				return err
@@ -13186,22 +13186,22 @@ func (s *Registration) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "id":
+		switch string(name) {
+		case `"id"`:
 			seenId = true
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
-		case "method":
+		case `"method"`:
 			seenMethod = true
 			if err := json.UnmarshalDecode(dec, &s.Method); err != nil {
 				return err
 			}
-		case "registerOptions":
+		case `"registerOptions"`:
 			if err := json.UnmarshalDecode(dec, &s.RegisterOptions); err != nil {
 				return err
 			}
@@ -13250,17 +13250,17 @@ func (s *Unregistration) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "id":
+		switch string(name) {
+		case `"id"`:
 			seenId = true
 			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
 				return err
 			}
-		case "method":
+		case `"method"`:
 			seenMethod = true
 			if err := json.UnmarshalDecode(dec, &s.Method); err != nil {
 				return err
@@ -13351,47 +13351,47 @@ func (s *InitializeParamsBase) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneToken":
+		switch string(name) {
+		case `"workDoneToken"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
 				return err
 			}
-		case "processId":
+		case `"processId"`:
 			seenProcessId = true
 			if err := json.UnmarshalDecode(dec, &s.ProcessId); err != nil {
 				return err
 			}
-		case "clientInfo":
+		case `"clientInfo"`:
 			if err := json.UnmarshalDecode(dec, &s.ClientInfo); err != nil {
 				return err
 			}
-		case "locale":
+		case `"locale"`:
 			if err := json.UnmarshalDecode(dec, &s.Locale); err != nil {
 				return err
 			}
-		case "rootPath":
+		case `"rootPath"`:
 			if err := json.UnmarshalDecode(dec, &s.RootPath); err != nil {
 				return err
 			}
-		case "rootUri":
+		case `"rootUri"`:
 			seenRootUri = true
 			if err := json.UnmarshalDecode(dec, &s.RootUri); err != nil {
 				return err
 			}
-		case "capabilities":
+		case `"capabilities"`:
 			seenCapabilities = true
 			if err := json.UnmarshalDecode(dec, &s.Capabilities); err != nil {
 				return err
 			}
-		case "initializationOptions":
+		case `"initializationOptions"`:
 			if err := json.UnmarshalDecode(dec, &s.InitializationOptions); err != nil {
 				return err
 			}
-		case "trace":
+		case `"trace"`:
 			if err := json.UnmarshalDecode(dec, &s.Trace); err != nil {
 				return err
 			}
@@ -13602,17 +13602,17 @@ func (s *ServerInfo) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "name":
+		switch string(name) {
+		case `"name"`:
 			seenName = true
 			if err := json.UnmarshalDecode(dec, &s.Name); err != nil {
 				return err
 			}
-		case "version":
+		case `"version"`:
 			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
 				return err
 			}
@@ -13657,17 +13657,17 @@ func (s *VersionedTextDocumentIdentifier) UnmarshalJSONFrom(dec *jsontext.Decode
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "uri":
+		switch string(name) {
+		case `"uri"`:
 			seenUri = true
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
 			}
-		case "version":
+		case `"version"`:
 			seenVersion = true
 			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
 				return err
@@ -13722,17 +13722,17 @@ func (s *FileEvent) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "uri":
+		switch string(name) {
+		case `"uri"`:
 			seenUri = true
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
 			}
-		case "type":
+		case `"type"`:
 			seenType = true
 			if err := json.UnmarshalDecode(dec, &s.Type); err != nil {
 				return err
@@ -13781,17 +13781,17 @@ func (s *FileSystemWatcher) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "globPattern":
+		switch string(name) {
+		case `"globPattern"`:
 			seenGlobPattern = true
 			if err := json.UnmarshalDecode(dec, &s.GlobPattern); err != nil {
 				return err
 			}
-		case "kind":
+		case `"kind"`:
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
@@ -13871,46 +13871,46 @@ func (s *Diagnostic) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "range":
+		switch string(name) {
+		case `"range"`:
 			seenRange = true
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
-		case "severity":
+		case `"severity"`:
 			if err := json.UnmarshalDecode(dec, &s.Severity); err != nil {
 				return err
 			}
-		case "code":
+		case `"code"`:
 			if err := json.UnmarshalDecode(dec, &s.Code); err != nil {
 				return err
 			}
-		case "codeDescription":
+		case `"codeDescription"`:
 			if err := json.UnmarshalDecode(dec, &s.CodeDescription); err != nil {
 				return err
 			}
-		case "source":
+		case `"source"`:
 			if err := json.UnmarshalDecode(dec, &s.Source); err != nil {
 				return err
 			}
-		case "message":
+		case `"message"`:
 			seenMessage = true
 			if err := json.UnmarshalDecode(dec, &s.Message); err != nil {
 				return err
 			}
-		case "tags":
+		case `"tags"`:
 			if err := json.UnmarshalDecode(dec, &s.Tags); err != nil {
 				return err
 			}
-		case "relatedInformation":
+		case `"relatedInformation"`:
 			if err := json.UnmarshalDecode(dec, &s.RelatedInformation); err != nil {
 				return err
 			}
-		case "data":
+		case `"data"`:
 			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
 				return err
 			}
@@ -13956,17 +13956,17 @@ func (s *CompletionContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "triggerKind":
+		switch string(name) {
+		case `"triggerKind"`:
 			seenTriggerKind = true
 			if err := json.UnmarshalDecode(dec, &s.TriggerKind); err != nil {
 				return err
 			}
-		case "triggerCharacter":
+		case `"triggerCharacter"`:
 			if err := json.UnmarshalDecode(dec, &s.TriggerCharacter); err != nil {
 				return err
 			}
@@ -14030,22 +14030,22 @@ func (s *InsertReplaceEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "newText":
+		switch string(name) {
+		case `"newText"`:
 			seenNewText = true
 			if err := json.UnmarshalDecode(dec, &s.NewText); err != nil {
 				return err
 			}
-		case "insert":
+		case `"insert"`:
 			seenInsert = true
 			if err := json.UnmarshalDecode(dec, &s.Insert); err != nil {
 				return err
 			}
-		case "replace":
+		case `"replace"`:
 			seenReplace = true
 			if err := json.UnmarshalDecode(dec, &s.Replace); err != nil {
 				return err
@@ -14255,26 +14255,26 @@ func (s *SignatureHelpContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "triggerKind":
+		switch string(name) {
+		case `"triggerKind"`:
 			seenTriggerKind = true
 			if err := json.UnmarshalDecode(dec, &s.TriggerKind); err != nil {
 				return err
 			}
-		case "triggerCharacter":
+		case `"triggerCharacter"`:
 			if err := json.UnmarshalDecode(dec, &s.TriggerCharacter); err != nil {
 				return err
 			}
-		case "isRetrigger":
+		case `"isRetrigger"`:
 			seenIsRetrigger = true
 			if err := json.UnmarshalDecode(dec, &s.IsRetrigger); err != nil {
 				return err
 			}
-		case "activeSignatureHelp":
+		case `"activeSignatureHelp"`:
 			if err := json.UnmarshalDecode(dec, &s.ActiveSignatureHelp); err != nil {
 				return err
 			}
@@ -14339,25 +14339,25 @@ func (s *SignatureInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "label":
+		switch string(name) {
+		case `"label"`:
 			seenLabel = true
 			if err := json.UnmarshalDecode(dec, &s.Label); err != nil {
 				return err
 			}
-		case "documentation":
+		case `"documentation"`:
 			if err := json.UnmarshalDecode(dec, &s.Documentation); err != nil {
 				return err
 			}
-		case "parameters":
+		case `"parameters"`:
 			if err := json.UnmarshalDecode(dec, &s.Parameters); err != nil {
 				return err
 			}
-		case "activeParameter":
+		case `"activeParameter"`:
 			if err := json.UnmarshalDecode(dec, &s.ActiveParameter); err != nil {
 				return err
 			}
@@ -14418,12 +14418,12 @@ func (s *ReferenceContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "includeDeclaration":
+		switch string(name) {
+		case `"includeDeclaration"`:
 			seenIncludeDeclaration = true
 			if err := json.UnmarshalDecode(dec, &s.IncludeDeclaration); err != nil {
 				return err
@@ -14490,26 +14490,26 @@ func (s *BaseSymbolInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "name":
+		switch string(name) {
+		case `"name"`:
 			seenName = true
 			if err := json.UnmarshalDecode(dec, &s.Name); err != nil {
 				return err
 			}
-		case "kind":
+		case `"kind"`:
 			seenKind = true
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
-		case "tags":
+		case `"tags"`:
 			if err := json.UnmarshalDecode(dec, &s.Tags); err != nil {
 				return err
 			}
-		case "containerName":
+		case `"containerName"`:
 			if err := json.UnmarshalDecode(dec, &s.ContainerName); err != nil {
 				return err
 			}
@@ -14578,21 +14578,21 @@ func (s *CodeActionContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "diagnostics":
+		switch string(name) {
+		case `"diagnostics"`:
 			seenDiagnostics = true
 			if err := json.UnmarshalDecode(dec, &s.Diagnostics); err != nil {
 				return err
 			}
-		case "only":
+		case `"only"`:
 			if err := json.UnmarshalDecode(dec, &s.Only); err != nil {
 				return err
 			}
-		case "triggerKind":
+		case `"triggerKind"`:
 			if err := json.UnmarshalDecode(dec, &s.TriggerKind); err != nil {
 				return err
 			}
@@ -14635,12 +14635,12 @@ func (s *CodeActionDisabled) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "reason":
+		switch string(name) {
+		case `"reason"`:
 			seenReason = true
 			if err := json.UnmarshalDecode(dec, &s.Reason); err != nil {
 				return err
@@ -14716,12 +14716,12 @@ func (s *LocationUriOnly) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "uri":
+		switch string(name) {
+		case `"uri"`:
 			seenUri = true
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
@@ -14809,30 +14809,30 @@ func (s *FormattingOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "tabSize":
+		switch string(name) {
+		case `"tabSize"`:
 			seenTabSize = true
 			if err := json.UnmarshalDecode(dec, &s.TabSize); err != nil {
 				return err
 			}
-		case "insertSpaces":
+		case `"insertSpaces"`:
 			seenInsertSpaces = true
 			if err := json.UnmarshalDecode(dec, &s.InsertSpaces); err != nil {
 				return err
 			}
-		case "trimTrailingWhitespace":
+		case `"trimTrailingWhitespace"`:
 			if err := json.UnmarshalDecode(dec, &s.TrimTrailingWhitespace); err != nil {
 				return err
 			}
-		case "insertFinalNewline":
+		case `"insertFinalNewline"`:
 			if err := json.UnmarshalDecode(dec, &s.InsertFinalNewline); err != nil {
 				return err
 			}
-		case "trimFinalNewlines":
+		case `"trimFinalNewlines"`:
 			if err := json.UnmarshalDecode(dec, &s.TrimFinalNewlines); err != nil {
 				return err
 			}
@@ -14894,17 +14894,17 @@ func (s *DocumentOnTypeFormattingOptions) UnmarshalJSONFrom(dec *jsontext.Decode
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "firstTriggerCharacter":
+		switch string(name) {
+		case `"firstTriggerCharacter"`:
 			seenFirstTriggerCharacter = true
 			if err := json.UnmarshalDecode(dec, &s.FirstTriggerCharacter); err != nil {
 				return err
 			}
-		case "moreTriggerCharacter":
+		case `"moreTriggerCharacter"`:
 			if err := json.UnmarshalDecode(dec, &s.MoreTriggerCharacter); err != nil {
 				return err
 			}
@@ -14957,17 +14957,17 @@ func (s *PrepareRenamePlaceholder) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "range":
+		switch string(name) {
+		case `"range"`:
 			seenRange = true
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
-		case "placeholder":
+		case `"placeholder"`:
 			seenPlaceholder = true
 			if err := json.UnmarshalDecode(dec, &s.Placeholder); err != nil {
 				return err
@@ -15009,12 +15009,12 @@ func (s *PrepareRenameDefaultBehavior) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "defaultBehavior":
+		switch string(name) {
+		case `"defaultBehavior"`:
 			seenDefaultBehavior = true
 			if err := json.UnmarshalDecode(dec, &s.DefaultBehavior); err != nil {
 				return err
@@ -15056,16 +15056,16 @@ func (s *ExecuteCommandOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "workDoneProgress":
+		switch string(name) {
+		case `"workDoneProgress"`:
 			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
 				return err
 			}
-		case "commands":
+		case `"commands"`:
 			seenCommands = true
 			if err := json.UnmarshalDecode(dec, &s.Commands); err != nil {
 				return err
@@ -15121,17 +15121,17 @@ func (s *SemanticTokensLegend) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "tokenTypes":
+		switch string(name) {
+		case `"tokenTypes"`:
 			seenTokenTypes = true
 			if err := json.UnmarshalDecode(dec, &s.TokenTypes); err != nil {
 				return err
 			}
-		case "tokenModifiers":
+		case `"tokenModifiers"`:
 			seenTokenModifiers = true
 			if err := json.UnmarshalDecode(dec, &s.TokenModifiers); err != nil {
 				return err
@@ -15192,17 +15192,17 @@ func (s *OptionalVersionedTextDocumentIdentifier) UnmarshalJSONFrom(dec *jsontex
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "uri":
+		switch string(name) {
+		case `"uri"`:
 			seenUri = true
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
 			}
-		case "version":
+		case `"version"`:
 			seenVersion = true
 			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
 				return err
@@ -15259,22 +15259,22 @@ func (s *AnnotatedTextEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "range":
+		switch string(name) {
+		case `"range"`:
 			seenRange = true
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
-		case "newText":
+		case `"newText"`:
 			seenNewText = true
 			if err := json.UnmarshalDecode(dec, &s.NewText); err != nil {
 				return err
 			}
-		case "annotationId":
+		case `"annotationId"`:
 			seenAnnotationId = true
 			if err := json.UnmarshalDecode(dec, &s.AnnotationId); err != nil {
 				return err
@@ -15333,22 +15333,22 @@ func (s *SnippetTextEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "range":
+		switch string(name) {
+		case `"range"`:
 			seenRange = true
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
-		case "snippet":
+		case `"snippet"`:
 			seenSnippet = true
 			if err := json.UnmarshalDecode(dec, &s.Snippet); err != nil {
 				return err
 			}
-		case "annotationId":
+		case `"annotationId"`:
 			if err := json.UnmarshalDecode(dec, &s.AnnotationId); err != nil {
 				return err
 			}
@@ -15395,17 +15395,17 @@ func (s *ResourceOperation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "kind":
+		switch string(name) {
+		case `"kind"`:
 			seenKind = true
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
-		case "annotationId":
+		case `"annotationId"`:
 			if err := json.UnmarshalDecode(dec, &s.AnnotationId); err != nil {
 				return err
 			}
@@ -15488,21 +15488,21 @@ func (s *FileOperationPattern) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "glob":
+		switch string(name) {
+		case `"glob"`:
 			seenGlob = true
 			if err := json.UnmarshalDecode(dec, &s.Glob); err != nil {
 				return err
 			}
-		case "matches":
+		case `"matches"`:
 			if err := json.UnmarshalDecode(dec, &s.Matches); err != nil {
 				return err
 			}
-		case "options":
+		case `"options"`:
 			if err := json.UnmarshalDecode(dec, &s.Options); err != nil {
 				return err
 			}
@@ -15563,31 +15563,31 @@ func (s *WorkspaceFullDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "kind":
+		switch string(name) {
+		case `"kind"`:
 			seenKind = true
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
-		case "resultId":
+		case `"resultId"`:
 			if err := json.UnmarshalDecode(dec, &s.ResultId); err != nil {
 				return err
 			}
-		case "items":
+		case `"items"`:
 			seenItems = true
 			if err := json.UnmarshalDecode(dec, &s.Items); err != nil {
 				return err
 			}
-		case "uri":
+		case `"uri"`:
 			seenUri = true
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
 			}
-		case "version":
+		case `"version"`:
 			seenVersion = true
 			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
 				return err
@@ -15657,27 +15657,27 @@ func (s *WorkspaceUnchangedDocumentDiagnosticReport) UnmarshalJSONFrom(dec *json
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "kind":
+		switch string(name) {
+		case `"kind"`:
 			seenKind = true
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
-		case "resultId":
+		case `"resultId"`:
 			seenResultId = true
 			if err := json.UnmarshalDecode(dec, &s.ResultId); err != nil {
 				return err
 			}
-		case "uri":
+		case `"uri"`:
 			seenUri = true
 			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
 				return err
 			}
-		case "version":
+		case `"version"`:
 			seenVersion = true
 			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
 				return err
@@ -15748,26 +15748,26 @@ func (s *NotebookCell) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "kind":
+		switch string(name) {
+		case `"kind"`:
 			seenKind = true
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
-		case "document":
+		case `"document"`:
 			seenDocument = true
 			if err := json.UnmarshalDecode(dec, &s.Document); err != nil {
 				return err
 			}
-		case "metadata":
+		case `"metadata"`:
 			if err := json.UnmarshalDecode(dec, &s.Metadata); err != nil {
 				return err
 			}
-		case "executionSummary":
+		case `"executionSummary"`:
 			if err := json.UnmarshalDecode(dec, &s.ExecutionSummary); err != nil {
 				return err
 			}
@@ -15814,17 +15814,17 @@ func (s *NotebookDocumentFilterWithNotebook) UnmarshalJSONFrom(dec *jsontext.Dec
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "notebook":
+		switch string(name) {
+		case `"notebook"`:
 			seenNotebook = true
 			if err := json.UnmarshalDecode(dec, &s.Notebook); err != nil {
 				return err
 			}
-		case "cells":
+		case `"cells"`:
 			if err := json.UnmarshalDecode(dec, &s.Cells); err != nil {
 				return err
 			}
@@ -15868,16 +15868,16 @@ func (s *NotebookDocumentFilterWithCells) UnmarshalJSONFrom(dec *jsontext.Decode
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "notebook":
+		switch string(name) {
+		case `"notebook"`:
 			if err := json.UnmarshalDecode(dec, &s.Notebook); err != nil {
 				return err
 			}
-		case "cells":
+		case `"cells"`:
 			seenCells = true
 			if err := json.UnmarshalDecode(dec, &s.Cells); err != nil {
 				return err
@@ -15943,17 +15943,17 @@ func (s *SelectedCompletionInfo) UnmarshalJSONFrom(dec *jsontext.Decoder) error 
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "range":
+		switch string(name) {
+		case `"range"`:
 			seenRange = true
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
-		case "text":
+		case `"text"`:
 			seenText = true
 			if err := json.UnmarshalDecode(dec, &s.Text); err != nil {
 				return err
@@ -16003,17 +16003,17 @@ func (s *ClientInfo) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "name":
+		switch string(name) {
+		case `"name"`:
 			seenName = true
 			if err := json.UnmarshalDecode(dec, &s.Name); err != nil {
 				return err
 			}
-		case "version":
+		case `"version"`:
 			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
 				return err
 			}
@@ -16132,21 +16132,21 @@ func (s *TextDocumentContentChangePartial) UnmarshalJSONFrom(dec *jsontext.Decod
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "range":
+		switch string(name) {
+		case `"range"`:
 			seenRange = true
 			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
 				return err
 			}
-		case "rangeLength":
+		case `"rangeLength"`:
 			if err := json.UnmarshalDecode(dec, &s.RangeLength); err != nil {
 				return err
 			}
-		case "text":
+		case `"text"`:
 			seenText = true
 			if err := json.UnmarshalDecode(dec, &s.Text); err != nil {
 				return err
@@ -16189,12 +16189,12 @@ func (s *TextDocumentContentChangeWholeDocument) UnmarshalJSONFrom(dec *jsontext
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "text":
+		switch string(name) {
+		case `"text"`:
 			seenText = true
 			if err := json.UnmarshalDecode(dec, &s.Text); err != nil {
 				return err
@@ -16236,12 +16236,12 @@ func (s *CodeDescription) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "href":
+		switch string(name) {
+		case `"href"`:
 			seenHref = true
 			if err := json.UnmarshalDecode(dec, &s.Href); err != nil {
 				return err
@@ -16289,17 +16289,17 @@ func (s *DiagnosticRelatedInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "location":
+		switch string(name) {
+		case `"location"`:
 			seenLocation = true
 			if err := json.UnmarshalDecode(dec, &s.Location); err != nil {
 				return err
 			}
-		case "message":
+		case `"message"`:
 			seenMessage = true
 			if err := json.UnmarshalDecode(dec, &s.Message); err != nil {
 				return err
@@ -16348,17 +16348,17 @@ func (s *EditRangeWithInsertReplace) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "insert":
+		switch string(name) {
+		case `"insert"`:
 			seenInsert = true
 			if err := json.UnmarshalDecode(dec, &s.Insert); err != nil {
 				return err
 			}
-		case "replace":
+		case `"replace"`:
 			seenReplace = true
 			if err := json.UnmarshalDecode(dec, &s.Replace); err != nil {
 				return err
@@ -16417,17 +16417,17 @@ func (s *MarkedStringWithLanguage) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "language":
+		switch string(name) {
+		case `"language"`:
 			seenLanguage = true
 			if err := json.UnmarshalDecode(dec, &s.Language); err != nil {
 				return err
 			}
-		case "value":
+		case `"value"`:
 			seenValue = true
 			if err := json.UnmarshalDecode(dec, &s.Value); err != nil {
 				return err
@@ -16486,17 +16486,17 @@ func (s *ParameterInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "label":
+		switch string(name) {
+		case `"label"`:
 			seenLabel = true
 			if err := json.UnmarshalDecode(dec, &s.Label); err != nil {
 				return err
 			}
-		case "documentation":
+		case `"documentation"`:
 			if err := json.UnmarshalDecode(dec, &s.Documentation); err != nil {
 				return err
 			}
@@ -16551,17 +16551,17 @@ func (s *CodeActionKindDocumentation) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "kind":
+		switch string(name) {
+		case `"kind"`:
 			seenKind = true
 			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
 				return err
 			}
-		case "command":
+		case `"command"`:
 			seenCommand = true
 			if err := json.UnmarshalDecode(dec, &s.Command); err != nil {
 				return err
@@ -16616,17 +16616,17 @@ func (s *NotebookCellTextDocumentFilter) UnmarshalJSONFrom(dec *jsontext.Decoder
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "notebook":
+		switch string(name) {
+		case `"notebook"`:
 			seenNotebook = true
 			if err := json.UnmarshalDecode(dec, &s.Notebook); err != nil {
 				return err
 			}
-		case "language":
+		case `"language"`:
 			if err := json.UnmarshalDecode(dec, &s.Language); err != nil {
 				return err
 			}
@@ -16678,17 +16678,17 @@ func (s *ExecutionSummary) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "executionOrder":
+		switch string(name) {
+		case `"executionOrder"`:
 			seenExecutionOrder = true
 			if err := json.UnmarshalDecode(dec, &s.ExecutionOrder); err != nil {
 				return err
 			}
-		case "success":
+		case `"success"`:
 			if err := json.UnmarshalDecode(dec, &s.Success); err != nil {
 				return err
 			}
@@ -16726,12 +16726,12 @@ func (s *NotebookCellLanguage) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "language":
+		switch string(name) {
+		case `"language"`:
 			seenLanguage = true
 			if err := json.UnmarshalDecode(dec, &s.Language); err != nil {
 				return err
@@ -16779,21 +16779,21 @@ func (s *NotebookDocumentCellChangeStructure) UnmarshalJSONFrom(dec *jsontext.De
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "array":
+		switch string(name) {
+		case `"array"`:
 			seenArray = true
 			if err := json.UnmarshalDecode(dec, &s.Array); err != nil {
 				return err
 			}
-		case "didOpen":
+		case `"didOpen"`:
 			if err := json.UnmarshalDecode(dec, &s.DidOpen); err != nil {
 				return err
 			}
-		case "didClose":
+		case `"didClose"`:
 			if err := json.UnmarshalDecode(dec, &s.DidClose); err != nil {
 				return err
 			}
@@ -16838,17 +16838,17 @@ func (s *NotebookDocumentCellContentChanges) UnmarshalJSONFrom(dec *jsontext.Dec
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "document":
+		switch string(name) {
+		case `"document"`:
 			seenDocument = true
 			if err := json.UnmarshalDecode(dec, &s.Document); err != nil {
 				return err
 			}
-		case "changes":
+		case `"changes"`:
 			seenChanges = true
 			if err := json.UnmarshalDecode(dec, &s.Changes); err != nil {
 				return err
@@ -17111,12 +17111,12 @@ func (s *NotebookDocumentClientCapabilities) UnmarshalJSONFrom(dec *jsontext.Dec
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "synchronization":
+		switch string(name) {
+		case `"synchronization"`:
 			seenSynchronization = true
 			if err := json.UnmarshalDecode(dec, &s.Synchronization); err != nil {
 				return err
@@ -17270,17 +17270,17 @@ func (s *RelativePattern) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "baseUri":
+		switch string(name) {
+		case `"baseUri"`:
 			seenBaseUri = true
 			if err := json.UnmarshalDecode(dec, &s.BaseUri); err != nil {
 				return err
 			}
-		case "pattern":
+		case `"pattern"`:
 			seenPattern = true
 			if err := json.UnmarshalDecode(dec, &s.Pattern); err != nil {
 				return err
@@ -17335,21 +17335,21 @@ func (s *TextDocumentFilterLanguage) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "language":
+		switch string(name) {
+		case `"language"`:
 			seenLanguage = true
 			if err := json.UnmarshalDecode(dec, &s.Language); err != nil {
 				return err
 			}
-		case "scheme":
+		case `"scheme"`:
 			if err := json.UnmarshalDecode(dec, &s.Scheme); err != nil {
 				return err
 			}
-		case "pattern":
+		case `"pattern"`:
 			if err := json.UnmarshalDecode(dec, &s.Pattern); err != nil {
 				return err
 			}
@@ -17400,21 +17400,21 @@ func (s *TextDocumentFilterScheme) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "language":
+		switch string(name) {
+		case `"language"`:
 			if err := json.UnmarshalDecode(dec, &s.Language); err != nil {
 				return err
 			}
-		case "scheme":
+		case `"scheme"`:
 			seenScheme = true
 			if err := json.UnmarshalDecode(dec, &s.Scheme); err != nil {
 				return err
 			}
-		case "pattern":
+		case `"pattern"`:
 			if err := json.UnmarshalDecode(dec, &s.Pattern); err != nil {
 				return err
 			}
@@ -17465,20 +17465,20 @@ func (s *TextDocumentFilterPattern) UnmarshalJSONFrom(dec *jsontext.Decoder) err
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "language":
+		switch string(name) {
+		case `"language"`:
 			if err := json.UnmarshalDecode(dec, &s.Language); err != nil {
 				return err
 			}
-		case "scheme":
+		case `"scheme"`:
 			if err := json.UnmarshalDecode(dec, &s.Scheme); err != nil {
 				return err
 			}
-		case "pattern":
+		case `"pattern"`:
 			seenPattern = true
 			if err := json.UnmarshalDecode(dec, &s.Pattern); err != nil {
 				return err
@@ -17526,21 +17526,21 @@ func (s *NotebookDocumentFilterNotebookType) UnmarshalJSONFrom(dec *jsontext.Dec
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "notebookType":
+		switch string(name) {
+		case `"notebookType"`:
 			seenNotebookType = true
 			if err := json.UnmarshalDecode(dec, &s.NotebookType); err != nil {
 				return err
 			}
-		case "scheme":
+		case `"scheme"`:
 			if err := json.UnmarshalDecode(dec, &s.Scheme); err != nil {
 				return err
 			}
-		case "pattern":
+		case `"pattern"`:
 			if err := json.UnmarshalDecode(dec, &s.Pattern); err != nil {
 				return err
 			}
@@ -17587,21 +17587,21 @@ func (s *NotebookDocumentFilterScheme) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "notebookType":
+		switch string(name) {
+		case `"notebookType"`:
 			if err := json.UnmarshalDecode(dec, &s.NotebookType); err != nil {
 				return err
 			}
-		case "scheme":
+		case `"scheme"`:
 			seenScheme = true
 			if err := json.UnmarshalDecode(dec, &s.Scheme); err != nil {
 				return err
 			}
-		case "pattern":
+		case `"pattern"`:
 			if err := json.UnmarshalDecode(dec, &s.Pattern); err != nil {
 				return err
 			}
@@ -17648,20 +17648,20 @@ func (s *NotebookDocumentFilterPattern) UnmarshalJSONFrom(dec *jsontext.Decoder)
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "notebookType":
+		switch string(name) {
+		case `"notebookType"`:
 			if err := json.UnmarshalDecode(dec, &s.NotebookType); err != nil {
 				return err
 			}
-		case "scheme":
+		case `"scheme"`:
 			if err := json.UnmarshalDecode(dec, &s.Scheme); err != nil {
 				return err
 			}
-		case "pattern":
+		case `"pattern"`:
 			seenPattern = true
 			if err := json.UnmarshalDecode(dec, &s.Pattern); err != nil {
 				return err
@@ -17713,22 +17713,22 @@ func (s *NotebookCellArrayChange) UnmarshalJSONFrom(dec *jsontext.Decoder) error
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "start":
+		switch string(name) {
+		case `"start"`:
 			seenStart = true
 			if err := json.UnmarshalDecode(dec, &s.Start); err != nil {
 				return err
 			}
-		case "deleteCount":
+		case `"deleteCount"`:
 			seenDeleteCount = true
 			if err := json.UnmarshalDecode(dec, &s.DeleteCount); err != nil {
 				return err
 			}
-		case "cells":
+		case `"cells"`:
 			if err := json.UnmarshalDecode(dec, &s.Cells); err != nil {
 				return err
 			}
@@ -18419,48 +18419,48 @@ func (s *SemanticTokensClientCapabilities) UnmarshalJSONFrom(dec *jsontext.Decod
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "dynamicRegistration":
+		switch string(name) {
+		case `"dynamicRegistration"`:
 			if err := json.UnmarshalDecode(dec, &s.DynamicRegistration); err != nil {
 				return err
 			}
-		case "requests":
+		case `"requests"`:
 			seenRequests = true
 			if err := json.UnmarshalDecode(dec, &s.Requests); err != nil {
 				return err
 			}
-		case "tokenTypes":
+		case `"tokenTypes"`:
 			seenTokenTypes = true
 			if err := json.UnmarshalDecode(dec, &s.TokenTypes); err != nil {
 				return err
 			}
-		case "tokenModifiers":
+		case `"tokenModifiers"`:
 			seenTokenModifiers = true
 			if err := json.UnmarshalDecode(dec, &s.TokenModifiers); err != nil {
 				return err
 			}
-		case "formats":
+		case `"formats"`:
 			seenFormats = true
 			if err := json.UnmarshalDecode(dec, &s.Formats); err != nil {
 				return err
 			}
-		case "overlappingTokenSupport":
+		case `"overlappingTokenSupport"`:
 			if err := json.UnmarshalDecode(dec, &s.OverlappingTokenSupport); err != nil {
 				return err
 			}
-		case "multilineTokenSupport":
+		case `"multilineTokenSupport"`:
 			if err := json.UnmarshalDecode(dec, &s.MultilineTokenSupport); err != nil {
 				return err
 			}
-		case "serverCancelSupport":
+		case `"serverCancelSupport"`:
 			if err := json.UnmarshalDecode(dec, &s.ServerCancelSupport); err != nil {
 				return err
 			}
-		case "augmentsSyntaxTokens":
+		case `"augmentsSyntaxTokens"`:
 			if err := json.UnmarshalDecode(dec, &s.AugmentsSyntaxTokens); err != nil {
 				return err
 			}
@@ -18623,12 +18623,12 @@ func (s *ShowDocumentClientCapabilities) UnmarshalJSONFrom(dec *jsontext.Decoder
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "support":
+		switch string(name) {
+		case `"support"`:
 			seenSupport = true
 			if err := json.UnmarshalDecode(dec, &s.Support); err != nil {
 				return err
@@ -18676,17 +18676,17 @@ func (s *StaleRequestSupportOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "cancel":
+		switch string(name) {
+		case `"cancel"`:
 			seenCancel = true
 			if err := json.UnmarshalDecode(dec, &s.Cancel); err != nil {
 				return err
 			}
-		case "retryOnContentModified":
+		case `"retryOnContentModified"`:
 			seenRetryOnContentModified = true
 			if err := json.UnmarshalDecode(dec, &s.RetryOnContentModified); err != nil {
 				return err
@@ -18734,17 +18734,17 @@ func (s *RegularExpressionsClientCapabilities) UnmarshalJSONFrom(dec *jsontext.D
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "engine":
+		switch string(name) {
+		case `"engine"`:
 			seenEngine = true
 			if err := json.UnmarshalDecode(dec, &s.Engine); err != nil {
 				return err
 			}
-		case "version":
+		case `"version"`:
 			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
 				return err
 			}
@@ -18794,21 +18794,21 @@ func (s *MarkdownClientCapabilities) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "parser":
+		switch string(name) {
+		case `"parser"`:
 			seenParser = true
 			if err := json.UnmarshalDecode(dec, &s.Parser); err != nil {
 				return err
 			}
-		case "version":
+		case `"version"`:
 			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
 				return err
 			}
-		case "allowedTags":
+		case `"allowedTags"`:
 			if err := json.UnmarshalDecode(dec, &s.AllowedTags); err != nil {
 				return err
 			}
@@ -18868,12 +18868,12 @@ func (s *ClientSymbolTagOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error 
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "valueSet":
+		switch string(name) {
+		case `"valueSet"`:
 			seenValueSet = true
 			if err := json.UnmarshalDecode(dec, &s.ValueSet); err != nil {
 				return err
@@ -18914,12 +18914,12 @@ func (s *ClientSymbolResolveOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) er
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "properties":
+		switch string(name) {
+		case `"properties"`:
 			seenProperties = true
 			if err := json.UnmarshalDecode(dec, &s.Properties); err != nil {
 				return err
@@ -19085,12 +19085,12 @@ func (s *ClientCodeActionLiteralOptions) UnmarshalJSONFrom(dec *jsontext.Decoder
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "codeActionKind":
+		switch string(name) {
+		case `"codeActionKind"`:
 			seenCodeActionKind = true
 			if err := json.UnmarshalDecode(dec, &s.CodeActionKind); err != nil {
 				return err
@@ -19130,12 +19130,12 @@ func (s *ClientCodeActionResolveOptions) UnmarshalJSONFrom(dec *jsontext.Decoder
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "properties":
+		switch string(name) {
+		case `"properties"`:
 			seenProperties = true
 			if err := json.UnmarshalDecode(dec, &s.Properties); err != nil {
 				return err
@@ -19175,12 +19175,12 @@ func (s *CodeActionTagOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "valueSet":
+		switch string(name) {
+		case `"valueSet"`:
 			seenValueSet = true
 			if err := json.UnmarshalDecode(dec, &s.ValueSet); err != nil {
 				return err
@@ -19220,12 +19220,12 @@ func (s *ClientCodeLensResolveOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) 
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "properties":
+		switch string(name) {
+		case `"properties"`:
 			seenProperties = true
 			if err := json.UnmarshalDecode(dec, &s.Properties); err != nil {
 				return err
@@ -19318,12 +19318,12 @@ func (s *ClientInlayHintResolveOptions) UnmarshalJSONFrom(dec *jsontext.Decoder)
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "properties":
+		switch string(name) {
+		case `"properties"`:
 			seenProperties = true
 			if err := json.UnmarshalDecode(dec, &s.Properties); err != nil {
 				return err
@@ -19371,12 +19371,12 @@ func (s *CompletionItemTagOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) erro
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "valueSet":
+		switch string(name) {
+		case `"valueSet"`:
 			seenValueSet = true
 			if err := json.UnmarshalDecode(dec, &s.ValueSet); err != nil {
 				return err
@@ -19416,12 +19416,12 @@ func (s *ClientCompletionItemResolveOptions) UnmarshalJSONFrom(dec *jsontext.Dec
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "properties":
+		switch string(name) {
+		case `"properties"`:
 			seenProperties = true
 			if err := json.UnmarshalDecode(dec, &s.Properties); err != nil {
 				return err
@@ -19460,12 +19460,12 @@ func (s *ClientCompletionItemInsertTextModeOptions) UnmarshalJSONFrom(dec *jsont
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "valueSet":
+		switch string(name) {
+		case `"valueSet"`:
 			seenValueSet = true
 			if err := json.UnmarshalDecode(dec, &s.ValueSet); err != nil {
 				return err
@@ -19517,12 +19517,12 @@ func (s *ClientCodeActionKindOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "valueSet":
+		switch string(name) {
+		case `"valueSet"`:
 			seenValueSet = true
 			if err := json.UnmarshalDecode(dec, &s.ValueSet); err != nil {
 				return err
@@ -19562,12 +19562,12 @@ func (s *ClientDiagnosticsTagOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) e
 	}
 
 	for dec.PeekKind() != '}' {
-		var name string
-		if err := json.UnmarshalDecode(dec, &name); err != nil {
+		name, err := dec.ReadValue()
+		if err != nil {
 			return err
 		}
-		switch name {
-		case "valueSet":
+		switch string(name) {
+		case `"valueSet"`:
 			seenValueSet = true
 			if err := json.UnmarshalDecode(dec, &s.ValueSet); err != nil {
 				return err

--- a/internal/lsp/lsproto/lsp_generated.go
+++ b/internal/lsp/lsproto/lsp_generated.go
@@ -5,7 +5,8 @@ package lsproto
 import (
 	"fmt"
 
-	"github.com/microsoft/typescript-go/internal/json"
+	"github.com/go-json-experiment/json"
+	"github.com/go-json-experiment/json/jsontext"
 )
 
 // Meta model version 3.17.0
@@ -27,34 +28,58 @@ type ImplementationParams struct {
 	PartialResultToken *IntegerOrString `json:"partialResultToken,omitzero"`
 }
 
-func (s *ImplementationParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Position     requiredProp `json:"position"`
-	}
+func (s *ImplementationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenPosition     bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "position":
+			seenPosition = true
+			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
+				return err
+			}
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "partialResultToken":
+			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Position {
+	if !seenPosition {
 		return fmt.Errorf("required key 'position' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		TextDocument       TextDocumentIdentifier `json:"textDocument"`
-		Position           Position               `json:"position"`
-		WorkDoneToken      *IntegerOrString       `json:"workDoneToken,omitzero"`
-		PartialResultToken *IntegerOrString       `json:"partialResultToken,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Represents a location inside a resource, such as a line
@@ -65,32 +90,50 @@ type Location struct {
 	Range Range `json:"range"`
 }
 
-func (s *Location) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Uri   requiredProp `json:"uri"`
-		Range requiredProp `json:"range"`
-	}
+func (s *Location) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenUri   bool
+		seenRange bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Uri {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "uri":
+			seenUri = true
+			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
+				return err
+			}
+		case "range":
+			seenRange = true
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenUri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
-	if !keys.Range {
+	if !seenRange {
 		return fmt.Errorf("required key 'range' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Uri   DocumentUri `json:"uri"`
-		Range Range       `json:"range"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type ImplementationRegistrationOptions struct {
@@ -105,29 +148,47 @@ type ImplementationRegistrationOptions struct {
 	Id *string `json:"id,omitzero"`
 }
 
-func (s *ImplementationRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-	}
+func (s *ImplementationRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDocumentSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		case "id":
+			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DocumentSelector DocumentSelectorOrNull `json:"documentSelector"`
-		WorkDoneProgress *bool                  `json:"workDoneProgress,omitzero"`
-		Id               *string                `json:"id,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type TypeDefinitionParams struct {
@@ -145,34 +206,58 @@ type TypeDefinitionParams struct {
 	PartialResultToken *IntegerOrString `json:"partialResultToken,omitzero"`
 }
 
-func (s *TypeDefinitionParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Position     requiredProp `json:"position"`
-	}
+func (s *TypeDefinitionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenPosition     bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "position":
+			seenPosition = true
+			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
+				return err
+			}
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "partialResultToken":
+			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Position {
+	if !seenPosition {
 		return fmt.Errorf("required key 'position' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		TextDocument       TextDocumentIdentifier `json:"textDocument"`
-		Position           Position               `json:"position"`
-		WorkDoneToken      *IntegerOrString       `json:"workDoneToken,omitzero"`
-		PartialResultToken *IntegerOrString       `json:"partialResultToken,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type TypeDefinitionRegistrationOptions struct {
@@ -187,29 +272,47 @@ type TypeDefinitionRegistrationOptions struct {
 	Id *string `json:"id,omitzero"`
 }
 
-func (s *TypeDefinitionRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-	}
+func (s *TypeDefinitionRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDocumentSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		case "id":
+			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DocumentSelector DocumentSelectorOrNull `json:"documentSelector"`
-		WorkDoneProgress *bool                  `json:"workDoneProgress,omitzero"`
-		Id               *string                `json:"id,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A workspace folder inside a client.
@@ -222,32 +325,50 @@ type WorkspaceFolder struct {
 	Name string `json:"name"`
 }
 
-func (s *WorkspaceFolder) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Uri  requiredProp `json:"uri"`
-		Name requiredProp `json:"name"`
-	}
+func (s *WorkspaceFolder) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenUri  bool
+		seenName bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Uri {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "uri":
+			seenUri = true
+			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
+				return err
+			}
+		case "name":
+			seenName = true
+			if err := json.UnmarshalDecode(dec, &s.Name); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenUri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
-	if !keys.Name {
+	if !seenName {
 		return fmt.Errorf("required key 'name' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Uri  URI    `json:"uri"`
-		Name string `json:"name"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The parameters of a `workspace/didChangeWorkspaceFolders` notification.
@@ -256,27 +377,39 @@ type DidChangeWorkspaceFoldersParams struct {
 	Event *WorkspaceFoldersChangeEvent `json:"event"`
 }
 
-func (s *DidChangeWorkspaceFoldersParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Event requiredProp `json:"event"`
-	}
+func (s *DidChangeWorkspaceFoldersParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenEvent bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Event {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "event":
+			seenEvent = true
+			if err := json.UnmarshalDecode(dec, &s.Event); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenEvent {
 		return fmt.Errorf("required key 'event' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Event *WorkspaceFoldersChangeEvent `json:"event"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The parameters of a configuration request.
@@ -284,27 +417,39 @@ type ConfigurationParams struct {
 	Items []*ConfigurationItem `json:"items"`
 }
 
-func (s *ConfigurationParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Items requiredProp `json:"items"`
-	}
+func (s *ConfigurationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenItems bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Items {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "items":
+			seenItems = true
+			if err := json.UnmarshalDecode(dec, &s.Items); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenItems {
 		return fmt.Errorf("required key 'items' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Items []*ConfigurationItem `json:"items"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Parameters for a DocumentColorRequest.
@@ -320,29 +465,47 @@ type DocumentColorParams struct {
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 }
 
-func (s *DocumentColorParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-	}
+func (s *DocumentColorParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenTextDocument bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "partialResultToken":
+			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
+				return err
+			}
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneToken      *IntegerOrString       `json:"workDoneToken,omitzero"`
-		PartialResultToken *IntegerOrString       `json:"partialResultToken,omitzero"`
-		TextDocument       TextDocumentIdentifier `json:"textDocument"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Represents a color range from a document.
@@ -354,32 +517,50 @@ type ColorInformation struct {
 	Color Color `json:"color"`
 }
 
-func (s *ColorInformation) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Range requiredProp `json:"range"`
-		Color requiredProp `json:"color"`
-	}
+func (s *ColorInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenRange bool
+		seenColor bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Range {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "range":
+			seenRange = true
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		case "color":
+			seenColor = true
+			if err := json.UnmarshalDecode(dec, &s.Color); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenRange {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if !keys.Color {
+	if !seenColor {
 		return fmt.Errorf("required key 'color' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Range Range `json:"range"`
-		Color Color `json:"color"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type DocumentColorRegistrationOptions struct {
@@ -394,29 +575,47 @@ type DocumentColorRegistrationOptions struct {
 	Id *string `json:"id,omitzero"`
 }
 
-func (s *DocumentColorRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-	}
+func (s *DocumentColorRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDocumentSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		case "id":
+			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DocumentSelector DocumentSelectorOrNull `json:"documentSelector"`
-		WorkDoneProgress *bool                  `json:"workDoneProgress,omitzero"`
-		Id               *string                `json:"id,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Parameters for a ColorPresentationRequest.
@@ -438,39 +637,67 @@ type ColorPresentationParams struct {
 	Range Range `json:"range"`
 }
 
-func (s *ColorPresentationParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Color        requiredProp `json:"color"`
-		Range        requiredProp `json:"range"`
-	}
+func (s *ColorPresentationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenColor        bool
+		seenRange        bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "partialResultToken":
+			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
+				return err
+			}
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "color":
+			seenColor = true
+			if err := json.UnmarshalDecode(dec, &s.Color); err != nil {
+				return err
+			}
+		case "range":
+			seenRange = true
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Color {
+	if !seenColor {
 		return fmt.Errorf("required key 'color' is missing")
 	}
-	if !keys.Range {
+	if !seenRange {
 		return fmt.Errorf("required key 'range' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneToken      *IntegerOrString       `json:"workDoneToken,omitzero"`
-		PartialResultToken *IntegerOrString       `json:"partialResultToken,omitzero"`
-		TextDocument       TextDocumentIdentifier `json:"textDocument"`
-		Color              Color                  `json:"color"`
-		Range              Range                  `json:"range"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type ColorPresentation struct {
@@ -489,29 +716,47 @@ type ColorPresentation struct {
 	AdditionalTextEdits *[]*TextEdit `json:"additionalTextEdits,omitzero"`
 }
 
-func (s *ColorPresentation) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Label requiredProp `json:"label"`
-	}
+func (s *ColorPresentation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenLabel bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Label {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "label":
+			seenLabel = true
+			if err := json.UnmarshalDecode(dec, &s.Label); err != nil {
+				return err
+			}
+		case "textEdit":
+			if err := json.UnmarshalDecode(dec, &s.TextEdit); err != nil {
+				return err
+			}
+		case "additionalTextEdits":
+			if err := json.UnmarshalDecode(dec, &s.AdditionalTextEdits); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenLabel {
 		return fmt.Errorf("required key 'label' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Label               string       `json:"label"`
-		TextEdit            *TextEdit    `json:"textEdit,omitzero"`
-		AdditionalTextEdits *[]*TextEdit `json:"additionalTextEdits,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type WorkDoneProgressOptions struct {
@@ -525,27 +770,39 @@ type TextDocumentRegistrationOptions struct {
 	DocumentSelector DocumentSelectorOrNull `json:"documentSelector"`
 }
 
-func (s *TextDocumentRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-	}
+func (s *TextDocumentRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDocumentSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DocumentSelector DocumentSelectorOrNull `json:"documentSelector"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Parameters for a FoldingRangeRequest.
@@ -561,29 +818,47 @@ type FoldingRangeParams struct {
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 }
 
-func (s *FoldingRangeParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-	}
+func (s *FoldingRangeParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenTextDocument bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "partialResultToken":
+			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
+				return err
+			}
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneToken      *IntegerOrString       `json:"workDoneToken,omitzero"`
-		PartialResultToken *IntegerOrString       `json:"partialResultToken,omitzero"`
-		TextDocument       TextDocumentIdentifier `json:"textDocument"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Represents a folding range. To be valid, start and end line must be bigger than zero and smaller
@@ -616,36 +891,66 @@ type FoldingRange struct {
 	CollapsedText *string `json:"collapsedText,omitzero"`
 }
 
-func (s *FoldingRange) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		StartLine requiredProp `json:"startLine"`
-		EndLine   requiredProp `json:"endLine"`
-	}
+func (s *FoldingRange) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenStartLine bool
+		seenEndLine   bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.StartLine {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "startLine":
+			seenStartLine = true
+			if err := json.UnmarshalDecode(dec, &s.StartLine); err != nil {
+				return err
+			}
+		case "startCharacter":
+			if err := json.UnmarshalDecode(dec, &s.StartCharacter); err != nil {
+				return err
+			}
+		case "endLine":
+			seenEndLine = true
+			if err := json.UnmarshalDecode(dec, &s.EndLine); err != nil {
+				return err
+			}
+		case "endCharacter":
+			if err := json.UnmarshalDecode(dec, &s.EndCharacter); err != nil {
+				return err
+			}
+		case "kind":
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		case "collapsedText":
+			if err := json.UnmarshalDecode(dec, &s.CollapsedText); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenStartLine {
 		return fmt.Errorf("required key 'startLine' is missing")
 	}
-	if !keys.EndLine {
+	if !seenEndLine {
 		return fmt.Errorf("required key 'endLine' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		StartLine      uint32            `json:"startLine"`
-		StartCharacter *uint32           `json:"startCharacter,omitzero"`
-		EndLine        uint32            `json:"endLine"`
-		EndCharacter   *uint32           `json:"endCharacter,omitzero"`
-		Kind           *FoldingRangeKind `json:"kind,omitzero"`
-		CollapsedText  *string           `json:"collapsedText,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type FoldingRangeRegistrationOptions struct {
@@ -660,29 +965,47 @@ type FoldingRangeRegistrationOptions struct {
 	Id *string `json:"id,omitzero"`
 }
 
-func (s *FoldingRangeRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-	}
+func (s *FoldingRangeRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDocumentSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		case "id":
+			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DocumentSelector DocumentSelectorOrNull `json:"documentSelector"`
-		WorkDoneProgress *bool                  `json:"workDoneProgress,omitzero"`
-		Id               *string                `json:"id,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type DeclarationParams struct {
@@ -700,34 +1023,58 @@ type DeclarationParams struct {
 	PartialResultToken *IntegerOrString `json:"partialResultToken,omitzero"`
 }
 
-func (s *DeclarationParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Position     requiredProp `json:"position"`
-	}
+func (s *DeclarationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenPosition     bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "position":
+			seenPosition = true
+			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
+				return err
+			}
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "partialResultToken":
+			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Position {
+	if !seenPosition {
 		return fmt.Errorf("required key 'position' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		TextDocument       TextDocumentIdentifier `json:"textDocument"`
-		Position           Position               `json:"position"`
-		WorkDoneToken      *IntegerOrString       `json:"workDoneToken,omitzero"`
-		PartialResultToken *IntegerOrString       `json:"partialResultToken,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type DeclarationRegistrationOptions struct {
@@ -742,29 +1089,47 @@ type DeclarationRegistrationOptions struct {
 	Id *string `json:"id,omitzero"`
 }
 
-func (s *DeclarationRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-	}
+func (s *DeclarationRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDocumentSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "id":
+			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneProgress *bool                  `json:"workDoneProgress,omitzero"`
-		DocumentSelector DocumentSelectorOrNull `json:"documentSelector"`
-		Id               *string                `json:"id,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A parameter literal used in selection range requests.
@@ -783,34 +1148,58 @@ type SelectionRangeParams struct {
 	Positions []Position `json:"positions"`
 }
 
-func (s *SelectionRangeParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Positions    requiredProp `json:"positions"`
-	}
+func (s *SelectionRangeParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenPositions    bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "partialResultToken":
+			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
+				return err
+			}
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "positions":
+			seenPositions = true
+			if err := json.UnmarshalDecode(dec, &s.Positions); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Positions {
+	if !seenPositions {
 		return fmt.Errorf("required key 'positions' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneToken      *IntegerOrString       `json:"workDoneToken,omitzero"`
-		PartialResultToken *IntegerOrString       `json:"partialResultToken,omitzero"`
-		TextDocument       TextDocumentIdentifier `json:"textDocument"`
-		Positions          []Position             `json:"positions"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A selection range represents a part of a selection hierarchy. A selection range
@@ -823,28 +1212,43 @@ type SelectionRange struct {
 	Parent *SelectionRange `json:"parent,omitzero"`
 }
 
-func (s *SelectionRange) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Range requiredProp `json:"range"`
-	}
+func (s *SelectionRange) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenRange bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Range {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "range":
+			seenRange = true
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		case "parent":
+			if err := json.UnmarshalDecode(dec, &s.Parent); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenRange {
 		return fmt.Errorf("required key 'range' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Range  Range           `json:"range"`
-		Parent *SelectionRange `json:"parent,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type SelectionRangeRegistrationOptions struct {
@@ -859,29 +1263,47 @@ type SelectionRangeRegistrationOptions struct {
 	Id *string `json:"id,omitzero"`
 }
 
-func (s *SelectionRangeRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-	}
+func (s *SelectionRangeRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDocumentSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "id":
+			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneProgress *bool                  `json:"workDoneProgress,omitzero"`
-		DocumentSelector DocumentSelectorOrNull `json:"documentSelector"`
-		Id               *string                `json:"id,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type WorkDoneProgressCreateParams struct {
@@ -889,27 +1311,39 @@ type WorkDoneProgressCreateParams struct {
 	Token IntegerOrString `json:"token"`
 }
 
-func (s *WorkDoneProgressCreateParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Token requiredProp `json:"token"`
-	}
+func (s *WorkDoneProgressCreateParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenToken bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Token {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "token":
+			seenToken = true
+			if err := json.UnmarshalDecode(dec, &s.Token); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenToken {
 		return fmt.Errorf("required key 'token' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Token IntegerOrString `json:"token"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type WorkDoneProgressCancelParams struct {
@@ -917,27 +1351,39 @@ type WorkDoneProgressCancelParams struct {
 	Token IntegerOrString `json:"token"`
 }
 
-func (s *WorkDoneProgressCancelParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Token requiredProp `json:"token"`
-	}
+func (s *WorkDoneProgressCancelParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenToken bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Token {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "token":
+			seenToken = true
+			if err := json.UnmarshalDecode(dec, &s.Token); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenToken {
 		return fmt.Errorf("required key 'token' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Token IntegerOrString `json:"token"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The parameter of a `textDocument/prepareCallHierarchy` request.
@@ -954,33 +1400,54 @@ type CallHierarchyPrepareParams struct {
 	WorkDoneToken *IntegerOrString `json:"workDoneToken,omitzero"`
 }
 
-func (s *CallHierarchyPrepareParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Position     requiredProp `json:"position"`
-	}
+func (s *CallHierarchyPrepareParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenPosition     bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "position":
+			seenPosition = true
+			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
+				return err
+			}
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Position {
+	if !seenPosition {
 		return fmt.Errorf("required key 'position' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		TextDocument  TextDocumentIdentifier `json:"textDocument"`
-		Position      Position               `json:"position"`
-		WorkDoneToken *IntegerOrString       `json:"workDoneToken,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Represents programming constructs like functions or constructors in the context
@@ -1015,50 +1482,89 @@ type CallHierarchyItem struct {
 	Data *any `json:"data,omitzero"`
 }
 
-func (s *CallHierarchyItem) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Name           requiredProp `json:"name"`
-		Kind           requiredProp `json:"kind"`
-		Uri            requiredProp `json:"uri"`
-		Range          requiredProp `json:"range"`
-		SelectionRange requiredProp `json:"selectionRange"`
-	}
+func (s *CallHierarchyItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenName           bool
+		seenKind           bool
+		seenUri            bool
+		seenRange          bool
+		seenSelectionRange bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Name {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "name":
+			seenName = true
+			if err := json.UnmarshalDecode(dec, &s.Name); err != nil {
+				return err
+			}
+		case "kind":
+			seenKind = true
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		case "tags":
+			if err := json.UnmarshalDecode(dec, &s.Tags); err != nil {
+				return err
+			}
+		case "detail":
+			if err := json.UnmarshalDecode(dec, &s.Detail); err != nil {
+				return err
+			}
+		case "uri":
+			seenUri = true
+			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
+				return err
+			}
+		case "range":
+			seenRange = true
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		case "selectionRange":
+			seenSelectionRange = true
+			if err := json.UnmarshalDecode(dec, &s.SelectionRange); err != nil {
+				return err
+			}
+		case "data":
+			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenName {
 		return fmt.Errorf("required key 'name' is missing")
 	}
-	if !keys.Kind {
+	if !seenKind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if !keys.Uri {
+	if !seenUri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
-	if !keys.Range {
+	if !seenRange {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if !keys.SelectionRange {
+	if !seenSelectionRange {
 		return fmt.Errorf("required key 'selectionRange' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Name           string       `json:"name"`
-		Kind           SymbolKind   `json:"kind"`
-		Tags           *[]SymbolTag `json:"tags,omitzero"`
-		Detail         *string      `json:"detail,omitzero"`
-		Uri            DocumentUri  `json:"uri"`
-		Range          Range        `json:"range"`
-		SelectionRange Range        `json:"selectionRange"`
-		Data           *any         `json:"data,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Call hierarchy options used during static or dynamic registration.
@@ -1076,29 +1582,47 @@ type CallHierarchyRegistrationOptions struct {
 	Id *string `json:"id,omitzero"`
 }
 
-func (s *CallHierarchyRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-	}
+func (s *CallHierarchyRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDocumentSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		case "id":
+			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DocumentSelector DocumentSelectorOrNull `json:"documentSelector"`
-		WorkDoneProgress *bool                  `json:"workDoneProgress,omitzero"`
-		Id               *string                `json:"id,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The parameter of a `callHierarchy/incomingCalls` request.
@@ -1115,29 +1639,47 @@ type CallHierarchyIncomingCallsParams struct {
 	Item *CallHierarchyItem `json:"item"`
 }
 
-func (s *CallHierarchyIncomingCallsParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Item requiredProp `json:"item"`
-	}
+func (s *CallHierarchyIncomingCallsParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenItem bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Item {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "partialResultToken":
+			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
+				return err
+			}
+		case "item":
+			seenItem = true
+			if err := json.UnmarshalDecode(dec, &s.Item); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenItem {
 		return fmt.Errorf("required key 'item' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneToken      *IntegerOrString   `json:"workDoneToken,omitzero"`
-		PartialResultToken *IntegerOrString   `json:"partialResultToken,omitzero"`
-		Item               *CallHierarchyItem `json:"item"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Represents an incoming call, e.g. a caller of a method or constructor.
@@ -1152,32 +1694,50 @@ type CallHierarchyIncomingCall struct {
 	FromRanges []Range `json:"fromRanges"`
 }
 
-func (s *CallHierarchyIncomingCall) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		From       requiredProp `json:"from"`
-		FromRanges requiredProp `json:"fromRanges"`
-	}
+func (s *CallHierarchyIncomingCall) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenFrom       bool
+		seenFromRanges bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.From {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "from":
+			seenFrom = true
+			if err := json.UnmarshalDecode(dec, &s.From); err != nil {
+				return err
+			}
+		case "fromRanges":
+			seenFromRanges = true
+			if err := json.UnmarshalDecode(dec, &s.FromRanges); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenFrom {
 		return fmt.Errorf("required key 'from' is missing")
 	}
-	if !keys.FromRanges {
+	if !seenFromRanges {
 		return fmt.Errorf("required key 'fromRanges' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		From       *CallHierarchyItem `json:"from"`
-		FromRanges []Range            `json:"fromRanges"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The parameter of a `callHierarchy/outgoingCalls` request.
@@ -1194,29 +1754,47 @@ type CallHierarchyOutgoingCallsParams struct {
 	Item *CallHierarchyItem `json:"item"`
 }
 
-func (s *CallHierarchyOutgoingCallsParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Item requiredProp `json:"item"`
-	}
+func (s *CallHierarchyOutgoingCallsParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenItem bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Item {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "partialResultToken":
+			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
+				return err
+			}
+		case "item":
+			seenItem = true
+			if err := json.UnmarshalDecode(dec, &s.Item); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenItem {
 		return fmt.Errorf("required key 'item' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneToken      *IntegerOrString   `json:"workDoneToken,omitzero"`
-		PartialResultToken *IntegerOrString   `json:"partialResultToken,omitzero"`
-		Item               *CallHierarchyItem `json:"item"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Represents an outgoing call, e.g. calling a getter from a method or a method from a constructor etc.
@@ -1232,32 +1810,50 @@ type CallHierarchyOutgoingCall struct {
 	FromRanges []Range `json:"fromRanges"`
 }
 
-func (s *CallHierarchyOutgoingCall) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		To         requiredProp `json:"to"`
-		FromRanges requiredProp `json:"fromRanges"`
-	}
+func (s *CallHierarchyOutgoingCall) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTo         bool
+		seenFromRanges bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.To {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "to":
+			seenTo = true
+			if err := json.UnmarshalDecode(dec, &s.To); err != nil {
+				return err
+			}
+		case "fromRanges":
+			seenFromRanges = true
+			if err := json.UnmarshalDecode(dec, &s.FromRanges); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTo {
 		return fmt.Errorf("required key 'to' is missing")
 	}
-	if !keys.FromRanges {
+	if !seenFromRanges {
 		return fmt.Errorf("required key 'fromRanges' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		To         *CallHierarchyItem `json:"to"`
-		FromRanges []Range            `json:"fromRanges"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.16.0
@@ -1273,29 +1869,47 @@ type SemanticTokensParams struct {
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 }
 
-func (s *SemanticTokensParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-	}
+func (s *SemanticTokensParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenTextDocument bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "partialResultToken":
+			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
+				return err
+			}
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneToken      *IntegerOrString       `json:"workDoneToken,omitzero"`
-		PartialResultToken *IntegerOrString       `json:"partialResultToken,omitzero"`
-		TextDocument       TextDocumentIdentifier `json:"textDocument"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.16.0
@@ -1310,28 +1924,43 @@ type SemanticTokens struct {
 	Data []uint32 `json:"data"`
 }
 
-func (s *SemanticTokens) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Data requiredProp `json:"data"`
-	}
+func (s *SemanticTokens) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenData bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Data {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "resultId":
+			if err := json.UnmarshalDecode(dec, &s.ResultId); err != nil {
+				return err
+			}
+		case "data":
+			seenData = true
+			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenData {
 		return fmt.Errorf("required key 'data' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		ResultId *string  `json:"resultId,omitzero"`
-		Data     []uint32 `json:"data"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.16.0
@@ -1339,27 +1968,39 @@ type SemanticTokensPartialResult struct {
 	Data []uint32 `json:"data"`
 }
 
-func (s *SemanticTokensPartialResult) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Data requiredProp `json:"data"`
-	}
+func (s *SemanticTokensPartialResult) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenData bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Data {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "data":
+			seenData = true
+			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenData {
 		return fmt.Errorf("required key 'data' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Data []uint32 `json:"data"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.16.0
@@ -1385,36 +2026,66 @@ type SemanticTokensRegistrationOptions struct {
 	Id *string `json:"id,omitzero"`
 }
 
-func (s *SemanticTokensRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-		Legend           requiredProp `json:"legend"`
-	}
+func (s *SemanticTokensRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenDocumentSelector bool
+		seenLegend           bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		case "legend":
+			seenLegend = true
+			if err := json.UnmarshalDecode(dec, &s.Legend); err != nil {
+				return err
+			}
+		case "range":
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		case "full":
+			if err := json.UnmarshalDecode(dec, &s.Full); err != nil {
+				return err
+			}
+		case "id":
+			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
-	if !keys.Legend {
+	if !seenLegend {
 		return fmt.Errorf("required key 'legend' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DocumentSelector DocumentSelectorOrNull            `json:"documentSelector"`
-		WorkDoneProgress *bool                             `json:"workDoneProgress,omitzero"`
-		Legend           *SemanticTokensLegend             `json:"legend"`
-		Range            *BooleanOrEmptyObject             `json:"range,omitzero"`
-		Full             *BooleanOrSemanticTokensFullDelta `json:"full,omitzero"`
-		Id               *string                           `json:"id,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.16.0
@@ -1434,34 +2105,58 @@ type SemanticTokensDeltaParams struct {
 	PreviousResultId string `json:"previousResultId"`
 }
 
-func (s *SemanticTokensDeltaParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument     requiredProp `json:"textDocument"`
-		PreviousResultId requiredProp `json:"previousResultId"`
-	}
+func (s *SemanticTokensDeltaParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument     bool
+		seenPreviousResultId bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "partialResultToken":
+			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
+				return err
+			}
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "previousResultId":
+			seenPreviousResultId = true
+			if err := json.UnmarshalDecode(dec, &s.PreviousResultId); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.PreviousResultId {
+	if !seenPreviousResultId {
 		return fmt.Errorf("required key 'previousResultId' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneToken      *IntegerOrString       `json:"workDoneToken,omitzero"`
-		PartialResultToken *IntegerOrString       `json:"partialResultToken,omitzero"`
-		TextDocument       TextDocumentIdentifier `json:"textDocument"`
-		PreviousResultId   string                 `json:"previousResultId"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.16.0
@@ -1472,28 +2167,43 @@ type SemanticTokensDelta struct {
 	Edits []*SemanticTokensEdit `json:"edits"`
 }
 
-func (s *SemanticTokensDelta) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Edits requiredProp `json:"edits"`
-	}
+func (s *SemanticTokensDelta) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenEdits bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Edits {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "resultId":
+			if err := json.UnmarshalDecode(dec, &s.ResultId); err != nil {
+				return err
+			}
+		case "edits":
+			seenEdits = true
+			if err := json.UnmarshalDecode(dec, &s.Edits); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenEdits {
 		return fmt.Errorf("required key 'edits' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		ResultId *string               `json:"resultId,omitzero"`
-		Edits    []*SemanticTokensEdit `json:"edits"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.16.0
@@ -1501,27 +2211,39 @@ type SemanticTokensDeltaPartialResult struct {
 	Edits []*SemanticTokensEdit `json:"edits"`
 }
 
-func (s *SemanticTokensDeltaPartialResult) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Edits requiredProp `json:"edits"`
-	}
+func (s *SemanticTokensDeltaPartialResult) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenEdits bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Edits {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "edits":
+			seenEdits = true
+			if err := json.UnmarshalDecode(dec, &s.Edits); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenEdits {
 		return fmt.Errorf("required key 'edits' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Edits []*SemanticTokensEdit `json:"edits"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.16.0
@@ -1540,34 +2262,58 @@ type SemanticTokensRangeParams struct {
 	Range Range `json:"range"`
 }
 
-func (s *SemanticTokensRangeParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Range        requiredProp `json:"range"`
-	}
+func (s *SemanticTokensRangeParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenRange        bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "partialResultToken":
+			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
+				return err
+			}
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "range":
+			seenRange = true
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Range {
+	if !seenRange {
 		return fmt.Errorf("required key 'range' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneToken      *IntegerOrString       `json:"workDoneToken,omitzero"`
-		PartialResultToken *IntegerOrString       `json:"partialResultToken,omitzero"`
-		TextDocument       TextDocumentIdentifier `json:"textDocument"`
-		Range              Range                  `json:"range"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Params to show a resource in the UI.
@@ -1595,30 +2341,51 @@ type ShowDocumentParams struct {
 	Selection *Range `json:"selection,omitzero"`
 }
 
-func (s *ShowDocumentParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Uri requiredProp `json:"uri"`
-	}
+func (s *ShowDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenUri bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Uri {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "uri":
+			seenUri = true
+			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
+				return err
+			}
+		case "external":
+			if err := json.UnmarshalDecode(dec, &s.External); err != nil {
+				return err
+			}
+		case "takeFocus":
+			if err := json.UnmarshalDecode(dec, &s.TakeFocus); err != nil {
+				return err
+			}
+		case "selection":
+			if err := json.UnmarshalDecode(dec, &s.Selection); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenUri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Uri       URI    `json:"uri"`
-		External  *bool  `json:"external,omitzero"`
-		TakeFocus *bool  `json:"takeFocus,omitzero"`
-		Selection *Range `json:"selection,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The result of a showDocument request.
@@ -1629,27 +2396,39 @@ type ShowDocumentResult struct {
 	Success bool `json:"success"`
 }
 
-func (s *ShowDocumentResult) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Success requiredProp `json:"success"`
-	}
+func (s *ShowDocumentResult) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenSuccess bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Success {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "success":
+			seenSuccess = true
+			if err := json.UnmarshalDecode(dec, &s.Success); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenSuccess {
 		return fmt.Errorf("required key 'success' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Success bool `json:"success"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type LinkedEditingRangeParams struct {
@@ -1663,33 +2442,54 @@ type LinkedEditingRangeParams struct {
 	WorkDoneToken *IntegerOrString `json:"workDoneToken,omitzero"`
 }
 
-func (s *LinkedEditingRangeParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Position     requiredProp `json:"position"`
-	}
+func (s *LinkedEditingRangeParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenPosition     bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "position":
+			seenPosition = true
+			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
+				return err
+			}
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Position {
+	if !seenPosition {
 		return fmt.Errorf("required key 'position' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		TextDocument  TextDocumentIdentifier `json:"textDocument"`
-		Position      Position               `json:"position"`
-		WorkDoneToken *IntegerOrString       `json:"workDoneToken,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The result of a linked editing range request.
@@ -1706,28 +2506,43 @@ type LinkedEditingRanges struct {
 	WordPattern *string `json:"wordPattern,omitzero"`
 }
 
-func (s *LinkedEditingRanges) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Ranges requiredProp `json:"ranges"`
-	}
+func (s *LinkedEditingRanges) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenRanges bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Ranges {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "ranges":
+			seenRanges = true
+			if err := json.UnmarshalDecode(dec, &s.Ranges); err != nil {
+				return err
+			}
+		case "wordPattern":
+			if err := json.UnmarshalDecode(dec, &s.WordPattern); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenRanges {
 		return fmt.Errorf("required key 'ranges' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Ranges      []Range `json:"ranges"`
-		WordPattern *string `json:"wordPattern,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type LinkedEditingRangeRegistrationOptions struct {
@@ -1742,29 +2557,47 @@ type LinkedEditingRangeRegistrationOptions struct {
 	Id *string `json:"id,omitzero"`
 }
 
-func (s *LinkedEditingRangeRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-	}
+func (s *LinkedEditingRangeRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDocumentSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		case "id":
+			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DocumentSelector DocumentSelectorOrNull `json:"documentSelector"`
-		WorkDoneProgress *bool                  `json:"workDoneProgress,omitzero"`
-		Id               *string                `json:"id,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The parameters sent in notifications/requests for user-initiated creation of
@@ -1776,27 +2609,39 @@ type CreateFilesParams struct {
 	Files []*FileCreate `json:"files"`
 }
 
-func (s *CreateFilesParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Files requiredProp `json:"files"`
-	}
+func (s *CreateFilesParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenFiles bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Files {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "files":
+			seenFiles = true
+			if err := json.UnmarshalDecode(dec, &s.Files); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenFiles {
 		return fmt.Errorf("required key 'files' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Files []*FileCreate `json:"files"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A workspace edit represents changes to many resources managed in the workspace. The edit
@@ -1844,27 +2689,39 @@ type FileOperationRegistrationOptions struct {
 	Filters []*FileOperationFilter `json:"filters"`
 }
 
-func (s *FileOperationRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Filters requiredProp `json:"filters"`
-	}
+func (s *FileOperationRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenFilters bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Filters {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "filters":
+			seenFilters = true
+			if err := json.UnmarshalDecode(dec, &s.Filters); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenFilters {
 		return fmt.Errorf("required key 'filters' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Filters []*FileOperationFilter `json:"filters"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The parameters sent in notifications/requests for user-initiated renames of
@@ -1877,27 +2734,39 @@ type RenameFilesParams struct {
 	Files []*FileRename `json:"files"`
 }
 
-func (s *RenameFilesParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Files requiredProp `json:"files"`
-	}
+func (s *RenameFilesParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenFiles bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Files {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "files":
+			seenFiles = true
+			if err := json.UnmarshalDecode(dec, &s.Files); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenFiles {
 		return fmt.Errorf("required key 'files' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Files []*FileRename `json:"files"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The parameters sent in notifications/requests for user-initiated deletes of
@@ -1909,27 +2778,39 @@ type DeleteFilesParams struct {
 	Files []*FileDelete `json:"files"`
 }
 
-func (s *DeleteFilesParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Files requiredProp `json:"files"`
-	}
+func (s *DeleteFilesParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenFiles bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Files {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "files":
+			seenFiles = true
+			if err := json.UnmarshalDecode(dec, &s.Files); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenFiles {
 		return fmt.Errorf("required key 'files' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Files []*FileDelete `json:"files"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type MonikerParams struct {
@@ -1947,34 +2828,58 @@ type MonikerParams struct {
 	PartialResultToken *IntegerOrString `json:"partialResultToken,omitzero"`
 }
 
-func (s *MonikerParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Position     requiredProp `json:"position"`
-	}
+func (s *MonikerParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenPosition     bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "position":
+			seenPosition = true
+			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
+				return err
+			}
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "partialResultToken":
+			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Position {
+	if !seenPosition {
 		return fmt.Errorf("required key 'position' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		TextDocument       TextDocumentIdentifier `json:"textDocument"`
-		Position           Position               `json:"position"`
-		WorkDoneToken      *IntegerOrString       `json:"workDoneToken,omitzero"`
-		PartialResultToken *IntegerOrString       `json:"partialResultToken,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Moniker definition to match LSIF 0.5 moniker definition.
@@ -1995,38 +2900,63 @@ type Moniker struct {
 	Kind *MonikerKind `json:"kind,omitzero"`
 }
 
-func (s *Moniker) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Scheme     requiredProp `json:"scheme"`
-		Identifier requiredProp `json:"identifier"`
-		Unique     requiredProp `json:"unique"`
-	}
+func (s *Moniker) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenScheme     bool
+		seenIdentifier bool
+		seenUnique     bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Scheme {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "scheme":
+			seenScheme = true
+			if err := json.UnmarshalDecode(dec, &s.Scheme); err != nil {
+				return err
+			}
+		case "identifier":
+			seenIdentifier = true
+			if err := json.UnmarshalDecode(dec, &s.Identifier); err != nil {
+				return err
+			}
+		case "unique":
+			seenUnique = true
+			if err := json.UnmarshalDecode(dec, &s.Unique); err != nil {
+				return err
+			}
+		case "kind":
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenScheme {
 		return fmt.Errorf("required key 'scheme' is missing")
 	}
-	if !keys.Identifier {
+	if !seenIdentifier {
 		return fmt.Errorf("required key 'identifier' is missing")
 	}
-	if !keys.Unique {
+	if !seenUnique {
 		return fmt.Errorf("required key 'unique' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Scheme     string          `json:"scheme"`
-		Identifier string          `json:"identifier"`
-		Unique     UniquenessLevel `json:"unique"`
-		Kind       *MonikerKind    `json:"kind,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type MonikerRegistrationOptions struct {
@@ -2037,28 +2967,43 @@ type MonikerRegistrationOptions struct {
 	WorkDoneProgress *bool `json:"workDoneProgress,omitzero"`
 }
 
-func (s *MonikerRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-	}
+func (s *MonikerRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDocumentSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DocumentSelector DocumentSelectorOrNull `json:"documentSelector"`
-		WorkDoneProgress *bool                  `json:"workDoneProgress,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The parameter of a `textDocument/prepareTypeHierarchy` request.
@@ -2075,33 +3020,54 @@ type TypeHierarchyPrepareParams struct {
 	WorkDoneToken *IntegerOrString `json:"workDoneToken,omitzero"`
 }
 
-func (s *TypeHierarchyPrepareParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Position     requiredProp `json:"position"`
-	}
+func (s *TypeHierarchyPrepareParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenPosition     bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "position":
+			seenPosition = true
+			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
+				return err
+			}
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Position {
+	if !seenPosition {
 		return fmt.Errorf("required key 'position' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		TextDocument  TextDocumentIdentifier `json:"textDocument"`
-		Position      Position               `json:"position"`
-		WorkDoneToken *IntegerOrString       `json:"workDoneToken,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.17.0
@@ -2137,50 +3103,89 @@ type TypeHierarchyItem struct {
 	Data *any `json:"data,omitzero"`
 }
 
-func (s *TypeHierarchyItem) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Name           requiredProp `json:"name"`
-		Kind           requiredProp `json:"kind"`
-		Uri            requiredProp `json:"uri"`
-		Range          requiredProp `json:"range"`
-		SelectionRange requiredProp `json:"selectionRange"`
-	}
+func (s *TypeHierarchyItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenName           bool
+		seenKind           bool
+		seenUri            bool
+		seenRange          bool
+		seenSelectionRange bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Name {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "name":
+			seenName = true
+			if err := json.UnmarshalDecode(dec, &s.Name); err != nil {
+				return err
+			}
+		case "kind":
+			seenKind = true
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		case "tags":
+			if err := json.UnmarshalDecode(dec, &s.Tags); err != nil {
+				return err
+			}
+		case "detail":
+			if err := json.UnmarshalDecode(dec, &s.Detail); err != nil {
+				return err
+			}
+		case "uri":
+			seenUri = true
+			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
+				return err
+			}
+		case "range":
+			seenRange = true
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		case "selectionRange":
+			seenSelectionRange = true
+			if err := json.UnmarshalDecode(dec, &s.SelectionRange); err != nil {
+				return err
+			}
+		case "data":
+			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenName {
 		return fmt.Errorf("required key 'name' is missing")
 	}
-	if !keys.Kind {
+	if !seenKind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if !keys.Uri {
+	if !seenUri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
-	if !keys.Range {
+	if !seenRange {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if !keys.SelectionRange {
+	if !seenSelectionRange {
 		return fmt.Errorf("required key 'selectionRange' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Name           string       `json:"name"`
-		Kind           SymbolKind   `json:"kind"`
-		Tags           *[]SymbolTag `json:"tags,omitzero"`
-		Detail         *string      `json:"detail,omitzero"`
-		Uri            DocumentUri  `json:"uri"`
-		Range          Range        `json:"range"`
-		SelectionRange Range        `json:"selectionRange"`
-		Data           *any         `json:"data,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Type hierarchy options used during static or dynamic registration.
@@ -2198,29 +3203,47 @@ type TypeHierarchyRegistrationOptions struct {
 	Id *string `json:"id,omitzero"`
 }
 
-func (s *TypeHierarchyRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-	}
+func (s *TypeHierarchyRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDocumentSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		case "id":
+			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DocumentSelector DocumentSelectorOrNull `json:"documentSelector"`
-		WorkDoneProgress *bool                  `json:"workDoneProgress,omitzero"`
-		Id               *string                `json:"id,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The parameter of a `typeHierarchy/supertypes` request.
@@ -2237,29 +3260,47 @@ type TypeHierarchySupertypesParams struct {
 	Item *TypeHierarchyItem `json:"item"`
 }
 
-func (s *TypeHierarchySupertypesParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Item requiredProp `json:"item"`
-	}
+func (s *TypeHierarchySupertypesParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenItem bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Item {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "partialResultToken":
+			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
+				return err
+			}
+		case "item":
+			seenItem = true
+			if err := json.UnmarshalDecode(dec, &s.Item); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenItem {
 		return fmt.Errorf("required key 'item' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneToken      *IntegerOrString   `json:"workDoneToken,omitzero"`
-		PartialResultToken *IntegerOrString   `json:"partialResultToken,omitzero"`
-		Item               *TypeHierarchyItem `json:"item"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The parameter of a `typeHierarchy/subtypes` request.
@@ -2276,29 +3317,47 @@ type TypeHierarchySubtypesParams struct {
 	Item *TypeHierarchyItem `json:"item"`
 }
 
-func (s *TypeHierarchySubtypesParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Item requiredProp `json:"item"`
-	}
+func (s *TypeHierarchySubtypesParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenItem bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Item {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "partialResultToken":
+			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
+				return err
+			}
+		case "item":
+			seenItem = true
+			if err := json.UnmarshalDecode(dec, &s.Item); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenItem {
 		return fmt.Errorf("required key 'item' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneToken      *IntegerOrString   `json:"workDoneToken,omitzero"`
-		PartialResultToken *IntegerOrString   `json:"partialResultToken,omitzero"`
-		Item               *TypeHierarchyItem `json:"item"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A parameter literal used in inline value requests.
@@ -2319,38 +3378,63 @@ type InlineValueParams struct {
 	Context *InlineValueContext `json:"context"`
 }
 
-func (s *InlineValueParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Range        requiredProp `json:"range"`
-		Context      requiredProp `json:"context"`
-	}
+func (s *InlineValueParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenRange        bool
+		seenContext      bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "range":
+			seenRange = true
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		case "context":
+			seenContext = true
+			if err := json.UnmarshalDecode(dec, &s.Context); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Range {
+	if !seenRange {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if !keys.Context {
+	if !seenContext {
 		return fmt.Errorf("required key 'context' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneToken *IntegerOrString       `json:"workDoneToken,omitzero"`
-		TextDocument  TextDocumentIdentifier `json:"textDocument"`
-		Range         Range                  `json:"range"`
-		Context       *InlineValueContext    `json:"context"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Inline value options used during static or dynamic registration.
@@ -2368,29 +3452,47 @@ type InlineValueRegistrationOptions struct {
 	Id *string `json:"id,omitzero"`
 }
 
-func (s *InlineValueRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-	}
+func (s *InlineValueRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDocumentSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "id":
+			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneProgress *bool                  `json:"workDoneProgress,omitzero"`
-		DocumentSelector DocumentSelectorOrNull `json:"documentSelector"`
-		Id               *string                `json:"id,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A parameter literal used in inlay hint requests.
@@ -2407,33 +3509,54 @@ type InlayHintParams struct {
 	Range Range `json:"range"`
 }
 
-func (s *InlayHintParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Range        requiredProp `json:"range"`
-	}
+func (s *InlayHintParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenRange        bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "range":
+			seenRange = true
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Range {
+	if !seenRange {
 		return fmt.Errorf("required key 'range' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneToken *IntegerOrString       `json:"workDoneToken,omitzero"`
-		TextDocument  TextDocumentIdentifier `json:"textDocument"`
-		Range         Range                  `json:"range"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Inlay hint information.
@@ -2485,38 +3608,74 @@ type InlayHint struct {
 	Data *any `json:"data,omitzero"`
 }
 
-func (s *InlayHint) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Position requiredProp `json:"position"`
-		Label    requiredProp `json:"label"`
-	}
+func (s *InlayHint) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenPosition bool
+		seenLabel    bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Position {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "position":
+			seenPosition = true
+			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
+				return err
+			}
+		case "label":
+			seenLabel = true
+			if err := json.UnmarshalDecode(dec, &s.Label); err != nil {
+				return err
+			}
+		case "kind":
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		case "textEdits":
+			if err := json.UnmarshalDecode(dec, &s.TextEdits); err != nil {
+				return err
+			}
+		case "tooltip":
+			if err := json.UnmarshalDecode(dec, &s.Tooltip); err != nil {
+				return err
+			}
+		case "paddingLeft":
+			if err := json.UnmarshalDecode(dec, &s.PaddingLeft); err != nil {
+				return err
+			}
+		case "paddingRight":
+			if err := json.UnmarshalDecode(dec, &s.PaddingRight); err != nil {
+				return err
+			}
+		case "data":
+			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenPosition {
 		return fmt.Errorf("required key 'position' is missing")
 	}
-	if !keys.Label {
+	if !seenLabel {
 		return fmt.Errorf("required key 'label' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Position     Position                    `json:"position"`
-		Label        StringOrInlayHintLabelParts `json:"label"`
-		Kind         *InlayHintKind              `json:"kind,omitzero"`
-		TextEdits    *[]*TextEdit                `json:"textEdits,omitzero"`
-		Tooltip      *StringOrMarkupContent      `json:"tooltip,omitzero"`
-		PaddingLeft  *bool                       `json:"paddingLeft,omitzero"`
-		PaddingRight *bool                       `json:"paddingRight,omitzero"`
-		Data         *any                        `json:"data,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Inlay hint options used during static or dynamic registration.
@@ -2538,30 +3697,51 @@ type InlayHintRegistrationOptions struct {
 	Id *string `json:"id,omitzero"`
 }
 
-func (s *InlayHintRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-	}
+func (s *InlayHintRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDocumentSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		case "resolveProvider":
+			if err := json.UnmarshalDecode(dec, &s.ResolveProvider); err != nil {
+				return err
+			}
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "id":
+			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneProgress *bool                  `json:"workDoneProgress,omitzero"`
-		ResolveProvider  *bool                  `json:"resolveProvider,omitzero"`
-		DocumentSelector DocumentSelectorOrNull `json:"documentSelector"`
-		Id               *string                `json:"id,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Parameters of the document diagnostic request.
@@ -2585,31 +3765,55 @@ type DocumentDiagnosticParams struct {
 	PreviousResultId *string `json:"previousResultId,omitzero"`
 }
 
-func (s *DocumentDiagnosticParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-	}
+func (s *DocumentDiagnosticParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenTextDocument bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "partialResultToken":
+			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
+				return err
+			}
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "identifier":
+			if err := json.UnmarshalDecode(dec, &s.Identifier); err != nil {
+				return err
+			}
+		case "previousResultId":
+			if err := json.UnmarshalDecode(dec, &s.PreviousResultId); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneToken      *IntegerOrString       `json:"workDoneToken,omitzero"`
-		PartialResultToken *IntegerOrString       `json:"partialResultToken,omitzero"`
-		TextDocument       TextDocumentIdentifier `json:"textDocument"`
-		Identifier         *string                `json:"identifier,omitzero"`
-		PreviousResultId   *string                `json:"previousResultId,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A partial result for a document diagnostic report.
@@ -2619,27 +3823,39 @@ type DocumentDiagnosticReportPartialResult struct {
 	RelatedDocuments map[DocumentUri]FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport `json:"relatedDocuments"`
 }
 
-func (s *DocumentDiagnosticReportPartialResult) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		RelatedDocuments requiredProp `json:"relatedDocuments"`
-	}
+func (s *DocumentDiagnosticReportPartialResult) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenRelatedDocuments bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.RelatedDocuments {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "relatedDocuments":
+			seenRelatedDocuments = true
+			if err := json.UnmarshalDecode(dec, &s.RelatedDocuments); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenRelatedDocuments {
 		return fmt.Errorf("required key 'relatedDocuments' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		RelatedDocuments map[DocumentUri]FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport `json:"relatedDocuments"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Cancellation data returned from a diagnostic request.
@@ -2649,27 +3865,39 @@ type DiagnosticServerCancellationData struct {
 	RetriggerRequest bool `json:"retriggerRequest"`
 }
 
-func (s *DiagnosticServerCancellationData) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		RetriggerRequest requiredProp `json:"retriggerRequest"`
-	}
+func (s *DiagnosticServerCancellationData) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenRetriggerRequest bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.RetriggerRequest {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "retriggerRequest":
+			seenRetriggerRequest = true
+			if err := json.UnmarshalDecode(dec, &s.RetriggerRequest); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenRetriggerRequest {
 		return fmt.Errorf("required key 'retriggerRequest' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		RetriggerRequest bool `json:"retriggerRequest"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Diagnostic registration options.
@@ -2700,40 +3928,71 @@ type DiagnosticRegistrationOptions struct {
 	Id *string `json:"id,omitzero"`
 }
 
-func (s *DiagnosticRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector      requiredProp `json:"documentSelector"`
-		InterFileDependencies requiredProp `json:"interFileDependencies"`
-		WorkspaceDiagnostics  requiredProp `json:"workspaceDiagnostics"`
-	}
+func (s *DiagnosticRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenDocumentSelector      bool
+		seenInterFileDependencies bool
+		seenWorkspaceDiagnostics  bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		case "identifier":
+			if err := json.UnmarshalDecode(dec, &s.Identifier); err != nil {
+				return err
+			}
+		case "interFileDependencies":
+			seenInterFileDependencies = true
+			if err := json.UnmarshalDecode(dec, &s.InterFileDependencies); err != nil {
+				return err
+			}
+		case "workspaceDiagnostics":
+			seenWorkspaceDiagnostics = true
+			if err := json.UnmarshalDecode(dec, &s.WorkspaceDiagnostics); err != nil {
+				return err
+			}
+		case "id":
+			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
-	if !keys.InterFileDependencies {
+	if !seenInterFileDependencies {
 		return fmt.Errorf("required key 'interFileDependencies' is missing")
 	}
-	if !keys.WorkspaceDiagnostics {
+	if !seenWorkspaceDiagnostics {
 		return fmt.Errorf("required key 'workspaceDiagnostics' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DocumentSelector      DocumentSelectorOrNull `json:"documentSelector"`
-		WorkDoneProgress      *bool                  `json:"workDoneProgress,omitzero"`
-		Identifier            *string                `json:"identifier,omitzero"`
-		InterFileDependencies bool                   `json:"interFileDependencies"`
-		WorkspaceDiagnostics  bool                   `json:"workspaceDiagnostics"`
-		Id                    *string                `json:"id,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Parameters of the workspace diagnostic request.
@@ -2755,30 +4014,51 @@ type WorkspaceDiagnosticParams struct {
 	PreviousResultIds []PreviousResultId `json:"previousResultIds"`
 }
 
-func (s *WorkspaceDiagnosticParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		PreviousResultIds requiredProp `json:"previousResultIds"`
-	}
+func (s *WorkspaceDiagnosticParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenPreviousResultIds bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.PreviousResultIds {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "partialResultToken":
+			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
+				return err
+			}
+		case "identifier":
+			if err := json.UnmarshalDecode(dec, &s.Identifier); err != nil {
+				return err
+			}
+		case "previousResultIds":
+			seenPreviousResultIds = true
+			if err := json.UnmarshalDecode(dec, &s.PreviousResultIds); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenPreviousResultIds {
 		return fmt.Errorf("required key 'previousResultIds' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneToken      *IntegerOrString   `json:"workDoneToken,omitzero"`
-		PartialResultToken *IntegerOrString   `json:"partialResultToken,omitzero"`
-		Identifier         *string            `json:"identifier,omitzero"`
-		PreviousResultIds  []PreviousResultId `json:"previousResultIds"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A workspace diagnostic report.
@@ -2788,27 +4068,39 @@ type WorkspaceDiagnosticReport struct {
 	Items []WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport `json:"items"`
 }
 
-func (s *WorkspaceDiagnosticReport) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Items requiredProp `json:"items"`
-	}
+func (s *WorkspaceDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenItems bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Items {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "items":
+			seenItems = true
+			if err := json.UnmarshalDecode(dec, &s.Items); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenItems {
 		return fmt.Errorf("required key 'items' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Items []WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport `json:"items"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A partial result for a workspace diagnostic report.
@@ -2818,27 +4110,39 @@ type WorkspaceDiagnosticReportPartialResult struct {
 	Items []WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport `json:"items"`
 }
 
-func (s *WorkspaceDiagnosticReportPartialResult) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Items requiredProp `json:"items"`
-	}
+func (s *WorkspaceDiagnosticReportPartialResult) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenItems bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Items {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "items":
+			seenItems = true
+			if err := json.UnmarshalDecode(dec, &s.Items); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenItems {
 		return fmt.Errorf("required key 'items' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Items []WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport `json:"items"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The params sent in an open notebook document notification.
@@ -2853,32 +4157,50 @@ type DidOpenNotebookDocumentParams struct {
 	CellTextDocuments []*TextDocumentItem `json:"cellTextDocuments"`
 }
 
-func (s *DidOpenNotebookDocumentParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		NotebookDocument  requiredProp `json:"notebookDocument"`
-		CellTextDocuments requiredProp `json:"cellTextDocuments"`
-	}
+func (s *DidOpenNotebookDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenNotebookDocument  bool
+		seenCellTextDocuments bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.NotebookDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "notebookDocument":
+			seenNotebookDocument = true
+			if err := json.UnmarshalDecode(dec, &s.NotebookDocument); err != nil {
+				return err
+			}
+		case "cellTextDocuments":
+			seenCellTextDocuments = true
+			if err := json.UnmarshalDecode(dec, &s.CellTextDocuments); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenNotebookDocument {
 		return fmt.Errorf("required key 'notebookDocument' is missing")
 	}
-	if !keys.CellTextDocuments {
+	if !seenCellTextDocuments {
 		return fmt.Errorf("required key 'cellTextDocuments' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		NotebookDocument  *NotebookDocument   `json:"notebookDocument"`
-		CellTextDocuments []*TextDocumentItem `json:"cellTextDocuments"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Registration options specific to a notebook.
@@ -2897,29 +4219,47 @@ type NotebookDocumentSyncRegistrationOptions struct {
 	Id *string `json:"id,omitzero"`
 }
 
-func (s *NotebookDocumentSyncRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		NotebookSelector requiredProp `json:"notebookSelector"`
-	}
+func (s *NotebookDocumentSyncRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenNotebookSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.NotebookSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "notebookSelector":
+			seenNotebookSelector = true
+			if err := json.UnmarshalDecode(dec, &s.NotebookSelector); err != nil {
+				return err
+			}
+		case "save":
+			if err := json.UnmarshalDecode(dec, &s.Save); err != nil {
+				return err
+			}
+		case "id":
+			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenNotebookSelector {
 		return fmt.Errorf("required key 'notebookSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		NotebookSelector []NotebookDocumentFilterWithNotebookOrCells `json:"notebookSelector"`
-		Save             *bool                                       `json:"save,omitzero"`
-		Id               *string                                     `json:"id,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The params sent in a change notebook document notification.
@@ -2948,32 +4288,50 @@ type DidChangeNotebookDocumentParams struct {
 	Change *NotebookDocumentChangeEvent `json:"change"`
 }
 
-func (s *DidChangeNotebookDocumentParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		NotebookDocument requiredProp `json:"notebookDocument"`
-		Change           requiredProp `json:"change"`
-	}
+func (s *DidChangeNotebookDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenNotebookDocument bool
+		seenChange           bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.NotebookDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "notebookDocument":
+			seenNotebookDocument = true
+			if err := json.UnmarshalDecode(dec, &s.NotebookDocument); err != nil {
+				return err
+			}
+		case "change":
+			seenChange = true
+			if err := json.UnmarshalDecode(dec, &s.Change); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenNotebookDocument {
 		return fmt.Errorf("required key 'notebookDocument' is missing")
 	}
-	if !keys.Change {
+	if !seenChange {
 		return fmt.Errorf("required key 'change' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		NotebookDocument VersionedNotebookDocumentIdentifier `json:"notebookDocument"`
-		Change           *NotebookDocumentChangeEvent        `json:"change"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The params sent in a save notebook document notification.
@@ -2984,27 +4342,39 @@ type DidSaveNotebookDocumentParams struct {
 	NotebookDocument NotebookDocumentIdentifier `json:"notebookDocument"`
 }
 
-func (s *DidSaveNotebookDocumentParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		NotebookDocument requiredProp `json:"notebookDocument"`
-	}
+func (s *DidSaveNotebookDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenNotebookDocument bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.NotebookDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "notebookDocument":
+			seenNotebookDocument = true
+			if err := json.UnmarshalDecode(dec, &s.NotebookDocument); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenNotebookDocument {
 		return fmt.Errorf("required key 'notebookDocument' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		NotebookDocument NotebookDocumentIdentifier `json:"notebookDocument"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The params sent in a close notebook document notification.
@@ -3019,32 +4389,50 @@ type DidCloseNotebookDocumentParams struct {
 	CellTextDocuments []TextDocumentIdentifier `json:"cellTextDocuments"`
 }
 
-func (s *DidCloseNotebookDocumentParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		NotebookDocument  requiredProp `json:"notebookDocument"`
-		CellTextDocuments requiredProp `json:"cellTextDocuments"`
-	}
+func (s *DidCloseNotebookDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenNotebookDocument  bool
+		seenCellTextDocuments bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.NotebookDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "notebookDocument":
+			seenNotebookDocument = true
+			if err := json.UnmarshalDecode(dec, &s.NotebookDocument); err != nil {
+				return err
+			}
+		case "cellTextDocuments":
+			seenCellTextDocuments = true
+			if err := json.UnmarshalDecode(dec, &s.CellTextDocuments); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenNotebookDocument {
 		return fmt.Errorf("required key 'notebookDocument' is missing")
 	}
-	if !keys.CellTextDocuments {
+	if !seenCellTextDocuments {
 		return fmt.Errorf("required key 'cellTextDocuments' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		NotebookDocument  NotebookDocumentIdentifier `json:"notebookDocument"`
-		CellTextDocuments []TextDocumentIdentifier   `json:"cellTextDocuments"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A parameter literal used in inline completion requests.
@@ -3067,38 +4455,63 @@ type InlineCompletionParams struct {
 	Context *InlineCompletionContext `json:"context"`
 }
 
-func (s *InlineCompletionParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Position     requiredProp `json:"position"`
-		Context      requiredProp `json:"context"`
-	}
+func (s *InlineCompletionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenPosition     bool
+		seenContext      bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "position":
+			seenPosition = true
+			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
+				return err
+			}
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "context":
+			seenContext = true
+			if err := json.UnmarshalDecode(dec, &s.Context); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Position {
+	if !seenPosition {
 		return fmt.Errorf("required key 'position' is missing")
 	}
-	if !keys.Context {
+	if !seenContext {
 		return fmt.Errorf("required key 'context' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		TextDocument  TextDocumentIdentifier   `json:"textDocument"`
-		Position      Position                 `json:"position"`
-		WorkDoneToken *IntegerOrString         `json:"workDoneToken,omitzero"`
-		Context       *InlineCompletionContext `json:"context"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Represents a collection of items to be presented in the editor.
@@ -3111,27 +4524,39 @@ type InlineCompletionList struct {
 	Items []*InlineCompletionItem `json:"items"`
 }
 
-func (s *InlineCompletionList) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Items requiredProp `json:"items"`
-	}
+func (s *InlineCompletionList) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenItems bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Items {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "items":
+			seenItems = true
+			if err := json.UnmarshalDecode(dec, &s.Items); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenItems {
 		return fmt.Errorf("required key 'items' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Items []*InlineCompletionItem `json:"items"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // An inline completion item represents a text snippet that is proposed inline to complete text that is being typed.
@@ -3153,30 +4578,51 @@ type InlineCompletionItem struct {
 	Command *Command `json:"command,omitzero"`
 }
 
-func (s *InlineCompletionItem) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		InsertText requiredProp `json:"insertText"`
-	}
+func (s *InlineCompletionItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenInsertText bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.InsertText {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "insertText":
+			seenInsertText = true
+			if err := json.UnmarshalDecode(dec, &s.InsertText); err != nil {
+				return err
+			}
+		case "filterText":
+			if err := json.UnmarshalDecode(dec, &s.FilterText); err != nil {
+				return err
+			}
+		case "range":
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		case "command":
+			if err := json.UnmarshalDecode(dec, &s.Command); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenInsertText {
 		return fmt.Errorf("required key 'insertText' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		InsertText StringOrStringValue `json:"insertText"`
-		FilterText *string             `json:"filterText,omitzero"`
-		Range      *Range              `json:"range,omitzero"`
-		Command    *Command            `json:"command,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Inline completion options used during static or dynamic registration.
@@ -3196,29 +4642,47 @@ type InlineCompletionRegistrationOptions struct {
 	Id *string `json:"id,omitzero"`
 }
 
-func (s *InlineCompletionRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-	}
+func (s *InlineCompletionRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDocumentSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "id":
+			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneProgress *bool                  `json:"workDoneProgress,omitzero"`
-		DocumentSelector DocumentSelectorOrNull `json:"documentSelector"`
-		Id               *string                `json:"id,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Parameters for the `workspace/textDocumentContent` request.
@@ -3231,27 +4695,39 @@ type TextDocumentContentParams struct {
 	Uri DocumentUri `json:"uri"`
 }
 
-func (s *TextDocumentContentParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Uri requiredProp `json:"uri"`
-	}
+func (s *TextDocumentContentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenUri bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Uri {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "uri":
+			seenUri = true
+			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenUri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Uri DocumentUri `json:"uri"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Result of the `workspace/textDocumentContent` request.
@@ -3267,27 +4743,39 @@ type TextDocumentContentResult struct {
 	Text string `json:"text"`
 }
 
-func (s *TextDocumentContentResult) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Text requiredProp `json:"text"`
-	}
+func (s *TextDocumentContentResult) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenText bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Text {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "text":
+			seenText = true
+			if err := json.UnmarshalDecode(dec, &s.Text); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenText {
 		return fmt.Errorf("required key 'text' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Text string `json:"text"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Text document content provider registration options.
@@ -3304,28 +4792,43 @@ type TextDocumentContentRegistrationOptions struct {
 	Id *string `json:"id,omitzero"`
 }
 
-func (s *TextDocumentContentRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Schemes requiredProp `json:"schemes"`
-	}
+func (s *TextDocumentContentRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenSchemes bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Schemes {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "schemes":
+			seenSchemes = true
+			if err := json.UnmarshalDecode(dec, &s.Schemes); err != nil {
+				return err
+			}
+		case "id":
+			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenSchemes {
 		return fmt.Errorf("required key 'schemes' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Schemes []string `json:"schemes"`
-		Id      *string  `json:"id,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Parameters for the `workspace/textDocumentContent/refresh` request.
@@ -3338,81 +4841,117 @@ type TextDocumentContentRefreshParams struct {
 	Uri DocumentUri `json:"uri"`
 }
 
-func (s *TextDocumentContentRefreshParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Uri requiredProp `json:"uri"`
-	}
+func (s *TextDocumentContentRefreshParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenUri bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Uri {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "uri":
+			seenUri = true
+			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenUri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Uri DocumentUri `json:"uri"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type RegistrationParams struct {
 	Registrations []*Registration `json:"registrations"`
 }
 
-func (s *RegistrationParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Registrations requiredProp `json:"registrations"`
-	}
+func (s *RegistrationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenRegistrations bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Registrations {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "registrations":
+			seenRegistrations = true
+			if err := json.UnmarshalDecode(dec, &s.Registrations); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenRegistrations {
 		return fmt.Errorf("required key 'registrations' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Registrations []*Registration `json:"registrations"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type UnregistrationParams struct {
 	Unregisterations []*Unregistration `json:"unregisterations"`
 }
 
-func (s *UnregistrationParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Unregisterations requiredProp `json:"unregisterations"`
-	}
+func (s *UnregistrationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenUnregisterations bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Unregisterations {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "unregisterations":
+			seenUnregisterations = true
+			if err := json.UnmarshalDecode(dec, &s.Unregisterations); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenUnregisterations {
 		return fmt.Errorf("required key 'unregisterations' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Unregisterations []*Unregistration `json:"unregisterations"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type InitializeParams struct {
@@ -3473,44 +5012,87 @@ type InitializeParams struct {
 	WorkspaceFolders *WorkspaceFoldersOrNull `json:"workspaceFolders,omitzero"`
 }
 
-func (s *InitializeParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		ProcessId    requiredProp `json:"processId"`
-		RootUri      requiredProp `json:"rootUri"`
-		Capabilities requiredProp `json:"capabilities"`
-	}
+func (s *InitializeParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenProcessId    bool
+		seenRootUri      bool
+		seenCapabilities bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.ProcessId {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "processId":
+			seenProcessId = true
+			if err := json.UnmarshalDecode(dec, &s.ProcessId); err != nil {
+				return err
+			}
+		case "clientInfo":
+			if err := json.UnmarshalDecode(dec, &s.ClientInfo); err != nil {
+				return err
+			}
+		case "locale":
+			if err := json.UnmarshalDecode(dec, &s.Locale); err != nil {
+				return err
+			}
+		case "rootPath":
+			if err := json.UnmarshalDecode(dec, &s.RootPath); err != nil {
+				return err
+			}
+		case "rootUri":
+			seenRootUri = true
+			if err := json.UnmarshalDecode(dec, &s.RootUri); err != nil {
+				return err
+			}
+		case "capabilities":
+			seenCapabilities = true
+			if err := json.UnmarshalDecode(dec, &s.Capabilities); err != nil {
+				return err
+			}
+		case "initializationOptions":
+			if err := json.UnmarshalDecode(dec, &s.InitializationOptions); err != nil {
+				return err
+			}
+		case "trace":
+			if err := json.UnmarshalDecode(dec, &s.Trace); err != nil {
+				return err
+			}
+		case "workspaceFolders":
+			if err := json.UnmarshalDecode(dec, &s.WorkspaceFolders); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenProcessId {
 		return fmt.Errorf("required key 'processId' is missing")
 	}
-	if !keys.RootUri {
+	if !seenRootUri {
 		return fmt.Errorf("required key 'rootUri' is missing")
 	}
-	if !keys.Capabilities {
+	if !seenCapabilities {
 		return fmt.Errorf("required key 'capabilities' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneToken         *IntegerOrString        `json:"workDoneToken,omitzero"`
-		ProcessId             IntegerOrNull           `json:"processId"`
-		ClientInfo            *ClientInfo             `json:"clientInfo,omitzero"`
-		Locale                *string                 `json:"locale,omitzero"`
-		RootPath              *StringOrNull           `json:"rootPath,omitzero"`
-		RootUri               DocumentUriOrNull       `json:"rootUri"`
-		Capabilities          *ClientCapabilities     `json:"capabilities"`
-		InitializationOptions *any                    `json:"initializationOptions,omitzero"`
-		Trace                 *TraceValue             `json:"trace,omitzero"`
-		WorkspaceFolders      *WorkspaceFoldersOrNull `json:"workspaceFolders,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The result returned from an initialize request.
@@ -3524,28 +5106,43 @@ type InitializeResult struct {
 	ServerInfo *ServerInfo `json:"serverInfo,omitzero"`
 }
 
-func (s *InitializeResult) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Capabilities requiredProp `json:"capabilities"`
-	}
+func (s *InitializeResult) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenCapabilities bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Capabilities {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "capabilities":
+			seenCapabilities = true
+			if err := json.UnmarshalDecode(dec, &s.Capabilities); err != nil {
+				return err
+			}
+		case "serverInfo":
+			if err := json.UnmarshalDecode(dec, &s.ServerInfo); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenCapabilities {
 		return fmt.Errorf("required key 'capabilities' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Capabilities *ServerCapabilities `json:"capabilities"`
-		ServerInfo   *ServerInfo         `json:"serverInfo,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The data type of the ResponseError if the
@@ -3558,27 +5155,39 @@ type InitializeError struct {
 	Retry bool `json:"retry"`
 }
 
-func (s *InitializeError) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Retry requiredProp `json:"retry"`
-	}
+func (s *InitializeError) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenRetry bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Retry {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "retry":
+			seenRetry = true
+			if err := json.UnmarshalDecode(dec, &s.Retry); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenRetry {
 		return fmt.Errorf("required key 'retry' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Retry bool `json:"retry"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type InitializedParams struct{}
@@ -3589,27 +5198,39 @@ type DidChangeConfigurationParams struct {
 	Settings any `json:"settings"`
 }
 
-func (s *DidChangeConfigurationParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Settings requiredProp `json:"settings"`
-	}
+func (s *DidChangeConfigurationParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenSettings bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Settings {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "settings":
+			seenSettings = true
+			if err := json.UnmarshalDecode(dec, &s.Settings); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenSettings {
 		return fmt.Errorf("required key 'settings' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Settings any `json:"settings"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type DidChangeConfigurationRegistrationOptions struct {
@@ -3625,32 +5246,50 @@ type ShowMessageParams struct {
 	Message string `json:"message"`
 }
 
-func (s *ShowMessageParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Type    requiredProp `json:"type"`
-		Message requiredProp `json:"message"`
-	}
+func (s *ShowMessageParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenType    bool
+		seenMessage bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Type {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "type":
+			seenType = true
+			if err := json.UnmarshalDecode(dec, &s.Type); err != nil {
+				return err
+			}
+		case "message":
+			seenMessage = true
+			if err := json.UnmarshalDecode(dec, &s.Message); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenType {
 		return fmt.Errorf("required key 'type' is missing")
 	}
-	if !keys.Message {
+	if !seenMessage {
 		return fmt.Errorf("required key 'message' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Type    MessageType `json:"type"`
-		Message string      `json:"message"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type ShowMessageRequestParams struct {
@@ -3664,33 +5303,54 @@ type ShowMessageRequestParams struct {
 	Actions *[]*MessageActionItem `json:"actions,omitzero"`
 }
 
-func (s *ShowMessageRequestParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Type    requiredProp `json:"type"`
-		Message requiredProp `json:"message"`
-	}
+func (s *ShowMessageRequestParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenType    bool
+		seenMessage bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Type {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "type":
+			seenType = true
+			if err := json.UnmarshalDecode(dec, &s.Type); err != nil {
+				return err
+			}
+		case "message":
+			seenMessage = true
+			if err := json.UnmarshalDecode(dec, &s.Message); err != nil {
+				return err
+			}
+		case "actions":
+			if err := json.UnmarshalDecode(dec, &s.Actions); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenType {
 		return fmt.Errorf("required key 'type' is missing")
 	}
-	if !keys.Message {
+	if !seenMessage {
 		return fmt.Errorf("required key 'message' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Type    MessageType           `json:"type"`
-		Message string                `json:"message"`
-		Actions *[]*MessageActionItem `json:"actions,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type MessageActionItem struct {
@@ -3698,27 +5358,39 @@ type MessageActionItem struct {
 	Title string `json:"title"`
 }
 
-func (s *MessageActionItem) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Title requiredProp `json:"title"`
-	}
+func (s *MessageActionItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenTitle bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Title {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "title":
+			seenTitle = true
+			if err := json.UnmarshalDecode(dec, &s.Title); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTitle {
 		return fmt.Errorf("required key 'title' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Title string `json:"title"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The log message parameters.
@@ -3730,32 +5402,50 @@ type LogMessageParams struct {
 	Message string `json:"message"`
 }
 
-func (s *LogMessageParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Type    requiredProp `json:"type"`
-		Message requiredProp `json:"message"`
-	}
+func (s *LogMessageParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenType    bool
+		seenMessage bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Type {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "type":
+			seenType = true
+			if err := json.UnmarshalDecode(dec, &s.Type); err != nil {
+				return err
+			}
+		case "message":
+			seenMessage = true
+			if err := json.UnmarshalDecode(dec, &s.Message); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenType {
 		return fmt.Errorf("required key 'type' is missing")
 	}
-	if !keys.Message {
+	if !seenMessage {
 		return fmt.Errorf("required key 'message' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Type    MessageType `json:"type"`
-		Message string      `json:"message"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The parameters sent in an open text document notification
@@ -3764,27 +5454,39 @@ type DidOpenTextDocumentParams struct {
 	TextDocument *TextDocumentItem `json:"textDocument"`
 }
 
-func (s *DidOpenTextDocumentParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-	}
+func (s *DidOpenTextDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenTextDocument bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		TextDocument *TextDocumentItem `json:"textDocument"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The change text document notification's parameters.
@@ -3808,32 +5510,50 @@ type DidChangeTextDocumentParams struct {
 	ContentChanges []TextDocumentContentChangePartialOrWholeDocument `json:"contentChanges"`
 }
 
-func (s *DidChangeTextDocumentParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument   requiredProp `json:"textDocument"`
-		ContentChanges requiredProp `json:"contentChanges"`
-	}
+func (s *DidChangeTextDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument   bool
+		seenContentChanges bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "contentChanges":
+			seenContentChanges = true
+			if err := json.UnmarshalDecode(dec, &s.ContentChanges); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.ContentChanges {
+	if !seenContentChanges {
 		return fmt.Errorf("required key 'contentChanges' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		TextDocument   VersionedTextDocumentIdentifier                   `json:"textDocument"`
-		ContentChanges []TextDocumentContentChangePartialOrWholeDocument `json:"contentChanges"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Describe options to be used when registered for text document change events.
@@ -3846,32 +5566,50 @@ type TextDocumentChangeRegistrationOptions struct {
 	SyncKind TextDocumentSyncKind `json:"syncKind"`
 }
 
-func (s *TextDocumentChangeRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-		SyncKind         requiredProp `json:"syncKind"`
-	}
+func (s *TextDocumentChangeRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenDocumentSelector bool
+		seenSyncKind         bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "syncKind":
+			seenSyncKind = true
+			if err := json.UnmarshalDecode(dec, &s.SyncKind); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
-	if !keys.SyncKind {
+	if !seenSyncKind {
 		return fmt.Errorf("required key 'syncKind' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DocumentSelector DocumentSelectorOrNull `json:"documentSelector"`
-		SyncKind         TextDocumentSyncKind   `json:"syncKind"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The parameters sent in a close text document notification
@@ -3880,27 +5618,39 @@ type DidCloseTextDocumentParams struct {
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 }
 
-func (s *DidCloseTextDocumentParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-	}
+func (s *DidCloseTextDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenTextDocument bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		TextDocument TextDocumentIdentifier `json:"textDocument"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The parameters sent in a save text document notification
@@ -3913,28 +5663,43 @@ type DidSaveTextDocumentParams struct {
 	Text *string `json:"text,omitzero"`
 }
 
-func (s *DidSaveTextDocumentParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-	}
+func (s *DidSaveTextDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenTextDocument bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "text":
+			if err := json.UnmarshalDecode(dec, &s.Text); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		TextDocument TextDocumentIdentifier `json:"textDocument"`
-		Text         *string                `json:"text,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Save registration options.
@@ -3947,28 +5712,43 @@ type TextDocumentSaveRegistrationOptions struct {
 	IncludeText *bool `json:"includeText,omitzero"`
 }
 
-func (s *TextDocumentSaveRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-	}
+func (s *TextDocumentSaveRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDocumentSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "includeText":
+			if err := json.UnmarshalDecode(dec, &s.IncludeText); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DocumentSelector DocumentSelectorOrNull `json:"documentSelector"`
-		IncludeText      *bool                  `json:"includeText,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The parameters sent in a will save text document notification.
@@ -3980,32 +5760,50 @@ type WillSaveTextDocumentParams struct {
 	Reason TextDocumentSaveReason `json:"reason"`
 }
 
-func (s *WillSaveTextDocumentParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Reason       requiredProp `json:"reason"`
-	}
+func (s *WillSaveTextDocumentParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenReason       bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "reason":
+			seenReason = true
+			if err := json.UnmarshalDecode(dec, &s.Reason); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Reason {
+	if !seenReason {
 		return fmt.Errorf("required key 'reason' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		TextDocument TextDocumentIdentifier `json:"textDocument"`
-		Reason       TextDocumentSaveReason `json:"reason"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A text edit applicable to a text document.
@@ -4019,32 +5817,50 @@ type TextEdit struct {
 	NewText string `json:"newText"`
 }
 
-func (s *TextEdit) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Range   requiredProp `json:"range"`
-		NewText requiredProp `json:"newText"`
-	}
+func (s *TextEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenRange   bool
+		seenNewText bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Range {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "range":
+			seenRange = true
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		case "newText":
+			seenNewText = true
+			if err := json.UnmarshalDecode(dec, &s.NewText); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenRange {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if !keys.NewText {
+	if !seenNewText {
 		return fmt.Errorf("required key 'newText' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Range   Range  `json:"range"`
-		NewText string `json:"newText"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The watched files change notification's parameters.
@@ -4053,27 +5869,39 @@ type DidChangeWatchedFilesParams struct {
 	Changes []*FileEvent `json:"changes"`
 }
 
-func (s *DidChangeWatchedFilesParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Changes requiredProp `json:"changes"`
-	}
+func (s *DidChangeWatchedFilesParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenChanges bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Changes {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "changes":
+			seenChanges = true
+			if err := json.UnmarshalDecode(dec, &s.Changes); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenChanges {
 		return fmt.Errorf("required key 'changes' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Changes []*FileEvent `json:"changes"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Describe options to be used when registered for text document change events.
@@ -4082,27 +5910,39 @@ type DidChangeWatchedFilesRegistrationOptions struct {
 	Watchers []*FileSystemWatcher `json:"watchers"`
 }
 
-func (s *DidChangeWatchedFilesRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Watchers requiredProp `json:"watchers"`
-	}
+func (s *DidChangeWatchedFilesRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenWatchers bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Watchers {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "watchers":
+			seenWatchers = true
+			if err := json.UnmarshalDecode(dec, &s.Watchers); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenWatchers {
 		return fmt.Errorf("required key 'watchers' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Watchers []*FileSystemWatcher `json:"watchers"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The publish diagnostic notification's parameters.
@@ -4119,33 +5959,54 @@ type PublishDiagnosticsParams struct {
 	Diagnostics []*Diagnostic `json:"diagnostics"`
 }
 
-func (s *PublishDiagnosticsParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Uri         requiredProp `json:"uri"`
-		Diagnostics requiredProp `json:"diagnostics"`
-	}
+func (s *PublishDiagnosticsParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenUri         bool
+		seenDiagnostics bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Uri {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "uri":
+			seenUri = true
+			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
+				return err
+			}
+		case "version":
+			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
+				return err
+			}
+		case "diagnostics":
+			seenDiagnostics = true
+			if err := json.UnmarshalDecode(dec, &s.Diagnostics); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenUri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
-	if !keys.Diagnostics {
+	if !seenDiagnostics {
 		return fmt.Errorf("required key 'diagnostics' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Uri         DocumentUri   `json:"uri"`
-		Version     *int32        `json:"version,omitzero"`
-		Diagnostics []*Diagnostic `json:"diagnostics"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Completion parameters
@@ -4168,35 +6029,62 @@ type CompletionParams struct {
 	Context *CompletionContext `json:"context,omitzero"`
 }
 
-func (s *CompletionParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Position     requiredProp `json:"position"`
-	}
+func (s *CompletionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenPosition     bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "position":
+			seenPosition = true
+			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
+				return err
+			}
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "partialResultToken":
+			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
+				return err
+			}
+		case "context":
+			if err := json.UnmarshalDecode(dec, &s.Context); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Position {
+	if !seenPosition {
 		return fmt.Errorf("required key 'position' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		TextDocument       TextDocumentIdentifier `json:"textDocument"`
-		Position           Position               `json:"position"`
-		WorkDoneToken      *IntegerOrString       `json:"workDoneToken,omitzero"`
-		PartialResultToken *IntegerOrString       `json:"partialResultToken,omitzero"`
-		Context            *CompletionContext     `json:"context,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A completion item represents a text snippet that is
@@ -4340,45 +6228,111 @@ type CompletionItem struct {
 	Data *any `json:"data,omitzero"`
 }
 
-func (s *CompletionItem) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Label requiredProp `json:"label"`
-	}
+func (s *CompletionItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenLabel bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Label {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "label":
+			seenLabel = true
+			if err := json.UnmarshalDecode(dec, &s.Label); err != nil {
+				return err
+			}
+		case "labelDetails":
+			if err := json.UnmarshalDecode(dec, &s.LabelDetails); err != nil {
+				return err
+			}
+		case "kind":
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		case "tags":
+			if err := json.UnmarshalDecode(dec, &s.Tags); err != nil {
+				return err
+			}
+		case "detail":
+			if err := json.UnmarshalDecode(dec, &s.Detail); err != nil {
+				return err
+			}
+		case "documentation":
+			if err := json.UnmarshalDecode(dec, &s.Documentation); err != nil {
+				return err
+			}
+		case "deprecated":
+			if err := json.UnmarshalDecode(dec, &s.Deprecated); err != nil {
+				return err
+			}
+		case "preselect":
+			if err := json.UnmarshalDecode(dec, &s.Preselect); err != nil {
+				return err
+			}
+		case "sortText":
+			if err := json.UnmarshalDecode(dec, &s.SortText); err != nil {
+				return err
+			}
+		case "filterText":
+			if err := json.UnmarshalDecode(dec, &s.FilterText); err != nil {
+				return err
+			}
+		case "insertText":
+			if err := json.UnmarshalDecode(dec, &s.InsertText); err != nil {
+				return err
+			}
+		case "insertTextFormat":
+			if err := json.UnmarshalDecode(dec, &s.InsertTextFormat); err != nil {
+				return err
+			}
+		case "insertTextMode":
+			if err := json.UnmarshalDecode(dec, &s.InsertTextMode); err != nil {
+				return err
+			}
+		case "textEdit":
+			if err := json.UnmarshalDecode(dec, &s.TextEdit); err != nil {
+				return err
+			}
+		case "textEditText":
+			if err := json.UnmarshalDecode(dec, &s.TextEditText); err != nil {
+				return err
+			}
+		case "additionalTextEdits":
+			if err := json.UnmarshalDecode(dec, &s.AdditionalTextEdits); err != nil {
+				return err
+			}
+		case "commitCharacters":
+			if err := json.UnmarshalDecode(dec, &s.CommitCharacters); err != nil {
+				return err
+			}
+		case "command":
+			if err := json.UnmarshalDecode(dec, &s.Command); err != nil {
+				return err
+			}
+		case "data":
+			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenLabel {
 		return fmt.Errorf("required key 'label' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Label               string                       `json:"label"`
-		LabelDetails        *CompletionItemLabelDetails  `json:"labelDetails,omitzero"`
-		Kind                *CompletionItemKind          `json:"kind,omitzero"`
-		Tags                *[]CompletionItemTag         `json:"tags,omitzero"`
-		Detail              *string                      `json:"detail,omitzero"`
-		Documentation       *StringOrMarkupContent       `json:"documentation,omitzero"`
-		Deprecated          *bool                        `json:"deprecated,omitzero"`
-		Preselect           *bool                        `json:"preselect,omitzero"`
-		SortText            *string                      `json:"sortText,omitzero"`
-		FilterText          *string                      `json:"filterText,omitzero"`
-		InsertText          *string                      `json:"insertText,omitzero"`
-		InsertTextFormat    *InsertTextFormat            `json:"insertTextFormat,omitzero"`
-		InsertTextMode      *InsertTextMode              `json:"insertTextMode,omitzero"`
-		TextEdit            *TextEditOrInsertReplaceEdit `json:"textEdit,omitzero"`
-		TextEditText        *string                      `json:"textEditText,omitzero"`
-		AdditionalTextEdits *[]*TextEdit                 `json:"additionalTextEdits,omitzero"`
-		CommitCharacters    *[]string                    `json:"commitCharacters,omitzero"`
-		Command             *Command                     `json:"command,omitzero"`
-		Data                *any                         `json:"data,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Represents a collection of items to be presented
@@ -4430,34 +6384,58 @@ type CompletionList struct {
 	Items []*CompletionItem `json:"items"`
 }
 
-func (s *CompletionList) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		IsIncomplete requiredProp `json:"isIncomplete"`
-		Items        requiredProp `json:"items"`
-	}
+func (s *CompletionList) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenIsIncomplete bool
+		seenItems        bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.IsIncomplete {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "isIncomplete":
+			seenIsIncomplete = true
+			if err := json.UnmarshalDecode(dec, &s.IsIncomplete); err != nil {
+				return err
+			}
+		case "itemDefaults":
+			if err := json.UnmarshalDecode(dec, &s.ItemDefaults); err != nil {
+				return err
+			}
+		case "applyKind":
+			if err := json.UnmarshalDecode(dec, &s.ApplyKind); err != nil {
+				return err
+			}
+		case "items":
+			seenItems = true
+			if err := json.UnmarshalDecode(dec, &s.Items); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenIsIncomplete {
 		return fmt.Errorf("required key 'isIncomplete' is missing")
 	}
-	if !keys.Items {
+	if !seenItems {
 		return fmt.Errorf("required key 'items' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		IsIncomplete bool                      `json:"isIncomplete"`
-		ItemDefaults *CompletionItemDefaults   `json:"itemDefaults,omitzero"`
-		ApplyKind    *CompletionItemApplyKinds `json:"applyKind,omitzero"`
-		Items        []*CompletionItem         `json:"items"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Registration options for a CompletionRequest.
@@ -4499,32 +6477,59 @@ type CompletionRegistrationOptions struct {
 	CompletionItem *ServerCompletionItemOptions `json:"completionItem,omitzero"`
 }
 
-func (s *CompletionRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-	}
+func (s *CompletionRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDocumentSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		case "triggerCharacters":
+			if err := json.UnmarshalDecode(dec, &s.TriggerCharacters); err != nil {
+				return err
+			}
+		case "allCommitCharacters":
+			if err := json.UnmarshalDecode(dec, &s.AllCommitCharacters); err != nil {
+				return err
+			}
+		case "resolveProvider":
+			if err := json.UnmarshalDecode(dec, &s.ResolveProvider); err != nil {
+				return err
+			}
+		case "completionItem":
+			if err := json.UnmarshalDecode(dec, &s.CompletionItem); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DocumentSelector    DocumentSelectorOrNull       `json:"documentSelector"`
-		WorkDoneProgress    *bool                        `json:"workDoneProgress,omitzero"`
-		TriggerCharacters   *[]string                    `json:"triggerCharacters,omitzero"`
-		AllCommitCharacters *[]string                    `json:"allCommitCharacters,omitzero"`
-		ResolveProvider     *bool                        `json:"resolveProvider,omitzero"`
-		CompletionItem      *ServerCompletionItemOptions `json:"completionItem,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Parameters for a HoverRequest.
@@ -4539,33 +6544,54 @@ type HoverParams struct {
 	WorkDoneToken *IntegerOrString `json:"workDoneToken,omitzero"`
 }
 
-func (s *HoverParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Position     requiredProp `json:"position"`
-	}
+func (s *HoverParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenPosition     bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "position":
+			seenPosition = true
+			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
+				return err
+			}
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Position {
+	if !seenPosition {
 		return fmt.Errorf("required key 'position' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		TextDocument  TextDocumentIdentifier `json:"textDocument"`
-		Position      Position               `json:"position"`
-		WorkDoneToken *IntegerOrString       `json:"workDoneToken,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The result of a hover request.
@@ -4578,28 +6604,43 @@ type Hover struct {
 	Range *Range `json:"range,omitzero"`
 }
 
-func (s *Hover) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Contents requiredProp `json:"contents"`
-	}
+func (s *Hover) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenContents bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Contents {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "contents":
+			seenContents = true
+			if err := json.UnmarshalDecode(dec, &s.Contents); err != nil {
+				return err
+			}
+		case "range":
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenContents {
 		return fmt.Errorf("required key 'contents' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Contents MarkupContentOrStringOrMarkedStringWithLanguageOrMarkedStrings `json:"contents"`
-		Range    *Range                                                         `json:"range,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Registration options for a HoverRequest.
@@ -4611,28 +6652,43 @@ type HoverRegistrationOptions struct {
 	WorkDoneProgress *bool `json:"workDoneProgress,omitzero"`
 }
 
-func (s *HoverRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-	}
+func (s *HoverRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDocumentSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DocumentSelector DocumentSelectorOrNull `json:"documentSelector"`
-		WorkDoneProgress *bool                  `json:"workDoneProgress,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Parameters for a SignatureHelpRequest.
@@ -4653,34 +6709,58 @@ type SignatureHelpParams struct {
 	Context *SignatureHelpContext `json:"context,omitzero"`
 }
 
-func (s *SignatureHelpParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Position     requiredProp `json:"position"`
-	}
+func (s *SignatureHelpParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenPosition     bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "position":
+			seenPosition = true
+			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
+				return err
+			}
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "context":
+			if err := json.UnmarshalDecode(dec, &s.Context); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Position {
+	if !seenPosition {
 		return fmt.Errorf("required key 'position' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		TextDocument  TextDocumentIdentifier `json:"textDocument"`
-		Position      Position               `json:"position"`
-		WorkDoneToken *IntegerOrString       `json:"workDoneToken,omitzero"`
-		Context       *SignatureHelpContext  `json:"context,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Signature help represents the signature of something
@@ -4720,29 +6800,47 @@ type SignatureHelp struct {
 	ActiveParameter *UintegerOrNull `json:"activeParameter,omitzero"`
 }
 
-func (s *SignatureHelp) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Signatures requiredProp `json:"signatures"`
-	}
+func (s *SignatureHelp) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenSignatures bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Signatures {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "signatures":
+			seenSignatures = true
+			if err := json.UnmarshalDecode(dec, &s.Signatures); err != nil {
+				return err
+			}
+		case "activeSignature":
+			if err := json.UnmarshalDecode(dec, &s.ActiveSignature); err != nil {
+				return err
+			}
+		case "activeParameter":
+			if err := json.UnmarshalDecode(dec, &s.ActiveParameter); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenSignatures {
 		return fmt.Errorf("required key 'signatures' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Signatures      []*SignatureInformation `json:"signatures"`
-		ActiveSignature *uint32                 `json:"activeSignature,omitzero"`
-		ActiveParameter *UintegerOrNull         `json:"activeParameter,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Registration options for a SignatureHelpRequest.
@@ -4765,30 +6863,51 @@ type SignatureHelpRegistrationOptions struct {
 	RetriggerCharacters *[]string `json:"retriggerCharacters,omitzero"`
 }
 
-func (s *SignatureHelpRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-	}
+func (s *SignatureHelpRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDocumentSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		case "triggerCharacters":
+			if err := json.UnmarshalDecode(dec, &s.TriggerCharacters); err != nil {
+				return err
+			}
+		case "retriggerCharacters":
+			if err := json.UnmarshalDecode(dec, &s.RetriggerCharacters); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DocumentSelector    DocumentSelectorOrNull `json:"documentSelector"`
-		WorkDoneProgress    *bool                  `json:"workDoneProgress,omitzero"`
-		TriggerCharacters   *[]string              `json:"triggerCharacters,omitzero"`
-		RetriggerCharacters *[]string              `json:"retriggerCharacters,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Parameters for a DefinitionRequest.
@@ -4807,34 +6926,58 @@ type DefinitionParams struct {
 	PartialResultToken *IntegerOrString `json:"partialResultToken,omitzero"`
 }
 
-func (s *DefinitionParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Position     requiredProp `json:"position"`
-	}
+func (s *DefinitionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenPosition     bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "position":
+			seenPosition = true
+			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
+				return err
+			}
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "partialResultToken":
+			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Position {
+	if !seenPosition {
 		return fmt.Errorf("required key 'position' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		TextDocument       TextDocumentIdentifier `json:"textDocument"`
-		Position           Position               `json:"position"`
-		WorkDoneToken      *IntegerOrString       `json:"workDoneToken,omitzero"`
-		PartialResultToken *IntegerOrString       `json:"partialResultToken,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Registration options for a DefinitionRequest.
@@ -4846,28 +6989,43 @@ type DefinitionRegistrationOptions struct {
 	WorkDoneProgress *bool `json:"workDoneProgress,omitzero"`
 }
 
-func (s *DefinitionRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-	}
+func (s *DefinitionRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDocumentSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DocumentSelector DocumentSelectorOrNull `json:"documentSelector"`
-		WorkDoneProgress *bool                  `json:"workDoneProgress,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Parameters for a ReferencesRequest.
@@ -4888,39 +7046,67 @@ type ReferenceParams struct {
 	Context *ReferenceContext `json:"context"`
 }
 
-func (s *ReferenceParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Position     requiredProp `json:"position"`
-		Context      requiredProp `json:"context"`
-	}
+func (s *ReferenceParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenPosition     bool
+		seenContext      bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "position":
+			seenPosition = true
+			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
+				return err
+			}
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "partialResultToken":
+			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
+				return err
+			}
+		case "context":
+			seenContext = true
+			if err := json.UnmarshalDecode(dec, &s.Context); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Position {
+	if !seenPosition {
 		return fmt.Errorf("required key 'position' is missing")
 	}
-	if !keys.Context {
+	if !seenContext {
 		return fmt.Errorf("required key 'context' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		TextDocument       TextDocumentIdentifier `json:"textDocument"`
-		Position           Position               `json:"position"`
-		WorkDoneToken      *IntegerOrString       `json:"workDoneToken,omitzero"`
-		PartialResultToken *IntegerOrString       `json:"partialResultToken,omitzero"`
-		Context            *ReferenceContext      `json:"context"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Registration options for a ReferencesRequest.
@@ -4932,28 +7118,43 @@ type ReferenceRegistrationOptions struct {
 	WorkDoneProgress *bool `json:"workDoneProgress,omitzero"`
 }
 
-func (s *ReferenceRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-	}
+func (s *ReferenceRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDocumentSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DocumentSelector DocumentSelectorOrNull `json:"documentSelector"`
-		WorkDoneProgress *bool                  `json:"workDoneProgress,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Parameters for a DocumentHighlightRequest.
@@ -4972,34 +7173,58 @@ type DocumentHighlightParams struct {
 	PartialResultToken *IntegerOrString `json:"partialResultToken,omitzero"`
 }
 
-func (s *DocumentHighlightParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Position     requiredProp `json:"position"`
-	}
+func (s *DocumentHighlightParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenPosition     bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "position":
+			seenPosition = true
+			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
+				return err
+			}
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "partialResultToken":
+			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Position {
+	if !seenPosition {
 		return fmt.Errorf("required key 'position' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		TextDocument       TextDocumentIdentifier `json:"textDocument"`
-		Position           Position               `json:"position"`
-		WorkDoneToken      *IntegerOrString       `json:"workDoneToken,omitzero"`
-		PartialResultToken *IntegerOrString       `json:"partialResultToken,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A document highlight is a range inside a text document which deserves
@@ -5013,28 +7238,43 @@ type DocumentHighlight struct {
 	Kind *DocumentHighlightKind `json:"kind,omitzero"`
 }
 
-func (s *DocumentHighlight) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Range requiredProp `json:"range"`
-	}
+func (s *DocumentHighlight) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenRange bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Range {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "range":
+			seenRange = true
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		case "kind":
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenRange {
 		return fmt.Errorf("required key 'range' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Range Range                  `json:"range"`
-		Kind  *DocumentHighlightKind `json:"kind,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Registration options for a DocumentHighlightRequest.
@@ -5046,28 +7286,43 @@ type DocumentHighlightRegistrationOptions struct {
 	WorkDoneProgress *bool `json:"workDoneProgress,omitzero"`
 }
 
-func (s *DocumentHighlightRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-	}
+func (s *DocumentHighlightRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDocumentSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DocumentSelector DocumentSelectorOrNull `json:"documentSelector"`
-		WorkDoneProgress *bool                  `json:"workDoneProgress,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Parameters for a DocumentSymbolRequest.
@@ -5083,29 +7338,47 @@ type DocumentSymbolParams struct {
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 }
 
-func (s *DocumentSymbolParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-	}
+func (s *DocumentSymbolParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenTextDocument bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "partialResultToken":
+			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
+				return err
+			}
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneToken      *IntegerOrString       `json:"workDoneToken,omitzero"`
-		PartialResultToken *IntegerOrString       `json:"partialResultToken,omitzero"`
-		TextDocument       TextDocumentIdentifier `json:"textDocument"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Represents information about programming constructs like variables, classes,
@@ -5145,40 +7418,71 @@ type SymbolInformation struct {
 	Location Location `json:"location"`
 }
 
-func (s *SymbolInformation) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Name     requiredProp `json:"name"`
-		Kind     requiredProp `json:"kind"`
-		Location requiredProp `json:"location"`
-	}
+func (s *SymbolInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenName     bool
+		seenKind     bool
+		seenLocation bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Name {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "name":
+			seenName = true
+			if err := json.UnmarshalDecode(dec, &s.Name); err != nil {
+				return err
+			}
+		case "kind":
+			seenKind = true
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		case "tags":
+			if err := json.UnmarshalDecode(dec, &s.Tags); err != nil {
+				return err
+			}
+		case "containerName":
+			if err := json.UnmarshalDecode(dec, &s.ContainerName); err != nil {
+				return err
+			}
+		case "deprecated":
+			if err := json.UnmarshalDecode(dec, &s.Deprecated); err != nil {
+				return err
+			}
+		case "location":
+			seenLocation = true
+			if err := json.UnmarshalDecode(dec, &s.Location); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenName {
 		return fmt.Errorf("required key 'name' is missing")
 	}
-	if !keys.Kind {
+	if !seenKind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if !keys.Location {
+	if !seenLocation {
 		return fmt.Errorf("required key 'location' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Name          string       `json:"name"`
-		Kind          SymbolKind   `json:"kind"`
-		Tags          *[]SymbolTag `json:"tags,omitzero"`
-		ContainerName *string      `json:"containerName,omitzero"`
-		Deprecated    *bool        `json:"deprecated,omitzero"`
-		Location      Location     `json:"location"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Represents programming constructs like variables, classes, interfaces etc.
@@ -5219,46 +7523,84 @@ type DocumentSymbol struct {
 	Children *[]*DocumentSymbol `json:"children,omitzero"`
 }
 
-func (s *DocumentSymbol) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Name           requiredProp `json:"name"`
-		Kind           requiredProp `json:"kind"`
-		Range          requiredProp `json:"range"`
-		SelectionRange requiredProp `json:"selectionRange"`
-	}
+func (s *DocumentSymbol) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenName           bool
+		seenKind           bool
+		seenRange          bool
+		seenSelectionRange bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Name {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "name":
+			seenName = true
+			if err := json.UnmarshalDecode(dec, &s.Name); err != nil {
+				return err
+			}
+		case "detail":
+			if err := json.UnmarshalDecode(dec, &s.Detail); err != nil {
+				return err
+			}
+		case "kind":
+			seenKind = true
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		case "tags":
+			if err := json.UnmarshalDecode(dec, &s.Tags); err != nil {
+				return err
+			}
+		case "deprecated":
+			if err := json.UnmarshalDecode(dec, &s.Deprecated); err != nil {
+				return err
+			}
+		case "range":
+			seenRange = true
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		case "selectionRange":
+			seenSelectionRange = true
+			if err := json.UnmarshalDecode(dec, &s.SelectionRange); err != nil {
+				return err
+			}
+		case "children":
+			if err := json.UnmarshalDecode(dec, &s.Children); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenName {
 		return fmt.Errorf("required key 'name' is missing")
 	}
-	if !keys.Kind {
+	if !seenKind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if !keys.Range {
+	if !seenRange {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if !keys.SelectionRange {
+	if !seenSelectionRange {
 		return fmt.Errorf("required key 'selectionRange' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Name           string             `json:"name"`
-		Detail         *string            `json:"detail,omitzero"`
-		Kind           SymbolKind         `json:"kind"`
-		Tags           *[]SymbolTag       `json:"tags,omitzero"`
-		Deprecated     *bool              `json:"deprecated,omitzero"`
-		Range          Range              `json:"range"`
-		SelectionRange Range              `json:"selectionRange"`
-		Children       *[]*DocumentSymbol `json:"children,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Registration options for a DocumentSymbolRequest.
@@ -5276,29 +7618,47 @@ type DocumentSymbolRegistrationOptions struct {
 	Label *string `json:"label,omitzero"`
 }
 
-func (s *DocumentSymbolRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-	}
+func (s *DocumentSymbolRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDocumentSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		case "label":
+			if err := json.UnmarshalDecode(dec, &s.Label); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DocumentSelector DocumentSelectorOrNull `json:"documentSelector"`
-		WorkDoneProgress *bool                  `json:"workDoneProgress,omitzero"`
-		Label            *string                `json:"label,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The parameters of a CodeActionRequest.
@@ -5320,39 +7680,67 @@ type CodeActionParams struct {
 	Context *CodeActionContext `json:"context"`
 }
 
-func (s *CodeActionParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Range        requiredProp `json:"range"`
-		Context      requiredProp `json:"context"`
-	}
+func (s *CodeActionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenRange        bool
+		seenContext      bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "partialResultToken":
+			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
+				return err
+			}
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "range":
+			seenRange = true
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		case "context":
+			seenContext = true
+			if err := json.UnmarshalDecode(dec, &s.Context); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Range {
+	if !seenRange {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if !keys.Context {
+	if !seenContext {
 		return fmt.Errorf("required key 'context' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneToken      *IntegerOrString       `json:"workDoneToken,omitzero"`
-		PartialResultToken *IntegerOrString       `json:"partialResultToken,omitzero"`
-		TextDocument       TextDocumentIdentifier `json:"textDocument"`
-		Range              Range                  `json:"range"`
-		Context            *CodeActionContext     `json:"context"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Represents a reference to a command. Provides a title which
@@ -5378,34 +7766,58 @@ type Command struct {
 	Arguments *[]any `json:"arguments,omitzero"`
 }
 
-func (s *Command) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Title   requiredProp `json:"title"`
-		Command requiredProp `json:"command"`
-	}
+func (s *Command) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTitle   bool
+		seenCommand bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Title {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "title":
+			seenTitle = true
+			if err := json.UnmarshalDecode(dec, &s.Title); err != nil {
+				return err
+			}
+		case "tooltip":
+			if err := json.UnmarshalDecode(dec, &s.Tooltip); err != nil {
+				return err
+			}
+		case "command":
+			seenCommand = true
+			if err := json.UnmarshalDecode(dec, &s.Command); err != nil {
+				return err
+			}
+		case "arguments":
+			if err := json.UnmarshalDecode(dec, &s.Arguments); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTitle {
 		return fmt.Errorf("required key 'title' is missing")
 	}
-	if !keys.Command {
+	if !seenCommand {
 		return fmt.Errorf("required key 'command' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Title     string  `json:"title"`
-		Tooltip   *string `json:"tooltip,omitzero"`
-		Command   string  `json:"command"`
-		Arguments *[]any  `json:"arguments,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A code action represents a change that can be performed in code, e.g. to fix a problem or
@@ -5470,35 +7882,71 @@ type CodeAction struct {
 	Tags *[]CodeActionTag `json:"tags,omitzero"`
 }
 
-func (s *CodeAction) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Title requiredProp `json:"title"`
-	}
+func (s *CodeAction) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenTitle bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Title {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "title":
+			seenTitle = true
+			if err := json.UnmarshalDecode(dec, &s.Title); err != nil {
+				return err
+			}
+		case "kind":
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		case "diagnostics":
+			if err := json.UnmarshalDecode(dec, &s.Diagnostics); err != nil {
+				return err
+			}
+		case "isPreferred":
+			if err := json.UnmarshalDecode(dec, &s.IsPreferred); err != nil {
+				return err
+			}
+		case "disabled":
+			if err := json.UnmarshalDecode(dec, &s.Disabled); err != nil {
+				return err
+			}
+		case "edit":
+			if err := json.UnmarshalDecode(dec, &s.Edit); err != nil {
+				return err
+			}
+		case "command":
+			if err := json.UnmarshalDecode(dec, &s.Command); err != nil {
+				return err
+			}
+		case "data":
+			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
+				return err
+			}
+		case "tags":
+			if err := json.UnmarshalDecode(dec, &s.Tags); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTitle {
 		return fmt.Errorf("required key 'title' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Title       string              `json:"title"`
-		Kind        *CodeActionKind     `json:"kind,omitzero"`
-		Diagnostics *[]*Diagnostic      `json:"diagnostics,omitzero"`
-		IsPreferred *bool               `json:"isPreferred,omitzero"`
-		Disabled    *CodeActionDisabled `json:"disabled,omitzero"`
-		Edit        *WorkspaceEdit      `json:"edit,omitzero"`
-		Command     *Command            `json:"command,omitzero"`
-		Data        *any                `json:"data,omitzero"`
-		Tags        *[]CodeActionTag    `json:"tags,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Registration options for a CodeActionRequest.
@@ -5540,31 +7988,55 @@ type CodeActionRegistrationOptions struct {
 	ResolveProvider *bool `json:"resolveProvider,omitzero"`
 }
 
-func (s *CodeActionRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-	}
+func (s *CodeActionRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDocumentSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		case "codeActionKinds":
+			if err := json.UnmarshalDecode(dec, &s.CodeActionKinds); err != nil {
+				return err
+			}
+		case "documentation":
+			if err := json.UnmarshalDecode(dec, &s.Documentation); err != nil {
+				return err
+			}
+		case "resolveProvider":
+			if err := json.UnmarshalDecode(dec, &s.ResolveProvider); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DocumentSelector DocumentSelectorOrNull          `json:"documentSelector"`
-		WorkDoneProgress *bool                           `json:"workDoneProgress,omitzero"`
-		CodeActionKinds  *[]CodeActionKind               `json:"codeActionKinds,omitzero"`
-		Documentation    *[]*CodeActionKindDocumentation `json:"documentation,omitzero"`
-		ResolveProvider  *bool                           `json:"resolveProvider,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The parameters of a WorkspaceSymbolRequest.
@@ -5587,29 +8059,47 @@ type WorkspaceSymbolParams struct {
 	Query string `json:"query"`
 }
 
-func (s *WorkspaceSymbolParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Query requiredProp `json:"query"`
-	}
+func (s *WorkspaceSymbolParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenQuery bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Query {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "partialResultToken":
+			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
+				return err
+			}
+		case "query":
+			seenQuery = true
+			if err := json.UnmarshalDecode(dec, &s.Query); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenQuery {
 		return fmt.Errorf("required key 'query' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneToken      *IntegerOrString `json:"workDoneToken,omitzero"`
-		PartialResultToken *IntegerOrString `json:"partialResultToken,omitzero"`
-		Query              string           `json:"query"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A special workspace symbol that supports locations without a range.
@@ -5647,40 +8137,71 @@ type WorkspaceSymbol struct {
 	Data *any `json:"data,omitzero"`
 }
 
-func (s *WorkspaceSymbol) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Name     requiredProp `json:"name"`
-		Kind     requiredProp `json:"kind"`
-		Location requiredProp `json:"location"`
-	}
+func (s *WorkspaceSymbol) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenName     bool
+		seenKind     bool
+		seenLocation bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Name {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "name":
+			seenName = true
+			if err := json.UnmarshalDecode(dec, &s.Name); err != nil {
+				return err
+			}
+		case "kind":
+			seenKind = true
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		case "tags":
+			if err := json.UnmarshalDecode(dec, &s.Tags); err != nil {
+				return err
+			}
+		case "containerName":
+			if err := json.UnmarshalDecode(dec, &s.ContainerName); err != nil {
+				return err
+			}
+		case "location":
+			seenLocation = true
+			if err := json.UnmarshalDecode(dec, &s.Location); err != nil {
+				return err
+			}
+		case "data":
+			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenName {
 		return fmt.Errorf("required key 'name' is missing")
 	}
-	if !keys.Kind {
+	if !seenKind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if !keys.Location {
+	if !seenLocation {
 		return fmt.Errorf("required key 'location' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Name          string                    `json:"name"`
-		Kind          SymbolKind                `json:"kind"`
-		Tags          *[]SymbolTag              `json:"tags,omitzero"`
-		ContainerName *string                   `json:"containerName,omitzero"`
-		Location      LocationOrLocationUriOnly `json:"location"`
-		Data          *any                      `json:"data,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Registration options for a WorkspaceSymbolRequest.
@@ -5707,29 +8228,47 @@ type CodeLensParams struct {
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 }
 
-func (s *CodeLensParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-	}
+func (s *CodeLensParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenTextDocument bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "partialResultToken":
+			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
+				return err
+			}
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneToken      *IntegerOrString       `json:"workDoneToken,omitzero"`
-		PartialResultToken *IntegerOrString       `json:"partialResultToken,omitzero"`
-		TextDocument       TextDocumentIdentifier `json:"textDocument"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A code lens represents a command that should be shown along with
@@ -5749,29 +8288,47 @@ type CodeLens struct {
 	Data *any `json:"data,omitzero"`
 }
 
-func (s *CodeLens) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Range requiredProp `json:"range"`
-	}
+func (s *CodeLens) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenRange bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Range {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "range":
+			seenRange = true
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		case "command":
+			if err := json.UnmarshalDecode(dec, &s.Command); err != nil {
+				return err
+			}
+		case "data":
+			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenRange {
 		return fmt.Errorf("required key 'range' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Range   Range    `json:"range"`
-		Command *Command `json:"command,omitzero"`
-		Data    *any     `json:"data,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Registration options for a CodeLensRequest.
@@ -5786,29 +8343,47 @@ type CodeLensRegistrationOptions struct {
 	ResolveProvider *bool `json:"resolveProvider,omitzero"`
 }
 
-func (s *CodeLensRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-	}
+func (s *CodeLensRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDocumentSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		case "resolveProvider":
+			if err := json.UnmarshalDecode(dec, &s.ResolveProvider); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DocumentSelector DocumentSelectorOrNull `json:"documentSelector"`
-		WorkDoneProgress *bool                  `json:"workDoneProgress,omitzero"`
-		ResolveProvider  *bool                  `json:"resolveProvider,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The parameters of a DocumentLinkRequest.
@@ -5824,29 +8399,47 @@ type DocumentLinkParams struct {
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 }
 
-func (s *DocumentLinkParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-	}
+func (s *DocumentLinkParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenTextDocument bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "partialResultToken":
+			if err := json.UnmarshalDecode(dec, &s.PartialResultToken); err != nil {
+				return err
+			}
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneToken      *IntegerOrString       `json:"workDoneToken,omitzero"`
-		PartialResultToken *IntegerOrString       `json:"partialResultToken,omitzero"`
-		TextDocument       TextDocumentIdentifier `json:"textDocument"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A document link is a range in a text document that links to an internal or external resource, like another
@@ -5872,30 +8465,51 @@ type DocumentLink struct {
 	Data *any `json:"data,omitzero"`
 }
 
-func (s *DocumentLink) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Range requiredProp `json:"range"`
-	}
+func (s *DocumentLink) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenRange bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Range {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "range":
+			seenRange = true
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		case "target":
+			if err := json.UnmarshalDecode(dec, &s.Target); err != nil {
+				return err
+			}
+		case "tooltip":
+			if err := json.UnmarshalDecode(dec, &s.Tooltip); err != nil {
+				return err
+			}
+		case "data":
+			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenRange {
 		return fmt.Errorf("required key 'range' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Range   Range   `json:"range"`
-		Target  *URI    `json:"target,omitzero"`
-		Tooltip *string `json:"tooltip,omitzero"`
-		Data    *any    `json:"data,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Registration options for a DocumentLinkRequest.
@@ -5910,29 +8524,47 @@ type DocumentLinkRegistrationOptions struct {
 	ResolveProvider *bool `json:"resolveProvider,omitzero"`
 }
 
-func (s *DocumentLinkRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-	}
+func (s *DocumentLinkRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDocumentSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		case "resolveProvider":
+			if err := json.UnmarshalDecode(dec, &s.ResolveProvider); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DocumentSelector DocumentSelectorOrNull `json:"documentSelector"`
-		WorkDoneProgress *bool                  `json:"workDoneProgress,omitzero"`
-		ResolveProvider  *bool                  `json:"resolveProvider,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The parameters of a DocumentFormattingRequest.
@@ -5947,33 +8579,54 @@ type DocumentFormattingParams struct {
 	Options *FormattingOptions `json:"options"`
 }
 
-func (s *DocumentFormattingParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Options      requiredProp `json:"options"`
-	}
+func (s *DocumentFormattingParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenOptions      bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "options":
+			seenOptions = true
+			if err := json.UnmarshalDecode(dec, &s.Options); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Options {
+	if !seenOptions {
 		return fmt.Errorf("required key 'options' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneToken *IntegerOrString       `json:"workDoneToken,omitzero"`
-		TextDocument  TextDocumentIdentifier `json:"textDocument"`
-		Options       *FormattingOptions     `json:"options"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Registration options for a DocumentFormattingRequest.
@@ -5985,28 +8638,43 @@ type DocumentFormattingRegistrationOptions struct {
 	WorkDoneProgress *bool `json:"workDoneProgress,omitzero"`
 }
 
-func (s *DocumentFormattingRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-	}
+func (s *DocumentFormattingRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDocumentSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DocumentSelector DocumentSelectorOrNull `json:"documentSelector"`
-		WorkDoneProgress *bool                  `json:"workDoneProgress,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The parameters of a DocumentRangeFormattingRequest.
@@ -6024,38 +8692,63 @@ type DocumentRangeFormattingParams struct {
 	Options *FormattingOptions `json:"options"`
 }
 
-func (s *DocumentRangeFormattingParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Range        requiredProp `json:"range"`
-		Options      requiredProp `json:"options"`
-	}
+func (s *DocumentRangeFormattingParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenRange        bool
+		seenOptions      bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "range":
+			seenRange = true
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		case "options":
+			seenOptions = true
+			if err := json.UnmarshalDecode(dec, &s.Options); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Range {
+	if !seenRange {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if !keys.Options {
+	if !seenOptions {
 		return fmt.Errorf("required key 'options' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneToken *IntegerOrString       `json:"workDoneToken,omitzero"`
-		TextDocument  TextDocumentIdentifier `json:"textDocument"`
-		Range         Range                  `json:"range"`
-		Options       *FormattingOptions     `json:"options"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Registration options for a DocumentRangeFormattingRequest.
@@ -6074,29 +8767,47 @@ type DocumentRangeFormattingRegistrationOptions struct {
 	RangesSupport *bool `json:"rangesSupport,omitzero"`
 }
 
-func (s *DocumentRangeFormattingRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-	}
+func (s *DocumentRangeFormattingRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDocumentSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		case "rangesSupport":
+			if err := json.UnmarshalDecode(dec, &s.RangesSupport); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DocumentSelector DocumentSelectorOrNull `json:"documentSelector"`
-		WorkDoneProgress *bool                  `json:"workDoneProgress,omitzero"`
-		RangesSupport    *bool                  `json:"rangesSupport,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The parameters of a DocumentRangesFormattingRequest.
@@ -6118,38 +8829,63 @@ type DocumentRangesFormattingParams struct {
 	Options *FormattingOptions `json:"options"`
 }
 
-func (s *DocumentRangesFormattingParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Ranges       requiredProp `json:"ranges"`
-		Options      requiredProp `json:"options"`
-	}
+func (s *DocumentRangesFormattingParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenRanges       bool
+		seenOptions      bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "ranges":
+			seenRanges = true
+			if err := json.UnmarshalDecode(dec, &s.Ranges); err != nil {
+				return err
+			}
+		case "options":
+			seenOptions = true
+			if err := json.UnmarshalDecode(dec, &s.Options); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Ranges {
+	if !seenRanges {
 		return fmt.Errorf("required key 'ranges' is missing")
 	}
-	if !keys.Options {
+	if !seenOptions {
 		return fmt.Errorf("required key 'options' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneToken *IntegerOrString       `json:"workDoneToken,omitzero"`
-		TextDocument  TextDocumentIdentifier `json:"textDocument"`
-		Ranges        []Range                `json:"ranges"`
-		Options       *FormattingOptions     `json:"options"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The parameters of a DocumentOnTypeFormattingRequest.
@@ -6172,42 +8908,68 @@ type DocumentOnTypeFormattingParams struct {
 	Options *FormattingOptions `json:"options"`
 }
 
-func (s *DocumentOnTypeFormattingParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Position     requiredProp `json:"position"`
-		Ch           requiredProp `json:"ch"`
-		Options      requiredProp `json:"options"`
-	}
+func (s *DocumentOnTypeFormattingParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenPosition     bool
+		seenCh           bool
+		seenOptions      bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "position":
+			seenPosition = true
+			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
+				return err
+			}
+		case "ch":
+			seenCh = true
+			if err := json.UnmarshalDecode(dec, &s.Ch); err != nil {
+				return err
+			}
+		case "options":
+			seenOptions = true
+			if err := json.UnmarshalDecode(dec, &s.Options); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Position {
+	if !seenPosition {
 		return fmt.Errorf("required key 'position' is missing")
 	}
-	if !keys.Ch {
+	if !seenCh {
 		return fmt.Errorf("required key 'ch' is missing")
 	}
-	if !keys.Options {
+	if !seenOptions {
 		return fmt.Errorf("required key 'options' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		TextDocument TextDocumentIdentifier `json:"textDocument"`
-		Position     Position               `json:"position"`
-		Ch           string                 `json:"ch"`
-		Options      *FormattingOptions     `json:"options"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Registration options for a DocumentOnTypeFormattingRequest.
@@ -6223,33 +8985,54 @@ type DocumentOnTypeFormattingRegistrationOptions struct {
 	MoreTriggerCharacter *[]string `json:"moreTriggerCharacter,omitzero"`
 }
 
-func (s *DocumentOnTypeFormattingRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector      requiredProp `json:"documentSelector"`
-		FirstTriggerCharacter requiredProp `json:"firstTriggerCharacter"`
-	}
+func (s *DocumentOnTypeFormattingRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenDocumentSelector      bool
+		seenFirstTriggerCharacter bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "firstTriggerCharacter":
+			seenFirstTriggerCharacter = true
+			if err := json.UnmarshalDecode(dec, &s.FirstTriggerCharacter); err != nil {
+				return err
+			}
+		case "moreTriggerCharacter":
+			if err := json.UnmarshalDecode(dec, &s.MoreTriggerCharacter); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
-	if !keys.FirstTriggerCharacter {
+	if !seenFirstTriggerCharacter {
 		return fmt.Errorf("required key 'firstTriggerCharacter' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DocumentSelector      DocumentSelectorOrNull `json:"documentSelector"`
-		FirstTriggerCharacter string                 `json:"firstTriggerCharacter"`
-		MoreTriggerCharacter  *[]string              `json:"moreTriggerCharacter,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The parameters of a RenameRequest.
@@ -6269,38 +9052,63 @@ type RenameParams struct {
 	NewName string `json:"newName"`
 }
 
-func (s *RenameParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Position     requiredProp `json:"position"`
-		NewName      requiredProp `json:"newName"`
-	}
+func (s *RenameParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenPosition     bool
+		seenNewName      bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "position":
+			seenPosition = true
+			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
+				return err
+			}
+		case "newName":
+			seenNewName = true
+			if err := json.UnmarshalDecode(dec, &s.NewName); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Position {
+	if !seenPosition {
 		return fmt.Errorf("required key 'position' is missing")
 	}
-	if !keys.NewName {
+	if !seenNewName {
 		return fmt.Errorf("required key 'newName' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneToken *IntegerOrString       `json:"workDoneToken,omitzero"`
-		TextDocument  TextDocumentIdentifier `json:"textDocument"`
-		Position      Position               `json:"position"`
-		NewName       string                 `json:"newName"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Registration options for a RenameRequest.
@@ -6317,29 +9125,47 @@ type RenameRegistrationOptions struct {
 	PrepareProvider *bool `json:"prepareProvider,omitzero"`
 }
 
-func (s *RenameRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DocumentSelector requiredProp `json:"documentSelector"`
-	}
+func (s *RenameRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDocumentSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DocumentSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "documentSelector":
+			seenDocumentSelector = true
+			if err := json.UnmarshalDecode(dec, &s.DocumentSelector); err != nil {
+				return err
+			}
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		case "prepareProvider":
+			if err := json.UnmarshalDecode(dec, &s.PrepareProvider); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocumentSelector {
 		return fmt.Errorf("required key 'documentSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DocumentSelector DocumentSelectorOrNull `json:"documentSelector"`
-		WorkDoneProgress *bool                  `json:"workDoneProgress,omitzero"`
-		PrepareProvider  *bool                  `json:"prepareProvider,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type PrepareRenameParams struct {
@@ -6353,33 +9179,54 @@ type PrepareRenameParams struct {
 	WorkDoneToken *IntegerOrString `json:"workDoneToken,omitzero"`
 }
 
-func (s *PrepareRenameParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Position     requiredProp `json:"position"`
-	}
+func (s *PrepareRenameParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenPosition     bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "position":
+			seenPosition = true
+			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
+				return err
+			}
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Position {
+	if !seenPosition {
 		return fmt.Errorf("required key 'position' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		TextDocument  TextDocumentIdentifier `json:"textDocument"`
-		Position      Position               `json:"position"`
-		WorkDoneToken *IntegerOrString       `json:"workDoneToken,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The parameters of a ExecuteCommandRequest.
@@ -6394,29 +9241,47 @@ type ExecuteCommandParams struct {
 	Arguments *[]any `json:"arguments,omitzero"`
 }
 
-func (s *ExecuteCommandParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Command requiredProp `json:"command"`
-	}
+func (s *ExecuteCommandParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenCommand bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Command {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "command":
+			seenCommand = true
+			if err := json.UnmarshalDecode(dec, &s.Command); err != nil {
+				return err
+			}
+		case "arguments":
+			if err := json.UnmarshalDecode(dec, &s.Arguments); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenCommand {
 		return fmt.Errorf("required key 'command' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneToken *IntegerOrString `json:"workDoneToken,omitzero"`
-		Command       string           `json:"command"`
-		Arguments     *[]any           `json:"arguments,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Registration options for a ExecuteCommandRequest.
@@ -6427,28 +9292,43 @@ type ExecuteCommandRegistrationOptions struct {
 	Commands []string `json:"commands"`
 }
 
-func (s *ExecuteCommandRegistrationOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Commands requiredProp `json:"commands"`
-	}
+func (s *ExecuteCommandRegistrationOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenCommands bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Commands {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		case "commands":
+			seenCommands = true
+			if err := json.UnmarshalDecode(dec, &s.Commands); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenCommands {
 		return fmt.Errorf("required key 'commands' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneProgress *bool    `json:"workDoneProgress,omitzero"`
-		Commands         []string `json:"commands"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The parameters passed via an apply workspace edit request.
@@ -6469,29 +9349,47 @@ type ApplyWorkspaceEditParams struct {
 	Metadata *WorkspaceEditMetadata `json:"metadata,omitzero"`
 }
 
-func (s *ApplyWorkspaceEditParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Edit requiredProp `json:"edit"`
-	}
+func (s *ApplyWorkspaceEditParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenEdit bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Edit {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "label":
+			if err := json.UnmarshalDecode(dec, &s.Label); err != nil {
+				return err
+			}
+		case "edit":
+			seenEdit = true
+			if err := json.UnmarshalDecode(dec, &s.Edit); err != nil {
+				return err
+			}
+		case "metadata":
+			if err := json.UnmarshalDecode(dec, &s.Metadata); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenEdit {
 		return fmt.Errorf("required key 'edit' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Label    *string                `json:"label,omitzero"`
-		Edit     *WorkspaceEdit         `json:"edit"`
-		Metadata *WorkspaceEditMetadata `json:"metadata,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The result returned from the apply workspace edit request.
@@ -6512,29 +9410,47 @@ type ApplyWorkspaceEditResult struct {
 	FailedChange *uint32 `json:"failedChange,omitzero"`
 }
 
-func (s *ApplyWorkspaceEditResult) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Applied requiredProp `json:"applied"`
-	}
+func (s *ApplyWorkspaceEditResult) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenApplied bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Applied {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "applied":
+			seenApplied = true
+			if err := json.UnmarshalDecode(dec, &s.Applied); err != nil {
+				return err
+			}
+		case "failureReason":
+			if err := json.UnmarshalDecode(dec, &s.FailureReason); err != nil {
+				return err
+			}
+		case "failedChange":
+			if err := json.UnmarshalDecode(dec, &s.FailedChange); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenApplied {
 		return fmt.Errorf("required key 'applied' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Applied       bool    `json:"applied"`
-		FailureReason *string `json:"failureReason,omitzero"`
-		FailedChange  *uint32 `json:"failedChange,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type WorkDoneProgressBegin struct {
@@ -6567,35 +9483,62 @@ type WorkDoneProgressBegin struct {
 	Percentage *uint32 `json:"percentage,omitzero"`
 }
 
-func (s *WorkDoneProgressBegin) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Kind  requiredProp `json:"kind"`
-		Title requiredProp `json:"title"`
-	}
+func (s *WorkDoneProgressBegin) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenKind  bool
+		seenTitle bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Kind {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "kind":
+			seenKind = true
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		case "title":
+			seenTitle = true
+			if err := json.UnmarshalDecode(dec, &s.Title); err != nil {
+				return err
+			}
+		case "cancellable":
+			if err := json.UnmarshalDecode(dec, &s.Cancellable); err != nil {
+				return err
+			}
+		case "message":
+			if err := json.UnmarshalDecode(dec, &s.Message); err != nil {
+				return err
+			}
+		case "percentage":
+			if err := json.UnmarshalDecode(dec, &s.Percentage); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenKind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if !keys.Title {
+	if !seenTitle {
 		return fmt.Errorf("required key 'title' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Kind        StringLiteralBegin `json:"kind"`
-		Title       string             `json:"title"`
-		Cancellable *bool              `json:"cancellable,omitzero"`
-		Message     *string            `json:"message,omitzero"`
-		Percentage  *uint32            `json:"percentage,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type WorkDoneProgressReport struct {
@@ -6623,30 +9566,51 @@ type WorkDoneProgressReport struct {
 	Percentage *uint32 `json:"percentage,omitzero"`
 }
 
-func (s *WorkDoneProgressReport) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Kind requiredProp `json:"kind"`
-	}
+func (s *WorkDoneProgressReport) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenKind bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Kind {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "kind":
+			seenKind = true
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		case "cancellable":
+			if err := json.UnmarshalDecode(dec, &s.Cancellable); err != nil {
+				return err
+			}
+		case "message":
+			if err := json.UnmarshalDecode(dec, &s.Message); err != nil {
+				return err
+			}
+		case "percentage":
+			if err := json.UnmarshalDecode(dec, &s.Percentage); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenKind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Kind        StringLiteralReport `json:"kind"`
-		Cancellable *bool               `json:"cancellable,omitzero"`
-		Message     *string             `json:"message,omitzero"`
-		Percentage  *uint32             `json:"percentage,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type WorkDoneProgressEnd struct {
@@ -6657,55 +9621,82 @@ type WorkDoneProgressEnd struct {
 	Message *string `json:"message,omitzero"`
 }
 
-func (s *WorkDoneProgressEnd) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Kind requiredProp `json:"kind"`
-	}
+func (s *WorkDoneProgressEnd) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenKind bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Kind {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "kind":
+			seenKind = true
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		case "message":
+			if err := json.UnmarshalDecode(dec, &s.Message); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenKind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Kind    StringLiteralEnd `json:"kind"`
-		Message *string          `json:"message,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type SetTraceParams struct {
 	Value TraceValue `json:"value"`
 }
 
-func (s *SetTraceParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Value requiredProp `json:"value"`
-	}
+func (s *SetTraceParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenValue bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Value {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "value":
+			seenValue = true
+			if err := json.UnmarshalDecode(dec, &s.Value); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenValue {
 		return fmt.Errorf("required key 'value' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Value TraceValue `json:"value"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type LogTraceParams struct {
@@ -6714,28 +9705,43 @@ type LogTraceParams struct {
 	Verbose *string `json:"verbose,omitzero"`
 }
 
-func (s *LogTraceParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Message requiredProp `json:"message"`
-	}
+func (s *LogTraceParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenMessage bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Message {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "message":
+			seenMessage = true
+			if err := json.UnmarshalDecode(dec, &s.Message); err != nil {
+				return err
+			}
+		case "verbose":
+			if err := json.UnmarshalDecode(dec, &s.Verbose); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenMessage {
 		return fmt.Errorf("required key 'message' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Message string  `json:"message"`
-		Verbose *string `json:"verbose,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type CancelParams struct {
@@ -6743,27 +9749,39 @@ type CancelParams struct {
 	Id IntegerOrString `json:"id"`
 }
 
-func (s *CancelParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Id requiredProp `json:"id"`
-	}
+func (s *CancelParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenId bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Id {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "id":
+			seenId = true
+			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenId {
 		return fmt.Errorf("required key 'id' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Id IntegerOrString `json:"id"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type ProgressParams struct {
@@ -6774,32 +9792,50 @@ type ProgressParams struct {
 	Value any `json:"value"`
 }
 
-func (s *ProgressParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Token requiredProp `json:"token"`
-		Value requiredProp `json:"value"`
-	}
+func (s *ProgressParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenToken bool
+		seenValue bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Token {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "token":
+			seenToken = true
+			if err := json.UnmarshalDecode(dec, &s.Token); err != nil {
+				return err
+			}
+		case "value":
+			seenValue = true
+			if err := json.UnmarshalDecode(dec, &s.Value); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenToken {
 		return fmt.Errorf("required key 'token' is missing")
 	}
-	if !keys.Value {
+	if !seenValue {
 		return fmt.Errorf("required key 'value' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Token IntegerOrString `json:"token"`
-		Value any             `json:"value"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A parameter literal used in requests to pass a text document and a position inside that
@@ -6812,32 +9848,50 @@ type TextDocumentPositionParams struct {
 	Position Position `json:"position"`
 }
 
-func (s *TextDocumentPositionParams) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Position     requiredProp `json:"position"`
-	}
+func (s *TextDocumentPositionParams) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenPosition     bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "position":
+			seenPosition = true
+			if err := json.UnmarshalDecode(dec, &s.Position); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Position {
+	if !seenPosition {
 		return fmt.Errorf("required key 'position' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		TextDocument TextDocumentIdentifier `json:"textDocument"`
-		Position     Position               `json:"position"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type WorkDoneProgressParams struct {
@@ -6873,38 +9927,63 @@ type LocationLink struct {
 	TargetSelectionRange Range `json:"targetSelectionRange"`
 }
 
-func (s *LocationLink) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TargetUri            requiredProp `json:"targetUri"`
-		TargetRange          requiredProp `json:"targetRange"`
-		TargetSelectionRange requiredProp `json:"targetSelectionRange"`
-	}
+func (s *LocationLink) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTargetUri            bool
+		seenTargetRange          bool
+		seenTargetSelectionRange bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TargetUri {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "originSelectionRange":
+			if err := json.UnmarshalDecode(dec, &s.OriginSelectionRange); err != nil {
+				return err
+			}
+		case "targetUri":
+			seenTargetUri = true
+			if err := json.UnmarshalDecode(dec, &s.TargetUri); err != nil {
+				return err
+			}
+		case "targetRange":
+			seenTargetRange = true
+			if err := json.UnmarshalDecode(dec, &s.TargetRange); err != nil {
+				return err
+			}
+		case "targetSelectionRange":
+			seenTargetSelectionRange = true
+			if err := json.UnmarshalDecode(dec, &s.TargetSelectionRange); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTargetUri {
 		return fmt.Errorf("required key 'targetUri' is missing")
 	}
-	if !keys.TargetRange {
+	if !seenTargetRange {
 		return fmt.Errorf("required key 'targetRange' is missing")
 	}
-	if !keys.TargetSelectionRange {
+	if !seenTargetSelectionRange {
 		return fmt.Errorf("required key 'targetSelectionRange' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		OriginSelectionRange *Range      `json:"originSelectionRange,omitzero"`
-		TargetUri            DocumentUri `json:"targetUri"`
-		TargetRange          Range       `json:"targetRange"`
-		TargetSelectionRange Range       `json:"targetSelectionRange"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A range in a text document expressed as (zero-based) start and end positions.
@@ -6928,32 +10007,50 @@ type Range struct {
 	End Position `json:"end"`
 }
 
-func (s *Range) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Start requiredProp `json:"start"`
-		End   requiredProp `json:"end"`
-	}
+func (s *Range) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenStart bool
+		seenEnd   bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Start {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "start":
+			seenStart = true
+			if err := json.UnmarshalDecode(dec, &s.Start); err != nil {
+				return err
+			}
+		case "end":
+			seenEnd = true
+			if err := json.UnmarshalDecode(dec, &s.End); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenStart {
 		return fmt.Errorf("required key 'start' is missing")
 	}
-	if !keys.End {
+	if !seenEnd {
 		return fmt.Errorf("required key 'end' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Start Position `json:"start"`
-		End   Position `json:"end"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type ImplementationOptions struct {
@@ -6981,32 +10078,50 @@ type WorkspaceFoldersChangeEvent struct {
 	Removed []*WorkspaceFolder `json:"removed"`
 }
 
-func (s *WorkspaceFoldersChangeEvent) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Added   requiredProp `json:"added"`
-		Removed requiredProp `json:"removed"`
-	}
+func (s *WorkspaceFoldersChangeEvent) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenAdded   bool
+		seenRemoved bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Added {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "added":
+			seenAdded = true
+			if err := json.UnmarshalDecode(dec, &s.Added); err != nil {
+				return err
+			}
+		case "removed":
+			seenRemoved = true
+			if err := json.UnmarshalDecode(dec, &s.Removed); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenAdded {
 		return fmt.Errorf("required key 'added' is missing")
 	}
-	if !keys.Removed {
+	if !seenRemoved {
 		return fmt.Errorf("required key 'removed' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Added   []*WorkspaceFolder `json:"added"`
-		Removed []*WorkspaceFolder `json:"removed"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type ConfigurationItem struct {
@@ -7023,27 +10138,39 @@ type TextDocumentIdentifier struct {
 	Uri DocumentUri `json:"uri"`
 }
 
-func (s *TextDocumentIdentifier) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Uri requiredProp `json:"uri"`
-	}
+func (s *TextDocumentIdentifier) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenUri bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Uri {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "uri":
+			seenUri = true
+			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenUri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Uri DocumentUri `json:"uri"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Represents a color in RGBA space.
@@ -7061,42 +10188,68 @@ type Color struct {
 	Alpha float64 `json:"alpha"`
 }
 
-func (s *Color) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Red   requiredProp `json:"red"`
-		Green requiredProp `json:"green"`
-		Blue  requiredProp `json:"blue"`
-		Alpha requiredProp `json:"alpha"`
-	}
+func (s *Color) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenRed   bool
+		seenGreen bool
+		seenBlue  bool
+		seenAlpha bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Red {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "red":
+			seenRed = true
+			if err := json.UnmarshalDecode(dec, &s.Red); err != nil {
+				return err
+			}
+		case "green":
+			seenGreen = true
+			if err := json.UnmarshalDecode(dec, &s.Green); err != nil {
+				return err
+			}
+		case "blue":
+			seenBlue = true
+			if err := json.UnmarshalDecode(dec, &s.Blue); err != nil {
+				return err
+			}
+		case "alpha":
+			seenAlpha = true
+			if err := json.UnmarshalDecode(dec, &s.Alpha); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenRed {
 		return fmt.Errorf("required key 'red' is missing")
 	}
-	if !keys.Green {
+	if !seenGreen {
 		return fmt.Errorf("required key 'green' is missing")
 	}
-	if !keys.Blue {
+	if !seenBlue {
 		return fmt.Errorf("required key 'blue' is missing")
 	}
-	if !keys.Alpha {
+	if !seenAlpha {
 		return fmt.Errorf("required key 'alpha' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Red   float64 `json:"red"`
-		Green float64 `json:"green"`
-		Blue  float64 `json:"blue"`
-		Alpha float64 `json:"alpha"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type DocumentColorOptions struct {
@@ -7149,32 +10302,50 @@ type Position struct {
 	Character uint32 `json:"character"`
 }
 
-func (s *Position) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Line      requiredProp `json:"line"`
-		Character requiredProp `json:"character"`
-	}
+func (s *Position) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenLine      bool
+		seenCharacter bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Line {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "line":
+			seenLine = true
+			if err := json.UnmarshalDecode(dec, &s.Line); err != nil {
+				return err
+			}
+		case "character":
+			seenCharacter = true
+			if err := json.UnmarshalDecode(dec, &s.Character); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenLine {
 		return fmt.Errorf("required key 'line' is missing")
 	}
-	if !keys.Character {
+	if !seenCharacter {
 		return fmt.Errorf("required key 'character' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Line      uint32 `json:"line"`
-		Character uint32 `json:"character"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type SelectionRangeOptions struct {
@@ -7203,30 +10374,51 @@ type SemanticTokensOptions struct {
 	Full *BooleanOrSemanticTokensFullDelta `json:"full,omitzero"`
 }
 
-func (s *SemanticTokensOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Legend requiredProp `json:"legend"`
-	}
+func (s *SemanticTokensOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenLegend bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Legend {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		case "legend":
+			seenLegend = true
+			if err := json.UnmarshalDecode(dec, &s.Legend); err != nil {
+				return err
+			}
+		case "range":
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		case "full":
+			if err := json.UnmarshalDecode(dec, &s.Full); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenLegend {
 		return fmt.Errorf("required key 'legend' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneProgress *bool                             `json:"workDoneProgress,omitzero"`
-		Legend           *SemanticTokensLegend             `json:"legend"`
-		Range            *BooleanOrEmptyObject             `json:"range,omitzero"`
-		Full             *BooleanOrSemanticTokensFullDelta `json:"full,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.16.0
@@ -7241,33 +10433,54 @@ type SemanticTokensEdit struct {
 	Data *[]uint32 `json:"data,omitzero"`
 }
 
-func (s *SemanticTokensEdit) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Start       requiredProp `json:"start"`
-		DeleteCount requiredProp `json:"deleteCount"`
-	}
+func (s *SemanticTokensEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenStart       bool
+		seenDeleteCount bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Start {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "start":
+			seenStart = true
+			if err := json.UnmarshalDecode(dec, &s.Start); err != nil {
+				return err
+			}
+		case "deleteCount":
+			seenDeleteCount = true
+			if err := json.UnmarshalDecode(dec, &s.DeleteCount); err != nil {
+				return err
+			}
+		case "data":
+			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenStart {
 		return fmt.Errorf("required key 'start' is missing")
 	}
-	if !keys.DeleteCount {
+	if !seenDeleteCount {
 		return fmt.Errorf("required key 'deleteCount' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Start       uint32    `json:"start"`
-		DeleteCount uint32    `json:"deleteCount"`
-		Data        *[]uint32 `json:"data,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type LinkedEditingRangeOptions struct {
@@ -7282,27 +10495,39 @@ type FileCreate struct {
 	Uri string `json:"uri"`
 }
 
-func (s *FileCreate) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Uri requiredProp `json:"uri"`
-	}
+func (s *FileCreate) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenUri bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Uri {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "uri":
+			seenUri = true
+			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenUri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Uri string `json:"uri"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Describes textual changes on a text document. A TextDocumentEdit describes all changes
@@ -7323,32 +10548,50 @@ type TextDocumentEdit struct {
 	Edits []TextEditOrAnnotatedTextEditOrSnippetTextEdit `json:"edits"`
 }
 
-func (s *TextDocumentEdit) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TextDocument requiredProp `json:"textDocument"`
-		Edits        requiredProp `json:"edits"`
-	}
+func (s *TextDocumentEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTextDocument bool
+		seenEdits        bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TextDocument {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "textDocument":
+			seenTextDocument = true
+			if err := json.UnmarshalDecode(dec, &s.TextDocument); err != nil {
+				return err
+			}
+		case "edits":
+			seenEdits = true
+			if err := json.UnmarshalDecode(dec, &s.Edits); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTextDocument {
 		return fmt.Errorf("required key 'textDocument' is missing")
 	}
-	if !keys.Edits {
+	if !seenEdits {
 		return fmt.Errorf("required key 'edits' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		TextDocument OptionalVersionedTextDocumentIdentifier        `json:"textDocument"`
-		Edits        []TextEditOrAnnotatedTextEditOrSnippetTextEdit `json:"edits"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Create file operation.
@@ -7368,34 +10611,58 @@ type CreateFile struct {
 	Options *CreateFileOptions `json:"options,omitzero"`
 }
 
-func (s *CreateFile) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Kind requiredProp `json:"kind"`
-		Uri  requiredProp `json:"uri"`
-	}
+func (s *CreateFile) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenKind bool
+		seenUri  bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Kind {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "kind":
+			seenKind = true
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		case "annotationId":
+			if err := json.UnmarshalDecode(dec, &s.AnnotationId); err != nil {
+				return err
+			}
+		case "uri":
+			seenUri = true
+			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
+				return err
+			}
+		case "options":
+			if err := json.UnmarshalDecode(dec, &s.Options); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenKind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if !keys.Uri {
+	if !seenUri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Kind         StringLiteralCreate `json:"kind"`
-		AnnotationId *string             `json:"annotationId,omitzero"`
-		Uri          DocumentUri         `json:"uri"`
-		Options      *CreateFileOptions  `json:"options,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Rename file operation
@@ -7418,39 +10685,67 @@ type RenameFile struct {
 	Options *RenameFileOptions `json:"options,omitzero"`
 }
 
-func (s *RenameFile) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Kind   requiredProp `json:"kind"`
-		OldUri requiredProp `json:"oldUri"`
-		NewUri requiredProp `json:"newUri"`
-	}
+func (s *RenameFile) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenKind   bool
+		seenOldUri bool
+		seenNewUri bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Kind {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "kind":
+			seenKind = true
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		case "annotationId":
+			if err := json.UnmarshalDecode(dec, &s.AnnotationId); err != nil {
+				return err
+			}
+		case "oldUri":
+			seenOldUri = true
+			if err := json.UnmarshalDecode(dec, &s.OldUri); err != nil {
+				return err
+			}
+		case "newUri":
+			seenNewUri = true
+			if err := json.UnmarshalDecode(dec, &s.NewUri); err != nil {
+				return err
+			}
+		case "options":
+			if err := json.UnmarshalDecode(dec, &s.Options); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenKind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if !keys.OldUri {
+	if !seenOldUri {
 		return fmt.Errorf("required key 'oldUri' is missing")
 	}
-	if !keys.NewUri {
+	if !seenNewUri {
 		return fmt.Errorf("required key 'newUri' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Kind         StringLiteralRename `json:"kind"`
-		AnnotationId *string             `json:"annotationId,omitzero"`
-		OldUri       DocumentUri         `json:"oldUri"`
-		NewUri       DocumentUri         `json:"newUri"`
-		Options      *RenameFileOptions  `json:"options,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Delete file operation
@@ -7470,34 +10765,58 @@ type DeleteFile struct {
 	Options *DeleteFileOptions `json:"options,omitzero"`
 }
 
-func (s *DeleteFile) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Kind requiredProp `json:"kind"`
-		Uri  requiredProp `json:"uri"`
-	}
+func (s *DeleteFile) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenKind bool
+		seenUri  bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Kind {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "kind":
+			seenKind = true
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		case "annotationId":
+			if err := json.UnmarshalDecode(dec, &s.AnnotationId); err != nil {
+				return err
+			}
+		case "uri":
+			seenUri = true
+			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
+				return err
+			}
+		case "options":
+			if err := json.UnmarshalDecode(dec, &s.Options); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenKind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if !keys.Uri {
+	if !seenUri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Kind         StringLiteralDelete `json:"kind"`
-		AnnotationId *string             `json:"annotationId,omitzero"`
-		Uri          DocumentUri         `json:"uri"`
-		Options      *DeleteFileOptions  `json:"options,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Additional information that describes document changes.
@@ -7517,29 +10836,47 @@ type ChangeAnnotation struct {
 	Description *string `json:"description,omitzero"`
 }
 
-func (s *ChangeAnnotation) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Label requiredProp `json:"label"`
-	}
+func (s *ChangeAnnotation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenLabel bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Label {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "label":
+			seenLabel = true
+			if err := json.UnmarshalDecode(dec, &s.Label); err != nil {
+				return err
+			}
+		case "needsConfirmation":
+			if err := json.UnmarshalDecode(dec, &s.NeedsConfirmation); err != nil {
+				return err
+			}
+		case "description":
+			if err := json.UnmarshalDecode(dec, &s.Description); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenLabel {
 		return fmt.Errorf("required key 'label' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Label             string  `json:"label"`
-		NeedsConfirmation *bool   `json:"needsConfirmation,omitzero"`
-		Description       *string `json:"description,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A filter to describe in which file operation requests or notifications
@@ -7554,28 +10891,43 @@ type FileOperationFilter struct {
 	Pattern *FileOperationPattern `json:"pattern"`
 }
 
-func (s *FileOperationFilter) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Pattern requiredProp `json:"pattern"`
-	}
+func (s *FileOperationFilter) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenPattern bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Pattern {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "scheme":
+			if err := json.UnmarshalDecode(dec, &s.Scheme); err != nil {
+				return err
+			}
+		case "pattern":
+			seenPattern = true
+			if err := json.UnmarshalDecode(dec, &s.Pattern); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenPattern {
 		return fmt.Errorf("required key 'pattern' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Scheme  *string               `json:"scheme,omitzero"`
-		Pattern *FileOperationPattern `json:"pattern"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Represents information on a file/folder rename.
@@ -7589,32 +10941,50 @@ type FileRename struct {
 	NewUri string `json:"newUri"`
 }
 
-func (s *FileRename) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		OldUri requiredProp `json:"oldUri"`
-		NewUri requiredProp `json:"newUri"`
-	}
+func (s *FileRename) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenOldUri bool
+		seenNewUri bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.OldUri {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "oldUri":
+			seenOldUri = true
+			if err := json.UnmarshalDecode(dec, &s.OldUri); err != nil {
+				return err
+			}
+		case "newUri":
+			seenNewUri = true
+			if err := json.UnmarshalDecode(dec, &s.NewUri); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenOldUri {
 		return fmt.Errorf("required key 'oldUri' is missing")
 	}
-	if !keys.NewUri {
+	if !seenNewUri {
 		return fmt.Errorf("required key 'newUri' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		OldUri string `json:"oldUri"`
-		NewUri string `json:"newUri"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Represents information on a file/folder delete.
@@ -7625,27 +10995,39 @@ type FileDelete struct {
 	Uri string `json:"uri"`
 }
 
-func (s *FileDelete) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Uri requiredProp `json:"uri"`
-	}
+func (s *FileDelete) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenUri bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Uri {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "uri":
+			seenUri = true
+			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenUri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Uri string `json:"uri"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type MonikerOptions struct {
@@ -7669,32 +11051,50 @@ type InlineValueContext struct {
 	StoppedLocation Range `json:"stoppedLocation"`
 }
 
-func (s *InlineValueContext) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		FrameId         requiredProp `json:"frameId"`
-		StoppedLocation requiredProp `json:"stoppedLocation"`
-	}
+func (s *InlineValueContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenFrameId         bool
+		seenStoppedLocation bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.FrameId {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "frameId":
+			seenFrameId = true
+			if err := json.UnmarshalDecode(dec, &s.FrameId); err != nil {
+				return err
+			}
+		case "stoppedLocation":
+			seenStoppedLocation = true
+			if err := json.UnmarshalDecode(dec, &s.StoppedLocation); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenFrameId {
 		return fmt.Errorf("required key 'frameId' is missing")
 	}
-	if !keys.StoppedLocation {
+	if !seenStoppedLocation {
 		return fmt.Errorf("required key 'stoppedLocation' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		FrameId         int32 `json:"frameId"`
-		StoppedLocation Range `json:"stoppedLocation"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Provide inline value as text.
@@ -7708,32 +11108,50 @@ type InlineValueText struct {
 	Text string `json:"text"`
 }
 
-func (s *InlineValueText) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Range requiredProp `json:"range"`
-		Text  requiredProp `json:"text"`
-	}
+func (s *InlineValueText) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenRange bool
+		seenText  bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Range {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "range":
+			seenRange = true
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		case "text":
+			seenText = true
+			if err := json.UnmarshalDecode(dec, &s.Text); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenRange {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if !keys.Text {
+	if !seenText {
 		return fmt.Errorf("required key 'text' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Range Range  `json:"range"`
-		Text  string `json:"text"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Provide inline value through a variable lookup.
@@ -7753,33 +11171,54 @@ type InlineValueVariableLookup struct {
 	CaseSensitiveLookup bool `json:"caseSensitiveLookup"`
 }
 
-func (s *InlineValueVariableLookup) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Range               requiredProp `json:"range"`
-		CaseSensitiveLookup requiredProp `json:"caseSensitiveLookup"`
-	}
+func (s *InlineValueVariableLookup) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenRange               bool
+		seenCaseSensitiveLookup bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Range {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "range":
+			seenRange = true
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		case "variableName":
+			if err := json.UnmarshalDecode(dec, &s.VariableName); err != nil {
+				return err
+			}
+		case "caseSensitiveLookup":
+			seenCaseSensitiveLookup = true
+			if err := json.UnmarshalDecode(dec, &s.CaseSensitiveLookup); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenRange {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if !keys.CaseSensitiveLookup {
+	if !seenCaseSensitiveLookup {
 		return fmt.Errorf("required key 'caseSensitiveLookup' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Range               Range   `json:"range"`
-		VariableName        *string `json:"variableName,omitzero"`
-		CaseSensitiveLookup bool    `json:"caseSensitiveLookup"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Provide an inline value through an expression evaluation.
@@ -7796,28 +11235,43 @@ type InlineValueEvaluatableExpression struct {
 	Expression *string `json:"expression,omitzero"`
 }
 
-func (s *InlineValueEvaluatableExpression) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Range requiredProp `json:"range"`
-	}
+func (s *InlineValueEvaluatableExpression) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenRange bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Range {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "range":
+			seenRange = true
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		case "expression":
+			if err := json.UnmarshalDecode(dec, &s.Expression); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenRange {
 		return fmt.Errorf("required key 'range' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Range      Range   `json:"range"`
-		Expression *string `json:"expression,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Inline value options used during static registration.
@@ -7860,30 +11314,51 @@ type InlayHintLabelPart struct {
 	Command *Command `json:"command,omitzero"`
 }
 
-func (s *InlayHintLabelPart) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Value requiredProp `json:"value"`
-	}
+func (s *InlayHintLabelPart) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenValue bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Value {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "value":
+			seenValue = true
+			if err := json.UnmarshalDecode(dec, &s.Value); err != nil {
+				return err
+			}
+		case "tooltip":
+			if err := json.UnmarshalDecode(dec, &s.Tooltip); err != nil {
+				return err
+			}
+		case "location":
+			if err := json.UnmarshalDecode(dec, &s.Location); err != nil {
+				return err
+			}
+		case "command":
+			if err := json.UnmarshalDecode(dec, &s.Command); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenValue {
 		return fmt.Errorf("required key 'value' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Value    string                 `json:"value"`
-		Tooltip  *StringOrMarkupContent `json:"tooltip,omitzero"`
-		Location *Location              `json:"location,omitzero"`
-		Command  *Command               `json:"command,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A `MarkupContent` literal represents a string value which content is interpreted base on its
@@ -7918,32 +11393,50 @@ type MarkupContent struct {
 	Value string `json:"value"`
 }
 
-func (s *MarkupContent) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Kind  requiredProp `json:"kind"`
-		Value requiredProp `json:"value"`
-	}
+func (s *MarkupContent) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenKind  bool
+		seenValue bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Kind {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "kind":
+			seenKind = true
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		case "value":
+			seenValue = true
+			if err := json.UnmarshalDecode(dec, &s.Value); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenKind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if !keys.Value {
+	if !seenValue {
 		return fmt.Errorf("required key 'value' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Kind  MarkupKind `json:"kind"`
-		Value string     `json:"value"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Inlay hint options used during static registration.
@@ -7982,34 +11475,58 @@ type RelatedFullDocumentDiagnosticReport struct {
 	RelatedDocuments *map[DocumentUri]FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport `json:"relatedDocuments,omitzero"`
 }
 
-func (s *RelatedFullDocumentDiagnosticReport) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Kind  requiredProp `json:"kind"`
-		Items requiredProp `json:"items"`
-	}
+func (s *RelatedFullDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenKind  bool
+		seenItems bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Kind {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "kind":
+			seenKind = true
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		case "resultId":
+			if err := json.UnmarshalDecode(dec, &s.ResultId); err != nil {
+				return err
+			}
+		case "items":
+			seenItems = true
+			if err := json.UnmarshalDecode(dec, &s.Items); err != nil {
+				return err
+			}
+		case "relatedDocuments":
+			if err := json.UnmarshalDecode(dec, &s.RelatedDocuments); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenKind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if !keys.Items {
+	if !seenItems {
 		return fmt.Errorf("required key 'items' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Kind             StringLiteralFull                                                                `json:"kind"`
-		ResultId         *string                                                                          `json:"resultId,omitzero"`
-		Items            []*Diagnostic                                                                    `json:"items"`
-		RelatedDocuments *map[DocumentUri]FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport `json:"relatedDocuments,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // An unchanged diagnostic report with a set of related documents.
@@ -8036,33 +11553,54 @@ type RelatedUnchangedDocumentDiagnosticReport struct {
 	RelatedDocuments *map[DocumentUri]FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport `json:"relatedDocuments,omitzero"`
 }
 
-func (s *RelatedUnchangedDocumentDiagnosticReport) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Kind     requiredProp `json:"kind"`
-		ResultId requiredProp `json:"resultId"`
-	}
+func (s *RelatedUnchangedDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenKind     bool
+		seenResultId bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Kind {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "kind":
+			seenKind = true
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		case "resultId":
+			seenResultId = true
+			if err := json.UnmarshalDecode(dec, &s.ResultId); err != nil {
+				return err
+			}
+		case "relatedDocuments":
+			if err := json.UnmarshalDecode(dec, &s.RelatedDocuments); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenKind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if !keys.ResultId {
+	if !seenResultId {
 		return fmt.Errorf("required key 'resultId' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Kind             StringLiteralUnchanged                                                           `json:"kind"`
-		ResultId         string                                                                           `json:"resultId"`
-		RelatedDocuments *map[DocumentUri]FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport `json:"relatedDocuments,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A diagnostic report with a full set of problems.
@@ -8081,33 +11619,54 @@ type FullDocumentDiagnosticReport struct {
 	Items []*Diagnostic `json:"items"`
 }
 
-func (s *FullDocumentDiagnosticReport) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Kind  requiredProp `json:"kind"`
-		Items requiredProp `json:"items"`
-	}
+func (s *FullDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenKind  bool
+		seenItems bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Kind {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "kind":
+			seenKind = true
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		case "resultId":
+			if err := json.UnmarshalDecode(dec, &s.ResultId); err != nil {
+				return err
+			}
+		case "items":
+			seenItems = true
+			if err := json.UnmarshalDecode(dec, &s.Items); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenKind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if !keys.Items {
+	if !seenItems {
 		return fmt.Errorf("required key 'items' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Kind     StringLiteralFull `json:"kind"`
-		ResultId *string           `json:"resultId,omitzero"`
-		Items    []*Diagnostic     `json:"items"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A diagnostic report indicating that the last returned
@@ -8126,32 +11685,50 @@ type UnchangedDocumentDiagnosticReport struct {
 	ResultId string `json:"resultId"`
 }
 
-func (s *UnchangedDocumentDiagnosticReport) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Kind     requiredProp `json:"kind"`
-		ResultId requiredProp `json:"resultId"`
-	}
+func (s *UnchangedDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenKind     bool
+		seenResultId bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Kind {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "kind":
+			seenKind = true
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		case "resultId":
+			seenResultId = true
+			if err := json.UnmarshalDecode(dec, &s.ResultId); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenKind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if !keys.ResultId {
+	if !seenResultId {
 		return fmt.Errorf("required key 'resultId' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Kind     StringLiteralUnchanged `json:"kind"`
-		ResultId string                 `json:"resultId"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Diagnostic options.
@@ -8174,34 +11751,58 @@ type DiagnosticOptions struct {
 	WorkspaceDiagnostics bool `json:"workspaceDiagnostics"`
 }
 
-func (s *DiagnosticOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		InterFileDependencies requiredProp `json:"interFileDependencies"`
-		WorkspaceDiagnostics  requiredProp `json:"workspaceDiagnostics"`
-	}
+func (s *DiagnosticOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenInterFileDependencies bool
+		seenWorkspaceDiagnostics  bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.InterFileDependencies {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		case "identifier":
+			if err := json.UnmarshalDecode(dec, &s.Identifier); err != nil {
+				return err
+			}
+		case "interFileDependencies":
+			seenInterFileDependencies = true
+			if err := json.UnmarshalDecode(dec, &s.InterFileDependencies); err != nil {
+				return err
+			}
+		case "workspaceDiagnostics":
+			seenWorkspaceDiagnostics = true
+			if err := json.UnmarshalDecode(dec, &s.WorkspaceDiagnostics); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenInterFileDependencies {
 		return fmt.Errorf("required key 'interFileDependencies' is missing")
 	}
-	if !keys.WorkspaceDiagnostics {
+	if !seenWorkspaceDiagnostics {
 		return fmt.Errorf("required key 'workspaceDiagnostics' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneProgress      *bool   `json:"workDoneProgress,omitzero"`
-		Identifier            *string `json:"identifier,omitzero"`
-		InterFileDependencies bool    `json:"interFileDependencies"`
-		WorkspaceDiagnostics  bool    `json:"workspaceDiagnostics"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A previous result id in a workspace pull request.
@@ -8216,32 +11817,50 @@ type PreviousResultId struct {
 	Value string `json:"value"`
 }
 
-func (s *PreviousResultId) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Uri   requiredProp `json:"uri"`
-		Value requiredProp `json:"value"`
-	}
+func (s *PreviousResultId) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenUri   bool
+		seenValue bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Uri {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "uri":
+			seenUri = true
+			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
+				return err
+			}
+		case "value":
+			seenValue = true
+			if err := json.UnmarshalDecode(dec, &s.Value); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenUri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
-	if !keys.Value {
+	if !seenValue {
 		return fmt.Errorf("required key 'value' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Uri   DocumentUri `json:"uri"`
-		Value string      `json:"value"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A notebook document.
@@ -8268,43 +11887,72 @@ type NotebookDocument struct {
 	Cells []*NotebookCell `json:"cells"`
 }
 
-func (s *NotebookDocument) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Uri          requiredProp `json:"uri"`
-		NotebookType requiredProp `json:"notebookType"`
-		Version      requiredProp `json:"version"`
-		Cells        requiredProp `json:"cells"`
-	}
+func (s *NotebookDocument) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenUri          bool
+		seenNotebookType bool
+		seenVersion      bool
+		seenCells        bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Uri {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "uri":
+			seenUri = true
+			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
+				return err
+			}
+		case "notebookType":
+			seenNotebookType = true
+			if err := json.UnmarshalDecode(dec, &s.NotebookType); err != nil {
+				return err
+			}
+		case "version":
+			seenVersion = true
+			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
+				return err
+			}
+		case "metadata":
+			if err := json.UnmarshalDecode(dec, &s.Metadata); err != nil {
+				return err
+			}
+		case "cells":
+			seenCells = true
+			if err := json.UnmarshalDecode(dec, &s.Cells); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenUri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
-	if !keys.NotebookType {
+	if !seenNotebookType {
 		return fmt.Errorf("required key 'notebookType' is missing")
 	}
-	if !keys.Version {
+	if !seenVersion {
 		return fmt.Errorf("required key 'version' is missing")
 	}
-	if !keys.Cells {
+	if !seenCells {
 		return fmt.Errorf("required key 'cells' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Uri          URI             `json:"uri"`
-		NotebookType string          `json:"notebookType"`
-		Version      int32           `json:"version"`
-		Metadata     *map[string]any `json:"metadata,omitzero"`
-		Cells        []*NotebookCell `json:"cells"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // An item to transfer a text document from the client to the
@@ -8324,42 +11972,68 @@ type TextDocumentItem struct {
 	Text string `json:"text"`
 }
 
-func (s *TextDocumentItem) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Uri        requiredProp `json:"uri"`
-		LanguageId requiredProp `json:"languageId"`
-		Version    requiredProp `json:"version"`
-		Text       requiredProp `json:"text"`
-	}
+func (s *TextDocumentItem) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenUri        bool
+		seenLanguageId bool
+		seenVersion    bool
+		seenText       bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Uri {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "uri":
+			seenUri = true
+			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
+				return err
+			}
+		case "languageId":
+			seenLanguageId = true
+			if err := json.UnmarshalDecode(dec, &s.LanguageId); err != nil {
+				return err
+			}
+		case "version":
+			seenVersion = true
+			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
+				return err
+			}
+		case "text":
+			seenText = true
+			if err := json.UnmarshalDecode(dec, &s.Text); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenUri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
-	if !keys.LanguageId {
+	if !seenLanguageId {
 		return fmt.Errorf("required key 'languageId' is missing")
 	}
-	if !keys.Version {
+	if !seenVersion {
 		return fmt.Errorf("required key 'version' is missing")
 	}
-	if !keys.Text {
+	if !seenText {
 		return fmt.Errorf("required key 'text' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Uri        DocumentUri  `json:"uri"`
-		LanguageId LanguageKind `json:"languageId"`
-		Version    int32        `json:"version"`
-		Text       string       `json:"text"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Options specific to a notebook plus its cells
@@ -8384,28 +12058,43 @@ type NotebookDocumentSyncOptions struct {
 	Save *bool `json:"save,omitzero"`
 }
 
-func (s *NotebookDocumentSyncOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		NotebookSelector requiredProp `json:"notebookSelector"`
-	}
+func (s *NotebookDocumentSyncOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenNotebookSelector bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.NotebookSelector {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "notebookSelector":
+			seenNotebookSelector = true
+			if err := json.UnmarshalDecode(dec, &s.NotebookSelector); err != nil {
+				return err
+			}
+		case "save":
+			if err := json.UnmarshalDecode(dec, &s.Save); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenNotebookSelector {
 		return fmt.Errorf("required key 'notebookSelector' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		NotebookSelector []NotebookDocumentFilterWithNotebookOrCells `json:"notebookSelector"`
-		Save             *bool                                       `json:"save,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A versioned notebook document identifier.
@@ -8419,32 +12108,50 @@ type VersionedNotebookDocumentIdentifier struct {
 	Uri URI `json:"uri"`
 }
 
-func (s *VersionedNotebookDocumentIdentifier) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Version requiredProp `json:"version"`
-		Uri     requiredProp `json:"uri"`
-	}
+func (s *VersionedNotebookDocumentIdentifier) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenVersion bool
+		seenUri     bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Version {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "version":
+			seenVersion = true
+			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
+				return err
+			}
+		case "uri":
+			seenUri = true
+			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenVersion {
 		return fmt.Errorf("required key 'version' is missing")
 	}
-	if !keys.Uri {
+	if !seenUri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Version int32 `json:"version"`
-		Uri     URI   `json:"uri"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A change event for a notebook document.
@@ -8468,27 +12175,39 @@ type NotebookDocumentIdentifier struct {
 	Uri URI `json:"uri"`
 }
 
-func (s *NotebookDocumentIdentifier) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Uri requiredProp `json:"uri"`
-	}
+func (s *NotebookDocumentIdentifier) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenUri bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Uri {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "uri":
+			seenUri = true
+			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenUri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Uri URI `json:"uri"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Provides information about the context in which an inline completion was requested.
@@ -8504,28 +12223,43 @@ type InlineCompletionContext struct {
 	SelectedCompletionInfo *SelectedCompletionInfo `json:"selectedCompletionInfo,omitzero"`
 }
 
-func (s *InlineCompletionContext) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TriggerKind requiredProp `json:"triggerKind"`
-	}
+func (s *InlineCompletionContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenTriggerKind bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TriggerKind {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "triggerKind":
+			seenTriggerKind = true
+			if err := json.UnmarshalDecode(dec, &s.TriggerKind); err != nil {
+				return err
+			}
+		case "selectedCompletionInfo":
+			if err := json.UnmarshalDecode(dec, &s.SelectedCompletionInfo); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTriggerKind {
 		return fmt.Errorf("required key 'triggerKind' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		TriggerKind            InlineCompletionTriggerKind `json:"triggerKind"`
-		SelectedCompletionInfo *SelectedCompletionInfo     `json:"selectedCompletionInfo,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A string value used as a snippet is a template which allows to insert text
@@ -8547,32 +12281,50 @@ type StringValue struct {
 	Value string `json:"value"`
 }
 
-func (s *StringValue) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Kind  requiredProp `json:"kind"`
-		Value requiredProp `json:"value"`
-	}
+func (s *StringValue) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenKind  bool
+		seenValue bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Kind {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "kind":
+			seenKind = true
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		case "value":
+			seenValue = true
+			if err := json.UnmarshalDecode(dec, &s.Value); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenKind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if !keys.Value {
+	if !seenValue {
 		return fmt.Errorf("required key 'value' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Kind  StringLiteralSnippet `json:"kind"`
-		Value string               `json:"value"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Inline completion options used during static registration.
@@ -8594,27 +12346,39 @@ type TextDocumentContentOptions struct {
 	Schemes []string `json:"schemes"`
 }
 
-func (s *TextDocumentContentOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Schemes requiredProp `json:"schemes"`
-	}
+func (s *TextDocumentContentOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenSchemes bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Schemes {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "schemes":
+			seenSchemes = true
+			if err := json.UnmarshalDecode(dec, &s.Schemes); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenSchemes {
 		return fmt.Errorf("required key 'schemes' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Schemes []string `json:"schemes"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // General parameters to register for a notification or to register a provider.
@@ -8630,33 +12394,54 @@ type Registration struct {
 	RegisterOptions *any `json:"registerOptions,omitzero"`
 }
 
-func (s *Registration) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Id     requiredProp `json:"id"`
-		Method requiredProp `json:"method"`
-	}
+func (s *Registration) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenId     bool
+		seenMethod bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Id {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "id":
+			seenId = true
+			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
+				return err
+			}
+		case "method":
+			seenMethod = true
+			if err := json.UnmarshalDecode(dec, &s.Method); err != nil {
+				return err
+			}
+		case "registerOptions":
+			if err := json.UnmarshalDecode(dec, &s.RegisterOptions); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenId {
 		return fmt.Errorf("required key 'id' is missing")
 	}
-	if !keys.Method {
+	if !seenMethod {
 		return fmt.Errorf("required key 'method' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Id              string `json:"id"`
-		Method          string `json:"method"`
-		RegisterOptions *any   `json:"registerOptions,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // General parameters to unregister a request or notification.
@@ -8669,32 +12454,50 @@ type Unregistration struct {
 	Method string `json:"method"`
 }
 
-func (s *Unregistration) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Id     requiredProp `json:"id"`
-		Method requiredProp `json:"method"`
-	}
+func (s *Unregistration) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenId     bool
+		seenMethod bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Id {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "id":
+			seenId = true
+			if err := json.UnmarshalDecode(dec, &s.Id); err != nil {
+				return err
+			}
+		case "method":
+			seenMethod = true
+			if err := json.UnmarshalDecode(dec, &s.Method); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenId {
 		return fmt.Errorf("required key 'id' is missing")
 	}
-	if !keys.Method {
+	if !seenMethod {
 		return fmt.Errorf("required key 'method' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Id     string `json:"id"`
-		Method string `json:"method"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The initialize parameters
@@ -8747,43 +12550,83 @@ type InitializeParamsBase struct {
 	Trace *TraceValue `json:"trace,omitzero"`
 }
 
-func (s *InitializeParamsBase) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		ProcessId    requiredProp `json:"processId"`
-		RootUri      requiredProp `json:"rootUri"`
-		Capabilities requiredProp `json:"capabilities"`
-	}
+func (s *InitializeParamsBase) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenProcessId    bool
+		seenRootUri      bool
+		seenCapabilities bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.ProcessId {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneToken":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneToken); err != nil {
+				return err
+			}
+		case "processId":
+			seenProcessId = true
+			if err := json.UnmarshalDecode(dec, &s.ProcessId); err != nil {
+				return err
+			}
+		case "clientInfo":
+			if err := json.UnmarshalDecode(dec, &s.ClientInfo); err != nil {
+				return err
+			}
+		case "locale":
+			if err := json.UnmarshalDecode(dec, &s.Locale); err != nil {
+				return err
+			}
+		case "rootPath":
+			if err := json.UnmarshalDecode(dec, &s.RootPath); err != nil {
+				return err
+			}
+		case "rootUri":
+			seenRootUri = true
+			if err := json.UnmarshalDecode(dec, &s.RootUri); err != nil {
+				return err
+			}
+		case "capabilities":
+			seenCapabilities = true
+			if err := json.UnmarshalDecode(dec, &s.Capabilities); err != nil {
+				return err
+			}
+		case "initializationOptions":
+			if err := json.UnmarshalDecode(dec, &s.InitializationOptions); err != nil {
+				return err
+			}
+		case "trace":
+			if err := json.UnmarshalDecode(dec, &s.Trace); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenProcessId {
 		return fmt.Errorf("required key 'processId' is missing")
 	}
-	if !keys.RootUri {
+	if !seenRootUri {
 		return fmt.Errorf("required key 'rootUri' is missing")
 	}
-	if !keys.Capabilities {
+	if !seenCapabilities {
 		return fmt.Errorf("required key 'capabilities' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneToken         *IntegerOrString    `json:"workDoneToken,omitzero"`
-		ProcessId             IntegerOrNull       `json:"processId"`
-		ClientInfo            *ClientInfo         `json:"clientInfo,omitzero"`
-		Locale                *string             `json:"locale,omitzero"`
-		RootPath              *StringOrNull       `json:"rootPath,omitzero"`
-		RootUri               DocumentUriOrNull   `json:"rootUri"`
-		Capabilities          *ClientCapabilities `json:"capabilities"`
-		InitializationOptions *any                `json:"initializationOptions,omitzero"`
-		Trace                 *TraceValue         `json:"trace,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type WorkspaceFoldersInitializeParams struct {
@@ -8958,28 +12801,43 @@ type ServerInfo struct {
 	Version *string `json:"version,omitzero"`
 }
 
-func (s *ServerInfo) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Name requiredProp `json:"name"`
-	}
+func (s *ServerInfo) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenName bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Name {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "name":
+			seenName = true
+			if err := json.UnmarshalDecode(dec, &s.Name); err != nil {
+				return err
+			}
+		case "version":
+			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenName {
 		return fmt.Errorf("required key 'name' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Name    string  `json:"name"`
-		Version *string `json:"version,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A text document identifier to denote a specific version of a text document.
@@ -8991,32 +12849,50 @@ type VersionedTextDocumentIdentifier struct {
 	Version int32 `json:"version"`
 }
 
-func (s *VersionedTextDocumentIdentifier) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Uri     requiredProp `json:"uri"`
-		Version requiredProp `json:"version"`
-	}
+func (s *VersionedTextDocumentIdentifier) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenUri     bool
+		seenVersion bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Uri {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "uri":
+			seenUri = true
+			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
+				return err
+			}
+		case "version":
+			seenVersion = true
+			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenUri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
-	if !keys.Version {
+	if !seenVersion {
 		return fmt.Errorf("required key 'version' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Uri     DocumentUri `json:"uri"`
-		Version int32       `json:"version"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Save options.
@@ -9034,32 +12910,50 @@ type FileEvent struct {
 	Type FileChangeType `json:"type"`
 }
 
-func (s *FileEvent) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Uri  requiredProp `json:"uri"`
-		Type requiredProp `json:"type"`
-	}
+func (s *FileEvent) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenUri  bool
+		seenType bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Uri {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "uri":
+			seenUri = true
+			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
+				return err
+			}
+		case "type":
+			seenType = true
+			if err := json.UnmarshalDecode(dec, &s.Type); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenUri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
-	if !keys.Type {
+	if !seenType {
 		return fmt.Errorf("required key 'type' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Uri  DocumentUri    `json:"uri"`
-		Type FileChangeType `json:"type"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type FileSystemWatcher struct {
@@ -9074,28 +12968,43 @@ type FileSystemWatcher struct {
 	Kind *WatchKind `json:"kind,omitzero"`
 }
 
-func (s *FileSystemWatcher) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		GlobPattern requiredProp `json:"globPattern"`
-	}
+func (s *FileSystemWatcher) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenGlobPattern bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.GlobPattern {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "globPattern":
+			seenGlobPattern = true
+			if err := json.UnmarshalDecode(dec, &s.GlobPattern); err != nil {
+				return err
+			}
+		case "kind":
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenGlobPattern {
 		return fmt.Errorf("required key 'globPattern' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		GlobPattern PatternOrRelativePattern `json:"globPattern"`
-		Kind        *WatchKind               `json:"kind,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Represents a diagnostic, such as a compiler error or warning. Diagnostic objects
@@ -9142,39 +13051,78 @@ type Diagnostic struct {
 	Data *any `json:"data,omitzero"`
 }
 
-func (s *Diagnostic) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Range   requiredProp `json:"range"`
-		Message requiredProp `json:"message"`
-	}
+func (s *Diagnostic) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenRange   bool
+		seenMessage bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Range {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "range":
+			seenRange = true
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		case "severity":
+			if err := json.UnmarshalDecode(dec, &s.Severity); err != nil {
+				return err
+			}
+		case "code":
+			if err := json.UnmarshalDecode(dec, &s.Code); err != nil {
+				return err
+			}
+		case "codeDescription":
+			if err := json.UnmarshalDecode(dec, &s.CodeDescription); err != nil {
+				return err
+			}
+		case "source":
+			if err := json.UnmarshalDecode(dec, &s.Source); err != nil {
+				return err
+			}
+		case "message":
+			seenMessage = true
+			if err := json.UnmarshalDecode(dec, &s.Message); err != nil {
+				return err
+			}
+		case "tags":
+			if err := json.UnmarshalDecode(dec, &s.Tags); err != nil {
+				return err
+			}
+		case "relatedInformation":
+			if err := json.UnmarshalDecode(dec, &s.RelatedInformation); err != nil {
+				return err
+			}
+		case "data":
+			if err := json.UnmarshalDecode(dec, &s.Data); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenRange {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if !keys.Message {
+	if !seenMessage {
 		return fmt.Errorf("required key 'message' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Range              Range                            `json:"range"`
-		Severity           *DiagnosticSeverity              `json:"severity,omitzero"`
-		Code               *IntegerOrString                 `json:"code,omitzero"`
-		CodeDescription    *CodeDescription                 `json:"codeDescription,omitzero"`
-		Source             *string                          `json:"source,omitzero"`
-		Message            string                           `json:"message"`
-		Tags               *[]DiagnosticTag                 `json:"tags,omitzero"`
-		RelatedInformation *[]*DiagnosticRelatedInformation `json:"relatedInformation,omitzero"`
-		Data               *any                             `json:"data,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Contains additional information about the context in which a completion request is triggered.
@@ -9187,28 +13135,43 @@ type CompletionContext struct {
 	TriggerCharacter *string `json:"triggerCharacter,omitzero"`
 }
 
-func (s *CompletionContext) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TriggerKind requiredProp `json:"triggerKind"`
-	}
+func (s *CompletionContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenTriggerKind bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TriggerKind {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "triggerKind":
+			seenTriggerKind = true
+			if err := json.UnmarshalDecode(dec, &s.TriggerKind); err != nil {
+				return err
+			}
+		case "triggerCharacter":
+			if err := json.UnmarshalDecode(dec, &s.TriggerCharacter); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTriggerKind {
 		return fmt.Errorf("required key 'triggerKind' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		TriggerKind      CompletionTriggerKind `json:"triggerKind"`
-		TriggerCharacter *string               `json:"triggerCharacter,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Additional details for a completion item label.
@@ -9238,37 +13201,59 @@ type InsertReplaceEdit struct {
 	Replace Range `json:"replace"`
 }
 
-func (s *InsertReplaceEdit) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		NewText requiredProp `json:"newText"`
-		Insert  requiredProp `json:"insert"`
-		Replace requiredProp `json:"replace"`
-	}
+func (s *InsertReplaceEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenNewText bool
+		seenInsert  bool
+		seenReplace bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.NewText {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "newText":
+			seenNewText = true
+			if err := json.UnmarshalDecode(dec, &s.NewText); err != nil {
+				return err
+			}
+		case "insert":
+			seenInsert = true
+			if err := json.UnmarshalDecode(dec, &s.Insert); err != nil {
+				return err
+			}
+		case "replace":
+			seenReplace = true
+			if err := json.UnmarshalDecode(dec, &s.Replace); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenNewText {
 		return fmt.Errorf("required key 'newText' is missing")
 	}
-	if !keys.Insert {
+	if !seenInsert {
 		return fmt.Errorf("required key 'insert' is missing")
 	}
-	if !keys.Replace {
+	if !seenReplace {
 		return fmt.Errorf("required key 'replace' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		NewText string `json:"newText"`
-		Insert  Range  `json:"insert"`
-		Replace Range  `json:"replace"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // In many cases the items of an actual completion result share the same
@@ -9438,34 +13423,58 @@ type SignatureHelpContext struct {
 	ActiveSignatureHelp *SignatureHelp `json:"activeSignatureHelp,omitzero"`
 }
 
-func (s *SignatureHelpContext) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TriggerKind requiredProp `json:"triggerKind"`
-		IsRetrigger requiredProp `json:"isRetrigger"`
-	}
+func (s *SignatureHelpContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTriggerKind bool
+		seenIsRetrigger bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TriggerKind {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "triggerKind":
+			seenTriggerKind = true
+			if err := json.UnmarshalDecode(dec, &s.TriggerKind); err != nil {
+				return err
+			}
+		case "triggerCharacter":
+			if err := json.UnmarshalDecode(dec, &s.TriggerCharacter); err != nil {
+				return err
+			}
+		case "isRetrigger":
+			seenIsRetrigger = true
+			if err := json.UnmarshalDecode(dec, &s.IsRetrigger); err != nil {
+				return err
+			}
+		case "activeSignatureHelp":
+			if err := json.UnmarshalDecode(dec, &s.ActiveSignatureHelp); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTriggerKind {
 		return fmt.Errorf("required key 'triggerKind' is missing")
 	}
-	if !keys.IsRetrigger {
+	if !seenIsRetrigger {
 		return fmt.Errorf("required key 'isRetrigger' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		TriggerKind         SignatureHelpTriggerKind `json:"triggerKind"`
-		TriggerCharacter    *string                  `json:"triggerCharacter,omitzero"`
-		IsRetrigger         bool                     `json:"isRetrigger"`
-		ActiveSignatureHelp *SignatureHelp           `json:"activeSignatureHelp,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Represents the signature of something callable. A signature
@@ -9497,30 +13506,51 @@ type SignatureInformation struct {
 	ActiveParameter *UintegerOrNull `json:"activeParameter,omitzero"`
 }
 
-func (s *SignatureInformation) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Label requiredProp `json:"label"`
-	}
+func (s *SignatureInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenLabel bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Label {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "label":
+			seenLabel = true
+			if err := json.UnmarshalDecode(dec, &s.Label); err != nil {
+				return err
+			}
+		case "documentation":
+			if err := json.UnmarshalDecode(dec, &s.Documentation); err != nil {
+				return err
+			}
+		case "parameters":
+			if err := json.UnmarshalDecode(dec, &s.Parameters); err != nil {
+				return err
+			}
+		case "activeParameter":
+			if err := json.UnmarshalDecode(dec, &s.ActiveParameter); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenLabel {
 		return fmt.Errorf("required key 'label' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Label           string                   `json:"label"`
-		Documentation   *StringOrMarkupContent   `json:"documentation,omitzero"`
-		Parameters      *[]*ParameterInformation `json:"parameters,omitzero"`
-		ActiveParameter *UintegerOrNull          `json:"activeParameter,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Server Capabilities for a SignatureHelpRequest.
@@ -9551,27 +13581,39 @@ type ReferenceContext struct {
 	IncludeDeclaration bool `json:"includeDeclaration"`
 }
 
-func (s *ReferenceContext) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		IncludeDeclaration requiredProp `json:"includeDeclaration"`
-	}
+func (s *ReferenceContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenIncludeDeclaration bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.IncludeDeclaration {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "includeDeclaration":
+			seenIncludeDeclaration = true
+			if err := json.UnmarshalDecode(dec, &s.IncludeDeclaration); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenIncludeDeclaration {
 		return fmt.Errorf("required key 'includeDeclaration' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		IncludeDeclaration bool `json:"includeDeclaration"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Reference options.
@@ -9604,34 +13646,58 @@ type BaseSymbolInformation struct {
 	ContainerName *string `json:"containerName,omitzero"`
 }
 
-func (s *BaseSymbolInformation) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Name requiredProp `json:"name"`
-		Kind requiredProp `json:"kind"`
-	}
+func (s *BaseSymbolInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenName bool
+		seenKind bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Name {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "name":
+			seenName = true
+			if err := json.UnmarshalDecode(dec, &s.Name); err != nil {
+				return err
+			}
+		case "kind":
+			seenKind = true
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		case "tags":
+			if err := json.UnmarshalDecode(dec, &s.Tags); err != nil {
+				return err
+			}
+		case "containerName":
+			if err := json.UnmarshalDecode(dec, &s.ContainerName); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenName {
 		return fmt.Errorf("required key 'name' is missing")
 	}
-	if !keys.Kind {
+	if !seenKind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Name          string       `json:"name"`
-		Kind          SymbolKind   `json:"kind"`
-		Tags          *[]SymbolTag `json:"tags,omitzero"`
-		ContainerName *string      `json:"containerName,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Provider options for a DocumentSymbolRequest.
@@ -9667,29 +13733,47 @@ type CodeActionContext struct {
 	TriggerKind *CodeActionTriggerKind `json:"triggerKind,omitzero"`
 }
 
-func (s *CodeActionContext) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Diagnostics requiredProp `json:"diagnostics"`
-	}
+func (s *CodeActionContext) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDiagnostics bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Diagnostics {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "diagnostics":
+			seenDiagnostics = true
+			if err := json.UnmarshalDecode(dec, &s.Diagnostics); err != nil {
+				return err
+			}
+		case "only":
+			if err := json.UnmarshalDecode(dec, &s.Only); err != nil {
+				return err
+			}
+		case "triggerKind":
+			if err := json.UnmarshalDecode(dec, &s.TriggerKind); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDiagnostics {
 		return fmt.Errorf("required key 'diagnostics' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Diagnostics []*Diagnostic          `json:"diagnostics"`
-		Only        *[]CodeActionKind      `json:"only,omitzero"`
-		TriggerKind *CodeActionTriggerKind `json:"triggerKind,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Captures why the code action is currently disabled.
@@ -9702,27 +13786,39 @@ type CodeActionDisabled struct {
 	Reason string `json:"reason"`
 }
 
-func (s *CodeActionDisabled) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Reason requiredProp `json:"reason"`
-	}
+func (s *CodeActionDisabled) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenReason bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Reason {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "reason":
+			seenReason = true
+			if err := json.UnmarshalDecode(dec, &s.Reason); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenReason {
 		return fmt.Errorf("required key 'reason' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Reason string `json:"reason"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Provider options for a CodeActionRequest.
@@ -9767,27 +13863,39 @@ type LocationUriOnly struct {
 	Uri DocumentUri `json:"uri"`
 }
 
-func (s *LocationUriOnly) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Uri requiredProp `json:"uri"`
-	}
+func (s *LocationUriOnly) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenUri bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Uri {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "uri":
+			seenUri = true
+			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenUri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Uri DocumentUri `json:"uri"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Server capabilities for a WorkspaceSymbolRequest.
@@ -9841,35 +13949,62 @@ type FormattingOptions struct {
 	TrimFinalNewlines *bool `json:"trimFinalNewlines,omitzero"`
 }
 
-func (s *FormattingOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TabSize      requiredProp `json:"tabSize"`
-		InsertSpaces requiredProp `json:"insertSpaces"`
-	}
+func (s *FormattingOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTabSize      bool
+		seenInsertSpaces bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TabSize {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "tabSize":
+			seenTabSize = true
+			if err := json.UnmarshalDecode(dec, &s.TabSize); err != nil {
+				return err
+			}
+		case "insertSpaces":
+			seenInsertSpaces = true
+			if err := json.UnmarshalDecode(dec, &s.InsertSpaces); err != nil {
+				return err
+			}
+		case "trimTrailingWhitespace":
+			if err := json.UnmarshalDecode(dec, &s.TrimTrailingWhitespace); err != nil {
+				return err
+			}
+		case "insertFinalNewline":
+			if err := json.UnmarshalDecode(dec, &s.InsertFinalNewline); err != nil {
+				return err
+			}
+		case "trimFinalNewlines":
+			if err := json.UnmarshalDecode(dec, &s.TrimFinalNewlines); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTabSize {
 		return fmt.Errorf("required key 'tabSize' is missing")
 	}
-	if !keys.InsertSpaces {
+	if !seenInsertSpaces {
 		return fmt.Errorf("required key 'insertSpaces' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		TabSize                uint32 `json:"tabSize"`
-		InsertSpaces           bool   `json:"insertSpaces"`
-		TrimTrailingWhitespace *bool  `json:"trimTrailingWhitespace,omitzero"`
-		InsertFinalNewline     *bool  `json:"insertFinalNewline,omitzero"`
-		TrimFinalNewlines      *bool  `json:"trimFinalNewlines,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Provider options for a DocumentFormattingRequest.
@@ -9898,28 +14033,43 @@ type DocumentOnTypeFormattingOptions struct {
 	MoreTriggerCharacter *[]string `json:"moreTriggerCharacter,omitzero"`
 }
 
-func (s *DocumentOnTypeFormattingOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		FirstTriggerCharacter requiredProp `json:"firstTriggerCharacter"`
-	}
+func (s *DocumentOnTypeFormattingOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenFirstTriggerCharacter bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.FirstTriggerCharacter {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "firstTriggerCharacter":
+			seenFirstTriggerCharacter = true
+			if err := json.UnmarshalDecode(dec, &s.FirstTriggerCharacter); err != nil {
+				return err
+			}
+		case "moreTriggerCharacter":
+			if err := json.UnmarshalDecode(dec, &s.MoreTriggerCharacter); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenFirstTriggerCharacter {
 		return fmt.Errorf("required key 'firstTriggerCharacter' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		FirstTriggerCharacter string    `json:"firstTriggerCharacter"`
-		MoreTriggerCharacter  *[]string `json:"moreTriggerCharacter,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Provider options for a RenameRequest.
@@ -9939,32 +14089,50 @@ type PrepareRenamePlaceholder struct {
 	Placeholder string `json:"placeholder"`
 }
 
-func (s *PrepareRenamePlaceholder) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Range       requiredProp `json:"range"`
-		Placeholder requiredProp `json:"placeholder"`
-	}
+func (s *PrepareRenamePlaceholder) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenRange       bool
+		seenPlaceholder bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Range {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "range":
+			seenRange = true
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		case "placeholder":
+			seenPlaceholder = true
+			if err := json.UnmarshalDecode(dec, &s.Placeholder); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenRange {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if !keys.Placeholder {
+	if !seenPlaceholder {
 		return fmt.Errorf("required key 'placeholder' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Range       Range  `json:"range"`
-		Placeholder string `json:"placeholder"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.18.0
@@ -9972,27 +14140,39 @@ type PrepareRenameDefaultBehavior struct {
 	DefaultBehavior bool `json:"defaultBehavior"`
 }
 
-func (s *PrepareRenameDefaultBehavior) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		DefaultBehavior requiredProp `json:"defaultBehavior"`
-	}
+func (s *PrepareRenameDefaultBehavior) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenDefaultBehavior bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.DefaultBehavior {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "defaultBehavior":
+			seenDefaultBehavior = true
+			if err := json.UnmarshalDecode(dec, &s.DefaultBehavior); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDefaultBehavior {
 		return fmt.Errorf("required key 'defaultBehavior' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DefaultBehavior bool `json:"defaultBehavior"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // The server capabilities of a ExecuteCommandRequest.
@@ -10003,28 +14183,43 @@ type ExecuteCommandOptions struct {
 	Commands []string `json:"commands"`
 }
 
-func (s *ExecuteCommandOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Commands requiredProp `json:"commands"`
-	}
+func (s *ExecuteCommandOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenCommands bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Commands {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "workDoneProgress":
+			if err := json.UnmarshalDecode(dec, &s.WorkDoneProgress); err != nil {
+				return err
+			}
+		case "commands":
+			seenCommands = true
+			if err := json.UnmarshalDecode(dec, &s.Commands); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenCommands {
 		return fmt.Errorf("required key 'commands' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		WorkDoneProgress *bool    `json:"workDoneProgress,omitzero"`
-		Commands         []string `json:"commands"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Additional data about a workspace edit.
@@ -10046,32 +14241,50 @@ type SemanticTokensLegend struct {
 	TokenModifiers []string `json:"tokenModifiers"`
 }
 
-func (s *SemanticTokensLegend) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		TokenTypes     requiredProp `json:"tokenTypes"`
-		TokenModifiers requiredProp `json:"tokenModifiers"`
-	}
+func (s *SemanticTokensLegend) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenTokenTypes     bool
+		seenTokenModifiers bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.TokenTypes {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "tokenTypes":
+			seenTokenTypes = true
+			if err := json.UnmarshalDecode(dec, &s.TokenTypes); err != nil {
+				return err
+			}
+		case "tokenModifiers":
+			seenTokenModifiers = true
+			if err := json.UnmarshalDecode(dec, &s.TokenModifiers); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenTokenTypes {
 		return fmt.Errorf("required key 'tokenTypes' is missing")
 	}
-	if !keys.TokenModifiers {
+	if !seenTokenModifiers {
 		return fmt.Errorf("required key 'tokenModifiers' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		TokenTypes     []string `json:"tokenTypes"`
-		TokenModifiers []string `json:"tokenModifiers"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Semantic tokens options to support deltas for full documents
@@ -10095,32 +14308,50 @@ type OptionalVersionedTextDocumentIdentifier struct {
 	Version IntegerOrNull `json:"version"`
 }
 
-func (s *OptionalVersionedTextDocumentIdentifier) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Uri     requiredProp `json:"uri"`
-		Version requiredProp `json:"version"`
-	}
+func (s *OptionalVersionedTextDocumentIdentifier) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenUri     bool
+		seenVersion bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Uri {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "uri":
+			seenUri = true
+			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
+				return err
+			}
+		case "version":
+			seenVersion = true
+			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenUri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
-	if !keys.Version {
+	if !seenVersion {
 		return fmt.Errorf("required key 'version' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Uri     DocumentUri   `json:"uri"`
-		Version IntegerOrNull `json:"version"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A special text edit with an additional change annotation.
@@ -10139,37 +14370,59 @@ type AnnotatedTextEdit struct {
 	AnnotationId string `json:"annotationId"`
 }
 
-func (s *AnnotatedTextEdit) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Range        requiredProp `json:"range"`
-		NewText      requiredProp `json:"newText"`
-		AnnotationId requiredProp `json:"annotationId"`
-	}
+func (s *AnnotatedTextEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenRange        bool
+		seenNewText      bool
+		seenAnnotationId bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Range {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "range":
+			seenRange = true
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		case "newText":
+			seenNewText = true
+			if err := json.UnmarshalDecode(dec, &s.NewText); err != nil {
+				return err
+			}
+		case "annotationId":
+			seenAnnotationId = true
+			if err := json.UnmarshalDecode(dec, &s.AnnotationId); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenRange {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if !keys.NewText {
+	if !seenNewText {
 		return fmt.Errorf("required key 'newText' is missing")
 	}
-	if !keys.AnnotationId {
+	if !seenAnnotationId {
 		return fmt.Errorf("required key 'annotationId' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Range        Range  `json:"range"`
-		NewText      string `json:"newText"`
-		AnnotationId string `json:"annotationId"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // An interactive text edit.
@@ -10188,33 +14441,54 @@ type SnippetTextEdit struct {
 	AnnotationId *string `json:"annotationId,omitzero"`
 }
 
-func (s *SnippetTextEdit) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Range   requiredProp `json:"range"`
-		Snippet requiredProp `json:"snippet"`
-	}
+func (s *SnippetTextEdit) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenRange   bool
+		seenSnippet bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Range {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "range":
+			seenRange = true
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		case "snippet":
+			seenSnippet = true
+			if err := json.UnmarshalDecode(dec, &s.Snippet); err != nil {
+				return err
+			}
+		case "annotationId":
+			if err := json.UnmarshalDecode(dec, &s.AnnotationId); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenRange {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if !keys.Snippet {
+	if !seenSnippet {
 		return fmt.Errorf("required key 'snippet' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Range        Range        `json:"range"`
-		Snippet      *StringValue `json:"snippet"`
-		AnnotationId *string      `json:"annotationId,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A generic resource operation.
@@ -10228,28 +14502,43 @@ type ResourceOperation struct {
 	AnnotationId *string `json:"annotationId,omitzero"`
 }
 
-func (s *ResourceOperation) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Kind requiredProp `json:"kind"`
-	}
+func (s *ResourceOperation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenKind bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Kind {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "kind":
+			seenKind = true
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		case "annotationId":
+			if err := json.UnmarshalDecode(dec, &s.AnnotationId); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenKind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Kind         string  `json:"kind"`
-		AnnotationId *string `json:"annotationId,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Options to create a file.
@@ -10302,29 +14591,47 @@ type FileOperationPattern struct {
 	Options *FileOperationPatternOptions `json:"options,omitzero"`
 }
 
-func (s *FileOperationPattern) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Glob requiredProp `json:"glob"`
-	}
+func (s *FileOperationPattern) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenGlob bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Glob {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "glob":
+			seenGlob = true
+			if err := json.UnmarshalDecode(dec, &s.Glob); err != nil {
+				return err
+			}
+		case "matches":
+			if err := json.UnmarshalDecode(dec, &s.Matches); err != nil {
+				return err
+			}
+		case "options":
+			if err := json.UnmarshalDecode(dec, &s.Options); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenGlob {
 		return fmt.Errorf("required key 'glob' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Glob    string                       `json:"glob"`
-		Matches *FileOperationPatternKind    `json:"matches,omitzero"`
-		Options *FileOperationPatternOptions `json:"options,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A full document diagnostic report for a workspace diagnostic result.
@@ -10350,43 +14657,72 @@ type WorkspaceFullDocumentDiagnosticReport struct {
 	Version IntegerOrNull `json:"version"`
 }
 
-func (s *WorkspaceFullDocumentDiagnosticReport) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Kind    requiredProp `json:"kind"`
-		Items   requiredProp `json:"items"`
-		Uri     requiredProp `json:"uri"`
-		Version requiredProp `json:"version"`
-	}
+func (s *WorkspaceFullDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenKind    bool
+		seenItems   bool
+		seenUri     bool
+		seenVersion bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Kind {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "kind":
+			seenKind = true
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		case "resultId":
+			if err := json.UnmarshalDecode(dec, &s.ResultId); err != nil {
+				return err
+			}
+		case "items":
+			seenItems = true
+			if err := json.UnmarshalDecode(dec, &s.Items); err != nil {
+				return err
+			}
+		case "uri":
+			seenUri = true
+			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
+				return err
+			}
+		case "version":
+			seenVersion = true
+			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenKind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if !keys.Items {
+	if !seenItems {
 		return fmt.Errorf("required key 'items' is missing")
 	}
-	if !keys.Uri {
+	if !seenUri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
-	if !keys.Version {
+	if !seenVersion {
 		return fmt.Errorf("required key 'version' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Kind     StringLiteralFull `json:"kind"`
-		ResultId *string           `json:"resultId,omitzero"`
-		Items    []*Diagnostic     `json:"items"`
-		Uri      DocumentUri       `json:"uri"`
-		Version  IntegerOrNull     `json:"version"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // An unchanged document diagnostic report for a workspace diagnostic result.
@@ -10411,42 +14747,68 @@ type WorkspaceUnchangedDocumentDiagnosticReport struct {
 	Version IntegerOrNull `json:"version"`
 }
 
-func (s *WorkspaceUnchangedDocumentDiagnosticReport) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Kind     requiredProp `json:"kind"`
-		ResultId requiredProp `json:"resultId"`
-		Uri      requiredProp `json:"uri"`
-		Version  requiredProp `json:"version"`
-	}
+func (s *WorkspaceUnchangedDocumentDiagnosticReport) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenKind     bool
+		seenResultId bool
+		seenUri      bool
+		seenVersion  bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Kind {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "kind":
+			seenKind = true
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		case "resultId":
+			seenResultId = true
+			if err := json.UnmarshalDecode(dec, &s.ResultId); err != nil {
+				return err
+			}
+		case "uri":
+			seenUri = true
+			if err := json.UnmarshalDecode(dec, &s.Uri); err != nil {
+				return err
+			}
+		case "version":
+			seenVersion = true
+			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenKind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if !keys.ResultId {
+	if !seenResultId {
 		return fmt.Errorf("required key 'resultId' is missing")
 	}
-	if !keys.Uri {
+	if !seenUri {
 		return fmt.Errorf("required key 'uri' is missing")
 	}
-	if !keys.Version {
+	if !seenVersion {
 		return fmt.Errorf("required key 'version' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Kind     StringLiteralUnchanged `json:"kind"`
-		ResultId string                 `json:"resultId"`
-		Uri      DocumentUri            `json:"uri"`
-		Version  IntegerOrNull          `json:"version"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A notebook cell.
@@ -10474,34 +14836,58 @@ type NotebookCell struct {
 	ExecutionSummary *ExecutionSummary `json:"executionSummary,omitzero"`
 }
 
-func (s *NotebookCell) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Kind     requiredProp `json:"kind"`
-		Document requiredProp `json:"document"`
-	}
+func (s *NotebookCell) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenKind     bool
+		seenDocument bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Kind {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "kind":
+			seenKind = true
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		case "document":
+			seenDocument = true
+			if err := json.UnmarshalDecode(dec, &s.Document); err != nil {
+				return err
+			}
+		case "metadata":
+			if err := json.UnmarshalDecode(dec, &s.Metadata); err != nil {
+				return err
+			}
+		case "executionSummary":
+			if err := json.UnmarshalDecode(dec, &s.ExecutionSummary); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenKind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if !keys.Document {
+	if !seenDocument {
 		return fmt.Errorf("required key 'document' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Kind             NotebookCellKind  `json:"kind"`
-		Document         DocumentUri       `json:"document"`
-		Metadata         *map[string]any   `json:"metadata,omitzero"`
-		ExecutionSummary *ExecutionSummary `json:"executionSummary,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.18.0
@@ -10515,28 +14901,43 @@ type NotebookDocumentFilterWithNotebook struct {
 	Cells *[]*NotebookCellLanguage `json:"cells,omitzero"`
 }
 
-func (s *NotebookDocumentFilterWithNotebook) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Notebook requiredProp `json:"notebook"`
-	}
+func (s *NotebookDocumentFilterWithNotebook) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenNotebook bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Notebook {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "notebook":
+			seenNotebook = true
+			if err := json.UnmarshalDecode(dec, &s.Notebook); err != nil {
+				return err
+			}
+		case "cells":
+			if err := json.UnmarshalDecode(dec, &s.Cells); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenNotebook {
 		return fmt.Errorf("required key 'notebook' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Notebook StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrNotebookDocumentFilterPattern `json:"notebook"`
-		Cells    *[]*NotebookCellLanguage                                                                                `json:"cells,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.18.0
@@ -10550,28 +14951,43 @@ type NotebookDocumentFilterWithCells struct {
 	Cells []*NotebookCellLanguage `json:"cells"`
 }
 
-func (s *NotebookDocumentFilterWithCells) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Cells requiredProp `json:"cells"`
-	}
+func (s *NotebookDocumentFilterWithCells) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenCells bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Cells {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "notebook":
+			if err := json.UnmarshalDecode(dec, &s.Notebook); err != nil {
+				return err
+			}
+		case "cells":
+			seenCells = true
+			if err := json.UnmarshalDecode(dec, &s.Cells); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenCells {
 		return fmt.Errorf("required key 'cells' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Notebook *StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrNotebookDocumentFilterPattern `json:"notebook,omitzero"`
-		Cells    []*NotebookCellLanguage                                                                                  `json:"cells"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Cell changes to a notebook document.
@@ -10603,32 +15019,50 @@ type SelectedCompletionInfo struct {
 	Text string `json:"text"`
 }
 
-func (s *SelectedCompletionInfo) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Range requiredProp `json:"range"`
-		Text  requiredProp `json:"text"`
-	}
+func (s *SelectedCompletionInfo) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenRange bool
+		seenText  bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Range {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "range":
+			seenRange = true
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		case "text":
+			seenText = true
+			if err := json.UnmarshalDecode(dec, &s.Text); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenRange {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if !keys.Text {
+	if !seenText {
 		return fmt.Errorf("required key 'text' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Range Range  `json:"range"`
-		Text  string `json:"text"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Information about the client
@@ -10644,28 +15078,43 @@ type ClientInfo struct {
 	Version *string `json:"version,omitzero"`
 }
 
-func (s *ClientInfo) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Name requiredProp `json:"name"`
-	}
+func (s *ClientInfo) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenName bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Name {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "name":
+			seenName = true
+			if err := json.UnmarshalDecode(dec, &s.Name); err != nil {
+				return err
+			}
+		case "version":
+			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenName {
 		return fmt.Errorf("required key 'name' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Name    string  `json:"name"`
-		Version *string `json:"version,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Defines the capabilities provided by the client.
@@ -10751,33 +15200,54 @@ type TextDocumentContentChangePartial struct {
 	Text string `json:"text"`
 }
 
-func (s *TextDocumentContentChangePartial) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Range requiredProp `json:"range"`
-		Text  requiredProp `json:"text"`
-	}
+func (s *TextDocumentContentChangePartial) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenRange bool
+		seenText  bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Range {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "range":
+			seenRange = true
+			if err := json.UnmarshalDecode(dec, &s.Range); err != nil {
+				return err
+			}
+		case "rangeLength":
+			if err := json.UnmarshalDecode(dec, &s.RangeLength); err != nil {
+				return err
+			}
+		case "text":
+			seenText = true
+			if err := json.UnmarshalDecode(dec, &s.Text); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenRange {
 		return fmt.Errorf("required key 'range' is missing")
 	}
-	if !keys.Text {
+	if !seenText {
 		return fmt.Errorf("required key 'text' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Range       Range   `json:"range"`
-		RangeLength *uint32 `json:"rangeLength,omitzero"`
-		Text        string  `json:"text"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.18.0
@@ -10786,27 +15256,39 @@ type TextDocumentContentChangeWholeDocument struct {
 	Text string `json:"text"`
 }
 
-func (s *TextDocumentContentChangeWholeDocument) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Text requiredProp `json:"text"`
-	}
+func (s *TextDocumentContentChangeWholeDocument) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenText bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Text {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "text":
+			seenText = true
+			if err := json.UnmarshalDecode(dec, &s.Text); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenText {
 		return fmt.Errorf("required key 'text' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Text string `json:"text"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Structure to capture a description for an error code.
@@ -10817,27 +15299,39 @@ type CodeDescription struct {
 	Href URI `json:"href"`
 }
 
-func (s *CodeDescription) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Href requiredProp `json:"href"`
-	}
+func (s *CodeDescription) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenHref bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Href {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "href":
+			seenHref = true
+			if err := json.UnmarshalDecode(dec, &s.Href); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenHref {
 		return fmt.Errorf("required key 'href' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Href URI `json:"href"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Represents a related message and source code location for a diagnostic. This should be
@@ -10851,32 +15345,50 @@ type DiagnosticRelatedInformation struct {
 	Message string `json:"message"`
 }
 
-func (s *DiagnosticRelatedInformation) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Location requiredProp `json:"location"`
-		Message  requiredProp `json:"message"`
-	}
+func (s *DiagnosticRelatedInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenLocation bool
+		seenMessage  bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Location {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "location":
+			seenLocation = true
+			if err := json.UnmarshalDecode(dec, &s.Location); err != nil {
+				return err
+			}
+		case "message":
+			seenMessage = true
+			if err := json.UnmarshalDecode(dec, &s.Message); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenLocation {
 		return fmt.Errorf("required key 'location' is missing")
 	}
-	if !keys.Message {
+	if !seenMessage {
 		return fmt.Errorf("required key 'message' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Location Location `json:"location"`
-		Message  string   `json:"message"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Edit range variant that includes ranges for insert and replace operations.
@@ -10888,32 +15400,50 @@ type EditRangeWithInsertReplace struct {
 	Replace Range `json:"replace"`
 }
 
-func (s *EditRangeWithInsertReplace) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Insert  requiredProp `json:"insert"`
-		Replace requiredProp `json:"replace"`
-	}
+func (s *EditRangeWithInsertReplace) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenInsert  bool
+		seenReplace bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Insert {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "insert":
+			seenInsert = true
+			if err := json.UnmarshalDecode(dec, &s.Insert); err != nil {
+				return err
+			}
+		case "replace":
+			seenReplace = true
+			if err := json.UnmarshalDecode(dec, &s.Replace); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenInsert {
 		return fmt.Errorf("required key 'insert' is missing")
 	}
-	if !keys.Replace {
+	if !seenReplace {
 		return fmt.Errorf("required key 'replace' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Insert  Range `json:"insert"`
-		Replace Range `json:"replace"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.18.0
@@ -10935,32 +15465,50 @@ type MarkedStringWithLanguage struct {
 	Value string `json:"value"`
 }
 
-func (s *MarkedStringWithLanguage) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Language requiredProp `json:"language"`
-		Value    requiredProp `json:"value"`
-	}
+func (s *MarkedStringWithLanguage) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenLanguage bool
+		seenValue    bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Language {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "language":
+			seenLanguage = true
+			if err := json.UnmarshalDecode(dec, &s.Language); err != nil {
+				return err
+			}
+		case "value":
+			seenValue = true
+			if err := json.UnmarshalDecode(dec, &s.Value); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenLanguage {
 		return fmt.Errorf("required key 'language' is missing")
 	}
-	if !keys.Value {
+	if !seenValue {
 		return fmt.Errorf("required key 'value' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Language string `json:"language"`
-		Value    string `json:"value"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Represents a parameter of a callable-signature. A parameter can
@@ -10985,28 +15533,43 @@ type ParameterInformation struct {
 	Documentation *StringOrMarkupContent `json:"documentation,omitzero"`
 }
 
-func (s *ParameterInformation) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Label requiredProp `json:"label"`
-	}
+func (s *ParameterInformation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenLabel bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Label {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "label":
+			seenLabel = true
+			if err := json.UnmarshalDecode(dec, &s.Label); err != nil {
+				return err
+			}
+		case "documentation":
+			if err := json.UnmarshalDecode(dec, &s.Documentation); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenLabel {
 		return fmt.Errorf("required key 'label' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Label         StringOrTuple          `json:"label"`
-		Documentation *StringOrMarkupContent `json:"documentation,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Documentation for a class of code actions.
@@ -11028,32 +15591,50 @@ type CodeActionKindDocumentation struct {
 	Command *Command `json:"command"`
 }
 
-func (s *CodeActionKindDocumentation) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Kind    requiredProp `json:"kind"`
-		Command requiredProp `json:"command"`
-	}
+func (s *CodeActionKindDocumentation) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenKind    bool
+		seenCommand bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Kind {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "kind":
+			seenKind = true
+			if err := json.UnmarshalDecode(dec, &s.Kind); err != nil {
+				return err
+			}
+		case "command":
+			seenCommand = true
+			if err := json.UnmarshalDecode(dec, &s.Command); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenKind {
 		return fmt.Errorf("required key 'kind' is missing")
 	}
-	if !keys.Command {
+	if !seenCommand {
 		return fmt.Errorf("required key 'command' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Kind    CodeActionKind `json:"kind"`
-		Command *Command       `json:"command"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A notebook cell text document filter denotes a cell text
@@ -11074,28 +15655,43 @@ type NotebookCellTextDocumentFilter struct {
 	Language *string `json:"language,omitzero"`
 }
 
-func (s *NotebookCellTextDocumentFilter) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Notebook requiredProp `json:"notebook"`
-	}
+func (s *NotebookCellTextDocumentFilter) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenNotebook bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Notebook {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "notebook":
+			seenNotebook = true
+			if err := json.UnmarshalDecode(dec, &s.Notebook); err != nil {
+				return err
+			}
+		case "language":
+			if err := json.UnmarshalDecode(dec, &s.Language); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenNotebook {
 		return fmt.Errorf("required key 'notebook' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Notebook StringOrNotebookDocumentFilterNotebookTypeOrNotebookDocumentFilterSchemeOrNotebookDocumentFilterPattern `json:"notebook"`
-		Language *string                                                                                                 `json:"language,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Matching options for the file operation pattern.
@@ -11117,28 +15713,43 @@ type ExecutionSummary struct {
 	Success *bool `json:"success,omitzero"`
 }
 
-func (s *ExecutionSummary) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		ExecutionOrder requiredProp `json:"executionOrder"`
-	}
+func (s *ExecutionSummary) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenExecutionOrder bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.ExecutionOrder {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "executionOrder":
+			seenExecutionOrder = true
+			if err := json.UnmarshalDecode(dec, &s.ExecutionOrder); err != nil {
+				return err
+			}
+		case "success":
+			if err := json.UnmarshalDecode(dec, &s.Success); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenExecutionOrder {
 		return fmt.Errorf("required key 'executionOrder' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		ExecutionOrder uint32 `json:"executionOrder"`
-		Success        *bool  `json:"success,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.18.0
@@ -11146,27 +15757,39 @@ type NotebookCellLanguage struct {
 	Language string `json:"language"`
 }
 
-func (s *NotebookCellLanguage) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Language requiredProp `json:"language"`
-	}
+func (s *NotebookCellLanguage) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenLanguage bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Language {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "language":
+			seenLanguage = true
+			if err := json.UnmarshalDecode(dec, &s.Language); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenLanguage {
 		return fmt.Errorf("required key 'language' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Language string `json:"language"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Structural changes to cells in a notebook document.
@@ -11183,29 +15806,47 @@ type NotebookDocumentCellChangeStructure struct {
 	DidClose *[]TextDocumentIdentifier `json:"didClose,omitzero"`
 }
 
-func (s *NotebookDocumentCellChangeStructure) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Array requiredProp `json:"array"`
-	}
+func (s *NotebookDocumentCellChangeStructure) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenArray bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Array {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "array":
+			seenArray = true
+			if err := json.UnmarshalDecode(dec, &s.Array); err != nil {
+				return err
+			}
+		case "didOpen":
+			if err := json.UnmarshalDecode(dec, &s.DidOpen); err != nil {
+				return err
+			}
+		case "didClose":
+			if err := json.UnmarshalDecode(dec, &s.DidClose); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenArray {
 		return fmt.Errorf("required key 'array' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Array    *NotebookCellArrayChange  `json:"array"`
-		DidOpen  *[]*TextDocumentItem      `json:"didOpen,omitzero"`
-		DidClose *[]TextDocumentIdentifier `json:"didClose,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Content changes to a cell in a notebook document.
@@ -11217,32 +15858,50 @@ type NotebookDocumentCellContentChanges struct {
 	Changes []TextDocumentContentChangePartialOrWholeDocument `json:"changes"`
 }
 
-func (s *NotebookDocumentCellContentChanges) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Document requiredProp `json:"document"`
-		Changes  requiredProp `json:"changes"`
-	}
+func (s *NotebookDocumentCellContentChanges) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenDocument bool
+		seenChanges  bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Document {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "document":
+			seenDocument = true
+			if err := json.UnmarshalDecode(dec, &s.Document); err != nil {
+				return err
+			}
+		case "changes":
+			seenChanges = true
+			if err := json.UnmarshalDecode(dec, &s.Changes); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenDocument {
 		return fmt.Errorf("required key 'document' is missing")
 	}
-	if !keys.Changes {
+	if !seenChanges {
 		return fmt.Errorf("required key 'changes' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Document VersionedTextDocumentIdentifier                   `json:"document"`
-		Changes  []TextDocumentContentChangePartialOrWholeDocument `json:"changes"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Workspace specific client capabilities.
@@ -11471,27 +16130,39 @@ type NotebookDocumentClientCapabilities struct {
 	Synchronization *NotebookDocumentSyncClientCapabilities `json:"synchronization"`
 }
 
-func (s *NotebookDocumentClientCapabilities) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Synchronization requiredProp `json:"synchronization"`
-	}
+func (s *NotebookDocumentClientCapabilities) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenSynchronization bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Synchronization {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "synchronization":
+			seenSynchronization = true
+			if err := json.UnmarshalDecode(dec, &s.Synchronization); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenSynchronization {
 		return fmt.Errorf("required key 'synchronization' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Synchronization *NotebookDocumentSyncClientCapabilities `json:"synchronization"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type WindowClientCapabilities struct {
@@ -11611,32 +16282,50 @@ type RelativePattern struct {
 	Pattern string `json:"pattern"`
 }
 
-func (s *RelativePattern) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		BaseUri requiredProp `json:"baseUri"`
-		Pattern requiredProp `json:"pattern"`
-	}
+func (s *RelativePattern) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenBaseUri bool
+		seenPattern bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.BaseUri {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "baseUri":
+			seenBaseUri = true
+			if err := json.UnmarshalDecode(dec, &s.BaseUri); err != nil {
+				return err
+			}
+		case "pattern":
+			seenPattern = true
+			if err := json.UnmarshalDecode(dec, &s.Pattern); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenBaseUri {
 		return fmt.Errorf("required key 'baseUri' is missing")
 	}
-	if !keys.Pattern {
+	if !seenPattern {
 		return fmt.Errorf("required key 'pattern' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		BaseUri WorkspaceFolderOrURI `json:"baseUri"`
-		Pattern string               `json:"pattern"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A document filter where `language` is required field.
@@ -11657,29 +16346,47 @@ type TextDocumentFilterLanguage struct {
 	Pattern *PatternOrRelativePattern `json:"pattern,omitzero"`
 }
 
-func (s *TextDocumentFilterLanguage) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Language requiredProp `json:"language"`
-	}
+func (s *TextDocumentFilterLanguage) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenLanguage bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Language {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "language":
+			seenLanguage = true
+			if err := json.UnmarshalDecode(dec, &s.Language); err != nil {
+				return err
+			}
+		case "scheme":
+			if err := json.UnmarshalDecode(dec, &s.Scheme); err != nil {
+				return err
+			}
+		case "pattern":
+			if err := json.UnmarshalDecode(dec, &s.Pattern); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenLanguage {
 		return fmt.Errorf("required key 'language' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Language string                    `json:"language"`
-		Scheme   *string                   `json:"scheme,omitzero"`
-		Pattern  *PatternOrRelativePattern `json:"pattern,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A document filter where `scheme` is required field.
@@ -11700,29 +16407,47 @@ type TextDocumentFilterScheme struct {
 	Pattern *PatternOrRelativePattern `json:"pattern,omitzero"`
 }
 
-func (s *TextDocumentFilterScheme) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Scheme requiredProp `json:"scheme"`
-	}
+func (s *TextDocumentFilterScheme) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenScheme bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Scheme {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "language":
+			if err := json.UnmarshalDecode(dec, &s.Language); err != nil {
+				return err
+			}
+		case "scheme":
+			seenScheme = true
+			if err := json.UnmarshalDecode(dec, &s.Scheme); err != nil {
+				return err
+			}
+		case "pattern":
+			if err := json.UnmarshalDecode(dec, &s.Pattern); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenScheme {
 		return fmt.Errorf("required key 'scheme' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Language *string                   `json:"language,omitzero"`
-		Scheme   string                    `json:"scheme"`
-		Pattern  *PatternOrRelativePattern `json:"pattern,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A document filter where `pattern` is required field.
@@ -11743,29 +16468,47 @@ type TextDocumentFilterPattern struct {
 	Pattern PatternOrRelativePattern `json:"pattern"`
 }
 
-func (s *TextDocumentFilterPattern) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Pattern requiredProp `json:"pattern"`
-	}
+func (s *TextDocumentFilterPattern) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenPattern bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Pattern {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "language":
+			if err := json.UnmarshalDecode(dec, &s.Language); err != nil {
+				return err
+			}
+		case "scheme":
+			if err := json.UnmarshalDecode(dec, &s.Scheme); err != nil {
+				return err
+			}
+		case "pattern":
+			seenPattern = true
+			if err := json.UnmarshalDecode(dec, &s.Pattern); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenPattern {
 		return fmt.Errorf("required key 'pattern' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Language *string                  `json:"language,omitzero"`
-		Scheme   *string                  `json:"scheme,omitzero"`
-		Pattern  PatternOrRelativePattern `json:"pattern"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A notebook document filter where `notebookType` is required field.
@@ -11782,29 +16525,47 @@ type NotebookDocumentFilterNotebookType struct {
 	Pattern *PatternOrRelativePattern `json:"pattern,omitzero"`
 }
 
-func (s *NotebookDocumentFilterNotebookType) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		NotebookType requiredProp `json:"notebookType"`
-	}
+func (s *NotebookDocumentFilterNotebookType) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenNotebookType bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.NotebookType {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "notebookType":
+			seenNotebookType = true
+			if err := json.UnmarshalDecode(dec, &s.NotebookType); err != nil {
+				return err
+			}
+		case "scheme":
+			if err := json.UnmarshalDecode(dec, &s.Scheme); err != nil {
+				return err
+			}
+		case "pattern":
+			if err := json.UnmarshalDecode(dec, &s.Pattern); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenNotebookType {
 		return fmt.Errorf("required key 'notebookType' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		NotebookType string                    `json:"notebookType"`
-		Scheme       *string                   `json:"scheme,omitzero"`
-		Pattern      *PatternOrRelativePattern `json:"pattern,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A notebook document filter where `scheme` is required field.
@@ -11821,29 +16582,47 @@ type NotebookDocumentFilterScheme struct {
 	Pattern *PatternOrRelativePattern `json:"pattern,omitzero"`
 }
 
-func (s *NotebookDocumentFilterScheme) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Scheme requiredProp `json:"scheme"`
-	}
+func (s *NotebookDocumentFilterScheme) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenScheme bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Scheme {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "notebookType":
+			if err := json.UnmarshalDecode(dec, &s.NotebookType); err != nil {
+				return err
+			}
+		case "scheme":
+			seenScheme = true
+			if err := json.UnmarshalDecode(dec, &s.Scheme); err != nil {
+				return err
+			}
+		case "pattern":
+			if err := json.UnmarshalDecode(dec, &s.Pattern); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenScheme {
 		return fmt.Errorf("required key 'scheme' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		NotebookType *string                   `json:"notebookType,omitzero"`
-		Scheme       string                    `json:"scheme"`
-		Pattern      *PatternOrRelativePattern `json:"pattern,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A notebook document filter where `pattern` is required field.
@@ -11860,29 +16639,47 @@ type NotebookDocumentFilterPattern struct {
 	Pattern PatternOrRelativePattern `json:"pattern"`
 }
 
-func (s *NotebookDocumentFilterPattern) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Pattern requiredProp `json:"pattern"`
-	}
+func (s *NotebookDocumentFilterPattern) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenPattern bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Pattern {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "notebookType":
+			if err := json.UnmarshalDecode(dec, &s.NotebookType); err != nil {
+				return err
+			}
+		case "scheme":
+			if err := json.UnmarshalDecode(dec, &s.Scheme); err != nil {
+				return err
+			}
+		case "pattern":
+			seenPattern = true
+			if err := json.UnmarshalDecode(dec, &s.Pattern); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenPattern {
 		return fmt.Errorf("required key 'pattern' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		NotebookType *string                  `json:"notebookType,omitzero"`
-		Scheme       *string                  `json:"scheme,omitzero"`
-		Pattern      PatternOrRelativePattern `json:"pattern"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // A change describing how to move a `NotebookCell`
@@ -11900,33 +16697,54 @@ type NotebookCellArrayChange struct {
 	Cells *[]*NotebookCell `json:"cells,omitzero"`
 }
 
-func (s *NotebookCellArrayChange) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Start       requiredProp `json:"start"`
-		DeleteCount requiredProp `json:"deleteCount"`
-	}
+func (s *NotebookCellArrayChange) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenStart       bool
+		seenDeleteCount bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Start {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "start":
+			seenStart = true
+			if err := json.UnmarshalDecode(dec, &s.Start); err != nil {
+				return err
+			}
+		case "deleteCount":
+			seenDeleteCount = true
+			if err := json.UnmarshalDecode(dec, &s.DeleteCount); err != nil {
+				return err
+			}
+		case "cells":
+			if err := json.UnmarshalDecode(dec, &s.Cells); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenStart {
 		return fmt.Errorf("required key 'start' is missing")
 	}
-	if !keys.DeleteCount {
+	if !seenDeleteCount {
 		return fmt.Errorf("required key 'deleteCount' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Start       uint32           `json:"start"`
-		DeleteCount uint32           `json:"deleteCount"`
-		Cells       *[]*NotebookCell `json:"cells,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 type WorkspaceEditClientCapabilities struct {
@@ -12579,47 +17397,88 @@ type SemanticTokensClientCapabilities struct {
 	AugmentsSyntaxTokens *bool `json:"augmentsSyntaxTokens,omitzero"`
 }
 
-func (s *SemanticTokensClientCapabilities) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Requests       requiredProp `json:"requests"`
-		TokenTypes     requiredProp `json:"tokenTypes"`
-		TokenModifiers requiredProp `json:"tokenModifiers"`
-		Formats        requiredProp `json:"formats"`
-	}
+func (s *SemanticTokensClientCapabilities) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenRequests       bool
+		seenTokenTypes     bool
+		seenTokenModifiers bool
+		seenFormats        bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Requests {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "dynamicRegistration":
+			if err := json.UnmarshalDecode(dec, &s.DynamicRegistration); err != nil {
+				return err
+			}
+		case "requests":
+			seenRequests = true
+			if err := json.UnmarshalDecode(dec, &s.Requests); err != nil {
+				return err
+			}
+		case "tokenTypes":
+			seenTokenTypes = true
+			if err := json.UnmarshalDecode(dec, &s.TokenTypes); err != nil {
+				return err
+			}
+		case "tokenModifiers":
+			seenTokenModifiers = true
+			if err := json.UnmarshalDecode(dec, &s.TokenModifiers); err != nil {
+				return err
+			}
+		case "formats":
+			seenFormats = true
+			if err := json.UnmarshalDecode(dec, &s.Formats); err != nil {
+				return err
+			}
+		case "overlappingTokenSupport":
+			if err := json.UnmarshalDecode(dec, &s.OverlappingTokenSupport); err != nil {
+				return err
+			}
+		case "multilineTokenSupport":
+			if err := json.UnmarshalDecode(dec, &s.MultilineTokenSupport); err != nil {
+				return err
+			}
+		case "serverCancelSupport":
+			if err := json.UnmarshalDecode(dec, &s.ServerCancelSupport); err != nil {
+				return err
+			}
+		case "augmentsSyntaxTokens":
+			if err := json.UnmarshalDecode(dec, &s.AugmentsSyntaxTokens); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenRequests {
 		return fmt.Errorf("required key 'requests' is missing")
 	}
-	if !keys.TokenTypes {
+	if !seenTokenTypes {
 		return fmt.Errorf("required key 'tokenTypes' is missing")
 	}
-	if !keys.TokenModifiers {
+	if !seenTokenModifiers {
 		return fmt.Errorf("required key 'tokenModifiers' is missing")
 	}
-	if !keys.Formats {
+	if !seenFormats {
 		return fmt.Errorf("required key 'formats' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		DynamicRegistration     *bool                               `json:"dynamicRegistration,omitzero"`
-		Requests                *ClientSemanticTokensRequestOptions `json:"requests"`
-		TokenTypes              []string                            `json:"tokenTypes"`
-		TokenModifiers          []string                            `json:"tokenModifiers"`
-		Formats                 []TokenFormat                       `json:"formats"`
-		OverlappingTokenSupport *bool                               `json:"overlappingTokenSupport,omitzero"`
-		MultilineTokenSupport   *bool                               `json:"multilineTokenSupport,omitzero"`
-		ServerCancelSupport     *bool                               `json:"serverCancelSupport,omitzero"`
-		AugmentsSyntaxTokens    *bool                               `json:"augmentsSyntaxTokens,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Client capabilities for the linked editing range request.
@@ -12743,27 +17602,39 @@ type ShowDocumentClientCapabilities struct {
 	Support bool `json:"support"`
 }
 
-func (s *ShowDocumentClientCapabilities) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Support requiredProp `json:"support"`
-	}
+func (s *ShowDocumentClientCapabilities) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenSupport bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Support {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "support":
+			seenSupport = true
+			if err := json.UnmarshalDecode(dec, &s.Support); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenSupport {
 		return fmt.Errorf("required key 'support' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Support bool `json:"support"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.18.0
@@ -12777,32 +17648,50 @@ type StaleRequestSupportOptions struct {
 	RetryOnContentModified []string `json:"retryOnContentModified"`
 }
 
-func (s *StaleRequestSupportOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Cancel                 requiredProp `json:"cancel"`
-		RetryOnContentModified requiredProp `json:"retryOnContentModified"`
-	}
+func (s *StaleRequestSupportOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var (
+		seenCancel                 bool
+		seenRetryOnContentModified bool
+	)
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Cancel {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "cancel":
+			seenCancel = true
+			if err := json.UnmarshalDecode(dec, &s.Cancel); err != nil {
+				return err
+			}
+		case "retryOnContentModified":
+			seenRetryOnContentModified = true
+			if err := json.UnmarshalDecode(dec, &s.RetryOnContentModified); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenCancel {
 		return fmt.Errorf("required key 'cancel' is missing")
 	}
-	if !keys.RetryOnContentModified {
+	if !seenRetryOnContentModified {
 		return fmt.Errorf("required key 'retryOnContentModified' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Cancel                 bool     `json:"cancel"`
-		RetryOnContentModified []string `json:"retryOnContentModified"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Client capabilities specific to regular expressions.
@@ -12816,28 +17705,43 @@ type RegularExpressionsClientCapabilities struct {
 	Version *string `json:"version,omitzero"`
 }
 
-func (s *RegularExpressionsClientCapabilities) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Engine requiredProp `json:"engine"`
-	}
+func (s *RegularExpressionsClientCapabilities) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenEngine bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Engine {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "engine":
+			seenEngine = true
+			if err := json.UnmarshalDecode(dec, &s.Engine); err != nil {
+				return err
+			}
+		case "version":
+			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenEngine {
 		return fmt.Errorf("required key 'engine' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Engine  string  `json:"engine"`
-		Version *string `json:"version,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Client capabilities specific to the used markdown parser.
@@ -12857,29 +17761,47 @@ type MarkdownClientCapabilities struct {
 	AllowedTags *[]string `json:"allowedTags,omitzero"`
 }
 
-func (s *MarkdownClientCapabilities) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Parser requiredProp `json:"parser"`
-	}
+func (s *MarkdownClientCapabilities) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenParser bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Parser {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "parser":
+			seenParser = true
+			if err := json.UnmarshalDecode(dec, &s.Parser); err != nil {
+				return err
+			}
+		case "version":
+			if err := json.UnmarshalDecode(dec, &s.Version); err != nil {
+				return err
+			}
+		case "allowedTags":
+			if err := json.UnmarshalDecode(dec, &s.AllowedTags); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenParser {
 		return fmt.Errorf("required key 'parser' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Parser      string    `json:"parser"`
-		Version     *string   `json:"version,omitzero"`
-		AllowedTags *[]string `json:"allowedTags,omitzero"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.18.0
@@ -12909,27 +17831,39 @@ type ClientSymbolTagOptions struct {
 	ValueSet []SymbolTag `json:"valueSet"`
 }
 
-func (s *ClientSymbolTagOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		ValueSet requiredProp `json:"valueSet"`
-	}
+func (s *ClientSymbolTagOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenValueSet bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.ValueSet {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "valueSet":
+			seenValueSet = true
+			if err := json.UnmarshalDecode(dec, &s.ValueSet); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenValueSet {
 		return fmt.Errorf("required key 'valueSet' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		ValueSet []SymbolTag `json:"valueSet"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.18.0
@@ -12939,27 +17873,39 @@ type ClientSymbolResolveOptions struct {
 	Properties []string `json:"properties"`
 }
 
-func (s *ClientSymbolResolveOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Properties requiredProp `json:"properties"`
-	}
+func (s *ClientSymbolResolveOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenProperties bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Properties {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "properties":
+			seenProperties = true
+			if err := json.UnmarshalDecode(dec, &s.Properties); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenProperties {
 		return fmt.Errorf("required key 'properties' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Properties []string `json:"properties"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.18.0
@@ -13094,27 +18040,39 @@ type ClientCodeActionLiteralOptions struct {
 	CodeActionKind *ClientCodeActionKindOptions `json:"codeActionKind"`
 }
 
-func (s *ClientCodeActionLiteralOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		CodeActionKind requiredProp `json:"codeActionKind"`
-	}
+func (s *ClientCodeActionLiteralOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenCodeActionKind bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.CodeActionKind {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "codeActionKind":
+			seenCodeActionKind = true
+			if err := json.UnmarshalDecode(dec, &s.CodeActionKind); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenCodeActionKind {
 		return fmt.Errorf("required key 'codeActionKind' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		CodeActionKind *ClientCodeActionKindOptions `json:"codeActionKind"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.18.0
@@ -13123,27 +18081,39 @@ type ClientCodeActionResolveOptions struct {
 	Properties []string `json:"properties"`
 }
 
-func (s *ClientCodeActionResolveOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Properties requiredProp `json:"properties"`
-	}
+func (s *ClientCodeActionResolveOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenProperties bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Properties {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "properties":
+			seenProperties = true
+			if err := json.UnmarshalDecode(dec, &s.Properties); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenProperties {
 		return fmt.Errorf("required key 'properties' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Properties []string `json:"properties"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.18.0 - proposed
@@ -13152,27 +18122,39 @@ type CodeActionTagOptions struct {
 	ValueSet []CodeActionTag `json:"valueSet"`
 }
 
-func (s *CodeActionTagOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		ValueSet requiredProp `json:"valueSet"`
-	}
+func (s *CodeActionTagOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenValueSet bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.ValueSet {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "valueSet":
+			seenValueSet = true
+			if err := json.UnmarshalDecode(dec, &s.ValueSet); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenValueSet {
 		return fmt.Errorf("required key 'valueSet' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		ValueSet []CodeActionTag `json:"valueSet"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.18.0
@@ -13181,27 +18163,39 @@ type ClientCodeLensResolveOptions struct {
 	Properties []string `json:"properties"`
 }
 
-func (s *ClientCodeLensResolveOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Properties requiredProp `json:"properties"`
-	}
+func (s *ClientCodeLensResolveOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenProperties bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Properties {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "properties":
+			seenProperties = true
+			if err := json.UnmarshalDecode(dec, &s.Properties); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenProperties {
 		return fmt.Errorf("required key 'properties' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Properties []string `json:"properties"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.18.0
@@ -13263,27 +18257,39 @@ type ClientInlayHintResolveOptions struct {
 	Properties []string `json:"properties"`
 }
 
-func (s *ClientInlayHintResolveOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Properties requiredProp `json:"properties"`
-	}
+func (s *ClientInlayHintResolveOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenProperties bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Properties {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "properties":
+			seenProperties = true
+			if err := json.UnmarshalDecode(dec, &s.Properties); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenProperties {
 		return fmt.Errorf("required key 'properties' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Properties []string `json:"properties"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.18.0
@@ -13300,27 +18306,39 @@ type CompletionItemTagOptions struct {
 	ValueSet []CompletionItemTag `json:"valueSet"`
 }
 
-func (s *CompletionItemTagOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		ValueSet requiredProp `json:"valueSet"`
-	}
+func (s *CompletionItemTagOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenValueSet bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.ValueSet {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "valueSet":
+			seenValueSet = true
+			if err := json.UnmarshalDecode(dec, &s.ValueSet); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenValueSet {
 		return fmt.Errorf("required key 'valueSet' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		ValueSet []CompletionItemTag `json:"valueSet"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.18.0
@@ -13329,27 +18347,39 @@ type ClientCompletionItemResolveOptions struct {
 	Properties []string `json:"properties"`
 }
 
-func (s *ClientCompletionItemResolveOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		Properties requiredProp `json:"properties"`
-	}
+func (s *ClientCompletionItemResolveOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenProperties bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.Properties {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "properties":
+			seenProperties = true
+			if err := json.UnmarshalDecode(dec, &s.Properties); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenProperties {
 		return fmt.Errorf("required key 'properties' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		Properties []string `json:"properties"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.18.0
@@ -13357,27 +18387,39 @@ type ClientCompletionItemInsertTextModeOptions struct {
 	ValueSet []InsertTextMode `json:"valueSet"`
 }
 
-func (s *ClientCompletionItemInsertTextModeOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		ValueSet requiredProp `json:"valueSet"`
-	}
+func (s *ClientCompletionItemInsertTextModeOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenValueSet bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.ValueSet {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "valueSet":
+			seenValueSet = true
+			if err := json.UnmarshalDecode(dec, &s.ValueSet); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenValueSet {
 		return fmt.Errorf("required key 'valueSet' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		ValueSet []InsertTextMode `json:"valueSet"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.18.0
@@ -13398,27 +18440,39 @@ type ClientCodeActionKindOptions struct {
 	ValueSet []CodeActionKind `json:"valueSet"`
 }
 
-func (s *ClientCodeActionKindOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		ValueSet requiredProp `json:"valueSet"`
-	}
+func (s *ClientCodeActionKindOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenValueSet bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.ValueSet {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "valueSet":
+			seenValueSet = true
+			if err := json.UnmarshalDecode(dec, &s.ValueSet); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenValueSet {
 		return fmt.Errorf("required key 'valueSet' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		ValueSet []CodeActionKind `json:"valueSet"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.18.0
@@ -13427,27 +18481,39 @@ type ClientDiagnosticsTagOptions struct {
 	ValueSet []DiagnosticTag `json:"valueSet"`
 }
 
-func (s *ClientDiagnosticsTagOptions) UnmarshalJSON(data []byte) error {
-	// Check required props
-	type requiredProps struct {
-		ValueSet requiredProp `json:"valueSet"`
-	}
+func (s *ClientDiagnosticsTagOptions) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var seenValueSet bool
 
-	var keys requiredProps
-	if err := json.Unmarshal(data, &keys); err != nil {
+	if k := dec.PeekKind(); k != '{' {
+		return fmt.Errorf("expected object start, but encountered %v", k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
 		return err
 	}
 
-	if !keys.ValueSet {
+	for dec.PeekKind() != '}' {
+		var name string
+		if err := json.UnmarshalDecode(dec, &name); err != nil {
+			return err
+		}
+		switch name {
+		case "valueSet":
+			seenValueSet = true
+			if err := json.UnmarshalDecode(dec, &s.ValueSet); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if !seenValueSet {
 		return fmt.Errorf("required key 'valueSet' is missing")
 	}
 
-	// Redeclare the struct to prevent infinite recursion
-	type temp struct {
-		ValueSet []DiagnosticTag `json:"valueSet"`
-	}
-
-	return json.Unmarshal(data, (*temp)(s))
+	return nil
 }
 
 // Since: 3.18.0

--- a/internal/lsp/lsproto/lsp_generated.go
+++ b/internal/lsp/lsproto/lsp_generated.go
@@ -20961,7 +20961,6 @@ func (o DocumentSelectorOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if o.DocumentSelector != nil {
 		return json.MarshalEncode(enc, *o.DocumentSelector)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -21386,7 +21385,6 @@ func (o IntegerOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if o.Integer != nil {
 		return json.MarshalEncode(enc, *o.Integer)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -21424,7 +21422,6 @@ func (o StringOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if o.String != nil {
 		return json.MarshalEncode(enc, *o.String)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -21462,7 +21459,6 @@ func (o DocumentUriOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if o.DocumentUri != nil {
 		return json.MarshalEncode(enc, *o.DocumentUri)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -21500,7 +21496,6 @@ func (o WorkspaceFoldersOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if o.WorkspaceFolders != nil {
 		return json.MarshalEncode(enc, *o.WorkspaceFolders)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -21720,7 +21715,6 @@ func (o UintegerOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if o.Uinteger != nil {
 		return json.MarshalEncode(enc, *o.Uinteger)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -23459,7 +23453,6 @@ func (o LocationOrLocationsOrDefinitionLinksOrNull) MarshalJSONTo(enc *jsontext.
 	if o.DefinitionLinks != nil {
 		return json.MarshalEncode(enc, *o.DefinitionLinks)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -23507,7 +23500,6 @@ func (o FoldingRangesOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if o.FoldingRanges != nil {
 		return json.MarshalEncode(enc, *o.FoldingRanges)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -23553,7 +23545,6 @@ func (o LocationOrLocationsOrDeclarationLinksOrNull) MarshalJSONTo(enc *jsontext
 	if o.DeclarationLinks != nil {
 		return json.MarshalEncode(enc, *o.DeclarationLinks)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -23601,7 +23592,6 @@ func (o SelectionRangesOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if o.SelectionRanges != nil {
 		return json.MarshalEncode(enc, *o.SelectionRanges)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -23639,7 +23629,6 @@ func (o CallHierarchyItemsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if o.CallHierarchyItems != nil {
 		return json.MarshalEncode(enc, *o.CallHierarchyItems)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -23677,7 +23666,6 @@ func (o CallHierarchyIncomingCallsOrNull) MarshalJSONTo(enc *jsontext.Encoder) e
 	if o.CallHierarchyIncomingCalls != nil {
 		return json.MarshalEncode(enc, *o.CallHierarchyIncomingCalls)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -23715,7 +23703,6 @@ func (o CallHierarchyOutgoingCallsOrNull) MarshalJSONTo(enc *jsontext.Encoder) e
 	if o.CallHierarchyOutgoingCalls != nil {
 		return json.MarshalEncode(enc, *o.CallHierarchyOutgoingCalls)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -23753,7 +23740,6 @@ func (o SemanticTokensOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if o.SemanticTokens != nil {
 		return json.MarshalEncode(enc, *o.SemanticTokens)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -23795,7 +23781,6 @@ func (o SemanticTokensOrSemanticTokensDeltaOrNull) MarshalJSONTo(enc *jsontext.E
 	if o.SemanticTokensDelta != nil {
 		return json.MarshalEncode(enc, *o.SemanticTokensDelta)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -23838,7 +23823,6 @@ func (o LinkedEditingRangesOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if o.LinkedEditingRanges != nil {
 		return json.MarshalEncode(enc, *o.LinkedEditingRanges)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -23876,7 +23860,6 @@ func (o WorkspaceEditOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if o.WorkspaceEdit != nil {
 		return json.MarshalEncode(enc, *o.WorkspaceEdit)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -23914,7 +23897,6 @@ func (o MonikersOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if o.Monikers != nil {
 		return json.MarshalEncode(enc, *o.Monikers)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -23952,7 +23934,6 @@ func (o TypeHierarchyItemsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if o.TypeHierarchyItems != nil {
 		return json.MarshalEncode(enc, *o.TypeHierarchyItems)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -23990,7 +23971,6 @@ func (o InlineValuesOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if o.InlineValues != nil {
 		return json.MarshalEncode(enc, *o.InlineValues)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -24028,7 +24008,6 @@ func (o InlayHintsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if o.InlayHints != nil {
 		return json.MarshalEncode(enc, *o.InlayHints)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -24111,7 +24090,6 @@ func (o InlineCompletionListOrItemsOrNull) MarshalJSONTo(enc *jsontext.Encoder) 
 	if o.Items != nil {
 		return json.MarshalEncode(enc, *o.Items)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -24154,7 +24132,6 @@ func (o MessageActionItemOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if o.MessageActionItem != nil {
 		return json.MarshalEncode(enc, *o.MessageActionItem)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -24192,7 +24169,6 @@ func (o TextEditsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if o.TextEdits != nil {
 		return json.MarshalEncode(enc, *o.TextEdits)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -24234,7 +24210,6 @@ func (o CompletionItemsOrListOrNull) MarshalJSONTo(enc *jsontext.Encoder) error 
 	if o.List != nil {
 		return json.MarshalEncode(enc, *o.List)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -24277,7 +24252,6 @@ func (o HoverOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if o.Hover != nil {
 		return json.MarshalEncode(enc, *o.Hover)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -24315,7 +24289,6 @@ func (o SignatureHelpOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if o.SignatureHelp != nil {
 		return json.MarshalEncode(enc, *o.SignatureHelp)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -24353,7 +24326,6 @@ func (o LocationsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if o.Locations != nil {
 		return json.MarshalEncode(enc, *o.Locations)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -24391,7 +24363,6 @@ func (o DocumentHighlightsOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if o.DocumentHighlights != nil {
 		return json.MarshalEncode(enc, *o.DocumentHighlights)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -24433,7 +24404,6 @@ func (o SymbolInformationsOrDocumentSymbolsOrNull) MarshalJSONTo(enc *jsontext.E
 	if o.DocumentSymbols != nil {
 		return json.MarshalEncode(enc, *o.DocumentSymbols)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -24517,7 +24487,6 @@ func (o CommandOrCodeActionArrayOrNull) MarshalJSONTo(enc *jsontext.Encoder) err
 	if o.CommandOrCodeActionArray != nil {
 		return json.MarshalEncode(enc, *o.CommandOrCodeActionArray)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -24559,7 +24528,6 @@ func (o SymbolInformationsOrWorkspaceSymbolsOrNull) MarshalJSONTo(enc *jsontext.
 	if o.WorkspaceSymbols != nil {
 		return json.MarshalEncode(enc, *o.WorkspaceSymbols)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -24602,7 +24570,6 @@ func (o CodeLenssOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if o.CodeLenss != nil {
 		return json.MarshalEncode(enc, *o.CodeLenss)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -24640,7 +24607,6 @@ func (o DocumentLinksOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if o.DocumentLinks != nil {
 		return json.MarshalEncode(enc, *o.DocumentLinks)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -24686,7 +24652,6 @@ func (o RangeOrPrepareRenamePlaceholderOrPrepareRenameDefaultBehaviorOrNull) Mar
 	if o.PrepareRenameDefaultBehavior != nil {
 		return json.MarshalEncode(enc, *o.PrepareRenameDefaultBehavior)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 
@@ -24734,7 +24699,6 @@ func (o LSPAnyOrNull) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if o.LSPAny != nil {
 		return json.MarshalEncode(enc, *o.LSPAny)
 	}
-	// All fields are nil, represent as null
 	return enc.WriteToken(jsontext.Null)
 }
 


### PR DESCRIPTION
- Replace `RawMessage` with `Value` (cleanup)
- Prevent double decode when checking required fields by using new `UnmarshalJSONFrom` and generated checks.
- Eliminate redundant unmarshal methods for enums; the defaults are fine as they are just values.
- Use `MarshalJSONTo` and `UnmarshalJSONFrom` in union/literal marshalling to avoid extra `[]byte` encoding; the former never produces an intermediary `[]byte`, and the latter slices out of the input buffer (zero copy).
- Use pointers for union type marshalling, now that it behaves consistently in v2.
