### PR TITLE
Include import specifiers as references in code lens

### DIFF
--- a/internal/ls/findallreferences.go
+++ b/internal/ls/findallreferences.go
@@ -1905,9 +1905,12 @@ func (state *refState) getReferencesAtLocation(sourceFile *ast.SourceFile, posit
 	}
 
 	parent := referenceLocation.Parent
-	if parent.Kind == ast.KindImportSpecifier && parent.PropertyName() == referenceLocation {
+	if parent.Kind == ast.KindImportSpecifier && search.comingFrom == ImpExpKindExport {
+		propName := parent.PropertyName()
 		// This is added through `singleReferences` in ImportsResult. If we happen to see it again, don't add it again.
-		return
+		if propName == referenceLocation || (propName == nil && parent.Name() == referenceLocation) {
+			return
+		}
 	}
 
 	if parent.Kind == ast.KindExportSpecifier {
@@ -2158,6 +2161,14 @@ func (state *refState) searchForImportsOfExport(exportLocation *ast.Node, export
 func (state *refState) shouldAddSingleReference(singleRef *ast.Node) bool {
 	if !state.hasMatchingMeaning(singleRef) {
 		return false
+	}
+	// Check if this node is already in any reference group to avoid duplicates
+	for _, symbolAndEntries := range state.result {
+		for _, ref := range symbolAndEntries.references {
+			if ref.node == singleRef {
+				return false
+			}
+		}
 	}
 	if state.options.use != referenceUseRename {
 		return true

--- a/internal/ls/importTracker.go
+++ b/internal/ls/importTracker.go
@@ -366,6 +366,11 @@ func getSearchesFromDirectImports(
 				} else {
 					localSymbol = checker.GetSymbolAtLocation(name)
 				}
+				// Include import specifiers as references to the exported symbol.
+				// Export specifiers are handled by getReferencesAtExportSpecifier, so skip them here.
+				if !ast.IsExportSpecifier(element) {
+					singleReferences = append(singleReferences, name)
+				}
 				addSearch(name, localSymbol)
 			}
 		}

--- a/testdata/baselines/reference/fourslash/codeLenses/codeLensFunctionsAndConstants01.baseline.jsonc
+++ b/testdata/baselines/reference/fourslash/codeLenses/codeLensFunctionsAndConstants01.baseline.jsonc
@@ -1,7 +1,7 @@
 // === Code Lenses ===
 // === /exports.ts ===
 // let callCount = 0;
-// export function /*CODELENS: 3 references*/foo(n: number): void {
+// export function /*CODELENS: 4 references*/foo(n: number): void {
 //   callCount++;
 //   if (n > 0) {
 // 	[|foo|](n - 1);
@@ -17,7 +17,7 @@
 // 
 
 // === /importer.ts ===
-// import { foo, bar } from "./exports";
+// import { [|foo|], bar } from "./exports";
 // 
 // [|foo|](5);
 // console.log(bar);
@@ -27,7 +27,7 @@
 
 // === Code Lenses ===
 // === /importer.ts ===
-// import { foo, bar } from "./exports";
+// import { foo, [|bar|] } from "./exports";
 // 
 // foo(5);
 // console.log([|bar|]);
@@ -38,5 +38,5 @@
 // 
 // foo(5);
 // 
-// export const /*CODELENS: 1 reference*/bar = 123;
+// export const /*CODELENS: 2 references*/bar = 123;
 // 

--- a/testdata/baselines/reference/fourslash/codeLenses/codeLensInterface01.baseline.jsonc
+++ b/testdata/baselines/reference/fourslash/codeLenses/codeLensInterface01.baseline.jsonc
@@ -89,7 +89,7 @@
 
 // === Code Lenses ===
 // === /classPointable.ts ===
-// import { Pointable } from "./pointable";
+// import { [|Pointable|] } from "./pointable";
 // 
 // class Point implements [|Pointable|] {
 //   getX(): number {
@@ -98,7 +98,7 @@
 // --- (line: 7) skipped ---
 
 // === /objectPointable.ts ===
-// import { Pointable } from "./pointable";
+// import { [|Pointable|] } from "./pointable";
 // 
 // let x = 0;
 // let y = 0;
@@ -109,7 +109,7 @@
 // --- (line: 9) skipped ---
 
 // === /pointable.ts ===
-// export interface /*CODELENS: 2 references*/Pointable {
+// export interface /*CODELENS: 4 references*/Pointable {
 //   getX(): number;
 //   getY(): number;
 // }

--- a/testdata/baselines/reference/fourslash/findAllReferences/findAllReferencesOfConstructor.baseline.jsonc
+++ b/testdata/baselines/reference/fourslash/findAllReferences/findAllReferencesOfConstructor.baseline.jsonc
@@ -14,11 +14,11 @@
 // new D();
 
 // === /b.ts ===
-// import { C } from "./a";
+// import { [|C|] } from "./a";
 // new [|C|]();
 
 // === /c.ts ===
-// import { C } from "./a";
+// import { [|C|] } from "./a";
 // class D extends C {
 //     constructor() {
 //         [|super|]();
@@ -50,11 +50,11 @@
 // new D();
 
 // === /b.ts ===
-// import { C } from "./a";
+// import { [|C|] } from "./a";
 // new [|C|]();
 
 // === /c.ts ===
-// import { C } from "./a";
+// import { [|C|] } from "./a";
 // class D extends C {
 //     constructor() {
 //         [|super|]();
@@ -86,11 +86,11 @@
 // new D();
 
 // === /b.ts ===
-// import { C } from "./a";
+// import { [|C|] } from "./a";
 // new [|C|]();
 
 // === /c.ts ===
-// import { C } from "./a";
+// import { [|C|] } from "./a";
 // class D extends C {
 //     constructor() {
 //         [|super|]();

--- a/testdata/baselines/reference/fourslash/findAllReferences/findAllRefsOfConstructor_multipleFiles.baseline.jsonc
+++ b/testdata/baselines/reference/fourslash/findAllReferences/findAllRefsOfConstructor_multipleFiles.baseline.jsonc
@@ -6,7 +6,7 @@
 // export { [|B|] as [|B1|] } from "./f";
 
 // === /b.ts ===
-// import B, { B1 } from "./a";
+// import B, { [|B1|] } from "./a";
 // const d = new [|B|]("b");
 // const d1 = new [|B1|]("b1");
 

--- a/testdata/baselines/reference/fourslash/state/codeLensAcrossProjects.baseline
+++ b/testdata/baselines/reference/fourslash/state/codeLensAcrossProjects.baseline
@@ -296,7 +296,7 @@ Config::
 
 // === Code Lenses ===
 // === /projects/container/compositeExec/index.ts ===
-// import { Pointable } from "../lib";
+// import { [|Pointable|] } from "../lib";
 // class Point2 implements [|Pointable|] {
 //   getX(): number {
 //     return 0;
@@ -304,7 +304,7 @@ Config::
 // --- (line: 6) skipped ---
 
 // === /projects/container/exec/index.ts ===
-// import { Pointable } from "../lib";
+// import { [|Pointable|] } from "../lib";
 // class Point1 implements [|Pointable|] {
 //   getX(): number {
 //     return 0;
@@ -312,7 +312,7 @@ Config::
 // --- (line: 6) skipped ---
 
 // === /projects/container/lib/bar.ts ===
-// import { Pointable } from "./index";
+// import { [|Pointable|] } from "./index";
 // class Point implements [|Pointable|] {
 //   getX(): number {
 //     return 0;
@@ -321,7 +321,7 @@ Config::
 
 // === /projects/container/lib/index.ts ===
 // 
-// export interface /*CODELENS: 3 references*/Pointable {
+// export interface /*CODELENS: 6 references*/Pointable {
 //   getX(): number;
 //   getY(): number;
 // }


### PR DESCRIPTION
## Summary
- Fixes issue where import specifiers were not counted as references in code lens
- For `export function foo()` and `import { foo } from "./a"`, the import `foo` is now properly counted as a reference
- Aligns behavior with TS 6.0

## Changes
- Added import specifiers to `singleReferences` in `getSearchesFromDirectImports` (`importTracker.go`)
- Export specifiers are excluded since they're already handled by `getReferencesAtExportSpecifier`
- Added deduplication in `shouldAddSingleReference` to prevent duplicate entries when traversing import/export chains
- Updated duplicate detection logic in `getReferencesAtLocation` to handle simple import specifiers (not just `import { foo as bar }` patterns)

## Test plan
- [x] All existing code lens tests pass with updated baselines
- [x] All findAllReferences tests pass with updated baselines
- [x] Verified `foo` now shows 4 references (was 3) in `codeLensFunctionsAndConstants01` test

Fixes #2367