### PR TITLE
Handle processing diagnostics similar to Strada

### DIFF
--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -424,7 +424,9 @@ func (p *Program) GetSuggestionDiagnostics(ctx context.Context, sourceFile *ast.
 }
 
 func (p *Program) GetProgramDiagnostics() []*ast.Diagnostic {
-	return SortAndDeduplicateDiagnostics(slices.Concat(p.programDiagnostics, p.includeProcessor.getDiagnostics(p).GetDiagnostics()))
+	return SortAndDeduplicateDiagnostics(slices.Concat(
+		p.programDiagnostics,
+		p.includeProcessor.getDiagnostics(p).GetGlobalDiagnostics()))
 }
 
 func (p *Program) getSourceFilesToEmit(targetSourceFile *ast.SourceFile, forceDtsEmit bool) []*ast.SourceFile {
@@ -1024,7 +1026,8 @@ func (p *Program) getSemanticDiagnosticsForFileNotFilter(ctx context.Context, so
 		fileChecker, done = p.checkerPool.GetCheckerForFile(ctx, sourceFile)
 		defer done()
 	}
-	diags := slices.Clip(sourceFile.BindDiagnostics())
+	diags := slices.Clip(p.includeProcessor.getDiagnostics(p).GetDiagnosticsForFile(sourceFile.FileName()))
+	diags = append(diags, sourceFile.BindDiagnostics()...)
 	checkers, closeCheckers := p.checkerPool.GetAllCheckers(ctx)
 	defer closeCheckers()
 

--- a/internal/execute/tsctests/tscbuild_test.go
+++ b/internal/execute/tsctests/tscbuild_test.go
@@ -556,7 +556,7 @@ func TestBuildDemoProject(t *testing.T) {
 			commandLineArgs: []string{"--b", "--verbose"},
 		},
 		{
-			// !!! sheetal - this has missing errors from strada about files not in rootDir (3) and value is declared but not used (1)
+			// !!! sheetal - this has missing errors from strada about files not in rootDir (3)
 			subScenario: "in bad-ref branch reports the error about files not in rootDir at the import location",
 			files: getBuildDemoFileMap(func(files FileMap) {
 				files["/user/username/projects/demo/core/utilities.ts"] = `import * as A from '../animals'

--- a/testdata/baselines/reference/compiler/processingDiagnosticSkipLibCheck.js
+++ b/testdata/baselines/reference/compiler/processingDiagnosticSkipLibCheck.js
@@ -1,0 +1,22 @@
+//// [tests/cases/compiler/processingDiagnosticSkipLibCheck.ts] ////
+
+//// [index.d.ts]
+/// <reference types="cookie-session"/>
+export const foo = 1;
+
+//// [package.json]
+{
+    "name": "foo",
+    "version": "1.0.0",
+    "types": "index.d.ts"
+}
+//// [index.ts]
+import { foo } from 'foo';
+const y = foo;
+
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const foo_1 = require("foo");
+const y = foo_1.foo;

--- a/testdata/baselines/reference/compiler/processingDiagnosticSkipLibCheck.symbols
+++ b/testdata/baselines/reference/compiler/processingDiagnosticSkipLibCheck.symbols
@@ -1,0 +1,15 @@
+//// [tests/cases/compiler/processingDiagnosticSkipLibCheck.ts] ////
+
+=== /index.ts ===
+import { foo } from 'foo';
+>foo : Symbol(foo, Decl(index.ts, 0, 8))
+
+const y = foo;
+>y : Symbol(y, Decl(index.ts, 1, 5))
+>foo : Symbol(foo, Decl(index.ts, 0, 8))
+
+=== /node_modules/foo/index.d.ts ===
+/// <reference types="cookie-session"/>
+export const foo = 1;
+>foo : Symbol(foo, Decl(index.d.ts, 1, 12))
+

--- a/testdata/baselines/reference/compiler/processingDiagnosticSkipLibCheck.types
+++ b/testdata/baselines/reference/compiler/processingDiagnosticSkipLibCheck.types
@@ -1,0 +1,16 @@
+//// [tests/cases/compiler/processingDiagnosticSkipLibCheck.ts] ////
+
+=== /index.ts ===
+import { foo } from 'foo';
+>foo : 1
+
+const y = foo;
+>y : 1
+>foo : 1
+
+=== /node_modules/foo/index.d.ts ===
+/// <reference types="cookie-session"/>
+export const foo = 1;
+>foo : 1
+>1 : 1
+

--- a/testdata/baselines/reference/tsbuild/demo/in-bad-ref-branch-reports-the-error-about-files-not-in-rootDir-at-the-import-location.js
+++ b/testdata/baselines/reference/tsbuild/demo/in-bad-ref-branch-reports-the-error-about-files-not-in-rootDir-at-the-import-location.js
@@ -133,6 +133,11 @@ Output::
 [7m4[0m import { createDog, Dog } from './dog';
 [7m [0m [91m                               ~~~~~~~[0m
 
+[96mcore/utilities.ts[0m:[93m1[0m:[93m13[0m - [91merror[0m[90m TS6133: [0m'A' is declared but its value is never read.
+
+[7m1[0m import * as A from '../animals'
+[7m [0m [91m            ~[0m
+
 [96mcore/utilities.ts[0m:[93m1[0m:[93m20[0m - [91merror[0m[90m TS6307: [0mFile '/user/username/projects/demo/animals/index.ts' is not listed within the file list of project '/user/username/projects/demo/core/tsconfig.json'. Projects must list all files or use an 'include' pattern.
   The file is in the program because:
     Imported via '../animals' from file '/user/username/projects/demo/core/utilities.ts'
@@ -154,11 +159,11 @@ Output::
 [[90mHH:MM:SS AM[0m] Building project 'zoo/tsconfig.json'...
 
 
-Found 3 errors in 2 files.
+Found 4 errors in 2 files.
 
 Errors  Files
      2  animals/index.ts[90m:1[0m
-     1  core/utilities.ts[90m:1[0m
+     2  core/utilities.ts[90m:1[0m
 
 //// [/home/src/tslibs/TS/Lib/lib.d.ts] *Lib*
 /// <reference no-default-lib="true"/>
@@ -395,11 +400,10 @@ Object.defineProperty(exports, "createDog", { enumerable: true, get: function ()
   "size": 2794
 }
 //// [/user/username/projects/demo/lib/core/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","errors":true,"root":[5],"fileNames":["lib.d.ts","../../animals/animal.ts","../../animals/dog.ts","../../animals/index.ts","../../core/utilities.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"47f086fff365b1e8b96a6df2c4313c1a-export type Size = \"small\" | \"medium\" | \"large\";\nexport default interface Animal {\n    size: Size;\n}","signature":"1d76529d4652ddf9ebdfa65e748240fb-export type Size = \"small\" | \"medium\" | \"large\";\nexport default interface Animal {\n    size: Size;\n}\n","impliedNodeFormat":1},{"version":"39dbb9b755eef022e56879989968e5cf-import Animal from '.';\nimport { makeRandomName } from '../core/utilities';\n\nexport interface Dog extends Animal {\n    woof(): void;\n    name: string;\n}\n\nexport function createDog(): Dog {\n    return ({\n        size: \"medium\",\n        woof: function(this: Dog) {\n            console.log(`${ this.name } says \"Woof\"!`);\n        },\n        name: makeRandomName()\n    });\n}","signature":"4dc4bc559452869bfd0d92b5ed5d604f-import Animal from '.';\nexport interface Dog extends Animal {\n    woof(): void;\n    name: string;\n}\nexport declare function createDog(): Dog;\n","impliedNodeFormat":1},{"version":"d6a6b65b86b0330b1a1bd96b1738d5a4-import Animal from './animal';\n\nexport default Animal;\nimport { createDog, Dog } from './dog';\nexport { createDog, Dog };","signature":"a3e41a5ccafc3d07a201f0603e28edcf-import Animal from './animal';\nexport default Animal;\nimport { createDog, Dog } from './dog';\nexport { createDog, Dog };\n","impliedNodeFormat":1},{"version":"c71a99e072793c29cda49dd3fea04661-import * as A from '../animals'\nexport function makeRandomName() {\n    return \"Bob!?! \";\n}\n\nexport function lastElementOf<T>(arr: T[]): T | undefined {\n    if (arr.length === 0) return undefined;\n    return arr[arr.length - 1];\n}","signature":"096c311e7aecdb577f7b613fbf1716e5-export declare function makeRandomName(): string;\nexport declare function lastElementOf<T>(arr: T[]): T | undefined;\n","impliedNodeFormat":1}],"fileIdsList":[[4,5],[2,3],[4]],"options":{"composite":true,"declaration":true,"module":1,"noFallthroughCasesInSwitch":true,"noImplicitReturns":true,"noUnusedLocals":true,"noUnusedParameters":true,"outDir":"./","rootDir":"../../core","strict":true,"target":1},"referencedMap":[[3,1],[4,2],[5,3]],"semanticDiagnosticsPerFile":[1,2,3,4,5],"latestChangedDtsFile":"./utilities.d.ts"}
+{"version":"FakeTSVersion","root":[5],"fileNames":["lib.d.ts","../../animals/animal.ts","../../animals/dog.ts","../../animals/index.ts","../../core/utilities.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"47f086fff365b1e8b96a6df2c4313c1a-export type Size = \"small\" | \"medium\" | \"large\";\nexport default interface Animal {\n    size: Size;\n}","signature":"1d76529d4652ddf9ebdfa65e748240fb-export type Size = \"small\" | \"medium\" | \"large\";\nexport default interface Animal {\n    size: Size;\n}\n","impliedNodeFormat":1},{"version":"39dbb9b755eef022e56879989968e5cf-import Animal from '.';\nimport { makeRandomName } from '../core/utilities';\n\nexport interface Dog extends Animal {\n    woof(): void;\n    name: string;\n}\n\nexport function createDog(): Dog {\n    return ({\n        size: \"medium\",\n        woof: function(this: Dog) {\n            console.log(`${ this.name } says \"Woof\"!`);\n        },\n        name: makeRandomName()\n    });\n}","signature":"4dc4bc559452869bfd0d92b5ed5d604f-import Animal from '.';\nexport interface Dog extends Animal {\n    woof(): void;\n    name: string;\n}\nexport declare function createDog(): Dog;\n","impliedNodeFormat":1},{"version":"d6a6b65b86b0330b1a1bd96b1738d5a4-import Animal from './animal';\n\nexport default Animal;\nimport { createDog, Dog } from './dog';\nexport { createDog, Dog };","signature":"a3e41a5ccafc3d07a201f0603e28edcf-import Animal from './animal';\nexport default Animal;\nimport { createDog, Dog } from './dog';\nexport { createDog, Dog };\n","impliedNodeFormat":1},{"version":"c71a99e072793c29cda49dd3fea04661-import * as A from '../animals'\nexport function makeRandomName() {\n    return \"Bob!?! \";\n}\n\nexport function lastElementOf<T>(arr: T[]): T | undefined {\n    if (arr.length === 0) return undefined;\n    return arr[arr.length - 1];\n}","signature":"096c311e7aecdb577f7b613fbf1716e5-export declare function makeRandomName(): string;\nexport declare function lastElementOf<T>(arr: T[]): T | undefined;\n","impliedNodeFormat":1}],"fileIdsList":[[4,5],[2,3],[4]],"options":{"composite":true,"declaration":true,"module":1,"noFallthroughCasesInSwitch":true,"noImplicitReturns":true,"noUnusedLocals":true,"noUnusedParameters":true,"outDir":"./","rootDir":"../../core","strict":true,"target":1},"referencedMap":[[3,1],[4,2],[5,3]],"semanticDiagnosticsPerFile":[[4,[{"pos":19,"end":29,"code":6307,"category":1,"message":"File '/user/username/projects/demo/animals/animal.ts' is not listed within the file list of project '/user/username/projects/demo/core/tsconfig.json'. Projects must list all files or use an 'include' pattern."},{"pos":86,"end":93,"code":6307,"category":1,"message":"File '/user/username/projects/demo/animals/dog.ts' is not listed within the file list of project '/user/username/projects/demo/core/tsconfig.json'. Projects must list all files or use an 'include' pattern."}]],[5,[{"pos":12,"end":13,"code":6133,"category":1,"message":"'A' is declared but its value is never read.","reportsUnnecessary":true},{"pos":19,"end":31,"code":6307,"category":1,"message":"File '/user/username/projects/demo/animals/index.ts' is not listed within the file list of project '/user/username/projects/demo/core/tsconfig.json'. Projects must list all files or use an 'include' pattern.","messageChain":[{"noFile":true,"pos":-1,"end":-1,"code":1430,"category":3,"message":"The file is in the program because:","messageChain":[{"noFile":true,"pos":-1,"end":-1,"code":1393,"category":3,"message":"Imported via '../animals' from file '/user/username/projects/demo/core/utilities.ts'"},{"noFile":true,"pos":-1,"end":-1,"code":1393,"category":3,"message":"Imported via '.' from file '/user/username/projects/demo/animals/dog.ts'"}]}],"relatedInformation":[{"file":3,"pos":19,"end":22,"code":1399,"category":3,"message":"File is included via import here."}]}]]],"latestChangedDtsFile":"./utilities.d.ts"}
 //// [/user/username/projects/demo/lib/core/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
