### PR TITLE
Update JsxOpeningElement type

### DIFF
--- a/_packages/ast/src/nodes.ts
+++ b/_packages/ast/src/nodes.ts
@@ -1551,7 +1551,7 @@ export interface JsxNamespacedName extends Node {
 }
 
 /// The opening element of a <Tag>...</Tag> JsxElement
-export interface JsxOpeningElement extends Expression {
+export interface JsxOpeningElement extends Node {
     readonly kind: SyntaxKind.JsxOpeningElement;
     readonly parent: JsxElement;
     readonly tagName: JsxTagNameExpression;


### PR DESCRIPTION
Given it can only be the child of a JsxElement, I think it's a mistake to mark it as an Expression