### PR TITLE
Fix race condition between flush and snapshot update

### DIFF
--- a/internal/project/api.go
+++ b/internal/project/api.go
@@ -8,6 +8,8 @@ import (
 
 func (s *Session) OpenProject(ctx context.Context, configFileName string) (*Project, error) {
 	s.snapshotUpdateMu.Lock()
+	defer s.snapshotUpdateMu.Unlock()
+
 	fileChanges, overlays, ataChanges, _ := s.flushChanges(ctx)
 	newSnapshot := s.UpdateSnapshot(ctx, overlays, SnapshotChange{
 		fileChanges: fileChanges,
@@ -16,7 +18,6 @@ func (s *Session) OpenProject(ctx context.Context, configFileName string) (*Proj
 			OpenProjects: collections.NewSetFromItems(configFileName),
 		},
 	})
-	s.snapshotUpdateMu.Unlock()
 
 	if newSnapshot.apiError != nil {
 		return nil, newSnapshot.apiError


### PR DESCRIPTION
This should fix a race condition that was causing intermittent CI failures in `TestCompletionListCladule` (and likely other tests) when running with `-race`. (e.g. see https://github.com/microsoft/typescript-go/actions/runs/20938617746/job/60167089124)

The problem is that `getSnapshot` would flush pending changes and then call `UpdateSnapshot`, but another goroutine could slip in, see an empty pending changes queue, and return with a stale snapshot.

The fix adds a mutex (`snapshotUpdateMu`) that serializes the flush+update sequence. I considerered recycling the existing snapshot mutexes for this but couldn't see a way to do that ergonomically and idiomatically.

EDIT: It's difficult to reproduce but the CI failure in the run linked above basically shows the race condition in action https://github.com/microsoft/TypeScript/blob/d7cd405bb23eacda2833f3e7fe1be6d1b377f882/tests/cases/fourslash/completionListCladule.ts where the cursor seemingly ends up elsewhere (not at `.` after `c3) and then shows all global completions instead of the expected `getStuff` completion.

So basically: When completions are calculated using stale file content (without the `.`):
- The LSP position (line/character after `.`) maps to a different offset in the old file
- This position may fall at end of identifier `f` or elsewhere
- Triggers global scope completions instead of member access