### PR TITLE
fix: Crash for completions after JSDoc * on line following string-named property signature

### DIFF
--- a/internal/astnav/tokens.go
+++ b/internal/astnav/tokens.go
@@ -190,7 +190,7 @@ func getTokenAtPosition(
 				flags := scanner.TokenFlags()
 				if tokenStart <= position && (position < tokenEnd) {
 					if token == ast.KindIdentifier || !ast.IsTokenKind(token) {
-						if ast.IsJSDocKind(current.Kind) {
+						if ast.IsJSDocKind(current.Kind) || ast.IsTypeElement(current) {
 							return current
 						}
 						panic(fmt.Sprintf("did not expect %s to have %s in its trivia", current.Kind.String(), token.String()))

--- a/internal/fourslash/tests/completionsJsdocStringProperty_test.go
+++ b/internal/fourslash/tests/completionsJsdocStringProperty_test.go
@@ -26,7 +26,7 @@ var someVariable;`
 	f.VerifyCompletions(t, nil, &fourslash.CompletionsExpectedList{
 		IsIncomplete: false,
 		ItemDefaults: &fourslash.CompletionsExpectedItemDefaults{
-			CommitCharacters: &[]string{},
+			CommitCharacters: &[]string{".", ",", ";"},
 			EditRange:        Ignored,
 		},
 		Items: &fourslash.CompletionsExpectedItems{},


### PR DESCRIPTION
This is a fix for https://github.com/microsoft/typescript-go/issues/2290.

It would seem that type elements can also be included in JSDoc comments, so a check was added in addition to `ast.ISJSDocKind` to allow for property signatures among other type elements.

Note: This is my first contribution to the TypeScript compiler, so if I'm totally off the mark, feel free to be blunt about it.