-  "errors": true,
   "root": [
     {
       "files": [
@@ -513,14 +517,86 @@ Object.defineProperty(exports, "createDog", { enumerable: true, get: function ()
     ]
   },
   "semanticDiagnosticsPerFile": [
-    "lib.d.ts",
-    "../../animals/animal.ts",
-    "../../animals/dog.ts",
-    "../../animals/index.ts",
-    "../../core/utilities.ts"
+    [
+      "../../animals/index.ts",
+      [
+        {
+          "pos": 19,
+          "end": 29,
+          "code": 6307,
+          "category": 1,
+          "message": "File '/user/username/projects/demo/animals/animal.ts' is not listed within the file list of project '/user/username/projects/demo/core/tsconfig.json'. Projects must list all files or use an 'include' pattern."
+        },
+        {
+          "pos": 86,
+          "end": 93,
+          "code": 6307,
+          "category": 1,
+          "message": "File '/user/username/projects/demo/animals/dog.ts' is not listed within the file list of project '/user/username/projects/demo/core/tsconfig.json'. Projects must list all files or use an 'include' pattern."
+        }
+      ]
+    ],
+    [
+      "../../core/utilities.ts",
+      [
+        {
+          "pos": 12,
+          "end": 13,
+          "code": 6133,
+          "category": 1,
+          "message": "'A' is declared but its value is never read.",
+          "reportsUnnecessary": true
+        },
+        {
+          "pos": 19,
+          "end": 31,
+          "code": 6307,
+          "category": 1,
+          "message": "File '/user/username/projects/demo/animals/index.ts' is not listed within the file list of project '/user/username/projects/demo/core/tsconfig.json'. Projects must list all files or use an 'include' pattern.",
+          "messageChain": [
+            {
+              "noFile": true,
+              "pos": -1,
+              "end": -1,
+              "code": 1430,
+              "category": 3,
+              "message": "The file is in the program because:",
+              "messageChain": [
+                {
+                  "noFile": true,
+                  "pos": -1,
+                  "end": -1,
+                  "code": 1393,
+                  "category": 3,
+                  "message": "Imported via '../animals' from file '/user/username/projects/demo/core/utilities.ts'"
+                },
+                {
+                  "noFile": true,
+                  "pos": -1,
+                  "end": -1,
+                  "code": 1393,
+                  "category": 3,
+                  "message": "Imported via '.' from file '/user/username/projects/demo/animals/dog.ts'"
+                }
+              ]
+            }
+          ],
+          "relatedInformation": [
+            {
+              "file": "../../animals/dog.ts",
+              "pos": 19,
+              "end": 22,
+              "code": 1399,
+              "category": 3,
+              "message": "File is included via import here."
+            }
+          ]
+        }
+      ]
+    ]
   ],
   "latestChangedDtsFile": "./utilities.d.ts",
-  "size": 3178
+  "size": 4652
 }
 //// [/user/username/projects/demo/lib/core/utilities.d.ts] *new* 
 export declare function makeRandomName(): string;
@@ -658,11 +734,11 @@ function createZoo() {
 
 core/tsconfig.json::
 SemanticDiagnostics::
-*not cached* /home/src/tslibs/TS/Lib/lib.d.ts
-*not cached* /user/username/projects/demo/animals/animal.ts
-*not cached* /user/username/projects/demo/animals/dog.ts
-*not cached* /user/username/projects/demo/animals/index.ts
-*not cached* /user/username/projects/demo/core/utilities.ts
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /user/username/projects/demo/animals/animal.ts
+*refresh*    /user/username/projects/demo/animals/dog.ts
+*refresh*    /user/username/projects/demo/animals/index.ts
+*refresh*    /user/username/projects/demo/core/utilities.ts
 Signatures::
 (stored at emit) /user/username/projects/demo/animals/animal.ts
 (stored at emit) /user/username/projects/demo/animals/dog.ts

--- a/testdata/baselines/reference/tsbuild/resolveJsonModule/include-only.js
+++ b/testdata/baselines/reference/tsbuild/resolveJsonModule/include-only.js
@@ -94,11 +94,10 @@ const hello_json_1 = __importDefault(require("./hello.json"));
 exports.default = hello_json_1.default.hello;
 
 //// [/home/src/workspaces/solution/project/dist/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","errors":true,"root":[3],"fileNames":["lib.d.ts","../src/hello.json","../src/index.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"18e7247c85a6a2e7a4ec2e284716edd8-{\n    \"hello\": \"world\"\n}"},{"version":"c15eb6733af1bd811cd113368bb377e5-import hello from \"./hello.json\"\nexport default hello.hello","signature":"a44184f4ac1ed50126ac624c885b51a8-declare const _default: string;\nexport default _default;\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"allowSyntheticDefaultImports":true,"composite":true,"esModuleInterop":true,"module":1,"outDir":"./","skipDefaultLibCheck":true},"referencedMap":[[3,1]],"semanticDiagnosticsPerFile":[1,2,3],"latestChangedDtsFile":"./src/index.d.ts"}
+{"version":"FakeTSVersion","root":[3],"fileNames":["lib.d.ts","../src/hello.json","../src/index.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"18e7247c85a6a2e7a4ec2e284716edd8-{\n    \"hello\": \"world\"\n}"},{"version":"c15eb6733af1bd811cd113368bb377e5-import hello from \"./hello.json\"\nexport default hello.hello","signature":"a44184f4ac1ed50126ac624c885b51a8-declare const _default: string;\nexport default _default;\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"allowSyntheticDefaultImports":true,"composite":true,"esModuleInterop":true,"module":1,"outDir":"./","skipDefaultLibCheck":true},"referencedMap":[[3,1]],"semanticDiagnosticsPerFile":[[3,[{"pos":18,"end":32,"code":6307,"category":1,"message":"File '/home/src/workspaces/solution/project/src/hello.json' is not listed within the file list of project '/home/src/workspaces/solution/project/tsconfig.json'. Projects must list all files or use an 'include' pattern."}]]],"latestChangedDtsFile":"./src/index.d.ts"}
 //// [/home/src/workspaces/solution/project/dist/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
-  "errors": true,
   "root": [
     {
       "files": [
@@ -165,18 +164,27 @@ exports.default = hello_json_1.default.hello;
     ]
   },
   "semanticDiagnosticsPerFile": [
-    "lib.d.ts",
-    "../src/hello.json",
-    "../src/index.ts"
+    [
+      "../src/index.ts",
+      [
+        {
+          "pos": 18,
+          "end": 32,
+          "code": 6307,
+          "category": 1,
+          "message": "File '/home/src/workspaces/solution/project/src/hello.json' is not listed within the file list of project '/home/src/workspaces/solution/project/tsconfig.json'. Projects must list all files or use an 'include' pattern."
+        }
+      ]
+    ]
   ],
   "latestChangedDtsFile": "./src/index.d.ts",
-  "size": 1479
+  "size": 1741
 }
 
 project/tsconfig.json::
 SemanticDiagnostics::
-*not cached* /home/src/tslibs/TS/Lib/lib.d.ts
-*not cached* /home/src/workspaces/solution/project/src/hello.json
-*not cached* /home/src/workspaces/solution/project/src/index.ts
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /home/src/workspaces/solution/project/src/hello.json
+*refresh*    /home/src/workspaces/solution/project/src/index.ts
 Signatures::
 (stored at emit) /home/src/workspaces/solution/project/src/index.ts

--- a/testdata/baselines/reference/tsc/libraryResolution/unknown-lib.js
+++ b/testdata/baselines/reference/tsc/libraryResolution/unknown-lib.js
@@ -142,11 +142,10 @@ exports.x = void 0;
 exports.x = "type1";
 
 //// [/home/src/workspace/projects/project1/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","errors":true,"root":[[3,7]],"fileNames":["lib.d.ts","lib.scripthost.d.ts","./core.d.ts","./file.ts","./file2.ts","./index.ts","./utils.d.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"2fa71959819338965a3c6b2122d95c96-interface ScriptHostInterface { }","affectsGlobalScope":true,"impliedNodeFormat":1},"a1f9b824326bab2c3c8f13eccf69f182-export const core = 10;",{"version":"69c4ea0c9ff13ab7fc078607d9363624-export const file = 10;","signature":"a224c1b0cbd2f5fe611e588db48243cb-export declare const file = 10;\n","impliedNodeFormat":1},{"version":"aceac74b29bc0f88aeca1c3e8d6b44c0-/// <reference lib=\"webworker2\"/>\n/// <reference lib=\"unknownlib\"/>\n/// <reference lib=\"scripthost\"/>","signature":"99aa06d3014798d86001c324468d497f-","impliedNodeFormat":1},{"version":"aeb695aed936d7539a32fc3cd25af558-export const x = \"type1\";","signature":"e2f8d12de2edba256e37cf4a656ac52d-export declare const x = \"type1\";\n","impliedNodeFormat":1},"4e905e76b648aae5f92e8bd5418e19b3-export const y = 10;"],"options":{"composite":true},"semanticDiagnosticsPerFile":[1,2,3,4,5,6,7],"latestChangedDtsFile":"./index.d.ts"}
+{"version":"FakeTSVersion","root":[[3,7]],"fileNames":["lib.d.ts","lib.scripthost.d.ts","./core.d.ts","./file.ts","./file2.ts","./index.ts","./utils.d.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"2fa71959819338965a3c6b2122d95c96-interface ScriptHostInterface { }","affectsGlobalScope":true,"impliedNodeFormat":1},"a1f9b824326bab2c3c8f13eccf69f182-export const core = 10;",{"version":"69c4ea0c9ff13ab7fc078607d9363624-export const file = 10;","signature":"a224c1b0cbd2f5fe611e588db48243cb-export declare const file = 10;\n","impliedNodeFormat":1},{"version":"aceac74b29bc0f88aeca1c3e8d6b44c0-/// <reference lib=\"webworker2\"/>\n/// <reference lib=\"unknownlib\"/>\n/// <reference lib=\"scripthost\"/>","signature":"99aa06d3014798d86001c324468d497f-","impliedNodeFormat":1},{"version":"aeb695aed936d7539a32fc3cd25af558-export const x = \"type1\";","signature":"e2f8d12de2edba256e37cf4a656ac52d-export declare const x = \"type1\";\n","impliedNodeFormat":1},"4e905e76b648aae5f92e8bd5418e19b3-export const y = 10;"],"options":{"composite":true},"semanticDiagnosticsPerFile":[[5,[{"pos":20,"end":30,"code":2727,"category":1,"message":"Cannot find lib definition for 'webworker2'. Did you mean 'webworker'?"},{"pos":54,"end":64,"code":2726,"category":1,"message":"Cannot find lib definition for 'unknownlib'."}]]],"latestChangedDtsFile":"./index.d.ts"}
 //// [/home/src/workspace/projects/project1/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
-  "errors": true,
   "root": [
     {
       "files": [
@@ -246,27 +245,39 @@ exports.x = "type1";
     "composite": true
   },
   "semanticDiagnosticsPerFile": [
-    "lib.d.ts",
-    "lib.scripthost.d.ts",
-    "./core.d.ts",
-    "./file.ts",
-    "./file2.ts",
-    "./index.ts",
-    "./utils.d.ts"
+    [
+      "./file2.ts",
+      [
+        {
+          "pos": 20,
+          "end": 30,
+          "code": 2727,
+          "category": 1,
+          "message": "Cannot find lib definition for 'webworker2'. Did you mean 'webworker'?"
+        },
+        {
+          "pos": 54,
+          "end": 64,
+          "code": 2726,
+          "category": 1,
+          "message": "Cannot find lib definition for 'unknownlib'."
+        }
+      ]
+    ]
   ],
   "latestChangedDtsFile": "./index.d.ts",
-  "size": 1893
+  "size": 2101
 }
 
 project1/tsconfig.json::
 SemanticDiagnostics::
-*not cached* /home/src/tslibs/TS/Lib/lib.d.ts
-*not cached* /home/src/tslibs/TS/Lib/lib.scripthost.d.ts
-*not cached* /home/src/workspace/projects/project1/core.d.ts
-*not cached* /home/src/workspace/projects/project1/file.ts
-*not cached* /home/src/workspace/projects/project1/file2.ts
-*not cached* /home/src/workspace/projects/project1/index.ts
-*not cached* /home/src/workspace/projects/project1/utils.d.ts
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /home/src/tslibs/TS/Lib/lib.scripthost.d.ts
+*refresh*    /home/src/workspace/projects/project1/core.d.ts
+*refresh*    /home/src/workspace/projects/project1/file.ts
+*refresh*    /home/src/workspace/projects/project1/file2.ts
+*refresh*    /home/src/workspace/projects/project1/index.ts
+*refresh*    /home/src/workspace/projects/project1/utils.d.ts
 Signatures::
 (stored at emit) /home/src/workspace/projects/project1/file.ts
 (stored at emit) /home/src/workspace/projects/project1/file2.ts

--- a/testdata/baselines/reference/tsc/projectReferences/errors-when-a-file-is-outside-the-rootdir.js
+++ b/testdata/baselines/reference/tsc/projectReferences/errors-when-a-file-is-outside-the-rootdir.js
@@ -56,11 +56,10 @@ export {};
 Object.defineProperty(exports, "__esModule", { value: true });
 
 //// [/home/src/workspaces/project/alpha/bin/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","errors":true,"root":[3],"fileNames":["lib.d.ts","../../beta/b.ts","../src/a.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"c7aa180f19a42166d3166e266d7e59ec-export { }","signature":"abe7d9981d6018efb6b2b794f40a1607-export {};\n","impliedNodeFormat":1},{"version":"48cb0b944bf6ab58a2c0fa2f1d92b81b-import * as b from '../../beta/b'","signature":"abe7d9981d6018efb6b2b794f40a1607-export {};\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./"},"referencedMap":[[3,1]],"semanticDiagnosticsPerFile":[1,2,3],"latestChangedDtsFile":"./src/a.d.ts"}
+{"version":"FakeTSVersion","root":[3],"fileNames":["lib.d.ts","../../beta/b.ts","../src/a.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"c7aa180f19a42166d3166e266d7e59ec-export { }","signature":"abe7d9981d6018efb6b2b794f40a1607-export {};\n","impliedNodeFormat":1},{"version":"48cb0b944bf6ab58a2c0fa2f1d92b81b-import * as b from '../../beta/b'","signature":"abe7d9981d6018efb6b2b794f40a1607-export {};\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./"},"referencedMap":[[3,1]],"semanticDiagnosticsPerFile":[[3,[{"pos":19,"end":33,"code":6307,"category":1,"message":"File '/home/src/workspaces/project/beta/b.ts' is not listed within the file list of project '/home/src/workspaces/project/alpha/tsconfig.json'. Projects must list all files or use an 'include' pattern."}]]],"latestChangedDtsFile":"./src/a.d.ts"}
 //// [/home/src/workspaces/project/alpha/bin/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
-  "errors": true,
   "root": [
     {
       "files": [
@@ -125,12 +124,21 @@ Object.defineProperty(exports, "__esModule", { value: true });
     ]
   },
   "semanticDiagnosticsPerFile": [
-    "lib.d.ts",
-    "../../beta/b.ts",
-    "../src/a.ts"
+    [
+      "../src/a.ts",
+      [
+        {
+          "pos": 19,
+          "end": 33,
+          "code": 6307,
+          "category": 1,
+          "message": "File '/home/src/workspaces/project/beta/b.ts' is not listed within the file list of project '/home/src/workspaces/project/alpha/tsconfig.json'. Projects must list all files or use an 'include' pattern."
+        }
+      ]
+    ]
   ],
   "latestChangedDtsFile": "./src/a.d.ts",
-  "size": 1358
+  "size": 1603
 }
 //// [/home/src/workspaces/project/beta/b.d.ts] *new* 
 export {};
@@ -142,9 +150,9 @@ Object.defineProperty(exports, "__esModule", { value: true });
 
 alpha/tsconfig.json::
 SemanticDiagnostics::
-*not cached* /home/src/tslibs/TS/Lib/lib.d.ts
-*not cached* /home/src/workspaces/project/beta/b.ts
-*not cached* /home/src/workspaces/project/alpha/src/a.ts
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /home/src/workspaces/project/beta/b.ts
+*refresh*    /home/src/workspaces/project/alpha/src/a.ts
 Signatures::
 (stored at emit) /home/src/workspaces/project/beta/b.ts
 (stored at emit) /home/src/workspaces/project/alpha/src/a.ts

--- a/testdata/baselines/reference/tsc/projectReferences/errors-when-the-file-list-is-not-exhaustive.js
+++ b/testdata/baselines/reference/tsc/projectReferences/errors-when-the-file-list-is-not-exhaustive.js
@@ -63,11 +63,10 @@ export {};
 Object.defineProperty(exports, "__esModule", { value: true });
 
 //// [/home/src/workspaces/project/primary/bin/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","errors":true,"root":[3],"fileNames":["lib.d.ts","../b.ts","../a.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"90c7c4de561fe02d475f60b509bcbb33-export {}","signature":"abe7d9981d6018efb6b2b794f40a1607-export {};\n","impliedNodeFormat":1},{"version":"a18553e6686c657dd18ba74b9d5c69ef-import * as b from './b'","signature":"abe7d9981d6018efb6b2b794f40a1607-export {};\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./"},"referencedMap":[[3,1]],"semanticDiagnosticsPerFile":[1,2,3],"latestChangedDtsFile":"./a.d.ts"}
+{"version":"FakeTSVersion","root":[3],"fileNames":["lib.d.ts","../b.ts","../a.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"90c7c4de561fe02d475f60b509bcbb33-export {}","signature":"abe7d9981d6018efb6b2b794f40a1607-export {};\n","impliedNodeFormat":1},{"version":"a18553e6686c657dd18ba74b9d5c69ef-import * as b from './b'","signature":"abe7d9981d6018efb6b2b794f40a1607-export {};\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./"},"referencedMap":[[3,1]],"semanticDiagnosticsPerFile":[[3,[{"pos":19,"end":24,"code":6307,"category":1,"message":"File '/home/src/workspaces/project/primary/b.ts' is not listed within the file list of project '/home/src/workspaces/project/primary/tsconfig.json'. Projects must list all files or use an 'include' pattern."}]]],"latestChangedDtsFile":"./a.d.ts"}
 //// [/home/src/workspaces/project/primary/bin/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
-  "errors": true,
   "root": [
     {
       "files": [
@@ -132,19 +131,28 @@ Object.defineProperty(exports, "__esModule", { value: true });
     ]
   },
   "semanticDiagnosticsPerFile": [
-    "lib.d.ts",
-    "../b.ts",
-    "../a.ts"
+    [
+      "../a.ts",
+      [
+        {
+          "pos": 19,
+          "end": 24,
+          "code": 6307,
+          "category": 1,
+          "message": "File '/home/src/workspaces/project/primary/b.ts' is not listed within the file list of project '/home/src/workspaces/project/primary/tsconfig.json'. Projects must list all files or use an 'include' pattern."
+        }
+      ]
+    ]
   ],
   "latestChangedDtsFile": "./a.d.ts",
-  "size": 1332
+  "size": 1582
 }
 
 primary/tsconfig.json::
 SemanticDiagnostics::
-*not cached* /home/src/tslibs/TS/Lib/lib.d.ts
-*not cached* /home/src/workspaces/project/primary/b.ts
-*not cached* /home/src/workspaces/project/primary/a.ts
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /home/src/workspaces/project/primary/b.ts
+*refresh*    /home/src/workspaces/project/primary/a.ts
 Signatures::
 (stored at emit) /home/src/workspaces/project/primary/b.ts
 (stored at emit) /home/src/workspaces/project/primary/a.ts

--- a/testdata/tests/cases/compiler/processingDiagnosticSkipLibCheck.ts
+++ b/testdata/tests/cases/compiler/processingDiagnosticSkipLibCheck.ts
@@ -1,0 +1,21 @@
+// @filename: /node_modules/foo/index.d.ts
+/// <reference types="cookie-session"/>
+export const foo = 1;
+
+// @filename: /node_modules/foo/package.json
+{
+    "name": "foo",
+    "version": "1.0.0",
+    "types": "index.d.ts"
+}
+// @filename: /index.ts
+import { foo } from 'foo';
+const y = foo;
+
+// @filename: /tsconfig.json
+{
+    "compilerOptions": {
+        "strict": true,
+        "skipLibCheck": true
+    }
+}


### PR DESCRIPTION
In Corsa, `GetProgramDiagnostics` was including all diagnostics of the `includeProcessor`, which includes `/// <reference ...>` diagnostics and resolution diagnostics. Because we did that, an error e.g. in a bad `/// <reference type="non-existent"/>` in a lib file would be included in the output of a command line execution even if the project had `skipLibCheck: true`.

This PR changes this so that `GetProgramDiagnostics` now only includes *global* `includeProcessor` diagnostics.
This is basically what Strada did (see `program.getCombinedDiagnostics` there).
The file-specific `includeProcessor` diagnostics are now obtained via `getSemanticDiagnosticsForFile`. This is also what Strada did.
The result is that in `getSemanticDiagnosticsForFile`, we have a chance to check if that file should be skipped per `skipLibCheck`, and we'll also handle `// @ts-ignore` correctly as well for these diagnostics.