### PR TITLE
Replace mutex with atomic in queue.go

### DIFF
--- a/internal/project/background/queue.go
+++ b/internal/project/background/queue.go
@@ -3,13 +3,13 @@ package background
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 )
 
 // Queue manages background tasks execution
 type Queue struct {
 	wg     sync.WaitGroup
-	mu     sync.RWMutex
-	closed bool
+	closed atomic.Bool
 }
 
 // NewQueue creates a new background queue for managing background tasks execution.
@@ -18,12 +18,9 @@ func NewQueue() *Queue {
 }
 
 func (q *Queue) Enqueue(ctx context.Context, fn func(context.Context)) {
-	q.mu.RLock()
-	if q.closed {
-		q.mu.RUnlock()
+	if q.closed.Load() {
 		return
 	}
-	q.mu.RUnlock()
 
 	q.wg.Add(1)
 	go func() {
@@ -39,7 +36,5 @@ func (q *Queue) Wait() {
 }
 
 func (q *Queue) Close() {
-	q.mu.Lock()
-	q.closed = true
-	q.mu.Unlock()
+	q.closed.Store(true)
 }


### PR DESCRIPTION
Tiny optimization to avoid unneeded locking