### PR TITLE
Rename line maps with ECMA/LSP prefix

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -10724,10 +10724,10 @@ type SourceFile struct {
 	ClassifiableNames         collections.Set[string]
 	PatternAmbientModules     []*PatternAmbientModule
 
-	// Fields set by LineMap
+	// Fields set by ECMALineMap
 
-	lineMapMu sync.RWMutex
-	lineMap   []core.TextPos
+	ecmaLineMapMu sync.RWMutex
+	ecmaLineMap   []core.TextPos
 
 	// Fields set by language service
 
@@ -10862,17 +10862,17 @@ func (f *NodeFactory) UpdateSourceFile(node *SourceFile, statements *StatementLi
 	return node.AsNode()
 }
 
-func (node *SourceFile) LineMap() []core.TextPos {
-	node.lineMapMu.RLock()
-	lineMap := node.lineMap
-	node.lineMapMu.RUnlock()
+func (node *SourceFile) ECMALineMap() []core.TextPos {
+	node.ecmaLineMapMu.RLock()
+	lineMap := node.ecmaLineMap
+	node.ecmaLineMapMu.RUnlock()
 	if lineMap == nil {
-		node.lineMapMu.Lock()
-		defer node.lineMapMu.Unlock()
-		lineMap = node.lineMap
+		node.ecmaLineMapMu.Lock()
+		defer node.ecmaLineMapMu.Unlock()
+		lineMap = node.ecmaLineMap
 		if lineMap == nil {
-			lineMap = core.ComputeLineStarts(node.Text())
-			node.lineMap = lineMap
+			lineMap = core.ComputeECMALineStarts(node.Text())
+			node.ecmaLineMap = lineMap
 		}
 	}
 	return lineMap
@@ -11054,7 +11054,7 @@ func getDeclarationName(declaration *Node) string {
 
 type SourceFileLike interface {
 	Text() string
-	LineMap() []core.TextPos
+	ECMALineMap() []core.TextPos
 }
 
 type CommentRange struct {

--- a/internal/astnav/tokens_test.go
+++ b/internal/astnav/tokens_test.go
@@ -240,7 +240,7 @@ func tsGetTouchingPropertyName(t testing.TB, fileText string, positions []int) [
 }
 
 func writeRangeDiff(output *strings.Builder, file *ast.SourceFile, diff tokenDiff, rng core.TextRange, position int) {
-	lines := file.LineMap()
+	lines := file.ECMALineMap()
 
 	tsTokenPos := position
 	goTokenPos := position

--- a/internal/checker/grammarchecks.go
+++ b/internal/checker/grammarchecks.go
@@ -814,8 +814,8 @@ func (c *Checker) checkGrammarArrowFunction(node *ast.Node, file *ast.SourceFile
 	}
 
 	equalsGreaterThanToken := arrowFunc.EqualsGreaterThanToken
-	startLine, _ := scanner.GetLineAndCharacterOfPosition(file, equalsGreaterThanToken.Pos())
-	endLine, _ := scanner.GetLineAndCharacterOfPosition(file, equalsGreaterThanToken.End())
+	startLine, _ := scanner.GetECMALineAndCharacterOfPosition(file, equalsGreaterThanToken.Pos())
+	endLine, _ := scanner.GetECMALineAndCharacterOfPosition(file, equalsGreaterThanToken.End())
 	return startLine != endLine && c.grammarErrorOnNode(equalsGreaterThanToken, diagnostics.Line_terminator_not_permitted_before_arrow)
 }
 

--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -1074,10 +1074,10 @@ func (p *Program) getDiagnosticsWithPrecedingDirectives(sourceFile *ast.SourceFi
 	// Build map of directives by line number
 	directivesByLine := make(map[int]ast.CommentDirective)
 	for _, directive := range sourceFile.CommentDirectives {
-		line, _ := scanner.GetLineAndCharacterOfPosition(sourceFile, directive.Loc.Pos())
+		line, _ := scanner.GetECMALineAndCharacterOfPosition(sourceFile, directive.Loc.Pos())
 		directivesByLine[line] = directive
 	}
-	lineStarts := scanner.GetLineStarts(sourceFile)
+	lineStarts := scanner.GetECMALineStarts(sourceFile)
 	filtered := make([]*ast.Diagnostic, 0, len(diags))
 	for _, diagnostic := range diags {
 		ignoreDiagnostic := false
@@ -1225,7 +1225,7 @@ func (p *Program) getDiagnosticsHelper(ctx context.Context, sourceFile *ast.Sour
 func (p *Program) LineCount() int {
 	var count int
 	for _, file := range p.files {
-		count += len(file.LineMap())
+		count += len(file.ECMALineMap())
 	}
 	return count
 }

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -362,12 +362,12 @@ func Coalesce[T *U, U any](a T, b T) T {
 	}
 }
 
-func ComputeLineStarts(text string) []TextPos {
+func ComputeECMALineStarts(text string) []TextPos {
 	result := make([]TextPos, 0, strings.Count(text, "\n")+1)
-	return slices.AppendSeq(result, ComputeLineStartsSeq(text))
+	return slices.AppendSeq(result, ComputeECMALineStartsSeq(text))
 }
 
-func ComputeLineStartsSeq(text string) iter.Seq[TextPos] {
+func ComputeECMALineStartsSeq(text string) iter.Seq[TextPos] {
 	return func(yield func(TextPos) bool) {
 		textLen := TextPos(len(text))
 		var pos TextPos

--- a/internal/diagnosticwriter/diagnosticwriter.go
+++ b/internal/diagnosticwriter/diagnosticwriter.go
@@ -84,13 +84,13 @@ func FormatDiagnosticWithColorAndContext(output io.Writer, diagnostic *ast.Diagn
 }
 
 func writeCodeSnippet(writer io.Writer, sourceFile *ast.SourceFile, start int, length int, squiggleColor string, indent string, formatOpts *FormattingOptions) {
-	firstLine, firstLineChar := scanner.GetLineAndCharacterOfPosition(sourceFile, start)
-	lastLine, lastLineChar := scanner.GetLineAndCharacterOfPosition(sourceFile, start+length)
+	firstLine, firstLineChar := scanner.GetECMALineAndCharacterOfPosition(sourceFile, start)
+	lastLine, lastLineChar := scanner.GetECMALineAndCharacterOfPosition(sourceFile, start+length)
 	if length == 0 {
 		lastLineChar++ // When length is zero, squiggle the character right after the start position.
 	}
 
-	lastLineOfFile, _ := scanner.GetLineAndCharacterOfPosition(sourceFile, len(sourceFile.Text()))
+	lastLineOfFile, _ := scanner.GetECMALineAndCharacterOfPosition(sourceFile, len(sourceFile.Text()))
 
 	hasMoreThanFiveLines := lastLine-firstLine >= 4
 	gutterWidth := len(strconv.Itoa(lastLine + 1))
@@ -113,10 +113,10 @@ func writeCodeSnippet(writer io.Writer, sourceFile *ast.SourceFile, start int, l
 			i = lastLine - 1
 		}
 
-		lineStart := scanner.GetPositionOfLineAndCharacter(sourceFile, i, 0)
+		lineStart := scanner.GetECMAPositionOfLineAndCharacter(sourceFile, i, 0)
 		var lineEnd int
 		if i < lastLineOfFile {
-			lineEnd = scanner.GetPositionOfLineAndCharacter(sourceFile, i+1, 0)
+			lineEnd = scanner.GetECMAPositionOfLineAndCharacter(sourceFile, i+1, 0)
 		} else {
 			lineEnd = sourceFile.Loc.End()
 		}
@@ -216,7 +216,7 @@ func writeWithStyleAndReset(output io.Writer, text string, formatStyle string) {
 }
 
 func WriteLocation(output io.Writer, file *ast.SourceFile, pos int, formatOpts *FormattingOptions, writeWithStyleAndReset FormattedWriter) {
-	firstLine, firstChar := scanner.GetLineAndCharacterOfPosition(file, pos)
+	firstLine, firstChar := scanner.GetECMALineAndCharacterOfPosition(file, pos)
 	var relativeFileName string
 	if formatOpts != nil {
 		relativeFileName = tspath.ConvertToRelativePath(file.FileName(), formatOpts.ComparePathsOptions)
@@ -357,7 +357,7 @@ func prettyPathForFileError(file *ast.SourceFile, fileErrors []*ast.Diagnostic, 
 	if file == nil || len(fileErrors) == 0 {
 		return ""
 	}
-	line, _ := scanner.GetLineAndCharacterOfPosition(file, fileErrors[0].Loc().Pos())
+	line, _ := scanner.GetECMALineAndCharacterOfPosition(file, fileErrors[0].Loc().Pos())
 	fileName := file.FileName()
 	if tspath.PathIsAbsolute(fileName) && tspath.PathIsAbsolute(formatOpts.CurrentDirectory) {
 		fileName = tspath.ConvertToRelativePath(file.FileName(), formatOpts.ComparePathsOptions)
@@ -378,7 +378,7 @@ func WriteFormatDiagnostics(output io.Writer, diagnostics []*ast.Diagnostic, for
 
 func WriteFormatDiagnostic(output io.Writer, diagnostic *ast.Diagnostic, formatOpts *FormattingOptions) {
 	if diagnostic.File() != nil {
-		line, character := scanner.GetLineAndCharacterOfPosition(diagnostic.File(), diagnostic.Loc().Pos())
+		line, character := scanner.GetECMALineAndCharacterOfPosition(diagnostic.File(), diagnostic.Loc().Pos())
 		fileName := diagnostic.File().FileName()
 		relativeFileName := tspath.ConvertToRelativePath(fileName, formatOpts.ComparePathsOptions)
 		fmt.Fprintf(output, "%s(%d,%d): ", relativeFileName, line+1, character+1)

--- a/internal/format/api.go
+++ b/internal/format/api.go
@@ -146,18 +146,18 @@ func FormatOnSemicolon(ctx context.Context, sourceFile *ast.SourceFile, position
 }
 
 func FormatOnEnter(ctx context.Context, sourceFile *ast.SourceFile, position int) []core.TextChange {
-	line, _ := scanner.GetLineAndCharacterOfPosition(sourceFile, position)
+	line, _ := scanner.GetECMALineAndCharacterOfPosition(sourceFile, position)
 	if line == 0 {
 		return nil
 	}
 	// get start position for the previous line
-	startPos := int(scanner.GetLineStarts(sourceFile)[line-1])
+	startPos := int(scanner.GetECMALineStarts(sourceFile)[line-1])
 	// After the enter key, the cursor is now at a new line. The new line may or may not contain non-whitespace characters.
 	// If the new line has only whitespaces, we won't want to format this line, because that would remove the indentation as
 	// trailing whitespaces. So the end of the formatting span should be the later one between:
 	//  1. the end of the previous line
 	//  2. the last non-whitespace character in the current line
-	endOfFormatSpan := scanner.GetEndLinePosition(sourceFile, line)
+	endOfFormatSpan := scanner.GetECMAEndLinePosition(sourceFile, line)
 	for endOfFormatSpan > startPos {
 		ch, s := utf8.DecodeRuneInString(sourceFile.Text()[endOfFormatSpan:])
 		if s == 0 || stringutil.IsWhiteSpaceSingleLine(ch) { // on multibyte character keep backing up

--- a/internal/format/rulecontext.go
+++ b/internal/format/rulecontext.go
@@ -584,8 +584,8 @@ func isSemicolonDeletionContext(context *formattingContext) bool {
 		nextTokenStart = scanner.GetTokenPosOfNode(nextRealToken, context.SourceFile, false)
 	}
 
-	startLine, _ := scanner.GetLineAndCharacterOfPosition(context.SourceFile, context.currentTokenSpan.Loc.Pos())
-	endLine, _ := scanner.GetLineAndCharacterOfPosition(context.SourceFile, nextTokenStart)
+	startLine, _ := scanner.GetECMALineAndCharacterOfPosition(context.SourceFile, context.currentTokenSpan.Loc.Pos())
+	endLine, _ := scanner.GetECMALineAndCharacterOfPosition(context.SourceFile, nextTokenStart)
 	if startLine == endLine {
 		return nextTokenKind == ast.KindCloseBraceToken || nextTokenKind == ast.KindEndOfFile
 	}

--- a/internal/format/util.go
+++ b/internal/format/util.go
@@ -10,8 +10,8 @@ import (
 )
 
 func rangeIsOnOneLine(node core.TextRange, file *ast.SourceFile) bool {
-	startLine, _ := scanner.GetLineAndCharacterOfPosition(file, node.Pos())
-	endLine, _ := scanner.GetLineAndCharacterOfPosition(file, node.End())
+	startLine, _ := scanner.GetECMALineAndCharacterOfPosition(file, node.Pos())
+	endLine, _ := scanner.GetECMALineAndCharacterOfPosition(file, node.End())
 	return startLine == endLine
 }
 
@@ -76,8 +76,8 @@ func getCloseTokenForOpenToken(kind ast.Kind) ast.Kind {
 }
 
 func GetLineStartPositionForPosition(position int, sourceFile *ast.SourceFile) int {
-	lineStarts := scanner.GetLineStarts(sourceFile)
-	line, _ := scanner.GetLineAndCharacterOfPosition(sourceFile, position)
+	lineStarts := scanner.GetECMALineStarts(sourceFile)
+	line, _ := scanner.GetECMALineAndCharacterOfPosition(sourceFile, position)
 	return int(lineStarts[line])
 }
 

--- a/internal/fourslash/baselineutil.go
+++ b/internal/fourslash/baselineutil.go
@@ -357,7 +357,7 @@ type textWithContext struct {
 	isLibFile  bool
 	fileName   string
 	content    string // content of the original file
-	lineStarts *ls.LineMap
+	lineStarts *ls.LSPLineMap
 	converters *ls.Converters
 
 	// posLineInfo
@@ -386,10 +386,10 @@ func newTextWithContext(fileName string, content string) *textWithContext {
 		pos:        lsproto.Position{Line: 0, Character: 0},
 		fileName:   fileName,
 		content:    content,
-		lineStarts: ls.ComputeLineStarts(content),
+		lineStarts: ls.ComputeLSPLineStarts(content),
 	}
 
-	t.converters = ls.NewConverters(lsproto.PositionEncodingKindUTF8, func(_ string) *ls.LineMap {
+	t.converters = ls.NewConverters(lsproto.PositionEncodingKindUTF8, func(_ string) *ls.LSPLineMap {
 		return t.lineStarts
 	})
 	t.readableContents.WriteString("// === " + fileName + " ===")

--- a/internal/fourslash/fourslash.go
+++ b/internal/fourslash/fourslash.go
@@ -51,7 +51,7 @@ type FourslashTest struct {
 type scriptInfo struct {
 	fileName string
 	content  string
-	lineMap  *ls.LineMap
+	lineMap  *ls.LSPLineMap
 	version  int32
 }
 
@@ -59,14 +59,14 @@ func newScriptInfo(fileName string, content string) *scriptInfo {
 	return &scriptInfo{
 		fileName: fileName,
 		content:  content,
-		lineMap:  ls.ComputeLineStarts(content),
+		lineMap:  ls.ComputeLSPLineStarts(content),
 		version:  1,
 	}
 }
 
 func (s *scriptInfo) editContent(start int, end int, newText string) {
 	s.content = s.content[:start] + newText + s.content[end:]
-	s.lineMap = ls.ComputeLineStarts(s.content)
+	s.lineMap = ls.ComputeLSPLineStarts(s.content)
 	s.version++
 }
 
@@ -170,7 +170,7 @@ func NewFourslash(t *testing.T, capabilities *lsproto.ClientCapabilities, conten
 		}
 	}()
 
-	converters := ls.NewConverters(lsproto.PositionEncodingKindUTF8, func(fileName string) *ls.LineMap {
+	converters := ls.NewConverters(lsproto.PositionEncodingKindUTF8, func(fileName string) *ls.LSPLineMap {
 		scriptInfo, ok := scriptInfos[fileName]
 		if !ok {
 			return nil
@@ -1484,7 +1484,7 @@ func (f *FourslashTest) BaselineAutoImportsCompletions(t *testing.T, markerNames
 		)))
 
 		currentFile := newScriptInfo(f.activeFilename, fileContent)
-		converters := ls.NewConverters(lsproto.PositionEncodingKindUTF8, func(_ string) *ls.LineMap {
+		converters := ls.NewConverters(lsproto.PositionEncodingKindUTF8, func(_ string) *ls.LSPLineMap {
 			return currentFile.lineMap
 		})
 		var list []*lsproto.CompletionItem

--- a/internal/fourslash/test_parser.go
+++ b/internal/fourslash/test_parser.go
@@ -368,8 +368,8 @@ func parseFileContent(fileName string, content string, fileOptions map[string]st
 
 	outputString := output.String()
 	// Set LS positions for markers
-	lineMap := ls.ComputeLineStarts(outputString)
-	converters := ls.NewConverters(lsproto.PositionEncodingKindUTF8, func(_ string) *ls.LineMap {
+	lineMap := ls.ComputeLSPLineStarts(outputString)
+	converters := ls.NewConverters(lsproto.PositionEncodingKindUTF8, func(_ string) *ls.LSPLineMap {
 		return lineMap
 	})
 

--- a/internal/ls/changetrackerimpl.go
+++ b/internal/ls/changetrackerimpl.go
@@ -204,7 +204,7 @@ func (ct *changeTracker) getAdjustedStartPosition(sourceFile *ast.SourceFile, no
 	if fullStart == start {
 		return start
 	}
-	lineStarts := sourceFile.LineMap()
+	lineStarts := sourceFile.ECMALineMap()
 	fullStartLineIndex := scanner.ComputeLineOfPosition(lineStarts, fullStart)
 	fullStartLinePos := int(lineStarts[fullStartLineIndex])
 	if startOfLinePos == fullStartLinePos {
@@ -249,7 +249,7 @@ func (ct *changeTracker) getEndPositionOfMultilineTrailingComment(sourceFile *as
 	if trailingOpt == trailingTriviaOptionInclude {
 		// If the trailing comment is a multiline comment that extends to the next lines,
 		// return the end of the comment and track it for the next nodes to adjust.
-		lineStarts := sourceFile.LineMap()
+		lineStarts := sourceFile.ECMALineMap()
 		nodeEndLine := scanner.ComputeLineOfPosition(lineStarts, node.End())
 		for comment := range scanner.GetTrailingCommentRanges(ct.NodeFactory, sourceFile.Text(), node.End()) {
 			// Single line can break the loop as trivia will only be this line.
@@ -363,7 +363,7 @@ func (ct *changeTracker) getInsertionPositionAtSourceFileTop(sourceFile *ast.Sou
 	firstNodeLine := -1
 
 	lenStatements := len(sourceFile.Statements.Nodes)
-	lineMap := sourceFile.LineMap()
+	lineMap := sourceFile.ECMALineMap()
 	for _, r := range ranges {
 		if r.Kind == ast.KindMultiLineCommentTrivia {
 			if printer.IsPinnedComment(text, r) {

--- a/internal/ls/completions.go
+++ b/internal/ls/completions.go
@@ -2541,13 +2541,13 @@ func jsxAttributeCompletionStyleIs(preferenceStyle *JsxAttributeCompletionStyle,
 }
 
 func getLineOfPosition(file *ast.SourceFile, pos int) int {
-	line, _ := scanner.GetLineAndCharacterOfPosition(file, pos)
+	line, _ := scanner.GetECMALineAndCharacterOfPosition(file, pos)
 	return line
 }
 
 func getLineEndOfPosition(file *ast.SourceFile, pos int) int {
 	line := getLineOfPosition(file, pos)
-	lineStarts := scanner.GetLineStarts(file)
+	lineStarts := scanner.GetECMALineStarts(file)
 	var lastCharPos int
 	if line+1 >= len(lineStarts) {
 		lastCharPos = file.End()
@@ -3532,8 +3532,8 @@ func getContextualKeywords(file *ast.SourceFile, contextToken *ast.Node, positio
 	// Source: https://tc39.es/proposal-import-assertions/
 	if contextToken != nil {
 		parent := contextToken.Parent
-		tokenLine, _ := scanner.GetLineAndCharacterOfPosition(file, contextToken.End())
-		currentLine, _ := scanner.GetLineAndCharacterOfPosition(file, position)
+		tokenLine, _ := scanner.GetECMALineAndCharacterOfPosition(file, contextToken.End())
+		currentLine, _ := scanner.GetECMALineAndCharacterOfPosition(file, position)
 		if (ast.IsImportDeclaration(parent) ||
 			ast.IsExportDeclaration(parent) && parent.AsExportDeclaration().ModuleSpecifier != nil) &&
 			contextToken == parent.ModuleSpecifier() &&

--- a/internal/ls/converters.go
+++ b/internal/ls/converters.go
@@ -14,7 +14,7 @@ import (
 )
 
 type Converters struct {
-	getLineMap       func(fileName string) *LineMap
+	getLineMap       func(fileName string) *LSPLineMap
 	positionEncoding lsproto.PositionEncodingKind
 }
 
@@ -23,7 +23,7 @@ type Script interface {
 	Text() string
 }
 
-func NewConverters(positionEncoding lsproto.PositionEncodingKind, getLineMap func(fileName string) *LineMap) *Converters {
+func NewConverters(positionEncoding lsproto.PositionEncodingKind, getLineMap func(fileName string) *LSPLineMap) *Converters {
 	return &Converters{
 		getLineMap:       getLineMap,
 		positionEncoding: positionEncoding,

--- a/internal/ls/linemap.go
+++ b/internal/ls/linemap.go
@@ -9,12 +9,12 @@ import (
 	"github.com/microsoft/typescript-go/internal/core"
 )
 
-type LineMap struct {
+type LSPLineMap struct {
 	LineStarts []core.TextPos
 	AsciiOnly  bool // TODO(jakebailey): collect ascii-only info per line
 }
 
-func ComputeLineStarts(text string) *LineMap {
+func ComputeLSPLineStarts(text string) *LSPLineMap {
 	// This is like core.ComputeLineStarts, but only considers "\n", "\r", and "\r\n" as line breaks,
 	// and reports when the text is ASCII-only.
 	lineStarts := make([]core.TextPos, 0, strings.Count(text, "\n")+1)
@@ -45,13 +45,13 @@ func ComputeLineStarts(text string) *LineMap {
 	}
 	lineStarts = append(lineStarts, lineStart)
 
-	return &LineMap{
+	return &LSPLineMap{
 		LineStarts: lineStarts,
 		AsciiOnly:  asciiOnly,
 	}
 }
 
-func (lm *LineMap) ComputeIndexOfLineStart(targetPos core.TextPos) int {
+func (lm *LSPLineMap) ComputeIndexOfLineStart(targetPos core.TextPos) int {
 	// port of computeLineOfPosition(lineStarts: readonly number[], position: number, lowerBound?: number): number {
 	lineNumber, ok := slices.BinarySearchFunc(lm.LineStarts, targetPos, func(p, t core.TextPos) int {
 		return cmp.Compare(int(p), int(t))

--- a/internal/ls/utilities.go
+++ b/internal/ls/utilities.go
@@ -490,10 +490,10 @@ func probablyUsesSemicolons(file *ast.SourceFile) bool {
 			if lastToken != nil && lastToken.Kind == ast.KindSemicolonToken {
 				withSemicolon++
 			} else if lastToken != nil && lastToken.Kind != ast.KindCommaToken {
-				lastTokenLine, _ := scanner.GetLineAndCharacterOfPosition(
+				lastTokenLine, _ := scanner.GetECMALineAndCharacterOfPosition(
 					file,
 					astnav.GetStartOfNode(lastToken, file, false /*includeJSDoc*/))
-				nextTokenLine, _ := scanner.GetLineAndCharacterOfPosition(
+				nextTokenLine, _ := scanner.GetECMALineAndCharacterOfPosition(
 					file,
 					scanner.GetRangeOfTokenAtPosition(file, lastToken.End()).Pos())
 				// Avoid counting missing semicolon in single-line objects:

--- a/internal/lsutil/asi.go
+++ b/internal/lsutil/asi.go
@@ -98,7 +98,7 @@ func NodeIsASICandidate(node *ast.Node, file *ast.SourceFile) bool {
 		return true
 	}
 
-	startLine, _ := scanner.GetLineAndCharacterOfPosition(file, node.End())
-	endLine, _ := scanner.GetLineAndCharacterOfPosition(file, astnav.GetStartOfNode(nextToken, file, false /*includeJSDoc*/))
+	startLine, _ := scanner.GetECMALineAndCharacterOfPosition(file, node.End())
+	endLine, _ := scanner.GetECMALineAndCharacterOfPosition(file, astnav.GetStartOfNode(nextToken, file, false /*includeJSDoc*/))
 	return startLine != endLine
 }

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -629,7 +629,7 @@ func (p *Printer) writeCommentRange(comment ast.CommentRange) {
 	}
 
 	text := p.currentSourceFile.Text()
-	lineMap := p.currentSourceFile.LineMap()
+	lineMap := p.currentSourceFile.ECMALineMap()
 	p.writeCommentRangeWorker(text, lineMap, comment.Kind, comment.TextRange)
 }
 
@@ -5227,7 +5227,7 @@ func (p *Printer) writeSynthesizedComment(comment SynthesizedComment) {
 	text := formatSynthesizedComment(comment)
 	var lineMap []core.TextPos
 	if comment.Kind == ast.KindMultiLineCommentTrivia {
-		lineMap = core.ComputeLineStarts(text)
+		lineMap = core.ComputeECMALineStarts(text)
 	}
 	p.writeCommentRangeWorker(text, lineMap, comment.Kind, core.NewTextRange(0, len(text)))
 }
@@ -5294,7 +5294,7 @@ func (p *Printer) shouldEmitNewLineBeforeLeadingCommentOfPosition(pos int, comme
 	// If the leading comments start on different line than the start of node, write new line
 	return p.currentSourceFile != nil &&
 		pos != commentPos &&
-		scanner.ComputeLineOfPosition(p.currentSourceFile.LineMap(), pos) != scanner.ComputeLineOfPosition(p.currentSourceFile.LineMap(), commentPos)
+		scanner.ComputeLineOfPosition(p.currentSourceFile.ECMALineMap(), pos) != scanner.ComputeLineOfPosition(p.currentSourceFile.ECMALineMap(), commentPos)
 }
 
 func (p *Printer) emitTrailingComments(pos int, commentSeparator commentSeparator) {
@@ -5329,7 +5329,7 @@ func (p *Printer) emitDetachedComments(textRange core.TextRange) (result detache
 	}
 
 	text := p.currentSourceFile.Text()
-	lineMap := p.currentSourceFile.LineMap()
+	lineMap := p.currentSourceFile.ECMALineMap()
 
 	var leadingComments []ast.CommentRange
 	if p.commentsDisabled {
@@ -5482,7 +5482,7 @@ func (p *Printer) emitPos(pos int) {
 		return
 	}
 
-	sourceLine, sourceCharacter := scanner.GetLineAndCharacterOfPosition(p.sourceMapSource, pos)
+	sourceLine, sourceCharacter := scanner.GetECMALineAndCharacterOfPosition(p.sourceMapSource, pos)
 	if err := p.sourceMapGenerator.AddSourceMapping(
 		p.writer.GetLine(),
 		p.writer.GetColumn(),

--- a/internal/printer/textwriter.go
+++ b/internal/printer/textwriter.go
@@ -89,7 +89,7 @@ func (w *textWriter) updateLineCountAndPosFor(s string) {
 	var count int
 	var lastLineStart core.TextPos
 
-	for lineStart := range core.ComputeLineStartsSeq(s) {
+	for lineStart := range core.ComputeECMALineStartsSeq(s) {
 		count++
 		lastLineStart = lineStart
 	}

--- a/internal/printer/utilities.go
+++ b/internal/printer/utilities.go
@@ -369,7 +369,7 @@ func GetLinesBetweenPositions(sourceFile *ast.SourceFile, pos1 int, pos2 int) in
 	if pos1 == pos2 {
 		return 0
 	}
-	lineStarts := scanner.GetLineStarts(sourceFile)
+	lineStarts := scanner.GetECMALineStarts(sourceFile)
 	lower := core.IfElse(pos1 < pos2, pos1, pos2)
 	isNegative := lower == pos2
 	upper := core.IfElse(isNegative, pos1, pos2)

--- a/internal/project/compilerhost.go
+++ b/internal/project/compilerhost.go
@@ -6,7 +6,6 @@ import (
 	"github.com/microsoft/typescript-go/internal/ast"
 	"github.com/microsoft/typescript-go/internal/collections"
 	"github.com/microsoft/typescript-go/internal/compiler"
-	"github.com/microsoft/typescript-go/internal/ls"
 	"github.com/microsoft/typescript-go/internal/project/logging"
 	"github.com/microsoft/typescript-go/internal/tsoptions"
 	"github.com/microsoft/typescript-go/internal/tspath"
@@ -127,13 +126,6 @@ func (c *compilerHost) GetSourceFile(opts ast.SourceFileParseOptions) *ast.Sourc
 	c.seenFiles.Add(opts.Path)
 	if fh := c.fs.GetFileByPath(opts.FileName, opts.Path); fh != nil {
 		return c.builder.parseCache.Acquire(fh, opts, fh.Kind())
-	}
-	return nil
-}
-
-func (c *compilerHost) GetLineMap(fileName string) *ls.LineMap {
-	if fh := c.compilerFS.source.GetFile(fileName); fh != nil {
-		return fh.LineMap()
 	}
 	return nil
 }

--- a/internal/project/overlayfs.go
+++ b/internal/project/overlayfs.go
@@ -23,7 +23,7 @@ type FileHandle interface {
 	Version() int32
 	MatchesDiskText() bool
 	IsOverlay() bool
-	LineMap() *ls.LineMap
+	LSPLineMap() *ls.LSPLineMap
 	Kind() core.ScriptKind
 }
 
@@ -33,7 +33,7 @@ type fileBase struct {
 	hash     xxh3.Uint128
 
 	lineMapOnce sync.Once
-	lineMap     *ls.LineMap
+	lineMap     *ls.LSPLineMap
 }
 
 func (f *fileBase) FileName() string {
@@ -48,9 +48,9 @@ func (f *fileBase) Content() string {
 	return f.content
 }
 
-func (f *fileBase) LineMap() *ls.LineMap {
+func (f *fileBase) LSPLineMap() *ls.LSPLineMap {
 	f.lineMapOnce.Do(func() {
-		f.lineMap = ls.ComputeLineStarts(f.content)
+		f.lineMap = ls.ComputeLSPLineStarts(f.content)
 	})
 	return f.lineMap
 }
@@ -318,8 +318,8 @@ func (fs *overlayFS) processChanges(changes []FileChange) (FileChangeSummary, ma
 				panic("overlay not found for changed file: " + uri)
 			}
 			for _, change := range events.changes {
-				converters := ls.NewConverters(fs.positionEncoding, func(fileName string) *ls.LineMap {
-					return o.LineMap()
+				converters := ls.NewConverters(fs.positionEncoding, func(fileName string) *ls.LSPLineMap {
+					return o.LSPLineMap()
 				})
 				for _, textChange := range change.Changes {
 					if partialChange := textChange.Partial; partialChange != nil {

--- a/internal/project/snapshot.go
+++ b/internal/project/snapshot.go
@@ -59,7 +59,7 @@ func NewSnapshot(
 		ProjectCollection:                  &ProjectCollection{toPath: toPath},
 		compilerOptionsForInferredProjects: compilerOptionsForInferredProjects,
 	}
-	s.converters = ls.NewConverters(s.sessionOptions.PositionEncoding, s.LineMap)
+	s.converters = ls.NewConverters(s.sessionOptions.PositionEncoding, s.LSPLineMap)
 	s.refCount.Store(1)
 	return s
 }
@@ -74,9 +74,9 @@ func (s *Snapshot) GetFile(fileName string) FileHandle {
 	return s.fs.GetFile(fileName)
 }
 
-func (s *Snapshot) LineMap(fileName string) *ls.LineMap {
+func (s *Snapshot) LSPLineMap(fileName string) *ls.LSPLineMap {
 	if file := s.fs.GetFile(fileName); file != nil {
-		return file.LineMap()
+		return file.LSPLineMap()
 	}
 	return nil
 }

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -2331,12 +2331,12 @@ func getErrorRangeForArrowFunction(sourceFile *ast.SourceFile, node *ast.Node) c
 	pos := SkipTrivia(sourceFile.Text(), node.Pos())
 	body := node.AsArrowFunction().Body
 	if body != nil && body.Kind == ast.KindBlock {
-		startLine, _ := GetLineAndCharacterOfPosition(sourceFile, body.Pos())
-		endLine, _ := GetLineAndCharacterOfPosition(sourceFile, body.End())
+		startLine, _ := GetECMALineAndCharacterOfPosition(sourceFile, body.Pos())
+		endLine, _ := GetECMALineAndCharacterOfPosition(sourceFile, body.End())
 		if startLine < endLine {
 			// The arrow function spans multiple lines,
 			// make the error span be the first line, inclusive.
-			return core.NewTextRange(pos, GetEndLinePosition(sourceFile, startLine))
+			return core.NewTextRange(pos, GetECMAEndLinePosition(sourceFile, startLine))
 		}
 	}
 	return core.NewTextRange(pos, node.End())
@@ -2424,19 +2424,19 @@ func ComputeLineOfPosition(lineStarts []core.TextPos, pos int) int {
 	return low - 1
 }
 
-func GetLineStarts(sourceFile ast.SourceFileLike) []core.TextPos {
-	return sourceFile.LineMap()
+func GetECMALineStarts(sourceFile ast.SourceFileLike) []core.TextPos {
+	return sourceFile.ECMALineMap()
 }
 
-func GetLineAndCharacterOfPosition(sourceFile ast.SourceFileLike, pos int) (line int, character int) {
-	lineMap := GetLineStarts(sourceFile)
+func GetECMALineAndCharacterOfPosition(sourceFile ast.SourceFileLike, pos int) (line int, character int) {
+	lineMap := GetECMALineStarts(sourceFile)
 	line = ComputeLineOfPosition(lineMap, pos)
 	character = utf8.RuneCountInString(sourceFile.Text()[lineMap[line]:pos])
 	return line, character
 }
 
-func GetEndLinePosition(sourceFile *ast.SourceFile, line int) int {
-	pos := int(GetLineStarts(sourceFile)[line])
+func GetECMAEndLinePosition(sourceFile *ast.SourceFile, line int) int {
+	pos := int(GetECMALineStarts(sourceFile)[line])
 	for {
 		ch, size := utf8.DecodeRuneInString(sourceFile.Text()[pos:])
 		if size == 0 || stringutil.IsLineBreak(ch) {
@@ -2446,8 +2446,8 @@ func GetEndLinePosition(sourceFile *ast.SourceFile, line int) int {
 	}
 }
 
-func GetPositionOfLineAndCharacter(sourceFile *ast.SourceFile, line int, character int) int {
-	return ComputePositionOfLineAndCharacter(GetLineStarts(sourceFile), line, character)
+func GetECMAPositionOfLineAndCharacter(sourceFile *ast.SourceFile, line int, character int) int {
+	return ComputePositionOfLineAndCharacter(GetECMALineStarts(sourceFile), line, character)
 }
 
 func ComputePositionOfLineAndCharacter(lineStarts []core.TextPos, line int, character int) int {

--- a/internal/sourcemap/lineinfo.go
+++ b/internal/sourcemap/lineinfo.go
@@ -2,23 +2,23 @@ package sourcemap
 
 import "github.com/microsoft/typescript-go/internal/core"
 
-type LineInfo struct {
+type ECMALineInfo struct {
 	text       string
 	lineStarts []core.TextPos
 }
 
-func GetLineInfo(text string, lineStarts []core.TextPos) *LineInfo {
-	return &LineInfo{
+func GetECMALineInfo(text string, lineStarts []core.TextPos) *ECMALineInfo {
+	return &ECMALineInfo{
 		text:       text,
 		lineStarts: lineStarts,
 	}
 }
 
-func (li *LineInfo) LineCount() int {
+func (li *ECMALineInfo) LineCount() int {
 	return len(li.lineStarts)
 }
 
-func (li *LineInfo) LineText(line int) string {
+func (li *ECMALineInfo) LineText(line int) string {
 	pos := li.lineStarts[line]
 	var end core.TextPos
 	if line+1 < len(li.lineStarts) {

--- a/internal/sourcemap/source.go
+++ b/internal/sourcemap/source.go
@@ -5,5 +5,5 @@ import "github.com/microsoft/typescript-go/internal/core"
 type Source interface {
 	Text() string
 	FileName() string
-	LineMap() []core.TextPos
+	ECMALineMap() []core.TextPos
 }

--- a/internal/sourcemap/util.go
+++ b/internal/sourcemap/util.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Tries to find the sourceMappingURL comment at the end of a file.
-func TryGetSourceMappingURL(lineInfo *LineInfo) string {
+func TryGetSourceMappingURL(lineInfo *ECMALineInfo) string {
 	for index := lineInfo.LineCount() - 1; index >= 0; index-- {
 		line := lineInfo.LineText(index)
 		line = strings.TrimLeftFunc(line, unicode.IsSpace)

--- a/internal/testutil/harnessutil/sourcemap_recorder.go
+++ b/internal/testutil/harnessutil/sourcemap_recorder.go
@@ -94,7 +94,7 @@ func newSourceMapSpanWriter(sourceMapRecorder *writerAggregator, sourceMap *sour
 		sourceMapSources:     sourceMap.Sources,
 		sourceMapNames:       sourceMap.Names,
 		jsFile:               jsFile,
-		jsLineMap:            core.ComputeLineStarts(jsFile.Content),
+		jsLineMap:            core.ComputeECMALineStarts(jsFile.Content),
 		spansOnSingleLine:    make([]sourceMapSpanWithDecodeErrors, 0),
 		prevWrittenSourcePos: 0,
 		nextJsLineToWrite:    0,
@@ -104,7 +104,7 @@ func newSourceMapSpanWriter(sourceMapRecorder *writerAggregator, sourceMap *sour
 
 	sourceMapRecorder.WriteLine("===================================================================")
 	sourceMapRecorder.WriteLineF("JsFile: %s", sourceMap.File)
-	sourceMapRecorder.WriteLineF("mapUrl: %s", sourcemap.TryGetSourceMappingURL(sourcemap.GetLineInfo(jsFile.Content, writer.jsLineMap)))
+	sourceMapRecorder.WriteLineF("mapUrl: %s", sourcemap.TryGetSourceMappingURL(sourcemap.GetECMALineInfo(jsFile.Content, writer.jsLineMap)))
 	sourceMapRecorder.WriteLineF("sourceRoot: %s", sourceMap.SourceRoot)
 	sourceMapRecorder.WriteLineF("sources: %s", strings.Join(sourceMap.Sources, ","))
 	if len(sourceMap.SourcesContent) > 0 {
@@ -187,7 +187,7 @@ func (w *sourceMapSpanWriter) recordNewSourceFileSpan(sourceMapSpan *sourcemap.M
 	w.sourceMapRecorder.WriteLineF("sourceFile:%s", w.sourceMapSources[w.spansOnSingleLine[0].sourceMapSpan.SourceIndex])
 	w.sourceMapRecorder.WriteLine("-------------------------------------------------------------------")
 
-	w.tsLineMap = core.ComputeLineStarts(newSourceFileCode)
+	w.tsLineMap = core.ComputeECMALineStarts(newSourceFileCode)
 	w.tsCode = newSourceFileCode
 	w.prevWrittenSourcePos = 0
 }
@@ -302,7 +302,7 @@ func (sw *recordedSpanWriter) writeSourceMapSourceText(currentSpan *sourceMapSpa
 		sw.w.sourceMapRecorder.WriteLine(decodeError)
 	}
 
-	tsCodeLineMap := core.ComputeLineStarts(sourceText)
+	tsCodeLineMap := core.ComputeECMALineStarts(sourceText)
 	for i := range tsCodeLineMap {
 		if i == 0 {
 			sw.writeSourceMapIndent(sw.prevEmittedCol, sw.markerIds[index])

--- a/internal/testutil/tsbaseline/error_baseline.go
+++ b/internal/testutil/tsbaseline/error_baseline.go
@@ -171,7 +171,7 @@ func iterateErrorBaseline(t *testing.T, inputFiles []*harnessutil.TestFile, inpu
 		markedErrorCount := 0
 		// For each line, emit the line followed by any error squiggles matching this line
 
-		lineStarts := core.ComputeLineStarts(inputFile.Content)
+		lineStarts := core.ComputeECMALineStarts(inputFile.Content)
 		lines := lineDelimiter.Split(inputFile.Content, -1)
 
 		for lineIndex, line := range lines {

--- a/internal/testutil/tsbaseline/type_symbol_baseline.go
+++ b/internal/testutil/tsbaseline/type_symbol_baseline.go
@@ -343,7 +343,7 @@ func forEachASTNode(node *ast.Node) []*ast.Node {
 
 func (walker *typeWriterWalker) writeTypeOrSymbol(node *ast.Node, isSymbolWalk bool) *typeWriterResult {
 	actualPos := scanner.SkipTrivia(walker.currentSourceFile.Text(), node.Pos())
-	line, _ := scanner.GetLineAndCharacterOfPosition(walker.currentSourceFile, actualPos)
+	line, _ := scanner.GetECMALineAndCharacterOfPosition(walker.currentSourceFile, actualPos)
 	sourceText := scanner.GetSourceTextOfNodeFromSourceFile(walker.currentSourceFile, node, false /*includeTrivia*/)
 	fileChecker, done := walker.getTypeCheckerForCurrentFile()
 	defer done()
@@ -434,7 +434,7 @@ func (walker *typeWriterWalker) writeTypeOrSymbol(node *ast.Node, isSymbolWalk b
 		}
 
 		declSourceFile := ast.GetSourceFileOfNode(declaration)
-		declLine, declChar := scanner.GetLineAndCharacterOfPosition(declSourceFile, declaration.Pos())
+		declLine, declChar := scanner.GetECMALineAndCharacterOfPosition(declSourceFile, declaration.Pos())
 		fileName := tspath.GetBaseFileName(declSourceFile.FileName())
 		symbolString.WriteString("Decl(")
 		symbolString.WriteString(fileName)

--- a/internal/transformers/jsxtransforms/jsx.go
+++ b/internal/transformers/jsxtransforms/jsx.go
@@ -577,7 +577,7 @@ func (tx *JSXTransformer) visitJsxOpeningLikeElementOrFragmentJSX(
 				args = append(args, tx.Factory().NewFalseExpression())
 			}
 			// __source development flag
-			line, col := scanner.GetLineAndCharacterOfPosition(originalFile.AsSourceFile(), location.Pos())
+			line, col := scanner.GetECMALineAndCharacterOfPosition(originalFile.AsSourceFile(), location.Pos())
 			args = append(args, tx.Factory().NewObjectLiteralExpression(tx.Factory().NewNodeList([]*ast.Node{
 				tx.Factory().NewPropertyAssignment(nil, tx.Factory().NewIdentifier("fileName"), nil, nil, tx.getCurrentFileNameExpression()),
 				tx.Factory().NewPropertyAssignment(nil, tx.Factory().NewIdentifier("lineNumber"), nil, nil, tx.Factory().NewNumericLiteral(strconv.FormatInt(int64(line+1), 10))),

--- a/internal/transformers/utilities.go
+++ b/internal/transformers/utilities.go
@@ -259,8 +259,8 @@ func IsOriginalNodeSingleLine(emitContext *printer.EmitContext, node *ast.Node) 
 	if source == nil {
 		return false
 	}
-	startLine, _ := scanner.GetLineAndCharacterOfPosition(source, original.Loc.Pos())
-	endLine, _ := scanner.GetLineAndCharacterOfPosition(source, original.Loc.End())
+	startLine, _ := scanner.GetECMALineAndCharacterOfPosition(source, original.Loc.Pos())
+	endLine, _ := scanner.GetECMALineAndCharacterOfPosition(source, original.Loc.End())
 	return startLine == endLine
 }
 


### PR DESCRIPTION
Renaming line map-related functions to make the distinction clear between ECMA and LSP lines.
ECMA line maps/line starts consider characters other than `\n` and `\r\n` as line breaks (see `stringutil.IsLineBreak`), unlike LSP.
This should help avoid future incorrect usages of those functions, and should make it easier to do #1578.