### PR TITLE
fix: make ResponseMessage.Result omitzero

### DIFF
--- a/internal/lsp/lsproto/jsonrpc.go
+++ b/internal/lsp/lsproto/jsonrpc.go
@@ -207,7 +207,7 @@ func (r *RequestMessage) UnmarshalJSON(data []byte) error {
 type ResponseMessage struct {
 	JSONRPC JSONRPCVersion `json:"jsonrpc"`
 	ID      *ID            `json:"id,omitzero"`
-	Result  any            `json:"result"`
+	Result  any            `json:"result,omitzero"`
 	Error   *ResponseError `json:"error,omitzero"`
 }
 


### PR DESCRIPTION
According to the JSON-RPC specification, a response object must include either a `result` field or an `error` field, but not both.

Without omitzero, if `Result` is nil, it is marshalled as 'null', causing both `result` and `error` fields to appear in the JSON object when `Error` is also present, which violates the specification.