### PR TITLE
fix: replace tsc with tsgo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Additional tasks are a work in progress.
 
 ### Running `tsgo`
 
-After running `hereby build`, you can run `built/local/tsgo`, which behaves mostly the same as `tsc`.
+After running `hereby build`, you can run `built/local/tsgo`, which behaves mostly the same as `tsgo`.
 
 ### LSP Server
 


### PR DESCRIPTION
I think this is a typing mistake. It should be tsgo, not tsc