### PR TITLE
Port "Provide string completions for `in` keyword checks"

### DIFF
--- a/internal/ls/string_completions.go
+++ b/internal/ls/string_completions.go
@@ -375,6 +375,22 @@ func (l *LanguageService) getStringLiteralCompletionEntries(
 				hasIndexSignature: false,
 			},
 		}
+	case ast.KindBinaryExpression:
+		if parent.AsBinaryExpression().OperatorToken.Kind == ast.KindInKeyword {
+			t := typeChecker.GetTypeAtLocation(parent.AsBinaryExpression().Right)
+			properties := getPropertiesForCompletion(t, typeChecker)
+			return &stringLiteralCompletions{
+				fromProperties: &completionsFromProperties{
+					symbols: core.Filter(properties, func(s *ast.Symbol) bool {
+						return s.ValueDeclaration == nil || !ast.IsPrivateIdentifierClassElementDeclaration(s.ValueDeclaration)
+					}),
+					hasIndexSignature: false,
+				},
+			}
+		}
+		return &stringLiteralCompletions{
+			fromTypes: fromContextualType(checker.ContextFlagsNone, node, typeChecker),
+		}
 	default:
 		result := fromContextualType(checker.ContextFlagsCompletions, node, typeChecker)
 		if result != nil {


### PR DESCRIPTION
ports https://github.com/microsoft/TypeScript/pull/60272

I still can't enable the related tests because in Corsa there is a pre-existing issue causing a label mismatch on the expected completion entry