### PR TITLE
Use go.mod ignore directive instead of postinstall

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -477,16 +477,6 @@ export const checkFormat = task({
     },
 });
 
-export const postinstall = task({
-    name: "postinstall",
-    hiddenFromTaskList: true,
-    run: () => {
-        // Ensure the go command doesn't waste time looking into node_modules.
-        // Remove once https://github.com/golang/go/issues/42965 is fixed.
-        fs.writeFileSync(path.join(__dirname, "node_modules", "go.mod"), `module example.org/ignoreme\n`);
-    },
-});
-
 /**
  * @param {string} localBaseline Path to the local copy of the baselines
  * @param {string} refBaseline Path to the reference copy of the baselines

--- a/go.mod
+++ b/go.mod
@@ -28,3 +28,12 @@ tool (
 	golang.org/x/tools/cmd/stringer
 	mvdan.cc/gofumpt
 )
+
+ignore (
+	node_modules
+	./_extension
+	./_packages
+	./_submodules
+	./built
+	./coverage
+)

--- a/go.mod
+++ b/go.mod
@@ -30,10 +30,10 @@ tool (
 )
 
 ignore (
-	node_modules
 	./_extension
 	./_packages
 	./_submodules
 	./built
 	./coverage
+	node_modules
 )

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
         "which": "^5.0.0"
     },
     "scripts": {
-        "postinstall": "hereby postinstall",
         "build": "hereby build",
         "build:watch": "hereby build:watch",
         "build:watch:debug": "hereby build:watch --debug",


### PR DESCRIPTION
Before 1.25, we needed a postinstall to force Go to ignore `node_modules`. Now, we can just stick it in `go.mod`.

This also means we can now drop the `_` prefix on the dirs, but it's probably too late to change that.