### PR TITLE
Types with extra properties are never subtypes of fresh object literals

### DIFF
--- a/internal/checker/relater.go
+++ b/internal/checker/relater.go
@@ -4153,16 +4153,13 @@ func (r *Relater) propertiesRelatedTo(source *Type, target *Type, reportErrors b
 		}
 		return TernaryFalse
 	}
-	if isObjectLiteralType(target) {
+	if target.objectFlags&ObjectFlagsFreshLiteral != 0 {
 		for _, sourceProp := range excludeProperties(r.c.getPropertiesOfType(source), excludedProperties) {
 			if r.c.getPropertyOfObjectType(target, sourceProp.Name) == nil {
-				sourceType := r.c.getTypeOfSymbol(sourceProp)
-				if sourceType.flags&TypeFlagsUndefined == 0 {
-					if reportErrors {
-						r.reportError(diagnostics.Property_0_does_not_exist_on_type_1, r.c.symbolToString(sourceProp), r.c.TypeToString(target))
-					}
-					return TernaryFalse
+				if reportErrors {
+					r.reportError(diagnostics.Property_0_does_not_exist_on_type_1, r.c.symbolToString(sourceProp), r.c.TypeToString(target))
 				}
+				return TernaryFalse
 			}
 		}
 	}

--- a/testdata/baselines/reference/compiler/freshObjectLiteralSubtype.symbols
+++ b/testdata/baselines/reference/compiler/freshObjectLiteralSubtype.symbols
@@ -1,0 +1,65 @@
+//// [tests/cases/compiler/freshObjectLiteralSubtype.ts] ////
+
+=== freshObjectLiteralSubtype.ts ===
+function f1() {
+>f1 : Symbol(f1, Decl(freshObjectLiteralSubtype.ts, 0, 0))
+
+    if (!!true) {
+        return { valid: true }
+>valid : Symbol(valid, Decl(freshObjectLiteralSubtype.ts, 2, 16))
+    }
+    return f2()
+>f2 : Symbol(f2, Decl(freshObjectLiteralSubtype.ts, 7, 13))
+}
+
+declare const f2: () => { valid: boolean, msg?: undefined }
+>f2 : Symbol(f2, Decl(freshObjectLiteralSubtype.ts, 7, 13))
+>valid : Symbol(valid, Decl(freshObjectLiteralSubtype.ts, 7, 25))
+>msg : Symbol(msg, Decl(freshObjectLiteralSubtype.ts, 7, 41))
+
+f1().msg
+>f1().msg : Symbol(msg, Decl(freshObjectLiteralSubtype.ts, 7, 41))
+>f1 : Symbol(f1, Decl(freshObjectLiteralSubtype.ts, 0, 0))
+>msg : Symbol(msg, Decl(freshObjectLiteralSubtype.ts, 7, 41))
+
+// Repro from https://github.com/microsoft/typescript-go/issues/1742
+
+function validate() {
+>validate : Symbol(validate, Decl(freshObjectLiteralSubtype.ts, 9, 8))
+
+    if(Math.random() > 0.5) {
+>Math.random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+
+        return utilValidate();
+>utilValidate : Symbol(utilValidate, Decl(freshObjectLiteralSubtype.ts, 18, 2))
+    }
+    return { valid: true };
+>valid : Symbol(valid, Decl(freshObjectLiteralSubtype.ts, 17, 12))
+
+};
+
+
+declare function utilValidate(): {
+>utilValidate : Symbol(utilValidate, Decl(freshObjectLiteralSubtype.ts, 18, 2))
+
+    valid: boolean;
+>valid : Symbol(valid, Decl(freshObjectLiteralSubtype.ts, 21, 34))
+
+    msg?: undefined;
+>msg : Symbol(msg, Decl(freshObjectLiteralSubtype.ts, 22, 19))
+
+} | {
+    valid: boolean;
+>valid : Symbol(valid, Decl(freshObjectLiteralSubtype.ts, 24, 5))
+
+    msg: string;
+>msg : Symbol(msg, Decl(freshObjectLiteralSubtype.ts, 25, 19))
+}
+
+validate().msg; // Error in TSGO
+>validate().msg : Symbol(msg, Decl(freshObjectLiteralSubtype.ts, 22, 19), Decl(freshObjectLiteralSubtype.ts, 25, 19))
+>validate : Symbol(validate, Decl(freshObjectLiteralSubtype.ts, 9, 8))
+>msg : Symbol(msg, Decl(freshObjectLiteralSubtype.ts, 22, 19), Decl(freshObjectLiteralSubtype.ts, 25, 19))
+

--- a/testdata/baselines/reference/compiler/freshObjectLiteralSubtype.types
+++ b/testdata/baselines/reference/compiler/freshObjectLiteralSubtype.types
@@ -1,0 +1,80 @@
+//// [tests/cases/compiler/freshObjectLiteralSubtype.ts] ////
+
+=== freshObjectLiteralSubtype.ts ===
+function f1() {
+>f1 : () => { valid: boolean; msg?: undefined; }
+
+    if (!!true) {
+>!!true : true
+>!true : false
+>true : true
+
+        return { valid: true }
+>{ valid: true } : { valid: boolean; }
+>valid : boolean
+>true : true
+    }
+    return f2()
+>f2() : { valid: boolean; msg?: undefined; }
+>f2 : () => { valid: boolean; msg?: undefined; }
+}
+
+declare const f2: () => { valid: boolean, msg?: undefined }
+>f2 : () => { valid: boolean; msg?: undefined; }
+>valid : boolean
+>msg : undefined
+
+f1().msg
+>f1().msg : undefined
+>f1() : { valid: boolean; msg?: undefined; }
+>f1 : () => { valid: boolean; msg?: undefined; }
+>msg : undefined
+
+// Repro from https://github.com/microsoft/typescript-go/issues/1742
+
+function validate() {
+>validate : () => { valid: boolean; msg?: undefined; } | { valid: boolean; msg: string; }
+
+    if(Math.random() > 0.5) {
+>Math.random() > 0.5 : boolean
+>Math.random() : number
+>Math.random : () => number
+>Math : Math
+>random : () => number
+>0.5 : 0.5
+
+        return utilValidate();
+>utilValidate() : { valid: boolean; msg?: undefined; } | { valid: boolean; msg: string; }
+>utilValidate : () => { valid: boolean; msg?: undefined; } | { valid: boolean; msg: string; }
+    }
+    return { valid: true };
+>{ valid: true } : { valid: boolean; }
+>valid : boolean
+>true : true
+
+};
+
+
+declare function utilValidate(): {
+>utilValidate : () => { valid: boolean; msg?: undefined; } | { valid: boolean; msg: string; }
+
+    valid: boolean;
+>valid : boolean
+
+    msg?: undefined;
+>msg : undefined
+
+} | {
+    valid: boolean;
+>valid : boolean
+
+    msg: string;
+>msg : string
+}
+
+validate().msg; // Error in TSGO
+>validate().msg : string | undefined
+>validate() : { valid: boolean; msg?: undefined; } | { valid: boolean; msg: string; }
+>validate : () => { valid: boolean; msg?: undefined; } | { valid: boolean; msg: string; }
+>msg : string | undefined
+

--- a/testdata/tests/cases/compiler/freshObjectLiteralSubtype.ts
+++ b/testdata/tests/cases/compiler/freshObjectLiteralSubtype.ts
@@ -1,0 +1,33 @@
+// @strict: true
+// @noEmit: true
+
+function f1() {
+    if (!!true) {
+        return { valid: true }
+    }
+    return f2()
+}
+
+declare const f2: () => { valid: boolean, msg?: undefined }
+
+f1().msg
+
+// Repro from https://github.com/microsoft/typescript-go/issues/1742
+
+function validate() {
+    if(Math.random() > 0.5) {
+        return utilValidate();
+    }
+    return { valid: true };
+};
+
+
+declare function utilValidate(): {
+    valid: boolean;
+    msg?: undefined;
+} | {
+    valid: boolean;
+    msg: string;
+}
+
+validate().msg; // Error in TSGO


### PR DESCRIPTION
This PR modifies type relationship checking such that types with extra properties are never subtypes of fresh object literals. This in turn ensures that fresh object literal types are subtypes of regular object types with optional properties that aren't specified in the fresh object literal types. For example, with this PR the fresh object literal type `{ valid: boolean }` is a subtype of the regular type `{ valid: boolean; msg?: undefined; }`, but not vice-versa, where previously both were subtypes of each other.

Fixes #1742.