### PR TITLE
feat(packagejson): remove RWMutex contention in InfoCache with atomic flag + SyncMap

### DIFF
--- a/internal/module/resolver.go
+++ b/internal/module/resolver.go
@@ -1669,14 +1669,14 @@ func (r *resolutionState) getPackageJsonInfo(packageDirectory string, onlyRecord
 				Fields: packageJsonContent,
 			},
 		}
-		r.resolver.packageJsonInfoCache.Set(packageJsonPath, result)
+		result = r.resolver.packageJsonInfoCache.Set(packageJsonPath, result)
 		r.affectingLocations = append(r.affectingLocations, packageJsonPath)
 		return result
 	} else {
 		if directoryExists && r.tracer != nil {
 			r.tracer.write(diagnostics.File_0_does_not_exist.Format(packageJsonPath))
 		}
-		r.resolver.packageJsonInfoCache.Set(packageJsonPath, &packagejson.InfoCacheEntry{
+		_ = r.resolver.packageJsonInfoCache.Set(packageJsonPath, &packagejson.InfoCacheEntry{
 			PackageDirectory: packageDirectory,
 			DirectoryExists:  directoryExists,
 		})

--- a/internal/packagejson/cache.go
+++ b/internal/packagejson/cache.go
@@ -141,7 +141,8 @@ func (p *InfoCache) Get(packageJsonPath string) *InfoCacheEntry {
 	return nil
 }
 
-func (p *InfoCache) Set(packageJsonPath string, info *InfoCacheEntry) {
+func (p *InfoCache) Set(packageJsonPath string, info *InfoCacheEntry) *InfoCacheEntry {
 	key := tspath.ToPath(packageJsonPath, p.currentDirectory, p.useCaseSensitiveFileNames)
-	p.cache.Store(key, info)
+	actual, _ := p.cache.LoadOrStore(key, info)
+	return actual
 }


### PR DESCRIPTION

 - Replaced sync.RWMutex with atomic.Bool for read-only state tracking to eliminate lock contention.
 - Switched underlying storage from map to collections.SyncMap for concurrent, lock-free Get/Set operations.
 - Updated getPackageJsonInfo to call new IsReadonly() method before writes.
 - Added SetReadonly() for efficient state changes without blocking readers.

Diff when running tsgo against vscode repo (top = before, bottom = after)

<img width="1370" height="853" alt="Screenshot 2025-08-13 at 16 44 23" src="https://github.com/user-attachments/assets/c7a2b9bb-57ee-446a-817f-c335ce46f112" />


Diff when running tsgolint against vscode repo (top = before, bottom = after)

<img width="1082" height="809" alt="Screenshot 2025-08-13 at 17 15 57" src="https://github.com/user-attachments/assets/e6f29f77-9555-4a1b-91c3-59a3ae30bd30" />


VIsible in the flamegraphs, the lock contention when getting `package.json`s from the cache is basically non-existant now