### PR TITLE
Fix isolatedDeclarations emit of computed property names in interfaces

### DIFF
--- a/internal/printer/emitresolver.go
+++ b/internal/printer/emitresolver.go
@@ -52,6 +52,7 @@ type EmitResolver interface {
 	RequiresAddingImplicitUndefined(node *ast.Node, symbol *ast.Symbol, enclosingDeclaration *ast.Node) bool
 	IsDeclarationVisible(node *ast.Node) bool
 	IsImportRequiredByAugmentation(decl *ast.ImportDeclaration) bool
+	IsDefinitelyReferenceToGlobalSymbolObject(node *ast.Node) bool
 	IsImplementationOfOverload(node *ast.SignatureDeclaration) bool
 	GetEnumMemberValue(node *ast.Node) evaluator.Result
 	IsLateBound(node *ast.Node) bool

--- a/testdata/baselines/reference/compiler/enumMemberInterfacePropertyDeclarationEmit.js
+++ b/testdata/baselines/reference/compiler/enumMemberInterfacePropertyDeclarationEmit.js
@@ -1,0 +1,43 @@
+//// [tests/cases/compiler/enumMemberInterfacePropertyDeclarationEmit.ts] ////
+
+//// [enum.ts]
+export enum WWMF{
+    AAR = 'AAR',
+}
+
+//// [base.ts]
+import type { WWMF } from "./enum";
+
+interface WWMFMap {
+    [WWMF.AAR]?: any;
+}
+
+export const wwmfMap: WWMFMap = {};
+
+
+//// [enum.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.WWMF = void 0;
+var WWMF;
+(function (WWMF) {
+    WWMF["AAR"] = "AAR";
+})(WWMF || (exports.WWMF = WWMF = {}));
+//// [base.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.wwmfMap = void 0;
+exports.wwmfMap = {};
+
+
+//// [enum.d.ts]
+export declare enum WWMF {
+    AAR = "AAR"
+}
+//// [base.d.ts]
+import type { WWMF } from "./enum";
+interface WWMFMap {
+    [WWMF.AAR]?: any;
+}
+export declare const wwmfMap: WWMFMap;
+export {};

--- a/testdata/baselines/reference/submodule/compiler/isolatedDeclarationErrorsClasses.js
+++ b/testdata/baselines/reference/submodule/compiler/isolatedDeclarationErrorsClasses.js
@@ -112,9 +112,14 @@ export declare class Cls {
     get getSetOk3(): number;
     set getSetOk3(value: number);
 }
+declare let noAnnotationStringName: string;
+declare const noAnnotationLiteralName = "noAnnotationLiteralName";
 export declare class C {
     [x: string]: any;
     [x: number]: number;
 }
 export interface I {
+    [noAnnotationStringName]: 10;
+    [noAnnotationLiteralName](): any;
 }
+export {};

--- a/testdata/baselines/reference/submodule/compiler/isolatedDeclarationErrorsClasses.js.diff
+++ b/testdata/baselines/reference/submodule/compiler/isolatedDeclarationErrorsClasses.js.diff
@@ -24,9 +24,14 @@
 +    get getSetOk3(): number;
 +    set getSetOk3(value: number);
 +}
++declare let noAnnotationStringName: string;
++declare const noAnnotationLiteralName = "noAnnotationLiteralName";
 +export declare class C {
 +    [x: string]: any;
 +    [x: number]: number;
 +}
 +export interface I {
++    [noAnnotationStringName]: 10;
++    [noAnnotationLiteralName](): any;
 +}
++export {};

--- a/testdata/tests/cases/compiler/enumMemberInterfacePropertyDeclarationEmit.ts
+++ b/testdata/tests/cases/compiler/enumMemberInterfacePropertyDeclarationEmit.ts
@@ -1,0 +1,17 @@
+// @declaration: true
+// @noTypesAndSymbols: true
+// @isolatedDeclarations: true
+
+// @Filename: enum.ts
+export enum WWMF{
+    AAR = 'AAR',
+}
+
+// @Filename: base.ts
+import type { WWMF } from "./enum";
+
+interface WWMFMap {
+    [WWMF.AAR]?: any;
+}
+
+export const wwmfMap: WWMFMap = {};


### PR DESCRIPTION
This was uncovered while trying to migrate an internal team onto `tsgo --build`.