### PR TITLE
Speedup GetSpellingSuggestion

### DIFF
--- a/internal/compiler/processingDiagnostic.go
+++ b/internal/compiler/processingDiagnostic.go
@@ -49,7 +49,7 @@ func (d *processingDiagnostic) toDiagnostic(program *Program) *ast.Diagnostic {
 		case fileIncludeKindLibReferenceDirective:
 			libName := tspath.ToFileNameLowerCase(loc.ref.FileName)
 			unqualifiedLibName := strings.TrimSuffix(strings.TrimPrefix(libName, "lib."), ".d.ts")
-			suggestion := core.GetSpellingSuggestion(unqualifiedLibName, tsoptions.Libs, core.Identity)
+			suggestion := core.GetSpellingSuggestion(unqualifiedLibName, tsoptions.Libs, core.Identity, nil)
 			return loc.diagnosticAt(core.IfElse(
 				suggestion != "",
 				diagnostics.Cannot_find_lib_definition_for_0_Did_you_mean_1,

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1884,7 +1884,7 @@ func (p *Parser) parseErrorForMissingSemicolonAfter(node *ast.Node) {
 		return
 	}
 	// The user alternatively might have misspelled or forgotten to add a space after a common keyword.
-	suggestion := core.GetSpellingSuggestion(expressionText, viableKeywordSuggestions, func(s string) string { return s })
+	suggestion := core.GetSpellingSuggestion(expressionText, viableKeywordSuggestions, func(s string) string { return s }, nil)
 	if suggestion == "" {
 		suggestion = getSpaceSuggestion(expressionText)
 	}


### PR DESCRIPTION
Noticed we weren't using buffers while trying the [Kibana repro](https://github.com/microsoft/typescript-go/issues/1520#issuecomment-3169391766).

Before:
```
➜  kibana git:(main) ✗ time ../typescript-go/tsgo -p tsconfig.json -pprofDir /tmp/pprof                    
tsconfig.json:3:3 - error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?

3   "compilerOptions": {
    ~~~~~~~~~~~~~~~~~
tsconfig.json:3:3 - error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
  Use '"paths": {"*": ["./*"]}' instead.

3   "compilerOptions": {
    ~~~~~~~~~~~~~~~~~

Found 2 errors in the same file, starting at: tsconfig.json:3

CPU profile: /tmp/pprof/92848-cpuprofile.pb.gz
Memory profile: /tmp/pprof/92848-memprofile.pb.gz
../typescript-go/tsgo -p tsconfig.json -pprofDir /tmp/pprof  273.49s user 45.88s system 299% cpu 1:46.77 total
```
<img width="1725" height="412" alt="image" src="https://github.com/user-attachments/assets/6fdce460-cf0b-4d0d-98e5-041872a0dff7" />


After:
```
../typescript-go/tsgo -p tsconfig.json -pprofDir /tmp/pprof  237.25s user 40.39s system 286% cpu 1:36.83 total
```
<img width="1728" height="586" alt="image" src="https://github.com/user-attachments/assets/111e1339-6d74-490b-b32b-1d5fe5cdf205" />

