### PR TITLE
Fix out of bounds panic when tsconfig "files" contains duplicates

### DIFF
--- a/internal/tsoptions/parsedcommandline_test.go
+++ b/internal/tsoptions/parsedcommandline_test.go
@@ -119,8 +119,8 @@ func TestParsedCommandLine(t *testing.T) {
 					`{
 						"files": [
 							"a.ts",
+							"a.ts",
 							"b.ts",
-							"a.ts"
 						]
 					}`,
 					files,

--- a/internal/tsoptions/parsedcommandline_test.go
+++ b/internal/tsoptions/parsedcommandline_test.go
@@ -111,6 +111,28 @@ func TestParsedCommandLine(t *testing.T) {
 					"/dev/b.ts",
 				})
 			})
+
+			t.Run("duplicates", func(t *testing.T) {
+				t.Parallel()
+				parsedCommandLine := tsoptionstest.GetParsedCommandLine(
+					t,
+					`{
+						"files": [
+							"a.ts",
+							"b.ts",
+							"a.ts"
+						]
+					}`,
+					files,
+					"/dev",
+					/*useCaseSensitiveFileNames*/ true,
+				)
+
+				assert.DeepEqual(t, parsedCommandLine.LiteralFileNames(), []string{
+					"/dev/a.ts",
+					"/dev/b.ts",
+				})
+			})
 		})
 
 		t.Run("with literal include list", func(t *testing.T) {


### PR DESCRIPTION
Discovered this while investigating something else