### PR TITLE
feat(checker/types): add public getter from `TypePredicate`

### DIFF
--- a/internal/checker/types.go
+++ b/internal/checker/types.go
@@ -1192,6 +1192,14 @@ type TypePredicate struct {
 	t              *Type
 }
 
+func (t *TypePredicate) Kind() TypePredicateKind { return t.kind }
+
+func (t *TypePredicate) ParameterIndex() int32 { return t.parameterIndex }
+
+func (t *TypePredicate) ParameterName() string { return t.parameterName }
+
+func (t *TypePredicate) Type() *Type { return t.t }
+
 // IndexInfo
 
 type IndexInfo struct {


### PR DESCRIPTION
While I implement https://github.com/oxc-project/tsgolint/pull/222,
I can't use return type of `GetTypePredicateOfSignature`
So i export fields from `TypePredicate`