### PR TITLE
finishNode returns its node parameter

### DIFF
--- a/internal/parser/jsdoc.go
+++ b/internal/parser/jsdoc.go
@@ -83,9 +83,7 @@ func (p *Parser) parseJSDocTypeExpression(mayOmitBraces bool) *ast.Node {
 		p.parseExpectedJSDoc(ast.KindCloseBraceToken)
 	}
 
-	result := p.factory.NewJSDocTypeExpression(t)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewJSDocTypeExpression(t), pos)
 }
 
 func (p *Parser) parseJSDocNameReference() *ast.Node {
@@ -96,16 +94,13 @@ func (p *Parser) parseJSDocNameReference() *ast.Node {
 	for p.token == ast.KindPrivateIdentifier {
 		p.scanner.ReScanHashToken() // rescan #id as # id
 		p.nextTokenJSDoc()          // then skip the #
-		entityName = p.factory.NewQualifiedName(entityName, p.parseIdentifier())
-		p.finishNode(entityName, p2)
+		entityName = p.finishNode(p.factory.NewQualifiedName(entityName, p.parseIdentifier()), p2)
 	}
 	if hasBrace {
 		p.parseExpectedJSDoc(ast.KindCloseBraceToken)
 	}
 
-	result := p.factory.NewJSDocNameReference(entityName)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewJSDocNameReference(entityName), pos)
 }
 
 // Pass end=-1 to parse the text to the end
@@ -258,8 +253,7 @@ loop:
 				if linkEnd == start {
 					comments = removeLeadingNewlines(comments)
 				}
-				jsdocText := p.factory.NewJSDocText(p.stringSlicePool.Clone(comments))
-				p.finishNodeWithEnd(jsdocText, linkEnd, commentEnd)
+				jsdocText := p.finishNodeWithEnd(p.factory.NewJSDocText(p.stringSlicePool.Clone(comments)), linkEnd, commentEnd)
 				commentParts = append(commentParts, jsdocText, link)
 				comments = comments[:0]
 				linkEnd = p.scanner.TokenEnd()
@@ -287,8 +281,7 @@ loop:
 
 	if len(comments) > 0 {
 		comments[len(comments)-1] = strings.TrimRightFunc(comments[len(comments)-1], unicode.IsSpace)
-		jsdocText := p.factory.NewJSDocText(p.stringSlicePool.Clone(comments))
-		p.finishNodeWithEnd(jsdocText, linkEnd, commentsPos)
+		jsdocText := p.finishNodeWithEnd(p.factory.NewJSDocText(p.stringSlicePool.Clone(comments)), linkEnd, commentsPos)
 		commentParts = append(commentParts, jsdocText)
 	}
 
@@ -305,8 +298,7 @@ loop:
 		p.newNodeList(core.NewTextRange(start, commentsPos), commentParts),
 		tagsNodeList,
 	)
-	p.finishNodeWithEnd(jsdocComment, fullStart, end)
-	return jsdocComment
+	return p.finishNodeWithEnd(jsdocComment, fullStart, end)
 }
 
 func removeLeadingNewlines(comments []string) []string {
@@ -532,14 +524,13 @@ loop:
 			linkStart := p.scanner.TokenEnd() - 1
 			link := p.parseJSDocLink(linkStart)
 			if link != nil {
-				text := p.factory.NewJSDocText(p.stringSlicePool.Clone(comments))
 				var commentStart int
 				if linkEnd > -1 {
 					commentStart = linkEnd
 				} else {
 					commentStart = commentsPos
 				}
-				p.finishNodeWithEnd(text, commentStart, commentEnd)
+				text := p.finishNodeWithEnd(p.factory.NewJSDocText(p.stringSlicePool.Clone(comments)), commentStart, commentEnd)
 				parts = append(parts, text)
 				parts = append(parts, link)
 				comments = comments[:0]
@@ -593,8 +584,7 @@ loop:
 		} else {
 			commentStart = commentsPos
 		}
-		text := p.factory.NewJSDocText(p.stringSlicePool.Clone(comments))
-		p.finishNode(text, commentStart)
+		text := p.finishNode(p.factory.NewJSDocText(p.stringSlicePool.Clone(comments)), commentStart)
 		parts = append(parts, text)
 	}
 
@@ -631,8 +621,7 @@ func (p *Parser) parseJSDocLink(start int) *ast.Node {
 	default:
 		create = p.factory.NewJSDocLinkPlain(name, text)
 	}
-	p.finishNodeWithEnd(create, start, p.scanner.TokenEnd())
-	return create
+	return p.finishNodeWithEnd(create, start, p.scanner.TokenEnd())
 }
 
 func (p *Parser) parseJSDocLinkName() *ast.Node {
@@ -647,15 +636,13 @@ func (p *Parser) parseJSDocLinkName() *ast.Node {
 			} else {
 				right = p.parseIdentifierName()
 			}
-			name = p.factory.NewQualifiedName(name, right)
-			p.finishNode(name, pos)
+			name = p.finishNode(p.factory.NewQualifiedName(name, right), pos)
 		}
 
 		for p.token == ast.KindPrivateIdentifier {
 			p.scanner.ReScanHashToken()
 			p.nextTokenJSDoc()
-			name = p.factory.NewQualifiedName(name, p.parseIdentifier())
-			p.finishNode(name, pos)
+			name = p.finishNode(p.factory.NewQualifiedName(name, p.parseIdentifier()), pos)
 		}
 		return name
 	}
@@ -678,9 +665,7 @@ func isJSDocLinkTag(kind string) bool {
 }
 
 func (p *Parser) parseUnknownTag(start int, tagName *ast.IdentifierNode, indent int, indentText string) *ast.Node {
-	tag := p.factory.NewJSDocUnknownTag(tagName, p.parseTrailingTagComments(start, p.nodePos(), indent, indentText))
-	p.finishNode(tag, start)
-	return tag
+	return p.finishNode(p.factory.NewJSDocUnknownTag(tagName, p.parseTrailingTagComments(start, p.nodePos(), indent, indentText)), start)
 }
 
 func (p *Parser) tryParseTypeExpression() *ast.Node {
@@ -757,8 +742,7 @@ func (p *Parser) parseParameterOrPropertyTag(start int, tagName *ast.IdentifierN
 	} else {
 		result = p.factory.NewJSDocParameterTag(tagName, name, isBracketed, typeExpression, isNameFirst, comment)
 	}
-	p.finishNode(result, start)
-	return result
+	return p.finishNode(result, start)
 }
 
 func (p *Parser) parseNestedTypeLiteral(typeExpression *ast.Node, name *ast.EntityName, target propertyLikeParse, indent int) *ast.Node {
@@ -779,11 +763,8 @@ func (p *Parser) parseNestedTypeLiteral(typeExpression *ast.Node, name *ast.Enti
 			}
 		}
 		if children != nil {
-			literal := p.factory.NewJSDocTypeLiteral(children, typeExpression.Type().Kind == ast.KindArrayType)
-			p.finishNode(literal, pos)
-			result := p.factory.NewJSDocTypeExpression(literal)
-			p.finishNode(result, pos)
-			return result
+			literal := p.finishNode(p.factory.NewJSDocTypeLiteral(children, typeExpression.Type().Kind == ast.KindArrayType), pos)
+			return p.finishNode(p.factory.NewJSDocTypeExpression(literal), pos)
 		}
 	}
 	return nil
@@ -795,9 +776,7 @@ func (p *Parser) parseReturnTag(previousTags []*ast.Node, start int, tagName *as
 	}
 
 	typeExpression := p.tryParseTypeExpression()
-	result := p.factory.NewJSDocReturnTag(tagName, typeExpression, p.parseTrailingTagComments(start, p.nodePos(), indent, indentText))
-	p.finishNode(result, start)
-	return result
+	return p.finishNode(p.factory.NewJSDocReturnTag(tagName, typeExpression, p.parseTrailingTagComments(start, p.nodePos(), indent, indentText)), start)
 }
 
 // pass indent=-1 to skip parsing trailing comments (as when a type tag is nested in a typedef)
