### PR TITLE
Switch dprint to new gofumpt Wasm plugin

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -59,6 +59,6 @@
         "https://plugins.dprint.dev/typescript-0.95.13.wasm",
         "https://plugins.dprint.dev/json-0.21.0.wasm",
         "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.1.wasm",
-        "https://plugins.dprint.dev/jakebailey/gofumpt-v0.0.1.wasm"
+        "https://plugins.dprint.dev/jakebailey/gofumpt-v0.0.3.wasm"
     ]
 }


### PR DESCRIPTION
This should eliminate the performance woes of formatting with exec + `go tool gofumpt` (especially on Windows).

```
Benchmark 1: dprint fmt --incremental=false (branch = main)
  Time (mean ± σ):     42.703 s ±  0.412 s    [User: 0.733 s, System: 0.569 s]
  Range (min … max):   41.742 s … 43.399 s    10 runs
 
Benchmark 2: dprint fmt --incremental=false (branch = jabaile/gofumpt-plugin)
  Time (mean ± σ):     633.1 ms ±  14.8 ms    [User: 4887.2 ms, System: 1083.9 ms]
  Range (min … max):   617.3 ms … 663.2 ms    10 runs
 
Summary
  dprint fmt --incremental=false (branch = jabaile/gofumpt-plugin) ran
   67.45 ± 1.70 times faster than dprint fmt --incremental=false (branch = main)
```

On Windows, `dprint fmt` takes just 2 seconds, rather than either failing completely or taking minutes.

Not in this PR is removing the `tool` in `go.mod`, since we still format generated files. That will be a more invasive change. And I'm not sure I want to make it, since right now `go:generate` is fully self contained to `go tool` and `go run` invocations.