### PR TITLE
Ensure os package is forbidden in lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -79,7 +79,7 @@ linters:
           pkg: ^(path|path/filepath)$
         - pattern: '.*'
           msg: a host implementation should likely be used instead
-          pkg: ^os/
+          pkg: ^os(/|$)
         - pattern: 'GOOS'
           msg: a host implementation should likely be used instead
           pkg: ^runtime$


### PR DESCRIPTION
In modifying #1911, I mistakenly forgot to ensure that this regex matched `os` itself, and not just `os/`.