### PR TITLE
Fix typo in baseUrl paths conversion message

### DIFF
--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -484,7 +484,7 @@ func (p *Program) verifyCompilerOptions() {
 				relative = "./" + relative
 			}
 			suggestion := tspath.CombinePaths(relative, "*")
-			useInstead = fmt.Sprintf(`"paths": {"*": %s}`, core.Must(json.Marshal(suggestion)))
+			useInstead = fmt.Sprintf(`"paths": {"*": [%s]}`, core.Must(json.Marshal(suggestion)))
 		}
 		createRemovedOptionDiagnostic("baseUrl", "", useInstead)
 	}

--- a/testdata/baselines/reference/submodule/compiler/declarationEmitMonorepoBaseUrl.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/declarationEmitMonorepoBaseUrl.errors.txt
@@ -1,5 +1,5 @@
 /tsconfig.json(6,5): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./*"}' instead.
+  Use '"paths": {"*": ["./*"]}' instead.
 
 
 ==== /tsconfig.json (1 errors) ====
@@ -11,7 +11,7 @@
         "baseUrl": "."
         ~~~~~~~~~
 !!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
+!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
       }
     }
     

--- a/testdata/baselines/reference/submodule/compiler/declarationEmitPathMappingMonorepo.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/declarationEmitPathMappingMonorepo.errors.txt
@@ -1,5 +1,5 @@
 packages/b/tsconfig.json(5,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./*"}' instead.
+  Use '"paths": {"*": ["./*"]}' instead.
 
 
 ==== packages/b/tsconfig.json (1 errors) ====
@@ -10,7 +10,7 @@ packages/b/tsconfig.json(5,9): error TS5102: Option 'baseUrl' has been removed. 
             "baseUrl": ".",
             ~~~~~~~~~
 !!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
+!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
             "paths": {
                 "@ts-bug/a": ["../a"]
             }

--- a/testdata/baselines/reference/submodule/compiler/declarationEmitPathMappingMonorepo2.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/declarationEmitPathMappingMonorepo2.errors.txt
@@ -1,6 +1,6 @@
 packages/lab/src/index.ts(1,31): error TS2307: Cannot find module '@ts-bug/core/utils' or its corresponding type declarations.
 packages/lab/tsconfig.json(5,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./../*"}' instead.
+  Use '"paths": {"*": ["./../*"]}' instead.
 
 
 ==== packages/lab/tsconfig.json (1 errors) ====
@@ -11,7 +11,7 @@ packages/lab/tsconfig.json(5,9): error TS5102: Option 'baseUrl' has been removed
             "baseUrl": "../",
             ~~~~~~~~~
 !!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-!!! error TS5102:   Use '"paths": {"*": "./../*"}' instead.
+!!! error TS5102:   Use '"paths": {"*": ["./../*"]}' instead.
             "paths": {
                 "@ts-bug/core": ["./core/src"],
                 "@ts-bug/core/*": ["./core/src/*"],

--- a/testdata/baselines/reference/submodule/compiler/moduleResolutionPackageIdWithRelativeAndAbsolutePath.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/moduleResolutionPackageIdWithRelativeAndAbsolutePath.errors.txt
@@ -1,5 +1,5 @@
 /project/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./*"}' instead.
+  Use '"paths": {"*": ["./*"]}' instead.
 
 
 ==== /project/tsconfig.json (1 errors) ====
@@ -8,7 +8,7 @@
             "baseUrl": ".",
             ~~~~~~~~~
 !!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
+!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
             "paths": {
                 "@shared/*": ["../shared/*"]
             }

--- a/testdata/baselines/reference/submodule/compiler/moduleResolutionWithExtensions_withPaths.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/moduleResolutionWithExtensions_withPaths.errors.txt
@@ -1,5 +1,5 @@
 /tsconfig.json(6,3): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./*"}' instead.
+  Use '"paths": {"*": ["./*"]}' instead.
 /tsconfig.json(11,14): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 
 
@@ -12,7 +12,7 @@
     		"baseUrl": "/",
     		~~~~~~~~~
 !!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
+!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
     		"moduleResolution": "Node",
     		"noImplicitAny": true,
     		"traceResolution": true,

--- a/testdata/baselines/reference/submodule/compiler/moduleResolutionWithSuffixes_one_externalModule_withPaths.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/moduleResolutionWithSuffixes_one_externalModule_withPaths.errors.txt
@@ -1,5 +1,5 @@
 /tsconfig.json(9,3): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./*"}' instead.
+  Use '"paths": {"*": ["./*"]}' instead.
 /tsconfig.json(11,21): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 /tsconfig.json(12,23): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 
@@ -16,7 +16,7 @@
     		"baseUrl": "/",
     		~~~~~~~~~
 !!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
+!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
     		"paths": {
     			"some-library": ["node_modules/some-library/lib"],
     			                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution2_node.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution2_node.errors.txt
@@ -1,5 +1,5 @@
 root/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./src/*"}' instead.
+  Use '"paths": {"*": ["./src/*"]}' instead.
 root/tsconfig.json(5,13): error TS5061: Pattern '*1*' can have at most one '*' character.
 root/tsconfig.json(5,22): error TS5062: Substitution '*2*' in pattern '*1*' can have at most one '*' character.
 root/tsconfig.json(5,22): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
@@ -11,7 +11,7 @@ root/tsconfig.json(5,22): error TS5090: Non-relative paths are not allowed. Did 
             "baseUrl": "./src",
             ~~~~~~~~~
 !!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-!!! error TS5102:   Use '"paths": {"*": "./src/*"}' instead.
+!!! error TS5102:   Use '"paths": {"*": ["./src/*"]}' instead.
             "paths": {
                 "*1*": [ "*2*" ]
                 ~~~~~

--- a/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution4_node.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution4_node.errors.txt
@@ -1,6 +1,6 @@
 c:/root/folder1/file1.ts(1,17): error TS2307: Cannot find module 'folder2/file2' or its corresponding type declarations.
 c:/root/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./*"}' instead.
+  Use '"paths": {"*": ["./*"]}' instead.
 
 
 ==== c:/root/tsconfig.json (1 errors) ====
@@ -9,7 +9,7 @@ c:/root/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Ple
             "baseUrl": "."
             ~~~~~~~~~
 !!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
+!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
         }
     }
     

--- a/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution5_node.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution5_node.errors.txt
@@ -1,5 +1,5 @@
 c:/root/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./*"}' instead.
+  Use '"paths": {"*": ["./*"]}' instead.
 c:/root/tsconfig.json(6,17): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 c:/root/tsconfig.json(7,17): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 c:/root/tsconfig.json(10,21): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
@@ -11,7 +11,7 @@ c:/root/tsconfig.json(10,21): error TS5090: Non-relative paths are not allowed. 
             "baseUrl": ".",
             ~~~~~~~~~
 !!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
+!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
                 "paths": {
                 "*": [
                     "*",

--- a/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution7_node.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution7_node.errors.txt
@@ -1,6 +1,6 @@
 c:/root/src/file1.ts(1,17): error TS2307: Cannot find module './project/file2' or its corresponding type declarations.
 c:/root/src/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./../*"}' instead.
+  Use '"paths": {"*": ["./../*"]}' instead.
 c:/root/src/tsconfig.json(6,17): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 c:/root/src/tsconfig.json(10,17): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 
@@ -11,7 +11,7 @@ c:/root/src/tsconfig.json(10,17): error TS5090: Non-relative paths are not allow
             "baseUrl": "../",
             ~~~~~~~~~
 !!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-!!! error TS5102:   Use '"paths": {"*": "./../*"}' instead.
+!!! error TS5102:   Use '"paths": {"*": ["./../*"]}' instead.
             "paths": {
                 "*": [
                     "*",

--- a/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution8_node.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution8_node.errors.txt
@@ -1,5 +1,5 @@
 c:/root/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./*"}' instead.
+  Use '"paths": {"*": ["./*"]}' instead.
 c:/root/tsconfig.json(6,16): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 
 
@@ -9,7 +9,7 @@ c:/root/tsconfig.json(6,16): error TS5090: Non-relative paths are not allowed. D
             "baseUrl": ".",
             ~~~~~~~~~
 !!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
+!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
             "paths": {
                 "@speedy/*/testing": [
                    "*/dist/index.ts"

