### PR TITLE
Fix addUndefinedForParameter check location

### DIFF
--- a/internal/checker/nodebuilderimpl.go
+++ b/internal/checker/nodebuilderimpl.go
@@ -2004,11 +2004,12 @@ func (b *nodeBuilderImpl) serializeTypeForDeclaration(declaration *ast.Declarati
 				t = b.ch.errorType
 			}
 		}
-		// !!! TODO: JSDoc, getEmitResolver call is unfortunate layering for the helper - hoist it into checker
-		addUndefinedForParameter := declaration != nil && (ast.IsParameter(declaration) /*|| ast.IsJSDocParameterTag(declaration)*/) && b.ch.GetEmitResolver().requiresAddingImplicitUndefined(declaration, symbol, b.ctx.enclosingDeclaration)
-		if addUndefinedForParameter {
-			t = b.ch.getOptionalType(t, false)
-		}
+	}
+
+	// !!! TODO: JSDoc, getEmitResolver call is unfortunate layering for the helper - hoist it into checker
+	addUndefinedForParameter := declaration != nil && (ast.IsParameter(declaration) /*|| ast.IsJSDocParameterTag(declaration)*/) && b.ch.GetEmitResolver().requiresAddingImplicitUndefined(declaration, symbol, b.ctx.enclosingDeclaration)
+	if addUndefinedForParameter {
+		t = b.ch.getOptionalType(t, false)
 	}
 
 	restoreFlags := b.saveRestoreFlags()

