### PR TITLE
Fix a typo in user preference parsing

### DIFF
--- a/internal/ls/lsutil/userpreferences.go
+++ b/internal/ls/lsutil/userpreferences.go
@@ -685,7 +685,7 @@ func (p *UserPreferences) set(name string, value any) {
 		p.InlayHints.IncludeInlayParameterNameHints = parseInlayParameterNameHints(value)
 	case "includeinlayparameternamehintswhenargumentmatchesname":
 		p.InlayHints.IncludeInlayParameterNameHintsWhenArgumentMatchesName = parseBoolWithDefault(value, false)
-	case "includeinlayfunctionparametertypeHints":
+	case "includeinlayfunctionparametertypehints":
 		p.InlayHints.IncludeInlayFunctionParameterTypeHints = parseBoolWithDefault(value, false)
 	case "includeinlayvariabletypehints":
 		p.InlayHints.IncludeInlayVariableTypeHints = parseBoolWithDefault(value, false)


### PR DESCRIPTION
Currently, user preferences do not take into consideration the `includeInlayFunctionParameterTypeHints` setting. The reason is that `set` lowers the string, but `includeinlayfunctionparametertypeHints` has an uppercase `H` by accident. This change fixes that.

> Found by trying to set said setting.