### PR TITLE
Organize imports for TypeScript and JavaScript

### DIFF
--- a/_extension/package.json
+++ b/_extension/package.json
@@ -85,6 +85,12 @@
                 "title": "Show LSP Trace",
                 "enablement": "typescript.native-preview.serverRunning",
                 "category": "TypeScript Native Preview"
+            },
+            {
+                "command": "typescript.native-preview.sortImports",
+                "title": "Sort Imports",
+                "enablement": "typescript.native-preview.serverRunning && editorLangId =~ /^(javascript|typescript|javascriptreact|typescriptreact)$/",
+                "category": "TypeScript Native Preview"
             }
         ]
     },

--- a/_extension/src/client.ts
+++ b/_extension/src/client.ts
@@ -158,4 +158,14 @@ export class Client {
         this.client.restart();
         return new vscode.Disposable(() => {});
     }
+
+    async executeCommand(command: string, ...args: any[]): Promise<any> {
+        if (!this.client) {
+            throw new Error("Language client is not initialized");
+        }
+        return this.client.sendRequest("workspace/executeCommand", {
+            command,
+            arguments: args,
+        });
+    }
 }

--- a/_extension/src/commands.ts
+++ b/_extension/src/commands.ts
@@ -33,6 +33,10 @@ export function registerLanguageCommands(context: vscode.ExtensionContext, clien
 
     disposables.push(vscode.commands.registerCommand("typescript.native-preview.showMenu", showCommands));
 
+    disposables.push(vscode.commands.registerCommand("typescript.native-preview.sortImports", async () => {
+        return sortImports(client);
+    }));
+
     return disposables;
 }
 
@@ -53,11 +57,41 @@ async function updateUseTsgoSetting(enable: boolean): Promise<void> {
     await vscode.commands.executeCommand("workbench.action.restartExtensionHost");
 }
 
