### PR TITLE
Simplify quick profiling

### DIFF
--- a/internal/pprof/pprof.go
+++ b/internal/pprof/pprof.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/pprof"
+
+	"github.com/microsoft/typescript-go/internal/repo"
 )
 
 type ProfileSession struct {
@@ -60,4 +62,13 @@ func (p *ProfileSession) Stop() {
 
 	fmt.Fprintf(p.logWriter, "CPU profile: %v\n", p.cpuFilePath)
 	fmt.Fprintf(p.logWriter, "Memory profile: %v\n", p.memFilePath)
+}
+
+// ProfileInPprofDir is a convenience function that starts profiling in the 'pprof' directory under the repository root.
+// The resulting files are logged to stderr. It returns a function that stops the profiling when called.
+func ProfileInPprofDir() func() {
+	session := BeginProfiling(filepath.Join(repo.RootPath, "pprof"), os.Stderr)
+	return func() {
+		session.Stop()
+	}
 }


### PR DESCRIPTION
I found myself typing out the absolute path to the repo frequently when profiling auto-imports. If nobody else thinks this is useful, we can close, but I would use it all the time.