### PR TITLE
Prefer implicit `{}` over explicitly declared `{}` in subtype reduction

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -25010,6 +25010,9 @@ func (c *Checker) removeSubtypes(types []*Type, hasObjectTypes bool) []*Type {
 							continue
 						}
 					}
+					if (source == c.emptyObjectType || source == c.unknownEmptyObjectType) && target.symbol != nil && c.IsEmptyAnonymousObjectType(target) {
+						continue
+					}
 					if c.isTypeRelatedTo(source, target, c.strictSubtypeRelation) && (c.getTargetType(source).objectFlags&ObjectFlagsClass == 0 ||
 						c.getTargetType(target).objectFlags&ObjectFlagsClass == 0 ||
 						c.isTypeDerivedFrom(source, target)) {

--- a/testdata/baselines/reference/compiler/implicitEmptyObjectType.errors.txt
+++ b/testdata/baselines/reference/compiler/implicitEmptyObjectType.errors.txt
@@ -1,0 +1,16 @@
+implicitEmptyObjectType.ts(6,17): error TS2345: Argument of type '{}' is not assignable to parameter of type 'Record<string, string>'.
+  Index signature for type 'string' is missing in type '{}'.
+
+
+==== implicitEmptyObjectType.ts (1 errors) ====
+    // https://github.com/microsoft/typescript-go/issues/1563
+    
+    function f() {
+      const v: unknown = "lol";
+      const acceptsRecord = (record: Record<string, string>) => {};
+      acceptsRecord(v || {});
+                    ~~~~~~~
+!!! error TS2345: Argument of type '{}' is not assignable to parameter of type 'Record<string, string>'.
+!!! error TS2345:   Index signature for type 'string' is missing in type '{}'.
+    }
+    

--- a/testdata/baselines/reference/compiler/implicitEmptyObjectType.symbols
+++ b/testdata/baselines/reference/compiler/implicitEmptyObjectType.symbols
@@ -1,0 +1,21 @@
+//// [tests/cases/compiler/implicitEmptyObjectType.ts] ////
+
+=== implicitEmptyObjectType.ts ===
+// https://github.com/microsoft/typescript-go/issues/1563
+
+function f() {
+>f : Symbol(f, Decl(implicitEmptyObjectType.ts, 0, 0))
+
+  const v: unknown = "lol";
+>v : Symbol(v, Decl(implicitEmptyObjectType.ts, 3, 7))
+
+  const acceptsRecord = (record: Record<string, string>) => {};
+>acceptsRecord : Symbol(acceptsRecord, Decl(implicitEmptyObjectType.ts, 4, 7))
+>record : Symbol(record, Decl(implicitEmptyObjectType.ts, 4, 25))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+
+  acceptsRecord(v || {});
+>acceptsRecord : Symbol(acceptsRecord, Decl(implicitEmptyObjectType.ts, 4, 7))
+>v : Symbol(v, Decl(implicitEmptyObjectType.ts, 3, 7))
+}
+

--- a/testdata/baselines/reference/compiler/implicitEmptyObjectType.types
+++ b/testdata/baselines/reference/compiler/implicitEmptyObjectType.types
@@ -1,0 +1,25 @@
+//// [tests/cases/compiler/implicitEmptyObjectType.ts] ////
+
+=== implicitEmptyObjectType.ts ===
+// https://github.com/microsoft/typescript-go/issues/1563
+
+function f() {
+>f : () => void
+
+  const v: unknown = "lol";
+>v : unknown
+>"lol" : "lol"
+
+  const acceptsRecord = (record: Record<string, string>) => {};
+>acceptsRecord : (record: Record<string, string>) => void
+>(record: Record<string, string>) => {} : (record: Record<string, string>) => void
+>record : Record<string, string>
+
+  acceptsRecord(v || {});
+>acceptsRecord(v || {}) : void
+>acceptsRecord : (record: Record<string, string>) => void
+>v || {} : {}
+>v : unknown
+>{} : {}
+}
+

--- a/testdata/tests/cases/compiler/implicitEmptyObjectType.ts
+++ b/testdata/tests/cases/compiler/implicitEmptyObjectType.ts
@@ -1,0 +1,10 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/typescript-go/issues/1563
+
+function f() {
+  const v: unknown = "lol";
+  const acceptsRecord = (record: Record<string, string>) => {};
+  acceptsRecord(v || {});
+}


### PR DESCRIPTION
Fixes #1563.