### PR TITLE
Release program after finishing program emit, Only cache dts and json source files

### DIFF
--- a/internal/execute/build/buildtask.go
+++ b/internal/execute/build/buildtask.go
@@ -70,8 +70,10 @@ func (t *buildTask) report(orchestrator *Orchestrator, configPath tspath.Path, b
 		buildResult.programStats = append(buildResult.programStats, t.statistics)
 	}
 	if t.program != nil {
+		if orchestrator.opts.Testing != nil {
+			orchestrator.opts.Testing.OnProgram(t.program)
+		}
 		t.program.MakeReadonly()
-		buildResult.result.IncrementalProgram = append(buildResult.result.IncrementalProgram, t.program)
 		buildResult.statistics.ProjectsBuilt++
 	}
 	if t.pseudoBuild {

--- a/internal/execute/build/buildtask.go
+++ b/internal/execute/build/buildtask.go
@@ -70,6 +70,7 @@ func (t *buildTask) report(orchestrator *Orchestrator, configPath tspath.Path, b
 		buildResult.programStats = append(buildResult.programStats, t.statistics)
 	}
 	if t.program != nil {
+		t.program.MakeReadonly()
 		buildResult.result.IncrementalProgram = append(buildResult.result.IncrementalProgram, t.program)
 		buildResult.statistics.ProjectsBuilt++
 	}

--- a/internal/execute/build/host.go
+++ b/internal/execute/build/host.go
@@ -114,7 +114,10 @@ func (h *host) GetSourceFile(opts ast.SourceFileParseOptions) *ast.SourceFile {
 	}
 
 	file := h.host.GetSourceFile(opts)
-	file, _ = h.sourceFiles.LoadOrStore(opts, file)
+	// Cache dts and json files as they will reused
+	if file != nil && (tspath.IsDeclarationFileName(file.FileName()) || tspath.FileExtensionIs(file.FileName(), tspath.ExtensionJson)) {
+		file, _ = h.sourceFiles.LoadOrStore(opts, file)
+	}
 	return file
 }
 

--- a/internal/execute/build/host.go
+++ b/internal/execute/build/host.go
@@ -114,7 +114,7 @@ func (h *host) GetSourceFile(opts ast.SourceFileParseOptions) *ast.SourceFile {
 	}
 
 	file := h.host.GetSourceFile(opts)
-	// Cache dts and json files as they will reused
+	// Cache dts and json files as they will be reused
 	if file != nil && (tspath.IsDeclarationFileName(file.FileName()) || tspath.FileExtensionIs(file.FileName(), tspath.ExtensionJson)) {
 		file, _ = h.sourceFiles.LoadOrStore(opts, file)
 	}

