### PR TITLE
test(jsnum): add binary/oct/hex BigInt cases including underscores and uppercase prefixes

### DIFF
--- a/internal/jsnum/pseudobigint_test.go
+++ b/internal/jsnum/pseudobigint_test.go
@@ -33,6 +33,42 @@ func TestParsePseudoBigInt(t *testing.T) {
 
 	// TODO(jakebailey): tests for other bases
 
+		t.Run("parse non-decimal bases (small numbers)", func(t *testing.T) {
+		t.Parallel()
+
+		type tc struct {
+			lit string
+			out string
+		}
+		cases := []tc{
+			// binary
+			{lit: "0b0n", out: "0"},
+			{lit: "0b1n", out: "1"},
+			{lit: "0b1010n", out: "10"},
+			{lit: "0b1010_0101n", out: "165"},
+			{lit: "0B1101n", out: "13"}, // uppercase prefix
+
+			// octal
+			{lit: "0o0n", out: "0"},
+			{lit: "0o7n", out: "7"},
+			{lit: "0o755n", out: "493"},
+			{lit: "0o7_5_5n", out: "493"},
+			{lit: "0O12n", out: "10"}, // uppercase prefix
+
+			// hex
+			{lit: "0x0n", out: "0"},
+			{lit: "0xFn", out: "15"},
+			{lit: "0xFFn", out: "255"},
+			{lit: "0xF_Fn", out: "255"},
+			{lit: "0X1Fn", out: "31"}, // uppercase prefix
+		}
+
+		for _, c := range cases {
+			got := ParsePseudoBigInt(c.lit)
+			assert.Equal(t, got, c.out, "literal: %q", c.lit)
+		}
+	})
+
 	t.Run("can parse large literals", func(t *testing.T) {
 		t.Parallel()
 		assert.Equal(t, ParsePseudoBigInt("123456789012345678901234567890n"), "123456789012345678901234567890")
@@ -41,3 +77,4 @@ func TestParsePseudoBigInt(t *testing.T) {
 		assert.Equal(t, ParsePseudoBigInt("0x18ee90ff6c373e0ee4e3f0ad2n"), "123456789012345678901234567890")
 	})
 }
+

--- a/internal/jsnum/pseudobigint_test.go
+++ b/internal/jsnum/pseudobigint_test.go
@@ -33,7 +33,7 @@ func TestParsePseudoBigInt(t *testing.T) {
 
 	// TODO(jakebailey): tests for other bases
 
-		t.Run("parse non-decimal bases (small numbers)", func(t *testing.T) {
+	t.Run("parse non-decimal bases (small numbers)", func(t *testing.T) {
 		t.Parallel()
 
 		type tc struct {
@@ -77,4 +77,3 @@ func TestParsePseudoBigInt(t *testing.T) {
 		assert.Equal(t, ParsePseudoBigInt("0x18ee90ff6c373e0ee4e3f0ad2n"), "123456789012345678901234567890")
 	})
 }
-

--- a/internal/jsnum/pseudobigint_test.go
+++ b/internal/jsnum/pseudobigint_test.go
@@ -31,8 +31,6 @@ func TestParsePseudoBigInt(t *testing.T) {
 		}
 	})
 
-	// TODO(jakebailey): tests for other bases
-
 	t.Run("parse non-decimal bases (small numbers)", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
Adds unit tests for ParsePseudoBigInt across non-decimal bases, responding to the
inline TODO ("tests for other bases") in internal/jsnum/pseudobigint_test.go.

- Binary (0b/0B), Octal (0o/0O), Hex (0x/0X)
- With/without underscore separators
- Small-number cases (0, 1, 10, 255)
No behavior changes; tests pass with the current implementation.