### PR TITLE
Fix crash in find-all-refs on `exports.xxx` in .js file

### DIFF
--- a/internal/ls/findallreferences.go
+++ b/internal/ls/findallreferences.go
@@ -1172,7 +1172,7 @@ func (l *LanguageService) getReferencedSymbolsForModule(ctx context.Context, pro
 			references: references,
 		}}
 	}
-	return nil
+	return []*SymbolAndEntries{}
 }
 
 func getReferenceAtPosition(sourceFile *ast.SourceFile, position int, program *compiler.Program) *refInfo {


### PR DESCRIPTION
This PR fixes a crash that occurs when doing find-all-refs in a .js file:

```js
exports.a = 1; // Find-all-refs on the exports identifier
```
