### PR TITLE
Avoid copying content when writing files

### DIFF
--- a/internal/vfs/iovfs/iofs.go
+++ b/internal/vfs/iovfs/iofs.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/fs"
 	"strings"
+	"unsafe"
 
 	"github.com/microsoft/typescript-go/internal/stringutil"
 	"github.com/microsoft/typescript-go/internal/tspath"
@@ -65,7 +66,8 @@ func From(fsys fs.FS, useCaseSensitiveFileNames bool) vfs.FS {
 				// \xEF\xBB\xBF.
 				content = stringutil.AddUTF8ByteOrderMark(content)
 			}
-			return fsys.WriteFile(rest, []byte(content), 0o666)
+			buf := unsafe.Slice(unsafe.StringData(content), len(content))
+			return fsys.WriteFile(rest, buf, 0o666)
 		}
 		mkdirAll = func(path string) error {
 			rest, _ := strings.CutPrefix(path, "/")


### PR DESCRIPTION
A well-behaved FS implementation should not mutate the bytes to be written. (Also, it seems like many call sites already have an `[]byte` and convert to a string just to call WriteFile)