### PR TITLE
Port "Fixed crash in `hasVisibleDeclarations` related to binding elements"

### DIFF
--- a/internal/checker/emitresolver.go
+++ b/internal/checker/emitresolver.go
@@ -409,7 +409,14 @@ func (r *emitResolver) hasVisibleDeclarations(symbol *ast.Symbol, shouldComputeA
 					continue
 				}
 				if symbol.Flags&ast.SymbolFlagsBlockScopedVariable != 0 {
-					variableStatement := ast.FindAncestor(declaration, ast.IsVariableStatement)
+					rootDeclaration := ast.WalkUpBindingElementsAndPatterns(declaration)
+					if ast.IsParameter(rootDeclaration) {
+						return nil
+					}
+					variableStatement := rootDeclaration.Parent.Parent;
+					if !ast.IsVariableStatement(variableStatement) {
+						return nil
+					}
 					if ast.HasSyntacticModifier(variableStatement, ast.ModifierFlagsExport) {
 						continue // no alias to add, already exported
 					}

--- a/internal/checker/emitresolver.go
+++ b/internal/checker/emitresolver.go
@@ -413,7 +413,7 @@ func (r *emitResolver) hasVisibleDeclarations(symbol *ast.Symbol, shouldComputeA
 					if ast.IsParameter(rootDeclaration) {
 						return nil
 					}
-					variableStatement := rootDeclaration.Parent.Parent;
+					variableStatement := rootDeclaration.Parent.Parent
 					if !ast.IsVariableStatement(variableStatement) {
 						return nil
 					}


### PR DESCRIPTION
ports https://github.com/microsoft/TypeScript/pull/61352

It seems this isn't strictly needed right now. Likely, reparsing fixed the original issue already but I think it might still be a good idea to pick up this change for the sake of code parity between Strada and Corsa