--- a/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution_rootImport_aliasWithRoot.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution_rootImport_aliasWithRoot.errors.txt
@@ -1,5 +1,5 @@
 /root/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./*"}' instead.
+  Use '"paths": {"*": ["./*"]}' instead.
 
 
 ==== /root/tsconfig.json (1 errors) ====
@@ -8,7 +8,7 @@
             "baseUrl": ".",
             ~~~~~~~~~
 !!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
+!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
             "paths": {
                 "/*": ["./src/*"]
             },

--- a/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution_rootImport_aliasWithRoot_differentRootTypes.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution_rootImport_aliasWithRoot_differentRootTypes.errors.txt
@@ -1,5 +1,5 @@
 /root/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./*"}' instead.
+  Use '"paths": {"*": ["./*"]}' instead.
 
 
 ==== /root/tsconfig.json (1 errors) ====
@@ -8,7 +8,7 @@
             "baseUrl": ".",
             ~~~~~~~~~
 !!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
+!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
             "paths": {
                 "/*": ["./src/*"],
                 "c:/*": ["./src/*"],

--- a/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution_rootImport_aliasWithRoot_multipleAliases.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution_rootImport_aliasWithRoot_multipleAliases.errors.txt
@@ -1,5 +1,5 @@
 /root/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./*"}' instead.
+  Use '"paths": {"*": ["./*"]}' instead.
 
 
 ==== /root/tsconfig.json (1 errors) ====
@@ -8,7 +8,7 @@
             "baseUrl": ".",
             ~~~~~~~~~
 !!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
+!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
             "paths": {
                 "/client/*": ["./client/*"],
                 "/import/*": ["./import/*"]

--- a/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution_rootImport_aliasWithRoot_realRootFile.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution_rootImport_aliasWithRoot_realRootFile.errors.txt
@@ -1,5 +1,5 @@
 /root/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./*"}' instead.
+  Use '"paths": {"*": ["./*"]}' instead.
 
 
 ==== /root/tsconfig.json (1 errors) ====
@@ -8,7 +8,7 @@
             "baseUrl": ".",
             ~~~~~~~~~
 !!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
+!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
             "paths": {
                 "/*": ["./src/*"]
             },

--- a/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution_rootImport_noAliasWithRoot.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution_rootImport_noAliasWithRoot.errors.txt
@@ -1,5 +1,5 @@
 /root/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./*"}' instead.
+  Use '"paths": {"*": ["./*"]}' instead.
 
 
 ==== /root/tsconfig.json (1 errors) ====
@@ -8,7 +8,7 @@
             "baseUrl": ".",
             ~~~~~~~~~
 !!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
+!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
             "paths": {
                 "*": ["./src/*"]
             },

--- a/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution_rootImport_noAliasWithRoot_realRootFile.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution_rootImport_noAliasWithRoot_realRootFile.errors.txt
@@ -1,5 +1,5 @@
 /root/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./*"}' instead.
+  Use '"paths": {"*": ["./*"]}' instead.
 
 
 ==== /root/tsconfig.json (1 errors) ====
@@ -8,7 +8,7 @@
             "baseUrl": ".",
             ~~~~~~~~~
 !!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
+!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
             "paths": {
                 "*": ["./src/*"]
             },

--- a/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution_withExtension.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution_withExtension.errors.txt
@@ -1,5 +1,5 @@
 /tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./*"}' instead.
+  Use '"paths": {"*": ["./*"]}' instead.
 /tsconfig.json(5,21): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 /tsconfig.json(6,21): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 
@@ -10,7 +10,7 @@
             "baseUrl": ".",
             ~~~~~~~~~
 !!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
+!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
             "paths": {
                 "foo": ["foo/foo.ts"],
                         ~~~~~~~~~~~~

--- a/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution_withExtensionInName.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution_withExtensionInName.errors.txt
@@ -1,5 +1,5 @@
 /tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./*"}' instead.
+  Use '"paths": {"*": ["./*"]}' instead.
 /tsconfig.json(5,19): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 
 
@@ -9,7 +9,7 @@
             "baseUrl": ".",
             ~~~~~~~~~
 !!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
+!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
             "paths": {
                 "*": ["foo/*"]
                       ~~~~~~~

--- a/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution_withExtension_MapedToNodeModules.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution_withExtension_MapedToNodeModules.errors.txt
@@ -1,5 +1,5 @@
 /tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./*"}' instead.
+  Use '"paths": {"*": ["./*"]}' instead.
 /tsconfig.json(5,19): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 /tsconfig.json(5,37): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 
@@ -10,7 +10,7 @@
             "baseUrl": ".",
             ~~~~~~~~~
 !!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
+!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
             "paths": {
                 "*": ["node_modules/*", "src/types"]
                       ~~~~~~~~~~~~~~~~

--- a/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution_withExtension_failedLookup.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathMappingBasedModuleResolution_withExtension_failedLookup.errors.txt
@@ -1,6 +1,6 @@
 /a.ts(1,21): error TS2307: Cannot find module 'foo' or its corresponding type declarations.
 /tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./*"}' instead.
+  Use '"paths": {"*": ["./*"]}' instead.
 /tsconfig.json(5,21): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 
 
@@ -10,7 +10,7 @@
             "baseUrl": ".",
             ~~~~~~~~~
 !!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
+!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
             "paths": {
                 "foo": ["foo/foo.ts"]
                         ~~~~~~~~~~~~

--- a/testdata/baselines/reference/submodule/compiler/pathMappingInheritedBaseUrl.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathMappingInheritedBaseUrl.errors.txt
@@ -1,6 +1,6 @@
 /project/index.ts(1,20): error TS2307: Cannot find module 'p1' or its corresponding type declarations.
 /project/tsconfig.json(3,3): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "../other/*"}' instead.
+  Use '"paths": {"*": ["../other/*"]}' instead.
 
 
 ==== /project/tsconfig.json (1 errors) ====
@@ -9,7 +9,7 @@
       "compilerOptions": {
       ~~~~~~~~~~~~~~~~~
 !!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-!!! error TS5102:   Use '"paths": {"*": "../other/*"}' instead.
+!!! error TS5102:   Use '"paths": {"*": ["../other/*"]}' instead.
         "module": "commonjs",
         "paths": {
           "p1": ["./lib/p1"]

--- a/testdata/baselines/reference/submodule/compiler/pathsValidation1.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathsValidation1.errors.txt
@@ -1,5 +1,5 @@
 tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./*"}' instead.
+  Use '"paths": {"*": ["./*"]}' instead.
 tsconfig.json(5,18): error TS5063: Substitutions for pattern '*' should be an array.
 
 
@@ -9,7 +9,7 @@ tsconfig.json(5,18): error TS5063: Substitutions for pattern '*' should be an ar
             "baseUrl": ".",
             ~~~~~~~~~
 !!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
+!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
             "paths": {
                 "*": "*"
                      ~~~

--- a/testdata/baselines/reference/submodule/compiler/pathsValidation2.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathsValidation2.errors.txt
@@ -1,5 +1,5 @@
 tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./*"}' instead.
+  Use '"paths": {"*": ["./*"]}' instead.
 tsconfig.json(5,18): error TS5066: Substitutions for pattern '*' shouldn't be an empty array.
 
 
@@ -9,7 +9,7 @@ tsconfig.json(5,18): error TS5066: Substitutions for pattern '*' shouldn't be an
             "baseUrl": ".",
             ~~~~~~~~~
 !!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
+!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
             "paths": {
                 "*": [1]
                      ~~~

--- a/testdata/baselines/reference/submodule/compiler/pathsValidation3.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathsValidation3.errors.txt
@@ -1,5 +1,5 @@
 tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./*"}' instead.
+  Use '"paths": {"*": ["./*"]}' instead.
 tsconfig.json(5,20): error TS5066: Substitutions for pattern 'foo' shouldn't be an empty array.
 
 
@@ -9,7 +9,7 @@ tsconfig.json(5,20): error TS5066: Substitutions for pattern 'foo' shouldn't be 
             "baseUrl": ".",
             ~~~~~~~~~
 !!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
+!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
             "paths": {
                 "foo": []
                        ~~

--- a/testdata/baselines/reference/submodule/compiler/pathsValidation4.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/pathsValidation4.errors.txt
@@ -1,5 +1,5 @@
 tsconfig.json(4,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./src/*"}' instead.
+  Use '"paths": {"*": ["./src/*"]}' instead.
 tsconfig.json(6,11): error TS5061: Pattern '@interface/**/*' can have at most one '*' character.
 tsconfig.json(7,11): error TS5061: Pattern '@service/**/*' can have at most one '*' character.
 tsconfig.json(7,29): error TS5062: Substitution './src/service/**/*' in pattern '@service/**/*' can have at most one '*' character.
