### PR TITLE
[WIP] fix go to definition

### DIFF
--- a/internal/ls/definition.go
+++ b/internal/ls/definition.go
@@ -1,15 +1,21 @@
 package ls
 
 import (
+	"bufio"
 	"context"
+	"os"
+	"regexp"
 	"slices"
+	"strings"
 
 	"github.com/microsoft/typescript-go/internal/ast"
 	"github.com/microsoft/typescript-go/internal/astnav"
 	"github.com/microsoft/typescript-go/internal/checker"
+	"github.com/microsoft/typescript-go/internal/compiler"
 	"github.com/microsoft/typescript-go/internal/core"
 	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
 	"github.com/microsoft/typescript-go/internal/scanner"
+	"github.com/microsoft/typescript-go/internal/tspath"
 )
 
 func (l *LanguageService) ProvideDefinition(ctx context.Context, documentURI lsproto.DocumentUri, position lsproto.Position) (lsproto.DefinitionResponse, error) {
@@ -104,10 +110,58 @@ func (l *LanguageService) createLocationsFromDeclarations(declarations []*ast.No
 	for _, decl := range declarations {
 		file := ast.GetSourceFileOfNode(decl)
 		name := core.OrElse(ast.GetNameOfDeclaration(decl), decl)
-		locations = core.AppendIfUnique(locations, lsproto.Location{
-			Uri:   FileNameToDocumentURI(file.FileName()),
-			Range: *l.createLspRangeFromNode(name, file),
-		})
+		
+		// Try to find the corresponding source file if this is a declaration file
+		// Use the file path directly so it works even for external declaration files
+		sourceFile := l.tryFindSourceFileForDeclarationByPath(file.FileName())
+		
+		// If we found a source file via project references, use it
+		if sourceFile != nil {
+			// Try to find the corresponding declaration in the source file
+			sourceDecl := l.tryFindDeclarationInSourceFile(decl, sourceFile)
+			
+			if sourceDecl != nil {
+				// Use the found declaration in the source file
+				sourceName := core.OrElse(ast.GetNameOfDeclaration(sourceDecl), sourceDecl)
+				locations = core.AppendIfUnique(locations, lsproto.Location{
+					Uri:   FileNameToDocumentURI(sourceFile.FileName()),
+					Range: *l.createLspRangeFromNode(sourceName, sourceFile),
+				})
+			} else {
+				// Fallback: point to the beginning of the source file
+				// This is not perfect but ensures we point to the right file
+				locations = core.AppendIfUnique(locations, lsproto.Location{
+					Uri:   FileNameToDocumentURI(sourceFile.FileName()),
+					Range: *l.createLspRangeFromBounds(0, 0, sourceFile),
+				})
+			}
+		} else {
+			// Fallback: Try heuristic approach for monorepos without project references
+			if candidateSourcePath := l.tryFindSourceFilePathHeuristic(file.FileName()); candidateSourcePath != "" {
+				// Try to find the approximate location of the symbol in the source file
+				if symbolLocation := l.tryFindSymbolLocationInFile(decl, candidateSourcePath); symbolLocation != nil {
+					locations = core.AppendIfUnique(locations, lsproto.Location{
+						Uri:   FileNameToDocumentURI(candidateSourcePath),
+						Range: *symbolLocation,
+					})
+				} else {
+					// Fallback: point to the beginning of the source file
+					locations = core.AppendIfUnique(locations, lsproto.Location{
+						Uri:   FileNameToDocumentURI(candidateSourcePath),
+						Range: lsproto.Range{
+							Start: lsproto.Position{Line: 0, Character: 0},
+							End:   lsproto.Position{Line: 0, Character: 0},
+						},
+					})
+				}
+			} else {
+				// Use the original approach for non-declaration files or when no mapping found
+				locations = core.AppendIfUnique(locations, lsproto.Location{
+					Uri:   FileNameToDocumentURI(file.FileName()),
+					Range: *l.createLspRangeFromNode(name, file),
+				})
+			}
+		}
 	}
 	return lsproto.LocationOrLocationsOrDefinitionLinksOrNull{Locations: &locations}
 }
@@ -119,6 +173,275 @@ func (l *LanguageService) createLocationFromFileAndRange(file *ast.SourceFile, t
 			Range: *l.createLspRangeFromBounds(textRange.Pos(), textRange.End(), file),
 		},
 	}
