### PR TITLE
Mention K and V in generic SyncMap struct fields

### DIFF
--- a/internal/collections/syncmap.go
+++ b/internal/collections/syncmap.go
@@ -6,6 +6,8 @@ import (
 )
 
 type SyncMap[K comparable, V any] struct {
+	_ [0]K
+	_ [0]V
 	m sync.Map
 }
 


### PR DESCRIPTION
When I added this type, I forgot to mention K and V in the struct fields, meaning that any SyncMap was convertible to any other one structurally. That's a mistake.

Nothing fails, thankfully.