### PR TITLE
Mark libReplacement default as false

### DIFF
--- a/internal/tsoptions/declscompiler.go
+++ b/internal/tsoptions/declscompiler.go
@@ -498,7 +498,7 @@ var optionsForCompiler = []*CommandLineOption{
 		AffectsProgramStructure: true,
 		Category:                diagnostics.Language_and_Environment,
 		Description:             diagnostics.Enable_lib_replacement,
-		DefaultValueDescription: true,
+		DefaultValueDescription: false,
 	},
 
 	// Strict Type Checks


### PR DESCRIPTION
I forgot to change this when I ported in the flag and defaulted it to `false`.