@@ -811,9 +790,7 @@ func (p *Parser) parseTypeTag(previousTags []*ast.Node, start int, tagName *ast.
 	if indent != -1 {
 		comments = p.parseTrailingTagComments(start, p.nodePos(), indent, indentText)
 	}
-	result := p.factory.NewJSDocTypeTag(tagName, typeExpression, comments)
-	p.finishNode(result, start)
-	return result
+	return p.finishNode(p.factory.NewJSDocTypeTag(tagName, typeExpression, comments), start)
 }
 
 func (p *Parser) parseSeeTag(start int, tagName *ast.IdentifierNode, indent int, indentText string) *ast.Node {
@@ -825,31 +802,23 @@ func (p *Parser) parseSeeTag(start int, tagName *ast.IdentifierNode, indent int,
 		nameExpression = p.parseJSDocNameReference()
 	}
 	comments := p.parseTrailingTagComments(start, p.nodePos(), indent, indentText)
-	result := p.factory.NewJSDocSeeTag(tagName, nameExpression, comments)
-	p.finishNode(result, start)
-	return result
+	return p.finishNode(p.factory.NewJSDocSeeTag(tagName, nameExpression, comments), start)
 }
 
 func (p *Parser) parseImplementsTag(start int, tagName *ast.IdentifierNode, margin int, indentText string) *ast.Node {
 	className := p.parseExpressionWithTypeArgumentsForAugments()
-	result := p.factory.NewJSDocImplementsTag(tagName, className, p.parseTrailingTagComments(start, p.nodePos(), margin, indentText))
-	p.finishNode(result, start)
-	return result
+	return p.finishNode(p.factory.NewJSDocImplementsTag(tagName, className, p.parseTrailingTagComments(start, p.nodePos(), margin, indentText)), start)
 }
 
 func (p *Parser) parseAugmentsTag(start int, tagName *ast.IdentifierNode, margin int, indentText string) *ast.Node {
 	className := p.parseExpressionWithTypeArgumentsForAugments()
-	result := p.factory.NewJSDocAugmentsTag(tagName, className, p.parseTrailingTagComments(start, p.nodePos(), margin, indentText))
-	p.finishNode(result, start)
-	return result
+	return p.finishNode(p.factory.NewJSDocAugmentsTag(tagName, className, p.parseTrailingTagComments(start, p.nodePos(), margin, indentText)), start)
 }
 
 func (p *Parser) parseSatisfiesTag(start int, tagName *ast.IdentifierNode, margin int, indentText string) *ast.Node {
 	typeExpression := p.parseJSDocTypeExpression(false)
 	comments := p.parseTrailingTagComments(start, p.nodePos(), margin, indentText)
-	result := p.factory.NewJSDocSatisfiesTag(tagName, typeExpression, comments)
-	p.finishNode(result, start)
-	return result
+	return p.finishNode(p.factory.NewJSDocSatisfiesTag(tagName, typeExpression, comments), start)
 }
 
 func (p *Parser) parseImportTag(start int, tagName *ast.IdentifierNode, margin int, indentText string) *ast.Node {
@@ -865,9 +834,7 @@ func (p *Parser) parseImportTag(start int, tagName *ast.IdentifierNode, margin i
 	attributes := p.tryParseImportAttributes()
 
 	comments := p.parseTrailingTagComments(start, p.nodePos(), margin, indentText)
-	result := p.factory.NewJSDocImportTag(tagName, importClause, moduleSpecifier, attributes, comments)
-	p.finishNode(result, start)
-	return result
+	return p.finishNode(p.factory.NewJSDocImportTag(tagName, importClause, moduleSpecifier, attributes, comments), start)
 }
 
 func (p *Parser) parseExpressionWithTypeArgumentsForAugments() *ast.Node {
@@ -877,14 +844,12 @@ func (p *Parser) parseExpressionWithTypeArgumentsForAugments() *ast.Node {
 	p.scanner.SetSkipJSDocLeadingAsterisks(true)
 	typeArguments := p.parseTypeArguments()
 	p.scanner.SetSkipJSDocLeadingAsterisks(false)
-	node := p.factory.NewExpressionWithTypeArguments(expression, typeArguments)
-	res := node
-	p.finishNode(node, pos)
+	node := p.finishNode(p.factory.NewExpressionWithTypeArguments(expression, typeArguments), pos)
 	if usedBrace {
 		p.skipWhitespace()
 		p.parseExpected(ast.KindCloseBraceToken)
 	}
-	return res
+	return node
 }
 
 func (p *Parser) parsePropertyAccessEntityNameExpression() *ast.Node {
@@ -892,24 +857,20 @@ func (p *Parser) parsePropertyAccessEntityNameExpression() *ast.Node {
 	node := p.parseJSDocIdentifierName(nil)
 	for p.parseOptional(ast.KindDotToken) {
 		name := p.parseJSDocIdentifierName(nil)
-		node = p.factory.NewPropertyAccessExpression(node, nil, name, ast.NodeFlagsNone)
-		p.finishNode(node, pos)
+		node = p.finishNode(p.factory.NewPropertyAccessExpression(node, nil, name, ast.NodeFlagsNone), pos)
 	}
 	return node
 }
 
 func (p *Parser) parseSimpleTag(start int, createTag func(tagName *ast.IdentifierNode, comment *ast.NodeList) *ast.Node, tagName *ast.IdentifierNode, margin int, indentText string) *ast.Node {
-	tag := createTag(tagName, p.parseTrailingTagComments(start, p.nodePos(), margin, indentText))
-	p.finishNode(tag, start)
-	return tag
+	return p.finishNode(createTag(tagName, p.parseTrailingTagComments(start, p.nodePos(), margin, indentText)), start)
 }
 
 func (p *Parser) parseThisTag(start int, tagName *ast.IdentifierNode, margin int, indentText string) *ast.Node {
 	typeExpression := p.parseJSDocTypeExpression(true)
 	p.skipWhitespace()
 	result := p.factory.NewJSDocThisTag(tagName, typeExpression, p.parseTrailingTagComments(start, p.nodePos(), margin, indentText))
-	p.finishNode(result, start)
-	return result
+	return p.finishNode(result, start)
 }
 
 func (p *Parser) parseTypedefTag(start int, tagName *ast.IdentifierNode, indent int, indentText string) *ast.Node {
@@ -957,8 +918,7 @@ func (p *Parser) parseTypedefTag(start int, tagName *ast.IdentifierNode, indent 
 			if childTypeTag != nil && childTypeTag.TypeExpression != nil && !isObjectOrObjectArrayTypeReference(childTypeTag.TypeExpression.Type()) {
 				typeExpression = childTypeTag.TypeExpression
 			} else {
-				p.finishNode(jsdocTypeLiteral, start)
-				typeExpression = jsdocTypeLiteral
+				typeExpression = p.finishNode(jsdocTypeLiteral, start)
 			}
 		}
 	}
@@ -982,8 +942,7 @@ func (p *Parser) parseTypedefTag(start int, tagName *ast.IdentifierNode, indent 
 		comment = p.parseTrailingTagComments(start, end, indent, indentText)
 	}
 
-	typedefTag := p.factory.NewJSDocTypedefTag(tagName, typeExpression, fullName, comment)
-	p.finishNodeWithEnd(typedefTag, start, end)
+	typedefTag := p.finishNodeWithEnd(p.factory.NewJSDocTypedefTag(tagName, typeExpression, fullName, comment), start, end)
 	if typeExpression != nil {
 		typeExpression.Parent = typedefTag // forcibly overwrite parent potentially set by inner type expression parse
 	}
@@ -1023,9 +982,7 @@ func (p *Parser) parseJSDocSignature(start int, indent int) *ast.Node {
 	if returnTag == nil {
 		p.rewind(state)
 	}
-	result := p.factory.NewJSDocSignature(nil, parameters, returnTag)
-	p.finishNode(result, start)
-	return result
+	return p.finishNode(p.factory.NewJSDocSignature(nil, parameters, returnTag), start)
 }
 
 func (p *Parser) parseCallbackTag(start int, tagName *ast.IdentifierNode, indent int, indentText string) *ast.Node {
@@ -1042,9 +999,7 @@ func (p *Parser) parseCallbackTag(start int, tagName *ast.IdentifierNode, indent
 	} else {
 		end = typeExpression.End()
 	}
-	result := p.factory.NewJSDocCallbackTag(tagName, typeExpression, fullName, comment)
-	p.finishNodeWithEnd(result, start, end)
-	return result
+	return p.finishNodeWithEnd(p.factory.NewJSDocCallbackTag(tagName, typeExpression, fullName, comment), start, end)
 }
 
 func (p *Parser) parseOverloadTag(start int, tagName *ast.IdentifierNode, indent int, indentText string) *ast.Node {
@@ -1060,9 +1015,7 @@ func (p *Parser) parseOverloadTag(start int, tagName *ast.IdentifierNode, indent
 	} else {
 		end = typeExpression.End()
 	}
-	result := p.factory.NewJSDocOverloadTag(tagName, typeExpression, comment)
-	p.finishNodeWithEnd(result, start, end)
-	return result
+	return p.finishNodeWithEnd(p.factory.NewJSDocOverloadTag(tagName, typeExpression, comment), start, end)
 }
 
 func textsEqual(a *ast.EntityName, b *ast.EntityName) bool {
@@ -1168,9 +1121,7 @@ func (p *Parser) parseTemplateTagTypeParameter() *ast.Node {
 	if ast.NodeIsMissing(name) {
 		return nil
 	}
-	result := p.factory.NewTypeParameterDeclaration(modifiers, name, nil /*constraint*/, defaultType)
-	p.finishNode(result, typeParameterPos)
-	return result
+	return p.finishNode(p.factory.NewTypeParameterDeclaration(modifiers, name, nil /*constraint*/, defaultType), typeParameterPos)
 }
 
 func (p *Parser) parseTemplateTagTypeParameters() *ast.TypeParameterList {
@@ -1204,8 +1155,7 @@ func (p *Parser) parseTemplateTag(start int, tagName *ast.IdentifierNode, indent
 	}
 	typeParameters := p.parseTemplateTagTypeParameters()
 	result := p.factory.NewJSDocTemplateTag(tagName, constraint, typeParameters, p.parseTrailingTagComments(start, p.nodePos(), indent, indentText))
-	p.finishNode(result, start)
-	return result
+	return p.finishNode(result, start)
 }
 
 func (p *Parser) parseOptionalJsdoc(t ast.Kind) bool {
@@ -1230,8 +1180,7 @@ func (p *Parser) parseJSDocEntityName() *ast.EntityName {
 			p.parseExpected(ast.KindCloseBracketToken)
 		}
 		pos := entity.Pos()
-		entity = p.factory.NewQualifiedName(entity, name)
-		p.finishNode(entity, pos)
+		entity = p.finishNode(p.factory.NewQualifiedName(entity, name), pos)
 	}
 	return entity
 }
@@ -1245,16 +1194,12 @@ func (p *Parser) parseJSDocIdentifierName(diagnosticMessage *diagnostics.Message
 		} else {
 			p.parseErrorAtCurrentToken(diagnostics.Identifier_expected)
 		}
-		result := p.newIdentifier("")
-		p.finishNode(result, p.nodePos())
-		return result
+		return p.finishNode(p.newIdentifier(""), p.nodePos())
 	}
 	pos := p.scanner.TokenStart()
 	end := p.scanner.TokenEnd()
 	text := p.scanner.TokenValue()
 	p.internIdentifier(text)
 	p.nextTokenJSDoc()
-	result := p.newIdentifier(text)
-	p.finishNodeWithEnd(result, pos, end)
-	return result
+	return p.finishNodeWithEnd(p.newIdentifier(text), pos, end)
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -182,13 +182,11 @@ func (p *Parser) parseJSONText() *ast.SourceFile {
 		} else {
 			expression = expressions.(*ast.Expression)
 		}
-		statement := p.factory.NewExpressionStatement(expression)
-		p.finishNode(statement, pos)
+		statement := p.finishNode(p.factory.NewExpressionStatement(expression), pos)
 		statements = p.newNodeList(core.NewTextRange(pos, p.nodePos()), []*ast.Node{statement})
 		eof = p.parseExpectedToken(ast.KindEndOfFile)
 	}
-	node := p.factory.NewSourceFile(p.opts, p.sourceText, statements, eof)
-	p.finishNode(node, pos)
+	node := p.finishNode(p.factory.NewSourceFile(p.opts, p.sourceText, statements, eof), pos)
 	result := node.AsSourceFile()
 	p.finishSourceFile(result, false)
 	return result
@@ -346,14 +344,12 @@ func (p *Parser) parseSourceFileWorker() *ast.SourceFile {
 		statements = append(statements, p.reparseList...)
 		p.reparseList = nil
 	}
-	node := p.factory.NewSourceFile(p.opts, p.sourceText, p.newNodeList(core.NewTextRange(pos, end), statements), eof)
-	p.finishNode(node, pos)
+	node := p.finishNode(p.factory.NewSourceFile(p.opts, p.sourceText, p.newNodeList(core.NewTextRange(pos, end), statements), eof), pos)
 	result := node.AsSourceFile()
 	p.finishSourceFile(result, isDeclarationFile)
 	if !result.IsDeclarationFile && result.ExternalModuleIndicator != nil && len(p.possibleAwaitSpans) > 0 {
-		reparse := p.reparseTopLevelAwait(result)
+		reparse := p.finishNode(p.reparseTopLevelAwait(result), pos)
 		if node != reparse {
-			p.finishNode(reparse, pos)
 			result = reparse.AsSourceFile()
 			p.finishSourceFile(result, isDeclarationFile)
 		}
@@ -887,17 +883,14 @@ func (p *Parser) parseTokenNode() *ast.Node {
 	pos := p.nodePos()
 	kind := p.token
 	p.nextToken()
-	result := p.factory.NewToken(kind)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewToken(kind), pos)
 }
 
 func (p *Parser) parseExpectedToken(kind ast.Kind) *ast.Node {
 	token := p.parseOptionalToken(kind)
 	if token == nil {
 		p.parseErrorAtCurrentToken(diagnostics.X_0_expected, scanner.TokenToString(kind))
-		token = p.factory.NewToken(kind)
-		p.finishNode(token, p.nodePos())
+		token = p.finishNode(p.factory.NewToken(kind), p.nodePos())
 	}
 	return token
 }
@@ -916,8 +909,7 @@ func (p *Parser) parseExpectedTokenJSDoc(kind ast.Kind) *ast.Node {
 			panic("expected keyword or punctuation")
 		}
 		p.parseErrorAtCurrentToken(diagnostics.X_0_expected, scanner.TokenToString(kind))
-		optional = p.factory.NewToken(kind)
-		p.finishNode(optional, p.nodePos())
+		optional = p.finishNode(p.factory.NewToken(kind), p.nodePos())
 	}
 	return optional
 }
@@ -1050,9 +1042,7 @@ func (p *Parser) parseDeclarationWorker(pos int, hasJSDoc bool, modifiers *ast.M
 		// We reached this point because we encountered decorators and/or modifiers and assumed a declaration
 		// would follow. For recovery and error reporting purposes, return an incomplete declaration.
 		p.parseErrorAt(p.nodePos(), p.nodePos(), diagnostics.Declaration_expected)
-		result := p.factory.NewMissingDeclaration(modifiers)
-		p.finishNode(result, pos)
-		return result
+		return p.finishNode(p.factory.NewMissingDeclaration(modifiers), pos)
 	}
 	panic("Unhandled case in parseDeclarationWorker")
 }
