### PR TITLE
Remove runtime.Breakpoint call

### DIFF
--- a/internal/debug/shared.go
+++ b/internal/debug/shared.go
@@ -2,7 +2,6 @@ package debug
 
 import (
 	"fmt"
-	"runtime"
 )
 
 func Fail(reason string) {
@@ -11,7 +10,7 @@ func Fail(reason string) {
 	} else {
 		reason = "Debug failure. " + reason
 	}
-	runtime.Breakpoint()
+	// runtime.Breakpoint()
 	panic(reason)
 }
 


### PR DESCRIPTION
I guess this is _not_ similar enough to `debugger;`, doing it without a debugger attach just does SIGTRAP. ☹️ 