### PR TITLE
Use a single shared cache for all CI workflows

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -5,12 +5,13 @@ inputs:
   go-version:
     description: Go version range to set up.
     default: '>=1.24.0'
-  cache-name:
-    description: Name of scoped cache for this set up.
-    default: 'cache'
+  create:
+    description: Create the cache
+    default: 'false'
 
 runs:
   using: composite
+
   steps:
     - name: Install Go
       id: install-go
@@ -19,18 +20,68 @@ runs:
         go-version: ${{ inputs.go-version }}
         cache: false
 
-    # There is more code downloaded and built than is covered by '**/go.sum',
-    # so give each job its own cache to try and not end up sharing the wrong
-    # cache between jobs, and hash the Herebyfile and golancgi-lint version.
-
-    - name: Go cache
+    - name: Cache Go modules
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
-        key: ts-setup-go-${{ runner.os }}-${{ steps.install-go.outputs.go-version }}-${{ hashFiles('**/go.sum', '**/Herebyfile.mjs', '**/.custom-gcl.yml') }}-${{ github.workflow }}-${{ inputs.cache-name }}
-        restore-keys: |
-          ts-setup-go-${{ runner.os }}-${{ steps.install-go.outputs.go-version }}-${{ hashFiles('**/go.sum', '**/Herebyfile.mjs', '**/.custom-gcl.yml') }}-${{ github.workflow }}-
+        key: go-modules-${{ runner.os }}-${{ steps.install-go.outputs.go-version }}-${{ hashFiles('**/go.sum', '**/Herebyfile.mjs', '**/.custom-gcl.yml') }}
         path: |
           ~/go/pkg/mod
+
+    - if: ${{ inputs.create == 'true' }}
+      shell: bash
+      run: npm ci
+
+    - name: Set mtimes
+      shell: bash
+      run: |
+        find . -type f ! -path ./.git/\*\* | go run github.com/slsyy/mtimehash/cmd/mtimehash@v1.0.0 || true
+        find . -type d ! -path ./.git/\*\* -exec touch -d '1970-01-01T00:00:01Z' {} + || true
+
+    - if: ${{ inputs.create == 'true' }}
+      shell: bash
+      run: npx hereby build
+
+    - if: ${{ inputs.create == 'true' }}
+      shell: bash
+      run: npx hereby test
+
+    - if: ${{ inputs.create == 'true' }}
+      shell: bash
+      run: npx hereby lint
+
+    - if: ${{ inputs.create == 'true' }}
+      shell: bash
+      run: npx dprint check
+
+    # Avoid hardcoding the cache key more than once.
+    - name: Create Go build cache key
+      shell: bash
+      id: go-build-cache-key
+      env:
+        CACHE_KEY: go-build-cache-${{ runner.os }}-${{ steps.install-go.outputs.go-version }}
+      run: |
+        echo "key=$CACHE_KEY" >> $GITHUB_OUTPUT
+
+    - if: ${{ inputs.create == 'true' }}
+      name: Save Go build cache
+      uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        # Save a new cache each time by including the unique run ID.
+        key: ${{ steps.go-build-cache-key.outputs.key }}-${{ github.run_id }}
+        path: |
+          ~/.cache/go-build
+          ~/Library/Caches/go-build
+          ~/AppData/Local/go-build
+
+    - if: ${{ inputs.create != 'true' }}
+      name: Restore Go build cache
+      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        # key is unused, but a required input.
+        key: ${{ steps.go-build-cache-key.outputs.key }}-
+        # Restore the most recent cache, ignoring the run ID.
+        restore-keys: ${{ steps.go-build-cache-key.outputs.key }}-
+        path: |
           ~/.cache/go-build
           ~/Library/Caches/go-build
           ~/AppData/Local/go-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,6 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       - uses: dtolnay/rust-toolchain@fcf085fcb4b4b8f63f96906cd713eb52181b5ea4 # stable
       - uses: ./.github/actions/setup-go
-        with:
-          cache-name: build
 
       # Avoid duplicate PR annotations.
       - name: Disable PR annotations
@@ -112,8 +110,6 @@ jobs:
           node-version: 'lts/*'
       - uses: dtolnay/rust-toolchain@fcf085fcb4b4b8f63f96906cd713eb52181b5ea4 # stable
       - uses: ./.github/actions/setup-go
-        with:
-          cache-name: test
 
       # Avoid duplicate PR annotations.
       - if: ${{ ! matrix.config.main }}
@@ -199,8 +195,6 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       - uses: dtolnay/rust-toolchain@fcf085fcb4b4b8f63f96906cd713eb52181b5ea4 # stable
       - uses: ./.github/actions/setup-go
-        with:
-          cache-name: lint${{ (matrix.config.noembed && '-noembed') || ''}}
 
       # Avoid duplicate PR annotations.
       - if: ${{ ! matrix.config.main }}
@@ -222,8 +216,6 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       - uses: dtolnay/rust-toolchain@fcf085fcb4b4b8f63f96906cd713eb52181b5ea4 # stable
       - uses: ./.github/actions/setup-go
-        with:
-          cache-name: format
 
       - run: npm ci
 
