### PR TITLE
Fix panic of empty string in type reference directive

### DIFF
--- a/internal/module/util.go
+++ b/internal/module/util.go
@@ -45,7 +45,7 @@ func ParsePackageName(moduleName string) (packageName, rest string) {
 }
 
 func MangleScopedPackageName(packageName string) string {
-	if packageName[0] == '@' {
+	if len(packageName) > 0 && packageName[0] == '@' {
 		idx := strings.Index(packageName, "/")
 		if idx == -1 {
 			return packageName


### PR DESCRIPTION
Prevents panics from empty strings in type reference directives.
Fixes #1891 

```typescript
/// <reference types="" />
```
panic:
```plaintext
panic: runtime error: index out of range [0] with length 0

goroutine 38 [running]:
github.com/microsoft/typescript-go/internal/module.MangleScopedPackageName({0x14000148000?, 0x100a64edc?})
	github.com/microsoft/typescript-go/internal/module/util.go:48 +0x110
github.com/microsoft/typescript-go/internal/module.(*resolutionState).mangleScopedPackageName(0x14000962000, {0x14000148000, 0x0})
	github.com/microsoft/typescript-go/internal/module/resolver.go:385 +0x34
github.com/microsoft/typescript-go/internal/module.(*resolutionState).getCandidateFromTypeRoot(0x14000962000, {0x14000030190, 0x43})
	github.com/microsoft/typescript-go/internal/module/resolver.go:379 +0xc0
github.com/microsoft/typescript-go/internal/module.(*resolutionState).resolveTypeReferenceDirective(0x14000962000, {0x140007c0600?, 0x140003a88c0?, 0x33?}, 0x0, 0x0)
	github.com/microsoft/typescript-go/internal/module/resolver.go:335 +0x49c
github.com/microsoft/typescript-go/internal/module.(*Resolver).ResolveTypeReferenceDirective(0x140003dcd20, {0x14000148000, 0x0}, {0x140003a88c0, 0x41}, 0x0, {0x101424ce8, 0x0})
	github.com/microsoft/typescript-go/internal/module/resolver.go:217 +0x2cc
github.com/microsoft/typescript-go/internal/compiler.(*fileLoader).resolveTypeReferenceDirectives(0x140003bbc08, 0x140004de240)
	github.com/microsoft/typescript-go/internal/compiler/fileloader.go:463 +0x1bc
github.com/microsoft/typescript-go/internal/compiler.(*parseTask).load(0x140004de240, 0x140003bbc08)
	github.com/microsoft/typescript-go/internal/compiler/filesparser.go:91 +0x2d8
github.com/microsoft/typescript-go/internal/compiler.(*filesParser).start.func1()
	github.com/microsoft/typescript-go/internal/compiler/filesparser.go:220 +0x170
github.com/microsoft/typescript-go/internal/core.(*parallelWorkGroup).Queue.func1()
	github.com/microsoft/typescript-go/internal/core/workgroup.go:42 +0x50
created by github.com/microsoft/typescript-go/internal/core.(*parallelWorkGroup).Queue in goroutine 33
	github.com/microsoft/typescript-go/internal/core/workgroup.go:40 +0x7c
```