### PR TITLE
Add type definitions for `Uint8Array` to/from base64 methods

### DIFF
--- a/internal/bundled/libs/lib.esnext.array.d.ts
+++ b/internal/bundled/libs/lib.esnext.array.d.ts
@@ -33,3 +33,73 @@ interface ArrayConstructor {
      */
     fromAsync<T, U>(iterableOrArrayLike: AsyncIterable<T> | Iterable<T> | ArrayLike<T>, mapFn: (value: Awaited<T>, index: number) => U, thisArg?: any): Promise<Awaited<U>[]>;
 }
+
+interface Uint8ArrayConstructor {
+    /**
+     * Creates a new `Uint8Array` from a base64-encoded string.
+     * @param string The base64-encoded string.
+     * @param options If provided, specifies the alphabet and handling of the last chunk.
+     * @returns A new `Uint8Array` instance.
+     * @throws {SyntaxError} If the input string contains characters outside the specified alphabet, or if the last
+     * chunk is inconsistent with the `lastChunkHandling` option.
+     */
+    fromBase64(
+        string: string,
+        options?: {
+            alphabet?: "base64" | "base64url";
+            lastChunkHandling?: "loose" | "strict" | "stop-before-partial";
+        },
+    ): Uint8Array<ArrayBuffer>;
+
+    /**
+     * Creates a new `Uint8Array` from a base16-encoded string.
+     * @returns A new `Uint8Array` instance.
+     */
+    fromHex(
+        string: string,
+    ): Uint8Array<ArrayBuffer>;
+}
+
+interface Uint8Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Converts the `Uint8Array` to a base64-encoded string.
+     * @param options If provided, sets the alphabet and padding behavior used.
+     * @returns A base64-encoded string.
+     */
+    toBase64(options?: {
+        alphabet?: "base64" | "base64url";
+        omitPadding?: boolean;
+    }): string;
+
+    /**
+     * Sets the `Uint8Array` from a base64-encoded string.
+     * @param string The base64-encoded string.
+     * @param options If provided, specifies the alphabet and handling of the last chunk.
+     * @returns An object containing the number of bytes read and written.
+     * @throws {SyntaxError} If the input string contains characters outside the specified alphabet, or if the last
+     * chunk is inconsistent with the `lastChunkHandling` option.
+     */
+    setFromBase64(string: string, options?: {
+        alphabet?: "base64" | "base64url";
+        lastChunkHandling?: "loose" | "strict" | "stop-before-partial";
+    }): {
+        read: number;
+        written: number;
+    };
+
+    /**
+     * Converts the `Uint8Array` to a base16-encoded string.
+     * @returns A base16-encoded string.
+     */
+    toHex(): string;
+
+    /**
+     * Sets the `Uint8Array` from a base16-encoded string.
+     * @param string The base16-encoded string.
+     * @returns An object containing the number of bytes read and written.
+     */
+    setFromHex(string: string): {
+        read: number;
+        written: number;
+    };
+}

--- a/internal/checker/utilities.go
+++ b/internal/checker/utilities.go
@@ -1717,6 +1717,10 @@ var getFeatureMap = sync.OnceValue(func() map[string][]FeatureMapEntry {
 		"Uint8Array": {
 			{lib: "es2022", props: []string{"at"}},
 			{lib: "es2023", props: []string{"findLastIndex", "findLast", "toReversed", "toSorted", "toSpliced", "with"}},
+			{lib: "esnext", props: []string{"toBase64", "setFromBase64", "toHex", "setFromHex"}},
+		},
+		"Uint8ArrayConstructor": {
+			{lib: "esnext", props: []string{"fromBase64", "fromHex"}},
 		},
 		"Uint8ClampedArray": {
 			{lib: "es2022", props: []string{"at"}},

--- a/testdata/baselines/reference/submodule/compiler/findLast(target=esnext).symbols
+++ b/testdata/baselines/reference/submodule/compiler/findLast(target=esnext).symbols
@@ -24,7 +24,7 @@ new Int8Array().findLast((item) => item === 0);
 
 new Uint8Array().findLast((item) => item === 0);
 >new Uint8Array().findLast : Symbol(Uint8Array.findLast, Decl(lib.es2023.array.d.ts, --, --), Decl(lib.es2023.array.d.ts, --, --))
->Uint8Array : Symbol(Uint8Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --) ... and 3 more)
+>Uint8Array : Symbol(Uint8Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --) ... and 4 more)
 >findLast : Symbol(Uint8Array.findLast, Decl(lib.es2023.array.d.ts, --, --), Decl(lib.es2023.array.d.ts, --, --))
 >item : Symbol(item, Decl(findLast.ts, 3, 27))
 >item : Symbol(item, Decl(findLast.ts, 3, 27))
@@ -117,7 +117,7 @@ new Int8Array().findLastIndex((item) => item === 0);
 
 new Uint8Array().findLastIndex((item) => item === 0);
 >new Uint8Array().findLastIndex : Symbol(Uint8Array.findLastIndex, Decl(lib.es2023.array.d.ts, --, --))
->Uint8Array : Symbol(Uint8Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --) ... and 3 more)
+>Uint8Array : Symbol(Uint8Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --) ... and 4 more)
 >findLastIndex : Symbol(Uint8Array.findLastIndex, Decl(lib.es2023.array.d.ts, --, --))
 >item : Symbol(item, Decl(findLast.ts, 17, 32))
 >item : Symbol(item, Decl(findLast.ts, 17, 32))

