### PR TITLE
Ensure `Parameters` property of arrow function is never nil

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -4198,6 +4198,7 @@ func (p *Parser) parseParenthesizedArrowFunctionExpression(allowAmbiguity bool, 
 		if !allowAmbiguity {
 			return nil
 		}
+		parameters = p.parseEmptyNodeList()
 	} else {
 		if !allowAmbiguity {
 			maybeParameters := p.parseParametersWorker(signatureFlags, allowAmbiguity)


### PR DESCRIPTION
Fixes a crash in the language service:

```ts
const f = () => 42  // Delete () and LSP panics
```