@@ -1082,8 +1072,7 @@ func (p *Parser) parseBlock(ignoreMissingOpenBrace bool, diagnosticMessage *diag
 		multiline = p.hasPrecedingLineBreak()
 		statements := p.parseList(PCBlockStatements, (*Parser).parseStatement)
 		p.parseExpectedMatchingBrackets(ast.KindOpenBraceToken, ast.KindCloseBraceToken, openBraceParsed, openBracePosition)
-		result := p.factory.NewBlock(statements, multiline)
-		p.finishNode(result, pos)
+		result := p.finishNode(p.factory.NewBlock(statements, multiline), pos)
 		p.withJSDoc(result, hasJSDoc)
 		if p.token == ast.KindEqualsToken {
 			p.parseErrorAtCurrentToken(diagnostics.Declaration_or_statement_expected_This_follows_a_block_of_statements_so_if_you_intended_to_write_a_destructuring_assignment_you_might_need_to_wrap_the_whole_assignment_in_parentheses)
@@ -1091,8 +1080,7 @@ func (p *Parser) parseBlock(ignoreMissingOpenBrace bool, diagnosticMessage *diag
 		}
 		return result
 	}
-	result := p.factory.NewBlock(p.parseEmptyNodeList(), multiline)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewBlock(p.parseEmptyNodeList(), multiline), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -1101,8 +1089,7 @@ func (p *Parser) parseEmptyStatement() *ast.Node {
 	pos := p.nodePos()
 	hasJSDoc := p.hasPrecedingJSDocComment()
 	p.parseExpected(ast.KindSemicolonToken)
-	result := p.factory.NewEmptyStatement()
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewEmptyStatement(), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -1120,8 +1107,7 @@ func (p *Parser) parseIfStatement() *ast.Node {
 	if p.parseOptional(ast.KindElseKeyword) {
 		elseStatement = p.parseStatement()
 	}
-	result := p.factory.NewIfStatement(expression, thenStatement, elseStatement)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewIfStatement(expression, thenStatement, elseStatement), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -1141,8 +1127,7 @@ func (p *Parser) parseDoStatement() *ast.Node {
 	// spec but allowed in consensus reality. Approved -- this is the de-facto standard whereby
 	//  do;while(0)x will have a semicolon inserted before x.
 	p.parseOptional(ast.KindSemicolonToken)
-	result := p.factory.NewDoStatement(statement, expression)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewDoStatement(statement, expression), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -1156,8 +1141,7 @@ func (p *Parser) parseWhileStatement() *ast.Node {
 	expression := p.parseExpressionAllowIn()
 	p.parseExpectedMatchingBrackets(ast.KindOpenParenToken, ast.KindCloseParenToken, openParenParsed, openParenPosition)
 	statement := p.parseStatement()
-	result := p.factory.NewWhileStatement(expression, statement)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewWhileStatement(expression, statement), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -1214,8 +1198,7 @@ func (p *Parser) parseBreakStatement() *ast.Node {
 	p.parseExpected(ast.KindBreakKeyword)
 	label := p.parseIdentifierUnlessAtSemicolon()
 	p.parseSemicolon()
-	result := p.factory.NewBreakStatement(label)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewBreakStatement(label), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -1226,8 +1209,7 @@ func (p *Parser) parseContinueStatement() *ast.Node {
 	p.parseExpected(ast.KindContinueKeyword)
 	label := p.parseIdentifierUnlessAtSemicolon()
 	p.parseSemicolon()
-	result := p.factory.NewContinueStatement(label)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewContinueStatement(label), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -1248,8 +1230,7 @@ func (p *Parser) parseReturnStatement() *ast.Node {
 		expression = p.parseExpressionAllowIn()
 	}
 	p.parseSemicolon()
-	result := p.factory.NewReturnStatement(expression)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewReturnStatement(expression), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -1263,8 +1244,7 @@ func (p *Parser) parseWithStatement() *ast.Node {
 	expression := p.parseExpressionAllowIn()
 	p.parseExpectedMatchingBrackets(ast.KindOpenParenToken, ast.KindCloseParenToken, openParenParsed, openParenPosition)
 	statement := doInContext(p, ast.NodeFlagsInWithStatement, true, (*Parser).parseStatement)
-	result := p.factory.NewWithStatement(expression, statement)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewWithStatement(expression, statement), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -1276,8 +1256,7 @@ func (p *Parser) parseCaseClause() *ast.Node {
 	expression := p.parseExpressionAllowIn()
 	p.parseExpected(ast.KindColonToken)
 	statements := p.parseList(PCSwitchClauseStatements, (*Parser).parseStatement)
-	result := p.factory.NewCaseOrDefaultClause(ast.KindCaseClause, expression, statements)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewCaseOrDefaultClause(ast.KindCaseClause, expression, statements), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -1288,8 +1267,7 @@ func (p *Parser) parseDefaultClause() *ast.Node {
 	p.parseExpected(ast.KindDefaultKeyword)
 	p.parseExpected(ast.KindColonToken)
 	statements := p.parseList(PCSwitchClauseStatements, (*Parser).parseStatement)
-	result := p.factory.NewCaseOrDefaultClause(ast.KindDefaultClause, nil /*expression*/, statements)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewCaseOrDefaultClause(ast.KindDefaultClause, nil /*expression*/, statements), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -1307,8 +1285,7 @@ func (p *Parser) parseCaseBlock() *ast.Node {
 	p.parseExpected(ast.KindOpenBraceToken)
 	clauses := p.parseList(PCSwitchClauses, (*Parser).parseCaseOrDefaultClause)
 	p.parseExpected(ast.KindCloseBraceToken)
-	result := p.factory.NewCaseBlock(clauses)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewCaseBlock(clauses), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -1321,8 +1298,7 @@ func (p *Parser) parseSwitchStatement() *ast.Node {
 	expression := p.parseExpressionAllowIn()
 	p.parseExpected(ast.KindCloseParenToken)
 	caseBlock := p.parseCaseBlock()
-	result := p.factory.NewSwitchStatement(expression, caseBlock)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewSwitchStatement(expression, caseBlock), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -1347,8 +1323,7 @@ func (p *Parser) parseThrowStatement() *ast.Node {
 	if !p.tryParseSemicolon() {
 		p.parseErrorForMissingSemicolonAfter(expression)
 	}
-	result := p.factory.NewThrowStatement(expression)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewThrowStatement(expression), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -1370,8 +1345,7 @@ func (p *Parser) parseTryStatement() *ast.Node {
 		p.parseExpectedWithDiagnostic(ast.KindFinallyKeyword, diagnostics.X_catch_or_finally_expected, true /*shouldAdvance*/)
 		finallyBlock = p.parseBlock(false /*ignoreMissingOpenBrace*/, nil)
 	}
-	result := p.factory.NewTryStatement(tryBlock, catchClause, finallyBlock)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewTryStatement(tryBlock, catchClause, finallyBlock), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -1385,8 +1359,7 @@ func (p *Parser) parseCatchClause() *ast.Node {
 		p.parseExpected(ast.KindCloseParenToken)
 	}
 	block := p.parseBlock(false /*ignoreMissingOpenBrace*/, nil)
-	result := p.factory.NewCatchClause(variableDeclaration, block)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewCatchClause(variableDeclaration, block), pos)
 	return result
 }
 
@@ -1395,8 +1368,7 @@ func (p *Parser) parseDebuggerStatement() *ast.Node {
 	hasJSDoc := p.hasPrecedingJSDocComment()
 	p.parseExpected(ast.KindDebuggerKeyword)
 	p.parseSemicolon()
-	result := p.factory.NewDebuggerStatement()
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewDebuggerStatement(), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -1411,8 +1383,7 @@ func (p *Parser) parseExpressionOrLabeledStatement() *ast.Statement {
 	expression := p.parseExpression()
 
 	if expression.Kind == ast.KindIdentifier && p.parseOptional(ast.KindColonToken) {
-		result := p.factory.NewLabeledStatement(expression, p.parseStatement())
-		p.finishNode(result, pos)
+		result := p.finishNode(p.factory.NewLabeledStatement(expression, p.parseStatement()), pos)
 		p.withJSDoc(result, hasJSDoc)
 		return result
 	}
@@ -1420,8 +1391,7 @@ func (p *Parser) parseExpressionOrLabeledStatement() *ast.Statement {
 	if !p.tryParseSemicolon() {
 		p.parseErrorForMissingSemicolonAfter(expression)
 	}
-	result := p.factory.NewExpressionStatement(expression)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewExpressionStatement(expression), pos)
 	jsdoc := p.withJSDoc(result, hasJSDoc && !hasParen)
 	p.reparseCommonJS(result, jsdoc)
 	return result
@@ -1430,8 +1400,7 @@ func (p *Parser) parseExpressionOrLabeledStatement() *ast.Statement {
 func (p *Parser) parseVariableStatement(pos int, hasJSDoc bool, modifiers *ast.ModifierList) *ast.Node {
 	declarationList := p.parseVariableDeclarationList(false /*inForStatementInitializer*/)
 	p.parseSemicolon()
-	result := p.factory.NewVariableStatement(modifiers, declarationList)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewVariableStatement(modifiers, declarationList), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -1474,8 +1443,7 @@ func (p *Parser) parseVariableDeclarationList(inForStatementInitializer bool) *a
 		declarations = p.parseDelimitedList(PCVariableDeclarations, core.IfElse(inForStatementInitializer, (*Parser).parseVariableDeclaration, (*Parser).parseVariableDeclarationAllowExclamation))
 		p.contextFlags = saveContextFlags
 	}
-	result := p.factory.NewVariableDeclarationList(flags, declarations)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewVariableDeclarationList(flags, declarations), pos)
 	return result
 }
 
@@ -1509,8 +1477,7 @@ func (p *Parser) parseVariableDeclarationWorker(allowExclamation bool) *ast.Node
 	if p.token != ast.KindInKeyword && p.token != ast.KindOfKeyword {
 		initializer = p.parseInitializer()
 	}
-	result := p.factory.NewVariableDeclaration(name, exclamationToken, typeNode, initializer)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewVariableDeclaration(name, exclamationToken, typeNode, initializer), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -1537,9 +1504,7 @@ func (p *Parser) parseArrayBindingPattern() *ast.Node {
 	elements := p.parseDelimitedList(PCArrayBindingElements, (*Parser).parseArrayBindingElement)
 	p.contextFlags = saveContextFlags
 	p.parseExpected(ast.KindCloseBracketToken)
-	result := p.factory.NewBindingPattern(ast.KindArrayBindingPattern, elements)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewBindingPattern(ast.KindArrayBindingPattern, elements), pos)
 }
 
 func (p *Parser) parseArrayBindingElement() *ast.Node {
@@ -1553,9 +1518,7 @@ func (p *Parser) parseArrayBindingElement() *ast.Node {
 		name = p.parseIdentifierOrPattern()
 		initializer = p.parseInitializer()
 	}
-	result := p.factory.NewBindingElement(dotDotDotToken, nil /*propertyName*/, name, initializer)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewBindingElement(dotDotDotToken, nil /*propertyName*/, name, initializer), pos)
 }
 
 func (p *Parser) parseObjectBindingPattern() *ast.Node {
@@ -1566,9 +1529,7 @@ func (p *Parser) parseObjectBindingPattern() *ast.Node {
 	elements := p.parseDelimitedList(PCObjectBindingElements, (*Parser).parseObjectBindingElement)
 	p.contextFlags = saveContextFlags
 	p.parseExpected(ast.KindCloseBraceToken)
-	result := p.factory.NewBindingPattern(ast.KindObjectBindingPattern, elements)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewBindingPattern(ast.KindObjectBindingPattern, elements), pos)
 }
 
 func (p *Parser) parseObjectBindingElement() *ast.Node {
@@ -1585,9 +1546,7 @@ func (p *Parser) parseObjectBindingElement() *ast.Node {
 		name = p.parseIdentifierOrPattern()
 	}
 	initializer := p.parseInitializer()
-	result := p.factory.NewBindingElement(dotDotDotToken, propertyName, name, initializer)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewBindingElement(dotDotDotToken, propertyName, name, initializer), pos)
 }
 
 func (p *Parser) parseInitializer() *ast.Expression {
@@ -1622,8 +1581,7 @@ func (p *Parser) parseFunctionDeclaration(pos int, hasJSDoc bool, modifiers *ast
 	returnType := p.parseReturnType(ast.KindColonToken, false /*isType*/)
 	body := p.parseFunctionBlockOrSemicolon(signatureFlags, diagnostics.X_or_expected)
 	p.contextFlags = saveContextFlags
-	result := p.factory.NewFunctionDeclaration(modifiers, asteriskToken, name, typeParameters, parameters, returnType, nil /*fullSignature*/, body)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewFunctionDeclaration(modifiers, asteriskToken, name, typeParameters, parameters, returnType, nil /*fullSignature*/, body), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -1712,9 +1670,7 @@ func (p *Parser) parseHeritageClause() *ast.Node {
 	kind := p.token
 	p.nextToken()
 	types := p.parseDelimitedList(PCHeritageClauseElement, (*Parser).parseExpressionWithTypeArguments)
-	result := p.factory.NewHeritageClause(kind, types)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewHeritageClause(kind, types), pos)
 }
 
 func (p *Parser) parseExpressionWithTypeArguments() *ast.Node {
@@ -1724,9 +1680,7 @@ func (p *Parser) parseExpressionWithTypeArguments() *ast.Node {
 		return expression
 	}
 	typeArguments := p.parseTypeArguments()
-	result := p.factory.NewExpressionWithTypeArguments(expression, typeArguments)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewExpressionWithTypeArguments(expression, typeArguments), pos)
 }
 
 func (p *Parser) parseClassElement() *ast.Node {
@@ -1734,8 +1688,7 @@ func (p *Parser) parseClassElement() *ast.Node {
 	hasJSDoc := p.hasPrecedingJSDocComment()
 	if p.token == ast.KindSemicolonToken {
 		p.nextToken()
-		result := p.factory.NewSemicolonClassElement()
-		p.finishNode(result, pos)
+		result := p.finishNode(p.factory.NewSemicolonClassElement(), pos)
 		p.withJSDoc(result, hasJSDoc)
 		return result
 	}
@@ -1788,8 +1741,7 @@ func (p *Parser) parseClassElement() *ast.Node {
 func (p *Parser) parseClassStaticBlockDeclaration(pos int, hasJSDoc bool, modifiers *ast.ModifierList) *ast.Node {
 	p.parseExpectedToken(ast.KindStaticKeyword)
 	body := p.parseClassStaticBlockBody()
-	result := p.factory.NewClassStaticBlockDeclaration(modifiers, body)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewClassStaticBlockDeclaration(modifiers, body), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -1811,8 +1763,7 @@ func (p *Parser) tryParseConstructorDeclaration(pos int, hasJSDoc bool, modifier
 		parameters := p.parseParameters(ParseFlagsNone)
 		returnType := p.parseReturnType(ast.KindColonToken, false /*isType*/)
 		body := p.parseFunctionBlockOrSemicolon(ParseFlagsNone, diagnostics.X_or_expected)
-		result := p.factory.NewConstructorDeclaration(modifiers, typeParameters, parameters, returnType, nil /*fullSignature*/, body)
-		p.finishNode(result, pos)
+		result := p.finishNode(p.factory.NewConstructorDeclaration(modifiers, typeParameters, parameters, returnType, nil /*fullSignature*/, body), pos)
 		p.withJSDoc(result, hasJSDoc)
 		return result
 	}
@@ -1842,8 +1793,7 @@ func (p *Parser) parseMethodDeclaration(pos int, hasJSDoc bool, modifiers *ast.M
 	parameters := p.parseParameters(signatureFlags)
 	typeNode := p.parseReturnType(ast.KindColonToken, false /*isType*/)
 	body := p.parseFunctionBlockOrSemicolon(signatureFlags, diagnosticMessage)
-	result := p.factory.NewMethodDeclaration(modifiers, asteriskToken, name, questionToken, typeParameters, parameters, typeNode, nil /*fullSignature*/, body)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewMethodDeclaration(modifiers, asteriskToken, name, questionToken, typeParameters, parameters, typeNode, nil /*fullSignature*/, body), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -1860,8 +1810,7 @@ func (p *Parser) parsePropertyDeclaration(pos int, hasJSDoc bool, modifiers *ast
 	typeNode := p.parseTypeAnnotation()
 	initializer := doInContext(p, ast.NodeFlagsYieldContext|ast.NodeFlagsAwaitContext|ast.NodeFlagsDisallowInContext, false, (*Parser).parseInitializer)
 	p.parseSemicolonAfterPropertyName(name, typeNode, initializer)
-	result := p.factory.NewPropertyDeclaration(modifiers, name, postfixToken, typeNode, initializer)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewPropertyDeclaration(modifiers, name, postfixToken, typeNode, initializer), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -1973,8 +1922,7 @@ func (p *Parser) parseInterfaceDeclaration(pos int, hasJSDoc bool, modifiers *as
 	typeParameters := p.parseTypeParameters()
 	heritageClauses := p.parseHeritageClauses()
 	members := p.parseObjectTypeMembers()
-	result := p.factory.NewInterfaceDeclaration(modifiers, name, typeParameters, heritageClauses, members)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewInterfaceDeclaration(modifiers, name, typeParameters, heritageClauses, members), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -1994,8 +1942,7 @@ func (p *Parser) parseTypeAliasDeclaration(pos int, hasJSDoc bool, modifiers *as
 		typeNode = p.parseType()
 	}
 	p.parseSemicolon()
-	result := p.factory.NewTypeAliasDeclaration(modifiers, name, typeParameters, typeNode)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewTypeAliasDeclaration(modifiers, name, typeParameters, typeNode), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -2013,8 +1960,7 @@ func (p *Parser) parseEnumMember() *ast.Node {
 	hasJSDoc := p.hasPrecedingJSDocComment()
 	name := p.parsePropertyName()
 	initializer := doInContext(p, ast.NodeFlagsDisallowInContext, false, (*Parser).parseInitializer)
-	result := p.factory.NewEnumMember(name, initializer)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewEnumMember(name, initializer), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -2033,8 +1979,7 @@ func (p *Parser) parseEnumDeclaration(pos int, hasJSDoc bool, modifiers *ast.Mod
 	} else {
 		members = p.parseEmptyNodeList()
 	}
-	result := p.factory.NewEnumDeclaration(modifiers, name, members)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewEnumDeclaration(modifiers, name, members), pos)
 	p.withJSDoc(result, hasJSDoc)
 	p.statementHasAwaitIdentifier = saveHasAwaitIdentifier
 	return result
@@ -2074,8 +2019,7 @@ func (p *Parser) parseAmbientExternalModuleDeclaration(pos int, hasJSDoc bool, m
 	} else {
 		p.parseSemicolon()
 	}
-	result := p.factory.NewModuleDeclaration(modifiers, keyword, name, body)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewModuleDeclaration(modifiers, keyword, name, body), pos)
 	p.withJSDoc(result, hasJSDoc)
 	p.statementHasAwaitIdentifier = saveHasAwaitIdentifier
 	return result
@@ -2090,9 +2034,7 @@ func (p *Parser) parseModuleBlock() *ast.Node {
 	} else {
 		statements = p.parseEmptyNodeList()
 	}
-	result := p.factory.NewModuleBlock(statements)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewModuleBlock(statements), pos)
 }
 
 func (p *Parser) parseModuleOrNamespaceDeclaration(pos int, hasJSDoc bool, modifiers *ast.ModifierList, nested bool, keyword ast.Kind) *ast.Node {
@@ -2113,8 +2055,7 @@ func (p *Parser) parseModuleOrNamespaceDeclaration(pos int, hasJSDoc bool, modif
 	} else {
 		body = p.parseModuleBlock()
 	}
-	result := p.factory.NewModuleDeclaration(modifiers, keyword, name, body)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewModuleDeclaration(modifiers, keyword, name, body), pos)
 	p.withJSDoc(result, hasJSDoc)
 	p.statementHasAwaitIdentifier = saveHasAwaitIdentifier
 	return result
@@ -2149,8 +2090,7 @@ func (p *Parser) parseImportDeclarationOrImportEqualsDeclaration(pos int, hasJSD
 	moduleSpecifier := p.parseModuleSpecifier()
 	attributes := p.tryParseImportAttributes()
 	p.parseSemicolon()
-	result := p.factory.NewImportDeclaration(modifiers, importClause, moduleSpecifier, attributes)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewImportDeclaration(modifiers, importClause, moduleSpecifier, attributes), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -2174,8 +2114,7 @@ func (p *Parser) parseImportEqualsDeclaration(pos int, hasJSDoc bool, modifiers 
 	p.parseExpected(ast.KindEqualsToken)
 	moduleReference := p.parseModuleReference()
 	p.parseSemicolon()
-	result := p.factory.NewImportEqualsDeclaration(modifiers, isTypeOnly, identifier, moduleReference)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewImportEqualsDeclaration(modifiers, isTypeOnly, identifier, moduleReference), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -2194,8 +2133,7 @@ func (p *Parser) parseExternalModuleReference() *ast.Node {
 	p.parseExpected(ast.KindOpenParenToken)
 	expression := p.parseModuleSpecifier()
 	p.parseExpected(ast.KindCloseParenToken)
-	result := p.factory.NewExternalModuleReference(expression)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewExternalModuleReference(expression), pos)
 	p.statementHasAwaitIdentifier = saveHasAwaitIdentifier
 	return result
 }
@@ -2247,8 +2185,7 @@ func (p *Parser) parseImportClause(identifier *ast.Node, pos int, isTypeOnly boo
 			p.scanner.SetSkipJSDocLeadingAsterisks(false)
 		}
 	}
-	result := p.factory.NewImportClause(isTypeOnly, identifier, namedBindings)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewImportClause(isTypeOnly, identifier, namedBindings), pos)
 	p.statementHasAwaitIdentifier = saveHasAwaitIdentifier
 	return result
 }
@@ -2260,9 +2197,7 @@ func (p *Parser) parseNamespaceImport() *ast.Node {
 	p.parseExpected(ast.KindAsteriskToken)
 	p.parseExpected(ast.KindAsKeyword)
 	name := p.parseIdentifier()
-	result := p.factory.NewNamespaceImport(name)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewNamespaceImport(name), pos)
 }
 
 func (p *Parser) parseNamedImports() *ast.Node {
@@ -2272,9 +2207,7 @@ func (p *Parser) parseNamedImports() *ast.Node {
 	//  { ImportsList }
 	//  { ImportsList, }
 	imports := p.parseBracketedList(PCImportOrExportSpecifiers, (*Parser).parseImportSpecifier, ast.KindOpenBraceToken, ast.KindCloseBraceToken)
-	result := p.factory.NewNamedImports(imports)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewNamedImports(imports), pos)
 }
 
 func (p *Parser) parseImportSpecifier() *ast.Node {
@@ -2288,9 +2221,7 @@ func (p *Parser) parseImportSpecifier() *ast.Node {
 		identifierName = p.newIdentifier("")
 		p.finishNode(identifierName, name.Pos())
 	}
-	result := p.factory.NewImportSpecifier(isTypeOnly, propertyName, identifierName)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewImportSpecifier(isTypeOnly, propertyName, identifierName), pos)
 }
 
 func (p *Parser) parseImportOrExportSpecifier(kind ast.Kind) (isTypeOnly bool, propertyName *ast.Node, name *ast.Node) {
@@ -2402,8 +2333,7 @@ func (p *Parser) parseExportAssignment(pos int, hasJSDoc bool, modifiers *ast.Mo
 	p.parseSemicolon()
 	p.contextFlags = saveContextFlags
 	p.statementHasAwaitIdentifier = saveHasAwaitIdentifier
-	result := p.factory.NewExportAssignment(modifiers, isExportEquals, nil /*typeNode*/, expression)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewExportAssignment(modifiers, isExportEquals, nil /*typeNode*/, expression), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -2416,8 +2346,7 @@ func (p *Parser) parseNamespaceExportDeclaration(pos int, hasJSDoc bool, modifie
 	p.statementHasAwaitIdentifier = saveHasAwaitIdentifier
 	p.parseSemicolon()
 	// NamespaceExportDeclaration nodes cannot have decorators or modifiers, we attach them here so we can report them in the grammar checker
-	result := p.factory.NewNamespaceExportDeclaration(modifiers, name)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewNamespaceExportDeclaration(modifiers, name), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -2453,17 +2382,14 @@ func (p *Parser) parseExportDeclaration(pos int, hasJSDoc bool, modifiers *ast.M
 	p.parseSemicolon()
 	p.contextFlags = saveContextFlags
 	p.statementHasAwaitIdentifier = saveHasAwaitIdentifier
-	result := p.factory.NewExportDeclaration(modifiers, isTypeOnly, exportClause, moduleSpecifier, attributes)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewExportDeclaration(modifiers, isTypeOnly, exportClause, moduleSpecifier, attributes), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
 
 func (p *Parser) parseNamespaceExport(pos int) *ast.Node {
 	exportName, _ := p.parseModuleExportName(false /*disallowKeywords*/)
-	result := p.factory.NewNamespaceExport(exportName)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewNamespaceExport(exportName), pos)
 }
 
 func (p *Parser) parseNamedExports() *ast.Node {
@@ -2473,17 +2399,14 @@ func (p *Parser) parseNamedExports() *ast.Node {
 	//  { ImportsList }
 	//  { ImportsList, }
 	exports := p.parseBracketedList(PCImportOrExportSpecifiers, (*Parser).parseExportSpecifier, ast.KindOpenBraceToken, ast.KindCloseBraceToken)
-	result := p.factory.NewNamedExports(exports)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewNamedExports(exports), pos)
 }
 
 func (p *Parser) parseExportSpecifier() *ast.Node {
 	pos := p.nodePos()
 	hasJSDoc := p.hasPrecedingJSDocComment()
 	isTypeOnly, propertyName, name := p.parseImportOrExportSpecifier(ast.KindExportSpecifier)
-	result := p.factory.NewExportSpecifier(isTypeOnly, propertyName, name)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewExportSpecifier(isTypeOnly, propertyName, name), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -2570,26 +2493,20 @@ func (p *Parser) parseTypeOperatorOrHigher() *ast.TypeNode {
 func (p *Parser) parseTypeOperator(operator ast.Kind) *ast.Node {
 	pos := p.nodePos()
 	p.parseExpected(operator)
-	result := p.factory.NewTypeOperatorNode(operator, p.parseTypeOperatorOrHigher())
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewTypeOperatorNode(operator, p.parseTypeOperatorOrHigher()), pos)
 }
 
 func (p *Parser) parseInferType() *ast.Node {
 	pos := p.nodePos()
 	p.parseExpected(ast.KindInferKeyword)
-	result := p.factory.NewInferTypeNode(p.parseTypeParameterOfInferType())
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewInferTypeNode(p.parseTypeParameterOfInferType()), pos)
 }
 
 func (p *Parser) parseTypeParameterOfInferType() *ast.Node {
 	pos := p.nodePos()
 	name := p.parseIdentifier()
 	constraint := p.tryParseConstraintOfInferType()
-	result := p.factory.NewTypeParameterDeclaration(nil /*modifiers*/, name, constraint, nil /*defaultType*/)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewTypeParameterDeclaration(nil /*modifiers*/, name, constraint, nil /*defaultType*/), pos)
 }
 
 func (p *Parser) tryParseConstraintOfInferType() *ast.Node {
@@ -2611,27 +2528,23 @@ func (p *Parser) parsePostfixTypeOrHigher() *ast.Node {
 		switch p.token {
 		case ast.KindExclamationToken:
 			p.nextToken()
-			typeNode = p.factory.NewJSDocNonNullableType(typeNode)
-			p.finishNode(typeNode, pos)
+			typeNode = p.finishNode(p.factory.NewJSDocNonNullableType(typeNode), pos)
 		case ast.KindQuestionToken:
 			// If next token is start of a type we have a conditional type
 			if p.lookAhead((*Parser).nextIsStartOfType) {
 				return typeNode
 			}
 			p.nextToken()
-			typeNode = p.factory.NewJSDocNullableType(typeNode)
-			p.finishNode(typeNode, pos)
+			typeNode = p.finishNode(p.factory.NewJSDocNullableType(typeNode), pos)
 		case ast.KindOpenBracketToken:
 			p.parseExpected(ast.KindOpenBracketToken)
 			if p.isStartOfType(false /*isStartOfParameter*/) {
 				indexType := p.parseType()
 				p.parseExpected(ast.KindCloseBracketToken)
-				typeNode = p.factory.NewIndexedAccessTypeNode(typeNode, indexType)
-				p.finishNode(typeNode, pos)
+				typeNode = p.finishNode(p.factory.NewIndexedAccessTypeNode(typeNode, indexType), pos)
 			} else {
 				p.parseExpected(ast.KindCloseBracketToken)
-				typeNode = p.factory.NewArrayTypeNode(typeNode)
-				p.finishNode(typeNode, pos)
+				typeNode = p.finishNode(p.factory.NewArrayTypeNode(typeNode), pos)
 			}
 		default:
 			return typeNode
@@ -2719,48 +2632,37 @@ func (p *Parser) parseKeywordTypeNode() *ast.Node {
 	pos := p.nodePos()
 	result := p.factory.NewKeywordTypeNode(p.token)
 	p.nextToken()
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(result, pos)
 }
 
 func (p *Parser) parseThisTypeNode() *ast.Node {
 	pos := p.nodePos()
 	p.nextToken()
-	result := p.factory.NewThisTypeNode()
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewThisTypeNode(), pos)
 }
 
 func (p *Parser) parseThisTypePredicate(lhs *ast.Node) *ast.Node {
 	p.nextToken()
-	result := p.factory.NewTypePredicateNode(nil /*assertsModifier*/, lhs, p.parseType())
-	p.finishNode(result, lhs.Pos())
-	return result
+	return p.finishNode(p.factory.NewTypePredicateNode(nil /*assertsModifier*/, lhs, p.parseType()), lhs.Pos())
 }
 
 func (p *Parser) parseJSDocAllType() *ast.Node {
 	pos := p.nodePos()
 	p.nextToken()
-	result := p.factory.NewJSDocAllType()
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewJSDocAllType(), pos)
 }
 
 func (p *Parser) parseJSDocNonNullableType() *ast.TypeNode {
 	pos := p.nodePos()
 	p.nextToken()
-	result := p.factory.NewJSDocNonNullableType(p.parseNonArrayType())
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewJSDocNonNullableType(p.parseNonArrayType()), pos)
 }
 
 func (p *Parser) parseJSDocNullableType() *ast.Node {
 	pos := p.nodePos()
 	// skip the ?
 	p.nextToken()
-	result := p.factory.NewJSDocNullableType(p.parseType())
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewJSDocNullableType(p.parseType()), pos)
 }
 
 func (p *Parser) parseJSDocType() *ast.TypeNode {
@@ -2771,14 +2673,11 @@ func (p *Parser) parseJSDocType() *ast.TypeNode {
 	t := p.parseTypeOrTypePredicate()
 	p.scanner.SetSkipJSDocLeadingAsterisks(false)
 	if hasDotDotDot {
-		t = p.factory.NewJSDocVariadicType(t)
-		p.finishNode(t, pos)
+		t = p.finishNode(p.factory.NewJSDocVariadicType(t), pos)
 	}
 	if p.token == ast.KindEqualsToken {
 		p.nextToken()
-		result := p.factory.NewJSDocOptionalType(t)
-		p.finishNode(result, pos)
-		return result
+		return p.finishNode(p.factory.NewJSDocOptionalType(t), pos)
 	}
 	return t
 }
@@ -2795,19 +2694,14 @@ func (p *Parser) parseLiteralTypeNode(negative bool) *ast.Node {
 		expression = p.parseLiteralExpression(false /*intern*/)
 	}
 	if negative {
-		expression = p.factory.NewPrefixUnaryExpression(ast.KindMinusToken, expression)
-		p.finishNode(expression, pos)
+		expression = p.finishNode(p.factory.NewPrefixUnaryExpression(ast.KindMinusToken, expression), pos)
 	}
-	result := p.factory.NewLiteralTypeNode(expression)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewLiteralTypeNode(expression), pos)
 }
 
 func (p *Parser) parseTypeReference() *ast.Node {
 	pos := p.nodePos()
-	result := p.factory.NewTypeReferenceNode(p.parseEntityNameOfTypeReference(), p.parseTypeArgumentsOfTypeReference())
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewTypeReferenceNode(p.parseEntityNameOfTypeReference(), p.parseTypeArgumentsOfTypeReference()), pos)
 }
 
 func (p *Parser) parseEntityNameOfTypeReference() *ast.Node {
@@ -2828,8 +2722,7 @@ func (p *Parser) parseEntityName(allowReservedWords bool, diagnosticMessage *dia
 			// `typeArguments` to report it as a grammar error in the checker.
 			break
 		}
-		entity = p.factory.NewQualifiedName(entity, p.parseRightSideOfDot(allowReservedWords, false /*allowPrivateIdentifiers*/, true /*allowUnicodeEscapeSequenceInIdentifierName*/))
-		p.finishNode(entity, pos)
+		entity = p.finishNode(p.factory.NewQualifiedName(entity, p.parseRightSideOfDot(allowReservedWords, false /*allowPrivateIdentifiers*/, true /*allowUnicodeEscapeSequenceInIdentifierName*/)), pos)
 	}
 	return entity
 }
@@ -2891,18 +2784,14 @@ func (p *Parser) newIdentifier(text string) *ast.Node {
 }
 
 func (p *Parser) createMissingIdentifier() *ast.Node {
-	result := p.newIdentifier("")
-	p.finishNode(result, p.nodePos())
-	return result
+	return p.finishNode(p.newIdentifier(""), p.nodePos())
 }
 
 func (p *Parser) parsePrivateIdentifier() *ast.Node {
 	pos := p.nodePos()
 	text := p.scanner.TokenValue()
 	p.nextToken()
-	result := p.factory.NewPrivateIdentifier(p.internIdentifier(text))
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewPrivateIdentifier(p.internIdentifier(text)), pos)
 }
 
 func (p *Parser) reScanLessThanToken() ast.Kind {
@@ -2979,9 +2868,7 @@ func (p *Parser) parseImportType() *ast.Node {
 		qualifier = p.parseEntityNameOfTypeReference()
 	}
 	typeArguments := p.parseTypeArgumentsOfTypeReference()
-	result := p.factory.NewImportTypeNode(isTypeOf, typeNode, attributes, qualifier, typeArguments)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewImportTypeNode(isTypeOf, typeNode, attributes, qualifier, typeArguments), pos)
 }
 
 func (p *Parser) parseImportAttribute() *ast.Node {
@@ -2998,9 +2885,7 @@ func (p *Parser) parseImportAttribute() *ast.Node {
 		p.parseErrorAtCurrentToken(diagnostics.Identifier_or_string_literal_expected)
 	}
 	value := p.parseAssignmentExpressionOrHigher()
-	result := p.factory.NewImportAttribute(name, value)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewImportAttribute(name, value), pos)
 }
 
 func (p *Parser) parseImportAttributes(token ast.Kind, skipKeyword bool) *ast.Node {
@@ -3026,9 +2911,7 @@ func (p *Parser) parseImportAttributes(token ast.Kind, skipKeyword bool) *ast.No
 	} else {
 		elements = p.parseEmptyNodeList()
 	}
-	result := p.factory.NewImportAttributes(token, elements, multiLine)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewImportAttributes(token, elements, multiLine), pos)
 }
 
 func (p *Parser) parseTypeQuery() *ast.Node {
@@ -3040,9 +2923,7 @@ func (p *Parser) parseTypeQuery() *ast.Node {
 	if !p.hasPrecedingLineBreak() {
 		typeArguments = p.parseTypeArguments()
 	}
-	result := p.factory.NewTypeQueryNode(entityName, typeArguments)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewTypeQueryNode(entityName, typeArguments), pos)
 }
 
 func (p *Parser) nextIsStartOfMappedType() bool {
@@ -3084,9 +2965,7 @@ func (p *Parser) parseMappedType() *ast.Node {
 	p.parseSemicolon()
 	members := p.parseList(PCTypeMembers, (*Parser).parseTypeMember)
 	p.parseExpected(ast.KindCloseBraceToken)
-	result := p.factory.NewMappedTypeNode(readonlyToken, typeParameter, nameType, questionToken, typeNode, members)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewMappedTypeNode(readonlyToken, typeParameter, nameType, questionToken, typeNode, members), pos)
 }
 
 func (p *Parser) parseMappedTypeParameter() *ast.Node {
@@ -3094,9 +2973,7 @@ func (p *Parser) parseMappedTypeParameter() *ast.Node {
 	name := p.parseIdentifierName()
 	p.parseExpected(ast.KindInKeyword)
 	typeNode := p.parseType()
-	result := p.factory.NewTypeParameterDeclaration(nil /*modifiers*/, name, typeNode, nil /*defaultType*/)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewTypeParameterDeclaration(nil /*modifiers*/, name, typeNode, nil /*defaultType*/), pos)
 }
 
 func (p *Parser) parseTypeMember() *ast.Node {
@@ -3182,9 +3059,8 @@ func (p *Parser) parseTypeParameter() *ast.Node {
 	if p.parseOptional(ast.KindEqualsToken) {
 		defaultType = p.parseType()
 	}
-	result := p.factory.NewTypeParameterDeclaration(modifiers, name, constraint, defaultType)
+	result := p.finishNode(p.factory.NewTypeParameterDeclaration(modifiers, name, constraint, defaultType), pos)
 	result.AsTypeParameter().Expression = expression
-	p.finishNode(result, pos)
 	return result
 }
 
@@ -3260,8 +3136,7 @@ func (p *Parser) parseParameterEx(inOuterAwaitContext bool, allowAmbiguity bool)
 		if modifiers != nil {
 			p.parseErrorAtRange(modifiers.Nodes[0].Loc, diagnostics.Neither_decorators_nor_modifiers_may_be_applied_to_this_parameters)
 		}
-		p.finishNode(result, pos)
-		p.withJSDoc(result, hasJSDoc)
+		p.withJSDoc(p.finishNode(result, pos), hasJSDoc)
 		return result
 	}
 	dotDotDotToken := p.parseOptionalToken(ast.KindDotDotDotToken)
@@ -3275,8 +3150,7 @@ func (p *Parser) parseParameterEx(inOuterAwaitContext bool, allowAmbiguity bool)
 		p.parseOptionalToken(ast.KindQuestionToken),
 		p.parseTypeAnnotation(),
 		p.parseInitializer())
-	p.finishNode(result, pos)
-	p.withJSDoc(result, hasJSDoc)
+	p.withJSDoc(p.finishNode(result, pos), hasJSDoc)
 	return result
 }
 
