### PR TITLE
Cache coverage builds in CI too

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -93,6 +93,10 @@ runs:
 
     - if: ${{ inputs.create == 'true' }}
       shell: bash
+      run: npx hereby test --coverage
+
+    - if: ${{ inputs.create == 'true' }}
+      shell: bash
       run: npx hereby lint
 
     - if: ${{ inputs.create == 'true' }}


### PR DESCRIPTION
Go coverage builds are source-rewritten compilations, so are all new cache entries; this explains why regular CI builds are not so fast.

The number of stuff that has to be cached is sort of absurd at this point, though. Hopefully this is better once 1.25 is out...