### PR TITLE
Don’t look in JSExportAssignment and CommonJSExport for nodes

### DIFF
--- a/internal/ast/utilities.go
+++ b/internal/ast/utilities.go
@@ -2641,7 +2641,7 @@ func GetNodeAtPosition(file *SourceFile, position int, includeJSDoc bool) *Node 
 		}
 		if child == nil {
 			current.ForEachChild(func(node *Node) bool {
-				if nodeContainsPosition(node, position) {
+				if nodeContainsPosition(node, position) && node.Kind != KindJSExportAssignment && node.Kind != KindCommonJSExport {
 					child = node
 					return true
 				}

--- a/testdata/tests/cases/compiler/nestedJSDocImportType.ts
+++ b/testdata/tests/cases/compiler/nestedJSDocImportType.ts
@@ -1,0 +1,15 @@
+// @checkJs: true
+// @noEmit: true
+// @noTypesAndSymbols: true
+
+// @Filename: a.js
+/** @typedef {string} A */
+
+// @Filename: b.js
+module.exports = {
+  create() {
+    /** @param {import("./a").A} x */
+    function f(x) {}
+    return f("hi");
+  }
+}


### PR DESCRIPTION
When looking for imports to resolve, we were hitting the cloned function inside the fake reparsed export, which says it has JSDoc attached, but isn’t actually the key into the JSDoc map because it’s the clone.