### PR TITLE
Use non-diagnostic reporting symbol lookups for API uses of getResolvedSymbol 

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -13450,6 +13450,22 @@ func (c *Checker) getResolvedSymbolOrNil(node *ast.Node) *ast.Symbol {
 	return c.symbolNodeLinks.Get(node).resolvedSymbol
 }
 
+func (c *Checker) getResolvedSymbolNoDiagnostics(node *ast.Node) *ast.Symbol {
+	links := c.symbolNodeLinks.Get(node)
+	if links.resolvedSymbol != nil {
+		return links.resolvedSymbol
+	}
+	if links.resolvedSymbolNoDiagnostics == nil {
+		var symbol *ast.Symbol
+		if !ast.NodeIsMissing(node) {
+			symbol = c.resolveName(node, node.Text(), ast.SymbolFlagsValue|ast.SymbolFlagsExportValue,
+				nil, !ast.IsWriteOnlyAccess(node), false /*excludeGlobals*/)
+		}
+		links.resolvedSymbolNoDiagnostics = core.OrElse(symbol, c.unknownSymbol)
+	}
+	return links.resolvedSymbolNoDiagnostics
+}
+
 func (c *Checker) getCannotFindNameDiagnosticForName(node *ast.Node) *diagnostics.Message {
 	switch node.Text() {
 	case "document", "console":

--- a/internal/checker/emitresolver.go
+++ b/internal/checker/emitresolver.go
@@ -828,7 +828,7 @@ func (r *EmitResolver) getReferenceResolver() binder.ReferenceResolver {
 	if r.referenceResolver == nil {
 		r.referenceResolver = binder.NewReferenceResolver(r.checker.compilerOptions, binder.ReferenceResolverHooks{
 			ResolveName:                            r.checker.resolveName,
-			GetResolvedSymbol:                      r.checker.getResolvedSymbol,
+			GetResolvedSymbol:                      r.checker.getResolvedSymbolNoDiagnostics,
 			GetMergedSymbol:                        r.checker.getMergedSymbol,
 			GetParentOfSymbol:                      r.checker.getParentOfSymbol,
 			GetSymbolOfDeclaration:                 r.checker.getSymbolOfDeclaration,

--- a/internal/checker/types.go
+++ b/internal/checker/types.go
@@ -337,7 +337,8 @@ type NodeLinks struct {
 }
 
 type SymbolNodeLinks struct {
-	resolvedSymbol *ast.Symbol // Resolved symbol associated with node
+	resolvedSymbol              *ast.Symbol // Resolved symbol associated with node
+	resolvedSymbolNoDiagnostics *ast.Symbol // Resolved symbol associated with node, generated without producing diagnostics for an API call
 }
 
 type TypeNodeLinks struct {


### PR DESCRIPTION
…to avoid endlessly repeating diagnostic work we never need in checkers we're only using for emit.

Fixes #2380.

Brings `vscode` `noCheck` `incremental: false` emit time down to 3.8s on my machine, from 41s.