### PR TITLE
Port "Fixed crash when adding unreachable code diagnostic in situations with missing nodes"

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -2302,8 +2302,8 @@ func (c *Checker) checkSourceElementUnreachable(node *ast.Node) bool {
 
 	sourceFile := ast.GetSourceFileOfNode(node)
 
-	start := node.Pos()
-	end := node.End()
+	startNode := node
+	endNode := node
 
 	parent := node.Parent
 	if parent.CanHaveStatements() {
@@ -2333,14 +2333,14 @@ func (c *Checker) checkSourceElementUnreachable(node *ast.Node) bool {
 				c.reportedUnreachableNodes.Add(nextNode)
 			}
 
-			start = statements[first].Pos()
-			end = statements[last].End()
+			startNode = statements[first]
+			endNode = statements[last]
 		}
 	}
 
-	start = scanner.SkipTrivia(sourceFile.Text(), start)
+	start := scanner.GetTokenPosOfNode(startNode, sourceFile, false /*includeJSDoc*/)
 
-	diagnostic := ast.NewDiagnostic(sourceFile, core.NewTextRange(start, end), diagnostics.Unreachable_code_detected)
+	diagnostic := ast.NewDiagnostic(sourceFile, core.NewTextRange(start, endNode.End()), diagnostics.Unreachable_code_detected)
 	c.addErrorOrSuggestion(c.compilerOptions.AllowUnreachableCode == core.TSFalse, diagnostic)
 
 	return true


### PR DESCRIPTION
ports https://github.com/microsoft/TypeScript/pull/62914

At the moment, Corsa doesn't crash because `NewTextRange`/`NewDiagnostic` don't have the same asserts that `assertDiagnosticLocation` had in Strada. But the example from the referenced PR very much creates `{pos: 202, end: 201}` text range in Corsa and that's a logical error worth fixing. cc @jakebailey 