### PR TITLE
Port "Fix Symbol completion priority and cursor positioning"

### DIFF
--- a/internal/ls/completions.go
+++ b/internal/ls/completions.go
@@ -767,6 +767,7 @@ func (l *LanguageService) getCompletionData(
 			}
 			if firstAccessibleSymbolId != 0 && seenPropertySymbols.AddIfAbsent(firstAccessibleSymbolId) {
 				symbols = append(symbols, firstAccessibleSymbol)
+				symbolToSortTextMap[firstAccessibleSymbolId] = SortTextGlobalsOrKeywords
 				moduleSymbol := firstAccessibleSymbol.Parent
 				if moduleSymbol == nil ||
 					!checker.IsExternalModuleSymbol(moduleSymbol) ||


### PR DESCRIPTION
There is no change in tests (yet) because all related tests fail at the first `assertDeepEqual` call in `verifyCompletionItem` for other reasons. So the code never reaches `assertDeepEqual` targeting `.SortText`

ports https://github.com/microsoft/TypeScript/pull/61945