### PR TITLE
Fix re-exported module augmentation auto import crash

### DIFF
--- a/internal/fourslash/tests/autoImportReexportOfCrossPackageAugmentation_test.go
+++ b/internal/fourslash/tests/autoImportReexportOfCrossPackageAugmentation_test.go
@@ -1,0 +1,44 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+// TestAutoImportReexportOfCrossPackageAugmentation verifies no crash when auto-importing
+// from a package that re-exports from another package that is also augmented.
+func TestAutoImportReexportOfCrossPackageAugmentation(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `// @Filename: /node_modules/vitest/package.json
+{ "name": "vitest", "version": "1.0.0", "types": "index.d.ts" }
+// @Filename: /node_modules/vitest/index.d.ts
+export { AugmentedInterface, uniqueFunction } from "@vitest/expect";
+// @Filename: /node_modules/vitest/augmentation.d.ts
+export {};
+declare module "@vitest/expect" {
+    interface AugmentedInterface {
+        bar: string;
+    }
+		function uniqueFunction(): void;
+}
+// @Filename: /node_modules/@vitest/expect/package.json
+{ "name": "@vitest/expect", "version": "1.0.0", "types": "index.d.ts" }
+// @Filename: /node_modules/@vitest/expect/index.d.ts
+export interface AugmentedInterface {
+    baz: number;
+}
+// @Filename: /tsconfig.json
+{ "compilerOptions": { "module": "commonjs", "strict": true } }
+// @Filename: /package.json
+{ "name": "test", "dependencies": { "vitest": "*" } }
+// @Filename: /index.ts
+uniqueFunction/**/`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+
+	f.GoToMarker(t, "")
+	f.BaselineAutoImportsCompletions(t, []string{""})
+}

--- a/internal/ls/autoimport/util.go
+++ b/internal/ls/autoimport/util.go
@@ -20,6 +20,23 @@ import (
 	"github.com/microsoft/typescript-go/internal/vfs"
 )
 
+func tryGetModuleIDAndFileNameOfModuleSymbol(symbol *ast.Symbol) (ModuleID, string, bool) {
+	if !symbol.IsExternalModule() {
+		return "", "", false
+	}
+	decl := ast.GetNonAugmentationDeclaration(symbol)
+	if decl == nil {
+		return "", "", false
+	}
+	if decl.Kind == ast.KindSourceFile {
+		return ModuleID(decl.AsSourceFile().Path()), decl.AsSourceFile().FileName(), true
+	}
+	if ast.IsModuleWithStringLiteralName(decl) {
+		return ModuleID(decl.Name().Text()), "", true
+	}
+	return "", "", false
+}
+
 func getModuleIDAndFileNameOfModuleSymbol(symbol *ast.Symbol) (ModuleID, string) {
 	if !symbol.IsExternalModule() {
 		panic("symbol is not an external module")

--- a/testdata/baselines/reference/fourslash/autoImports/autoImportReexportOfCrossPackageAugmentation.baseline.md
+++ b/testdata/baselines/reference/fourslash/autoImports/autoImportReexportOfCrossPackageAugmentation.baseline.md
@@ -1,0 +1,16 @@
+// === Auto Imports === 
+```ts
+// @FileName: /index.ts
+uniqueFunction/**/
+``````ts
+import { uniqueFunction } from "vitest";
+
+uniqueFunction
+```
+
+```ts
+import { uniqueFunction } from "@vitest/expect";
+
+uniqueFunction
+```
+


### PR DESCRIPTION
The `symbol.Parent` of an export that appears only in an augmentation of a module is the unmerged module augmentation symbol; you need to call `checker.GetMergedSymbol` on it to get a symbol that includes a non-augmentation declaration.

Moreover, export extraction is pretty accurate but is fundamentally a best-effort process that shouldn't crash for reasons like this. Worst case scenario of misidentifying an alias target is we fail to group some auto-imports that should have been grouped. Added a variant of the utility function that never panics.

Fixes #2467 