### PR TITLE
Fix three snapshots bugs

### DIFF
--- a/internal/project/extendedconfigcache.go
+++ b/internal/project/extendedconfigcache.go
@@ -23,10 +23,14 @@ type extendedConfigCacheEntry struct {
 func (c *extendedConfigCache) Acquire(fh FileHandle, path tspath.Path, parse func() *tsoptions.ExtendedConfigCacheEntry) *tsoptions.ExtendedConfigCacheEntry {
 	entry, loaded := c.loadOrStoreNewLockedEntry(path)
 	defer entry.mu.Unlock()
-	if !loaded || entry.hash != fh.Hash() {
+	var hash xxh3.Uint128
+	if fh != nil {
+		hash = fh.Hash()
+	}
+	if !loaded || entry.hash != hash {
 		// Reparse the config if the hash has changed, or parse for the first time.
 		entry.entry = parse()
-		entry.hash = fh.Hash()
+		entry.hash = hash
 	}
 	return entry.entry
 }

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -130,3 +130,46 @@ func TestProjectProgramUpdateKind(t *testing.T) {
 		assert.Equal(t, configured.ProgramUpdateKind, project.ProgramUpdateKindSameFileNames)
 	})
 }
+
+func TestProject(t *testing.T) {
+	t.Parallel()
+	if !bundled.Embedded {
+		t.Skip("bundled files are not embedded")
+	}
+
+	t.Run("commandLineWithTypingsFiles is reset on CommandLine change", func(t *testing.T) {
+		files := map[string]any{
+			"/user/username/projects/project1/app.js":       ``,
+			"/user/username/projects/project1/package.json": `{"name":"p1","dependencies":{"jquery":"^3.1.0"}}`,
+			"/user/username/projects/project2/app.js":       ``,
+		}
+
+		session, utils := projecttestutil.SetupWithTypingsInstaller(files, &projecttestutil.TypingsInstallerOptions{
+			PackageToFile: map[string]string{
+				// Provide typings content to be installed for jquery so ATA actually installs something
+				"jquery": `declare const $: { x: number }`,
+			},
+		})
+
+		// 1) Open an inferred project file that triggers ATA
+		uri1 := lsproto.DocumentUri("file:///user/username/projects/project1/app.js")
+		session.DidOpenFile(context.Background(), uri1, 1, files["/user/username/projects/project1/app.js"].(string), lsproto.LanguageKindJavaScript)
+
+		// 2) Wait for ATA/background tasks to finish, then get a language service for the first file
+		session.WaitForBackgroundTasks()
+		// Sanity check: ensure ATA performed at least one install
+		npmCalls := utils.NpmExecutor().NpmInstallCalls()
+		assert.Assert(t, len(npmCalls) > 0, "expected at least one npm install call from ATA")
+		_, err := session.GetLanguageService(context.Background(), uri1)
+
+		// 3) Open another inferred project file
+		uri2 := lsproto.DocumentUri("file:///user/username/projects/project2/app.js")
+		session.DidOpenFile(context.Background(), uri2, 1, ``, lsproto.LanguageKindJavaScript)
+
+		// 4) Get a language service for the second file
+		//    If commandLineWithTypingsFiles was not reset, the new program command line
+		//    won't include the newly opened file and this will fail.
+		_, err = session.GetLanguageService(context.Background(), uri2)
+		assert.NilError(t, err)
+	})
+}

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -138,6 +138,7 @@ func TestProject(t *testing.T) {
 	}
 
 	t.Run("commandLineWithTypingsFiles is reset on CommandLine change", func(t *testing.T) {
+		t.Parallel()
 		files := map[string]any{
 			"/user/username/projects/project1/app.js":       ``,
 			"/user/username/projects/project1/package.json": `{"name":"p1","dependencies":{"jquery":"^3.1.0"}}`,
@@ -161,6 +162,7 @@ func TestProject(t *testing.T) {
 		npmCalls := utils.NpmExecutor().NpmInstallCalls()
 		assert.Assert(t, len(npmCalls) > 0, "expected at least one npm install call from ATA")
 		_, err := session.GetLanguageService(context.Background(), uri1)
+		assert.NilError(t, err)
 
 		// 3) Open another inferred project file
 		uri2 := lsproto.DocumentUri("file:///user/username/projects/project2/app.js")

--- a/internal/project/projectcollectionbuilder.go
+++ b/internal/project/projectcollectionbuilder.go
@@ -515,6 +515,7 @@ func (b *projectCollectionBuilder) findOrCreateDefaultConfiguredProjectWorker(
 			configFilePath := b.toPath(node.configFileName)
 			config := b.configFileRegistryBuilder.findOrAcquireConfigForOpenFile(node.configFileName, configFilePath, path, node.loadKind, node.logger.Fork("Acquiring config for open file"))
 			if config == nil {
+				node.logger.Log("Config file for project does not already exist")
 				return false, false
 			}
 			configs.Store(configFilePath, config)
@@ -535,6 +536,11 @@ func (b *projectCollectionBuilder) findOrCreateDefaultConfiguredProjectWorker(
 			}
 
 			project := b.findOrCreateProject(node.configFileName, configFilePath, node.loadKind, node.logger)
+			if project == nil {
+				node.logger.Log("Project does not already exist")
+				return false, false
+			}
+
 			if node.loadKind == projectLoadKindCreate {
 				// Ensure project is up to date before checking for file inclusion
 				b.updateProgram(project, node.logger)

--- a/internal/project/projectcollectionbuilder.go
+++ b/internal/project/projectcollectionbuilder.go
@@ -720,6 +720,7 @@ func (b *projectCollectionBuilder) updateInferredProjectRoots(rootFileNames []st
 					logger.Log(fmt.Sprintf("Updating inferred project config with %d root files", len(rootFileNames)))
 				}
 				p.CommandLine = newCommandLine
+				p.commandLineWithTypingsFiles = nil
 				p.dirty = true
 				p.dirtyFilePath = ""
 			},
@@ -753,7 +754,10 @@ func (b *projectCollectionBuilder) updateProgram(entry dirty.Value[*Project], lo
 					filesChanged = true
 					return
 				}
-				entry.Change(func(p *Project) { p.CommandLine = commandLine })
+				entry.Change(func(p *Project) {
+					p.CommandLine = commandLine
+					p.commandLineWithTypingsFiles = nil
+				})
 			}
 		}
 		if !updateProgram {

--- a/internal/tsoptions/tsconfigparsing.go
+++ b/internal/tsoptions/tsconfigparsing.go
@@ -961,20 +961,22 @@ func getExtendedConfig(
 		cacheEntry = parse()
 	}
 
-	if cacheEntry != nil && len(cacheEntry.errors) > 0 {
+	if len(cacheEntry.errors) > 0 {
 		errors = append(errors, cacheEntry.errors...)
 	}
 
-	if sourceFile != nil {
-		result.extendedSourceFiles.Add(cacheEntry.extendedResult.SourceFile.FileName())
-		for _, extendedSourceFile := range cacheEntry.extendedResult.ExtendedSourceFiles {
-			result.extendedSourceFiles.Add(extendedSourceFile)
+	if cacheEntry.extendedResult != nil {
+		if sourceFile != nil {
+			result.extendedSourceFiles.Add(cacheEntry.extendedResult.SourceFile.FileName())
+			for _, extendedSourceFile := range cacheEntry.extendedResult.ExtendedSourceFiles {
+				result.extendedSourceFiles.Add(extendedSourceFile)
+			}
 		}
-	}
 
-	if len(cacheEntry.extendedResult.SourceFile.Diagnostics()) != 0 {
-		errors = append(errors, cacheEntry.extendedResult.SourceFile.Diagnostics()...)
-		return nil, errors
+		if len(cacheEntry.extendedResult.SourceFile.Diagnostics()) != 0 {
+			errors = append(errors, cacheEntry.extendedResult.SourceFile.Diagnostics()...)
+			return nil, errors
+		}
 	}
 	return cacheEntry.extendedConfig, errors
 }


### PR DESCRIPTION
- Fixes an issue with ATA caching that could cause a "No project found for file" error message when opening JS files in inferred projects
- Fixes a crash when a tsconfig.json `"extends"` target doesn't exist
- Fixes #1630 (pretty sure)