### PR TITLE
Get node's children with `forEachChild` + scanner in signature help

### DIFF
--- a/internal/fourslash/fourslash.go
+++ b/internal/fourslash/fourslash.go
@@ -544,12 +544,7 @@ func (f *FourslashTest) VerifyCompletions(t *testing.T, markerInput MarkerInput,
 }
 
 func (f *FourslashTest) verifyCompletionsWorker(t *testing.T, expected *CompletionsExpectedList) {
-	var prefix string
-	if f.lastKnownMarkerName != nil {
-		prefix = fmt.Sprintf("At marker '%s': ", *f.lastKnownMarkerName)
-	} else {
-		prefix = fmt.Sprintf("At position (Ln %d, Col %d): ", f.currentCaretPosition.Line, f.currentCaretPosition.Character)
-	}
+	prefix := f.getCurrentPositionPrefix()
 	params := &lsproto.CompletionParams{
 		TextDocument: lsproto.TextDocumentIdentifier{
 			Uri: ls.FileNameToDocumentURI(f.activeFilename),
@@ -931,17 +926,11 @@ func (f *FourslashTest) VerifyBaselineHover(t *testing.T) {
 		}
 
 		resMsg, result, resultOk := sendRequest(t, f, lsproto.TextDocumentHoverInfo, params)
-		var prefix string
-		if f.lastKnownMarkerName != nil {
-			prefix = fmt.Sprintf("At marker '%s': ", *f.lastKnownMarkerName)
-		} else {
-			prefix = fmt.Sprintf("At position (Ln %d, Col %d): ", f.currentCaretPosition.Line, f.currentCaretPosition.Character)
-		}
 		if resMsg == nil {
-			t.Fatalf(prefix+"Nil response received for quick info request", f.lastKnownMarkerName)
+			t.Fatalf(f.getCurrentPositionPrefix()+"Nil response received for quick info request", f.lastKnownMarkerName)
 		}
 		if !resultOk {
-			t.Fatalf(prefix+"Unexpected response type for quick info request: %T", resMsg.AsResponse().Result)
+			t.Fatalf(f.getCurrentPositionPrefix()+"Unexpected response type for quick info request: %T", resMsg.AsResponse().Result)
 		}
 
 		return markerAndItem[*lsproto.Hover]{Marker: marker, Item: result.Hover}, true
@@ -1024,17 +1013,11 @@ func (f *FourslashTest) VerifyBaselineSignatureHelp(t *testing.T) {
 		}
 
 		resMsg, result, resultOk := sendRequest(t, f, lsproto.TextDocumentSignatureHelpInfo, params)
-		var prefix string
-		if f.lastKnownMarkerName != nil {
-			prefix = fmt.Sprintf("At marker '%s': ", *f.lastKnownMarkerName)
-		} else {
-			prefix = fmt.Sprintf("At position (Ln %d, Col %d): ", f.currentCaretPosition.Line, f.currentCaretPosition.Character)
-		}
 		if resMsg == nil {
-			t.Fatalf(prefix+"Nil response received for signature help request", f.lastKnownMarkerName)
+			t.Fatalf(f.getCurrentPositionPrefix()+"Nil response received for signature help request", f.lastKnownMarkerName)
 		}
 		if !resultOk {
-			t.Fatalf(prefix+"Unexpected response type for signature help request: %T", resMsg.AsResponse().Result)
+			t.Fatalf(f.getCurrentPositionPrefix()+"Unexpected response type for signature help request: %T", resMsg.AsResponse().Result)
 		}
 
 		return markerAndItem[*lsproto.SignatureHelp]{Marker: marker, Item: result.SignatureHelp}, true
@@ -1318,8 +1301,7 @@ func (f *FourslashTest) getScriptInfo(fileName string) *scriptInfo {
 func (f *FourslashTest) VerifyQuickInfoAt(t *testing.T, marker string, expectedText string, expectedDocumentation string) {
 	f.GoToMarker(t, marker)
 	hover := f.getQuickInfoAtCurrentPosition(t)
-
-	f.verifyHoverContent(t, hover.Contents, expectedText, expectedDocumentation, fmt.Sprintf("At marker '%s': ", marker))
+	f.verifyHoverContent(t, hover.Contents, expectedText, expectedDocumentation, f.getCurrentPositionPrefix())
 }
 
 func (f *FourslashTest) getQuickInfoAtCurrentPosition(t *testing.T) *lsproto.Hover {
@@ -1391,13 +1373,7 @@ func (f *FourslashTest) quickInfoIsEmpty(t *testing.T) (bool, *lsproto.Hover) {
 
 func (f *FourslashTest) VerifyQuickInfoIs(t *testing.T, expectedText string, expectedDocumentation string) {
 	hover := f.getQuickInfoAtCurrentPosition(t)
-	var prefix string
-	if f.lastKnownMarkerName != nil {
-		prefix = fmt.Sprintf("At marker '%s': ", *f.lastKnownMarkerName)
-	} else {
-		prefix = fmt.Sprintf("At position (Ln %d, Col %d): ", f.currentCaretPosition.Line, f.currentCaretPosition.Character)
-	}
-	f.verifyHoverContent(t, hover.Contents, expectedText, expectedDocumentation, prefix)
+	f.verifyHoverContent(t, hover.Contents, expectedText, expectedDocumentation, f.getCurrentPositionPrefix())
 }
 
 type SignatureHelpCase struct {
@@ -1438,12 +1414,7 @@ func (f *FourslashTest) verifySignatureHelp(
 	context *lsproto.SignatureHelpContext,
 	expected *lsproto.SignatureHelp,
 ) {
-	var prefix string
-	if f.lastKnownMarkerName != nil {
-		prefix = fmt.Sprintf("At marker '%s': ", *f.lastKnownMarkerName)
-	} else {
-		prefix = fmt.Sprintf("At position (Ln %d, Col %d): ", f.currentCaretPosition.Line, f.currentCaretPosition.Character)
-	}
+	prefix := f.getCurrentPositionPrefix()
 	params := &lsproto.SignatureHelpParams{
 		TextDocument: lsproto.TextDocumentIdentifier{
 			Uri: ls.FileNameToDocumentURI(f.activeFilename),
@@ -1468,4 +1439,11 @@ func (f *FourslashTest) verifySignatureHelpResult(
 	prefix string,
 ) {
 	assertDeepEqual(t, actual, expected, prefix+" SignatureHelp mismatch")
+}
+
+func (f *FourslashTest) getCurrentPositionPrefix() string {
+	if f.lastKnownMarkerName != nil {
+		return fmt.Sprintf("At marker '%s': ", *f.lastKnownMarkerName)
+	}
+	return fmt.Sprintf("At position (Ln %d, Col %d): ", f.currentCaretPosition.Line, f.currentCaretPosition.Character)
 }

--- a/internal/fourslash/tests/signatureHelpTokenCrash_test.go
+++ b/internal/fourslash/tests/signatureHelpTokenCrash_test.go
@@ -1,0 +1,44 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	. "github.com/microsoft/typescript-go/internal/fourslash/tests/util"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestSignatureHelpTokenCrash(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `
+function foo(a: any, b: any) {
+
+}
+
+foo((/*1*/
+
+/** This is a JSDoc comment */
+foo/** More comments*/((/*2*/
+`
+	f := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	f.VerifySignatureHelp(t, &fourslash.SignatureHelpCase{
+		MarkerInput: "1",
+		Expected:    nil,
+		Context: &lsproto.SignatureHelpContext{
+			IsRetrigger:      false,
+			TriggerCharacter: PtrTo("("),
+			TriggerKind:      lsproto.SignatureHelpTriggerKindTriggerCharacter,
+		},
+	})
+	f.VerifySignatureHelp(t, &fourslash.SignatureHelpCase{
+		MarkerInput: "2",
+		Expected:    nil,
+		Context: &lsproto.SignatureHelpContext{
+			IsRetrigger:      false,
+			TriggerCharacter: PtrTo("("),
+			TriggerKind:      lsproto.SignatureHelpTriggerKindTriggerCharacter,
+		},
+	})
+}


### PR DESCRIPTION
Fixes #1298.

The issue had two different call stacks, but it turned out to be the same bug that was showing up in two different places.

I had to add a very minimal version of `fourslash.VerifySignatureHelp` to be able to write a fourslash test for this.

Context:
`node.getChildren()` has been replaced in Corsa by code that visits child nodes and uses the scanner to obtain child tokens. In this new setup, we use `sourceFile.GetOrCreateToken` to get a token object if one has been created before, or creating a new token object and caching it. That's done like that because we want the invariant that if you call `sourceFile.GetOrCreateToken` with the same token information (i.e. same kind, position, etc), you get the same Go object and comparing tokens by pointer equality will work out. A consequence of this is that you have to provide the same parent when getting or creating a token, i.e. the parent the token would have in Strada.

`getTokensFromNode` in signature help was not respecting this: it was using the scanner to scan all tokens in the range of a given node, and assuming the given node would be the token's parent. That's wrong because a token in the given node's range could have e.g. a child of that node as its parent. For instance, if you have the call expression node `foo(())`, then the first `(` token has the call expression as parent, but the second `(` has as parent the parenthesized expression `()`.