### PR TITLE
Do not store include processing diagnsotics in buildInfo

### DIFF
--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -1005,10 +1005,6 @@ func (p *Program) getBindDiagnosticsForFile(ctx context.Context, sourceFile *ast
 }
 
 func FilterNoEmitSemanticDiagnostics(diagnostics []*ast.Diagnostic, options *core.CompilerOptions) []*ast.Diagnostic {
-	if diagnostics == nil {
-		return diagnostics
-	}
-
 	if !options.NoEmit.IsTrue() {
 		return diagnostics
 	}

--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -429,6 +429,13 @@ func (p *Program) GetProgramDiagnostics() []*ast.Diagnostic {
 		p.includeProcessor.getDiagnostics(p).GetGlobalDiagnostics()))
 }
 
+func (p *Program) GetIncludeProcessorDiagnostics(sourceFile *ast.SourceFile) []*ast.Diagnostic {
+	if checker.SkipTypeChecking(sourceFile, p.Options(), p, false) {
+		return nil
+	}
+	return p.includeProcessor.getDiagnostics(p).GetDiagnosticsForFile(sourceFile.FileName())
+}
+
 func (p *Program) getSourceFilesToEmit(targetSourceFile *ast.SourceFile, forceDtsEmit bool) []*ast.SourceFile {
 	if targetSourceFile == nil && !forceDtsEmit {
 		p.sourceFilesToEmitOnce.Do(func() {
@@ -998,6 +1005,10 @@ func (p *Program) getBindDiagnosticsForFile(ctx context.Context, sourceFile *ast
 }
 
 func FilterNoEmitSemanticDiagnostics(diagnostics []*ast.Diagnostic, options *core.CompilerOptions) []*ast.Diagnostic {
+	if diagnostics == nil {
+		return diagnostics
+	}
+
 	if !options.NoEmit.IsTrue() {
 		return diagnostics
 	}
@@ -1007,11 +1018,10 @@ func FilterNoEmitSemanticDiagnostics(diagnostics []*ast.Diagnostic, options *cor
 }
 
 func (p *Program) getSemanticDiagnosticsForFile(ctx context.Context, sourceFile *ast.SourceFile) []*ast.Diagnostic {
-	diagnostics := p.getSemanticDiagnosticsForFileNotFilter(ctx, sourceFile)
-	if diagnostics == nil {
-		return nil
-	}
-	return FilterNoEmitSemanticDiagnostics(diagnostics, p.Options())
+	return slices.Concat(
+		FilterNoEmitSemanticDiagnostics(p.getSemanticDiagnosticsForFileNotFilter(ctx, sourceFile), p.Options()),
+		p.GetIncludeProcessorDiagnostics(sourceFile),
+	)
 }
 
 func (p *Program) getSemanticDiagnosticsForFileNotFilter(ctx context.Context, sourceFile *ast.SourceFile) []*ast.Diagnostic {
@@ -1026,8 +1036,7 @@ func (p *Program) getSemanticDiagnosticsForFileNotFilter(ctx context.Context, so
 		fileChecker, done = p.checkerPool.GetCheckerForFile(ctx, sourceFile)
 		defer done()
 	}
-	diags := slices.Clip(p.includeProcessor.getDiagnostics(p).GetDiagnosticsForFile(sourceFile.FileName()))
-	diags = append(diags, sourceFile.BindDiagnostics()...)
+	diags := slices.Clip(sourceFile.BindDiagnostics())
 	checkers, closeCheckers := p.checkerPool.GetAllCheckers(ctx)
 	defer closeCheckers()
 

--- a/testdata/baselines/reference/tsbuild/demo/in-bad-ref-branch-reports-the-error-about-files-not-in-rootDir-at-the-import-location.js
+++ b/testdata/baselines/reference/tsbuild/demo/in-bad-ref-branch-reports-the-error-about-files-not-in-rootDir-at-the-import-location.js
@@ -400,10 +400,11 @@ Object.defineProperty(exports, "createDog", { enumerable: true, get: function ()
   "size": 2794
 }
 //// [/user/username/projects/demo/lib/core/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","root":[5],"fileNames":["lib.d.ts","../../animals/animal.ts","../../animals/dog.ts","../../animals/index.ts","../../core/utilities.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"47f086fff365b1e8b96a6df2c4313c1a-export type Size = \"small\" | \"medium\" | \"large\";\nexport default interface Animal {\n    size: Size;\n}","signature":"1d76529d4652ddf9ebdfa65e748240fb-export type Size = \"small\" | \"medium\" | \"large\";\nexport default interface Animal {\n    size: Size;\n}\n","impliedNodeFormat":1},{"version":"39dbb9b755eef022e56879989968e5cf-import Animal from '.';\nimport { makeRandomName } from '../core/utilities';\n\nexport interface Dog extends Animal {\n    woof(): void;\n    name: string;\n}\n\nexport function createDog(): Dog {\n    return ({\n        size: \"medium\",\n        woof: function(this: Dog) {\n            console.log(`${ this.name } says \"Woof\"!`);\n        },\n        name: makeRandomName()\n    });\n}","signature":"4dc4bc559452869bfd0d92b5ed5d604f-import Animal from '.';\nexport interface Dog extends Animal {\n    woof(): void;\n    name: string;\n}\nexport declare function createDog(): Dog;\n","impliedNodeFormat":1},{"version":"d6a6b65b86b0330b1a1bd96b1738d5a4-import Animal from './animal';\n\nexport default Animal;\nimport { createDog, Dog } from './dog';\nexport { createDog, Dog };","signature":"a3e41a5ccafc3d07a201f0603e28edcf-import Animal from './animal';\nexport default Animal;\nimport { createDog, Dog } from './dog';\nexport { createDog, Dog };\n","impliedNodeFormat":1},{"version":"c71a99e072793c29cda49dd3fea04661-import * as A from '../animals'\nexport function makeRandomName() {\n    return \"Bob!?! \";\n}\n\nexport function lastElementOf<T>(arr: T[]): T | undefined {\n    if (arr.length === 0) return undefined;\n    return arr[arr.length - 1];\n}","signature":"096c311e7aecdb577f7b613fbf1716e5-export declare function makeRandomName(): string;\nexport declare function lastElementOf<T>(arr: T[]): T | undefined;\n","impliedNodeFormat":1}],"fileIdsList":[[4,5],[2,3],[4]],"options":{"composite":true,"declaration":true,"module":1,"noFallthroughCasesInSwitch":true,"noImplicitReturns":true,"noUnusedLocals":true,"noUnusedParameters":true,"outDir":"./","rootDir":"../../core","strict":true,"target":1},"referencedMap":[[3,1],[4,2],[5,3]],"semanticDiagnosticsPerFile":[[4,[{"pos":19,"end":29,"code":6307,"category":1,"message":"File '/user/username/projects/demo/animals/animal.ts' is not listed within the file list of project '/user/username/projects/demo/core/tsconfig.json'. Projects must list all files or use an 'include' pattern."},{"pos":86,"end":93,"code":6307,"category":1,"message":"File '/user/username/projects/demo/animals/dog.ts' is not listed within the file list of project '/user/username/projects/demo/core/tsconfig.json'. Projects must list all files or use an 'include' pattern."}]],[5,[{"pos":12,"end":13,"code":6133,"category":1,"message":"'A' is declared but its value is never read.","reportsUnnecessary":true},{"pos":19,"end":31,"code":6307,"category":1,"message":"File '/user/username/projects/demo/animals/index.ts' is not listed within the file list of project '/user/username/projects/demo/core/tsconfig.json'. Projects must list all files or use an 'include' pattern.","messageChain":[{"noFile":true,"pos":-1,"end":-1,"code":1430,"category":3,"message":"The file is in the program because:","messageChain":[{"noFile":true,"pos":-1,"end":-1,"code":1393,"category":3,"message":"Imported via '../animals' from file '/user/username/projects/demo/core/utilities.ts'"},{"noFile":true,"pos":-1,"end":-1,"code":1393,"category":3,"message":"Imported via '.' from file '/user/username/projects/demo/animals/dog.ts'"}]}],"relatedInformation":[{"file":3,"pos":19,"end":22,"code":1399,"category":3,"message":"File is included via import here."}]}]]],"latestChangedDtsFile":"./utilities.d.ts"}
+{"version":"FakeTSVersion","errors":true,"root":[5],"fileNames":["lib.d.ts","../../animals/animal.ts","../../animals/dog.ts","../../animals/index.ts","../../core/utilities.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"47f086fff365b1e8b96a6df2c4313c1a-export type Size = \"small\" | \"medium\" | \"large\";\nexport default interface Animal {\n    size: Size;\n}","signature":"1d76529d4652ddf9ebdfa65e748240fb-export type Size = \"small\" | \"medium\" | \"large\";\nexport default interface Animal {\n    size: Size;\n}\n","impliedNodeFormat":1},{"version":"39dbb9b755eef022e56879989968e5cf-import Animal from '.';\nimport { makeRandomName } from '../core/utilities';\n\nexport interface Dog extends Animal {\n    woof(): void;\n    name: string;\n}\n\nexport function createDog(): Dog {\n    return ({\n        size: \"medium\",\n        woof: function(this: Dog) {\n            console.log(`${ this.name } says \"Woof\"!`);\n        },\n        name: makeRandomName()\n    });\n}","signature":"4dc4bc559452869bfd0d92b5ed5d604f-import Animal from '.';\nexport interface Dog extends Animal {\n    woof(): void;\n    name: string;\n}\nexport declare function createDog(): Dog;\n","impliedNodeFormat":1},{"version":"d6a6b65b86b0330b1a1bd96b1738d5a4-import Animal from './animal';\n\nexport default Animal;\nimport { createDog, Dog } from './dog';\nexport { createDog, Dog };","signature":"a3e41a5ccafc3d07a201f0603e28edcf-import Animal from './animal';\nexport default Animal;\nimport { createDog, Dog } from './dog';\nexport { createDog, Dog };\n","impliedNodeFormat":1},{"version":"c71a99e072793c29cda49dd3fea04661-import * as A from '../animals'\nexport function makeRandomName() {\n    return \"Bob!?! \";\n}\n\nexport function lastElementOf<T>(arr: T[]): T | undefined {\n    if (arr.length === 0) return undefined;\n    return arr[arr.length - 1];\n}","signature":"096c311e7aecdb577f7b613fbf1716e5-export declare function makeRandomName(): string;\nexport declare function lastElementOf<T>(arr: T[]): T | undefined;\n","impliedNodeFormat":1}],"fileIdsList":[[4,5],[2,3],[4]],"options":{"composite":true,"declaration":true,"module":1,"noFallthroughCasesInSwitch":true,"noImplicitReturns":true,"noUnusedLocals":true,"noUnusedParameters":true,"outDir":"./","rootDir":"../../core","strict":true,"target":1},"referencedMap":[[3,1],[4,2],[5,3]],"semanticDiagnosticsPerFile":[[5,[{"pos":12,"end":13,"code":6133,"category":1,"message":"'A' is declared but its value is never read.","reportsUnnecessary":true}]]],"latestChangedDtsFile":"./utilities.d.ts"}
 //// [/user/username/projects/demo/lib/core/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
+  "errors": true,
   "root": [
     {
       "files": [
@@ -518,25 +519,6 @@ Object.defineProperty(exports, "createDog", { enumerable: true, get: function ()
   },
   "semanticDiagnosticsPerFile": [
     [
-      "../../animals/index.ts",
-      [
-        {
-          "pos": 19,
-          "end": 29,
-          "code": 6307,
-          "category": 1,
-          "message": "File '/user/username/projects/demo/animals/animal.ts' is not listed within the file list of project '/user/username/projects/demo/core/tsconfig.json'. Projects must list all files or use an 'include' pattern."
-        },
-        {
-          "pos": 86,
-          "end": 93,
-          "code": 6307,
-          "category": 1,
-          "message": "File '/user/username/projects/demo/animals/dog.ts' is not listed within the file list of project '/user/username/projects/demo/core/tsconfig.json'. Projects must list all files or use an 'include' pattern."
-        }
-      ]
-    ],
-    [
       "../../core/utilities.ts",
       [
         {
@@ -546,57 +528,12 @@ Object.defineProperty(exports, "createDog", { enumerable: true, get: function ()
           "category": 1,
           "message": "'A' is declared but its value is never read.",
           "reportsUnnecessary": true
-        },
-        {
-          "pos": 19,
-          "end": 31,
-          "code": 6307,
-          "category": 1,
-          "message": "File '/user/username/projects/demo/animals/index.ts' is not listed within the file list of project '/user/username/projects/demo/core/tsconfig.json'. Projects must list all files or use an 'include' pattern.",
-          "messageChain": [
-            {
-              "noFile": true,
-              "pos": -1,
-              "end": -1,
-              "code": 1430,
-              "category": 3,
-              "message": "The file is in the program because:",
-              "messageChain": [
-                {
-                  "noFile": true,
-                  "pos": -1,
-                  "end": -1,
-                  "code": 1393,
-                  "category": 3,
-                  "message": "Imported via '../animals' from file '/user/username/projects/demo/core/utilities.ts'"
-                },
-                {
-                  "noFile": true,
-                  "pos": -1,
-                  "end": -1,
-                  "code": 1393,
-                  "category": 3,
-                  "message": "Imported via '.' from file '/user/username/projects/demo/animals/dog.ts'"
-                }
-              ]
-            }
-          ],
-          "relatedInformation": [
-            {
-              "file": "../../animals/dog.ts",
-              "pos": 19,
-              "end": 22,
-              "code": 1399,
-              "category": 3,
-              "message": "File is included via import here."
-            }
-          ]
         }
       ]
     ]
   ],
   "latestChangedDtsFile": "./utilities.d.ts",
-  "size": 4652
+  "size": 3302
 }
 //// [/user/username/projects/demo/lib/core/utilities.d.ts] *new* 
 export declare function makeRandomName(): string;

--- a/testdata/baselines/reference/tsbuild/resolveJsonModule/include-only.js
+++ b/testdata/baselines/reference/tsbuild/resolveJsonModule/include-only.js
@@ -94,10 +94,11 @@ const hello_json_1 = __importDefault(require("./hello.json"));
 exports.default = hello_json_1.default.hello;
 
 //// [/home/src/workspaces/solution/project/dist/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","root":[3],"fileNames":["lib.d.ts","../src/hello.json","../src/index.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"18e7247c85a6a2e7a4ec2e284716edd8-{\n    \"hello\": \"world\"\n}"},{"version":"c15eb6733af1bd811cd113368bb377e5-import hello from \"./hello.json\"\nexport default hello.hello","signature":"a44184f4ac1ed50126ac624c885b51a8-declare const _default: string;\nexport default _default;\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"allowSyntheticDefaultImports":true,"composite":true,"esModuleInterop":true,"module":1,"outDir":"./","skipDefaultLibCheck":true},"referencedMap":[[3,1]],"semanticDiagnosticsPerFile":[[3,[{"pos":18,"end":32,"code":6307,"category":1,"message":"File '/home/src/workspaces/solution/project/src/hello.json' is not listed within the file list of project '/home/src/workspaces/solution/project/tsconfig.json'. Projects must list all files or use an 'include' pattern."}]]],"latestChangedDtsFile":"./src/index.d.ts"}
+{"version":"FakeTSVersion","errors":true,"root":[3],"fileNames":["lib.d.ts","../src/hello.json","../src/index.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"18e7247c85a6a2e7a4ec2e284716edd8-{\n    \"hello\": \"world\"\n}"},{"version":"c15eb6733af1bd811cd113368bb377e5-import hello from \"./hello.json\"\nexport default hello.hello","signature":"a44184f4ac1ed50126ac624c885b51a8-declare const _default: string;\nexport default _default;\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"allowSyntheticDefaultImports":true,"composite":true,"esModuleInterop":true,"module":1,"outDir":"./","skipDefaultLibCheck":true},"referencedMap":[[3,1]],"latestChangedDtsFile":"./src/index.d.ts"}
 //// [/home/src/workspaces/solution/project/dist/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
+  "errors": true,
   "root": [
     {
       "files": [
@@ -163,22 +164,8 @@ exports.default = hello_json_1.default.hello;
       "../src/hello.json"
     ]
   },
-  "semanticDiagnosticsPerFile": [
-    [
-      "../src/index.ts",
-      [
-        {
-          "pos": 18,
-          "end": 32,
-          "code": 6307,
-          "category": 1,
-          "message": "File '/home/src/workspaces/solution/project/src/hello.json' is not listed within the file list of project '/home/src/workspaces/solution/project/tsconfig.json'. Projects must list all files or use an 'include' pattern."
-        }
-      ]
-    ]
-  ],
   "latestChangedDtsFile": "./src/index.d.ts",
-  "size": 1741
+  "size": 1442
 }
 
 project/tsconfig.json::

--- a/testdata/baselines/reference/tsc/libraryResolution/unknown-lib.js
+++ b/testdata/baselines/reference/tsc/libraryResolution/unknown-lib.js
@@ -142,10 +142,11 @@ exports.x = void 0;
 exports.x = "type1";
 
 //// [/home/src/workspace/projects/project1/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","root":[[3,7]],"fileNames":["lib.d.ts","lib.scripthost.d.ts","./core.d.ts","./file.ts","./file2.ts","./index.ts","./utils.d.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"2fa71959819338965a3c6b2122d95c96-interface ScriptHostInterface { }","affectsGlobalScope":true,"impliedNodeFormat":1},"a1f9b824326bab2c3c8f13eccf69f182-export const core = 10;",{"version":"69c4ea0c9ff13ab7fc078607d9363624-export const file = 10;","signature":"a224c1b0cbd2f5fe611e588db48243cb-export declare const file = 10;\n","impliedNodeFormat":1},{"version":"aceac74b29bc0f88aeca1c3e8d6b44c0-/// <reference lib=\"webworker2\"/>\n/// <reference lib=\"unknownlib\"/>\n/// <reference lib=\"scripthost\"/>","signature":"99aa06d3014798d86001c324468d497f-","impliedNodeFormat":1},{"version":"aeb695aed936d7539a32fc3cd25af558-export const x = \"type1\";","signature":"e2f8d12de2edba256e37cf4a656ac52d-export declare const x = \"type1\";\n","impliedNodeFormat":1},"4e905e76b648aae5f92e8bd5418e19b3-export const y = 10;"],"options":{"composite":true},"semanticDiagnosticsPerFile":[[5,[{"pos":20,"end":30,"code":2727,"category":1,"message":"Cannot find lib definition for 'webworker2'. Did you mean 'webworker'?"},{"pos":54,"end":64,"code":2726,"category":1,"message":"Cannot find lib definition for 'unknownlib'."}]]],"latestChangedDtsFile":"./index.d.ts"}
+{"version":"FakeTSVersion","errors":true,"root":[[3,7]],"fileNames":["lib.d.ts","lib.scripthost.d.ts","./core.d.ts","./file.ts","./file2.ts","./index.ts","./utils.d.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"2fa71959819338965a3c6b2122d95c96-interface ScriptHostInterface { }","affectsGlobalScope":true,"impliedNodeFormat":1},"a1f9b824326bab2c3c8f13eccf69f182-export const core = 10;",{"version":"69c4ea0c9ff13ab7fc078607d9363624-export const file = 10;","signature":"a224c1b0cbd2f5fe611e588db48243cb-export declare const file = 10;\n","impliedNodeFormat":1},{"version":"aceac74b29bc0f88aeca1c3e8d6b44c0-/// <reference lib=\"webworker2\"/>\n/// <reference lib=\"unknownlib\"/>\n/// <reference lib=\"scripthost\"/>","signature":"99aa06d3014798d86001c324468d497f-","impliedNodeFormat":1},{"version":"aeb695aed936d7539a32fc3cd25af558-export const x = \"type1\";","signature":"e2f8d12de2edba256e37cf4a656ac52d-export declare const x = \"type1\";\n","impliedNodeFormat":1},"4e905e76b648aae5f92e8bd5418e19b3-export const y = 10;"],"options":{"composite":true},"latestChangedDtsFile":"./index.d.ts"}
 //// [/home/src/workspace/projects/project1/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
+  "errors": true,
   "root": [
     {
       "files": [
@@ -244,29 +245,8 @@ exports.x = "type1";
   "options": {
     "composite": true
   },
-  "semanticDiagnosticsPerFile": [
-    [
-      "./file2.ts",
-      [
-        {
-          "pos": 20,
-          "end": 30,
-          "code": 2727,
-          "category": 1,
-          "message": "Cannot find lib definition for 'webworker2'. Did you mean 'webworker'?"
-        },
-        {
-          "pos": 54,
-          "end": 64,
-          "code": 2726,
-          "category": 1,
-          "message": "Cannot find lib definition for 'unknownlib'."
-        }
-      ]
-    ]
-  ],
   "latestChangedDtsFile": "./index.d.ts",
-  "size": 2101
+  "size": 1848
 }
 
 project1/tsconfig.json::

--- a/testdata/baselines/reference/tsc/projectReferences/errors-when-a-file-is-outside-the-rootdir.js
+++ b/testdata/baselines/reference/tsc/projectReferences/errors-when-a-file-is-outside-the-rootdir.js
@@ -56,10 +56,11 @@ export {};
 Object.defineProperty(exports, "__esModule", { value: true });
 
 //// [/home/src/workspaces/project/alpha/bin/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","root":[3],"fileNames":["lib.d.ts","../../beta/b.ts","../src/a.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"c7aa180f19a42166d3166e266d7e59ec-export { }","signature":"abe7d9981d6018efb6b2b794f40a1607-export {};\n","impliedNodeFormat":1},{"version":"48cb0b944bf6ab58a2c0fa2f1d92b81b-import * as b from '../../beta/b'","signature":"abe7d9981d6018efb6b2b794f40a1607-export {};\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./"},"referencedMap":[[3,1]],"semanticDiagnosticsPerFile":[[3,[{"pos":19,"end":33,"code":6307,"category":1,"message":"File '/home/src/workspaces/project/beta/b.ts' is not listed within the file list of project '/home/src/workspaces/project/alpha/tsconfig.json'. Projects must list all files or use an 'include' pattern."}]]],"latestChangedDtsFile":"./src/a.d.ts"}
+{"version":"FakeTSVersion","errors":true,"root":[3],"fileNames":["lib.d.ts","../../beta/b.ts","../src/a.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"c7aa180f19a42166d3166e266d7e59ec-export { }","signature":"abe7d9981d6018efb6b2b794f40a1607-export {};\n","impliedNodeFormat":1},{"version":"48cb0b944bf6ab58a2c0fa2f1d92b81b-import * as b from '../../beta/b'","signature":"abe7d9981d6018efb6b2b794f40a1607-export {};\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./"},"referencedMap":[[3,1]],"latestChangedDtsFile":"./src/a.d.ts"}
 //// [/home/src/workspaces/project/alpha/bin/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
+  "errors": true,
   "root": [
     {
       "files": [
@@ -123,22 +124,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
       "../../beta/b.ts"
     ]
   },
-  "semanticDiagnosticsPerFile": [
-    [
-      "../src/a.ts",
-      [
-        {
-          "pos": 19,
-          "end": 33,
-          "code": 6307,
-          "category": 1,
-          "message": "File '/home/src/workspaces/project/beta/b.ts' is not listed within the file list of project '/home/src/workspaces/project/alpha/tsconfig.json'. Projects must list all files or use an 'include' pattern."
-        }
-      ]
-    ]
-  ],
   "latestChangedDtsFile": "./src/a.d.ts",
-  "size": 1603
+  "size": 1321
 }
 //// [/home/src/workspaces/project/beta/b.d.ts] *new* 
 export {};

--- a/testdata/baselines/reference/tsc/projectReferences/errors-when-the-file-list-is-not-exhaustive.js
+++ b/testdata/baselines/reference/tsc/projectReferences/errors-when-the-file-list-is-not-exhaustive.js
@@ -63,10 +63,11 @@ export {};
 Object.defineProperty(exports, "__esModule", { value: true });
 
 //// [/home/src/workspaces/project/primary/bin/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","root":[3],"fileNames":["lib.d.ts","../b.ts","../a.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"90c7c4de561fe02d475f60b509bcbb33-export {}","signature":"abe7d9981d6018efb6b2b794f40a1607-export {};\n","impliedNodeFormat":1},{"version":"a18553e6686c657dd18ba74b9d5c69ef-import * as b from './b'","signature":"abe7d9981d6018efb6b2b794f40a1607-export {};\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./"},"referencedMap":[[3,1]],"semanticDiagnosticsPerFile":[[3,[{"pos":19,"end":24,"code":6307,"category":1,"message":"File '/home/src/workspaces/project/primary/b.ts' is not listed within the file list of project '/home/src/workspaces/project/primary/tsconfig.json'. Projects must list all files or use an 'include' pattern."}]]],"latestChangedDtsFile":"./a.d.ts"}
+{"version":"FakeTSVersion","errors":true,"root":[3],"fileNames":["lib.d.ts","../b.ts","../a.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"90c7c4de561fe02d475f60b509bcbb33-export {}","signature":"abe7d9981d6018efb6b2b794f40a1607-export {};\n","impliedNodeFormat":1},{"version":"a18553e6686c657dd18ba74b9d5c69ef-import * as b from './b'","signature":"abe7d9981d6018efb6b2b794f40a1607-export {};\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./"},"referencedMap":[[3,1]],"latestChangedDtsFile":"./a.d.ts"}
 //// [/home/src/workspaces/project/primary/bin/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
+  "errors": true,
   "root": [
     {
       "files": [
@@ -130,22 +131,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
       "../b.ts"
     ]
   },
-  "semanticDiagnosticsPerFile": [
-    [
-      "../a.ts",
-      [
-        {
-          "pos": 19,
-          "end": 24,
-          "code": 6307,
-          "category": 1,
-          "message": "File '/home/src/workspaces/project/primary/b.ts' is not listed within the file list of project '/home/src/workspaces/project/primary/tsconfig.json'. Projects must list all files or use an 'include' pattern."
-        }
-      ]
-    ]
-  ],
   "latestChangedDtsFile": "./a.d.ts",
-  "size": 1582
+  "size": 1295
 }
 
 primary/tsconfig.json::


### PR DESCRIPTION
#1628 started adding program diagnostics to semantic diagnostic reporting like Strada
This handles incremental scenarios like Strada where we don't store program diagnostics to file because we don't know if they change or not if program structure changes and semantic diagnostics from cache are used