### PR TITLE
perf(tspath): optimize the fast path case for `ToFileNameLowerCase`

### DIFF
--- a/internal/tspath/path.go
+++ b/internal/tspath/path.go
@@ -533,13 +533,42 @@ func GetCanonicalFileName(fileName string, useCaseSensitiveFileNames bool) strin
 // Rest special characters are either already in lower case format or
 // they have corresponding upper case character so they dont need special handling
 
-func ToFileNameLowerCase(fileName string) string {
+func ToFileNameLowerCase(s string) string {
+	const IWithDot = '\u0130'
+
+	ascii := true
+	needsLower := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 0x80 {
+			ascii = false
+			break
+		}
+		if 'A' <= c && c <= 'Z' {
+			needsLower = true
+		}
+	}
+	if ascii {
+		if !needsLower {
+			return s
+		}
+		b := make([]byte, len(s))
+		for i := 0; i < len(s); i++ {
+			c := s[i]
+			if 'A' <= c && c <= 'Z' {
+				c += 'a' - 'A' // +32
+			}
+			b[i] = c
+		}
+		return string(b)
+	}
+
 	return strings.Map(func(r rune) rune {
-		if r == '\u0130' {
+		if r == IWithDot {
 			return r
 		}
 		return unicode.ToLower(r)
-	}, fileName)
+	}, s)
 }
 
 func ToPath(fileName string, basePath string, useCaseSensitiveFileNames bool) Path {

--- a/internal/tspath/path.go
+++ b/internal/tspath/path.go
@@ -533,12 +533,12 @@ func GetCanonicalFileName(fileName string, useCaseSensitiveFileNames bool) strin
 // Rest special characters are either already in lower case format or
 // they have corresponding upper case character so they dont need special handling
 
-func ToFileNameLowerCase(s string) string {
+func ToFileNameLowerCase(fileName string) string {
 	const IWithDot = '\u0130'
 
 	ascii := true
 	needsLower := false
-	for _, c := range []byte(s) {
+	for _, c := range []byte(fileName) {
 		if c >= 0x80 {
 			ascii = false
 			break
@@ -549,10 +549,10 @@ func ToFileNameLowerCase(s string) string {
 	}
 	if ascii {
 		if !needsLower {
-			return s
+			return fileName
 		}
-		b := make([]byte, len(s))
-		for i, c := range []byte(s) {
+		b := make([]byte, len(fileName))
+		for i, c := range []byte(fileName) {
 			if 'A' <= c && c <= 'Z' {
 				c += 'a' - 'A' // +32
 			}
@@ -566,7 +566,7 @@ func ToFileNameLowerCase(s string) string {
 			return r
 		}
 		return unicode.ToLower(r)
-	}, s)
+	}, fileName)
 }
 
 func ToPath(fileName string, basePath string, useCaseSensitiveFileNames bool) Path {

--- a/internal/tspath/path.go
+++ b/internal/tspath/path.go
@@ -538,8 +538,7 @@ func ToFileNameLowerCase(s string) string {
 
 	ascii := true
 	needsLower := false
-	for i := 0; i < len(s); i++ {
-		c := s[i]
+	for _, c := range []byte(s) {
 		if c >= 0x80 {
 			ascii = false
 			break
@@ -553,8 +552,7 @@ func ToFileNameLowerCase(s string) string {
 			return s
 		}
 		b := make([]byte, len(s))
-		for i := 0; i < len(s); i++ {
-			c := s[i]
+		for i, c := range []byte(s) {
 			if 'A' <= c && c <= 'Z' {
 				c += 'a' - 'A' // +32
 			}


### PR DESCRIPTION
When using project services, `ToFileNameLowerCase` is called 10, 312, 056 times on various paths, this means that it's incredibly hot path.

Since most projects won't hav e non-ascii filenames, we can optimize for this case. This yields up to a 5x perf improvement in some scenarios.

Please feel free to close, if the perf degregation againt non-ascii file paths outweighs the perf gains for the common case

| Test Case                     | Likelihood Category | Old (ns) | New (ns) |
| ----------------------------- | ------------------- | -------- | -------- |
| All lowercase ASCII short     | High                | 45.1     | 8.5      |
| All uppercase ASCII short     | Medium              | 71.8     | 37.9     |
| Mixed case ASCII short        | High                | 62.2     | 41.9     |
| Mixed case ASCII longer       | High                | 134.0    | 60.9     |
| Non-ASCII without İ (e.g., ß) | Low                 | 152.0    | 166.7    |
| Non-ASCII with İ              | Very low            | 147.5    | 156.8    |
| Non-ASCII with ı              | Low                 | 128.2    | 138.1    |
| Long mixed ASCII              | Low                 | 1260.6   | 547.8    |