-/**
- * Shows the quick pick menu for TypeScript Native Preview commands
- */
+async function sortImports(client: Client): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+        vscode.window.showErrorMessage("No active editor");
+        return;
+    }
+
+    const document = editor.document;
+    const languageId = document.languageId;
+
+    // Check if the file is TypeScript or JavaScript
+    if (!["typescript", "javascript", "typescriptreact", "javascriptreact"].includes(languageId)) {
+        vscode.window.showErrorMessage("Sort Imports is only available for TypeScript and JavaScript files");
+        return;
+    }
+
+    try {
+        // Execute the sort imports command on the server via LSP
+        await client.executeCommand(
+            "typescript-go.organizeImports",
+            document.uri.toString()
+        );
+        vscode.window.showInformationMessage("Imports sorted successfully");
+    } catch (error) {
+        vscode.window.showErrorMessage(`Failed to sort imports: ${error}`);
+    }
+}
+
 async function showCommands(): Promise<void> {
     const commands: readonly { label: string; description: string; command: string; }[] = [
+        {
+            label: "$(symbol-namespace) Sort Imports",
+            description: "Sort imports in the current file",
+            command: "typescript.native-preview.sortImports",
+        },
         {
             label: "$(refresh) Restart Server",
             description: "Restart the TypeScript Native Preview language server",

--- a/internal/ls/organizeimports.go
+++ b/internal/ls/organizeimports.go
@@ -11,10 +11,166 @@ import (
 	"github.com/microsoft/typescript-go/internal/tspath"
 )
 
+// GetImportDeclarationInsertIndex determines where to insert a new import in a sorted list
+// It uses binary search to find the appropriate insertion index
 // statement = anyImportOrRequireStatement
-func getImportDeclarationInsertIndex(sortedImports []*ast.Statement, newImport *ast.Statement, comparer func(a, b *ast.Statement) int) int {
-	// !!!
-	return len(sortedImports)
+func GetImportDeclarationInsertIndex(sortedImports []*ast.Statement, newImport *ast.Statement, comparer func(a, b *ast.Statement) int) int {
+	n := len(sortedImports)
+	if n == 0 {
+		return 0
+	}
+
+	low, high := 0, n
+	for low < high {
+		mid := low + (high-low)/2
+		if comparer(sortedImports[mid], newImport) < 0 {
+			low = mid + 1
+		} else {
+			high = mid
+		}
+	}
+	return low
+}
+
+// CompareImportsOrRequireStatements compares two import statements for sorting purposes
+// Returns:
+//   - negative if s1 should come before s2
+//   - 0 if they are equivalent
+//   - positive if s1 should come after s2
+func CompareImportsOrRequireStatements(s1, s2 *ast.Statement, comparer func(a, b string) int) int {
+	// First compare module specifiers
+	comparison := compareModuleSpecifiersWorker(
+		GetModuleSpecifierExpression(s1),
+		GetModuleSpecifierExpression(s2),
+		comparer,
+	)
+	if comparison != 0 {
+		return comparison
+	}
+	// If module specifiers are equal, compare by import kind
+	return compareImportKind(s1, s2)
+}
+
+// GetModuleSpecifierExpression extracts the module specifier expression from an import/export statement
+func GetModuleSpecifierExpression(declaration *ast.Statement) *ast.Expression {
+	switch declaration.Kind {
+	case ast.KindImportDeclaration, ast.KindJSImportDeclaration:
+		return declaration.AsImportDeclaration().ModuleSpecifier
+	case ast.KindImportEqualsDeclaration:
+		moduleRef := declaration.AsImportEqualsDeclaration().ModuleReference
+		if moduleRef != nil && moduleRef.Kind == ast.KindExternalModuleReference {
+			return moduleRef.AsExternalModuleReference().Expression
+		}
+		return nil
+	case ast.KindVariableStatement:
+		// Handle require statements: const x = require("...")
+		declList := declaration.AsVariableStatement().DeclarationList
+		if declList != nil && declList.Kind == ast.KindVariableDeclarationList {
+			decls := declList.AsVariableDeclarationList().Declarations.Nodes
+			if len(decls) > 0 {
+				varDecl := decls[0].AsVariableDeclaration()
+				if varDecl.Initializer != nil && ast.IsCallExpression(varDecl.Initializer) {
+					call := varDecl.Initializer.AsCallExpression()
+					if len(call.Arguments.Nodes) > 0 {
+						return call.Arguments.Nodes[0]
+					}
+				}
+			}
+		}
+		return nil
+	}
+	return nil
+}
+
+// compareModuleSpecifiersWorker compares two module specifier expressions.
+// Ordering:
+//  1. undefined module specifiers come last
+//  2. Relative imports come after absolute imports
+//  3. Otherwise, compare by the comparer function
+func compareModuleSpecifiersWorker(m1, m2 *ast.Expression, comparer func(a, b string) int) int {
+	name1 := getExternalModuleNameText(m1)
+	name2 := getExternalModuleNameText(m2)
+
+	// undefined names come last
+	if comparison := compareBooleans(name1 == "", name2 == ""); comparison != 0 {
+		return comparison
+	}
+
+	// If both are defined, absolute imports come before relative imports
+	if name1 != "" && name2 != "" {
+		isRelative1 := tspath.IsExternalModuleNameRelative(name1)
+		isRelative2 := tspath.IsExternalModuleNameRelative(name2)
+		// compareBooleans returns -1 if first is true and second is false
+		// We want relative (true) to come after non-relative (false), so reverse the comparison
+		if comparison := compareBooleans(isRelative2, isRelative1); comparison != 0 {
+			return comparison
+		}
+
+		// Finally, compare by the provided comparer
+		return comparer(name1, name2)
+	}
+
+	return 0
+}
+
+// getExternalModuleNameText extracts the text of a module name from an expression
+func getExternalModuleNameText(expr *ast.Expression) string {
+	if expr == nil {
+		return ""
+	}
+
+	if ast.IsStringLiteral(expr) {
+		return expr.AsStringLiteral().Text
+	}
+
+	return ""
+}
+
+// compareImportKind compares imports by their kind/type for sorting
+// Import order:
+//  1. Side-effect imports (import "foo")
+//  2. Type-only imports (import type { Foo } from "foo")
+//  3. Namespace imports (import * as foo from "foo")
+//  4. Default imports (import foo from "foo")
+//  5. Named imports (import { foo } from "foo")
+//  6. ImportEquals declarations (import foo = require("foo"))
+//  7. Require variable statements (const foo = require("foo"))
+func compareImportKind(s1, s2 *ast.Statement) int {
+	order1 := getImportKindOrder(s1)
+	order2 := getImportKindOrder(s2)
+	return cmp.Compare(order1, order2)
+}
+
+// getImportKindOrder returns the sorting order for different import kinds
+func getImportKindOrder(statement *ast.Statement) int {
+	switch statement.Kind {
+	case ast.KindImportDeclaration, ast.KindJSImportDeclaration:
+		importDecl := statement.AsImportDeclaration()
+		// Side-effect import (no import clause)
+		if importDecl.ImportClause == nil {
+			return 0
+		}
+		importClause := importDecl.ImportClause.AsImportClause()
+		// Type-only import
+		if importClause.IsTypeOnly {
+			return 1
+		}
+		// Namespace import (import * as foo)
+		if importClause.NamedBindings != nil && importClause.NamedBindings.Kind == ast.KindNamespaceImport {
+			return 2
+		}
+		// Default import (import foo)
+		if importClause.Name() != nil {
+			return 3
+		}
+		// Named import (import { foo })
+		return 4
+	case ast.KindImportEqualsDeclaration:
+		return 5
+	case ast.KindVariableStatement:
+		return 6
+	}
+	return 999
 }
 
 // returns `-1` if `a` is better than `b`

--- a/internal/ls/organizeimports_service.go
+++ b/internal/ls/organizeimports_service.go
@@ -1,0 +1,172 @@
+package ls
+
+import (
+	"context"
+	"slices"
+	"strings"
+
+	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/compiler"
+	"github.com/microsoft/typescript-go/internal/core"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
+	"github.com/microsoft/typescript-go/internal/scanner"
+)
+
+// OrganizeImportsMode defines different modes for organizing imports
+type OrganizeImportsMode int
+
+const (
+	// OrganizeImportsModeAll removes unused imports, combines, and sorts imports
+	OrganizeImportsModeAll OrganizeImportsMode = iota
+	// OrganizeImportsModeSortAndCombine only sorts and combines imports without removing unused ones
+	OrganizeImportsModeSortAndCombine
+	// OrganizeImportsModeRemoveUnused only removes unused imports
+	OrganizeImportsModeRemoveUnused
+)
+
+// OrganizeImports organizes the imports in a TypeScript/JavaScript file
+// Currently supports sorting imports while preserving blank line groupings
+func (l *LanguageService) OrganizeImports(ctx context.Context, documentURI lsproto.DocumentUri, mode OrganizeImportsMode) ([]lsproto.TextEdit, error) {
+	program, file := l.getProgramAndFile(documentURI)
+	if file == nil {
+		return nil, nil
+	}
+
+	edits := l.organizeImportsCore(file, program, mode)
+	return edits, nil
+}
+
+// organizeImportsCore sorts imports within groups separated by blank lines
+func (l *LanguageService) organizeImportsCore(file *ast.SourceFile, program *compiler.Program, mode OrganizeImportsMode) []lsproto.TextEdit {
+	_ = program
+	_ = mode
+
+	var imports []*ast.Statement
+	for _, stmt := range file.Statements.Nodes {
+		if stmt.Kind == ast.KindImportDeclaration ||
+			stmt.Kind == ast.KindJSImportDeclaration ||
+			stmt.Kind == ast.KindImportEqualsDeclaration {
+			imports = append(imports, stmt)
+		}
+	}
+
+	if len(imports) == 0 {
+		return nil
+	}
+
+	// Group imports by blank lines to preserve intentional grouping
+	importGroups := l.groupImportsByNewline(file, imports)
+
+	comparer := func(a, b string) int {
+		return strings.Compare(a, b)
+	}
+
+	var allEdits []lsproto.TextEdit
+
+	// Process each group independently
+	for _, group := range importGroups {
+		if len(group) == 0 {
+			continue
+		}
+
+		sortedGroup := make([]*ast.Statement, len(group))
+		copy(sortedGroup, group)
+
+		slices.SortFunc(sortedGroup, func(a, b *ast.Statement) int {
+			return CompareImportsOrRequireStatements(a, b, comparer)
+		})
+
+		// Check if already sorted
+		isSorted := true
+		for i := range group {
+			if group[i] != sortedGroup[i] {
+				isSorted = false
+				break
+			}
+		}
+
+		if isSorted {
+			continue
+		}
+
+		// Create text edit for this group
+		firstImport := group[0]
+		lastImport := group[len(group)-1]
+
+		startPos := scanner.SkipTrivia(file.Text(), firstImport.Pos())
+		endPos := lastImport.End()
+
+		var newText strings.Builder
+		for i, sortedImp := range sortedGroup {
+			if i > 0 {
+				newText.WriteString("\n")
+			}
+			importText := scanner.GetTextOfNodeFromSourceText(file.Text(), sortedImp.AsNode(), false)
+			newText.WriteString(importText)
+		}
+
+		startPosition := l.converters.PositionToLineAndCharacter(file, core.TextPos(startPos))
+		endPosition := l.converters.PositionToLineAndCharacter(file, core.TextPos(endPos))
+
+		edit := lsproto.TextEdit{
+			Range: lsproto.Range{
+				Start: startPosition,
+				End:   endPosition,
+			},
+			NewText: newText.String(),
+		}
+
+		allEdits = append(allEdits, edit)
+	}
+
+	return allEdits
+}
+
+// groupImportsByNewline groups consecutive imports separated by blank lines
+func (l *LanguageService) groupImportsByNewline(file *ast.SourceFile, imports []*ast.Statement) [][]*ast.Statement {
+	if len(imports) == 0 {
+		return nil
+	}
+
+	var groups [][]*ast.Statement
+	currentGroup := []*ast.Statement{imports[0]}
+
+	for i := 1; i < len(imports); i++ {
+		if l.hasBlankLineBeforeStatement(file, imports[i]) {
+			groups = append(groups, currentGroup)
+			currentGroup = []*ast.Statement{imports[i]}
+		} else {
+			currentGroup = append(currentGroup, imports[i])
+		}
+	}
+
+	if len(currentGroup) > 0 {
+		groups = append(groups, currentGroup)
+	}
+
+	return groups
+}
+
+// hasBlankLineBeforeStatement checks if a statement has a blank line before it
+// A blank line is indicated by 2+ consecutive newlines in the leading trivia
+func (l *LanguageService) hasBlankLineBeforeStatement(file *ast.SourceFile, stmt *ast.Statement) bool {
+	text := file.Text()
+	pos := stmt.Pos()
+	newlineCount := 0
+
+	for i := pos; i < stmt.End() && i < len(text); i++ {
+		ch := text[i]
+		if ch == '\n' {
+			newlineCount++
+		} else if ch == '\r' {
+			if i+1 < len(text) && text[i+1] == '\n' {
+				i++
+			}
+			newlineCount++
+		} else if ch != ' ' && ch != '\t' {
+			break
+		}
+	}
+
+	return newlineCount >= 2
+}

--- a/internal/ls/organizeimports_test.go
+++ b/internal/ls/organizeimports_test.go
@@ -1,0 +1,381 @@
+package ls_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/core"
+	"github.com/microsoft/typescript-go/internal/ls"
+	"github.com/microsoft/typescript-go/internal/parser"
+	"gotest.tools/v3/assert"
+)
+
+func parseImports(t *testing.T, source string) []*ast.Statement {
+	t.Helper()
+
+	opts := ast.SourceFileParseOptions{
+		FileName: "/test.ts",
+	}
+	sourceFile := parser.ParseSourceFile(opts, source, core.ScriptKindTS)
+	assert.Assert(t, sourceFile != nil, "Failed to parse source")
+
+	var imports []*ast.Statement
+	for _, stmt := range sourceFile.Statements.Nodes {
+		if stmt.Kind == ast.KindImportDeclaration || stmt.Kind == ast.KindJSImportDeclaration || stmt.Kind == ast.KindImportEqualsDeclaration {
+			imports = append(imports, stmt)
+		}
+	}
+	return imports
+}
+
+func TestCompareImportsOrRequireStatements_ModuleSpecifiers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		import1  string
+		import2  string
+		expected int
+	}{
+		{
+			name:     "absolute imports come before relative imports",
+			import1:  `import "lodash";`,
+			import2:  `import "./local";`,
+			expected: -1,
+		},
+		{
+			name:     "relative imports come after absolute imports",
+			import1:  `import "./local";`,
+			import2:  `import "react";`,
+			expected: 1,
+		},
+		{
+			name:     "alphabetical order for absolute imports",
+			import1:  `import "react";`,
+			import2:  `import "lodash";`,
+			expected: 1,
+		},
+		{
+			name:     "alphabetical order for relative imports",
+			import1:  `import "./utils";`,
+			import2:  `import "./api";`,
+			expected: 1,
+		},
+		{
+			name:     "same module specifier",
+			import1:  `import { foo } from "react";`,
+			import2:  `import { bar } from "react";`,
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			
+			imports1 := parseImports(t, tt.import1)
+			imports2 := parseImports(t, tt.import2)
+			
+			assert.Assert(t, len(imports1) == 1, "Expected 1 import in import1")
+			assert.Assert(t, len(imports2) == 1, "Expected 1 import in import2")
+			
+			comparer := strings.Compare
+			result := ls.CompareImportsOrRequireStatements(imports1[0], imports2[0], comparer)
+			
+			if tt.expected == 0 {
+				assert.Equal(t, 0, result, "Expected imports to be equal")
+			} else if tt.expected < 0 {
+				assert.Assert(t, result < 0, "Expected import1 < import2, got %d", result)
+			} else {
+				assert.Assert(t, result > 0, "Expected import1 > import2, got %d", result)
+			}
+		})
+	}
+}
+
+func TestCompareImportsOrRequireStatements_ImportKind(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		import1  string
+		import2  string
+		expected int
+	}{
+		{
+			name:     "side-effect import comes before type-only import",
+			import1:  `import "react";`,
+			import2:  `import type { FC } from "react";`,
+			expected: -1,
+		},
+		{
+			name:     "type-only import comes before namespace import",
+			import1:  `import type { FC } from "react";`,
+			import2:  `import * as React from "react";`,
+			expected: -1,
+		},
+		{
+			name:     "namespace import comes before default import",
+			import1:  `import * as React from "react";`,
+			import2:  `import React from "react";`,
+			expected: -1,
+		},
+		{
+			name:     "default import comes before named import",
+			import1:  `import React from "react";`,
+			import2:  `import { useState } from "react";`,
+			expected: -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			
+			imports1 := parseImports(t, tt.import1)
+			imports2 := parseImports(t, tt.import2)
+			
+			assert.Assert(t, len(imports1) == 1, "Expected 1 import in import1")
+			assert.Assert(t, len(imports2) == 1, "Expected 1 import in import2")
+			
+			comparer := strings.Compare
+			result := ls.CompareImportsOrRequireStatements(imports1[0], imports2[0], comparer)
+			
+			if tt.expected < 0 {
+				assert.Assert(t, result < 0, "Expected import1 < import2, got %d", result)
+			} else if tt.expected > 0 {
+				assert.Assert(t, result > 0, "Expected import1 > import2, got %d", result)
+			} else {
+				assert.Equal(t, 0, result, "Expected imports to be equal")
+			}
+		})
+	}
+}
+
+func TestGetImportDeclarationInsertIndex(t *testing.T) {
+	t.Parallel()
+
+	source := `import "side-effect";
+import type { Type } from "library";
+import { namedImport } from "another";
+import defaultImport from "yet-another";
+import * as namespace from "namespace-lib";
+`
+
+	imports := parseImports(t, source)
+	assert.Assert(t, len(imports) > 0, "Expected to parse imports")
+
+	newImportSource := `import { newImport } from "library";`
+	newImports := parseImports(t, newImportSource)
+	assert.Assert(t, len(newImports) == 1, "Expected 1 new import")
+
+	comparer := func(a, b *ast.Statement) int {
+		return ls.CompareImportsOrRequireStatements(a, b, strings.Compare)
+	}
+
+	index := ls.GetImportDeclarationInsertIndex(imports, newImports[0], comparer)
+	assert.Assert(t, index >= 0 && index <= len(imports), 
+		"Insert index %d out of range [0, %d]", index, len(imports))
+}
+
+func TestGetImportDeclarationInsertIndex_EmptyList(t *testing.T) {
+	t.Parallel()
+
+	newImportSource := `import { foo } from "bar";`
+	newImports := parseImports(t, newImportSource)
+	assert.Assert(t, len(newImports) == 1, "Expected 1 new import")
+
+	comparer := func(a, b *ast.Statement) int {
+		return ls.CompareImportsOrRequireStatements(a, b, strings.Compare)
+	}
+
+	index := ls.GetImportDeclarationInsertIndex([]*ast.Statement{}, newImports[0], comparer)
+	assert.Equal(t, 0, index, "Expected index 0 for empty list")
+}
+
+func TestCompareImports_RelativeVsAbsolute(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		imports []string
+		want    []string
+	}{
+		{
+			name: "mix of relative and absolute",
+			imports: []string{
+				`import "./utils";`,
+				`import "react";`,
+				`import "../parent";`,
+				`import "lodash";`,
+			},
+			want: []string{
+				`import "lodash";`,
+				`import "react";`,
+				`import "../parent";`,
+				`import "./utils";`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			
+			var imports []*ast.Statement
+			for _, imp := range tt.imports {
+				parsed := parseImports(t, imp)
+				assert.Assert(t, len(parsed) == 1, "Expected 1 import")
+				imports = append(imports, parsed[0])
+			}
+
+			comparer := func(a, b *ast.Statement) int {
+				return ls.CompareImportsOrRequireStatements(a, b, strings.Compare)
+			}
+			
+			for i := 0; i < len(imports); i++ {
+				for j := i + 1; j < len(imports); j++ {
+					if comparer(imports[i], imports[j]) > 0 {
+						imports[i], imports[j] = imports[j], imports[i]
+					}
+				}
+			}
+
+			for i, want := range tt.want {
+				wantImports := parseImports(t, want)
+				assert.Assert(t, len(wantImports) == 1, "Expected 1 wanted import")
+				
+				gotSpec := ls.GetModuleSpecifierExpression(imports[i])
+				wantSpec := ls.GetModuleSpecifierExpression(wantImports[0])
+				
+				if gotSpec != nil && wantSpec != nil {
+					assert.Assert(t, ast.IsStringLiteral(gotSpec), "Expected string literal in got")
+					assert.Assert(t, ast.IsStringLiteral(wantSpec), "Expected string literal in want")
+					
+					gotText := gotSpec.AsStringLiteral().Text
+					wantText := wantSpec.AsStringLiteral().Text
+					assert.Equal(t, wantText, gotText, "Import at position %d doesn't match", i)
+				}
+			}
+		})
+	}
+}
+
+func TestGetModuleSpecifierExpression(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		source   string
+		expected string
+	}{
+		{
+			name:     "import declaration",
+			source:   `import { foo } from "react";`,
+			expected: "react",
+		},
+		{
+			name:     "import equals declaration with external module",
+			source:   `import foo = require("lodash");`,
+			expected: "lodash",
+		},
+		{
+			name:     "variable statement with require",
+			source:   `const foo = require("express");`,
+			expected: "express",
+		},
+		{
+			name:     "side-effect import",
+			source:   `import "./styles.css";`,
+			expected: "./styles.css",
+		},
+		{
+			name:     "namespace import",
+			source:   `import * as React from "react";`,
+			expected: "react",
+		},
+		{
+			name:     "type-only import",
+			source:   `import type { FC } from "react";`,
+			expected: "react",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := ast.SourceFileParseOptions{
+				FileName: "/test.ts",
+			}
+			sourceFile := parser.ParseSourceFile(opts, tt.source, core.ScriptKindTS)
+			assert.Assert(t, sourceFile != nil, "Failed to parse source")
+			assert.Assert(t, len(sourceFile.Statements.Nodes) > 0, "Expected at least one statement")
+
+			stmt := sourceFile.Statements.Nodes[0]
+			expr := ls.GetModuleSpecifierExpression(stmt)
+			
+			assert.Assert(t, expr != nil, "Expected non-nil module specifier")
+			assert.Assert(t, ast.IsStringLiteral(expr), "Expected string literal")
+			
+			gotText := expr.AsStringLiteral().Text
+			assert.Equal(t, tt.expected, gotText)
+		})
+	}
+}
+
+func TestCompareImportsWithDifferentTypes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		import1  string
+		import2  string
+		expected string
+	}{
+		{
+			name:     "import equals vs import declaration",
+			import1:  `import foo = require("library");`,
+			import2:  `import { bar } from "library";`,
+			expected: "import2 first",
+		},
+		{
+			name:     "namespace import with named import",
+			import1:  `import * as NS from "library";`,
+			import2:  `import { foo } from "library";`,
+			expected: "import1 first",
+		},
+		{
+			name:     "default and named combined vs named only",
+			import1:  `import React, { useState } from "react";`,
+			import2:  `import { useEffect } from "react";`,
+			expected: "import1 first",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			imports1 := parseImports(t, tt.import1)
+			imports2 := parseImports(t, tt.import2)
+
+			if len(imports1) == 0 || len(imports2) == 0 {
+				t.Skip("Failed to parse one of the imports")
+			}
+
+			comparer := strings.Compare
+			result := ls.CompareImportsOrRequireStatements(imports1[0], imports2[0], comparer)
+
+			switch tt.expected {
+			case "import1 first":
+				assert.Assert(t, result < 0, "Expected import1 < import2, got %d", result)
+			case "import2 first":
+				assert.Assert(t, result > 0, "Expected import1 > import2, got %d", result)
+			case "equal":
+				assert.Equal(t, 0, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
In this PR:

- Port organize imports functionality for TypeScript and JavaScript
- Preserve blank line groupings to respect user's logical organization
- Support all import types: side-effect, type-only, namespace, default, named, and require

Imports are sorted by:
1. Module type: absolute imports before relative imports
2. Import kind: side-effect → type-only → namespace → default → named → require
3. Alphabetically within each category

The feature is exposed via LSP `workspace/executeCommand` with command `typescript-go.organizeImports` and integrated into the VS Code extension as the "Sort Imports" command.

Fixes #1724