### PR TITLE
Fix various named enum types

### DIFF
--- a/internal/ast/parseoptions.go
+++ b/internal/ast/parseoptions.go
@@ -5,7 +5,7 @@ import (
 	"github.com/microsoft/typescript-go/internal/tspath"
 )
 
-type JSDocParsingMode int
+type JSDocParsingMode uint8
 
 const (
 	JSDocParsingModeParseAll JSDocParsingMode = iota

--- a/internal/ast/subtreefacts.go
+++ b/internal/ast/subtreefacts.go
@@ -4,7 +4,7 @@ import (
 	"github.com/microsoft/typescript-go/internal/core"
 )
 
-type SubtreeFacts int32
+type SubtreeFacts uint32
 
 const (
 	// Facts

--- a/internal/checker/types.go
+++ b/internal/checker/types.go
@@ -82,7 +82,7 @@ const TypeFormatFlagsNodeBuilderFlagsMask = TypeFormatFlagsNoTruncation | TypeFo
 	TypeFormatFlagsUseTypeOfFunction | TypeFormatFlagsOmitParameterModifiers | TypeFormatFlagsUseAliasDefinedOutsideCurrentScope | TypeFormatFlagsAllowUniqueESSymbolType | TypeFormatFlagsInTypeAlias |
 	TypeFormatFlagsUseSingleQuotesForStringLiteralType | TypeFormatFlagsNoTypeReduction | TypeFormatFlagsOmitThisParameter
 
-type SymbolFormatFlags int32
+type SymbolFormatFlags uint32
 
 const (
 	SymbolFormatFlagsNone SymbolFormatFlags = 0

--- a/internal/module/resolver_test.go
+++ b/internal/module/resolver_test.go
@@ -211,7 +211,7 @@ type rawArgs struct {
 	Name            string                `json:"name"`
 	ContainingFile  string                `json:"containingFile"`
 	CompilerOptions *core.CompilerOptions `json:"compilerOptions"`
-	ResolutionMode  int                   `json:"resolutionMode"`
+	ResolutionMode  core.ModuleKind       `json:"resolutionMode"`
 	RedirectedRef   *struct {
 		SourceFile struct {
 			FileName string `json:"fileName"`
@@ -265,7 +265,7 @@ func doCall(t *testing.T, resolver *module.Resolver, call functionCall, skipLoca
 
 		errorMessageArgs := []any{call.args.Name, call.args.ContainingFile}
 		if call.call == "resolveModuleName" {
-			resolved, _ := resolver.ResolveModuleName(call.args.Name, call.args.ContainingFile, core.ModuleKind(call.args.ResolutionMode), redirectedReference)
+			resolved, _ := resolver.ResolveModuleName(call.args.Name, call.args.ContainingFile, call.args.ResolutionMode, redirectedReference)
 			assert.Check(t, resolved != nil, "ResolveModuleName should not return nil", errorMessageArgs)
 			if expectedResolvedModule, ok := call.returnValue["resolvedModule"].(map[string]any); ok {
 				assert.Check(t, resolved.IsResolved(), errorMessageArgs)
@@ -277,7 +277,7 @@ func doCall(t *testing.T, resolver *module.Resolver, call functionCall, skipLoca
 				assert.Check(t, !resolved.IsResolved(), errorMessageArgs)
 			}
 		} else {
-			resolved, _ := resolver.ResolveTypeReferenceDirective(call.args.Name, call.args.ContainingFile, core.ModuleKind(call.args.ResolutionMode), redirectedReference)
+			resolved, _ := resolver.ResolveTypeReferenceDirective(call.args.Name, call.args.ContainingFile, call.args.ResolutionMode, redirectedReference)
 			assert.Check(t, resolved != nil, "ResolveTypeReferenceDirective should not return nil", errorMessageArgs)
 			if expectedResolvedTypeReferenceDirective, ok := call.returnValue["resolvedTypeReferenceDirective"].(map[string]any); ok {
 				assert.Check(t, resolved.IsResolved(), errorMessageArgs)

--- a/internal/nodebuilder/types.go
+++ b/internal/nodebuilder/types.go
@@ -26,7 +26,7 @@ type SymbolTracker interface {
 }
 
 // NOTE: If modifying this enum, must modify `TypeFormatFlags` too!
-type Flags int32
+type Flags uint32
 
 const (
 	FlagsNone Flags = 0

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -111,11 +111,11 @@ func FuzzParser(f *testing.F) {
 			sourceText, err := os.ReadFile(file.path)
 			assert.NilError(f, err)
 			extension := tspath.TryGetExtensionFromPath(file.path)
-			f.Add(extension, string(sourceText), int(core.ScriptTargetESNext), int(ast.JSDocParsingModeParseAll))
+			f.Add(extension, string(sourceText), int32(core.ScriptTargetESNext), uint8(ast.JSDocParsingModeParseAll))
 		}
 	}
 
-	f.Fuzz(func(t *testing.T, extension string, sourceText string, scriptTarget_ int, jsdocParsingMode_ int) {
+	f.Fuzz(func(t *testing.T, extension string, sourceText string, scriptTarget_ int32, jsdocParsingMode_ uint8) {
 		scriptTarget := core.ScriptTarget(scriptTarget_)
 		jsdocParsingMode := ast.JSDocParsingMode(jsdocParsingMode_)
 

--- a/internal/parser/testdata/fuzz/FuzzParser/02b74efe61495c2a
+++ b/internal/parser/testdata/fuzz/FuzzParser/02b74efe61495c2a
@@ -1,5 +1,5 @@
 go test fuzz v1
 string(".ts")
 string("/**@0\n     * */0")
-int(99)
-int(0)
+int32(99)
+uint8(0)

--- a/internal/parser/testdata/fuzz/FuzzParser/9ce2d994c65c7bfe
+++ b/internal/parser/testdata/fuzz/FuzzParser/9ce2d994c65c7bfe
@@ -1,5 +1,5 @@
 go test fuzz v1
 string(".ts")
 string("/")
-int(99)
-int(1)
+int32(99)
+uint8(1)

--- a/internal/vfs/utilities.go
+++ b/internal/vfs/utilities.go
@@ -314,11 +314,10 @@ var (
 )
 
 func GetRegexFromPattern(pattern string, useCaseSensitiveFileNames bool) *regexp2.Regexp {
-	flags := regexp2.ECMAScript
+	opts := regexp2.RegexOptions(regexp2.ECMAScript)
 	if !useCaseSensitiveFileNames {
-		flags |= regexp2.IgnoreCase
+		opts |= regexp2.IgnoreCase
 	}
-	opts := regexp2.RegexOptions(flags)
 
 	key := regexp2CacheKey{pattern, opts}
 


### PR DESCRIPTION
Noticed these while trying `gosec`. Most of these are enum types that are paired up with another but underlying types differed, which is weird.

`regexp2`'s constants are broken; they mistakenly forgot that only `iota` keeps inferring the same type as the first "enum" value in a block.