### PR TITLE
Don't ask for checker immediately in ProvideCodeActions

### DIFF
--- a/internal/ls/codeactions.go
+++ b/internal/ls/codeactions.go
@@ -5,7 +5,6 @@ import (
 	"slices"
 
 	"github.com/microsoft/typescript-go/internal/ast"
-	"github.com/microsoft/typescript-go/internal/checker"
 	"github.com/microsoft/typescript-go/internal/compiler"
 	"github.com/microsoft/typescript-go/internal/core"
 	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
@@ -25,7 +24,6 @@ type CodeFixContext struct {
 	Span       core.TextRange
 	ErrorCode  int32
 	Program    *compiler.Program
-	Checker    *checker.Checker
 	LS         *LanguageService
 	Diagnostic *lsproto.Diagnostic
 	Params     *lsproto.CodeActionParams
@@ -53,12 +51,6 @@ var codeFixProviders = []*CodeFixProvider{
 func (l *LanguageService) ProvideCodeActions(ctx context.Context, params *lsproto.CodeActionParams) (lsproto.CodeActionResponse, error) {
 	program, file := l.getProgramAndFile(params.TextDocument.Uri)
 
-	// Get the type checker
-	ch, done := program.GetTypeCheckerForFile(ctx, file)
-	if done != nil {
-		defer done()
-	}
-
 	var actions []lsproto.CommandOrCodeAction
 
 	// Process diagnostics in the context to generate quick fixes
@@ -84,7 +76,6 @@ func (l *LanguageService) ProvideCodeActions(ctx context.Context, params *lsprot
 					Span:       core.NewTextRange(int(position), int(endPosition)),
 					ErrorCode:  errorCode,
 					Program:    program,
-					Checker:    ch,
 					LS:         l,
 					Diagnostic: diag,
 					Params:     params,


### PR DESCRIPTION
This code is unused, leftover from a previous iteration.