@@ -3334,9 +3208,7 @@ func (p *Parser) parseTypeOrTypePredicate() *ast.TypeNode {
 		id := p.parseIdentifier()
 		if p.token == ast.KindIsKeyword && !p.hasPrecedingLineBreak() {
 			p.nextToken()
-			result := p.factory.NewTypePredicateNode(nil /*assertsModifier*/, id, p.parseType())
-			p.finishNode(result, pos)
-			return result
+			return p.finishNode(p.factory.NewTypePredicateNode(nil /*assertsModifier*/, id, p.parseType()), pos)
 		}
 		p.rewind(state)
 	}
@@ -3366,8 +3238,7 @@ func (p *Parser) parseAccessorDeclaration(pos int, hasJSDoc bool, modifiers *ast
 	} else {
 		result = p.factory.NewSetAccessorDeclaration(modifiers, name, typeParameters, parameters, returnType, nil /*fullSignature*/, body)
 	}
-	p.finishNode(result, pos)
-	p.withJSDoc(result, hasJSDoc)
+	p.withJSDoc(p.finishNode(result, pos), hasJSDoc)
 	return result
 }
 
@@ -3403,9 +3274,7 @@ func (p *Parser) parseComputedPropertyName() *ast.Node {
 	// will error if it sees a comma expression.
 	expression := p.parseExpressionAllowIn()
 	p.parseExpected(ast.KindCloseBracketToken)
-	result := p.factory.NewComputedPropertyName(expression)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewComputedPropertyName(expression), pos)
 }
 
 func (p *Parser) parseFunctionBlockOrSemicolon(flags ParseFlags, diagnosticMessage *diagnostics.Message) *ast.Node {
@@ -3493,8 +3362,7 @@ func (p *Parser) parseIndexSignatureDeclaration(pos int, hasJSDoc bool, modifier
 	parameters := p.parseBracketedList(PCParameters, (*Parser).parseParameter, ast.KindOpenBracketToken, ast.KindCloseBracketToken)
 	typeNode := p.parseTypeAnnotation()
 	p.parseTypeMemberSemicolon()
-	result := p.factory.NewIndexSignatureDeclaration(modifiers, parameters, typeNode)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewIndexSignatureDeclaration(modifiers, parameters, typeNode), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -3522,15 +3390,13 @@ func (p *Parser) parsePropertyOrMethodSignature(pos int, hasJSDoc bool, modifier
 		result = p.factory.NewPropertySignatureDeclaration(modifiers, name, questionToken, typeNode, initializer)
 	}
 	p.parseTypeMemberSemicolon()
-	p.finishNode(result, pos)
-	p.withJSDoc(result, hasJSDoc)
+	p.withJSDoc(p.finishNode(result, pos), hasJSDoc)
 	return result
 }
 
 func (p *Parser) parseTypeLiteral() *ast.Node {
 	pos := p.nodePos()
-	result := p.factory.NewTypeLiteralNode(p.parseObjectTypeMembers())
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewTypeLiteralNode(p.parseObjectTypeMembers()), pos)
 	return result
 }
 
