### PR TITLE
Update to golangci-lint v2.4.0

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://golangci-lint.run/jsonschema/custom-gcl.jsonschema.json
 
-version: v2.3.1
+version: v2.4.0
 
 destination: ./_tools
 


### PR DESCRIPTION
This one officially supports Go 1.25 now. I guess I could have waited a couple hours more on #1577. Oops.