### PR TITLE
Clean up disk space in CI before running

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
           large-packages: false
           docker-images: false
           swap-storage: false
+          dotnet: false
 
       - run: git config --system core.longpaths true
         if: ${{ matrix.config.os == 'windows-latest' }}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -24,6 +24,7 @@ jobs:
           large-packages: false
           docker-images: false
           swap-storage: false
+          dotnet: false
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           submodules: true

--- a/.github/workflows/create-cache.yml
+++ b/.github/workflows/create-cache.yml
@@ -38,6 +38,7 @@ jobs:
           large-packages: false
           docker-images: false
           swap-storage: false
+          dotnet: false
 
       - run: git config --system core.longpaths true
         if: ${{ matrix.os == 'windows-latest' }}


### PR DESCRIPTION
Our build cache is not small anymore. And if you happen to modify one of the root packages like `core` or `ast`, it can end up being unused.

The GHA linux runners only start with a little bit of disk space, and don't even have `/tmp`.

Use an action to delete stuff off of the runner before we do anything:

```
================================================================================
********************************************************************************
=> Android library: Saved 12GiB
********************************************************************************
********************************************************************************
=> Haskell runtime: Saved 6.2GiB
********************************************************************************
================================================================================
```