@@ -3545,9 +3411,7 @@ func (p *Parser) parseObjectTypeMembers() *ast.NodeList {
 
 func (p *Parser) parseTupleType() *ast.Node {
 	pos := p.nodePos()
-	result := p.factory.NewTupleTypeNode(p.parseBracketedList(PCTupleElementTypes, (*Parser).parseTupleElementNameOrTupleElementType, ast.KindOpenBracketToken, ast.KindCloseBracketToken))
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewTupleTypeNode(p.parseBracketedList(PCTupleElementTypes, (*Parser).parseTupleElementNameOrTupleElementType, ast.KindOpenBracketToken, ast.KindCloseBracketToken)), pos)
 }
 
 func (p *Parser) parseTupleElementNameOrTupleElementType() *ast.Node {
@@ -3559,8 +3423,7 @@ func (p *Parser) parseTupleElementNameOrTupleElementType() *ast.Node {
 		questionToken := p.parseOptionalToken(ast.KindQuestionToken)
 		p.parseExpected(ast.KindColonToken)
 		typeNode := p.parseTupleElementType()
-		result := p.factory.NewNamedTupleMember(dotDotDotToken, name, questionToken, typeNode)
-		p.finishNode(result, pos)
+		result := p.finishNode(p.factory.NewNamedTupleMember(dotDotDotToken, name, questionToken, typeNode), pos)
 		p.withJSDoc(result, hasJSDoc)
 		return result
 	}
@@ -3581,9 +3444,7 @@ func (p *Parser) nextTokenIsColonOrQuestionColon() bool {
 func (p *Parser) parseTupleElementType() *ast.TypeNode {
 	pos := p.nodePos()
 	if p.parseOptional(ast.KindDotDotDotToken) {
-		result := p.factory.NewRestTypeNode(p.parseType())
-		p.finishNode(result, pos)
-		return result
+		return p.finishNode(p.factory.NewRestTypeNode(p.parseType()), pos)
 	}
 	typeNode := p.parseType()
 	if ast.IsJSDocNullableType(typeNode) && typeNode.Pos() == typeNode.Type().Pos() {
@@ -3601,9 +3462,7 @@ func (p *Parser) parseParenthesizedType() *ast.Node {
 	p.parseExpected(ast.KindOpenParenToken)
 	typeNode := p.parseType()
 	p.parseExpected(ast.KindCloseParenToken)
-	result := p.factory.NewParenthesizedTypeNode(typeNode)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewParenthesizedTypeNode(typeNode), pos)
 }
 
 func (p *Parser) parseAssertsTypePredicate() *ast.TypeNode {
@@ -3619,16 +3478,12 @@ func (p *Parser) parseAssertsTypePredicate() *ast.TypeNode {
 	if p.parseOptional(ast.KindIsKeyword) {
 		typeNode = p.parseType()
 	}
-	result := p.factory.NewTypePredicateNode(assertsModifier, parameterName, typeNode)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewTypePredicateNode(assertsModifier, parameterName, typeNode), pos)
 }
 
 func (p *Parser) parseTemplateType() *ast.Node {
 	pos := p.nodePos()
-	result := p.factory.NewTemplateLiteralTypeNode(p.parseTemplateHead(false /*isTaggedTemplate*/), p.parseTemplateTypeSpans())
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewTemplateLiteralTypeNode(p.parseTemplateHead(false /*isTaggedTemplate*/), p.parseTemplateTypeSpans()), pos)
 }
 
 func (p *Parser) parseTemplateHead(isTaggedTemplate bool) *ast.Node {
@@ -3638,8 +3493,7 @@ func (p *Parser) parseTemplateHead(isTaggedTemplate bool) *ast.Node {
 	pos := p.nodePos()
 	result := p.factory.NewTemplateHead(p.scanner.TokenValue(), p.getTemplateLiteralRawText(2 /*endLength*/), p.scanner.TokenFlags()&ast.TokenFlagsTemplateLiteralLikeFlags)
 	p.nextToken()
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(result, pos)
 }
 
 func (p *Parser) getTemplateLiteralRawText(endLength int) string {
@@ -3665,9 +3519,7 @@ func (p *Parser) parseTemplateTypeSpans() *ast.NodeList {
 
 func (p *Parser) parseTemplateTypeSpan() *ast.Node {
 	pos := p.nodePos()
-	result := p.factory.NewTemplateLiteralTypeSpan(p.parseType(), p.parseLiteralOfTemplateSpan(false /*isTaggedTemplate*/))
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewTemplateLiteralTypeSpan(p.parseType(), p.parseLiteralOfTemplateSpan(false /*isTaggedTemplate*/)), pos)
 }
 
 func (p *Parser) parseLiteralOfTemplateSpan(isTaggedTemplate bool) *ast.Node {
@@ -3676,9 +3528,7 @@ func (p *Parser) parseLiteralOfTemplateSpan(isTaggedTemplate bool) *ast.Node {
 		return p.parseTemplateMiddleOrTail()
 	}
 	p.parseErrorAtCurrentToken(diagnostics.X_0_expected, scanner.TokenToString(ast.KindCloseBraceToken))
-	result := p.factory.NewTemplateTail("", "", ast.TokenFlagsNone)
-	p.finishNode(result, p.nodePos())
-	return result
+	return p.finishNode(p.factory.NewTemplateTail("", "", ast.TokenFlagsNone), p.nodePos())
 }
 
 func (p *Parser) parseTemplateMiddleOrTail() *ast.Node {
@@ -3690,8 +3540,7 @@ func (p *Parser) parseTemplateMiddleOrTail() *ast.Node {
 		result = p.factory.NewTemplateTail(p.scanner.TokenValue(), p.getTemplateLiteralRawText(1 /*endLength*/), p.scanner.TokenFlags()&ast.TokenFlagsTemplateLiteralLikeFlags)
 	}
 	p.nextToken()
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(result, pos)
 }
 
 func (p *Parser) parseFunctionOrConstructorTypeToError(isInUnionType bool, parseConstituentType func(p *Parser) *ast.TypeNode) *ast.TypeNode {
@@ -3850,9 +3699,7 @@ func (p *Parser) parseDecorator() *ast.Node {
 	pos := p.nodePos()
 	p.parseExpected(ast.KindAtToken)
 	expression := doInContext(p, ast.NodeFlagsDecoratorContext, true, (*Parser).parseDecoratorExpression)
-	result := p.factory.NewDecorator(expression)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewDecorator(expression), pos)
 }
 
 func (p *Parser) parseDecoratorExpression() *ast.Expression {
@@ -3888,9 +3735,7 @@ func (p *Parser) tryParseModifier(hasSeenStaticModifier bool, permitConstAsModif
 			return nil
 		}
 	}
-	result := p.factory.NewModifier(kind)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewModifier(kind), pos)
 }
 
 func (p *Parser) parseContextualModifier(t ast.Kind) bool {
@@ -4143,8 +3988,7 @@ func (p *Parser) parseYieldExpression() *ast.Node {
 		// the start of an expression, then this is just a simple "yield" expression.
 		result = p.factory.NewYieldExpression(nil /*asteriskToken*/, nil /*expression*/)
 	}
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(result, pos)
 }
 
 func (p *Parser) isParenthesizedArrowFunctionExpression() core.Tristate {
@@ -4384,8 +4228,7 @@ func (p *Parser) parseParenthesizedArrowFunctionExpression(allowAmbiguity bool, 
 			return nil
 		}
 	}
-	result := p.factory.NewArrowFunction(modifiers, typeParameters, parameters, returnType, nil /*fullSignature*/, equalsGreaterThanToken, body)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewArrowFunction(modifiers, typeParameters, parameters, returnType, nil /*fullSignature*/, equalsGreaterThanToken, body), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -4394,8 +4237,7 @@ func (p *Parser) parseModifiersForArrowFunction() *ast.ModifierList {
 	if p.token == ast.KindAsyncKeyword {
 		pos := p.nodePos()
 		p.nextToken()
-		modifier := p.factory.NewModifier(ast.KindAsyncKeyword)
-		p.finishNode(modifier, pos)
+		modifier := p.finishNode(p.factory.NewModifier(ast.KindAsyncKeyword), pos)
 		return p.newModifierList(modifier.Loc, p.nodeSlicePool.NewSlice1(modifier))
 	}
 	return nil
@@ -4493,13 +4335,11 @@ func (p *Parser) nextIsUnParenthesizedAsyncArrowFunction() bool {
 
 func (p *Parser) parseSimpleArrowFunctionExpression(pos int, identifier *ast.Node, allowReturnTypeInArrowFunction bool, hasJSDoc bool, asyncModifier *ast.ModifierList) *ast.Node {
 	// Debug.assert(token() == ast.KindEqualsGreaterThanToken, "parseSimpleArrowFunctionExpression should only have been called if we had a =>");
-	parameter := p.factory.NewParameterDeclaration(nil /*modifiers*/, nil /*dotDotDotToken*/, identifier, nil /*questionToken*/, nil /*typeNode*/, nil /*initializer*/)
-	p.finishNode(parameter, identifier.Pos())
+	parameter := p.finishNode(p.factory.NewParameterDeclaration(nil /*modifiers*/, nil /*dotDotDotToken*/, identifier, nil /*questionToken*/, nil /*typeNode*/, nil /*initializer*/), identifier.Pos())
 	parameters := p.newNodeList(parameter.Loc, []*ast.Node{parameter})
 	equalsGreaterThanToken := p.parseExpectedToken(ast.KindEqualsGreaterThanToken)
 	body := p.parseArrowFunctionExpressionBody(asyncModifier != nil /*isAsync*/, allowReturnTypeInArrowFunction)
-	result := p.factory.NewArrowFunction(asyncModifier, nil /*typeParameters*/, parameters, nil /*returnType*/, nil /*fullSignature*/, equalsGreaterThanToken, body)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewArrowFunction(asyncModifier, nil /*typeParameters*/, parameters, nil /*returnType*/, nil /*fullSignature*/, equalsGreaterThanToken, body), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -4524,9 +4364,7 @@ func (p *Parser) parseConditionalExpressionRest(leftOperand *ast.Expression, pos
 		p.parseErrorAtCurrentToken(diagnostics.X_0_expected, scanner.TokenToString(ast.KindColonToken))
 		falseExpression = p.createMissingIdentifier()
 	}
-	result := p.factory.NewConditionalExpression(leftOperand, questionToken, trueExpression, colonToken, falseExpression)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewConditionalExpression(leftOperand, questionToken, trueExpression, colonToken, falseExpression), pos)
 }
 
 func (p *Parser) parseBinaryExpressionOrHigher(precedence ast.OperatorPrecedence) *ast.Expression {
@@ -4599,21 +4437,15 @@ func (p *Parser) parseBinaryExpressionRest(precedence ast.OperatorPrecedence, le
 }
 
 func (p *Parser) makeSatisfiesExpression(expression *ast.Expression, typeNode *ast.TypeNode) *ast.Node {
-	result := p.factory.NewSatisfiesExpression(expression, typeNode)
-	p.finishNode(result, expression.Pos())
-	return result
+	return p.finishNode(p.factory.NewSatisfiesExpression(expression, typeNode), expression.Pos())
 }
 
 func (p *Parser) makeAsExpression(left *ast.Expression, right *ast.TypeNode) *ast.Node {
-	result := p.factory.NewAsExpression(left, right)
-	p.finishNode(result, left.Pos())
-	return result
+	return p.finishNode(p.factory.NewAsExpression(left, right), left.Pos())
 }
 
 func (p *Parser) makeBinaryExpression(left *ast.Expression, operatorToken *ast.Node, right *ast.Expression, pos int) *ast.Node {
-	result := p.factory.NewBinaryExpression(nil /*modifiers*/, left, nil /*typeNode*/, operatorToken, right)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewBinaryExpression(nil /*modifiers*/, left, nil /*typeNode*/, operatorToken, right), pos)
 }
 
 func (p *Parser) parseUnaryExpressionOrHigher() *ast.Expression {
@@ -4670,9 +4502,7 @@ func (p *Parser) parseUpdateExpression() *ast.Expression {
 	if p.token == ast.KindPlusPlusToken || p.token == ast.KindMinusMinusToken {
 		operator := p.token
 		p.nextToken()
-		result := p.factory.NewPrefixUnaryExpression(operator, p.parseLeftHandSideExpressionOrHigher())
-		p.finishNode(result, pos)
-		return result
+		return p.finishNode(p.factory.NewPrefixUnaryExpression(operator, p.parseLeftHandSideExpressionOrHigher()), pos)
 	} else if p.languageVariant == core.LanguageVariantJSX && p.token == ast.KindLessThanToken && p.lookAhead((*Parser).nextTokenIsIdentifierOrKeywordOrGreaterThan) {
 		// JSXElement is part of primaryExpression
 		return p.parseJsxElementOrSelfClosingElementOrFragment(true /*inExpressionContext*/, -1 /*topInvalidNodePosition*/, nil /*openingTag*/, false /*mustBeUnary*/)
@@ -4681,9 +4511,7 @@ func (p *Parser) parseUpdateExpression() *ast.Expression {
 	if (p.token == ast.KindPlusPlusToken || p.token == ast.KindMinusMinusToken) && !p.hasPrecedingLineBreak() {
 		operator := p.token
 		p.nextToken()
-		result := p.factory.NewPostfixUnaryExpression(expression, operator)
-		p.finishNode(result, pos)
-		return result
+		return p.finishNode(p.factory.NewPostfixUnaryExpression(expression, operator), pos)
 	}
 	return expression
 }
@@ -4704,12 +4532,13 @@ func (p *Parser) parseJsxElementOrSelfClosingElementOrFragment(inExpressionConte
 			// restructure (<div>(...<span>...</div>)) --> (<div>(...<span>...</>)</div>)
 			// (no need to error; the parent will error)
 			end := lastChild.AsJsxElement().OpeningElement.End()
-			missingIdentifier := p.newIdentifier("")
-			p.finishNodeWithEnd(missingIdentifier, end, end)
-			newClosingElement := p.factory.NewJsxClosingElement(missingIdentifier)
-			p.finishNodeWithEnd(newClosingElement, end, end)
-			newLast := p.factory.NewJsxElement(lastChild.AsJsxElement().OpeningElement, lastChild.AsJsxElement().Children, newClosingElement)
-			p.finishNodeWithEnd(newLast, lastChild.AsJsxElement().OpeningElement.Pos(), end)
+			missingIdentifier := p.finishNodeWithEnd(p.newIdentifier(""), end, end)
+			newClosingElement := p.finishNodeWithEnd(p.factory.NewJsxClosingElement(missingIdentifier), end, end)
+			newLast := p.finishNodeWithEnd(
+				p.factory.NewJsxElement(lastChild.AsJsxElement().OpeningElement, lastChild.AsJsxElement().Children, newClosingElement),
+				lastChild.AsJsxElement().OpeningElement.Pos(),
+				end,
+			)
 			// force reset parent pointers from discarded parse result
 			if lastChild.AsJsxElement().OpeningElement != nil {
 				lastChild.AsJsxElement().OpeningElement.Parent = newLast
@@ -4734,12 +4563,10 @@ func (p *Parser) parseJsxElementOrSelfClosingElementOrFragment(inExpressionConte
 				}
 			}
 		}
-		result = p.factory.NewJsxElement(opening, children, closingElement)
-		p.finishNode(result, pos)
+		result = p.finishNode(p.factory.NewJsxElement(opening, children, closingElement), pos)
 		closingElement.Parent = result // force reset parent pointers from possibly discarded parse result
 	case ast.KindJsxOpeningFragment:
-		result = p.factory.NewJsxFragment(opening, p.parseJsxChildren(opening), p.parseJsxClosingFragment(inExpressionContext))
-		p.finishNode(result, pos)
+		result = p.finishNode(p.factory.NewJsxFragment(opening, p.parseJsxChildren(opening), p.parseJsxClosingFragment(inExpressionContext)), pos)
 	case ast.KindJsxSelfClosingElement:
 		// Nothing else to do for self-closing elements
 		result = opening
@@ -4764,8 +4591,7 @@ func (p *Parser) parseJsxElementOrSelfClosingElementOrFragment(inExpressionConte
 		operatorToken := p.factory.NewToken(ast.KindCommaToken)
 		operatorToken.Loc = core.NewTextRange(invalidElement.Pos(), invalidElement.Pos())
 		p.parseErrorAt(scanner.SkipTrivia(p.sourceText, topBadPos), invalidElement.End(), diagnostics.JSX_expressions_must_have_one_parent_element)
-		result = p.factory.NewBinaryExpression(nil /*modifiers*/, result, nil /*typeNode*/, operatorToken, invalidElement)
-		p.finishNode(result, pos)
+		result = p.finishNode(p.factory.NewBinaryExpression(nil /*modifiers*/, result, nil /*typeNode*/, operatorToken, invalidElement), pos)
 	}
 	return result
 }
@@ -4825,8 +4651,7 @@ func (p *Parser) parseJsxText() *ast.Node {
 	pos := p.nodePos()
 	result := p.factory.NewJsxText(p.scanner.TokenValue(), p.token == ast.KindJsxTextAllWhiteSpaces)
 	p.scanJsxText()
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(result, pos)
 }
 
 func (p *Parser) parseJsxExpression(inExpressionContext bool) *ast.Node {
@@ -4850,9 +4675,7 @@ func (p *Parser) parseJsxExpression(inExpressionContext bool) *ast.Node {
 	} else if p.parseExpectedWithoutAdvancing(ast.KindCloseBraceToken) {
 		p.scanJsxText()
 	}
-	result := p.factory.NewJsxExpression(dotDotDotToken, expression)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewJsxExpression(dotDotDotToken, expression), pos)
 }
 
 func (p *Parser) scanJsxText() ast.Kind {
@@ -4882,9 +4705,7 @@ func (p *Parser) parseJsxClosingElement(open *ast.Node, inExpressionContext bool
 			p.scanJsxText()
 		}
 	}
-	result := p.factory.NewJsxClosingElement(tagName)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewJsxClosingElement(tagName), pos)
 }
 
 func (p *Parser) parseJsxOpeningOrSelfClosingElementOrOpeningFragment(inExpressionContext bool) *ast.Expression {
@@ -4893,9 +4714,7 @@ func (p *Parser) parseJsxOpeningOrSelfClosingElementOrOpeningFragment(inExpressi
 	if p.token == ast.KindGreaterThanToken {
 		// See below for explanation of scanJsxText
 		p.scanJsxText()
-		result := p.factory.NewJsxOpeningFragment()
-		p.finishNode(result, pos)
-		return result
+		return p.finishNode(p.factory.NewJsxOpeningFragment(), pos)
 	}
 	tagName := p.parseJsxElementName()
 	var typeArguments *ast.NodeList
@@ -4921,8 +4740,7 @@ func (p *Parser) parseJsxOpeningOrSelfClosingElementOrOpeningFragment(inExpressi
 		}
 		result = p.factory.NewJsxSelfClosingElement(tagName, typeArguments, attributes)
 	}
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(result, pos)
 }
 
 func (p *Parser) parseJsxElementName() *ast.Expression {
@@ -4938,8 +4756,7 @@ func (p *Parser) parseJsxElementName() *ast.Expression {
 	}
 	expression := initialExpression
 	for p.parseOptional(ast.KindDotToken) {
-		expression = p.factory.NewPropertyAccessExpression(expression, nil, p.parseRightSideOfDot(true /*allowIdentifierNames*/, false /*allowPrivateIdentifiers*/, false /*allowUnicodeEscapeSequenceInIdentifierName*/), ast.NodeFlagsNone)
-		p.finishNode(expression, pos)
+		expression = p.finishNode(p.factory.NewPropertyAccessExpression(expression, nil, p.parseRightSideOfDot(true /*allowIdentifierNames*/, false /*allowPrivateIdentifiers*/, false /*allowUnicodeEscapeSequenceInIdentifierName*/), ast.NodeFlagsNone), pos)
 	}
 	return expression
 }
@@ -4951,23 +4768,18 @@ func (p *Parser) parseJsxTagName() *ast.Expression {
 	tagName := p.parseIdentifierNameErrorOnUnicodeEscapeSequence()
 	if p.parseOptional(ast.KindColonToken) {
 		p.scanJsxIdentifier()
-		result := p.factory.NewJsxNamespacedName(tagName, p.parseIdentifierNameErrorOnUnicodeEscapeSequence())
-		p.finishNode(result, pos)
-		return result
+		return p.finishNode(p.factory.NewJsxNamespacedName(tagName, p.parseIdentifierNameErrorOnUnicodeEscapeSequence()), pos)
 	}
 	if isThis {
 		result := p.factory.NewKeywordExpression(ast.KindThisKeyword)
-		p.finishNode(result, pos)
-		return result
+		return p.finishNode(result, pos)
 	}
 	return tagName
 }
 
 func (p *Parser) parseJsxAttributes() *ast.Node {
 	pos := p.nodePos()
-	result := p.factory.NewJsxAttributes(p.parseList(PCJsxAttributes, (*Parser).parseJsxAttribute))
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewJsxAttributes(p.parseList(PCJsxAttributes, (*Parser).parseJsxAttribute)), pos)
 }
 
 func (p *Parser) parseJsxAttribute() *ast.Node {
@@ -4975,9 +4787,7 @@ func (p *Parser) parseJsxAttribute() *ast.Node {
 		return p.parseJsxSpreadAttribute()
 	}
 	pos := p.nodePos()
-	result := p.factory.NewJsxAttribute(p.parseJsxAttributeName(), p.parseJsxAttributeValue())
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewJsxAttribute(p.parseJsxAttributeName(), p.parseJsxAttributeValue()), pos)
 }
 
 func (p *Parser) parseJsxSpreadAttribute() *ast.Node {
@@ -4986,9 +4796,7 @@ func (p *Parser) parseJsxSpreadAttribute() *ast.Node {
 	p.parseExpected(ast.KindDotDotDotToken)
 	expression := p.parseExpression()
 	p.parseExpected(ast.KindCloseBraceToken)
-	result := p.factory.NewJsxSpreadAttribute(expression)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewJsxSpreadAttribute(expression), pos)
 }
 
 func (p *Parser) parseJsxAttributeName() *ast.Node {
@@ -4997,9 +4805,7 @@ func (p *Parser) parseJsxAttributeName() *ast.Node {
 	attrName := p.parseIdentifierNameErrorOnUnicodeEscapeSequence()
 	if p.parseOptional(ast.KindColonToken) {
 		p.scanJsxIdentifier()
-		result := p.factory.NewJsxNamespacedName(attrName, p.parseIdentifierNameErrorOnUnicodeEscapeSequence())
-		p.finishNode(result, pos)
-		return result
+		return p.finishNode(p.factory.NewJsxNamespacedName(attrName, p.parseIdentifierNameErrorOnUnicodeEscapeSequence()), pos)
 	}
 	return attrName
 }
@@ -5031,9 +4837,7 @@ func (p *Parser) parseJsxClosingFragment(inExpressionContext bool) *ast.Node {
 			p.scanJsxText()
 		}
 	}
