### PR TITLE
Fix panic for small export only files

### DIFF
--- a/internal/ls/utilities.go
+++ b/internal/ls/utilities.go
@@ -917,7 +917,14 @@ func getAdjustedLocation(node *ast.Node, forRename bool, sourceFile *ast.SourceF
 	// specially by `getSymbolAtLocation`.
 	isModifier := func(node *ast.Node) bool {
 		if ast.IsModifier(node) && (forRename || node.Kind != ast.KindDefaultKeyword) {
-			return ast.CanHaveModifiers(parent) && slices.Contains(parent.Modifiers().NodeList.Nodes, node)
+			if !ast.CanHaveModifiers(parent) {
+				return false
+			}
+			modifiers := parent.Modifiers()
+			if modifiers == nil {
+				return false
+			}
+			return slices.Contains(modifiers.NodeList.Nodes, node)
 		}
 		switch node.Kind {
 		case ast.KindClassKeyword:


### PR DESCRIPTION
Fixes an issue I was seeing with a file like this `jest.config.ts` with. I validated this locally and it went away after this change. This may end up fixing a few other small panics seen given where this is used.

```typescript
export default {
  preset: '@package/build',
};
```

Throwing this panic:
```
panic handling request textDocument/documentHighlight runtime error: invalid memory address or nil pointer dereference goroutine 547756 [running]:
runtime/debug.Stack()
	/opt/homebrew/Cellar/go/1.25.2/libexec/src/runtime/debug/stack.go:26 +0x64
github.com/microsoft/typescript-go/internal/lsp.(*Server).recover(0x1400017cdc0, 0x1429addd140)
	/Users/rishi/Developer/forks/typescript-go/internal/lsp/server.go:542 +0x44
panic({0x102be4e40?, 0x10338fe50?})
	/opt/homebrew/Cellar/go/1.25.2/libexec/src/runtime/panic.go:783 +0x120
github.com/microsoft/typescript-go/internal/ls.getAdjustedLocation.func1(...)
	/Users/rishi/Developer/forks/typescript-go/internal/ls/utilities.go:920
github.com/microsoft/typescript-go/internal/ls.getAdjustedLocation(0x142915a7b90, 0x0, 0x0)
	/Users/rishi/Developer/forks/typescript-go/internal/ls/utilities.go:944 +0x1a4
github.com/microsoft/typescript-go/internal/ls.getMeaningFromLocation(0x14115abca18?)
	/Users/rishi/Developer/forks/typescript-go/internal/ls/utilities.go:1245 +0x24
github.com/microsoft/typescript-go/internal/ls.getIntersectingMeaningFromDeclarations(0x14287c36f50?, 0x14287c36f50, 0x99e5c608?)
	/Users/rishi/Developer/forks/typescript-go/internal/ls/utilities.go:1322 +0x24
github.com/microsoft/typescript-go/internal/ls.getReferencedSymbolsForSymbol(0x14287c36f50, 0x142915a7b90, {0x14178ee8040, 0x1, 0x1}, 0x14178ee8050, 0x14299e5c608, {0x0, 0x0, 0x2, ...})
	/Users/rishi/Developer/forks/typescript-go/internal/ls/findallreferences.go:1197 +0xb0
github.com/microsoft/typescript-go/internal/ls.(*LanguageService).getReferencedSymbolsForNode(0x142b4c11bf0, {0x102dce3b0, 0x142b4f6d4f0}, 0x0, 0x142915a7b90, 0x1412c00a1e0, {0x14178ee8040, 0x1, 0x1}, {0x0, ...}, ...)
	/Users/rishi/Developer/forks/typescript-go/internal/ls/findallreferences.go:683 +0x5ec
github.com/microsoft/typescript-go/internal/ls.(*LanguageService).getSemanticDocumentHighlights(0x142b4c11bf0, {0x102dce3b0, 0x142b4f6d4f0}, 0x0, 0x142915a7b90, 0x1412c00a1e0, 0x1412f498608)
	/Users/rishi/Developer/forks/typescript-go/internal/ls/documenthighlights.go:55 +0xc4
github.com/microsoft/typescript-go/internal/ls.(*LanguageService).ProvideDocumentHighlights(0x142b4c11bf0, {0x102dce3b0, 0x142b4f6d4f0}, {0x14053ad3770?, 0x14000360000?}, {0x2dce3b0?, 0x1?})
	/Users/rishi/Developer/forks/typescript-go/internal/ls/documenthighlights.go:45 +0x34c
github.com/microsoft/typescript-go/internal/lsp.(*Server).handleDocumentHighlight(0x14000360000?, {0x102dce3b0?, 0x142b4f6d4f0?}, 0x14053ad3770?, 0x46?)
	/Users/rishi/Developer/forks/typescript-go/internal/lsp/server.go:863 +0x38
github.com/microsoft/typescript-go/internal/lsp.init.func1.registerLanguageServiceDocumentRequestHandler[...].24({0x102dce3b0, 0x142b4f6d4f0}, 0x1429addd140)
	/Users/rishi/Developer/forks/typescript-go/internal/lsp/server.go:528 +0xe0
github.com/microsoft/typescript-go/internal/lsp.(*Server).handleRequestOrNotification(0x1400017cdc0, {0x102dce3b0, 0x142b4f6d4f0}, 0x1429addd140)
	/Users/rishi/Developer/forks/typescript-go/internal/lsp/server.go:425 +0xf4
github.com/microsoft/typescript-go/internal/lsp.(*Server).dispatchLoop.func1()
	/Users/rishi/Developer/forks/typescript-go/internal/lsp/server.go:330 +0x34
created by github.com/microsoft/typescript-go/internal/lsp.(*Server).dispatchLoop in goroutine 22
	/Users/rishi/Developer/forks/typescript-go/internal/lsp/server.go:350 +0x6f8
```