### PR TITLE
fourslash userpreferences (and fetch inlay hints userpreferences from vscode) 

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -160,7 +160,7 @@ func (api *API) GetSymbolAtPosition(ctx context.Context, projectId Handle[projec
 		return nil, errors.New("project not found")
 	}
 
-	languageService := ls.NewLanguageService(project, snapshot.Converters())
+	languageService := ls.NewLanguageService(project, snapshot.Converters(), snapshot.UserPreferences())
 	symbol, err := languageService.GetSymbolAtPosition(ctx, fileName, position)
 	if err != nil || symbol == nil {
 		return nil, err
@@ -202,7 +202,7 @@ func (api *API) GetSymbolAtLocation(ctx context.Context, projectId Handle[projec
 	if node == nil {
 		return nil, fmt.Errorf("node of kind %s not found at position %d in file %q", kind.String(), pos, sourceFile.FileName())
 	}
-	languageService := ls.NewLanguageService(project, snapshot.Converters())
+	languageService := ls.NewLanguageService(project, snapshot.Converters(), snapshot.UserPreferences())
 	symbol := languageService.GetSymbolAtLocation(ctx, node)
 	if symbol == nil {
 		return nil, nil
@@ -232,7 +232,7 @@ func (api *API) GetTypeOfSymbol(ctx context.Context, projectId Handle[project.Pr
 	if !ok {
 		return nil, fmt.Errorf("symbol %q not found", symbolHandle)
 	}
-	languageService := ls.NewLanguageService(project, snapshot.Converters())
+	languageService := ls.NewLanguageService(project, snapshot.Converters(), snapshot.UserPreferences())
 	t := languageService.GetTypeOfSymbol(ctx, symbol)
 	if t == nil {
 		return nil, nil

--- a/internal/fourslash/tests/autoImportCompletion_test.go
+++ b/internal/fourslash/tests/autoImportCompletion_test.go
@@ -39,6 +39,19 @@ a/**/
 		},
 	})
 	f.BaselineAutoImportsCompletions(t, []string{""})
+	f.VerifyCompletions(t, "", &fourslash.CompletionsExpectedList{
+		UserPreferences: &ls.UserPreferences{
+			// completion autoimport preferences off; this tests if fourslash server communication correctly registers changes in user preferences
+		},
+		IsIncomplete: false,
+		ItemDefaults: &fourslash.CompletionsExpectedItemDefaults{
+			CommitCharacters: &DefaultCommitCharacters,
+			EditRange:        Ignored,
+		},
+		Items: &fourslash.CompletionsExpectedItems{
+			Excludes: []string{"anotherVar"},
+		},
+	})
 }
 
 func TestAutoImportCompletion2(t *testing.T) {

--- a/internal/ls/languageservice.go
+++ b/internal/ls/languageservice.go
@@ -7,19 +7,29 @@ import (
 )
 
 type LanguageService struct {
-	host       Host
-	converters *Converters
+	host            Host
+	converters      *Converters
+	userPreferences *UserPreferences
 }
 
-func NewLanguageService(host Host, converters *Converters) *LanguageService {
+func NewLanguageService(host Host, converters *Converters, preferences *UserPreferences) *LanguageService {
 	return &LanguageService{
-		host:       host,
-		converters: converters,
+		host:            host,
+		converters:      converters,
+		userPreferences: preferences,
 	}
 }
 
 func (l *LanguageService) GetProgram() *compiler.Program {
 	return l.host.GetProgram()
+}
+
+func (l *LanguageService) UpdateUserPreferences(preferences *UserPreferences) {
+	l.userPreferences = preferences
+}
+
+func (l *LanguageService) UserPreferences() *UserPreferences {
+	return l.userPreferences
 }
 
 func (l *LanguageService) tryGetProgramAndFile(fileName string) (*compiler.Program, *ast.SourceFile) {

--- a/internal/ls/types.go
+++ b/internal/ls/types.go
@@ -56,6 +56,24 @@ type UserPreferences struct {
 	AutoImportFileExcludePatterns         []string
 
 	UseAliasesForRename *bool
+
+	// Inlay Hints
+	IncludeInlayParameterNameHints                        string
+	IncludeInlayParameterNameHintsWhenArgumentMatchesName *bool
+	IncludeInlayFunctionParameterTypeHints                *bool
+	IncludeInlayVariableTypeHints                         *bool
+	IncludeInlayVariableTypeHintsWhenTypeMatchesName      *bool
+	IncludeInlayPropertyDeclarationTypeHints              *bool
+	IncludeInlayFunctionLikeReturnTypeHints               *bool
+	IncludeInlayEnumMemberValueHints                      *bool
+	InteractiveInlayHints                                 *bool
+}
+
+func (p *UserPreferences) GetOrDefault() UserPreferences {
+	if p == nil {
+		return UserPreferences{}
+	}
+	return *p
 }
 
 func (p *UserPreferences) ModuleSpecifierPreferences() modulespecifiers.UserPreferences {

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -917,13 +917,6 @@ func (s *Server) handleDocumentOnTypeFormat(ctx context.Context, ls *ls.Language
 	)
 }
 
-func (s *Server) handleInlayHints(ctx context.Context, ls *ls.LanguageService, params *lsproto.InlayHintParams) (lsproto.InlayHintResponse, error) {
-	// !!!
-	// userPreferences, _ := s.Configure(ctx)
-	// return ls.ProvideInlayHints(ctx, params, userPreferences), nil
-	panic("unimplemented")
-}
-
 func (s *Server) handleWorkspaceSymbol(ctx context.Context, params *lsproto.WorkspaceSymbolParams, reqMsg *lsproto.RequestMessage) (lsproto.WorkspaceSymbolResponse, error) {
 	snapshot, release := s.session.Snapshot()
 	defer release()

--- a/internal/project/api.go
+++ b/internal/project/api.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (s *Session) OpenProject(ctx context.Context, configFileName string) (*Project, error) {
-	fileChanges, overlays, ataChanges := s.flushChanges(ctx)
+	fileChanges, overlays, ataChanges, _ := s.flushChanges(ctx)
 	newSnapshot := s.UpdateSnapshot(ctx, overlays, SnapshotChange{
 		fileChanges: fileChanges,
 		ataChanges:  ataChanges,

--- a/internal/project/snapshot.go
+++ b/internal/project/snapshot.go
@@ -32,6 +32,7 @@ type Snapshot struct {
 	ProjectCollection                  *ProjectCollection
 	ConfigFileRegistry                 *ConfigFileRegistry
 	compilerOptionsForInferredProjects *core.CompilerOptions
+	userPreferences                    ls.UserPreferences
 
 	builderLogs *logging.LogTree
 	apiError    error
@@ -46,6 +47,7 @@ func NewSnapshot(
 	extendedConfigCache *extendedConfigCache,
 	configFileRegistry *ConfigFileRegistry,
 	compilerOptionsForInferredProjects *core.CompilerOptions,
+	userPreferences *ls.UserPreferences,
 	toPath func(fileName string) tspath.Path,
 ) *Snapshot {
 	s := &Snapshot{
@@ -58,6 +60,7 @@ func NewSnapshot(
 		ConfigFileRegistry:                 configFileRegistry,
 		ProjectCollection:                  &ProjectCollection{toPath: toPath},
 		compilerOptionsForInferredProjects: compilerOptionsForInferredProjects,
+		userPreferences:                    userPreferences.GetOrDefault(),
 	}
 	s.converters = ls.NewConverters(s.sessionOptions.PositionEncoding, s.LineMap)
 	s.refCount.Store(1)
@@ -79,6 +82,10 @@ func (s *Snapshot) LineMap(fileName string) *ls.LineMap {
 		return file.LineMap()
 	}
 	return nil
+}
+
+func (s *Snapshot) UserPreferences() *ls.UserPreferences {
+	return &s.userPreferences
 }
 
 func (s *Snapshot) Converters() *ls.Converters {
@@ -234,6 +241,7 @@ func (s *Snapshot) Clone(ctx context.Context, change SnapshotChange, overlays ma
 		session.extendedConfigCache,
 		nil,
 		compilerOptionsForInferredProjects,
+		session.userPreferences,
 		s.toPath,
 	)
 	newSnapshot.parentId = s.id


### PR DESCRIPTION
Goal is to unblock https://github.com/microsoft/typescript-go/pull/1705

- fourslash supports all userpreferences
- only inlay hints preferences are parsed from vscode's client config responses. 

A full implementation of LSP compliant config getting/updating requires more work in the extension (currently in progress)