--- a/testdata/baselines/reference/submodule/compiler/findLast(target=esnext).symbols.diff
+++ b/testdata/baselines/reference/submodule/compiler/findLast(target=esnext).symbols.diff
@@ -1,0 +1,20 @@
+--- old.findLast(target=esnext).symbols
++++ new.findLast(target=esnext).symbols
+@@= skipped -23, +23 lines =@@
+
+ new Uint8Array().findLast((item) => item === 0);
+ >new Uint8Array().findLast : Symbol(Uint8Array.findLast, Decl(lib.es2023.array.d.ts, --, --), Decl(lib.es2023.array.d.ts, --, --))
+->Uint8Array : Symbol(Uint8Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --) ... and 3 more)
++>Uint8Array : Symbol(Uint8Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --) ... and 4 more)
+ >findLast : Symbol(Uint8Array.findLast, Decl(lib.es2023.array.d.ts, --, --), Decl(lib.es2023.array.d.ts, --, --))
+ >item : Symbol(item, Decl(findLast.ts, 3, 27))
+ >item : Symbol(item, Decl(findLast.ts, 3, 27))
+@@= skipped -93, +93 lines =@@
+
+ new Uint8Array().findLastIndex((item) => item === 0);
+ >new Uint8Array().findLastIndex : Symbol(Uint8Array.findLastIndex, Decl(lib.es2023.array.d.ts, --, --))
+->Uint8Array : Symbol(Uint8Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --) ... and 3 more)
++>Uint8Array : Symbol(Uint8Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --) ... and 4 more)
+ >findLastIndex : Symbol(Uint8Array.findLastIndex, Decl(lib.es2023.array.d.ts, --, --))
+ >item : Symbol(item, Decl(findLast.ts, 17, 32))
+ >item : Symbol(item, Decl(findLast.ts, 17, 32))

--- a/testdata/baselines/reference/submodule/compiler/indexAt(target=esnext).symbols
+++ b/testdata/baselines/reference/submodule/compiler/indexAt(target=esnext).symbols
@@ -16,7 +16,7 @@ new Int8Array().at(0);
 
 new Uint8Array().at(0);
 >new Uint8Array().at : Symbol(Uint8Array.at, Decl(lib.es2022.array.d.ts, --, --))
->Uint8Array : Symbol(Uint8Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --) ... and 3 more)
+>Uint8Array : Symbol(Uint8Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --) ... and 4 more)
 >at : Symbol(Uint8Array.at, Decl(lib.es2022.array.d.ts, --, --))
 
 new Uint8ClampedArray().at(0);

--- a/testdata/baselines/reference/submodule/compiler/indexAt(target=esnext).symbols.diff
+++ b/testdata/baselines/reference/submodule/compiler/indexAt(target=esnext).symbols.diff
@@ -1,0 +1,11 @@
+--- old.indexAt(target=esnext).symbols
++++ new.indexAt(target=esnext).symbols
+@@= skipped -15, +15 lines =@@
+
+ new Uint8Array().at(0);
+ >new Uint8Array().at : Symbol(Uint8Array.at, Decl(lib.es2022.array.d.ts, --, --))
+->Uint8Array : Symbol(Uint8Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --) ... and 3 more)
++>Uint8Array : Symbol(Uint8Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --) ... and 4 more)
+ >at : Symbol(Uint8Array.at, Decl(lib.es2022.array.d.ts, --, --))
+
+ new Uint8ClampedArray().at(0);

--- a/testdata/baselines/reference/submodule/compiler/subclassUint8Array.symbols
+++ b/testdata/baselines/reference/submodule/compiler/subclassUint8Array.symbols
@@ -3,6 +3,6 @@
 === subclassUint8Array.ts ===
 class CustomBuffer extends Uint8Array {
 >CustomBuffer : Symbol(CustomBuffer, Decl(subclassUint8Array.ts, 0, 0))
->Uint8Array : Symbol(Uint8Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --) ... and 3 more)
+>Uint8Array : Symbol(Uint8Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --) ... and 4 more)
 }
 

--- a/testdata/baselines/reference/submodule/compiler/subclassUint8Array.symbols.diff
+++ b/testdata/baselines/reference/submodule/compiler/subclassUint8Array.symbols.diff
@@ -1,0 +1,9 @@
+--- old.subclassUint8Array.symbols
++++ new.subclassUint8Array.symbols
+@@= skipped -2, +2 lines =@@
+ === subclassUint8Array.ts ===
+ class CustomBuffer extends Uint8Array {
+ >CustomBuffer : Symbol(CustomBuffer, Decl(subclassUint8Array.ts, 0, 0))
+->Uint8Array : Symbol(Uint8Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --) ... and 3 more)
++>Uint8Array : Symbol(Uint8Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --) ... and 4 more)
+ }


### PR DESCRIPTION
Fixes https://github.com/microsoft/TypeScript/issues/61695.

For more information, see https://github.com/microsoft/TypeScript/issues/61695.