+}
+
+// tryFindSourceFileForDeclaration attempts to find the corresponding source file
+// for a declaration file using the project reference system.
+//
+// This handles monorepo scenarios where packages have aliases like 
+// @alias/package that resolve to packages/package/dist/*.d.ts files.
+// The project reference system maps these back to the original source files.
+func (l *LanguageService) tryFindSourceFileForDeclaration(declFile *ast.SourceFile) *ast.SourceFile {
+	return l.tryFindSourceFileForDeclarationByPath(declFile.FileName())
+}
+
+// tryFindSourceFileForDeclarationByPath attempts to find the corresponding source file
+// for a declaration file path using the project reference system.
+// This works even for external declaration files that aren't loaded in the current program.
+func (l *LanguageService) tryFindSourceFileForDeclarationByPath(declFilePath string) *ast.SourceFile {
+	// If not a declaration file, return nil (caller should use original)
+	if !strings.HasSuffix(declFilePath, ".d.ts") {
+		return nil
+	}
+
+	program := l.GetProgram()
+
+	// Convert the file path to a tspath.Path for lookup
+	path := tspath.ToPath(declFilePath, program.Host().GetCurrentDirectory(), program.Host().FS().UseCaseSensitiveFileNames())
+	
+	// Strategy 1: Use the project reference system to find the source file
+	// This works when TypeScript project references are properly configured
+	if projectRef := program.GetProjectReferenceFromOutputDts(path); projectRef != nil && projectRef.Source != "" {
+		if sourceFile := program.GetSourceFile(projectRef.Source); sourceFile != nil {
+			return sourceFile
+		}
+	}
+	
+	// Strategy 2: Fallback heuristic mapping for monorepos without project references
+	// This handles common patterns like: packages/pkg/dist/file.d.ts -> packages/pkg/src/file.ts
+	if sourceFile := l.tryHeuristicSourceMapping(declFilePath, program); sourceFile != nil {
+		return sourceFile
+	}
+	
+	return nil // No mapping found
+}
+
+// tryHeuristicSourceMapping attempts to map declaration files to source files using common patterns
+// when project references aren't configured. This handles typical monorepo structures.
+func (l *LanguageService) tryHeuristicSourceMapping(declFilePath string, program *compiler.Program) *ast.SourceFile {
+	// Common monorepo patterns to try
+	mappings := []struct {
+		buildPattern string
+		sourcePattern string
+	}{
+		// Most common: packages/pkg/dist/ -> packages/pkg/src/
+		{"/dist/", "/src/"},
+		// Alternative patterns
+		{"/lib/", "/src/"},
+		{"/build/", "/src/"},
+		{"/out/", "/src/"},
+		// Sometimes dist is alongside src
+		{"/dist/", "/"},
+	}
+	
+	for _, mapping := range mappings {
+		if strings.Contains(declFilePath, mapping.buildPattern) {
+			// Replace the build directory with source directory
+			sourceDir := strings.Replace(declFilePath, mapping.buildPattern, mapping.sourcePattern, 1)
+			
+			// Try different source file extensions
+			baseName := strings.TrimSuffix(sourceDir, ".d.ts")
+			candidates := []string{
+				baseName + ".ts",
+				baseName + ".tsx",
+				baseName + ".js",
+				baseName + ".jsx",
+			}
+			
+			for _, candidate := range candidates {
+				if sourceFile := program.GetSourceFile(candidate); sourceFile != nil {
+					return sourceFile
+				}
+			}
+		}
+	}
+	
+	return nil
+}
+
+// tryFindSourceFilePathHeuristic attempts to find source files on the filesystem using common patterns
+// This is used when project references aren't configured and source files aren't loaded in the program
+func (l *LanguageService) tryFindSourceFilePathHeuristic(declFilePath string) string {
+	// Only process declaration files
+	if !strings.HasSuffix(declFilePath, ".d.ts") {
+		return ""
+	}
+	
+	// Common monorepo patterns to try
+	mappings := []struct {
+		buildPattern  string
+		sourcePattern string
+	}{
+		// Most common: packages/pkg/dist/ -> packages/pkg/src/
+		{"/dist/", "/src/"},
+		// Alternative patterns
+		{"/lib/", "/src/"},
+		{"/build/", "/src/"},
+		{"/out/", "/src/"},
+		// Sometimes dist is alongside src
+		{"/dist/", "/"},
+	}
+	
+	for _, mapping := range mappings {
+		if strings.Contains(declFilePath, mapping.buildPattern) {
+			// Replace the build directory with source directory
+			sourceDir := strings.Replace(declFilePath, mapping.buildPattern, mapping.sourcePattern, 1)
+			
+			// Try different source file extensions
+			baseName := strings.TrimSuffix(sourceDir, ".d.ts")
+			candidates := []string{
+				baseName + ".ts",
+				baseName + ".tsx",
+				baseName + ".js",
+				baseName + ".jsx",
+			}
+			
+			// Check if any candidate exists on the filesystem
+			for _, candidate := range candidates {
+				if _, err := os.Stat(candidate); err == nil {
+					// File exists! Return this path
+					return candidate
+				}
+			}
+		}
+	}
+	
+	return ""
+}
+
+// tryLoadSourceFile attempts to load a source file into the TypeScript program
+// This allows us to analyze the file and find specific declarations within it
+func (l *LanguageService) tryLoadSourceFile(sourceFilePath string) *ast.SourceFile {
+	program := l.GetProgram()
+	
+	// First, try to get the file if it's already loaded in the program
+	if existingFile := program.GetSourceFile(sourceFilePath); existingFile != nil {
+		return existingFile
+	}
+	
+	// For now, return nil - dynamic loading is complex and may not be necessary
+	// since the TypeScript server can handle the source file once we navigate to it
+	return nil
+}
+
+// tryFindSymbolLocationInFile attempts to find the location of a symbol in a source file
+// using text-based search patterns. This provides approximate location when AST analysis isn't available.
+func (l *LanguageService) tryFindSymbolLocationInFile(declNode *ast.Node, sourceFilePath string) *lsproto.Range {
+	// Get the name of the symbol we're looking for
+	symbolName := l.getSymbolName(declNode)
+	if symbolName == "" {
+		return nil
+	}
+	
+	// Read the source file
+	file, err := os.Open(sourceFilePath)
+	if err != nil {
+		return nil
+	}
+	defer file.Close()
+	
+	scanner := bufio.NewScanner(file)
+	lineNumber := 0
+	
+	// Common TypeScript/JavaScript declaration patterns
+	patterns := []*regexp.Regexp{
+		// export function funcName(
+		regexp.MustCompile(`export\s+function\s+` + regexp.QuoteMeta(symbolName) + `\s*\(`),
+		// export const funcName = 
+		regexp.MustCompile(`export\s+const\s+` + regexp.QuoteMeta(symbolName) + `\s*[=:]`),
+		// function funcName(
+		regexp.MustCompile(`function\s+` + regexp.QuoteMeta(symbolName) + `\s*\(`),
+		// const funcName = 
+		regexp.MustCompile(`const\s+` + regexp.QuoteMeta(symbolName) + `\s*[=:]`),
+		// let funcName = 
+		regexp.MustCompile(`let\s+` + regexp.QuoteMeta(symbolName) + `\s*[=:]`),
+		// var funcName = 
+		regexp.MustCompile(`var\s+` + regexp.QuoteMeta(symbolName) + `\s*[=:]`),
+		// class ClassName
+		regexp.MustCompile(`class\s+` + regexp.QuoteMeta(symbolName) + `\s*[{<]`),
+		// interface InterfaceName
+		regexp.MustCompile(`interface\s+` + regexp.QuoteMeta(symbolName) + `\s*[{<]`),
+		// type TypeName
+		regexp.MustCompile(`type\s+` + regexp.QuoteMeta(symbolName) + `\s*[=<]`),
+	}
+	
+	for scanner.Scan() {
+		line := scanner.Text()
+		
+		// Check each pattern
+		for _, pattern := range patterns {
+			if match := pattern.FindStringIndex(line); match != nil {
+				// Found a match! Calculate the position
+				character := match[0]
+				
+				// Try to find the exact position of the symbol name within the match
+				symbolIndex := strings.Index(line[character:], symbolName)
+				if symbolIndex != -1 {
+					character += symbolIndex
+				}
+				
+				return &lsproto.Range{
+					Start: lsproto.Position{
+						Line:      uint32(lineNumber),
+						Character: uint32(character),
+					},
+					End: lsproto.Position{
+						Line:      uint32(lineNumber),
+						Character: uint32(character + len(symbolName)),
+					},
+				}
+			}
+		}
+		
+		lineNumber++
+	}
+	
+	return nil
+}
+
+// getSymbolName extracts the symbol name from a declaration node
+func (l *LanguageService) getSymbolName(declNode *ast.Node) string {
+	if nameNode := ast.GetNameOfDeclaration(declNode); nameNode != nil {
+		return nameNode.Text()
+	}
+	
+	// Fallback: try to extract from the node text
+	nodeText := strings.TrimSpace(declNode.Text())
+	
+	// Simple patterns to extract symbol names
+	patterns := []string{
+		`function\s+(\w+)`,
+		`const\s+(\w+)`,
+		`let\s+(\w+)`,
+		`var\s+(\w+)`,
+		`class\s+(\w+)`,
+		`interface\s+(\w+)`,
+		`type\s+(\w+)`,
+	}
+	
+	for _, pattern := range patterns {
+		re := regexp.MustCompile(pattern)
+		if matches := re.FindStringSubmatch(nodeText); len(matches) > 1 {
+			return matches[1]
+		}
+	}
+	
+	return ""
+}
+
+// tryFindDeclarationInSourceFile attempts to find a declaration with the same name
+// in the source file. This is a simple heuristic that may not always be accurate.
+func (l *LanguageService) tryFindDeclarationInSourceFile(declNode *ast.Node, sourceFile *ast.SourceFile) *ast.Node {
+	// Get the name of the original declaration
+	originalName := ast.GetNameOfDeclaration(declNode)
+	if originalName == nil {
+		return nil
+	}
+	
+	// For now, return nil to use the fallback approach
+	// TODO: Implement proper symbol matching in the source file
+	// This would require walking the AST and finding declarations with matching names
+	return nil
 }
 
 func getDeclarationsFromLocation(c *checker.Checker, node *ast.Node) []*ast.Node {

--- a/internal/ls/definition_test.go
+++ b/internal/ls/definition_test.go
@@ -1,0 +1,145 @@
+package ls_test
+
+import (
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// Test project reference-based source file detection
+func TestProjectReferenceBasedDetection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		inputFileName  string
+		isDeclaration  bool
+	}{
+		{
+			name:          "Declaration file should be detected",
+			inputFileName: "packages/o11y/dist/logger.d.ts",
+			isDeclaration: true,
+		},
+		{
+			name:          "TypeScript file should not be processed",
+			inputFileName: "src/app.ts",
+			isDeclaration: false,
+		},
+		{
+			name:          "JavaScript file should not be processed", 
+			inputFileName: "lib/utils.js",
+			isDeclaration: false,
+		},
+		{
+			name:          "Nested declaration file should be detected",
+			inputFileName: "node_modules/@types/react/index.d.ts",
+			isDeclaration: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Test the declaration file detection logic used in tryFindSourceFileForDeclaration
+			isDecl := strings.HasSuffix(tt.inputFileName, ".d.ts")
+			assert.Equal(t, isDecl, tt.isDeclaration)
+		})
+	}
+}
+
+// Test heuristic source mapping patterns 
+func TestHeuristicSourceMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		declFilePath   string
+		expectedMappings []string // Paths that should be tried
+	}{
+		{
+			name:         "packages dist to src mapping",
+			declFilePath: "/Users/person/Developer/repo/packages/o11y/dist/logger/logger.d.ts",
+			expectedMappings: []string{
+				"/Users/person/Developer/repo/packages/o11y/src/logger/logger.ts",
+				"/Users/person/Developer/repo/packages/o11y/src/logger/logger.tsx",
+				"/Users/person/Developer/repo/packages/o11y/src/logger/logger.js",
+				"/Users/person/Developer/repo/packages/o11y/src/logger/logger.jsx",
+			},
+		},
+		{
+			name:         "lib to src mapping",
+			declFilePath: "/project/lib/utils/helper.d.ts",
+			expectedMappings: []string{
+				"/project/src/utils/helper.ts",
+				"/project/src/utils/helper.tsx",
+				"/project/src/utils/helper.js",
+				"/project/src/utils/helper.jsx",
+			},
+		},
+		{
+			name:         "build to src mapping",
+			declFilePath: "/app/build/components/Button.d.ts",
+			expectedMappings: []string{
+				"/app/src/components/Button.ts",
+				"/app/src/components/Button.tsx", 
+				"/app/src/components/Button.js",
+				"/app/src/components/Button.jsx",
+			},
+		},
+		{
+			name:         "dist to src mapping (most common pattern)", 
+			declFilePath: "/simple/dist/index.d.ts",
+			expectedMappings: []string{
+				"/simple/src/index.ts",
+				"/simple/src/index.tsx",
+				"/simple/src/index.js",
+				"/simple/src/index.jsx",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Test the heuristic mapping logic that would be used
+			var candidates []string
+			
+			// Common monorepo patterns  
+			mappings := []struct {
+				buildPattern string
+				sourcePattern string
+			}{
+				{"/dist/", "/src/"},
+				{"/lib/", "/src/"},
+				{"/build/", "/src/"}, 
+				{"/out/", "/src/"},
+				{"/dist/", "/"},
+			}
+			
+			for _, mapping := range mappings {
+				if strings.Contains(tt.declFilePath, mapping.buildPattern) {
+					sourceDir := strings.Replace(tt.declFilePath, mapping.buildPattern, mapping.sourcePattern, 1)
+					baseName := strings.TrimSuffix(sourceDir, ".d.ts")
+					candidates = append(candidates,
+						baseName+".ts",
+						baseName+".tsx", 
+						baseName+".js",
+						baseName+".jsx",
+					)
+					break // Only use first matching pattern
+				}
+			}
+
+			assert.DeepEqual(t, candidates, tt.expectedMappings)
+		})
+	}
+}
+
+// Integration test placeholder - this would need a real TypeScript program to test properly
+func TestGoToDefinitionIntegration(t *testing.T) {
+	t.Parallel()
+	t.Skip("Integration test requires full TypeScript program setup - implement when needed")
+}


### PR DESCRIPTION
These changes made it so I could go to a proper definition. This isn't the cleanest approach although it gives an idea of what can work. 

Basically we have a situation where we have an import in a `.ts` file like
```
import { getLogger } from '@latticehr/o11y';
```
in a directory like `apps/app-one` in an `index.ts` file and the `@latticehr` is an alias that should reference `packages/o11y` and it does go to the `packages/o11y/dist/*.d.ts` file although not the source file implementation 

I'd love to get some feedback and modify this to fit standards that you all have. 