### PR TITLE
Fixes to make tsc -b and incremental work for memory issues

### DIFF
--- a/internal/execute/build/buildtask.go
+++ b/internal/execute/build/buildtask.go
@@ -121,7 +121,7 @@ func (t *buildTask) report(orchestrator *Orchestrator, configPath tspath.Path, b
 		if orchestrator.opts.Testing != nil {
 			orchestrator.opts.Testing.OnProgram(t.program)
 		}
-		t.program.MakeReadonly()
+		t.program = nil
 		buildResult.statistics.ProjectsBuilt++
 		t.buildKind = buildKindNone
 	case buildKindPseudo:
@@ -212,11 +212,7 @@ func (t *buildTask) compileAndEmit(orchestrator *Orchestrator, path tspath.Path)
 	buildInfoReadStart := orchestrator.opts.Sys.Now()
 	var oldProgram *incremental.Program
 	if !orchestrator.opts.Command.BuildOptions.Force.IsTrue() {
-		if t.program != nil {
-			oldProgram = t.program
-		} else {
-			oldProgram = incremental.ReadBuildInfoProgram(t.resolved, orchestrator.host, orchestrator.host)
-		}
+		oldProgram = incremental.ReadBuildInfoProgram(t.resolved, orchestrator.host, orchestrator.host)
 	}
 	compileTimes.BuildInfoReadTime = orchestrator.opts.Sys.Now().Sub(buildInfoReadStart)
 	parseStart := orchestrator.opts.Sys.Now()

--- a/internal/execute/build/buildtask.go
+++ b/internal/execute/build/buildtask.go
@@ -114,7 +114,7 @@ func (t *buildTask) report(orchestrator *Orchestrator, configPath tspath.Path, b
 		buildResult.result.Status = t.result.exitStatus
 	}
 	if t.result.statistics != nil {
-		buildResult.programStats = append(buildResult.programStats, t.result.statistics)
+		buildResult.statistics.Aggregate(t.result.statistics)
 	}
 	// If we built the program, or updated timestamps, or had errors, we need to
 	// delete files that are no longer needed

--- a/internal/execute/build/buildtask.go
+++ b/internal/execute/build/buildtask.go
@@ -46,6 +46,17 @@ type buildInfoEntry struct {
 	dtsTime   *time.Time
 }
 
+type taskResult struct {
+	builder            strings.Builder
+	reportStatus       tsc.DiagnosticReporter
+	diagnosticReporter tsc.DiagnosticReporter
+	exitStatus         tsc.ExitStatus
+	statistics         *tsc.Statistics
+	program            *incremental.Program
+	buildKind          buildKind
+	filesToDelete      []string
+}
+
 type buildTask struct {
 	config     string
 	resolved   *tsoptions.ParsedCommandLine
@@ -55,17 +66,9 @@ type buildTask struct {
 	done       chan struct{}
 
 	// task reporting
-	builder            strings.Builder
-	errors             []*ast.Diagnostic
-	reportStatus       tsc.DiagnosticReporter
-	diagnosticReporter tsc.DiagnosticReporter
-	exitStatus         tsc.ExitStatus
-	statistics         *tsc.Statistics
-	program            *incremental.Program
-	buildKind          buildKind
-	filesToDelete      []string
-	prevReporter       *buildTask
-	reportDone         chan struct{}
+	result       *taskResult
+	prevReporter *buildTask
+	reportDone   chan struct{}
 
 	// Watching things
 	configTime          time.Time
@@ -75,6 +78,7 @@ type buildTask struct {
 	buildInfoEntry   *buildInfoEntry
 	buildInfoEntryMu sync.Mutex
 
+	errors             []*ast.Diagnostic
 	pending            atomic.Bool
 	isInitialCycle     bool
 	downStreamUpdateMu sync.Mutex
@@ -95,7 +99,7 @@ func (t *buildTask) unblockDownstream() {
 
 func (t *buildTask) reportDiagnostic(err *ast.Diagnostic) {
 	t.errors = append(t.errors, err)
-	t.diagnosticReporter(err)
+	t.result.diagnosticReporter(err)
 }
 
 func (t *buildTask) report(orchestrator *Orchestrator, configPath tspath.Path, buildResult *orchestratorResult) {
@@ -105,30 +109,26 @@ func (t *buildTask) report(orchestrator *Orchestrator, configPath tspath.Path, b
 	if len(t.errors) > 0 {
 		buildResult.errors = append(core.IfElse(buildResult.errors != nil, buildResult.errors, []*ast.Diagnostic{}), t.errors...)
 	}
-	fmt.Fprint(orchestrator.opts.Sys.Writer(), t.builder.String())
-	t.builder.Reset()
-	if t.exitStatus > buildResult.result.Status {
-		buildResult.result.Status = t.exitStatus
+	fmt.Fprint(orchestrator.opts.Sys.Writer(), t.result.builder.String())
+	if t.result.exitStatus > buildResult.result.Status {
+		buildResult.result.Status = t.result.exitStatus
 	}
-	if t.statistics != nil {
-		buildResult.programStats = append(buildResult.programStats, t.statistics)
-		t.statistics = nil
+	if t.result.statistics != nil {
+		buildResult.programStats = append(buildResult.programStats, t.result.statistics)
 	}
 	// If we built the program, or updated timestamps, or had errors, we need to
 	// delete files that are no longer needed
-	switch t.buildKind {
+	switch t.result.buildKind {
 	case buildKindProgram:
 		if orchestrator.opts.Testing != nil {
-			orchestrator.opts.Testing.OnProgram(t.program)
+			orchestrator.opts.Testing.OnProgram(t.result.program)
 		}
-		t.program = nil
 		buildResult.statistics.ProjectsBuilt++
-		t.buildKind = buildKindNone
 	case buildKindPseudo:
 		buildResult.statistics.TimestampUpdates++
-		t.buildKind = buildKindNone
 	}
-	buildResult.filesToDelete = append(buildResult.filesToDelete, t.filesToDelete...)
+	buildResult.filesToDelete = append(buildResult.filesToDelete, t.result.filesToDelete...)
+	t.result = nil
 	close(t.reportDone)
 }
 
@@ -148,7 +148,7 @@ func (t *buildTask) buildProject(orchestrator *Orchestrator, path tspath.Path) {
 				}
 			}
 			if len(t.errors) > 0 {
-				t.exitStatus = tsc.ExitStatusDiagnosticsPresent_OutputsSkipped
+				t.result.exitStatus = tsc.ExitStatusDiagnosticsPresent_OutputsSkipped
 			}
 		}
 	} else {
@@ -156,7 +156,7 @@ func (t *buildTask) buildProject(orchestrator *Orchestrator, path tspath.Path) {
 			t.reportUpToDateStatus(orchestrator)
 			for _, err := range t.errors {
 				// Should not add the diagnostics so just reporting
-				t.diagnosticReporter(err)
+				t.result.diagnosticReporter(err)
 			}
 		}
 	}
@@ -176,14 +176,14 @@ func (t *buildTask) updateDownstream(orchestrator *Orchestrator, path tspath.Pat
 		if downStream.status != nil {
 			switch downStream.status.kind {
 			case upToDateStatusTypeUpToDate:
-				if !t.program.HasChangedDtsFile() {
+				if !t.result.program.HasChangedDtsFile() {
 					downStream.status = &upToDateStatus{kind: upToDateStatusTypeUpToDateWithUpstreamTypes, data: downStream.status.data}
 					break
 				}
 				fallthrough
 			case upToDateStatusTypeUpToDateWithUpstreamTypes,
 				upToDateStatusTypeUpToDateWithInputFileText:
-				if t.program.HasChangedDtsFile() {
+				if t.result.program.HasChangedDtsFile() {
 					downStream.status = &upToDateStatus{kind: upToDateStatusTypeInputFileNewer, data: &inputOutputName{t.config, downStream.status.oldestOutputFileName()}}
 				}
 			case upToDateStatusTypeUpstreamErrors:
@@ -202,7 +202,7 @@ func (t *buildTask) updateDownstream(orchestrator *Orchestrator, path tspath.Pat
 func (t *buildTask) compileAndEmit(orchestrator *Orchestrator, path tspath.Path) {
 	t.errors = nil
 	if orchestrator.opts.Command.BuildOptions.Verbose.IsTrue() {
-		t.reportStatus(ast.NewCompilerDiagnostic(diagnostics.Building_project_0, orchestrator.relativeFileName(t.config)))
+		t.result.reportStatus(ast.NewCompilerDiagnostic(diagnostics.Building_project_0, orchestrator.relativeFileName(t.config)))
 	}
 
 	// Real build
@@ -220,23 +220,23 @@ func (t *buildTask) compileAndEmit(orchestrator *Orchestrator, path tspath.Path)
 		Config: t.resolved,
 		Host: &compilerHost{
 			host:  orchestrator.host,
-			trace: tsc.GetTraceWithWriterFromSys(&t.builder, orchestrator.opts.Testing),
+			trace: tsc.GetTraceWithWriterFromSys(&t.result.builder, orchestrator.opts.Testing),
 		},
 		JSDocParsingMode: ast.JSDocParsingModeParseForTypeErrors,
 	})
 	compileTimes.ParseTime = orchestrator.opts.Sys.Now().Sub(parseStart)
 	changesComputeStart := orchestrator.opts.Sys.Now()
-	t.program = incremental.NewProgram(program, oldProgram, orchestrator.host, orchestrator.opts.Testing != nil)
+	t.result.program = incremental.NewProgram(program, oldProgram, orchestrator.host, orchestrator.opts.Testing != nil)
 	compileTimes.ChangesComputeTime = orchestrator.opts.Sys.Now().Sub(changesComputeStart)
 
 	result, statistics := tsc.EmitAndReportStatistics(tsc.EmitInput{
 		Sys:                orchestrator.opts.Sys,
-		ProgramLike:        t.program,
+		ProgramLike:        t.result.program,
 		Program:            program,
 		Config:             t.resolved,
 		ReportDiagnostic:   t.reportDiagnostic,
 		ReportErrorSummary: tsc.QuietDiagnosticsReporter,
-		Writer:             &t.builder,
+		Writer:             &t.result.builder,
 		WriteFile: func(fileName, text string, writeByteOrderMark bool, data *compiler.WriteFileData) error {
 			return t.writeFile(orchestrator, fileName, text, writeByteOrderMark, data)
 		},
@@ -244,14 +244,14 @@ func (t *buildTask) compileAndEmit(orchestrator *Orchestrator, path tspath.Path)
 		Testing:            orchestrator.opts.Testing,
 		TestingMTimesCache: orchestrator.host.mTimes,
 	})
-	t.exitStatus = result.Status
-	t.statistics = statistics
+	t.result.exitStatus = result.Status
+	t.result.statistics = statistics
 	if (!program.Options().NoEmitOnError.IsTrue() || len(result.Diagnostics) == 0) &&
 		(len(result.EmitResult.EmittedFiles) > 0 || t.status.kind != upToDateStatusTypeOutOfDateBuildInfoWithErrors) {
 		// Update time stamps for rest of the outputs
 		t.updateTimeStamps(orchestrator, result.EmitResult.EmittedFiles, diagnostics.Updating_unchanged_output_timestamps_of_project_0)
 	}
-	t.buildKind = buildKindProgram
+	t.result.buildKind = buildKindProgram
 	if result.Status == tsc.ExitStatusDiagnosticsPresent_OutputsSkipped || result.Status == tsc.ExitStatusDiagnosticsPresent_OutputsGenerated {
 		t.status = &upToDateStatus{kind: upToDateStatusTypeBuildErrors}
 	} else {
@@ -269,13 +269,13 @@ func (t *buildTask) handleStatusThatDoesntRequireBuild(orchestrator *Orchestrato
 	switch t.status.kind {
 	case upToDateStatusTypeUpToDate:
 		if orchestrator.opts.Command.BuildOptions.Dry.IsTrue() {
-			t.reportStatus(ast.NewCompilerDiagnostic(diagnostics.Project_0_is_up_to_date, t.config))
+			t.result.reportStatus(ast.NewCompilerDiagnostic(diagnostics.Project_0_is_up_to_date, t.config))
 		}
 		return true
 	case upToDateStatusTypeUpstreamErrors:
 		upstreamStatus := t.status.upstreamErrors()
 		if orchestrator.opts.Command.BuildOptions.Verbose.IsTrue() {
-			t.reportStatus(ast.NewCompilerDiagnostic(
+			t.result.reportStatus(ast.NewCompilerDiagnostic(
 				core.IfElse(
 					upstreamStatus.refHasUpstreamErrors,
 					diagnostics.Skipping_build_of_project_0_because_its_dependency_1_was_not_built,
@@ -296,19 +296,19 @@ func (t *buildTask) handleStatusThatDoesntRequireBuild(orchestrator *Orchestrato
 	// update timestamps
 	if t.status.isPseudoBuild() {
 		if orchestrator.opts.Command.BuildOptions.Dry.IsTrue() {
-			t.reportStatus(ast.NewCompilerDiagnostic(diagnostics.A_non_dry_build_would_update_timestamps_for_output_of_project_0, t.config))
+			t.result.reportStatus(ast.NewCompilerDiagnostic(diagnostics.A_non_dry_build_would_update_timestamps_for_output_of_project_0, t.config))
 			t.status = &upToDateStatus{kind: upToDateStatusTypeUpToDate}
 			return true
 		}
 
 		t.updateTimeStamps(orchestrator, nil, diagnostics.Updating_output_timestamps_of_project_0)
 		t.status = &upToDateStatus{kind: upToDateStatusTypeUpToDate, data: t.status.data}
-		t.buildKind = buildKindPseudo
+		t.result.buildKind = buildKindPseudo
 		return true
 	}
 
 	if orchestrator.opts.Command.BuildOptions.Dry.IsTrue() {
-		t.reportStatus(ast.NewCompilerDiagnostic(diagnostics.A_non_dry_build_would_build_project_0, t.config))
+		t.result.reportStatus(ast.NewCompilerDiagnostic(diagnostics.A_non_dry_build_would_build_project_0, t.config))
 		t.status = &upToDateStatus{kind: upToDateStatusTypeUpToDate}
 		return true
 	}
@@ -533,13 +533,13 @@ func (t *buildTask) reportUpToDateStatus(orchestrator *Orchestrator) {
 	}
 	switch t.status.kind {
 	case upToDateStatusTypeConfigFileNotFound:
-		t.reportStatus(ast.NewCompilerDiagnostic(
+		t.result.reportStatus(ast.NewCompilerDiagnostic(
 			diagnostics.Project_0_is_out_of_date_because_config_file_does_not_exist,
 			orchestrator.relativeFileName(t.config),
 		))
 	case upToDateStatusTypeUpstreamErrors:
 		upstreamStatus := t.status.upstreamErrors()
-		t.reportStatus(ast.NewCompilerDiagnostic(
+		t.result.reportStatus(ast.NewCompilerDiagnostic(
 			core.IfElse(
 				upstreamStatus.refHasUpstreamErrors,
 				diagnostics.Project_0_can_t_be_built_because_its_dependency_1_was_not_built,
@@ -549,7 +549,7 @@ func (t *buildTask) reportUpToDateStatus(orchestrator *Orchestrator) {
 			orchestrator.relativeFileName(upstreamStatus.ref),
 		))
 	case upToDateStatusTypeBuildErrors:
-		t.reportStatus(ast.NewCompilerDiagnostic(
+		t.result.reportStatus(ast.NewCompilerDiagnostic(
 			diagnostics.Project_0_is_out_of_date_because_it_has_errors,
 			orchestrator.relativeFileName(t.config),
 		))
@@ -557,7 +557,7 @@ func (t *buildTask) reportUpToDateStatus(orchestrator *Orchestrator) {
 		// This is to ensure skipping verbose log for projects that were built,
 		// and then some other package changed but this package doesnt need update
 		if inputOutputFileAndTime := t.status.inputOutputFileAndTime(); inputOutputFileAndTime != nil {
-			t.reportStatus(ast.NewCompilerDiagnostic(
+			t.result.reportStatus(ast.NewCompilerDiagnostic(
 				diagnostics.Project_0_is_up_to_date_because_newest_input_1_is_older_than_output_2,
 				orchestrator.relativeFileName(t.config),
 				orchestrator.relativeFileName(inputOutputFileAndTime.input.file),
@@ -565,70 +565,70 @@ func (t *buildTask) reportUpToDateStatus(orchestrator *Orchestrator) {
 			))
 		}
 	case upToDateStatusTypeUpToDateWithUpstreamTypes:
-		t.reportStatus(ast.NewCompilerDiagnostic(
+		t.result.reportStatus(ast.NewCompilerDiagnostic(
 			diagnostics.Project_0_is_up_to_date_with_d_ts_files_from_its_dependencies,
 			orchestrator.relativeFileName(t.config),
 		))
 	case upToDateStatusTypeUpToDateWithInputFileText:
-		t.reportStatus(ast.NewCompilerDiagnostic(
+		t.result.reportStatus(ast.NewCompilerDiagnostic(
 			diagnostics.Project_0_is_up_to_date_but_needs_to_update_timestamps_of_output_files_that_are_older_than_input_files,
 			orchestrator.relativeFileName(t.config),
 		))
 	case upToDateStatusTypeInputFileMissing:
-		t.reportStatus(ast.NewCompilerDiagnostic(
+		t.result.reportStatus(ast.NewCompilerDiagnostic(
 			diagnostics.Project_0_is_out_of_date_because_input_1_does_not_exist,
 			orchestrator.relativeFileName(t.config),
 			orchestrator.relativeFileName(t.status.data.(string)),
 		))
 	case upToDateStatusTypeOutputMissing:
-		t.reportStatus(ast.NewCompilerDiagnostic(
+		t.result.reportStatus(ast.NewCompilerDiagnostic(
 			diagnostics.Project_0_is_out_of_date_because_output_file_1_does_not_exist,
 			orchestrator.relativeFileName(t.config),
 			orchestrator.relativeFileName(t.status.data.(string)),
 		))
 	case upToDateStatusTypeInputFileNewer:
 		inputOutput := t.status.inputOutputName()
-		t.reportStatus(ast.NewCompilerDiagnostic(
+		t.result.reportStatus(ast.NewCompilerDiagnostic(
 			diagnostics.Project_0_is_out_of_date_because_output_1_is_older_than_input_2,
 			orchestrator.relativeFileName(t.config),
 			orchestrator.relativeFileName(inputOutput.output),
 			orchestrator.relativeFileName(inputOutput.input),
 		))
 	case upToDateStatusTypeOutOfDateBuildInfoWithPendingEmit:
-		t.reportStatus(ast.NewCompilerDiagnostic(
+		t.result.reportStatus(ast.NewCompilerDiagnostic(
 			diagnostics.Project_0_is_out_of_date_because_buildinfo_file_1_indicates_that_some_of_the_changes_were_not_emitted,
 			orchestrator.relativeFileName(t.config),
 			orchestrator.relativeFileName(t.status.data.(string)),
 		))
 	case upToDateStatusTypeOutOfDateBuildInfoWithErrors:
-		t.reportStatus(ast.NewCompilerDiagnostic(
+		t.result.reportStatus(ast.NewCompilerDiagnostic(
 			diagnostics.Project_0_is_out_of_date_because_buildinfo_file_1_indicates_that_program_needs_to_report_errors,
 			orchestrator.relativeFileName(t.config),
 			orchestrator.relativeFileName(t.status.data.(string)),
 		))
 	case upToDateStatusTypeOutOfDateOptions:
-		t.reportStatus(ast.NewCompilerDiagnostic(
+		t.result.reportStatus(ast.NewCompilerDiagnostic(
 			diagnostics.Project_0_is_out_of_date_because_buildinfo_file_1_indicates_there_is_change_in_compilerOptions,
 			orchestrator.relativeFileName(t.config),
 			orchestrator.relativeFileName(t.status.data.(string)),
 		))
 	case upToDateStatusTypeOutOfDateRoots:
 		inputOutput := t.status.inputOutputName()
-		t.reportStatus(ast.NewCompilerDiagnostic(
+		t.result.reportStatus(ast.NewCompilerDiagnostic(
 			diagnostics.Project_0_is_out_of_date_because_buildinfo_file_1_indicates_that_file_2_was_root_file_of_compilation_but_not_any_more,
 			orchestrator.relativeFileName(t.config),
 			orchestrator.relativeFileName(inputOutput.output),
 			orchestrator.relativeFileName(inputOutput.input),
 		))
 	case upToDateStatusTypeTsVersionOutputOfDate:
-		t.reportStatus(ast.NewCompilerDiagnostic(
+		t.result.reportStatus(ast.NewCompilerDiagnostic(
 			diagnostics.Project_0_is_out_of_date_because_output_for_it_was_generated_with_version_1_that_differs_with_current_version_2,
 			orchestrator.relativeFileName(t.config),
 			orchestrator.relativeFileName(t.status.data.(string)),
 			core.Version(),
 		))
 	case upToDateStatusTypeForceBuild:
-		t.reportStatus(ast.NewCompilerDiagnostic(
+		t.result.reportStatus(ast.NewCompilerDiagnostic(
 			diagnostics.Project_0_is_being_forcibly_rebuilt,
 			orchestrator.relativeFileName(t.config),
 		))
@@ -653,7 +653,7 @@ func (t *buildTask) updateTimeStamps(orchestrator *Orchestrator, emittedFiles []
 			return
 		}
 		if !verboseMessageReported && orchestrator.opts.Command.BuildOptions.Verbose.IsTrue() {
-			t.reportStatus(ast.NewCompilerDiagnostic(verboseMessage, orchestrator.relativeFileName(t.config)))
+			t.result.reportStatus(ast.NewCompilerDiagnostic(verboseMessage, orchestrator.relativeFileName(t.config)))
 			verboseMessageReported = true
 		}
 		err := orchestrator.host.SetMTime(file, now)
@@ -681,7 +681,7 @@ func (t *buildTask) updateTimeStamps(orchestrator *Orchestrator, emittedFiles []
 func (t *buildTask) cleanProject(orchestrator *Orchestrator, path tspath.Path) {
 	if t.resolved == nil {
 		t.reportDiagnostic(ast.NewCompilerDiagnostic(diagnostics.File_0_not_found, t.config))
-		t.exitStatus = tsc.ExitStatusDiagnosticsPresent_OutputsSkipped
+		t.result.exitStatus = tsc.ExitStatusDiagnosticsPresent_OutputsSkipped
 		return
 	}
 
@@ -705,7 +705,7 @@ func (t *buildTask) cleanProjectOutput(orchestrator *Orchestrator, outputFile st
 				t.reportDiagnostic(ast.NewCompilerDiagnostic(diagnostics.Failed_to_delete_file_0, outputFile))
 			}
 		} else {
-			t.filesToDelete = append(t.filesToDelete, outputFile)
+			t.result.filesToDelete = append(t.result.filesToDelete, outputFile)
 		}
 	}
 }
@@ -845,7 +845,7 @@ func (t *buildTask) writeFile(orchestrator *Orchestrator, fileName string, text 
 	err := orchestrator.host.FS().WriteFile(fileName, text, writeByteOrderMark)
 	if err == nil {
 		if data != nil && data.BuildInfo != nil {
-			t.onBuildInfoEmit(orchestrator, fileName, data.BuildInfo.(*incremental.BuildInfo), t.program.HasChangedDtsFile())
+			t.onBuildInfoEmit(orchestrator, fileName, data.BuildInfo.(*incremental.BuildInfo), t.result.program.HasChangedDtsFile())
 		} else if t.storeOutputTimeStamp(orchestrator) {
 			// Store time stamps
 			orchestrator.host.storeMTime(fileName, orchestrator.opts.Sys.Now())

--- a/internal/execute/build/orchestrator.go
+++ b/internal/execute/build/orchestrator.go
@@ -339,8 +339,9 @@ func (o *Orchestrator) buildOrClean() tsc.CommandLineResult {
 }
 
 func (o *Orchestrator) buildOrCleanProject(task *buildTask, path tspath.Path, buildResult *orchestratorResult) {
-	task.reportStatus = o.createBuilderStatusReporter(task)
-	task.diagnosticReporter = o.createDiagnosticReporter(task)
+	task.result = &taskResult{}
+	task.result.reportStatus = o.createBuilderStatusReporter(task)
+	task.result.diagnosticReporter = o.createDiagnosticReporter(task)
 	if !o.opts.Command.BuildOptions.Clean.IsTrue() {
 		task.buildProject(o, path)
 	} else {
@@ -353,7 +354,7 @@ func (o *Orchestrator) getWriter(task *buildTask) io.Writer {
 	if task == nil {
 		return o.opts.Sys.Writer()
 	}
-	return &task.builder
+	return &task.result.builder
 }
 
 func (o *Orchestrator) createBuilderStatusReporter(task *buildTask) tsc.DiagnosticReporter {

--- a/internal/execute/build/orchestrator.go
+++ b/internal/execute/build/orchestrator.go
@@ -11,7 +11,6 @@ import (
 	"github.com/microsoft/typescript-go/internal/compiler"
 	"github.com/microsoft/typescript-go/internal/core"
 	"github.com/microsoft/typescript-go/internal/diagnostics"
-	"github.com/microsoft/typescript-go/internal/execute/incremental"
 	"github.com/microsoft/typescript-go/internal/execute/tsc"
 	"github.com/microsoft/typescript-go/internal/tsoptions"
 	"github.com/microsoft/typescript-go/internal/tspath"
@@ -114,7 +113,6 @@ func (o *Orchestrator) createBuildTasks(oldTasks *collections.SyncMap[tspath.Pat
 		wg.Queue(func() {
 			path := o.toPath(config)
 			var task *buildTask
-			var program *incremental.Program
 			var buildInfo *buildInfoEntry
 			if oldTasks != nil {
 				if existing, ok := oldTasks.Load(path); ok {
@@ -122,7 +120,6 @@ func (o *Orchestrator) createBuildTasks(oldTasks *collections.SyncMap[tspath.Pat
 						// Reuse existing task if config is same
 						task = existing
 					} else {
-						program = existing.program
 						buildInfo = existing.buildInfoEntry
 					}
 				}
@@ -130,7 +127,6 @@ func (o *Orchestrator) createBuildTasks(oldTasks *collections.SyncMap[tspath.Pat
 			if task == nil {
 				task = &buildTask{config: config, isInitialCycle: oldTasks == nil}
 				task.pending.Store(true)
-				task.program = program
 				task.buildInfoEntry = buildInfo
 			}
 			if _, loaded := o.tasks.LoadOrStore(path, task); loaded {

--- a/internal/execute/build/orchestrator.go
+++ b/internal/execute/build/orchestrator.go
@@ -27,7 +27,6 @@ type orchestratorResult struct {
 	result        tsc.CommandLineResult
 	errors        []*ast.Diagnostic
 	statistics    tsc.Statistics
-	programStats  []*tsc.Statistics
 	filesToDelete []string
 }
 
@@ -46,13 +45,10 @@ func (b *orchestratorResult) report(o *Orchestrator) {
 				}), ""),
 			))
 	}
-	if len(b.programStats) == 0 {
-		return
-	}
 	if !o.opts.Command.CompilerOptions.Diagnostics.IsTrue() && !o.opts.Command.CompilerOptions.ExtendedDiagnostics.IsTrue() {
 		return
 	}
-	b.statistics.Aggregate(b.programStats, o.opts.Sys.SinceStart())
+	b.statistics.SetTotalTime(o.opts.Sys.SinceStart())
 	b.statistics.Report(o.opts.Sys.Writer(), o.opts.Testing)
 }
 

--- a/internal/execute/incremental/emitfileshandler.go
+++ b/internal/execute/incremental/emitfileshandler.go
@@ -2,6 +2,7 @@ package incremental
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	"github.com/microsoft/typescript-go/internal/ast"
@@ -26,6 +27,7 @@ type emitFilesHandler struct {
 	latestChangedDtsFiles collections.SyncMap[tspath.Path, string]
 	deletedPendingKinds   collections.Set[tspath.Path]
 	emitUpdates           collections.SyncMap[tspath.Path, *emitUpdate]
+	hasEmitDiagnostics    atomic.Bool
 }
 
 // Determining what all is pending to be emitted based on previous options or previous file emit flags
@@ -44,14 +46,57 @@ func (h *emitFilesHandler) getPendingEmitKindForEmitOptions(emitKind FileEmitKin
 // The first of writeFile if provided, writeFile of BuilderProgramHost if provided, writeFile of compiler host
 // in that order would be used to write the files
 func (h *emitFilesHandler) emitAllAffectedFiles(options compiler.EmitOptions) *compiler.EmitResult {
+	// Emit all affected files
+	if h.program.snapshot.canUseIncrementalState() {
+		results := h.emitFilesIncremental(options)
+		if h.isForDtsErrors {
+			if options.TargetSourceFile != nil {
+				// Result from cache
+				diagnostics, _ := h.program.snapshot.emitDiagnosticsPerFile.Load(options.TargetSourceFile.Path())
+				return &compiler.EmitResult{
+					EmitSkipped: true,
+					Diagnostics: diagnostics.getDiagnostics(h.program.program, options.TargetSourceFile),
+				}
+			}
+			return compiler.CombineEmitResults(results)
+		} else {
+			// Combine results and update buildInfo
+			result := compiler.CombineEmitResults(results)
+			h.emitBuildInfo(options, result)
+			return result
+		}
+	} else if !h.isForDtsErrors {
+		result := h.program.program.Emit(h.ctx, h.getEmitOptions(options))
+		h.updateSnapshot()
+		h.emitBuildInfo(options, result)
+		return result
+	} else {
+		result := &compiler.EmitResult{
+			EmitSkipped: true,
+			Diagnostics: h.program.program.GetDeclarationDiagnostics(h.ctx, options.TargetSourceFile),
+		}
+		if len(result.Diagnostics) != 0 {
+			h.program.snapshot.hasEmitDiagnostics = true
+		}
+		return result
+	}
+}
+
+func (h *emitFilesHandler) emitBuildInfo(options compiler.EmitOptions, result *compiler.EmitResult) {
+	buildInfoResult := h.program.emitBuildInfo(h.ctx, options)
+	if buildInfoResult != nil {
+		result.Diagnostics = append(result.Diagnostics, buildInfoResult.Diagnostics...)
+		result.EmittedFiles = append(result.EmittedFiles, buildInfoResult.EmittedFiles...)
+	}
+}
+
+func (h *emitFilesHandler) emitFilesIncremental(options compiler.EmitOptions) []*compiler.EmitResult {
 	// Get all affected files
 	collectAllAffectedFiles(h.ctx, h.program)
 	if h.ctx.Err() != nil {
 		return nil
 	}
 
-	// Emit all affected files
-	var results []*compiler.EmitResult
 	wg := core.NewWorkGroup(h.program.program.SingleThreaded())
 	h.program.snapshot.affectedFilesPendingEmit.Range(func(path tspath.Path, emitKind FileEmitKind) bool {
 		affectedFile := h.program.program.GetSourceFileByPath(path)
@@ -120,58 +165,42 @@ func (h *emitFilesHandler) emitAllAffectedFiles(options compiler.EmitOptions) *c
 		return true
 	})
 
-	results = h.updateSnapshot()
-
-	// Combine results and update buildInfo
-	if h.isForDtsErrors && options.TargetSourceFile != nil {
-		// Result from cache
-		diagnostics, _ := h.program.snapshot.emitDiagnosticsPerFile.Load(options.TargetSourceFile.Path())
-		return &compiler.EmitResult{
-			EmitSkipped: true,
-			Diagnostics: diagnostics.getDiagnostics(h.program.program, options.TargetSourceFile),
-		}
-	}
-
-	result := compiler.CombineEmitResults(results)
-	if !h.isForDtsErrors {
-		buildInfoResult := h.program.emitBuildInfo(h.ctx, options)
-		if buildInfoResult != nil {
-			result.Diagnostics = append(result.Diagnostics, buildInfoResult.Diagnostics...)
-			result.EmittedFiles = append(result.EmittedFiles, buildInfoResult.EmittedFiles...)
-		}
-	}
-
-	return result
+	return h.updateSnapshot()
 }
 
 func (h *emitFilesHandler) getEmitOptions(options compiler.EmitOptions) compiler.EmitOptions {
 	if !h.program.snapshot.options.GetEmitDeclarations() {
 		return options
 	}
+	canUseIncrementalState := h.program.snapshot.canUseIncrementalState()
 	return compiler.EmitOptions{
 		TargetSourceFile: options.TargetSourceFile,
 		EmitOnly:         options.EmitOnly,
 		WriteFile: func(fileName string, text string, writeByteOrderMark bool, data *compiler.WriteFileData) error {
 			var differsOnlyInMap bool
 			if tspath.IsDeclarationFileName(fileName) {
-				var emitSignature string
-				info, _ := h.program.snapshot.fileInfos.Load(options.TargetSourceFile.Path())
-				if info.signature == info.version {
-					signature := h.program.snapshot.computeSignatureWithDiagnostics(options.TargetSourceFile, text, data)
-					// With d.ts diagnostics they are also part of the signature so emitSignature will be different from it since its just hash of d.ts
-					if len(data.Diagnostics) == 0 {
-						emitSignature = signature
+				if canUseIncrementalState {
+					var emitSignature string
+					info, _ := h.program.snapshot.fileInfos.Load(options.TargetSourceFile.Path())
+					if info.signature == info.version {
+						signature := h.program.snapshot.computeSignatureWithDiagnostics(options.TargetSourceFile, text, data)
+						// With d.ts diagnostics they are also part of the signature so emitSignature will be different from it since its just hash of d.ts
+						if len(data.Diagnostics) == 0 {
+							emitSignature = signature
+						}
+						if signature != info.version { // Update it
+							h.signatures.Store(options.TargetSourceFile.Path(), signature)
+						}
 					}
-					if signature != info.version { // Update it
-						h.signatures.Store(options.TargetSourceFile.Path(), signature)
-					}
-				}
 
-				// Store d.ts emit hash so later can be compared to check if d.ts has changed.
-				// Currently we do this only for composite projects since these are the only projects that can be referenced by other projects
-				// and would need their d.ts change time in --build mode
-				if h.skipDtsOutputOfComposite(options.TargetSourceFile, fileName, text, data, emitSignature, &differsOnlyInMap) {
-					return nil
+					// Store d.ts emit hash so later can be compared to check if d.ts has changed.
+					// Currently we do this only for composite projects since these are the only projects that can be referenced by other projects
+					// and would need their d.ts change time in --build mode
+					if h.skipDtsOutputOfComposite(options.TargetSourceFile, fileName, text, data, emitSignature, &differsOnlyInMap) {
+						return nil
+					}
+				} else if len(data.Diagnostics) > 0 {
+					h.hasEmitDiagnostics.Store(true)
 				}
 			}
 
@@ -231,56 +260,61 @@ func (h *emitFilesHandler) skipDtsOutputOfComposite(file *ast.SourceFile, output
 }
 
 func (h *emitFilesHandler) updateSnapshot() []*compiler.EmitResult {
-	h.signatures.Range(func(file tspath.Path, signature string) bool {
-		info, _ := h.program.snapshot.fileInfos.Load(file)
-		info.signature = signature
-		if h.program.testingData != nil {
-			h.program.testingData.UpdatedSignatureKinds[file] = SignatureUpdateKindStoredAtEmit
-		}
-		h.program.snapshot.buildInfoEmitPending.Store(true)
-		return true
-	})
-	h.emitSignatures.Range(func(file tspath.Path, signature *emitSignature) bool {
-		h.program.snapshot.emitSignatures.Store(file, signature)
-		h.program.snapshot.buildInfoEmitPending.Store(true)
-		return true
-	})
-	for file := range h.deletedPendingKinds.Keys() {
-		h.program.snapshot.affectedFilesPendingEmit.Delete(file)
-		h.program.snapshot.buildInfoEmitPending.Store(true)
-	}
-	// Always use correct order when to collect the result
-	var results []*compiler.EmitResult
-	for _, file := range h.program.GetSourceFiles() {
-		if latestChangedDtsFile, ok := h.latestChangedDtsFiles.Load(file.Path()); ok {
-			h.program.snapshot.latestChangedDtsFile = latestChangedDtsFile
+	if h.program.snapshot.canUseIncrementalState() {
+		h.signatures.Range(func(file tspath.Path, signature string) bool {
+			info, _ := h.program.snapshot.fileInfos.Load(file)
+			info.signature = signature
+			if h.program.testingData != nil {
+				h.program.testingData.UpdatedSignatureKinds[file] = SignatureUpdateKindStoredAtEmit
+			}
 			h.program.snapshot.buildInfoEmitPending.Store(true)
-			h.program.snapshot.hasChangedDtsFile = true
+			return true
+		})
+		h.emitSignatures.Range(func(file tspath.Path, signature *emitSignature) bool {
+			h.program.snapshot.emitSignatures.Store(file, signature)
+			h.program.snapshot.buildInfoEmitPending.Store(true)
+			return true
+		})
+		for file := range h.deletedPendingKinds.Keys() {
+			h.program.snapshot.affectedFilesPendingEmit.Delete(file)
+			h.program.snapshot.buildInfoEmitPending.Store(true)
 		}
-		if update, ok := h.emitUpdates.Load(file.Path()); ok {
-			if !update.dtsErrorsFromCache {
-				if update.pendingKind == 0 {
-					h.program.snapshot.affectedFilesPendingEmit.Delete(file.Path())
-				} else {
-					h.program.snapshot.affectedFilesPendingEmit.Store(file.Path(), update.pendingKind)
-				}
+		// Always use correct order when to collect the result
+		var results []*compiler.EmitResult
+		for _, file := range h.program.GetSourceFiles() {
+			if latestChangedDtsFile, ok := h.latestChangedDtsFiles.Load(file.Path()); ok {
+				h.program.snapshot.latestChangedDtsFile = latestChangedDtsFile
 				h.program.snapshot.buildInfoEmitPending.Store(true)
+				h.program.snapshot.hasChangedDtsFile = true
 			}
-			if update.result != nil {
-				results = append(results, update.result)
-				if len(update.result.Diagnostics) != 0 {
-					h.program.snapshot.emitDiagnosticsPerFile.Store(file.Path(), &diagnosticsOrBuildInfoDiagnosticsWithFileName{diagnostics: update.result.Diagnostics})
+			if update, ok := h.emitUpdates.Load(file.Path()); ok {
+				if !update.dtsErrorsFromCache {
+					if update.pendingKind == 0 {
+						h.program.snapshot.affectedFilesPendingEmit.Delete(file.Path())
+					} else {
+						h.program.snapshot.affectedFilesPendingEmit.Store(file.Path(), update.pendingKind)
+					}
+					h.program.snapshot.buildInfoEmitPending.Store(true)
+				}
+				if update.result != nil {
+					results = append(results, update.result)
+					if len(update.result.Diagnostics) != 0 {
+						h.program.snapshot.emitDiagnosticsPerFile.Store(file.Path(), &diagnosticsOrBuildInfoDiagnosticsWithFileName{diagnostics: update.result.Diagnostics})
+					}
 				}
 			}
 		}
+		return results
+	} else if h.hasEmitDiagnostics.Load() {
+		h.program.snapshot.hasEmitDiagnostics = true
 	}
-	return results
+	return nil
 }
 
 func emitFiles(ctx context.Context, program *Program, options compiler.EmitOptions, isForDtsErrors bool) *compiler.EmitResult {
 	emitHandler := &emitFilesHandler{ctx: ctx, program: program, isForDtsErrors: isForDtsErrors}
 
-	if options.TargetSourceFile != nil {
+	if !isForDtsErrors && options.TargetSourceFile != nil {
 		result := program.program.Emit(ctx, emitHandler.getEmitOptions(options))
 		if ctx.Err() != nil {
 			return nil

--- a/internal/execute/incremental/program.go
+++ b/internal/execute/incremental/program.go
@@ -203,15 +203,17 @@ func (p *Program) Emit(ctx context.Context, options compiler.EmitOptions) *compi
 
 // Handle affected files and cache the semantic diagnostics for all of them or the file asked for
 func (p *Program) collectSemanticDiagnosticsOfAffectedFiles(ctx context.Context, file *ast.SourceFile) {
-	// Get all affected files
-	collectAllAffectedFiles(ctx, p)
-	if ctx.Err() != nil {
-		return
-	}
+	if p.snapshot.canUseIncrementalState() {
+		// Get all affected files
+		collectAllAffectedFiles(ctx, p)
+		if ctx.Err() != nil {
+			return
+		}
 
-	if p.snapshot.semanticDiagnosticsPerFile.Size() == len(p.program.GetSourceFiles()) {
-		// If we have all the files,
-		return
+		if p.snapshot.semanticDiagnosticsPerFile.Size() == len(p.program.GetSourceFiles()) {
+			// If we have all the files,
+			return
+		}
 	}
 
 	var affectedFiles []*ast.SourceFile
@@ -294,24 +296,42 @@ func (p *Program) emitBuildInfo(ctx context.Context, options compiler.EmitOption
 }
 
 func (p *Program) ensureHasErrorsForState(ctx context.Context, program *compiler.Program) {
-	var hasIncludeProcessingDiagnostics bool
-	if slices.ContainsFunc(program.GetSourceFiles(), func(file *ast.SourceFile) bool {
-		if _, ok := p.snapshot.emitDiagnosticsPerFile.Load(file.Path()); ok {
-			// emit diagnostics will be encoded in buildInfo;
-			return true
+	var hasIncludeProcessingDiagnostics func() bool
+	var hasEmitDiagnostics bool
+	if p.snapshot.canUseIncrementalState() {
+		if slices.ContainsFunc(program.GetSourceFiles(), func(file *ast.SourceFile) bool {
+			if _, ok := p.snapshot.emitDiagnosticsPerFile.Load(file.Path()); ok {
+				// emit diagnostics will be encoded in buildInfo;
+				return true
+			}
+			if hasIncludeProcessingDiagnostics == nil && len(p.program.GetIncludeProcessorDiagnostics(file)) > 0 {
+				hasIncludeProcessingDiagnostics = func() bool { return true }
+			}
+			return false
+		}) {
+			hasEmitDiagnostics = true
 		}
-		if !hasIncludeProcessingDiagnostics && len(p.program.GetIncludeProcessorDiagnostics(file)) > 0 {
-			hasIncludeProcessingDiagnostics = true
+		if hasIncludeProcessingDiagnostics == nil {
+			hasIncludeProcessingDiagnostics = func() bool { return false }
 		}
-		return false
-	}) {
+	} else {
+		hasEmitDiagnostics = p.snapshot.hasEmitDiagnostics
+		hasIncludeProcessingDiagnostics = func() bool {
+			return slices.ContainsFunc(program.GetSourceFiles(), func(file *ast.SourceFile) bool {
+				return len(p.program.GetIncludeProcessorDiagnostics(file)) > 0
+			})
+		}
+	}
+
+	if hasEmitDiagnostics {
 		// Record this for only non incremental build info
 		p.snapshot.hasErrors = core.IfElse(p.snapshot.options.IsIncremental(), core.TSFalse, core.TSTrue)
 		// Dont need to encode semantic errors state since the emit diagnostics are encoded
 		p.snapshot.hasSemanticErrors = false
 		return
 	}
-	if hasIncludeProcessingDiagnostics ||
+
+	if hasIncludeProcessingDiagnostics() ||
 		len(program.GetConfigFileParsingDiagnostics()) > 0 ||
 		len(program.GetSyntacticDiagnostics(ctx, nil)) > 0 ||
 		len(program.GetProgramDiagnostics()) > 0 ||

--- a/internal/execute/incremental/program.go
+++ b/internal/execute/incremental/program.go
@@ -75,11 +75,6 @@ func (p *Program) GetProgram() *compiler.Program {
 	return p.program
 }
 
-func (p *Program) MakeReadonly() {
-	p.program = nil
-	p.testingData = nil
-}
-
 func (p *Program) HasChangedDtsFile() bool {
 	return p.snapshot.hasChangedDtsFile
 }

--- a/internal/execute/incremental/programtosnapshot.go
+++ b/internal/execute/incremental/programtosnapshot.go
@@ -16,14 +16,14 @@ func programToSnapshot(program *compiler.Program, oldProgram *Program, hashWithT
 	if oldProgram != nil && oldProgram.program == program {
 		return oldProgram.snapshot
 	}
-
+	snapshot := &snapshot{
+		options:      program.Options(),
+		hashWithText: hashWithText,
+	}
 	to := &toProgramSnapshot{
 		program:    program,
 		oldProgram: oldProgram,
-		snapshot: &snapshot{
-			options:      program.Options(),
-			hashWithText: hashWithText,
-		},
+		snapshot:   snapshot,
 	}
 
 	to.reuseFromOldProgram()
@@ -31,7 +31,7 @@ func programToSnapshot(program *compiler.Program, oldProgram *Program, hashWithT
 	to.handleFileDelete()
 	to.handlePendingEmit()
 	to.handlePendingCheck()
-	return to.snapshot
+	return snapshot
 }
 
 type toProgramSnapshot struct {

--- a/internal/execute/incremental/snapshot.go
+++ b/internal/execute/incremental/snapshot.go
@@ -227,6 +227,7 @@ type snapshot struct {
 	//  Cache of all files excluding default library file for the current program
 	allFilesExcludingDefaultLibraryFile []*ast.SourceFile
 	hasChangedDtsFile                   bool
+	hasEmitDiagnostics                  bool
 
 	// Used with testing to add text of hash for better comparison
 	hashWithText bool
@@ -311,4 +312,12 @@ func diagnosticToStringBuilder(diagnostic *ast.Diagnostic, file *ast.SourceFile,
 
 func (s *snapshot) computeHash(text string) string {
 	return ComputeHash(text, s.hashWithText)
+}
+
+func (s *snapshot) canUseIncrementalState() bool {
+	if !s.options.IsIncremental() && s.options.Build.IsTrue() {
+		// If not incremental build (with tsc -b), we don't need to track state except diagnostics per file so we can use it
+		return false
+	}
+	return true
 }

--- a/internal/execute/incremental/snapshottobuildinfo.go
+++ b/internal/execute/incremental/snapshottobuildinfo.go
@@ -195,7 +195,7 @@ func (t *toBuildInfo) collectRootFiles() {
 }
 
 func (t *toBuildInfo) setFileInfoAndEmitSignatures() {
-	t.buildInfo.FileInfos = core.Map(t.program.GetSourceFiles(), func(file *ast.SourceFile) *BuildInfoFileInfo {
+	t.buildInfo.FileInfos = core.MapNonNil(t.program.GetSourceFiles(), func(file *ast.SourceFile) *BuildInfoFileInfo {
 		info, _ := t.snapshot.fileInfos.Load(file.Path())
 		fileId := t.toFileId(file.Path())
 		//  tryAddRoot(key, fileId);
@@ -204,6 +204,11 @@ func (t *toBuildInfo) setFileInfoAndEmitSignatures() {
 				panic(fmt.Sprintf("File name at index %d does not match expected relative path or libName: %s != %s", fileId-1, t.buildInfo.FileNames[fileId-1], t.relativeToBuildInfo(string(file.Path()))))
 			}
 		}
+		if int(fileId) != len(t.buildInfo.FileNames) {
+			// Duplicate - for now ignore
+			return nil
+		}
+
 		if t.snapshot.options.Composite.IsTrue() {
 			if !ast.IsJsonSourceFile(file) && t.program.SourceFileMayBeEmitted(file, false) {
 				if emitSignature, loaded := t.snapshot.emitSignatures.Load(file.Path()); !loaded {
@@ -228,6 +233,9 @@ func (t *toBuildInfo) setFileInfoAndEmitSignatures() {
 		}
 		return newBuildInfoFileInfo(info)
 	})
+	if t.buildInfo.FileInfos == nil {
+		t.buildInfo.FileInfos = []*BuildInfoFileInfo{}
+	}
 }
 
 func (t *toBuildInfo) setRootOfIncrementalProgram() {

--- a/internal/execute/incremental/snapshottobuildinfo.go
+++ b/internal/execute/incremental/snapshottobuildinfo.go
@@ -16,9 +16,13 @@ import (
 )
 
 func snapshotToBuildInfo(snapshot *snapshot, program *compiler.Program, buildInfoFileName string) *BuildInfo {
+	buildInfo := &BuildInfo{
+		Version: core.Version(),
+	}
 	to := &toBuildInfo{
 		snapshot:           snapshot,
 		program:            program,
+		buildInfo:          buildInfo,
 		buildInfoDirectory: tspath.GetDirectoryPath(buildInfoFileName),
 		comparePathsOptions: tspath.ComparePathsOptions{
 			CurrentDirectory:          program.GetCurrentDirectory(),
@@ -29,7 +33,6 @@ func snapshotToBuildInfo(snapshot *snapshot, program *compiler.Program, buildInf
 		roots:                   make(map[*ast.SourceFile]tspath.Path),
 	}
 
-	to.buildInfo.Version = core.Version()
 	if snapshot.options.IsIncremental() {
 		to.collectRootFiles()
 		to.setFileInfoAndEmitSignatures()
@@ -41,21 +44,21 @@ func snapshotToBuildInfo(snapshot *snapshot, program *compiler.Program, buildInf
 		to.setEmitDiagnostics()
 		to.setAffectedFilesPendingEmit()
 		if snapshot.latestChangedDtsFile != "" {
-			to.buildInfo.LatestChangedDtsFile = to.relativeToBuildInfo(snapshot.latestChangedDtsFile)
+			buildInfo.LatestChangedDtsFile = to.relativeToBuildInfo(snapshot.latestChangedDtsFile)
 		}
 	} else {
 		to.setRootOfNonIncrementalProgram()
 	}
-	to.buildInfo.Errors = snapshot.hasErrors.IsTrue()
-	to.buildInfo.SemanticErrors = snapshot.hasSemanticErrors
-	to.buildInfo.CheckPending = snapshot.checkPending
-	return &to.buildInfo
+	buildInfo.Errors = snapshot.hasErrors.IsTrue()
+	buildInfo.SemanticErrors = snapshot.hasSemanticErrors
+	buildInfo.CheckPending = snapshot.checkPending
+	return buildInfo
 }
 
 type toBuildInfo struct {
 	snapshot                *snapshot
 	program                 *compiler.Program
-	buildInfo               BuildInfo
+	buildInfo               *BuildInfo
 	buildInfoDirectory      string
 	comparePathsOptions     tspath.ComparePathsOptions
 	fileNameToFileId        map[string]BuildInfoFileId

--- a/internal/execute/tsc/statistics.go
+++ b/internal/execute/tsc/statistics.go
@@ -126,26 +126,29 @@ func (s *Statistics) Report(w io.Writer, testing CommandLineTesting) {
 	table.print(w)
 }
 
-func (s *Statistics) Aggregate(stats []*Statistics, totalTime time.Duration) {
+func (s *Statistics) Aggregate(stat *Statistics) {
 	s.isAggregate = true
-	s.compileTimes = &CompileTimes{}
-	for _, stat := range stats {
-		// Aggregate statistics
-		s.files += stat.files
-		s.lines += stat.lines
-		s.identifiers += stat.identifiers
-		s.symbols += stat.symbols
-		s.types += stat.types
-		s.instantiations += stat.instantiations
-		s.memoryUsed += stat.memoryUsed
-		s.memoryAllocs += stat.memoryAllocs
-		s.compileTimes.ConfigTime += stat.compileTimes.ConfigTime
-		s.compileTimes.BuildInfoReadTime += stat.compileTimes.BuildInfoReadTime
-		s.compileTimes.ParseTime += stat.compileTimes.ParseTime
-		s.compileTimes.bindTime += stat.compileTimes.bindTime
-		s.compileTimes.checkTime += stat.compileTimes.checkTime
-		s.compileTimes.emitTime += stat.compileTimes.emitTime
-		s.compileTimes.ChangesComputeTime += stat.compileTimes.ChangesComputeTime
+	if s.compileTimes == nil {
+		s.compileTimes = &CompileTimes{}
 	}
+	// Aggregate statistics
+	s.files += stat.files
+	s.lines += stat.lines
+	s.identifiers += stat.identifiers
+	s.symbols += stat.symbols
+	s.types += stat.types
+	s.instantiations += stat.instantiations
+	s.memoryUsed += stat.memoryUsed
+	s.memoryAllocs += stat.memoryAllocs
+	s.compileTimes.ConfigTime += stat.compileTimes.ConfigTime
+	s.compileTimes.BuildInfoReadTime += stat.compileTimes.BuildInfoReadTime
+	s.compileTimes.ParseTime += stat.compileTimes.ParseTime
+	s.compileTimes.bindTime += stat.compileTimes.bindTime
+	s.compileTimes.checkTime += stat.compileTimes.checkTime
+	s.compileTimes.emitTime += stat.compileTimes.emitTime
+	s.compileTimes.ChangesComputeTime += stat.compileTimes.ChangesComputeTime
+}
+
+func (s *Statistics) SetTotalTime(totalTime time.Duration) {
 	s.compileTimes.totalTime = totalTime
 }

--- a/testdata/baselines/reference/tsbuild/clean/tsx-with-dts-emit.js
+++ b/testdata/baselines/reference/tsbuild/clean/tsx-with-dts-emit.js
@@ -76,7 +76,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
 *refresh*    /home/src/workspaces/solution/project/src/main.tsx
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project/src/main.tsx
 
 
 Edit [0]:: no change

--- a/testdata/baselines/reference/tsbuild/commandLine/emitDeclarationOnly-false-on-commandline-with-declaration.js
+++ b/testdata/baselines/reference/tsbuild/commandLine/emitDeclarationOnly-false-on-commandline-with-declaration.js
@@ -162,10 +162,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/solution/project1/src/c.ts
 *refresh*    /home/src/workspaces/solution/project1/src/d.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project1/src/a.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/b.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/c.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/d.ts
 
 project2/src/tsconfig.json::
 SemanticDiagnostics::
@@ -176,9 +172,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/solution/project1/src/b.d.ts
 *not cached* /home/src/workspaces/solution/project2/src/g.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project2/src/e.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/f.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/g.ts
 
 
 Edit [0]:: no change
@@ -219,9 +212,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/solution/project1/src/b.d.ts
 *not cached* /home/src/workspaces/solution/project2/src/g.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project2/src/e.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/f.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/g.ts
 
 
 Edit [1]:: change
@@ -271,10 +261,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/solution/project1/src/c.ts
 *refresh*    /home/src/workspaces/solution/project1/src/d.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project1/src/a.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/b.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/c.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/d.ts
 
 project2/src/tsconfig.json::
 SemanticDiagnostics::
@@ -285,9 +271,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/solution/project1/src/b.d.ts
 *not cached* /home/src/workspaces/solution/project2/src/g.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project2/src/e.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/f.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/g.ts
 
 
 Edit [2]:: emit js files
@@ -384,10 +367,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/solution/project1/src/c.ts
 *refresh*    /home/src/workspaces/solution/project1/src/d.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project1/src/a.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/b.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/c.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/d.ts
 
 project2/src/tsconfig.json::
 SemanticDiagnostics::
@@ -398,9 +377,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/solution/project1/src/b.d.ts
 *not cached* /home/src/workspaces/solution/project2/src/g.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project2/src/e.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/f.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/g.ts
 
 
 Edit [3]:: no change
@@ -441,9 +417,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/solution/project1/src/b.d.ts
 *not cached* /home/src/workspaces/solution/project2/src/g.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project2/src/e.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/f.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/g.ts
 
 
 Edit [4]:: no change run with js emit
@@ -487,9 +460,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/solution/project1/src/b.d.ts
 *not cached* /home/src/workspaces/solution/project2/src/g.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project2/src/e.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/f.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/g.ts
 
 
 Edit [5]:: js emit with change
@@ -553,10 +523,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/solution/project1/src/c.ts
 *refresh*    /home/src/workspaces/solution/project1/src/d.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project1/src/a.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/b.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/c.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/d.ts
 
 project2/src/tsconfig.json::
 SemanticDiagnostics::
@@ -567,6 +533,3 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/solution/project1/src/b.d.ts
 *not cached* /home/src/workspaces/solution/project2/src/g.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project2/src/e.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/f.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/g.ts

--- a/testdata/baselines/reference/tsbuild/commandLine/emitDeclarationOnly-on-commandline-with-declaration.js
+++ b/testdata/baselines/reference/tsbuild/commandLine/emitDeclarationOnly-on-commandline-with-declaration.js
@@ -162,10 +162,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/solution/project1/src/c.ts
 *refresh*    /home/src/workspaces/solution/project1/src/d.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project1/src/a.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/b.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/c.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/d.ts
 
 project2/src/tsconfig.json::
 SemanticDiagnostics::
@@ -176,9 +172,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/solution/project1/src/b.d.ts
 *not cached* /home/src/workspaces/solution/project2/src/g.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project2/src/e.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/f.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/g.ts
 
 
 Edit [0]:: no change
@@ -219,9 +212,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/solution/project1/src/b.d.ts
 *not cached* /home/src/workspaces/solution/project2/src/g.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project2/src/e.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/f.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/g.ts
 
 
 Edit [1]:: local change
@@ -271,10 +261,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/solution/project1/src/c.ts
 *refresh*    /home/src/workspaces/solution/project1/src/d.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project1/src/a.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/b.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/c.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/d.ts
 
 project2/src/tsconfig.json::
 SemanticDiagnostics::
@@ -285,9 +271,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/solution/project1/src/b.d.ts
 *not cached* /home/src/workspaces/solution/project2/src/g.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project2/src/e.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/f.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/g.ts
 
 
 Edit [2]:: non local change
@@ -340,10 +323,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/solution/project1/src/c.ts
 *refresh*    /home/src/workspaces/solution/project1/src/d.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project1/src/a.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/b.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/c.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/d.ts
 
 project2/src/tsconfig.json::
 SemanticDiagnostics::
@@ -354,9 +333,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/solution/project1/src/b.d.ts
 *not cached* /home/src/workspaces/solution/project2/src/g.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project2/src/e.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/f.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/g.ts
 
 
 Edit [3]:: emit js files
@@ -454,10 +430,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/solution/project1/src/c.ts
 *refresh*    /home/src/workspaces/solution/project1/src/d.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project1/src/a.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/b.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/c.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/d.ts
 
 project2/src/tsconfig.json::
 SemanticDiagnostics::
@@ -468,9 +440,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/solution/project1/src/b.d.ts
 *not cached* /home/src/workspaces/solution/project2/src/g.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project2/src/e.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/f.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/g.ts
 
 
 Edit [4]:: no change
@@ -511,9 +480,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/solution/project1/src/b.d.ts
 *not cached* /home/src/workspaces/solution/project2/src/g.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project2/src/e.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/f.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/g.ts
 
 
 Edit [5]:: js emit with change without emitDeclarationOnly
@@ -577,10 +543,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/solution/project1/src/c.ts
 *refresh*    /home/src/workspaces/solution/project1/src/d.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project1/src/a.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/b.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/c.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/d.ts
 
 project2/src/tsconfig.json::
 SemanticDiagnostics::
@@ -591,9 +553,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/solution/project1/src/b.d.ts
 *not cached* /home/src/workspaces/solution/project2/src/g.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project2/src/e.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/f.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/g.ts
 
 
 Edit [6]:: local change
@@ -643,10 +602,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/solution/project1/src/c.ts
 *refresh*    /home/src/workspaces/solution/project1/src/d.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project1/src/a.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/b.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/c.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/d.ts
 
 project2/src/tsconfig.json::
 SemanticDiagnostics::
@@ -657,9 +612,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/solution/project1/src/b.d.ts
 *not cached* /home/src/workspaces/solution/project2/src/g.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project2/src/e.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/f.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/g.ts
 
 
 Edit [7]:: non local change
@@ -712,10 +664,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/solution/project1/src/c.ts
 *refresh*    /home/src/workspaces/solution/project1/src/d.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project1/src/a.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/b.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/c.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/d.ts
 
 project2/src/tsconfig.json::
 SemanticDiagnostics::
@@ -726,9 +674,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/solution/project1/src/b.d.ts
 *not cached* /home/src/workspaces/solution/project2/src/g.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project2/src/e.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/f.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/g.ts
 
 
 Edit [8]:: js emit with change without emitDeclarationOnly
@@ -799,10 +744,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/solution/project1/src/c.ts
 *refresh*    /home/src/workspaces/solution/project1/src/d.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project1/src/a.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/b.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/c.ts
-(stored at emit) /home/src/workspaces/solution/project1/src/d.ts
 
 project2/src/tsconfig.json::
 SemanticDiagnostics::
@@ -813,6 +754,3 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/solution/project1/src/b.d.ts
 *not cached* /home/src/workspaces/solution/project2/src/g.ts
 Signatures::
-(stored at emit) /home/src/workspaces/solution/project2/src/e.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/f.ts
-(stored at emit) /home/src/workspaces/solution/project2/src/g.ts

--- a/testdata/baselines/reference/tsbuild/declarationEmit/reports-dts-generation-errors.js
+++ b/testdata/baselines/reference/tsbuild/declarationEmit/reports-dts-generation-errors.js
@@ -117,7 +117,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/project/node_modules/ky/distribution/index.d.ts
 *refresh*    /home/src/workspaces/project/index.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/index.ts
 
 
 Edit [0]:: no change
@@ -162,4 +161,3 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/project/node_modules/ky/distribution/index.d.ts
 *refresh*    /home/src/workspaces/project/index.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/index.ts

--- a/testdata/baselines/reference/tsbuild/extends/configDir-template.js
+++ b/testdata/baselines/reference/tsbuild/extends/configDir-template.js
@@ -129,5 +129,3 @@ SemanticDiagnostics::
 *refresh*    /home/src/projects/myproject/types/sometype.ts
 *refresh*    /home/src/projects/myproject/main.ts
 Signatures::
-(stored at emit) /home/src/projects/myproject/types/sometype.ts
-(stored at emit) /home/src/projects/myproject/main.ts

--- a/testdata/baselines/reference/tsbuild/noCheck/dts-errors.js
+++ b/testdata/baselines/reference/tsbuild/noCheck/dts-errors.js
@@ -113,8 +113,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/project/a.ts
 *not cached* /home/src/workspaces/project/b.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
 
 
 Edit [0]:: no change
@@ -154,8 +152,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/project/a.ts
 *not cached* /home/src/workspaces/project/b.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
 
 
 Edit [1]:: Fix `a` error with noCheck
@@ -212,8 +208,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/project/a.ts
 *not cached* /home/src/workspaces/project/b.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
 
 
 Edit [2]:: no change
@@ -273,8 +267,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/project/a.ts
 *refresh*    /home/src/workspaces/project/b.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
 
 
 Edit [4]:: No Change run with checking
@@ -377,8 +369,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/project/a.ts
 *not cached* /home/src/workspaces/project/b.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
 
 
 Edit [7]:: no change
@@ -418,8 +408,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/project/a.ts
 *not cached* /home/src/workspaces/project/b.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
 
 
 Edit [8]:: No Change run with checking
@@ -479,8 +467,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/project/a.ts
 *refresh*    /home/src/workspaces/project/b.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
 
 
 Edit [9]:: Fix `a` error with noCheck
@@ -537,8 +523,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/project/a.ts
 *not cached* /home/src/workspaces/project/b.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
 
 
 Edit [10]:: No Change run with checking
@@ -585,8 +569,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/project/a.ts
 *refresh*    /home/src/workspaces/project/b.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
 
 
 Edit [11]:: Add file with error
@@ -660,9 +642,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/project/b.ts
 *refresh*    /home/src/workspaces/project/c.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
-(stored at emit) /home/src/workspaces/project/c.ts
 
 
 Edit [12]:: Introduce error with noCheck
@@ -748,9 +727,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/project/b.ts
 *not cached* /home/src/workspaces/project/c.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
-(stored at emit) /home/src/workspaces/project/c.ts
 
 
 Edit [13]:: Fix `a` error with noCheck
@@ -816,9 +792,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/project/b.ts
 *not cached* /home/src/workspaces/project/c.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
-(stored at emit) /home/src/workspaces/project/c.ts
 
 
 Edit [14]:: No Change run with checking
@@ -883,9 +856,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/project/b.ts
 *refresh*    /home/src/workspaces/project/c.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
-(stored at emit) /home/src/workspaces/project/c.ts
 
 
 Edit [15]:: no change
@@ -937,6 +907,3 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/project/b.ts
 *refresh*    /home/src/workspaces/project/c.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
-(stored at emit) /home/src/workspaces/project/c.ts

--- a/testdata/baselines/reference/tsbuild/noCheck/semantic-errors.js
+++ b/testdata/baselines/reference/tsbuild/noCheck/semantic-errors.js
@@ -93,8 +93,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/project/a.ts
 *not cached* /home/src/workspaces/project/b.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
 
 
 Edit [0]:: no change
@@ -139,8 +137,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/project/a.ts
 *not cached* /home/src/workspaces/project/b.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
 
 
 Edit [2]:: no change
@@ -200,8 +196,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/project/a.ts
 *refresh*    /home/src/workspaces/project/b.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
 
 
 Edit [4]:: No Change run with checking
@@ -279,8 +273,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/project/a.ts
 *not cached* /home/src/workspaces/project/b.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
 
 
 Edit [7]:: no change
@@ -349,8 +341,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/project/a.ts
 *refresh*    /home/src/workspaces/project/b.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
 
 
 Edit [9]:: Fix `a` error with noCheck
@@ -402,8 +392,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/project/a.ts
 *not cached* /home/src/workspaces/project/b.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
 
 
 Edit [10]:: No Change run with checking
@@ -450,8 +438,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/project/a.ts
 *refresh*    /home/src/workspaces/project/b.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
 
 
 Edit [11]:: Add file with error
@@ -525,9 +511,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/project/b.ts
 *refresh*    /home/src/workspaces/project/c.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
-(stored at emit) /home/src/workspaces/project/c.ts
 
 
 Edit [12]:: Introduce error with noCheck
@@ -588,9 +571,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/project/b.ts
 *not cached* /home/src/workspaces/project/c.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
-(stored at emit) /home/src/workspaces/project/c.ts
 
 
 Edit [13]:: Fix `a` error with noCheck
@@ -625,9 +605,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/project/b.ts
 *not cached* /home/src/workspaces/project/c.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
-(stored at emit) /home/src/workspaces/project/c.ts
 
 
 Edit [14]:: No Change run with checking
@@ -692,9 +669,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/project/b.ts
 *refresh*    /home/src/workspaces/project/c.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
-(stored at emit) /home/src/workspaces/project/c.ts
 
 
 Edit [15]:: no change
@@ -746,6 +720,3 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/project/b.ts
 *refresh*    /home/src/workspaces/project/c.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
-(stored at emit) /home/src/workspaces/project/c.ts

--- a/testdata/baselines/reference/tsbuild/noCheck/syntax-errors.js
+++ b/testdata/baselines/reference/tsbuild/noCheck/syntax-errors.js
@@ -102,8 +102,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/project/a.ts
 *not cached* /home/src/workspaces/project/b.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
 
 
 Edit [0]:: no change
@@ -139,8 +137,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/project/a.ts
 *not cached* /home/src/workspaces/project/b.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
 
 
 Edit [1]:: Fix `a` error with noCheck
@@ -195,8 +191,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/project/a.ts
 *not cached* /home/src/workspaces/project/b.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
 
 
 Edit [2]:: no change
@@ -256,8 +250,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/project/a.ts
 *refresh*    /home/src/workspaces/project/b.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
 
 
 Edit [4]:: No Change run with checking
@@ -347,8 +339,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/project/a.ts
 *not cached* /home/src/workspaces/project/b.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
 
 
 Edit [7]:: no change
@@ -384,8 +374,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/project/a.ts
 *not cached* /home/src/workspaces/project/b.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
 
 
 Edit [8]:: No Change run with checking
@@ -441,8 +429,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/project/a.ts
 *not cached* /home/src/workspaces/project/b.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
 
 
 Edit [9]:: Fix `a` error with noCheck
@@ -497,8 +483,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/project/a.ts
 *not cached* /home/src/workspaces/project/b.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
 
 
 Edit [10]:: No Change run with checking
@@ -545,8 +529,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/project/a.ts
 *refresh*    /home/src/workspaces/project/b.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
 
 
 Edit [11]:: Add file with error
@@ -620,9 +602,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/project/b.ts
 *refresh*    /home/src/workspaces/project/c.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
-(stored at emit) /home/src/workspaces/project/c.ts
 
 
 Edit [12]:: Introduce error with noCheck
@@ -695,9 +674,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/project/b.ts
 *not cached* /home/src/workspaces/project/c.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
-(stored at emit) /home/src/workspaces/project/c.ts
 
 
 Edit [13]:: Fix `a` error with noCheck
@@ -761,9 +737,6 @@ SemanticDiagnostics::
 *not cached* /home/src/workspaces/project/b.ts
 *not cached* /home/src/workspaces/project/c.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
-(stored at emit) /home/src/workspaces/project/c.ts
 
 
 Edit [14]:: No Change run with checking
@@ -828,9 +801,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/project/b.ts
 *refresh*    /home/src/workspaces/project/c.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
-(stored at emit) /home/src/workspaces/project/c.ts
 
 
 Edit [15]:: no change
@@ -882,6 +852,3 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/project/b.ts
 *refresh*    /home/src/workspaces/project/c.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/a.ts
-(stored at emit) /home/src/workspaces/project/b.ts
-(stored at emit) /home/src/workspaces/project/c.ts

--- a/testdata/baselines/reference/tsbuild/noEmit/dts-errors-with-declaration-enable-changes.js
+++ b/testdata/baselines/reference/tsbuild/noEmit/dts-errors-with-declaration-enable-changes.js
@@ -263,7 +263,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
 *refresh*    /home/src/projects/project/a.ts
 Signatures::
-(stored at emit) /home/src/projects/project/a.ts
 
 
 Edit [5]:: Fix the error

--- a/testdata/baselines/reference/tsbuild/noEmit/dts-errors.js
+++ b/testdata/baselines/reference/tsbuild/noEmit/dts-errors.js
@@ -199,7 +199,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
 *refresh*    /home/src/projects/project/a.ts
 Signatures::
-(stored at emit) /home/src/projects/project/a.ts
 
 
 Edit [4]:: no change
@@ -309,7 +308,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
 *refresh*    /home/src/projects/project/a.ts
 Signatures::
-(stored at emit) /home/src/projects/project/a.ts
 
 
 Edit [7]:: no change

--- a/testdata/baselines/reference/tsbuild/noEmitOnError/dts-errors-with-declaration.js
+++ b/testdata/baselines/reference/tsbuild/noEmitOnError/dts-errors-with-declaration.js
@@ -223,9 +223,6 @@ SemanticDiagnostics::
 *refresh*    /user/username/projects/noEmitOnError/src/main.ts
 *refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::
-(stored at emit) /user/username/projects/noEmitOnError/shared/types/db.ts
-(stored at emit) /user/username/projects/noEmitOnError/src/main.ts
-(stored at emit) /user/username/projects/noEmitOnError/src/other.ts
 
 
 Edit [2]:: no change

--- a/testdata/baselines/reference/tsbuild/noEmitOnError/semantic-errors-with-declaration.js
+++ b/testdata/baselines/reference/tsbuild/noEmitOnError/semantic-errors-with-declaration.js
@@ -207,9 +207,6 @@ SemanticDiagnostics::
 *refresh*    /user/username/projects/noEmitOnError/src/main.ts
 *refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::
-(stored at emit) /user/username/projects/noEmitOnError/shared/types/db.ts
-(stored at emit) /user/username/projects/noEmitOnError/src/main.ts
-(stored at emit) /user/username/projects/noEmitOnError/src/other.ts
 
 
 Edit [2]:: no change

--- a/testdata/baselines/reference/tsbuild/noEmitOnError/syntax-errors-with-declaration.js
+++ b/testdata/baselines/reference/tsbuild/noEmitOnError/syntax-errors-with-declaration.js
@@ -213,9 +213,6 @@ SemanticDiagnostics::
 *refresh*    /user/username/projects/noEmitOnError/src/main.ts
 *refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::
-(stored at emit) /user/username/projects/noEmitOnError/shared/types/db.ts
-(stored at emit) /user/username/projects/noEmitOnError/src/main.ts
-(stored at emit) /user/username/projects/noEmitOnError/src/other.ts
 
 
 Edit [2]:: no change

--- a/testdata/baselines/reference/tsbuild/projectReferenceWithRootDirInParent/reports-error-for-same-tsbuildinfo-file-without-incremental.js
+++ b/testdata/baselines/reference/tsbuild/projectReferenceWithRootDirInParent/reports-error-for-same-tsbuildinfo-file-without-incremental.js
@@ -159,8 +159,7 @@ Signatures::
 
 src/main/tsconfig.json::
 SemanticDiagnostics::
+*not cached* /home/src/tslibs/TS/Lib/lib.d.ts
 *not cached* /home/src/workspaces/solution/src/main/b.ts
 *not cached* /home/src/workspaces/solution/src/main/a.ts
 Signatures::
-(computed .d.ts) /home/src/workspaces/solution/src/main/b.ts
-(computed .d.ts) /home/src/workspaces/solution/src/main/a.ts

--- a/testdata/baselines/reference/tsbuild/sample/builds-correctly-when-project-is-not-composite-or-doesnt-have-any-references.js
+++ b/testdata/baselines/reference/tsbuild/sample/builds-correctly-when-project-is-not-composite-or-doesnt-have-any-references.js
@@ -156,5 +156,3 @@ SemanticDiagnostics::
 *refresh*    /user/username/projects/sample1/core/index.ts
 *refresh*    /user/username/projects/sample1/core/some_decl.d.ts
 Signatures::
-(stored at emit) /user/username/projects/sample1/core/anotherModule.ts
-(stored at emit) /user/username/projects/sample1/core/index.ts

--- a/testdata/baselines/reference/tsbuildWatch/extends/configDir-template.js
+++ b/testdata/baselines/reference/tsbuildWatch/extends/configDir-template.js
@@ -174,14 +174,20 @@ types/sometype.ts
    Imported via "@myscope/sometype" from file 'main.ts'
 main.ts
    Part of 'files' list in tsconfig.json
-[[90mHH:MM:SS AM[0m] Updating unchanged output timestamps of project 'tsconfig.json'...
-
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-//// [/home/src/projects/myproject/decls/main.d.ts] *mTime changed*
-//// [/home/src/projects/myproject/outDir/main.js] *mTime changed*
-//// [/home/src/projects/myproject/outDir/tsconfig.tsbuildinfo] *mTime changed*
+//// [/home/src/projects/myproject/decls/main.d.ts] *rewrite with same content*
+//// [/home/src/projects/myproject/decls/types/sometype.d.ts] *rewrite with same content*
+//// [/home/src/projects/myproject/outDir/main.js] *rewrite with same content*
+//// [/home/src/projects/myproject/outDir/tsconfig.tsbuildinfo] *rewrite with same content*
+//// [/home/src/projects/myproject/outDir/tsconfig.tsbuildinfo.readable.baseline.txt] *rewrite with same content*
+//// [/home/src/projects/myproject/outDir/types/sometype.js] *rewrite with same content*
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /home/src/projects/myproject/types/sometype.ts
+*refresh*    /home/src/projects/myproject/main.ts
 Signatures::
+(stored at emit) /home/src/projects/myproject/types/sometype.ts
+(stored at emit) /home/src/projects/myproject/main.ts

--- a/testdata/baselines/reference/tsbuildWatch/extends/configDir-template.js
+++ b/testdata/baselines/reference/tsbuildWatch/extends/configDir-template.js
@@ -133,8 +133,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/projects/myproject/types/sometype.ts
 *refresh*    /home/src/projects/myproject/main.ts
 Signatures::
-(stored at emit) /home/src/projects/myproject/types/sometype.ts
-(stored at emit) /home/src/projects/myproject/main.ts
 
 
 Edit [0]:: edit extended config file
@@ -189,5 +187,3 @@ SemanticDiagnostics::
 *refresh*    /home/src/projects/myproject/types/sometype.ts
 *refresh*    /home/src/projects/myproject/main.ts
 Signatures::
-(stored at emit) /home/src/projects/myproject/types/sometype.ts
-(stored at emit) /home/src/projects/myproject/main.ts

--- a/testdata/baselines/reference/tsbuildWatch/moduleResolution/resolves-specifier-in-output-declaration-file-from-referenced-project-correctly-with-cts-and-mts-extensions.js
+++ b/testdata/baselines/reference/tsbuildWatch/moduleResolution/resolves-specifier-in-output-declaration-file-from-referenced-project-correctly-with-cts-and-mts-extensions.js
@@ -494,8 +494,8 @@ Signatures::
 
 packages/pkg1/tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.es2022.full.d.ts
+*refresh*    /user/username/projects/myproject/packages/pkg2/build/const.d.cts
 *refresh*    /user/username/projects/myproject/packages/pkg2/build/index.d.cts
 *refresh*    /user/username/projects/myproject/packages/pkg1/index.ts
 Signatures::
-(used version)   /user/username/projects/myproject/packages/pkg2/build/index.d.cts
-(computed .d.ts) /user/username/projects/myproject/packages/pkg1/index.ts

--- a/testdata/baselines/reference/tsbuildWatch/noEmit/does-not-go-in-loop-when-watching-when-no-files-are-emitted.js
+++ b/testdata/baselines/reference/tsbuildWatch/noEmit/does-not-go-in-loop-when-watching-when-no-files-are-emitted.js
@@ -94,14 +94,16 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Updating unchanged output timestamps of project 'tsconfig.json'...
-
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-//// [/user/username/projects/myproject/tsconfig.tsbuildinfo] *mTime changed*
+//// [/user/username/projects/myproject/tsconfig.tsbuildinfo] *rewrite with same content*
+//// [/user/username/projects/myproject/tsconfig.tsbuildinfo.readable.baseline.txt] *rewrite with same content*
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /user/username/projects/myproject/a.js
+*refresh*    /user/username/projects/myproject/b.ts
 Signatures::
 
 
@@ -129,5 +131,5 @@ tsconfig.json::
 SemanticDiagnostics::
 *refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
 *refresh*    /user/username/projects/myproject/a.js
+*refresh*    /user/username/projects/myproject/b.ts
 Signatures::
-(computed .d.ts) /user/username/projects/myproject/a.js

--- a/testdata/baselines/reference/tsbuildWatch/noEmit/dts-errors-without-dts-enabled.js
+++ b/testdata/baselines/reference/tsbuildWatch/noEmit/dts-errors-without-dts-enabled.js
@@ -96,7 +96,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
 *refresh*    /home/src/projects/project/a.ts
 Signatures::
-(computed .d.ts) /home/src/projects/project/a.ts
 
 
 Edit [1]:: Emit after fixing error
@@ -129,6 +128,8 @@ const a = "hello";
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /home/src/projects/project/a.ts
 Signatures::
 
 
@@ -152,14 +153,15 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Updating unchanged output timestamps of project 'tsconfig.json'...
-
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-//// [/home/src/projects/project/tsconfig.tsbuildinfo] *mTime changed*
+//// [/home/src/projects/project/tsconfig.tsbuildinfo] *rewrite with same content*
+//// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *rewrite with same content*
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /home/src/projects/project/a.ts
 Signatures::
 
 
@@ -188,7 +190,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
 *refresh*    /home/src/projects/project/a.ts
 Signatures::
-(computed .d.ts) /home/src/projects/project/a.ts
 
 
 Edit [4]:: Emit when error
@@ -223,6 +224,8 @@ const a = class {
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /home/src/projects/project/a.ts
 Signatures::
 
 
@@ -246,12 +249,13 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Updating unchanged output timestamps of project 'tsconfig.json'...
-
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-//// [/home/src/projects/project/tsconfig.tsbuildinfo] *mTime changed*
+//// [/home/src/projects/project/tsconfig.tsbuildinfo] *rewrite with same content*
+//// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *rewrite with same content*
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /home/src/projects/project/a.ts
 Signatures::

--- a/testdata/baselines/reference/tsbuildWatch/noEmit/dts-errors.js
+++ b/testdata/baselines/reference/tsbuildWatch/noEmit/dts-errors.js
@@ -157,7 +157,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
 *refresh*    /home/src/projects/project/a.ts
 Signatures::
-(stored at emit) /home/src/projects/project/a.ts
 
 
 Edit [2]:: no Emit run after fixing error
@@ -293,7 +292,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
 *refresh*    /home/src/projects/project/a.ts
 Signatures::
-(stored at emit) /home/src/projects/project/a.ts
 
 
 Edit [5]:: no Emit run when error

--- a/testdata/baselines/reference/tsbuildWatch/noEmit/dts-errors.js
+++ b/testdata/baselines/reference/tsbuildWatch/noEmit/dts-errors.js
@@ -119,7 +119,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
 *refresh*    /home/src/projects/project/a.ts
 Signatures::
-(computed .d.ts) /home/src/projects/project/a.ts
 
 
 Edit [1]:: Emit after fixing error
@@ -155,7 +154,10 @@ const a = "hello";
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /home/src/projects/project/a.ts
 Signatures::
+(stored at emit) /home/src/projects/project/a.ts
 
 
 Edit [2]:: no Emit run after fixing error
@@ -178,14 +180,15 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Updating unchanged output timestamps of project 'tsconfig.json'...
-
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-//// [/home/src/projects/project/tsconfig.tsbuildinfo] *mTime changed*
+//// [/home/src/projects/project/tsconfig.tsbuildinfo] *rewrite with same content*
+//// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *rewrite with same content*
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /home/src/projects/project/a.ts
 Signatures::
 
 
@@ -237,7 +240,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
 *refresh*    /home/src/projects/project/a.ts
 Signatures::
-(computed .d.ts) /home/src/projects/project/a.ts
 
 
 Edit [4]:: Emit when error
@@ -288,7 +290,10 @@ const a = class {
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /home/src/projects/project/a.ts
 Signatures::
+(stored at emit) /home/src/projects/project/a.ts
 
 
 Edit [5]:: no Emit run when error
@@ -322,7 +327,11 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
 
+//// [/home/src/projects/project/tsconfig.tsbuildinfo] *rewrite with same content*
+//// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *rewrite with same content*
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /home/src/projects/project/a.ts
 Signatures::

--- a/testdata/baselines/reference/tsbuildWatch/noEmit/semantic-errors.js
+++ b/testdata/baselines/reference/tsbuildWatch/noEmit/semantic-errors.js
@@ -115,7 +115,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
 *refresh*    /home/src/projects/project/a.ts
 Signatures::
-(computed .d.ts) /home/src/projects/project/a.ts
 
 
 Edit [1]:: Emit after fixing error
@@ -148,6 +147,8 @@ const a = "hello";
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /home/src/projects/project/a.ts
 Signatures::
 
 
@@ -171,14 +172,15 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Updating unchanged output timestamps of project 'tsconfig.json'...
-
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-//// [/home/src/projects/project/tsconfig.tsbuildinfo] *mTime changed*
+//// [/home/src/projects/project/tsconfig.tsbuildinfo] *rewrite with same content*
+//// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *rewrite with same content*
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /home/src/projects/project/a.ts
 Signatures::
 
 
@@ -226,7 +228,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
 *refresh*    /home/src/projects/project/a.ts
 Signatures::
-(computed .d.ts) /home/src/projects/project/a.ts
 
 
 Edit [4]:: Emit when error
@@ -262,6 +263,8 @@ Output::
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /home/src/projects/project/a.ts
 Signatures::
 
 
@@ -292,7 +295,11 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
 
+//// [/home/src/projects/project/tsconfig.tsbuildinfo] *rewrite with same content*
+//// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *rewrite with same content*
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /home/src/projects/project/a.ts
 Signatures::

--- a/testdata/baselines/reference/tsbuildWatch/noEmit/syntax-errors.js
+++ b/testdata/baselines/reference/tsbuildWatch/noEmit/syntax-errors.js
@@ -115,7 +115,6 @@ SemanticDiagnostics::
 *refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
 *refresh*    /home/src/projects/project/a.ts
 Signatures::
-(computed .d.ts) /home/src/projects/project/a.ts
 
 
 Edit [1]:: Emit after fixing error
@@ -148,6 +147,8 @@ const a = "hello";
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /home/src/projects/project/a.ts
 Signatures::
 
 
@@ -171,14 +172,15 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Updating unchanged output timestamps of project 'tsconfig.json'...
-
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-//// [/home/src/projects/project/tsconfig.tsbuildinfo] *mTime changed*
+//// [/home/src/projects/project/tsconfig.tsbuildinfo] *rewrite with same content*
+//// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *rewrite with same content*
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /home/src/projects/project/a.ts
 Signatures::
 
 
@@ -223,6 +225,7 @@ Output::
 
 tsconfig.json::
 SemanticDiagnostics::
+*not cached* /home/src/tslibs/TS/Lib/lib.d.ts
 *not cached* /home/src/projects/project/a.ts
 Signatures::
 
@@ -262,9 +265,9 @@ const a = "hello;
 
 tsconfig.json::
 SemanticDiagnostics::
+*not cached* /home/src/tslibs/TS/Lib/lib.d.ts
 *not cached* /home/src/projects/project/a.ts
 Signatures::
-(computed .d.ts) /home/src/projects/project/a.ts
 
 
 Edit [5]:: no Emit run when error
@@ -294,8 +297,11 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
 
+//// [/home/src/projects/project/tsconfig.tsbuildinfo] *rewrite with same content*
+//// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *rewrite with same content*
 
 tsconfig.json::
 SemanticDiagnostics::
+*not cached* /home/src/tslibs/TS/Lib/lib.d.ts
 *not cached* /home/src/projects/project/a.ts
 Signatures::

--- a/testdata/baselines/reference/tsbuildWatch/noEmitOnError/noEmitOnError-with-declaration.js
+++ b/testdata/baselines/reference/tsbuildWatch/noEmitOnError/noEmitOnError-with-declaration.js
@@ -124,6 +124,8 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
 
+//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo.readable.baseline.txt] *rewrite with same content*
 
 tsconfig.json::
 SemanticDiagnostics::
@@ -217,7 +219,7 @@ SemanticDiagnostics::
 *refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::
 (stored at emit) /user/username/projects/noEmitOnError/shared/types/db.ts
-(computed .d.ts) /user/username/projects/noEmitOnError/src/main.ts
+(stored at emit) /user/username/projects/noEmitOnError/src/main.ts
 (stored at emit) /user/username/projects/noEmitOnError/src/other.ts
 
 
@@ -235,21 +237,27 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Updating unchanged output timestamps of project 'tsconfig.json'...
-
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.d.ts] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.js] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/src/main.d.ts] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/src/main.js] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/src/other.d.ts] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/src/other.js] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo] *mTime changed*
+//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.d.ts] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.js] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/src/main.d.ts] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/src/main.js] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/src/other.d.ts] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/src/other.js] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo.readable.baseline.txt] *rewrite with same content*
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /user/username/projects/noEmitOnError/shared/types/db.ts
+*refresh*    /user/username/projects/noEmitOnError/src/main.ts
+*refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::
+(stored at emit) /user/username/projects/noEmitOnError/shared/types/db.ts
+(stored at emit) /user/username/projects/noEmitOnError/src/main.ts
+(stored at emit) /user/username/projects/noEmitOnError/src/other.ts
 
 
 Edit [3]:: semantic errors
@@ -306,9 +314,11 @@ Output::
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /user/username/projects/noEmitOnError/shared/types/db.ts
 *refresh*    /user/username/projects/noEmitOnError/src/main.ts
+*refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::
-(computed .d.ts) /user/username/projects/noEmitOnError/src/main.ts
 
 
 Edit [4]:: No Change
@@ -332,9 +342,15 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
 
+//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo.readable.baseline.txt] *rewrite with same content*
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /user/username/projects/noEmitOnError/shared/types/db.ts
+*refresh*    /user/username/projects/noEmitOnError/src/main.ts
+*refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::
 
 
@@ -354,20 +370,18 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Updating unchanged output timestamps of project 'tsconfig.json'...
-
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.d.ts] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.js] *mTime changed*
+//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.d.ts] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.js] *rewrite with same content*
 //// [/user/username/projects/noEmitOnError/dev-build/src/main.d.ts] *rewrite with same content*
 //// [/user/username/projects/noEmitOnError/dev-build/src/main.js] *modified* 
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const a = "hello";
 
-//// [/user/username/projects/noEmitOnError/dev-build/src/other.d.ts] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/src/other.js] *mTime changed*
+//// [/user/username/projects/noEmitOnError/dev-build/src/other.d.ts] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/src/other.js] *rewrite with same content*
 //// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo] *modified* 
 {"version":"FakeTSVersion","root":["../shared/types/db.ts","../src/main.ts","../src/other.ts"]}
 //// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
@@ -398,9 +412,14 @@ const a = "hello";
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /user/username/projects/noEmitOnError/shared/types/db.ts
 *refresh*    /user/username/projects/noEmitOnError/src/main.ts
+*refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::
-(computed .d.ts) /user/username/projects/noEmitOnError/src/main.ts
+(stored at emit) /user/username/projects/noEmitOnError/shared/types/db.ts
+(stored at emit) /user/username/projects/noEmitOnError/src/main.ts
+(stored at emit) /user/username/projects/noEmitOnError/src/other.ts
 
 
 Edit [6]:: No Change
@@ -417,21 +436,27 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Updating unchanged output timestamps of project 'tsconfig.json'...
-
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.d.ts] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.js] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/src/main.d.ts] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/src/main.js] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/src/other.d.ts] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/src/other.js] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo] *mTime changed*
+//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.d.ts] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.js] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/src/main.d.ts] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/src/main.js] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/src/other.d.ts] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/src/other.js] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo.readable.baseline.txt] *rewrite with same content*
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /user/username/projects/noEmitOnError/shared/types/db.ts
+*refresh*    /user/username/projects/noEmitOnError/src/main.ts
+*refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::
+(stored at emit) /user/username/projects/noEmitOnError/shared/types/db.ts
+(stored at emit) /user/username/projects/noEmitOnError/src/main.ts
+(stored at emit) /user/username/projects/noEmitOnError/src/other.ts
 
 
 Edit [7]:: dts errors
@@ -492,9 +517,11 @@ Output::
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /user/username/projects/noEmitOnError/shared/types/db.ts
 *refresh*    /user/username/projects/noEmitOnError/src/main.ts
+*refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::
-(computed .d.ts) /user/username/projects/noEmitOnError/src/main.ts
 
 
 Edit [8]:: No Change
@@ -522,9 +549,15 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
 
+//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo.readable.baseline.txt] *rewrite with same content*
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /user/username/projects/noEmitOnError/shared/types/db.ts
+*refresh*    /user/username/projects/noEmitOnError/src/main.ts
+*refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::
 
 
@@ -544,12 +577,10 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Updating unchanged output timestamps of project 'tsconfig.json'...
-
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.d.ts] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.js] *mTime changed*
+//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.d.ts] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.js] *rewrite with same content*
 //// [/user/username/projects/noEmitOnError/dev-build/src/main.d.ts] *modified* 
 export declare const a: {
     new (): {
@@ -566,8 +597,8 @@ const a = class {
 };
 exports.a = a;
 
-//// [/user/username/projects/noEmitOnError/dev-build/src/other.d.ts] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/src/other.js] *mTime changed*
+//// [/user/username/projects/noEmitOnError/dev-build/src/other.d.ts] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/src/other.js] *rewrite with same content*
 //// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo] *modified* 
 {"version":"FakeTSVersion","root":["../shared/types/db.ts","../src/main.ts","../src/other.ts"]}
 //// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
@@ -598,9 +629,14 @@ exports.a = a;
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /user/username/projects/noEmitOnError/shared/types/db.ts
 *refresh*    /user/username/projects/noEmitOnError/src/main.ts
+*refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::
-(computed .d.ts) /user/username/projects/noEmitOnError/src/main.ts
+(stored at emit) /user/username/projects/noEmitOnError/shared/types/db.ts
+(stored at emit) /user/username/projects/noEmitOnError/src/main.ts
+(stored at emit) /user/username/projects/noEmitOnError/src/other.ts
 
 
 Edit [10]:: No Change
@@ -617,18 +653,24 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Updating unchanged output timestamps of project 'tsconfig.json'...
-
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.d.ts] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.js] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/src/main.d.ts] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/src/main.js] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/src/other.d.ts] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/src/other.js] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo] *mTime changed*
+//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.d.ts] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.js] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/src/main.d.ts] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/src/main.js] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/src/other.d.ts] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/src/other.js] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo.readable.baseline.txt] *rewrite with same content*
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /user/username/projects/noEmitOnError/shared/types/db.ts
+*refresh*    /user/username/projects/noEmitOnError/src/main.ts
+*refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::
+(stored at emit) /user/username/projects/noEmitOnError/shared/types/db.ts
+(stored at emit) /user/username/projects/noEmitOnError/src/main.ts
+(stored at emit) /user/username/projects/noEmitOnError/src/other.ts

--- a/testdata/baselines/reference/tsbuildWatch/noEmitOnError/noEmitOnError-with-declaration.js
+++ b/testdata/baselines/reference/tsbuildWatch/noEmitOnError/noEmitOnError-with-declaration.js
@@ -218,9 +218,6 @@ SemanticDiagnostics::
 *refresh*    /user/username/projects/noEmitOnError/src/main.ts
 *refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::
-(stored at emit) /user/username/projects/noEmitOnError/shared/types/db.ts
-(stored at emit) /user/username/projects/noEmitOnError/src/main.ts
-(stored at emit) /user/username/projects/noEmitOnError/src/other.ts
 
 
 Edit [2]:: No Change
@@ -255,9 +252,6 @@ SemanticDiagnostics::
 *refresh*    /user/username/projects/noEmitOnError/src/main.ts
 *refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::
-(stored at emit) /user/username/projects/noEmitOnError/shared/types/db.ts
-(stored at emit) /user/username/projects/noEmitOnError/src/main.ts
-(stored at emit) /user/username/projects/noEmitOnError/src/other.ts
 
 
 Edit [3]:: semantic errors
@@ -417,9 +411,6 @@ SemanticDiagnostics::
 *refresh*    /user/username/projects/noEmitOnError/src/main.ts
 *refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::
-(stored at emit) /user/username/projects/noEmitOnError/shared/types/db.ts
-(stored at emit) /user/username/projects/noEmitOnError/src/main.ts
-(stored at emit) /user/username/projects/noEmitOnError/src/other.ts
 
 
 Edit [6]:: No Change
@@ -454,9 +445,6 @@ SemanticDiagnostics::
 *refresh*    /user/username/projects/noEmitOnError/src/main.ts
 *refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::
-(stored at emit) /user/username/projects/noEmitOnError/shared/types/db.ts
-(stored at emit) /user/username/projects/noEmitOnError/src/main.ts
-(stored at emit) /user/username/projects/noEmitOnError/src/other.ts
 
 
 Edit [7]:: dts errors
@@ -634,9 +622,6 @@ SemanticDiagnostics::
 *refresh*    /user/username/projects/noEmitOnError/src/main.ts
 *refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::
-(stored at emit) /user/username/projects/noEmitOnError/shared/types/db.ts
-(stored at emit) /user/username/projects/noEmitOnError/src/main.ts
-(stored at emit) /user/username/projects/noEmitOnError/src/other.ts
 
 
 Edit [10]:: No Change
@@ -671,6 +656,3 @@ SemanticDiagnostics::
 *refresh*    /user/username/projects/noEmitOnError/src/main.ts
 *refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::
-(stored at emit) /user/username/projects/noEmitOnError/shared/types/db.ts
-(stored at emit) /user/username/projects/noEmitOnError/src/main.ts
-(stored at emit) /user/username/projects/noEmitOnError/src/other.ts

--- a/testdata/baselines/reference/tsbuildWatch/noEmitOnError/noEmitOnError.js
+++ b/testdata/baselines/reference/tsbuildWatch/noEmitOnError/noEmitOnError.js
@@ -124,6 +124,8 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
 
+//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo.readable.baseline.txt] *rewrite with same content*
 
 tsconfig.json::
 SemanticDiagnostics::
@@ -205,7 +207,6 @@ SemanticDiagnostics::
 *refresh*    /user/username/projects/noEmitOnError/src/main.ts
 *refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::
-(computed .d.ts) /user/username/projects/noEmitOnError/src/main.ts
 
 
 Edit [2]:: No Change
@@ -222,17 +223,20 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Updating unchanged output timestamps of project 'tsconfig.json'...
-
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.js] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/src/main.js] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/src/other.js] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo] *mTime changed*
+//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.js] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/src/main.js] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/src/other.js] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo.readable.baseline.txt] *rewrite with same content*
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /user/username/projects/noEmitOnError/shared/types/db.ts
+*refresh*    /user/username/projects/noEmitOnError/src/main.ts
+*refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::
 
 
@@ -290,9 +294,11 @@ Output::
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /user/username/projects/noEmitOnError/shared/types/db.ts
 *refresh*    /user/username/projects/noEmitOnError/src/main.ts
+*refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::
-(computed .d.ts) /user/username/projects/noEmitOnError/src/main.ts
 
 
 Edit [4]:: No Change
@@ -316,9 +322,15 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
 
+//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo.readable.baseline.txt] *rewrite with same content*
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /user/username/projects/noEmitOnError/shared/types/db.ts
+*refresh*    /user/username/projects/noEmitOnError/src/main.ts
+*refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::
 
 
@@ -338,17 +350,15 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Updating unchanged output timestamps of project 'tsconfig.json'...
-
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.js] *mTime changed*
+//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.js] *rewrite with same content*
 //// [/user/username/projects/noEmitOnError/dev-build/src/main.js] *modified* 
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const a = "hello";
 
-//// [/user/username/projects/noEmitOnError/dev-build/src/other.js] *mTime changed*
+//// [/user/username/projects/noEmitOnError/dev-build/src/other.js] *rewrite with same content*
 //// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo] *modified* 
 {"version":"FakeTSVersion","root":["../shared/types/db.ts","../src/main.ts","../src/other.ts"]}
 //// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
@@ -379,9 +389,11 @@ const a = "hello";
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /user/username/projects/noEmitOnError/shared/types/db.ts
 *refresh*    /user/username/projects/noEmitOnError/src/main.ts
+*refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::
-(computed .d.ts) /user/username/projects/noEmitOnError/src/main.ts
 
 
 Edit [6]:: No Change
@@ -398,17 +410,20 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Updating unchanged output timestamps of project 'tsconfig.json'...
-
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.js] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/src/main.js] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/src/other.js] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo] *mTime changed*
+//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.js] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/src/main.js] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/src/other.js] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo.readable.baseline.txt] *rewrite with same content*
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /user/username/projects/noEmitOnError/shared/types/db.ts
+*refresh*    /user/username/projects/noEmitOnError/src/main.ts
+*refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::
 
 
@@ -428,11 +443,9 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Updating unchanged output timestamps of project 'tsconfig.json'...
-
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.js] *mTime changed*
+//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.js] *rewrite with same content*
 //// [/user/username/projects/noEmitOnError/dev-build/src/main.js] *modified* 
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
@@ -442,15 +455,17 @@ const a = class {
 };
 exports.a = a;
 
-//// [/user/username/projects/noEmitOnError/dev-build/src/other.js] *mTime changed*
+//// [/user/username/projects/noEmitOnError/dev-build/src/other.js] *rewrite with same content*
 //// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo] *rewrite with same content*
 //// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo.readable.baseline.txt] *rewrite with same content*
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /user/username/projects/noEmitOnError/shared/types/db.ts
 *refresh*    /user/username/projects/noEmitOnError/src/main.ts
+*refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::
-(computed .d.ts) /user/username/projects/noEmitOnError/src/main.ts
 
 
 Edit [8]:: No Change
@@ -467,17 +482,20 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Updating unchanged output timestamps of project 'tsconfig.json'...
-
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.js] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/src/main.js] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/src/other.js] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo] *mTime changed*
+//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.js] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/src/main.js] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/src/other.js] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo.readable.baseline.txt] *rewrite with same content*
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /user/username/projects/noEmitOnError/shared/types/db.ts
+*refresh*    /user/username/projects/noEmitOnError/src/main.ts
+*refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::
 
 
@@ -497,21 +515,21 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Updating unchanged output timestamps of project 'tsconfig.json'...
-
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.js] *mTime changed*
+//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.js] *rewrite with same content*
 //// [/user/username/projects/noEmitOnError/dev-build/src/main.js] *rewrite with same content*
-//// [/user/username/projects/noEmitOnError/dev-build/src/other.js] *mTime changed*
+//// [/user/username/projects/noEmitOnError/dev-build/src/other.js] *rewrite with same content*
 //// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo] *rewrite with same content*
 //// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo.readable.baseline.txt] *rewrite with same content*
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /user/username/projects/noEmitOnError/shared/types/db.ts
 *refresh*    /user/username/projects/noEmitOnError/src/main.ts
+*refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::
-(computed .d.ts) /user/username/projects/noEmitOnError/src/main.ts
 
 
 Edit [10]:: No Change
@@ -528,15 +546,18 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Updating unchanged output timestamps of project 'tsconfig.json'...
-
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.js] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/src/main.js] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/src/other.js] *mTime changed*
-//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo] *mTime changed*
+//// [/user/username/projects/noEmitOnError/dev-build/shared/types/db.js] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/src/main.js] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/src/other.js] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo] *rewrite with same content*
+//// [/user/username/projects/noEmitOnError/dev-build/tsconfig.tsbuildinfo.readable.baseline.txt] *rewrite with same content*
 
 tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
+*refresh*    /user/username/projects/noEmitOnError/shared/types/db.ts
+*refresh*    /user/username/projects/noEmitOnError/src/main.ts
+*refresh*    /user/username/projects/noEmitOnError/src/other.ts
 Signatures::

--- a/testdata/baselines/reference/tsbuildWatch/programUpdates/when-referenced-project-change-introduces-error-in-the-down-stream-project-and-then-fixes-it.js
+++ b/testdata/baselines/reference/tsbuildWatch/programUpdates/when-referenced-project-change-introduces-error-in-the-down-stream-project-and-then-fixes-it.js
@@ -279,11 +279,10 @@ Signatures::
 
 App/tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
 *refresh*    /user/username/projects/sample1/Library/library.d.ts
 *refresh*    /user/username/projects/sample1/App/app.ts
 Signatures::
-(used version)   /user/username/projects/sample1/Library/library.d.ts
-(computed .d.ts) /user/username/projects/sample1/App/app.ts
 
 
 Edit [1]:: Fix error
@@ -396,8 +395,7 @@ Signatures::
 
 App/tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
 *refresh*    /user/username/projects/sample1/Library/library.d.ts
 *refresh*    /user/username/projects/sample1/App/app.ts
 Signatures::
-(used version)   /user/username/projects/sample1/Library/library.d.ts
-(computed .d.ts) /user/username/projects/sample1/App/app.ts

--- a/testdata/baselines/reference/tsbuildWatch/programUpdates/works-when-noUnusedParameters-changes-to-false.js
+++ b/testdata/baselines/reference/tsbuildWatch/programUpdates/works-when-noUnusedParameters-changes-to-false.js
@@ -86,7 +86,7 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-//// [/user/username/projects/myproject/index.js] *mTime changed*
+//// [/user/username/projects/myproject/index.js] *rewrite with same content*
 //// [/user/username/projects/myproject/tsconfig.tsbuildinfo] *modified* 
 {"version":"FakeTSVersion","root":["./index.ts"]}
 //// [/user/username/projects/myproject/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 

--- a/testdata/baselines/reference/tsbuildWatch/programUpdates/works-with-extended-source-files.js
+++ b/testdata/baselines/reference/tsbuildWatch/programUpdates/works-with-extended-source-files.js
@@ -601,9 +601,6 @@ SemanticDiagnostics::
 *refresh*    /user/username/projects/project/other.ts
 *refresh*    /user/username/projects/project/other2.ts
 Signatures::
-(computed .d.ts) /user/username/projects/project/commonFile1.ts
-(computed .d.ts) /user/username/projects/project/commonFile2.ts
-(computed .d.ts) /user/username/projects/project/other2.ts
 
 
 Edit [3]:: update aplha config

--- a/testdata/baselines/reference/tsbuildWatch/programUpdates/works-with-extended-source-files.js
+++ b/testdata/baselines/reference/tsbuildWatch/programUpdates/works-with-extended-source-files.js
@@ -740,11 +740,9 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project 'project3.tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Updating unchanged output timestamps of project 'project3.tsconfig.json'...
-
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-//// [/user/username/projects/project/other2.js] *mTime changed*
+//// [/user/username/projects/project/other2.js] *rewrite with same content*
 //// [/user/username/projects/project/project3.tsconfig.tsbuildinfo] *rewrite with same content*
 //// [/user/username/projects/project/project3.tsconfig.tsbuildinfo.readable.baseline.txt] *rewrite with same content*
 
@@ -776,11 +774,9 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project 'project3.tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Updating unchanged output timestamps of project 'project3.tsconfig.json'...
-
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-//// [/user/username/projects/project/other2.js] *mTime changed*
+//// [/user/username/projects/project/other2.js] *rewrite with same content*
 //// [/user/username/projects/project/project3.tsconfig.tsbuildinfo] *rewrite with same content*
 //// [/user/username/projects/project/project3.tsconfig.tsbuildinfo.readable.baseline.txt] *rewrite with same content*
 

--- a/testdata/baselines/reference/tsbuildWatch/reexport/Reports-errors-correctly.js
+++ b/testdata/baselines/reference/tsbuildWatch/reexport/Reports-errors-correctly.js
@@ -264,11 +264,9 @@ Output::
     [7m3[0m     bar: number;
     [7m [0m [96m    ~~~[0m
 
-[[90mHH:MM:SS AM[0m] Updating unchanged output timestamps of project 'src/main/tsconfig.json'...
-
 [[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
 
-//// [/user/username/projects/reexport/out/main/index.js] *mTime changed*
+//// [/user/username/projects/reexport/out/main/index.js] *rewrite with same content*
 //// [/user/username/projects/reexport/out/main/tsconfig.tsbuildinfo] *modified* 
 {"version":"FakeTSVersion","root":["../../src/main/index.ts"],"semanticErrors":true}
 //// [/user/username/projects/reexport/out/main/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
@@ -380,13 +378,11 @@ Signatures::
 
 src/main/tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
 *refresh*    /user/username/projects/reexport/out/pure/session.d.ts
 *refresh*    /user/username/projects/reexport/out/pure/index.d.ts
 *refresh*    /user/username/projects/reexport/src/main/index.ts
 Signatures::
-(used version)   /user/username/projects/reexport/out/pure/session.d.ts
-(used version)   /user/username/projects/reexport/out/pure/index.d.ts
-(used version)   /user/username/projects/reexport/src/main/index.ts
 
 
 Edit [1]:: Fix error
@@ -413,11 +409,9 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project 'src/main/tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Updating unchanged output timestamps of project 'src/main/tsconfig.json'...
-
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
-//// [/user/username/projects/reexport/out/main/index.js] *mTime changed*
+//// [/user/username/projects/reexport/out/main/index.js] *rewrite with same content*
 //// [/user/username/projects/reexport/out/main/tsconfig.tsbuildinfo] *modified* 
 {"version":"FakeTSVersion","root":["../../src/main/index.ts"]}
 //// [/user/username/projects/reexport/out/main/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
@@ -527,10 +521,8 @@ Signatures::
 
 src/main/tsconfig.json::
 SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.d.ts
 *refresh*    /user/username/projects/reexport/out/pure/session.d.ts
 *refresh*    /user/username/projects/reexport/out/pure/index.d.ts
 *refresh*    /user/username/projects/reexport/src/main/index.ts
 Signatures::
-(used version)   /user/username/projects/reexport/out/pure/session.d.ts
-(used version)   /user/username/projects/reexport/out/pure/index.d.ts
-(used version)   /user/username/projects/reexport/src/main/index.ts

--- a/testdata/baselines/reference/tsc/declarationEmit/reports-dts-generation-errors.js
+++ b/testdata/baselines/reference/tsc/declarationEmit/reports-dts-generation-errors.js
@@ -173,4 +173,3 @@ SemanticDiagnostics::
 *refresh*    /home/src/workspaces/project/node_modules/ky/distribution/index.d.ts
 *refresh*    /home/src/workspaces/project/index.ts
 Signatures::
-(stored at emit) /home/src/workspaces/project/index.ts


### PR DESCRIPTION
- Buildinfo was on "toBuildInfo" object made it separate allocation so that it doesnt form cycle with incremental program and snapshot
- Do not store incremental program past compilation as we are storing buildInfo anyways
- handled single threaded build to build in order to ensure that it does not create a deadlock
- Handled the case where same file exists multiple times in program 
- optimized to not calculate "referenceMap" and other incremental state when we are building for tsc -b for non incremental programs