@@ -13,7 +13,7 @@ tsconfig.json(8,29): error TS5090: Non-relative paths are not allowed. Did you f
             "baseUrl": "./src",
             ~~~~~~~~~
 !!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-!!! error TS5102:   Use '"paths": {"*": "./src/*"}' instead.
+!!! error TS5102:   Use '"paths": {"*": ["./src/*"]}' instead.
             "paths": {
               "@interface/**/*" : ["./src/interface/*"],
               ~~~~~~~~~~~~~~~~~

--- a/testdata/baselines/reference/submodule/compiler/requireOfJsonFileWithoutResolveJsonModuleAndPathMapping.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/requireOfJsonFileWithoutResolveJsonModuleAndPathMapping.errors.txt
@@ -1,6 +1,6 @@
 /a.ts(1,20): error TS2732: Cannot find module 'foo/bar/foobar.json'. Consider using '--resolveJsonModule' to import module with '.json' extension.
 /tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./*"}' instead.
+  Use '"paths": {"*": ["./*"]}' instead.
 /tsconfig.json(5,19): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 /tsconfig.json(5,37): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 
@@ -11,7 +11,7 @@
             "baseUrl": ".",
             ~~~~~~~~~
 !!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
+!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
             "paths": {
                 "*": ["node_modules/*", "src/types"]
                       ~~~~~~~~~~~~~~~~

--- a/testdata/baselines/reference/submodule/compiler/requireOfJsonFile_PathMapping.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/requireOfJsonFile_PathMapping.errors.txt
@@ -1,5 +1,5 @@
 /tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./*"}' instead.
+  Use '"paths": {"*": ["./*"]}' instead.
 /tsconfig.json(5,19): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 /tsconfig.json(5,37): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 
@@ -10,7 +10,7 @@
             "baseUrl": ".",
             ~~~~~~~~~
 !!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
+!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
             "paths": {
                 "*": ["node_modules/*", "src/types"]
                       ~~~~~~~~~~~~~~~~

--- a/testdata/baselines/reference/submoduleAccepted/compiler/declarationEmitMonorepoBaseUrl.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/declarationEmitMonorepoBaseUrl.errors.txt.diff
@@ -3,7 +3,7 @@
 @@= skipped -0, +0 lines =@@
 -<no content>
 +/tsconfig.json(6,5): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+  Use '"paths": {"*": "./*"}' instead.
++  Use '"paths": {"*": ["./*"]}' instead.
 +
 +
 +==== /tsconfig.json (1 errors) ====
@@ -15,7 +15,7 @@
 +        "baseUrl": "."
 +        ~~~~~~~~~
 +!!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
++!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
 +      }
 +    }
 +    

--- a/testdata/baselines/reference/submoduleAccepted/compiler/declarationEmitPathMappingMonorepo.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/declarationEmitPathMappingMonorepo.errors.txt.diff
@@ -3,7 +3,7 @@
 @@= skipped -0, +0 lines =@@
 -<no content>
 +packages/b/tsconfig.json(5,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+  Use '"paths": {"*": "./*"}' instead.
++  Use '"paths": {"*": ["./*"]}' instead.
 +
 +
 +==== packages/b/tsconfig.json (1 errors) ====
@@ -14,7 +14,7 @@
 +            "baseUrl": ".",
 +            ~~~~~~~~~
 +!!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
++!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
 +            "paths": {
 +                "@ts-bug/a": ["../a"]
 +            }

--- a/testdata/baselines/reference/submoduleAccepted/compiler/declarationEmitPathMappingMonorepo2.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/declarationEmitPathMappingMonorepo2.errors.txt.diff
@@ -4,7 +4,7 @@
 -<no content>
 +packages/lab/src/index.ts(1,31): error TS2307: Cannot find module '@ts-bug/core/utils' or its corresponding type declarations.
 +packages/lab/tsconfig.json(5,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+  Use '"paths": {"*": "./../*"}' instead.
++  Use '"paths": {"*": ["./../*"]}' instead.
 +
 +
 +==== packages/lab/tsconfig.json (1 errors) ====
@@ -15,7 +15,7 @@
 +            "baseUrl": "../",
 +            ~~~~~~~~~
 +!!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+!!! error TS5102:   Use '"paths": {"*": "./../*"}' instead.
++!!! error TS5102:   Use '"paths": {"*": ["./../*"]}' instead.
 +            "paths": {
 +                "@ts-bug/core": ["./core/src"],
 +                "@ts-bug/core/*": ["./core/src/*"],

--- a/testdata/baselines/reference/submoduleAccepted/compiler/moduleResolutionPackageIdWithRelativeAndAbsolutePath.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/moduleResolutionPackageIdWithRelativeAndAbsolutePath.errors.txt.diff
@@ -3,7 +3,7 @@
 @@= skipped -0, +0 lines =@@
 -<no content>
 +/project/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+  Use '"paths": {"*": "./*"}' instead.
++  Use '"paths": {"*": ["./*"]}' instead.
 +
 +
 +==== /project/tsconfig.json (1 errors) ====
@@ -12,7 +12,7 @@
 +            "baseUrl": ".",
 +            ~~~~~~~~~
 +!!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
++!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
 +            "paths": {
 +                "@shared/*": ["../shared/*"]
 +            }

--- a/testdata/baselines/reference/submoduleAccepted/compiler/moduleResolutionWithExtensions_withPaths.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/moduleResolutionWithExtensions_withPaths.errors.txt.diff
@@ -3,7 +3,7 @@
 @@= skipped -0, +0 lines =@@
 -<no content>
 +/tsconfig.json(6,3): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+  Use '"paths": {"*": "./*"}' instead.
++  Use '"paths": {"*": ["./*"]}' instead.
 +/tsconfig.json(11,14): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +
 +
@@ -16,7 +16,7 @@
 +    		"baseUrl": "/",
 +    		~~~~~~~~~
 +!!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
++!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
 +    		"moduleResolution": "Node",
 +    		"noImplicitAny": true,
 +    		"traceResolution": true,

--- a/testdata/baselines/reference/submoduleAccepted/compiler/moduleResolutionWithSuffixes_one_externalModule_withPaths.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/moduleResolutionWithSuffixes_one_externalModule_withPaths.errors.txt.diff
@@ -3,7 +3,7 @@
 @@= skipped -0, +0 lines =@@
 -<no content>
 +/tsconfig.json(9,3): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+  Use '"paths": {"*": "./*"}' instead.
++  Use '"paths": {"*": ["./*"]}' instead.
 +/tsconfig.json(11,21): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +/tsconfig.json(12,23): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +
@@ -20,7 +20,7 @@
 +    		"baseUrl": "/",
 +    		~~~~~~~~~
 +!!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
++!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
 +    		"paths": {
 +    			"some-library": ["node_modules/some-library/lib"],
 +    			                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution2_node.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution2_node.errors.txt.diff
@@ -2,7 +2,7 @@
 +++ new.pathMappingBasedModuleResolution2_node.errors.txt
 @@= skipped -0, +0 lines =@@
 +root/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+  Use '"paths": {"*": "./src/*"}' instead.
++  Use '"paths": {"*": ["./src/*"]}' instead.
  root/tsconfig.json(5,13): error TS5061: Pattern '*1*' can have at most one '*' character.
  root/tsconfig.json(5,22): error TS5062: Substitution '*2*' in pattern '*1*' can have at most one '*' character.
 -
@@ -17,7 +17,7 @@
              "baseUrl": "./src",
 +            ~~~~~~~~~
 +!!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+!!! error TS5102:   Use '"paths": {"*": "./src/*"}' instead.
++!!! error TS5102:   Use '"paths": {"*": ["./src/*"]}' instead.
              "paths": {
                  "*1*": [ "*2*" ]
                  ~~~~~

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution4_node.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution4_node.errors.txt.diff
@@ -4,7 +4,7 @@
 -<no content>
 +c:/root/folder1/file1.ts(1,17): error TS2307: Cannot find module 'folder2/file2' or its corresponding type declarations.
 +c:/root/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+  Use '"paths": {"*": "./*"}' instead.
++  Use '"paths": {"*": ["./*"]}' instead.
 +
 +
 +==== c:/root/tsconfig.json (1 errors) ====
@@ -13,7 +13,7 @@
 +            "baseUrl": "."
 +            ~~~~~~~~~
 +!!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
++!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
 +        }
 +    }
 +    

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution5_node.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution5_node.errors.txt.diff
@@ -3,7 +3,7 @@
 @@= skipped -0, +0 lines =@@
 -<no content>
 +c:/root/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+  Use '"paths": {"*": "./*"}' instead.
++  Use '"paths": {"*": ["./*"]}' instead.
 +c:/root/tsconfig.json(6,17): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +c:/root/tsconfig.json(7,17): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +c:/root/tsconfig.json(10,21): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
@@ -15,7 +15,7 @@
 +            "baseUrl": ".",
 +            ~~~~~~~~~
 +!!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
++!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
 +                "paths": {
 +                "*": [
 +                    "*",

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution7_node.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution7_node.errors.txt.diff
@@ -4,7 +4,7 @@
 -<no content>
 +c:/root/src/file1.ts(1,17): error TS2307: Cannot find module './project/file2' or its corresponding type declarations.
 +c:/root/src/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+  Use '"paths": {"*": "./../*"}' instead.
++  Use '"paths": {"*": ["./../*"]}' instead.
 +c:/root/src/tsconfig.json(6,17): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +c:/root/src/tsconfig.json(10,17): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +
@@ -15,7 +15,7 @@
 +            "baseUrl": "../",
 +            ~~~~~~~~~
 +!!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+!!! error TS5102:   Use '"paths": {"*": "./../*"}' instead.
++!!! error TS5102:   Use '"paths": {"*": ["./../*"]}' instead.
 +            "paths": {
 +                "*": [
 +                    "*",

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution8_node.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution8_node.errors.txt.diff
@@ -3,7 +3,7 @@
 @@= skipped -0, +0 lines =@@
 -<no content>
 +c:/root/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+  Use '"paths": {"*": "./*"}' instead.
++  Use '"paths": {"*": ["./*"]}' instead.
 +c:/root/tsconfig.json(6,16): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +
 +
@@ -13,7 +13,7 @@
 +            "baseUrl": ".",
 +            ~~~~~~~~~
 +!!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
++!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
 +            "paths": {
 +                "@speedy/*/testing": [
 +                   "*/dist/index.ts"

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution_rootImport_aliasWithRoot.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution_rootImport_aliasWithRoot.errors.txt.diff
@@ -3,7 +3,7 @@
 @@= skipped -0, +0 lines =@@
 -<no content>
 +/root/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+  Use '"paths": {"*": "./*"}' instead.
++  Use '"paths": {"*": ["./*"]}' instead.
 +
 +
 +==== /root/tsconfig.json (1 errors) ====
@@ -12,7 +12,7 @@
 +            "baseUrl": ".",
 +            ~~~~~~~~~
 +!!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
++!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
 +            "paths": {
 +                "/*": ["./src/*"]
 +            },

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution_rootImport_aliasWithRoot_differentRootTypes.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution_rootImport_aliasWithRoot_differentRootTypes.errors.txt.diff
@@ -3,7 +3,7 @@
 @@= skipped -0, +0 lines =@@
 -<no content>
 +/root/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+  Use '"paths": {"*": "./*"}' instead.
++  Use '"paths": {"*": ["./*"]}' instead.
 +
 +
 +==== /root/tsconfig.json (1 errors) ====
@@ -12,7 +12,7 @@
 +            "baseUrl": ".",
 +            ~~~~~~~~~
 +!!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
++!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
 +            "paths": {
 +                "/*": ["./src/*"],
 +                "c:/*": ["./src/*"],

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution_rootImport_aliasWithRoot_multipleAliases.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution_rootImport_aliasWithRoot_multipleAliases.errors.txt.diff
@@ -3,7 +3,7 @@
 @@= skipped -0, +0 lines =@@
 -<no content>
 +/root/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+  Use '"paths": {"*": "./*"}' instead.
++  Use '"paths": {"*": ["./*"]}' instead.
 +
 +
 +==== /root/tsconfig.json (1 errors) ====
@@ -12,7 +12,7 @@
 +            "baseUrl": ".",
 +            ~~~~~~~~~
 +!!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
++!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
 +            "paths": {
 +                "/client/*": ["./client/*"],
 +                "/import/*": ["./import/*"]

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution_rootImport_aliasWithRoot_realRootFile.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution_rootImport_aliasWithRoot_realRootFile.errors.txt.diff
@@ -3,7 +3,7 @@
 @@= skipped -0, +0 lines =@@
 -<no content>
 +/root/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+  Use '"paths": {"*": "./*"}' instead.
++  Use '"paths": {"*": ["./*"]}' instead.
 +
 +
 +==== /root/tsconfig.json (1 errors) ====
@@ -12,7 +12,7 @@
 +            "baseUrl": ".",
 +            ~~~~~~~~~
 +!!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
++!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
 +            "paths": {
 +                "/*": ["./src/*"]
 +            },

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution_rootImport_noAliasWithRoot.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution_rootImport_noAliasWithRoot.errors.txt.diff
@@ -3,7 +3,7 @@
 @@= skipped -0, +0 lines =@@
 -<no content>
 +/root/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+  Use '"paths": {"*": "./*"}' instead.
++  Use '"paths": {"*": ["./*"]}' instead.
 +
 +
 +==== /root/tsconfig.json (1 errors) ====
@@ -12,7 +12,7 @@
 +            "baseUrl": ".",
 +            ~~~~~~~~~
 +!!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
++!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
 +            "paths": {
 +                "*": ["./src/*"]
 +            },

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution_rootImport_noAliasWithRoot_realRootFile.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution_rootImport_noAliasWithRoot_realRootFile.errors.txt.diff
@@ -3,7 +3,7 @@
 @@= skipped -0, +0 lines =@@
 -<no content>
 +/root/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+  Use '"paths": {"*": "./*"}' instead.
++  Use '"paths": {"*": ["./*"]}' instead.
 +
 +
 +==== /root/tsconfig.json (1 errors) ====
@@ -12,7 +12,7 @@
 +            "baseUrl": ".",
 +            ~~~~~~~~~
 +!!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
++!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
 +            "paths": {
 +                "*": ["./src/*"]
 +            },

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution_withExtension.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution_withExtension.errors.txt.diff
@@ -3,7 +3,7 @@
 @@= skipped -0, +0 lines =@@
 -<no content>
 +/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+  Use '"paths": {"*": "./*"}' instead.
++  Use '"paths": {"*": ["./*"]}' instead.
 +/tsconfig.json(5,21): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +/tsconfig.json(6,21): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +
@@ -14,7 +14,7 @@
 +            "baseUrl": ".",
 +            ~~~~~~~~~
 +!!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
++!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
 +            "paths": {
 +                "foo": ["foo/foo.ts"],
 +                        ~~~~~~~~~~~~

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution_withExtensionInName.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution_withExtensionInName.errors.txt.diff
@@ -3,7 +3,7 @@
 @@= skipped -0, +0 lines =@@
 -<no content>
 +/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+  Use '"paths": {"*": "./*"}' instead.
++  Use '"paths": {"*": ["./*"]}' instead.
 +/tsconfig.json(5,19): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +
 +
@@ -13,7 +13,7 @@
 +            "baseUrl": ".",
 +            ~~~~~~~~~
 +!!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
++!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
 +            "paths": {
 +                "*": ["foo/*"]
 +                      ~~~~~~~

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution_withExtension_MapedToNodeModules.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution_withExtension_MapedToNodeModules.errors.txt.diff
@@ -3,7 +3,7 @@
 @@= skipped -0, +0 lines =@@
 -<no content>
 +/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+  Use '"paths": {"*": "./*"}' instead.
++  Use '"paths": {"*": ["./*"]}' instead.
 +/tsconfig.json(5,19): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +/tsconfig.json(5,37): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +
@@ -14,7 +14,7 @@
 +            "baseUrl": ".",
 +            ~~~~~~~~~
 +!!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
++!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
 +            "paths": {
 +                "*": ["node_modules/*", "src/types"]
 +                      ~~~~~~~~~~~~~~~~

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution_withExtension_failedLookup.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingBasedModuleResolution_withExtension_failedLookup.errors.txt.diff
@@ -6,7 +6,7 @@
 -
 -==== /tsconfig.json (0 errors) ====
 +/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+  Use '"paths": {"*": "./*"}' instead.
++  Use '"paths": {"*": ["./*"]}' instead.
 +/tsconfig.json(5,21): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +
 +
@@ -16,7 +16,7 @@
              "baseUrl": ".",
 +            ~~~~~~~~~
 +!!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
++!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
              "paths": {
                  "foo": ["foo/foo.ts"]
 +                        ~~~~~~~~~~~~

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingInheritedBaseUrl.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathMappingInheritedBaseUrl.errors.txt.diff
@@ -4,7 +4,7 @@
 -<no content>
 +/project/index.ts(1,20): error TS2307: Cannot find module 'p1' or its corresponding type declarations.
 +/project/tsconfig.json(3,3): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+  Use '"paths": {"*": "../other/*"}' instead.
++  Use '"paths": {"*": ["../other/*"]}' instead.
 +
 +
 +==== /project/tsconfig.json (1 errors) ====
@@ -13,7 +13,7 @@
 +      "compilerOptions": {
 +      ~~~~~~~~~~~~~~~~~
 +!!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+!!! error TS5102:   Use '"paths": {"*": "../other/*"}' instead.
++!!! error TS5102:   Use '"paths": {"*": ["../other/*"]}' instead.
 +        "module": "commonjs",
 +        "paths": {
 +          "p1": ["./lib/p1"]

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathsValidation1.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathsValidation1.errors.txt.diff
@@ -2,7 +2,7 @@
 +++ new.pathsValidation1.errors.txt
 @@= skipped -0, +0 lines =@@
 +tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+  Use '"paths": {"*": "./*"}' instead.
++  Use '"paths": {"*": ["./*"]}' instead.
  tsconfig.json(5,18): error TS5063: Substitutions for pattern '*' should be an array.
 
 
@@ -13,7 +13,7 @@
              "baseUrl": ".",
 +            ~~~~~~~~~
 +!!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
++!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
              "paths": {
                  "*": "*"
                       ~~~

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathsValidation2.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathsValidation2.errors.txt.diff
@@ -6,7 +6,7 @@
 -
 -==== tsconfig.json (1 errors) ====
 +tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+  Use '"paths": {"*": "./*"}' instead.
++  Use '"paths": {"*": ["./*"]}' instead.
 +tsconfig.json(5,18): error TS5066: Substitutions for pattern '*' shouldn't be an empty array.
 +
 +
@@ -16,7 +16,7 @@
              "baseUrl": ".",
 +            ~~~~~~~~~
 +!!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
++!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
              "paths": {
                  "*": [1]
 -                      ~

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathsValidation3.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathsValidation3.errors.txt.diff
@@ -2,7 +2,7 @@
 +++ new.pathsValidation3.errors.txt
 @@= skipped -0, +0 lines =@@
 +tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+  Use '"paths": {"*": "./*"}' instead.
++  Use '"paths": {"*": ["./*"]}' instead.
  tsconfig.json(5,20): error TS5066: Substitutions for pattern 'foo' shouldn't be an empty array.
 
 
@@ -13,7 +13,7 @@
              "baseUrl": ".",
 +            ~~~~~~~~~
 +!!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
++!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
              "paths": {
                  "foo": []
                         ~~

--- a/testdata/baselines/reference/submoduleAccepted/compiler/pathsValidation4.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/pathsValidation4.errors.txt.diff
@@ -2,7 +2,7 @@
 +++ new.pathsValidation4.errors.txt
 @@= skipped -0, +0 lines =@@
 +tsconfig.json(4,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+  Use '"paths": {"*": "./src/*"}' instead.
++  Use '"paths": {"*": ["./src/*"]}' instead.
  tsconfig.json(6,11): error TS5061: Pattern '@interface/**/*' can have at most one '*' character.
  tsconfig.json(7,11): error TS5061: Pattern '@service/**/*' can have at most one '*' character.
  tsconfig.json(7,29): error TS5062: Substitution './src/service/**/*' in pattern '@service/**/*' can have at most one '*' character.
@@ -19,7 +19,7 @@
              "baseUrl": "./src",
 +            ~~~~~~~~~
 +!!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+!!! error TS5102:   Use '"paths": {"*": "./src/*"}' instead.
++!!! error TS5102:   Use '"paths": {"*": ["./src/*"]}' instead.
              "paths": {
                "@interface/**/*" : ["./src/interface/*"],
                ~~~~~~~~~~~~~~~~~

--- a/testdata/baselines/reference/submoduleAccepted/compiler/requireOfJsonFileWithoutResolveJsonModuleAndPathMapping.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/requireOfJsonFileWithoutResolveJsonModuleAndPathMapping.errors.txt.diff
@@ -6,7 +6,7 @@
 -
 -==== /tsconfig.json (0 errors) ====
 +/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+  Use '"paths": {"*": "./*"}' instead.
++  Use '"paths": {"*": ["./*"]}' instead.
 +/tsconfig.json(5,19): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +/tsconfig.json(5,37): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +
@@ -17,7 +17,7 @@
              "baseUrl": ".",
 +            ~~~~~~~~~
 +!!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
++!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
              "paths": {
                  "*": ["node_modules/*", "src/types"]
 +                      ~~~~~~~~~~~~~~~~

--- a/testdata/baselines/reference/submoduleAccepted/compiler/requireOfJsonFile_PathMapping.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/requireOfJsonFile_PathMapping.errors.txt.diff
@@ -3,7 +3,7 @@
 @@= skipped -0, +0 lines =@@
 -<no content>
 +/tsconfig.json(3,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+  Use '"paths": {"*": "./*"}' instead.
++  Use '"paths": {"*": ["./*"]}' instead.
 +/tsconfig.json(5,19): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +/tsconfig.json(5,37): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
 +
@@ -14,7 +14,7 @@
 +            "baseUrl": ".",
 +            ~~~~~~~~~
 +!!! error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
-+!!! error TS5102:   Use '"paths": {"*": "./*"}' instead.
++!!! error TS5102:   Use '"paths": {"*": ["./*"]}' instead.
 +            "paths": {
 +                "*": ["node_modules/*", "src/types"]
 +                      ~~~~~~~~~~~~~~~~

--- a/testdata/baselines/reference/tsc/extends/configDir-template-with-commandline.js
+++ b/testdata/baselines/reference/tsc/extends/configDir-template-with-commandline.js
@@ -57,7 +57,7 @@ Output::
 [7m [0m [91m    ~~~~~~~~~~~~~~~~~[0m
 
 [96mtsconfig.json[0m:[93m3[0m:[93m5[0m - [91merror[0m[90m TS5102: [0mOption 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./*"}' instead.
+  Use '"paths": {"*": ["./*"]}' instead.
 
 [7m3[0m     "compilerOptions": {
 [7m [0m [91m    ~~~~~~~~~~~~~~~~~[0m

--- a/testdata/baselines/reference/tsc/extends/configDir-template.js
+++ b/testdata/baselines/reference/tsc/extends/configDir-template.js
@@ -57,7 +57,7 @@ Output::
 [7m [0m [91m    ~~~~~~~~~~~~~~~~~[0m
 
 [96mtsconfig.json[0m:[93m3[0m:[93m5[0m - [91merror[0m[90m TS5102: [0mOption 'baseUrl' has been removed. Please remove it from your configuration.
-  Use '"paths": {"*": "./*"}' instead.
+  Use '"paths": {"*": ["./*"]}' instead.
 
 [7m3[0m     "compilerOptions": {
 [7m [0m [91m    ~~~~~~~~~~~~~~~~~[0m


### PR DESCRIPTION
Fixes #1544

I forgot the `[]`.