@@ -240,8 +232,6 @@ jobs:
           node-version: '>=22.16.0'
       - uses: dtolnay/rust-toolchain@fcf085fcb4b4b8f63f96906cd713eb52181b5ea4 # stable
       - uses: ./.github/actions/setup-go
-        with:
-          cache-name: generate
 
       - run: npm ci
 
@@ -261,8 +251,6 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-go
-        with:
-          cache-name: tidy
 
       - run: go mod tidy -diff
       - run: go -C ./_tools mod tidy -diff
@@ -276,8 +264,6 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       - uses: dtolnay/rust-toolchain@fcf085fcb4b4b8f63f96906cd713eb52181b5ea4 # stable
       - uses: ./.github/actions/setup-go
-        with:
-          cache-name: smoke
 
       # Avoid duplicate PR annotations.
       - name: Disable PR annotations
@@ -302,8 +288,6 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-go
-        with:
-          cache-name: misc
 
       - run: go -C ./_tools run ./cmd/checkmodpaths $PWD
 
@@ -316,8 +300,6 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       - uses: dtolnay/rust-toolchain@fcf085fcb4b4b8f63f96906cd713eb52181b5ea4 # stable
       - uses: ./.github/actions/setup-go
-        with:
-          cache-name: baselines
 
       - run: npm ci
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -25,11 +25,7 @@ jobs:
         with:
           # Updated to 1.25.0-rc.1 to improve compilation time
           go-version: '>=1.25.0-rc.1'
-          cache-name: copilot-setup-steps
       - run: npm i -g @playwright/mcp@0.0.28
       - run: npm ci
       # pull dprint caches before network access is blocked
       - run: npx hereby check:format || true
-      # cache build and lint operations
-      - run: npx hereby build || true
-      - run: npx hereby lint || true

--- a/.github/workflows/create-cache.yml
+++ b/.github/workflows/create-cache.yml
@@ -1,0 +1,45 @@
+name: Create CI cache
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  schedule:
+    # Run every day at 10:00 UTC / 03:00 PST
+    - cron: '0 10 * * *'
+
+permissions:
+  contents: read
+
+# Ensure scripts are run with pipefail. See:
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  cache:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+        go-version:
+          - '>=1.24.0'
+          - '>=1.25.0-rc.1'
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: true
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: dtolnay/rust-toolchain@fcf085fcb4b4b8f63f96906cd713eb52181b5ea4 # stable
+      - uses: ./.github/actions/setup-go
+        with:
+          go-version: ${{ matrix.go-version }}
+          create: 'true'

--- a/.github/workflows/create-cache.yml
+++ b/.github/workflows/create-cache.yml
@@ -23,16 +23,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+        go-version:
+          - '>=1.24.0'
+
         include:
-          - os: ubuntu-latest
-            go-version: '>=1.24.0'
           # Temporary for the Copilot setup steps
           - os: ubuntu-latest
             go-version: '>=1.25.0-rc.1'
-          - os: windows-latest
-            go-version: '>=1.24.0'
-          - os: macos-latest
-            go-version: '>=1.24.0'
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/create-cache.yml
+++ b/.github/workflows/create-cache.yml
@@ -23,15 +23,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
-          - macos-latest
-        go-version:
-          - '>=1.24.0'
-          - '>=1.25.0-rc.1'
+        include:
+          - os: ubuntu-latest
+            go-version: '>=1.24.0'
+          # Temporary for the Copilot setup steps
+          - os: ubuntu-latest
+            go-version: '>=1.25.0-rc.1'
+          - os: windows-latest
+            go-version: '>=1.24.0'
+          - os: macos-latest
+            go-version: '>=1.24.0'
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
This is a new attempt at getting CI caching to work, based on how I set up DT's pnpm cache, https://500.keboola.com/in-depth-of-go-build-cache/, and https://github.com/golang/go/issues/58571.

It works like this:

- The caches are produced from a dedicated `create-cache` workflow on `main`.
- Before doing anything, the workflow sets the `mtime` of the files/dirs in the repo; this is important so that the build/test caches are consistent.
- The module cache is set up with `actions/cache`, which restores a cache at the start, then saves a cache at the end, so any module we download will be saved.
- We run a build, test, lint, format, which exercises the full suite of things that a workflow could do.
- The build cache is saved.

The `create-cache` workflow runs on pushes to `main` and on a schedule early in the morning; GitHub has a 10GB limit for the Action caches, so these jobs just keep the latest caches up to date. Since the module cache rarely changes, we need the scheduled job so that we don't accidentally drop the module cache out of the rolling window.

Then, in other workflows:

- We restore restore the `mtimes` so the caches will apply.
- We restore the module and build caches from `main`. These are _only_ restored, never saved.
- The jobs proceed as normal.

This should have a few positive effects:

- PRs have caches for everything they don't touch. Most PRs don't touch the `ast` or even the `checker`, so this should be pretty optimal.
- Copilot jobs should have a fully populated cache from the start, without needing to run any extra setup builds/lints like we do today. We still need to run `dprint` as I did not add that into a cache yet (another PR). It should also be faster to add a new test, since the actual code builds would have been cached.
- Pushes to main will reuse the cache from the previous commit, so multiple pushes to main should be no worse than if you were on a local dev machine running things in sequence.