### PR TITLE
Remove the minimum node version from @typescript/native-preview-* packages

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -1077,7 +1077,7 @@ export const buildNativePreviewPackages = task({
         const inputPackageJson = JSON.parse(fs.readFileSync(path.join(inputDir, "package.json"), "utf8"));
         inputPackageJson.version = getVersion();
         delete inputPackageJson.private;
-        delete inputPackageJson.engines.node;
+        delete inputPackageJson.engines;
 
         const { stdout: gitHead } = await $pipe`git rev-parse HEAD`;
         inputPackageJson.gitHead = gitHead;


### PR DESCRIPTION
The platform-specific packages are currently being published with:
```json
"engines": {
   "node": ">=20.6.0"
}
```
This will prevent the correct architecture's package from automatically installing when running an older version of node.  (At least, this happened with `pnpm` - not sure if other bundlers use the `engines` field when checking `optionalDependencies`)