-	result := p.factory.NewJsxClosingFragment()
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewJsxClosingFragment(), pos)
 }
 
 func (p *Parser) parseSimpleUnaryExpression() *ast.Expression {
@@ -5070,33 +4874,25 @@ func (p *Parser) parsePrefixUnaryExpression() *ast.Node {
 	pos := p.nodePos()
 	operator := p.token
 	p.nextToken()
-	result := p.factory.NewPrefixUnaryExpression(operator, p.parseSimpleUnaryExpression())
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewPrefixUnaryExpression(operator, p.parseSimpleUnaryExpression()), pos)
 }
 
 func (p *Parser) parseDeleteExpression() *ast.Node {
 	pos := p.nodePos()
 	p.nextToken()
-	result := p.factory.NewDeleteExpression(p.parseSimpleUnaryExpression())
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewDeleteExpression(p.parseSimpleUnaryExpression()), pos)
 }
 
 func (p *Parser) parseTypeOfExpression() *ast.Node {
 	pos := p.nodePos()
 	p.nextToken()
-	result := p.factory.NewTypeOfExpression(p.parseSimpleUnaryExpression())
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewTypeOfExpression(p.parseSimpleUnaryExpression()), pos)
 }
 
 func (p *Parser) parseVoidExpression() *ast.Node {
 	pos := p.nodePos()
 	p.nextToken()
-	result := p.factory.NewVoidExpression(p.parseSimpleUnaryExpression())
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewVoidExpression(p.parseSimpleUnaryExpression()), pos)
 }
 
 func (p *Parser) isAwaitExpression() bool {
@@ -5113,9 +4909,7 @@ func (p *Parser) isAwaitExpression() bool {
 func (p *Parser) parseAwaitExpression() *ast.Node {
 	pos := p.nodePos()
 	p.nextToken()
-	result := p.factory.NewAwaitExpression(p.parseSimpleUnaryExpression())
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewAwaitExpression(p.parseSimpleUnaryExpression()), pos)
 }
 
 func (p *Parser) parseTypeAssertion() *ast.Node {
@@ -5125,9 +4919,7 @@ func (p *Parser) parseTypeAssertion() *ast.Node {
 	typeNode := p.parseType()
 	p.parseExpected(ast.KindGreaterThanToken)
 	expression := p.parseSimpleUnaryExpression()
-	result := p.factory.NewTypeAssertion(typeNode, expression)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewTypeAssertion(typeNode, expression), pos)
 }
 
 func (p *Parser) parseLeftHandSideExpressionOrHigher() *ast.Expression {
@@ -5177,8 +4969,7 @@ func (p *Parser) parseLeftHandSideExpressionOrHigher() *ast.Expression {
 			// This is an 'import.*' metaproperty (i.e. 'import.meta')
 			p.nextToken() // advance past the 'import'
 			p.nextToken() // advance past the dot
-			expression = p.factory.NewMetaProperty(ast.KindImportKeyword, p.parseIdentifierName())
-			p.finishNode(expression, pos)
+			expression = p.finishNode(p.factory.NewMetaProperty(ast.KindImportKeyword, p.parseIdentifierName()), pos)
 			p.sourceFlags |= ast.NodeFlagsPossiblyContainsImportMeta
 		} else {
 			expression = p.parseMemberExpressionOrHigher()
@@ -5207,8 +4998,7 @@ func (p *Parser) parseSuperExpression() *ast.Expression {
 		if typeArguments != nil {
 			p.parseErrorAt(startPos, p.nodePos(), diagnostics.X_super_may_not_use_type_arguments)
 			if !p.isTemplateStartOfTaggedTemplate() {
-				expression = p.factory.NewExpressionWithTypeArguments(expression, typeArguments)
-				p.finishNode(expression, pos)
+				expression = p.finishNode(p.factory.NewExpressionWithTypeArguments(expression, typeArguments), pos)
 			}
 		}
 	}
@@ -5219,9 +5009,7 @@ func (p *Parser) parseSuperExpression() *ast.Expression {
 	// If it wasn't then just try to parse out a '.' and report an error.
 	p.parseErrorAtCurrentToken(diagnostics.X_super_must_be_followed_by_an_argument_list_or_member_access)
 	// private names will never work with `super` (`super.#foo`), but that's a semantic error, not syntactic
-	result := p.factory.NewPropertyAccessExpression(expression, nil /*questionDotToken*/, p.parseRightSideOfDot(true /*allowIdentifierNames*/, true /*allowPrivateIdentifiers*/, true /*allowUnicodeEscapeSequenceInIdentifierName*/), ast.NodeFlagsNone)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewPropertyAccessExpression(expression, nil /*questionDotToken*/, p.parseRightSideOfDot(true /*allowIdentifierNames*/, true /*allowPrivateIdentifiers*/, true /*allowUnicodeEscapeSequenceInIdentifierName*/), ast.NodeFlagsNone), pos)
 }
 
 func (p *Parser) isTemplateStartOfTaggedTemplate() bool {
@@ -5355,14 +5143,12 @@ func (p *Parser) parseMemberExpressionRest(pos int, expression *ast.Expression, 
 		if questionDotToken == nil {
 			if p.token == ast.KindExclamationToken && !p.hasPrecedingLineBreak() {
 				p.nextToken()
-				expression = p.factory.NewNonNullExpression(expression, ast.NodeFlagsNone)
-				p.finishNode(expression, pos)
+				expression = p.finishNode(p.factory.NewNonNullExpression(expression, ast.NodeFlagsNone), pos)
 				continue
 			}
 			typeArguments := p.tryParseTypeArgumentsInExpression()
 			if typeArguments != nil {
-				expression = p.factory.NewExpressionWithTypeArguments(expression, typeArguments)
-				p.finishNode(expression, pos)
+				expression = p.finishNode(p.factory.NewExpressionWithTypeArguments(expression, typeArguments), pos)
 				continue
 			}
 		}
@@ -5393,8 +5179,7 @@ func (p *Parser) parsePropertyAccessExpressionRest(pos int, expression *ast.Expr
 			p.parseErrorAtRange(loc, diagnostics.An_instantiation_expression_cannot_be_followed_by_a_property_access)
 		}
 	}
-	p.finishNode(propertyAccess, pos)
-	return propertyAccess
+	return p.finishNode(propertyAccess, pos)
 }
 
 func (p *Parser) tryReparseOptionalChain(node *ast.Expression) bool {
@@ -5438,9 +5223,7 @@ func (p *Parser) parseElementAccessExpressionRest(pos int, expression *ast.Expre
 	}
 	p.parseExpected(ast.KindCloseBracketToken)
 	isOptionalChain := questionDotToken != nil || p.tryReparseOptionalChain(expression)
-	elementAccess := p.factory.NewElementAccessExpression(expression, questionDotToken, argumentExpression, core.IfElse(isOptionalChain, ast.NodeFlagsOptionalChain, ast.NodeFlagsNone))
-	p.finishNode(elementAccess, pos)
-	return elementAccess
+	return p.finishNode(p.factory.NewElementAccessExpression(expression, questionDotToken, argumentExpression, core.IfElse(isOptionalChain, ast.NodeFlagsOptionalChain, ast.NodeFlagsNone)), pos)
 }
 
 func (p *Parser) parseCallExpressionRest(pos int, expression *ast.Expression) *ast.Expression {
@@ -5464,8 +5247,7 @@ func (p *Parser) parseCallExpressionRest(pos int, expression *ast.Expression) *a
 			inner := expression
 			argumentList := p.parseArgumentList()
 			isOptionalChain := questionDotToken != nil || p.tryReparseOptionalChain(expression)
-			expression = p.factory.NewCallExpression(expression, questionDotToken, typeArguments, argumentList, core.IfElse(isOptionalChain, ast.NodeFlagsOptionalChain, ast.NodeFlagsNone))
-			p.finishNode(expression, pos)
+			expression = p.finishNode(p.factory.NewCallExpression(expression, questionDotToken, typeArguments, argumentList, core.IfElse(isOptionalChain, ast.NodeFlagsOptionalChain, ast.NodeFlagsNone)), pos)
 			p.unparseExpressionWithTypeArguments(inner, typeArguments, expression)
 			continue
 		}
@@ -5473,8 +5255,7 @@ func (p *Parser) parseCallExpressionRest(pos int, expression *ast.Expression) *a
 			// We parsed `?.` but then failed to parse anything, so report a missing identifier here.
 			p.parseErrorAtCurrentToken(diagnostics.Identifier_expected)
 			name := p.createMissingIdentifier()
-			expression = p.factory.NewPropertyAccessExpression(expression, questionDotToken, name, ast.NodeFlagsOptionalChain)
-			p.finishNode(expression, pos)
+			expression = p.finishNode(p.factory.NewPropertyAccessExpression(expression, questionDotToken, name, ast.NodeFlagsOptionalChain), pos)
 		}
 		break
 	}
