### PR TITLE
feat(configfileregistry): optimize config discovery

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -65,9 +65,9 @@ func NewAPI(host APIHost, options APIOptions) *API {
 		},
 	})
 
-	api.configFileRegistry = &project.ConfigFileRegistry{
+	api.configFileRegistry = project.NewConfigFileRegistry(&project.ConfigFileRegistry{
 		Host: api,
-	}
+	})
 	return api
 }
 


### PR DESCRIPTION
Refactor hot paths in project setup for better performance and simplicity.

- Config acquisition and parsing: Add fast-path for already-parsed configs, deduplicate concurrent parses using a wait group, use narrower locks (read locks for reads, write locks only for updates), avoid full reloads on entry creation, and support targeted reloads (file lists only).
- Default project discovery: Replace recursive goroutine-based traversal with a single-threaded iterative BFS queue. Track visited paths by (path, loadKind) pair, upgrade loadKind monotonically, and exit early on a good match. This removes recursion depth issues, goroutine overload, and sync overhead, while making resolution deterministic.
- Result tracking and service wiring: Use a single mutex with plain maps instead of SyncMaps and multiple locks. Ensure monotonic updates to prevent revisits with weaker loadKind. Initialize activeParsing in NewService and make cleanup consistent with BFS using plain maps under mutex.

These changes eliminate duplicate parsing, cut CPU spikes, and avoid goroutine storms in large reference graphs. The design now scales linearly with project size and offers more predictable latency under load.

Performance:

Old design: O(E) goroutines (E = edges in tsconfig graph), with duplicate work on converging paths. Parsing was O(N * c) worst-case (N = configs, c = concurrent requests per config).

New design: O(V + E) traversal (V = tsconfigs), visiting each config once per strongest loadKind. Parsing is O(N) amortized, as each config parses only once.

See https://github.com/oxc-project/tsgolint/pull/99 for before/after analysis.