### PR TITLE
Fix misported emitCommentsBeforeToken

### DIFF
--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -5051,13 +5051,13 @@ func (p *Printer) emitCommentsBeforeToken(token ast.Kind, pos int, contextNode *
 		return nil, pos
 	}
 
+	node := p.emitContext.ParseNode(contextNode)
+	isSimilarNode := node != nil && node.Kind == contextNode.Kind
 	startPos := pos
-	if p.currentSourceFile != nil {
+	if isSimilarNode && p.currentSourceFile != nil {
 		pos = scanner.SkipTrivia(p.currentSourceFile.Text(), startPos)
 	}
 
-	node := p.emitContext.ParseNode(contextNode)
-	isSimilarNode := node != nil && node.Kind == contextNode.Kind
 	if !isSimilarNode {
 		return nil, pos
 	}


### PR DESCRIPTION
This PR's order of operations differed from the original Strada code. Fixing it stops the crashes.

I'm not really happy about the fix because it feels like I'm papering over another problem where we are setting positions on a node incorrectly. But this is simply porting the code as it was.

Fixes #1314