### PR TITLE
Fix `getCompletionItemActions` add nil checks for symbol origin data

### DIFF
--- a/internal/ls/completions.go
+++ b/internal/ls/completions.go
@@ -5322,7 +5322,7 @@ func (l *LanguageService) getCompletionItemActions(ctx context.Context, ch *chec
 	// !!! origin.isTypeOnlyAlias
 	// entryId.source == CompletionSourceObjectLiteralMemberWithComma && contextToken
 
-	if symbolDetails.origin == nil {
+	if symbolDetails.origin == nil || symbolDetails.origin.data == nil {
 		return nil
 	}
 


### PR DESCRIPTION
Temporary symbols/Literal Syntax Sugar (e.g., `[].`, `(class {}).`) have no origin data - I just want to check if they're nil and skip processing if so.

Fixes #1950 