### PR TITLE
Use SkipTrivia instead of GetRangeOfTokenAtPosition where possible

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -3968,7 +3968,7 @@ func (c *Checker) checkWithStatement(node *ast.Node) {
 	c.checkExpression(node.Expression())
 	sourceFile := ast.GetSourceFileOfNode(node)
 	if !c.hasParseDiagnostics(sourceFile) {
-		start := scanner.GetRangeOfTokenAtPosition(sourceFile, node.Pos()).Pos()
+		start := scanner.SkipTrivia(sourceFile.Text(), node.Pos())
 		end := node.Statement().Pos()
 		c.grammarErrorAtPos(sourceFile.AsNode(), start, end-start, diagnostics.The_with_statement_is_not_supported_All_symbols_in_a_with_block_will_have_type_any)
 	}

--- a/internal/ls/lsutil/utilities.go
+++ b/internal/ls/lsutil/utilities.go
@@ -37,7 +37,7 @@ func ProbablyUsesSemicolons(file *ast.SourceFile) bool {
 					astnav.GetStartOfNode(lastToken, file, false /*includeJSDoc*/))
 				nextTokenLine := scanner.GetECMALineOfPosition(
 					file,
-					scanner.GetRangeOfTokenAtPosition(file, lastToken.End()).Pos())
+					scanner.SkipTrivia(file.Text(), lastToken.End()))
 				// Avoid counting missing semicolon in single-line objects:
 				// `function f(p: { x: string /*no semicolon here is insignificant*/ }) {`
 				if lastTokenLine != nextTokenLine {


### PR DESCRIPTION
@DanielRosenwasser noticed I made this same mistake. `GetRangeOfTokenAtPosition` implicitly skips trivia, but then also scans a token. This is wasteful for callers that could just skip trivia.