### PR TITLE
Use xxh3.HashString128 instead of converting to byte slice

### DIFF
--- a/internal/execute/incremental/snapshot.go
+++ b/internal/execute/incremental/snapshot.go
@@ -29,7 +29,7 @@ func (f *FileInfo) AffectsGlobalScope() bool               { return f.affectsGlo
 func (f *FileInfo) ImpliedNodeFormat() core.ResolutionMode { return f.impliedNodeFormat }
 
 func ComputeHash(text string, hashWithText bool) string {
-	hashBytes := xxh3.Hash128([]byte(text)).Bytes()
+	hashBytes := xxh3.HashString128(text).Bytes()
 	hash := hex.EncodeToString(hashBytes[:])
 	if hashWithText {
 		hash += "-" + text

--- a/internal/project/overlayfs.go
+++ b/internal/project/overlayfs.go
@@ -78,7 +78,7 @@ func newDiskFile(fileName string, content string) *diskFile {
 		fileBase: fileBase{
 			fileName: fileName,
 			content:  content,
-			hash:     xxh3.Hash128([]byte(content)),
+			hash:     xxh3.HashString128(content),
 		},
 	}
 }
@@ -125,7 +125,7 @@ func newOverlay(fileName string, content string, version int32, kind core.Script
 		fileBase: fileBase{
 			fileName: fileName,
 			content:  content,
-			hash:     xxh3.Hash128([]byte(content)),
+			hash:     xxh3.HashString128(content),
 		},
 		version: version,
 		kind:    kind,
@@ -154,7 +154,7 @@ func (o *Overlay) computeMatchesDiskText(fs vfs.FS) bool {
 	if !ok {
 		return false
 	}
-	return xxh3.Hash128([]byte(diskContent)) == o.hash
+	return xxh3.HashString128(diskContent) == o.hash
 }
 
 func (o *Overlay) IsOverlay() bool {
@@ -348,7 +348,7 @@ func (fs *overlayFS) processChanges(changes []FileChange) (FileChangeSummary, ma
 				}
 				if len(change.Changes) > 0 {
 					o.version = change.Version
-					o.hash = xxh3.Hash128([]byte(o.content))
+					o.hash = xxh3.HashString128(o.content)
 					o.matchesDiskText = false
 					newOverlays[path] = o
 				}

--- a/internal/project/snapshotfs.go
+++ b/internal/project/snapshotfs.go
@@ -119,7 +119,7 @@ func (s *snapshotFSBuilder) GetFileByPath(fileName string, path tspath.Path) Fil
 				if content, ok := s.fs.ReadFile(fileName); ok {
 					entry.Change(func(file *diskFile) {
 						file.content = content
-						file.hash = xxh3.Hash128([]byte(content))
+						file.hash = xxh3.HashString128(content)
 						file.needsReload = false
 					})
 				} else {


### PR DESCRIPTION
The Go compiler isn't smart enough to elide the `[]byte` conversion from any of these. Thankfully. the xxhash library has a string variant!

Reduces the memory allocated in fourslash by 50% and makes them about 30% faster.