### PR TITLE
Use a more cross-architecture-friendly devcontainer image.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
     "name": "TypeScript Compiler Development",
     // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-    "image": "mcr.microsoft.com/devcontainers/go:2-1.24-bookworm",
+    "image": "mcr.microsoft.com/devcontainers/go:2-1.25-bookworm",
     // Features to add to the dev container. More info: https://containers.dev/features.
     "features": {
         "ghcr.io/devcontainers/features/node:1": {
@@ -37,7 +37,6 @@
             ]
         }
     }
-
     // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
     // "remoteUser": "root"
 }


### PR DESCRIPTION
Also much smaller in theory. Fixes #539.