--- a/testdata/baselines/reference/submodule/compiler/defaultParameterAddsUndefinedWithStrictNullChecks.types
+++ b/testdata/baselines/reference/submodule/compiler/defaultParameterAddsUndefinedWithStrictNullChecks.types
@@ -18,7 +18,7 @@ function f(addUndefined1 = "J", addUndefined2?: number) {
 >0 : 0
 }
 function g(addUndefined = "J", addDefined: number) {
->g : (addUndefined: string, addDefined: number) => number
+>g : (addUndefined: string | undefined, addDefined: number) => number
 >addUndefined : string
 >"J" : "J"
 >addDefined : number
@@ -54,16 +54,16 @@ total = g('c', 3) + g(undefined, 4);
 >total : number
 >g('c', 3) + g(undefined, 4) : number
 >g('c', 3) : number
->g : (addUndefined: string, addDefined: number) => number
+>g : (addUndefined: string | undefined, addDefined: number) => number
 >'c' : "c"
 >3 : 3
 >g(undefined, 4) : number
->g : (addUndefined: string, addDefined: number) => number
+>g : (addUndefined: string | undefined, addDefined: number) => number
 >undefined : undefined
 >4 : 4
 
 function foo1(x: string = "string", b: number) {
->foo1 : (x: string, b: number) => void
+>foo1 : (x: string | undefined, b: number) => void
 >x : string
 >"string" : "string"
 >b : number
@@ -75,7 +75,7 @@ function foo1(x: string = "string", b: number) {
 }
 
 function foo2(x = "string", b: number) {
->foo2 : (x: string, b: number) => void
+>foo2 : (x: string | undefined, b: number) => void
 >x : string
 >"string" : "string"
 >b : number
@@ -144,13 +144,13 @@ allowsNull(null); // still allows passing null
 // .d.ts should have `string | undefined` for foo1, foo2, foo3 and foo4
 foo1(undefined, 1);
 >foo1(undefined, 1) : void
->foo1 : (x: string, b: number) => void
+>foo1 : (x: string | undefined, b: number) => void
 >undefined : undefined
 >1 : 1
 
 foo2(undefined, 1);
 >foo2(undefined, 1) : void
->foo2 : (x: string, b: number) => void
+>foo2 : (x: string | undefined, b: number) => void
 >undefined : undefined
 >1 : 1
 

--- a/testdata/baselines/reference/submodule/compiler/defaultParameterAddsUndefinedWithStrictNullChecks.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/defaultParameterAddsUndefinedWithStrictNullChecks.types.diff
@@ -9,16 +9,7 @@
  >addUndefined1 : string
  >"J" : "J"
  >addUndefined2 : number | undefined
-@@= skipped -16, +16 lines =@@
- >0 : 0
- }
- function g(addUndefined = "J", addDefined: number) {
-->g : (addUndefined: string | undefined, addDefined: number) => number
-+>g : (addUndefined: string, addDefined: number) => number
- >addUndefined : string
- >"J" : "J"
- >addDefined : number
-@@= skipped -18, +18 lines =@@
+@@= skipped -34, +34 lines =@@
  >f() + f('a', 1) + f('b') : number
  >f() + f('a', 1) : number
  >f() : number
@@ -38,48 +29,3 @@
 +>f : (addUndefined1?: string, addUndefined2?: number | undefined) => number
  >undefined : undefined
  >2 : 2
-
-@@= skipped -18, +18 lines =@@
- >total : number
- >g('c', 3) + g(undefined, 4) : number
- >g('c', 3) : number
-->g : (addUndefined: string | undefined, addDefined: number) => number
-+>g : (addUndefined: string, addDefined: number) => number
- >'c' : "c"
- >3 : 3
- >g(undefined, 4) : number
-->g : (addUndefined: string | undefined, addDefined: number) => number
-+>g : (addUndefined: string, addDefined: number) => number
- >undefined : undefined
- >4 : 4
-
- function foo1(x: string = "string", b: number) {
-->foo1 : (x: string | undefined, b: number) => void
-+>foo1 : (x: string, b: number) => void
- >x : string
- >"string" : "string"
- >b : number
-@@= skipped -21, +21 lines =@@
- }
-
- function foo2(x = "string", b: number) {
-->foo2 : (x: string | undefined, b: number) => void
-+>foo2 : (x: string, b: number) => void
- >x : string
- >"string" : "string"
- >b : number
-@@= skipped -69, +69 lines =@@
- // .d.ts should have `string | undefined` for foo1, foo2, foo3 and foo4
- foo1(undefined, 1);
- >foo1(undefined, 1) : void
-->foo1 : (x: string | undefined, b: number) => void
-+>foo1 : (x: string, b: number) => void
- >undefined : undefined
- >1 : 1
-
- foo2(undefined, 1);
- >foo2(undefined, 1) : void
-->foo2 : (x: string | undefined, b: number) => void
-+>foo2 : (x: string, b: number) => void
- >undefined : undefined
- >1 : 1

--- a/testdata/baselines/reference/submodule/compiler/isolatedDeclarationsAddUndefined.js
+++ b/testdata/baselines/reference/submodule/compiler/isolatedDeclarationsAddUndefined.js
@@ -54,8 +54,8 @@ export declare class Bar {
     f: number;
 }
 //// [file2.d.ts]
-export declare function foo(p?: (ip: number, v: number) => void): void;
-export declare function foo2(p?: (ip: number, v: number) => void): void;
+export declare function foo(p?: (ip: number | undefined, v: number) => void): void;
+export declare function foo2(p?: (ip: number | undefined, v: number) => void): void;
 export declare class Bar2 {
     readonly r: number;
     f: number;

--- a/testdata/baselines/reference/submodule/compiler/isolatedDeclarationsAddUndefined.js.diff
+++ b/testdata/baselines/reference/submodule/compiler/isolatedDeclarationsAddUndefined.js.diff
@@ -45,8 +45,8 @@
 +    f: number;
 +}
 +//// [file2.d.ts]
-+export declare function foo(p?: (ip: number, v: number) => void): void;
-+export declare function foo2(p?: (ip: number, v: number) => void): void;
++export declare function foo(p?: (ip: number | undefined, v: number) => void): void;
++export declare function foo2(p?: (ip: number | undefined, v: number) => void): void;
 +export declare class Bar2 {
 +    readonly r: number;
 +    f: number;

--- a/testdata/baselines/reference/submodule/compiler/isolatedDeclarationsAddUndefined.types
+++ b/testdata/baselines/reference/submodule/compiler/isolatedDeclarationsAddUndefined.types
@@ -30,9 +30,9 @@ export class Bar {
 
 === file2.ts ===
 export function foo(p = (ip = 10, v: number): void => {}): void{
->foo : (p?: (ip: number, v: number) => void) => void
->p : (ip: number, v: number) => void
->(ip = 10, v: number): void => {} : (ip: number, v: number) => void
+>foo : (p?: (ip: number | undefined, v: number) => void) => void
+>p : (ip: number | undefined, v: number) => void
+>(ip = 10, v: number): void => {} : (ip: number | undefined, v: number) => void
 >ip : number
 >10 : 10
 >v : number
@@ -41,9 +41,9 @@ type T = number
 >T : number
 
 export function foo2(p = (ip = 10 as T, v: number): void => {}): void{}
->foo2 : (p?: (ip: number, v: number) => void) => void
->p : (ip: number, v: number) => void
->(ip = 10 as T, v: number): void => {} : (ip: number, v: number) => void
+>foo2 : (p?: (ip: number | undefined, v: number) => void) => void
+>p : (ip: number | undefined, v: number) => void
+>(ip = 10 as T, v: number): void => {} : (ip: number | undefined, v: number) => void
 >ip : number
 >10 as T : number
 >10 : 10

--- a/testdata/baselines/reference/submodule/compiler/isolatedDeclarationsAddUndefined.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/isolatedDeclarationsAddUndefined.types.diff
@@ -1,28 +1,15 @@
 --- old.isolatedDeclarationsAddUndefined.types
 +++ new.isolatedDeclarationsAddUndefined.types
-@@= skipped -29, +29 lines =@@
-
- === file2.ts ===
- export function foo(p = (ip = 10, v: number): void => {}): void{
-->foo : (p?: (ip: number | undefined, v: number) => void) => void
-->p : (ip: number | undefined, v: number) => void
-->(ip = 10, v: number): void => {} : (ip: number | undefined, v: number) => void
-+>foo : (p?: (ip: number, v: number) => void) => void
-+>p : (ip: number, v: number) => void
-+>(ip = 10, v: number): void => {} : (ip: number, v: number) => void
- >ip : number
- >10 : 10
- >v : number
-@@= skipped -11, +11 lines =@@
+@@= skipped -40, +40 lines =@@
  >T : number
 
  export function foo2(p = (ip = 10 as T, v: number): void => {}): void{}
 ->foo2 : (p?: (ip: T | undefined, v: number) => void) => void
 ->p : (ip: T | undefined, v: number) => void
 ->(ip = 10 as T, v: number): void => {} : (ip: T | undefined, v: number) => void
-+>foo2 : (p?: (ip: number, v: number) => void) => void
-+>p : (ip: number, v: number) => void
-+>(ip = 10 as T, v: number): void => {} : (ip: number, v: number) => void
++>foo2 : (p?: (ip: number | undefined, v: number) => void) => void
++>p : (ip: number | undefined, v: number) => void
++>(ip = 10 as T, v: number): void => {} : (ip: number | undefined, v: number) => void
  >ip : number
  >10 as T : number
  >10 : 10

--- a/testdata/baselines/reference/submodule/compiler/verbatim-declarations-parameters.types
+++ b/testdata/baselines/reference/submodule/compiler/verbatim-declarations-parameters.types
@@ -26,7 +26,7 @@ export class Foo {
 }
 
 export function foo1(
->foo1 : (reuseTypeNode: { [x: string]: any; } | undefined, reuseTypeNode2: { [x: string]: any; } | undefined, resolveType: { [x: string]: any; }, requiredParam: number) => void
+>foo1 : (reuseTypeNode: { [x: string]: any; } | undefined, reuseTypeNode2: { [x: string]: any; } | undefined, resolveType: { [x: string]: any; } | undefined, requiredParam: number) => void
 
     // Type node is accurate, preserve
     reuseTypeNode: Map | undefined = {},

--- a/testdata/baselines/reference/submodule/compiler/verbatim-declarations-parameters.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/verbatim-declarations-parameters.types.diff
@@ -5,7 +5,7 @@
 
  export function foo1(
 ->foo1 : (reuseTypeNode: Map | undefined, reuseTypeNode2: Exclude<MapOrUndefined, "dummy">, resolveType: Map | undefined, requiredParam: number) => void
-+>foo1 : (reuseTypeNode: { [x: string]: any; } | undefined, reuseTypeNode2: { [x: string]: any; } | undefined, resolveType: { [x: string]: any; }, requiredParam: number) => void
++>foo1 : (reuseTypeNode: { [x: string]: any; } | undefined, reuseTypeNode2: { [x: string]: any; } | undefined, resolveType: { [x: string]: any; } | undefined, requiredParam: number) => void
 
      // Type node is accurate, preserve
      reuseTypeNode: Map | undefined = {},


### PR DESCRIPTION
Noticed this when looking at #1600. In Strada, this is unconditional if the type node isn't being reused.