### PR TITLE
Clear local baseline dir in hereby test

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -57,6 +57,7 @@ const { values: rawOptions } = parseArgs({
         tests: { type: "string", short: "t" },
         fix: { type: "boolean" },
         debug: { type: "boolean" },
+        dirty: { type: "boolean" },
 
         insiders: { type: "boolean" },
 
@@ -325,6 +326,12 @@ function goTest(taskName) {
 
 async function runTests() {
     warnIfTypeScriptSubmoduleNotCloned();
+
+    if (!options.dirty) {
+        await rimraf(localBaseline);
+        await fs.promises.mkdir(localBaseline, { recursive: true });
+    }
+
     await $test`${gotestsum("tests")} ./... ${isCI ? ["--timeout=45m"] : []}`;
 }
 
@@ -520,10 +527,13 @@ function baselineAcceptTask(localBaseline, refBaseline) {
     };
 }
 
+const localBaseline = "testdata/baselines/local/";
+const refBaseline = "testdata/baselines/reference/";
+
 export const baselineAccept = task({
     name: "baseline-accept",
     description: "Makes the most recent test results the new baseline, overwriting the old baseline.",
-    run: baselineAcceptTask("testdata/baselines/local/", "testdata/baselines/reference/"),
+    run: baselineAcceptTask(localBaseline, refBaseline),
 });
 
 /**


### PR DESCRIPTION
This fixes some issues, but not the flow of using `updatefailing` and `baseline-accept`, since those affect reference baselines.