### PR TITLE
fix: improve panic message for unspecified ScriptKind in `Parser::initializeState`

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"fmt"
 	"strings"
 	"sync"
 
@@ -208,7 +207,7 @@ func ParseIsolatedEntityName(text string) *ast.EntityName {
 
 func (p *Parser) initializeState(opts ast.SourceFileParseOptions, sourceText string, scriptKind core.ScriptKind) {
 	if scriptKind == core.ScriptKindUnknown {
-		panic(fmt.Errorf("ScriptKind must be specified when parsing source file: %s", opts.FileName))
+		panic("ScriptKind must be specified when parsing source file: " + opts.FileName)
 	}
 
 	if p.scanner == nil {


### PR DESCRIPTION
Currently this message give no diagnostic information, and no information about how to fix the issue.

ScriptKindUnknown, probably comes from here when the extension failed to be fetched, by including the filename in the diagnostic, it should allow devs/users to more easily track down the source of the panic

https://github.com/microsoft/typescript-go/blob/fc4f2039c877fd3e851a3653f7a518346a023b32/internal/core/core.go#L434-L451

Ref: https://github.com/oxc-project/oxc/issues/12950