### PR TITLE
(not intending to merge) Add option for overriding GOMEMLIMIT

### DIFF
--- a/_extension/package.json
+++ b/_extension/package.json
@@ -30,6 +30,13 @@
                         ],
                         "default": "verbose",
                         "description": "Trace TypeScript Go server communication."
+                    },
+                    "typescript-go.memoryLimit": {
+                        "type": "string",
+                        "default": "",
+                        "description": "Memory limit for the TypeScript Go language server (e.g., '2GiB', '500MiB'). Leave empty for no limit.",
+                        "pattern": "^([0-9]+(\\.[0-9]+)?([KMGT]i)?B)?$",
+                        "patternErrorMessage": "Must be a valid memory size (e.g., '2GiB', '500MiB', '1024B')"
                     }
                 }
             }

--- a/_extension/src/extension.ts
+++ b/_extension/src/extension.ts
@@ -39,6 +39,9 @@ export function activate(context: vscode.ExtensionContext) {
         },
     };
 
+    const config = vscode.workspace.getConfiguration("typescript-go");
+    const memoryLimit = config.get<string>("memoryLimit");
+
     const clientOptions: LanguageClientOptions = {
         documentSelector: [
             { scheme: "file", language: "typescript" },
@@ -52,6 +55,7 @@ export function activate(context: vscode.ExtensionContext) {
         ],
         outputChannel: output,
         traceOutputChannel: traceOutput,
+        ...(memoryLimit ? { initializationOptions: { memoryLimit: memoryLimit } } : {}),
         diagnosticPullOptions: {
             onChange: true,
             onSave: true,


### PR DESCRIPTION
Just a conversation starter. On a very large monorepo by setting this pretty low we can get very good performance with 25% less memory usage.