### PR TITLE
perf(stringutil): optimize `Format`

### DIFF
--- a/internal/stringutil/format.go
+++ b/internal/stringutil/format.go
@@ -2,18 +2,62 @@ package stringutil
 
 import (
 	"fmt"
-	"regexp"
-	"strconv"
+	"strings"
 )
 
-var placeholderRegexp = regexp.MustCompile(`{(\d+)}`)
+const maxInt = int(^uint(0) >> 1)
 
 func Format(text string, args []any) string {
-	return placeholderRegexp.ReplaceAllStringFunc(text, func(match string) string {
-		index, err := strconv.ParseInt(match[1:len(match)-1], 10, 0)
-		if err != nil || int(index) >= len(args) {
+	if !strings.Contains(text, "{") {
+		return text
+	}
+
+	var b strings.Builder
+	b.Grow(len(text) + len(text)/4)
+
+	for i := 0; i < len(text); {
+		if text[i] != '{' {
+			j := i + 1
+			for j < len(text) && text[j] != '{' {
+				j++
+			}
+			b.WriteString(text[i:j])
+			i = j
+			continue
+		}
+
+		j := i + 1
+		if j >= len(text) || text[j] < '0' || text[j] > '9' {
+			b.WriteByte('{')
+			i++
+			continue
+		}
+
+		k := j
+		for k < len(text) && text[k] >= '0' && text[k] <= '9' {
+			k++
+		}
+		if k >= len(text) || text[k] != '}' {
+			b.WriteByte('{')
+			i++
+			continue
+		}
+
+		n := 0
+		for p := j; p < k; p++ {
+			d := int(text[p] - '0')
+			if n > (maxInt-d)/10 {
+				panic("Invalid formatting placeholder")
+			}
+			n = n*10 + d
+		}
+		if n >= len(args) {
 			panic("Invalid formatting placeholder")
 		}
-		return fmt.Sprintf("%v", args[int(index)])
-	})
+
+		b.WriteString(fmt.Sprint(args[n]))
+		i = k + 1
+	}
+
+	return b.String()
 }


### PR DESCRIPTION
This PR improves the performance of `stringutils::Format`, by removing the slow regex, in favour of a manual implementation.

<img width="1270" height="764" alt="Screenshot 2025-08-14 at 13 43 54" src="https://github.com/user-attachments/assets/80a51ec3-e33e-44d6-86e4-8cf5c6976a59" />
