### PR TITLE
Don't report errors on `{@link foo.bar}` references

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -11081,6 +11081,9 @@ func (c *Checker) checkPrivateIdentifierPropertyAccess(leftType *Type, right *as
 }
 
 func (c *Checker) reportNonexistentProperty(propNode *ast.Node, containingType *Type) {
+	if ast.IsJSDocNameReferenceContext(propNode) {
+		return
+	}
 	var diagnostic *ast.Diagnostic
 	if !ast.IsPrivateIdentifier(propNode) && containingType.flags&TypeFlagsUnion != 0 && containingType.flags&TypeFlagsPrimitive == 0 {
 		for _, subtype := range containingType.Types() {


### PR DESCRIPTION
This is a follow-up to #1935 that suppresses generation of diagnostics during resolution of `{@link foo.bar}` references. Those diagnostics would sporadically show up because of checker reuse.