### PR TITLE
Fix panic recovery in server and fail test updater on unrecovered panics

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -260,7 +260,7 @@ func (s *Server) readLoop(ctx context.Context) error {
 		if s.initializeParams == nil && msg.Kind == lsproto.MessageKindRequest {
 			req := msg.AsRequest()
 			if req.Method == lsproto.MethodInitialize {
-				resp, err := s.handleInitialize(ctx, req.Params.(*lsproto.InitializeParams), func() {})
+				resp, err := s.handleInitialize(ctx, req.Params.(*lsproto.InitializeParams), req)
 				if err != nil {
 					return err
 				}
@@ -480,16 +480,18 @@ func registerNotificationHandler[Req any](handlers handlerMap, info lsproto.Noti
 	}
 }
 
-func registerRequestHandler[Req, Resp any](handlers handlerMap, info lsproto.RequestInfo[Req, Resp], fn func(*Server, context.Context, Req, func()) (Resp, error)) {
+func registerRequestHandler[Req, Resp any](
+	handlers handlerMap,
+	info lsproto.RequestInfo[Req, Resp],
+	fn func(*Server, context.Context, Req, *lsproto.RequestMessage) (Resp, error),
+) {
 	handlers[info.Method] = func(s *Server, ctx context.Context, req *lsproto.RequestMessage) error {
 		var params Req
 		// Ignore empty params.
 		if req.Params != nil {
 			params = req.Params.(Req)
 		}
-		resp, err := fn(s, ctx, params, func() {
-			s.recover(req)
-		})
+		resp, err := fn(s, ctx, params, req)
 		if err != nil {
 			return err
 		}
@@ -537,7 +539,7 @@ func (s *Server) recover(req *lsproto.RequestMessage) {
 	}
 }
 
-func (s *Server) handleInitialize(ctx context.Context, params *lsproto.InitializeParams, _ func()) (lsproto.InitializeResponse, error) {
+func (s *Server) handleInitialize(ctx context.Context, params *lsproto.InitializeParams, _ *lsproto.RequestMessage) (lsproto.InitializeResponse, error) {
 	if s.initializeParams != nil {
 		return nil, lsproto.ErrInvalidRequest
 	}
@@ -661,7 +663,7 @@ func (s *Server) handleInitialized(ctx context.Context, params *lsproto.Initiali
 	return nil
 }
 
-func (s *Server) handleShutdown(ctx context.Context, params any, _ func()) (lsproto.ShutdownResponse, error) {
+func (s *Server) handleShutdown(ctx context.Context, params any, _ *lsproto.RequestMessage) (lsproto.ShutdownResponse, error) {
 	s.session.Close()
 	return lsproto.ShutdownResponse{}, nil
 }
@@ -758,7 +760,7 @@ func (s *Server) handleCompletion(ctx context.Context, languageService *ls.Langu
 		&ls.UserPreferences{})
 }
 
-func (s *Server) handleCompletionItemResolve(ctx context.Context, params *lsproto.CompletionItem, recoverAndSendError func()) (lsproto.CompletionResolveResponse, error) {
+func (s *Server) handleCompletionItemResolve(ctx context.Context, params *lsproto.CompletionItem, reqMsg *lsproto.RequestMessage) (lsproto.CompletionResolveResponse, error) {
 	data, err := ls.GetCompletionItemData(params)
 	if err != nil {
 		return nil, err
@@ -767,7 +769,7 @@ func (s *Server) handleCompletionItemResolve(ctx context.Context, params *lsprot
 	if err != nil {
 		return nil, err
 	}
-	defer recoverAndSendError()
+	defer s.recover(reqMsg)
 	return languageService.ResolveCompletionItem(
 		ctx,
 		params,
@@ -804,10 +806,10 @@ func (s *Server) handleDocumentOnTypeFormat(ctx context.Context, ls *ls.Language
 	)
 }
 
-func (s *Server) handleWorkspaceSymbol(ctx context.Context, params *lsproto.WorkspaceSymbolParams, recoverAndSendError func()) (lsproto.WorkspaceSymbolResponse, error) {
+func (s *Server) handleWorkspaceSymbol(ctx context.Context, params *lsproto.WorkspaceSymbolParams, reqMsg *lsproto.RequestMessage) (lsproto.WorkspaceSymbolResponse, error) {
 	snapshot, release := s.session.Snapshot()
 	defer release()
-	defer recoverAndSendError()
+	defer s.recover(reqMsg)
 	programs := core.Map(snapshot.ProjectCollection.Projects(), (*project.Project).GetProgram)
 	return ls.ProvideWorkspaceSymbols(ctx, programs, snapshot.Converters(), params.Query)
 }


### PR DESCRIPTION
According to the Go language spec:
> The return value of recover is nil when the goroutine is not panicking or recover was not called directly by a deferred function.

So the panic recovery in `server.go` wasn't working, because the deferred function wasn't directly calling `recover()` (instead, it would call `s.recover()` which would call `recover()`, which returned `nil` even if a panic happened).
I got rid of the indirection when calling `recover()`. A downside to it is that we now have to pass a request message to the `handle...` methods, because the recovery code accesses request message properties.

This PR also makes the fourslash test failure updater script throw when it detects an unrecovered panic, because that means `go test` will have stopped as soon as the panic happens, and since it didn't run all tests, we can't know which tests fail and which don't.