@@ -5497,9 +5278,7 @@ func (p *Parser) parseArgumentOrArrayLiteralElement() *ast.Expression {
 	case ast.KindDotDotDotToken:
 		return p.parseSpreadElement()
 	case ast.KindCommaToken:
-		result := p.factory.NewOmittedExpression()
-		p.finishNode(result, p.nodePos())
-		return result
+		return p.finishNode(p.factory.NewOmittedExpression(), p.nodePos())
 	}
 	return p.parseAssignmentExpressionOrHigher()
 }
@@ -5508,9 +5287,7 @@ func (p *Parser) parseSpreadElement() *ast.Node {
 	pos := p.nodePos()
 	p.parseExpected(ast.KindDotDotDotToken)
 	expression := p.parseAssignmentExpressionOrHigher()
-	result := p.factory.NewSpreadElement(expression)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewSpreadElement(expression), pos)
 }
 
 func (p *Parser) parseTaggedTemplateRest(pos int, tag *ast.Expression, questionDotToken *ast.Node, typeArguments *ast.NodeList) *ast.Node {
@@ -5522,16 +5299,12 @@ func (p *Parser) parseTaggedTemplateRest(pos int, tag *ast.Expression, questionD
 		template = p.parseTemplateExpression(true /*isTaggedTemplate*/)
 	}
 	isOptionalChain := questionDotToken != nil || tag.Flags&ast.NodeFlagsOptionalChain != 0
-	result := p.factory.NewTaggedTemplateExpression(tag, questionDotToken, typeArguments, template, core.IfElse(isOptionalChain, ast.NodeFlagsOptionalChain, ast.NodeFlagsNone))
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewTaggedTemplateExpression(tag, questionDotToken, typeArguments, template, core.IfElse(isOptionalChain, ast.NodeFlagsOptionalChain, ast.NodeFlagsNone)), pos)
 }
 
 func (p *Parser) parseTemplateExpression(isTaggedTemplate bool) *ast.Expression {
 	pos := p.nodePos()
-	result := p.factory.NewTemplateExpression(p.parseTemplateHead(isTaggedTemplate), p.parseTemplateSpans(isTaggedTemplate))
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewTemplateExpression(p.parseTemplateHead(isTaggedTemplate), p.parseTemplateSpans(isTaggedTemplate)), pos)
 }
 
 func (p *Parser) parseTemplateSpans(isTaggedTemplate bool) *ast.NodeList {
@@ -5551,9 +5324,7 @@ func (p *Parser) parseTemplateSpan(isTaggedTemplate bool) *ast.Node {
 	pos := p.nodePos()
 	expression := p.parseExpressionAllowIn()
 	literal := p.parseLiteralOfTemplateSpan(isTaggedTemplate)
-	result := p.factory.NewTemplateSpan(expression, literal)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewTemplateSpan(expression, literal), pos)
 }
 
 func (p *Parser) parsePrimaryExpression() *ast.Expression {
@@ -5607,8 +5378,7 @@ func (p *Parser) parseParenthesizedExpression() *ast.Expression {
 	p.parseExpected(ast.KindOpenParenToken)
 	expression := p.parseExpressionAllowIn()
 	p.parseExpected(ast.KindCloseParenToken)
-	result := p.factory.NewParenthesizedExpression(expression)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewParenthesizedExpression(expression), pos)
 	p.withJSDoc(result, hasJSDoc)
 	return result
 }
