### PR TITLE
Add missing nil check that causes panic in LSP document-highlight

### DIFF
--- a/internal/ls/findallreferences.go
+++ b/internal/ls/findallreferences.go
@@ -616,7 +616,7 @@ func (l *LanguageService) getReferencedSymbolsForNode(ctx context.Context, posit
 
 	if node.Kind == ast.KindSourceFile {
 		resolvedRef := getReferenceAtPosition(node.AsSourceFile(), position, program)
-		if resolvedRef.file == nil {
+		if resolvedRef == nil || resolvedRef.file == nil {
 			return nil
 		}
 


### PR DESCRIPTION
Panic occurs when opening a file with cursor positioned in a commented out section at the beginning of the file.
