### PR TITLE
Don't error on referenced project's noEmit if program has empty files

### DIFF
--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -862,7 +862,7 @@ func (p *Program) verifyProjectReferences() {
 		}
 		refOptions := config.CompilerOptions()
 		if !refOptions.Composite.IsTrue() || refOptions.NoEmit.IsTrue() {
-			if len(config.FileNames()) > 0 {
+			if len(parent.FileNames()) > 0 {
 				if !refOptions.Composite.IsTrue() {
 					createDiagnosticForReference(parent, index, diagnostics.Referenced_project_0_must_have_setting_composite_Colon_true, ref.Path)
 				}

--- a/internal/execute/tsc_test.go
+++ b/internal/execute/tsc_test.go
@@ -122,6 +122,30 @@ func TestTscCommandline(t *testing.T) {
 			subScenario:     "Parse watch interval option without tsconfig.json",
 			commandLineArgs: []string{"-w", "--watchInterval", "1000"},
 		},
+		{
+			subScenario: "Config with references and empty file and refers to config with noEmit",
+			files: FileMap{
+				"/home/src/workspaces/project/tsconfig.json": stringtestutil.Dedent(`{
+					"files": [],
+					"references": [
+						{
+							"path": "./packages/pkg1"
+						},
+					],
+				}`),
+				"/home/src/workspaces/project/packages/pkg1/tsconfig.json": stringtestutil.Dedent(`{
+					"compilerOptions": {
+						"composite": true,
+						"noEmit": true
+					},
+					"files": [
+						"./index.ts",
+					],
+				}`),
+				"/home/src/workspaces/project/packages/pkg1/index.ts": `export const a = 1;`,
+			},
+			commandLineArgs: []string{"-p", "."},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
Fixes what seems like a porting bug in checking config references. If a tsconfig has no files (i.e. it's a top-level tsconfig that refers every project entry point in your monorepo), it's ok for a project it references to have `noEmit` true (same for having `composite` false).