### PR TITLE
Port "Stop reassigning `.valueDeclaration` to avoid replacing earlier declarations with late ones"

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -15400,9 +15400,7 @@ func (c *Checker) addDeclarationToLateBoundSymbol(symbol *ast.Symbol, member *as
 		symbol.Declarations = append(symbol.Declarations, member)
 	}
 	if symbolFlags&ast.SymbolFlagsValue != 0 {
-		if symbol.ValueDeclaration == nil || symbol.ValueDeclaration.Kind != member.Kind {
-			symbol.ValueDeclaration = member
-		}
+		binder.SetValueDeclaration(symbol, member)
 	}
 }
 


### PR DESCRIPTION
ports https://github.com/microsoft/TypeScript/pull/60857

It seems this isn't strictly needed right now. Likely, reparsing fixed the original issue already but I think it might still be a good idea to pick up this change for the sake of code parity between Strada and Corsa