### PR TITLE
fix: preserve comments on import attribute values

### DIFF
--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -3802,8 +3802,12 @@ func (p *Printer) emitImportAttribute(node *ast.ImportAttribute) {
 	p.emitImportAttributeName(node.Name())
 	p.writePunctuation(":")
 	p.writeSpace()
-	/// !!! emit trailing comments of value
-	p.emitExpression(node.Value, ast.OperatorPrecedenceDisallowComma)
+	value := node.Value
+	if p.emitContext.EmitFlags(node.Value)&EFNoLeadingComments == 0 {
+		commentRange := getCommentRange(value)
+		p.emitTrailingComments(commentRange.Pos(), commentSeparatorAfter)
+	}
+	p.emitExpression(value, ast.OperatorPrecedenceDisallowComma)
 	p.exitNode(node.AsNode(), state)
 }
 

--- a/testdata/baselines/reference/compiler/importAttributesWithValueComments.js
+++ b/testdata/baselines/reference/compiler/importAttributesWithValueComments.js
@@ -1,0 +1,23 @@
+//// [tests/cases/compiler/importAttributesWithValueComments.ts] ////
+
+//// [a.ts]
+export default {
+    a: "a",
+    b: "b",
+    1: "1",
+}
+
+//// [b.ts]
+import a from "./a" with { a: /* a */ "a", "b": /* b */ "b" };
+a;
+
+
+//// [a.js]
+export default {
+    a: "a",
+    b: "b",
+    1: "1",
+};
+//// [b.js]
+import a from "./a" with { a: /* a */ "a", "b": /* b */ "b" };
+a;

--- a/testdata/baselines/reference/compiler/importAttributesWithValueComments.symbols
+++ b/testdata/baselines/reference/compiler/importAttributesWithValueComments.symbols
@@ -1,0 +1,21 @@
+//// [tests/cases/compiler/importAttributesWithValueComments.ts] ////
+
+=== /a.ts ===
+export default {
+    a: "a",
+>a : Symbol(a, Decl(a.ts, 0, 16))
+
+    b: "b",
+>b : Symbol(b, Decl(a.ts, 1, 11))
+
+    1: "1",
+>1 : Symbol(1, Decl(a.ts, 2, 11))
+}
+
+=== /b.ts ===
+import a from "./a" with { a: /* a */ "a", "b": /* b */ "b" };
+>a : Symbol(a, Decl(b.ts, 0, 6))
+
+a;
+>a : Symbol(a, Decl(b.ts, 0, 6))
+

--- a/testdata/baselines/reference/compiler/importAttributesWithValueComments.types
+++ b/testdata/baselines/reference/compiler/importAttributesWithValueComments.types
@@ -1,0 +1,27 @@
+//// [tests/cases/compiler/importAttributesWithValueComments.ts] ////
+
+=== /a.ts ===
+export default {
+>{    a: "a",    b: "b",    1: "1",} : { a: string; b: string; 1: string; }
+
+    a: "a",
+>a : string
+>"a" : "a"
+
+    b: "b",
+>b : string
+>"b" : "b"
+
+    1: "1",
+>1 : string
+>"1" : "1"
+}
+
+=== /b.ts ===
+import a from "./a" with { a: /* a */ "a", "b": /* b */ "b" };
+>a : { a: string; b: string; 1: string; }
+>a : any
+
+a;
+>a : { a: string; b: string; 1: string; }
+

--- a/testdata/tests/cases/compiler/importAttributesWithValueComments.ts
+++ b/testdata/tests/cases/compiler/importAttributesWithValueComments.ts
@@ -1,0 +1,13 @@
+// @target: esnext
+// @module: esnext
+
+// @filename: /a.ts
+export default {
+    a: "a",
+    b: "b",
+    1: "1",
+}
+
+// @filename: /b.ts
+import a from "./a" with { a: /* a */ "a", "b": /* b */ "b" };
+a;


### PR DESCRIPTION
This PR adds the missing support for [`trailing comments`](
https://github.com/microsoft/TypeScript/blob/669c25c091ad4d32298d0f33b0e4e681d46de3ea/src/compiler/emitter.ts#L3787-L3792) on import attribute values


```ts
const value = node.value;
/** @see {emitPropertyAssignment} */
if ((getEmitFlags(value) & EmitFlags.NoLeadingComments) === 0) {
    const commentRange = getCommentRange(value);
    emitTrailingCommentsOfPosition(commentRange.pos);
}
```
