### PR TITLE
Update to Go 1.25

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -41,7 +41,7 @@
         "cwd": "${configDir}",
         "cacheKey": "4",
         "commands": [
-            { "command": "go tool mvdan.cc/gofumpt -lang=go1.24", "exts": ["go"] }
+            { "command": "go tool mvdan.cc/gofumpt -lang=go1.25", "exts": ["go"] }
         ]
     },
     "excludes": [

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -4,7 +4,7 @@ description: Setup Go
 inputs:
   go-version:
     description: Go version range to set up.
-    default: '>=1.24.0'
+    default: '>=1.25.0'
   create:
     description: Create the cache
     default: 'false'

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -23,8 +23,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@fcf085fcb4b4b8f63f96906cd713eb52181b5ea4 # stable
       - uses: ./.github/actions/setup-go
         with:
-          # Updated to 1.25.0-rc.1 to improve compilation time
-          go-version: '>=1.25.0-rc.1'
           lint-cache: 'true'
       - run: npm i -g @playwright/mcp@0.0.28
       - run: npm ci

--- a/.github/workflows/create-cache.yml
+++ b/.github/workflows/create-cache.yml
@@ -28,12 +28,7 @@ jobs:
           - windows-latest
           - macos-latest
         go-version:
-          - '>=1.24.0'
-
-        include:
-          # Temporary for the Copilot setup steps
-          - os: ubuntu-latest
-            go-version: '>=1.25.0-rc.1'
+          - '>=1.25.0'
 
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To use this, set this in your VS Code settings:
 
 ## How to Build and Run
 
-This repo uses [Go 1.24 or higher](https://go.dev/dl/), [Rust 1.85 or higher](https://www.rust-lang.org/tools/install), [Node.js with npm](https://nodejs.org/), and [`hereby`](https://www.npmjs.com/package/hereby).
+This repo uses [Go 1.25 or higher](https://go.dev/dl/), [Rust 1.85 or higher](https://www.rust-lang.org/tools/install), [Node.js with npm](https://nodejs.org/), and [`hereby`](https://www.npmjs.com/package/hereby).
 
 For tests and code generation, this repo contains a git submodule to the main TypeScript repo pointing to the commit being ported.
 When cloning, you'll want to clone with submodules:

--- a/_tools/customlint/testdata/go.mod
+++ b/_tools/customlint/testdata/go.mod
@@ -1,3 +1,3 @@
 module testdata
 
-go 1.24.0
+go 1.25

--- a/_tools/go.mod
+++ b/_tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/typescript-go/_tools
 
-go 1.24.0
+go 1.25
 
 require (
 	github.com/golangci/plugin-module-register v0.1.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/typescript-go
 
-go 1.24.2
+go 1.25
 
 require (
 	github.com/dlclark/regexp2 v1.11.5

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -18,7 +18,7 @@ import (
 )
 
 //go:generate go tool golang.org/x/tools/cmd/stringer -type=MessageType -output=stringer_generated.go
-//go:generate go tool mvdan.cc/gofumpt -lang=go1.24 -w stringer_generated.go
+//go:generate go tool mvdan.cc/gofumpt -lang=go1.25 -w stringer_generated.go
 
 type MessageType uint8
 

--- a/internal/ast/kind.go
+++ b/internal/ast/kind.go
@@ -1,7 +1,7 @@
 package ast
 
 //go:generate go tool golang.org/x/tools/cmd/stringer -type=Kind -output=kind_stringer_generated.go
-//go:generate go tool mvdan.cc/gofumpt -lang=go1.24 -w kind_stringer_generated.go
+//go:generate go tool mvdan.cc/gofumpt -lang=go1.25 -w kind_stringer_generated.go
 
 type Kind int16
 

--- a/internal/checker/types.go
+++ b/internal/checker/types.go
@@ -10,7 +10,7 @@ import (
 )
 
 //go:generate go tool golang.org/x/tools/cmd/stringer -type=SignatureKind -output=stringer_generated.go
-//go:generate go tool mvdan.cc/gofumpt -lang=go1.24 -w stringer_generated.go
+//go:generate go tool mvdan.cc/gofumpt -lang=go1.25 -w stringer_generated.go
 
 // ParseFlags
 

--- a/internal/core/compileroptions.go
+++ b/internal/core/compileroptions.go
@@ -11,7 +11,7 @@ import (
 
 //go:generate go tool golang.org/x/tools/cmd/stringer -type=ModuleKind -trimprefix=ModuleKind -output=modulekind_stringer_generated.go
 //go:generate go tool golang.org/x/tools/cmd/stringer -type=ScriptTarget -trimprefix=ScriptTarget -output=scripttarget_stringer_generated.go
-//go:generate go tool mvdan.cc/gofumpt -lang=go1.24 -w modulekind_stringer_generated.go scripttarget_stringer_generated.go
+//go:generate go tool mvdan.cc/gofumpt -lang=go1.25 -w modulekind_stringer_generated.go scripttarget_stringer_generated.go
 
 type CompilerOptions struct {
 	_ noCopy

--- a/internal/core/languagevariant.go
+++ b/internal/core/languagevariant.go
@@ -1,7 +1,7 @@
 package core
 
 //go:generate go tool golang.org/x/tools/cmd/stringer -type=LanguageVariant -output=languagevariant_stringer_generated.go
-//go:generate go tool mvdan.cc/gofumpt -lang=go1.24 -w languagevariant_stringer_generated.go
+//go:generate go tool mvdan.cc/gofumpt -lang=go1.25 -w languagevariant_stringer_generated.go
 
 type LanguageVariant int32
 

--- a/internal/core/scriptkind.go
+++ b/internal/core/scriptkind.go
@@ -1,7 +1,7 @@
 package core
 
 //go:generate go tool golang.org/x/tools/cmd/stringer -type=ScriptKind -output=scriptkind_stringer_generated.go
-//go:generate go tool mvdan.cc/gofumpt -lang=go1.24 -w scriptkind_stringer_generated.go
+//go:generate go tool mvdan.cc/gofumpt -lang=go1.25 -w scriptkind_stringer_generated.go
 
 type ScriptKind int32
 

--- a/internal/core/tristate.go
+++ b/internal/core/tristate.go
@@ -1,7 +1,7 @@
 package core
 
 //go:generate go tool golang.org/x/tools/cmd/stringer -type=Tristate -output=tristate_stringer_generated.go
-//go:generate go tool mvdan.cc/gofumpt -lang=go1.24 -w tristate_stringer_generated.go
+//go:generate go tool mvdan.cc/gofumpt -lang=go1.25 -w tristate_stringer_generated.go
 
 // Tristate
 

--- a/internal/diagnostics/diagnostics.go
+++ b/internal/diagnostics/diagnostics.go
@@ -5,7 +5,7 @@ import "github.com/microsoft/typescript-go/internal/stringutil"
 
 //go:generate go run generate.go -output ./diagnostics_generated.go
 //go:generate go tool golang.org/x/tools/cmd/stringer -type=Category -output=stringer_generated.go
-//go:generate go tool mvdan.cc/gofumpt -lang=go1.24 -w diagnostics_generated.go stringer_generated.go
+//go:generate go tool mvdan.cc/gofumpt -lang=go1.25 -w diagnostics_generated.go stringer_generated.go
 
 type Category int32
 

--- a/internal/fourslash/_scripts/convertFourslash.mts
+++ b/internal/fourslash/_scripts/convertFourslash.mts
@@ -46,7 +46,7 @@ export function main() {
     parseTypeScriptFiles(getFailingTests(), getManualTests(), stradaFourslashPath);
     console.log(unparsedFiles.join("\n"));
     const gofmt = which.sync("go");
-    cp.execFileSync(gofmt, ["tool", "mvdan.cc/gofumpt", "-lang=go1.24", "-w", outputDir]);
+    cp.execFileSync(gofmt, ["tool", "mvdan.cc/gofumpt", "-lang=go1.25", "-w", outputDir]);
 }
 
 function parseTypeScriptFiles(failingTests: Set<string>, manualTests: Set<string>, folder: string): void {

--- a/internal/lsp/lsproto/_generate/generate.mts
+++ b/internal/lsp/lsproto/_generate/generate.mts
@@ -883,7 +883,7 @@ function main() {
 
         // Format with gofmt
         const gofmt = which.sync("go");
-        cp.execFileSync(gofmt, ["tool", "mvdan.cc/gofumpt", "-lang=go1.24", "-w", out]);
+        cp.execFileSync(gofmt, ["tool", "mvdan.cc/gofumpt", "-lang=go1.25", "-w", out]);
 
         console.log(`Successfully generated ${out}`);
     }

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -23,7 +23,7 @@ import (
 )
 
 //go:generate go tool golang.org/x/tools/cmd/stringer -type=Kind -output=project_stringer_generated.go
-//go:generate go tool mvdan.cc/gofumpt -lang=go1.24 -w project_stringer_generated.go
+//go:generate go tool mvdan.cc/gofumpt -lang=go1.25 -w project_stringer_generated.go
 
 const hr = "-----------------------------------------------"
 

--- a/internal/testutil/projecttestutil/projecttestutil.go
+++ b/internal/testutil/projecttestutil/projecttestutil.go
@@ -19,7 +19,7 @@ import (
 )
 
 //go:generate go tool github.com/matryer/moq -stub -fmt goimports -pkg projecttestutil -out clientmock_generated.go ../../project Client
-//go:generate go tool mvdan.cc/gofumpt -lang=go1.24 -w clientmock_generated.go
+//go:generate go tool mvdan.cc/gofumpt -lang=go1.25 -w clientmock_generated.go
 
 type TestTypingsInstallerOptions struct {
 	TypesRegistry         []string

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -5,7 +5,7 @@ import (
 )
 
 //go:generate go tool github.com/matryer/moq -fmt goimports -out vfsmock/mock_generated.go -pkg vfsmock . FS
-//go:generate go tool mvdan.cc/gofumpt -lang=go1.24 -w vfsmock/mock_generated.go
+//go:generate go tool mvdan.cc/gofumpt -lang=go1.25 -w vfsmock/mock_generated.go
 
 // FS is a file system abstraction.
 type FS interface {


### PR DESCRIPTION
Goodbye, slow compile times

There is no need to update the release pipelines (not in this repo), since I configured them to extract the Go version from `go.mod`. Phew.

`golangci-lint` technically does not support this yet ([golangci/golangci-lint#5873](https://redirect.github.com/golangci/golangci-lint/issues/5873)), but since we custom build the binaries, it works fine.