@@ -5620,9 +5390,7 @@ func (p *Parser) parseArrayLiteralExpression() *ast.Expression {
 	multiLine := p.hasPrecedingLineBreak()
 	elements := p.parseDelimitedList(PCArrayLiteralMembers, (*Parser).parseArgumentOrArrayLiteralElement)
 	p.parseExpectedMatchingBrackets(ast.KindOpenBracketToken, ast.KindCloseBracketToken, openBracketParsed, openBracketPosition)
-	result := p.factory.NewArrayLiteralExpression(elements, multiLine)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewArrayLiteralExpression(elements, multiLine), pos)
 }
 
 func (p *Parser) parseObjectLiteralExpression() *ast.Expression {
@@ -5632,9 +5400,7 @@ func (p *Parser) parseObjectLiteralExpression() *ast.Expression {
 	multiLine := p.hasPrecedingLineBreak()
 	properties := p.parseDelimitedList(PCObjectLiteralMembers, (*Parser).parseObjectLiteralElement)
 	p.parseExpectedMatchingBrackets(ast.KindOpenBraceToken, ast.KindCloseBraceToken, openBraceParsed, openBracePosition)
-	result := p.factory.NewObjectLiteralExpression(properties, multiLine)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewObjectLiteralExpression(properties, multiLine), pos)
 }
 
 func (p *Parser) parseObjectLiteralElement() *ast.Node {
@@ -5642,8 +5408,7 @@ func (p *Parser) parseObjectLiteralElement() *ast.Node {
 	hasJSDoc := p.hasPrecedingJSDocComment()
 	if p.parseOptional(ast.KindDotDotDotToken) {
 		expression := p.parseAssignmentExpressionOrHigher()
-		result := p.factory.NewSpreadAssignment(expression)
-		p.finishNode(result, pos)
+		result := p.finishNode(p.factory.NewSpreadAssignment(expression), pos)
 		p.withJSDoc(result, hasJSDoc)
 		return result
 	}
@@ -5743,9 +5508,7 @@ func (p *Parser) parseDecoratedExpression() *ast.Expression {
 		return p.parseClassDeclarationOrExpression(pos, hasJSDoc, modifiers, ast.KindClassExpression)
 	}
 	p.parseErrorAt(p.nodePos(), p.nodePos(), diagnostics.Expression_expected)
-	result := p.factory.NewMissingDeclaration(modifiers)
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(p.factory.NewMissingDeclaration(modifiers), pos)
 }
 
 func (p *Parser) unparseExpressionWithTypeArguments(expression *ast.Node, typeArguments *ast.NodeList, result *ast.Node) {
@@ -5765,9 +5528,7 @@ func (p *Parser) parseNewExpressionOrNewDotTarget() *ast.Node {
 	p.parseExpected(ast.KindNewKeyword)
 	if p.parseOptional(ast.KindDotToken) {
 		name := p.parseIdentifierName()
-		result := p.factory.NewMetaProperty(ast.KindNewKeyword, name)
-		p.finishNode(result, pos)
-		return result
+		return p.finishNode(p.factory.NewMetaProperty(ast.KindNewKeyword, name), pos)
 	}
 	expressionPos := p.nodePos()
 	expression := p.parseMemberExpressionRest(expressionPos, p.parsePrimaryExpression(), false /*allowOptionalChain*/)
@@ -5784,8 +5545,7 @@ func (p *Parser) parseNewExpressionOrNewDotTarget() *ast.Node {
 	if p.token == ast.KindOpenParenToken {
 		argumentList = p.parseArgumentList()
 	}
-	result := p.factory.NewNewExpression(expression, typeArguments, argumentList)
-	p.finishNode(result, pos)
+	result := p.finishNode(p.factory.NewNewExpression(expression, typeArguments, argumentList), pos)
 	p.unparseExpressionWithTypeArguments(expression, typeArguments, result)
 	return result
 }
@@ -5794,8 +5554,7 @@ func (p *Parser) parseKeywordExpression() *ast.Node {
 	pos := p.nodePos()
 	result := p.factory.NewKeywordExpression(p.token)
 	p.nextToken()
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(result, pos)
 }
 
 func (p *Parser) parseLiteralExpression(intern bool) *ast.Node {
@@ -5826,8 +5585,7 @@ func (p *Parser) parseLiteralExpression(intern bool) *ast.Node {
 		panic("Unhandled case in parseLiteralExpression")
 	}
 	p.nextToken()
-	p.finishNode(result, pos)
-	return result
+	return p.finishNode(result, pos)
 }
 
 func (p *Parser) parseIdentifierNameErrorOnUnicodeEscapeSequence() *ast.Node {
@@ -5878,9 +5636,7 @@ func (p *Parser) createIdentifierWithDiagnostic(isIdentifier bool, diagnosticMes
 		}
 		text := p.scanner.TokenValue()
 		p.nextTokenWithoutCheck()
-		result := p.newIdentifier(p.internIdentifier(text))
-		p.finishNode(result, pos)
-		return result
+		return p.finishNode(p.newIdentifier(p.internIdentifier(text)), pos)
 	}
 	if p.token == ast.KindPrivateIdentifier {
 		if privateIdentifierDiagnosticMessage != nil {
@@ -5924,11 +5680,11 @@ func (p *Parser) newModifierList(loc core.TextRange, nodes []*ast.Node) *ast.Mod
 	return list
 }
 
-func (p *Parser) finishNode(node *ast.Node, pos int) {
-	p.finishNodeWithEnd(node, pos, p.nodePos())
+func (p *Parser) finishNode(node *ast.Node, pos int) *ast.Node {
+	return p.finishNodeWithEnd(node, pos, p.nodePos())
 }
 
-func (p *Parser) finishNodeWithEnd(node *ast.Node, pos int, end int) {
+func (p *Parser) finishNodeWithEnd(node *ast.Node, pos int, end int) *ast.Node {
 	node.Loc = core.NewTextRange(pos, end)
 	node.Flags |= p.contextFlags
 	if p.hasParseError {
@@ -5936,6 +5692,7 @@ func (p *Parser) finishNodeWithEnd(node *ast.Node, pos int, end int) {
 		p.hasParseError = false
 	}
 	p.overrideParentInImmediateChildren(node)
+	return node
 }
 
 func (p *Parser) overrideParentInImmediateChildren(node *ast.Node) {


### PR DESCRIPTION
This allows it to be used inline, the way it is in Strada. I discussed this with the team weeks ago and we agreed it was a good idea&mdash; and I've had this sitting on my laptop 98% done but I forgot about it till I went on a working vacation and the branch had a bunch of changes.

I didn't do this for withJSDoc, because it currently has a return value that I use to add JSDoc to commonjs nodes in reparseCommonJS. Maybe there's a better way to do that.

I started by asking agent-mode to do this for me, but it currently cannot handle 250 simple changes across 2 files. Before that, I briefly tried letting copilot completions fill it in, but the gaps were often too far apart for NES. So I made a couple of vi macros instead. Now, I would greatly appreciate if agent-mode could make vi macros because it is slow, error-prone and iterative for me.