### PR TITLE
Fix losing options from command line in watch mode

### DIFF
--- a/internal/execute/tsc.go
+++ b/internal/execute/tsc.go
@@ -193,7 +193,14 @@ func tscCompilation(sys tsc.System, commandLine *tsoptions.ParsedCommandLine, te
 		return tsc.CommandLineResult{Status: tsc.ExitStatusSuccess}
 	}
 	if configForCompilation.CompilerOptions().Watch.IsTrue() {
-		watcher := createWatcher(sys, configForCompilation, reportDiagnostic, reportErrorSummary, testing)
+		watcher := createWatcher(
+			sys,
+			configForCompilation,
+			compilerOptionsFromCommandLine,
+			reportDiagnostic,
+			reportErrorSummary,
+			testing,
+		)
 		watcher.start()
 		return tsc.CommandLineResult{Status: tsc.ExitStatusSuccess, Watcher: watcher}
 	} else if configForCompilation.CompilerOptions().IsIncremental() {

--- a/internal/execute/watcher.go
+++ b/internal/execute/watcher.go
@@ -14,12 +14,13 @@ import (
 )
 
 type Watcher struct {
-	sys                tsc.System
-	configFileName     string
-	config             *tsoptions.ParsedCommandLine
-	reportDiagnostic   tsc.DiagnosticReporter
-	reportErrorSummary tsc.DiagnosticsReporter
-	testing            tsc.CommandLineTesting
+	sys                            tsc.System
+	configFileName                 string
+	config                         *tsoptions.ParsedCommandLine
+	compilerOptionsFromCommandLine *core.CompilerOptions
+	reportDiagnostic               tsc.DiagnosticReporter
+	reportErrorSummary             tsc.DiagnosticsReporter
+	testing                        tsc.CommandLineTesting
 
 	host           compiler.CompilerHost
 	program        *incremental.Program
@@ -29,13 +30,21 @@ type Watcher struct {
 
 var _ tsc.Watcher = (*Watcher)(nil)
 
-func createWatcher(sys tsc.System, configParseResult *tsoptions.ParsedCommandLine, reportDiagnostic tsc.DiagnosticReporter, reportErrorSummary tsc.DiagnosticsReporter, testing tsc.CommandLineTesting) *Watcher {
+func createWatcher(
+	sys tsc.System,
+	configParseResult *tsoptions.ParsedCommandLine,
+	compilerOptionsFromCommandLine *core.CompilerOptions,
+	reportDiagnostic tsc.DiagnosticReporter,
+	reportErrorSummary tsc.DiagnosticsReporter,
+	testing tsc.CommandLineTesting,
+) *Watcher {
 	w := &Watcher{
-		sys:                sys,
-		config:             configParseResult,
-		reportDiagnostic:   reportDiagnostic,
-		reportErrorSummary: reportErrorSummary,
-		testing:            testing,
+		sys:                            sys,
+		config:                         configParseResult,
+		compilerOptionsFromCommandLine: compilerOptionsFromCommandLine,
+		reportDiagnostic:               reportDiagnostic,
+		reportErrorSummary:             reportErrorSummary,
+		testing:                        testing,
 		// reportWatchStatus: createWatchStatusReporter(sys, configParseResult.CompilerOptions().Pretty),
 	}
 	if configParseResult.ConfigFile != nil {
@@ -108,7 +117,7 @@ func (w *Watcher) hasErrorsInTsConfig() bool {
 	extendedConfigCache := &tsc.ExtendedConfigCache{}
 	if w.configFileName != "" {
 		// !!! need to check that this merges compileroptions correctly. This differs from non-watch, since we allow overriding of previous options
-		configParseResult, errors := tsoptions.GetParsedCommandLineOfConfigFile(w.configFileName, &core.CompilerOptions{}, w.sys, extendedConfigCache)
+		configParseResult, errors := tsoptions.GetParsedCommandLineOfConfigFile(w.configFileName, w.compilerOptionsFromCommandLine, w.sys, extendedConfigCache)
 		if len(errors) > 0 {
 			for _, e := range errors {
 				w.reportDiagnostic(e)

--- a/testdata/baselines/reference/tscWatch/commandLineWatch/watch-with-tsconfig-and-incremental.js
+++ b/testdata/baselines/reference/tscWatch/commandLineWatch/watch-with-tsconfig-and-incremental.js
@@ -36,6 +36,45 @@ interface Symbol {
 declare const console: { log(msg: any): void; };
 //// [/home/src/workspaces/project/index.js] *new* 
 
+//// [/home/src/workspaces/project/tsconfig.tsbuildinfo] *new* 
+{"version":"FakeTSVersion","root":[2],"fileNames":["lib.d.ts","./index.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"99aa06d3014798d86001c324468d497f-"]}
+//// [/home/src/workspaces/project/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
+{
+  "version": "FakeTSVersion",
+  "root": [
+    {
+      "files": [
+        "./index.ts"
+      ],
+      "original": 2
+    }
+  ],
+  "fileNames": [
+    "lib.d.ts",
+    "./index.ts"
+  ],
+  "fileInfos": [
+    {
+      "fileName": "lib.d.ts",
+      "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "signature": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "affectsGlobalScope": true,
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true,
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "./index.ts",
+      "version": "99aa06d3014798d86001c324468d497f-",
+      "signature": "99aa06d3014798d86001c324468d497f-",
+      "impliedNodeFormat": "CommonJS"
+    }
+  ],
+  "size": 896
+}
 
 tsconfig.json::
 SemanticDiagnostics::


### PR DESCRIPTION
`watcher` loses options from command line after reloading options from the config file.

Fixes #1645.