--- a/internal/execute/incremental/affectedfileshandler.go
+++ b/internal/execute/incremental/affectedfileshandler.go
@@ -324,7 +324,7 @@ func (h *affectedFilesHandler) updateSnapshot() {
 	h.updatedSignatures.Range(func(filePath tspath.Path, update *updatedSignature) bool {
 		if info, ok := h.program.snapshot.fileInfos.Load(filePath); ok {
 			info.signature = update.signature
-			if h.program.testingData.UpdatedSignatureKinds != nil {
+			if h.program.testingData != nil {
 				h.program.testingData.UpdatedSignatureKinds[filePath] = update.kind
 			}
 		}

--- a/internal/execute/incremental/affectedfileshandler.go
+++ b/internal/execute/incremental/affectedfileshandler.go
@@ -324,8 +324,8 @@ func (h *affectedFilesHandler) updateSnapshot() {
 	h.updatedSignatures.Range(func(filePath tspath.Path, update *updatedSignature) bool {
 		if info, ok := h.program.snapshot.fileInfos.Load(filePath); ok {
 			info.signature = update.signature
-			if h.program.updatedSignatureKinds != nil {
-				h.program.updatedSignatureKinds[filePath] = update.kind
+			if h.program.testingData.UpdatedSignatureKinds != nil {
+				h.program.testingData.UpdatedSignatureKinds[filePath] = update.kind
 			}
 		}
 		return true

--- a/internal/execute/incremental/emitfileshandler.go
+++ b/internal/execute/incremental/emitfileshandler.go
@@ -229,8 +229,8 @@ func (h *emitFilesHandler) updateSnapshot() []*compiler.EmitResult {
 	h.signatures.Range(func(file tspath.Path, signature string) bool {
 		info, _ := h.program.snapshot.fileInfos.Load(file)
 		info.signature = signature
-		if h.program.updatedSignatureKinds != nil {
-			h.program.updatedSignatureKinds[file] = SignatureUpdateKindStoredAtEmit
+		if h.program.testingData.UpdatedSignatureKinds != nil {
+			h.program.testingData.UpdatedSignatureKinds[file] = SignatureUpdateKindStoredAtEmit
 		}
 		h.program.snapshot.buildInfoEmitPending.Store(true)
 		return true

--- a/internal/execute/incremental/emitfileshandler.go
+++ b/internal/execute/incremental/emitfileshandler.go
@@ -229,7 +229,7 @@ func (h *emitFilesHandler) updateSnapshot() []*compiler.EmitResult {
 	h.signatures.Range(func(file tspath.Path, signature string) bool {
 		info, _ := h.program.snapshot.fileInfos.Load(file)
 		info.signature = signature
-		if h.program.testingData.UpdatedSignatureKinds != nil {
+		if h.program.testingData != nil {
 			h.program.testingData.UpdatedSignatureKinds[file] = SignatureUpdateKindStoredAtEmit
 		}
 		h.program.snapshot.buildInfoEmitPending.Store(true)

--- a/internal/execute/tsc.go
+++ b/internal/execute/tsc.go
@@ -290,9 +290,11 @@ func performIncrementalCompilation(
 		compileTimes,
 		testing,
 	)
+	if testing != nil {
+		testing.OnProgram(incrementalProgram)
+	}
 	return tsc.CommandLineResult{
-		Status:             result.Status,
-		IncrementalProgram: []*incremental.Program{incrementalProgram},
+		Status: result.Status,
 	}
 }
 

--- a/internal/execute/tsc/compile.go
+++ b/internal/execute/tsc/compile.go
@@ -40,9 +40,8 @@ type Watcher interface {
 }
 
 type CommandLineResult struct {
-	Status             ExitStatus
-	IncrementalProgram []*incremental.Program
-	Watcher            Watcher
+	Status  ExitStatus
+	Watcher Watcher
 }
 
 type CommandLineTesting interface {
@@ -55,6 +54,7 @@ type CommandLineTesting interface {
 	OnBuildStatusReportStart(w io.Writer)
 	OnBuildStatusReportEnd(w io.Writer)
 	GetTrace(w io.Writer) func(msg string)
+	OnProgram(program *incremental.Program)
 }
 
 type CompileTimes struct {

--- a/internal/execute/tsctests/runner.go
+++ b/internal/execute/tsctests/runner.go
@@ -80,7 +80,7 @@ func (test *tscInput) run(t *testing.T, scenario string) {
 		sys.baselineFSwithDiff(baselineBuilder)
 		result := test.executeCommand(sys, baselineBuilder, test.commandLineArgs)
 		sys.serializeState(baselineBuilder)
-		sys.baselinePrograms(baselineBuilder, result.IncrementalProgram, result.Watcher)
+		sys.baselinePrograms(baselineBuilder)
 		var unexpectedDiff string
 
 		for index, do := range test.edits {
@@ -95,14 +95,13 @@ func (test *tscInput) run(t *testing.T, scenario string) {
 				}
 				sys.baselineFSwithDiff(baselineBuilder)
 
-				var editResult tsc.CommandLineResult
 				if result.Watcher == nil {
-					editResult = test.executeCommand(sys, baselineBuilder, commandLineArgs)
+					result = test.executeCommand(sys, baselineBuilder, commandLineArgs)
 				} else {
 					result.Watcher.DoCycle()
 				}
 				sys.serializeState(baselineBuilder)
-				sys.baselinePrograms(baselineBuilder, editResult.IncrementalProgram, result.Watcher)
+				sys.baselinePrograms(baselineBuilder)
 			})
 			wg.Queue(func() {
 				// Compute build with all the edits

--- a/internal/execute/tsctests/sys.go
+++ b/internal/execute/tsctests/sys.go
@@ -280,7 +280,7 @@ func (s *testSys) baselineProgram(baseline *strings.Builder, program *incrementa
 		return
 	}
 
-	testingData := program.GetTestingData(program.GetProgram())
+	testingData := program.GetTestingData()
 	if testingData.ConfigFilePath != "" {
 		baseline.WriteString(tspath.GetRelativePathFromDirectory(s.cwd, testingData.ConfigFilePath, tspath.ComparePathsOptions{
 			UseCaseSensitiveFileNames: s.FS().UseCaseSensitiveFileNames(),
@@ -288,7 +288,7 @@ func (s *testSys) baselineProgram(baseline *strings.Builder, program *incrementa
 		}) + "::\n")
 	}
 	baseline.WriteString("SemanticDiagnostics::\n")
-	for _, file := range program.GetProgram().GetSourceFiles() {
+	for _, file := range testingData.Files {
 		if diagnostics, ok := testingData.SemanticDiagnosticsPerFile.Load(file.Path()); ok {
 			if oldDiagnostics, ok := testingData.OldProgramSemanticDiagnosticsPerFile.Load(file.Path()); !ok || oldDiagnostics != diagnostics {
 				baseline.WriteString("*refresh*    " + file.FileName() + "\n")
@@ -300,7 +300,7 @@ func (s *testSys) baselineProgram(baseline *strings.Builder, program *incrementa
 
 	// Write signature updates
 	baseline.WriteString("Signatures::\n")
-	for _, file := range program.GetProgram().GetSourceFiles() {
+	for _, file := range testingData.Files {
 		if kind, ok := testingData.UpdatedSignatureKinds[file.Path()]; ok {
 			switch kind {
 			case incremental.SignatureUpdateKindComputedDts:

--- a/internal/execute/tsctests/sys.go
+++ b/internal/execute/tsctests/sys.go
@@ -140,6 +140,7 @@ type snapshot struct {
 
 type testSys struct {
 	currentWrite              *strings.Builder
+	programBaselines          strings.Builder
 	tracer                    *harnessutil.TracerForBaselining
 	serializedDiff            *snapshot
 	forIncrementalCorrectness bool
@@ -263,55 +264,51 @@ func (s *testSys) GetTrace(w io.Writer) func(str string) {
 	}
 }
 
-func (s *testSys) baselinePrograms(baseline *strings.Builder, programs []*incremental.Program, watcher tsc.Watcher) {
-	if watcher != nil {
-		programs = []*incremental.Program{watcher.GetProgram()}
-	}
-	for index, program := range programs {
-		if index > 0 {
-			baseline.WriteString("\n")
-		}
-		s.baselineProgram(baseline, program)
-	}
-}
-
-func (s *testSys) baselineProgram(baseline *strings.Builder, program *incremental.Program) {
-	if program == nil {
-		return
+func (s *testSys) OnProgram(program *incremental.Program) {
+	if s.programBaselines.Len() != 0 {
+		s.programBaselines.WriteString("\n")
 	}
 
 	testingData := program.GetTestingData()
-	if testingData.ConfigFilePath != "" {
-		baseline.WriteString(tspath.GetRelativePathFromDirectory(s.cwd, testingData.ConfigFilePath, tspath.ComparePathsOptions{
+	if configFilePath := program.Options().ConfigFilePath; configFilePath != "" {
+		s.programBaselines.WriteString(tspath.GetRelativePathFromDirectory(s.cwd, configFilePath, tspath.ComparePathsOptions{
 			UseCaseSensitiveFileNames: s.FS().UseCaseSensitiveFileNames(),
 			CurrentDirectory:          s.GetCurrentDirectory(),
 		}) + "::\n")
 	}
-	baseline.WriteString("SemanticDiagnostics::\n")
-	for _, file := range testingData.Files {
+	s.programBaselines.WriteString("SemanticDiagnostics::\n")
+	for _, file := range program.GetProgram().GetSourceFiles() {
 		if diagnostics, ok := testingData.SemanticDiagnosticsPerFile.Load(file.Path()); ok {
 			if oldDiagnostics, ok := testingData.OldProgramSemanticDiagnosticsPerFile.Load(file.Path()); !ok || oldDiagnostics != diagnostics {
-				baseline.WriteString("*refresh*    " + file.FileName() + "\n")
+				s.programBaselines.WriteString("*refresh*    " + file.FileName() + "\n")
 			}
 		} else {
-			baseline.WriteString("*not cached* " + file.FileName() + "\n")
+			s.programBaselines.WriteString("*not cached* " + file.FileName() + "\n")
 		}
 	}
 
 	// Write signature updates
-	baseline.WriteString("Signatures::\n")
-	for _, file := range testingData.Files {
+	s.programBaselines.WriteString("Signatures::\n")
+	for _, file := range program.GetProgram().GetSourceFiles() {
 		if kind, ok := testingData.UpdatedSignatureKinds[file.Path()]; ok {
 			switch kind {
 			case incremental.SignatureUpdateKindComputedDts:
-				baseline.WriteString("(computed .d.ts) " + file.FileName() + "\n")
+				s.programBaselines.WriteString("(computed .d.ts) " + file.FileName() + "\n")
 			case incremental.SignatureUpdateKindStoredAtEmit:
-				baseline.WriteString("(stored at emit) " + file.FileName() + "\n")
+				s.programBaselines.WriteString("(stored at emit) " + file.FileName() + "\n")
 			case incremental.SignatureUpdateKindUsedVersion:
-				baseline.WriteString("(used version)   " + file.FileName() + "\n")
+				s.programBaselines.WriteString("(used version)   " + file.FileName() + "\n")
 			}
 		}
 	}
+}
+
+func (s *testSys) baselinePrograms(baseline *strings.Builder) {
+	baseline.WriteString(s.programBaselines.String())
+	s.programBaselines.Reset()
+}
+
+func (s *testSys) baselineProgram(program *incremental.Program) {
 }
 
 func (s *testSys) serializeState(baseline *strings.Builder) {

--- a/internal/execute/watcher.go
+++ b/internal/execute/watcher.go
@@ -86,6 +86,9 @@ func (w *Watcher) DoCycle() {
 		// print something???
 		// fmt.Fprintln(w.sys.Writer(), "no changes detected at ", w.sys.Now())
 	}
+	if w.testing != nil {
+		w.testing.OnProgram(w.program)
+	}
 }
 
 func (w *Watcher) compileAndEmit() {


### PR DESCRIPTION
Parity with Strada:
Release program after emit - (this releases program all together and snapshot for now but it will be retained for --w like in strada)
Cache only source files for d.ts and json files as those are the ones that are exepected to be reused

Fixes #1622
