### PR TITLE
[LSP] Fix panic autoimport completions when there are no lines above

### DIFF
--- a/internal/ls/completions.go
+++ b/internal/ls/completions.go
@@ -5373,7 +5373,7 @@ func (l *LanguageService) getCompletionItemActions(ctx context.Context, ch *chec
 		symbol = symbol.ExportSymbol
 	}
 	targetSymbol := ch.GetMergedSymbol(ch.SkipAlias(symbol))
-	isJsxOpeningTagName := symbolDetails.contextToken.Kind == ast.KindLessThanToken && ast.IsJsxOpeningLikeElement(symbolDetails.contextToken.Parent)
+	isJsxOpeningTagName := symbolDetails.contextToken != nil && symbolDetails.contextToken.Kind == ast.KindLessThanToken && ast.IsJsxOpeningLikeElement(symbolDetails.contextToken.Parent)
 	if symbolDetails.previousToken != nil && ast.IsIdentifier(symbolDetails.previousToken) {
 		// If the previous token is an identifier, we can use its start position.
 		position = astnav.GetStartOfNode(symbolDetails.previousToken, file, false)


### PR DESCRIPTION
i think this is related to #1658

This PR fix panic when try to use autoimport completions without code lines above

It's easier to demonstrate with a demo

with panic:

https://github.com/user-attachments/assets/83cb20d6-3c42-48d5-ac62-4933d401c6dc



After fix:

https://github.com/user-attachments/assets/791ad34b-9002-47f6-8558-e613b384f029



