### PR TITLE
fix(docs): builds actually require rust 1.88 or higher

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## How to Build and Run
 
-This repo uses [Go 1.25 or higher](https://go.dev/dl/), [Rust 1.85 or higher](https://www.rust-lang.org/tools/install), [Node.js with npm](https://nodejs.org/), and [`hereby`](https://www.npmjs.com/package/hereby).
+This repo uses [Go 1.25 or higher](https://go.dev/dl/), [Rust 1.88 or higher](https://www.rust-lang.org/tools/install), [Node.js with npm](https://nodejs.org/), and [`hereby`](https://www.npmjs.com/package/hereby).
 
 For tests and code generation, this repo contains a git submodule to the main TypeScript repo pointing to the commit being ported.
 When cloning, you'll want to clone with submodules:


### PR DESCRIPTION
Tiny update, I was trying a local build on rust 1.87 and `npm i` failed due to `@typescript/libsyncrpc`'s prepare step using a newer napi version that requires rust 1.88 or higher:

```
❯ npm i
npm warn skipping integrity check for git dependency ssh://git@github.com/microsoft/libsyncrpc.git
npm error code 1
npm error git dep preparation failed
npm error command /usr/local/bin/node /usr/local/lib/node_modules/npm/bin/npm-cli.js install --force --cache=/Users/walker/.npm --prefer-offline=false --prefer-online=false --offline=false --no-progress --no-save --no-audit --include=dev --include=peer --include=optional --no-package-lock-only --no-dry-run
npm error > @typescript/libsyncrpc@0.0.0 prepare
npm error > napi build --release --platform --strip --no-const-enum
npm error
npm error Internal Error: Build failed with exit code 101
npm error     at ChildProcess.<anonymous> (file:///Users/walker/.npm/_cacache/tmp/git-clonepKKiok/node_modules/@napi-rs/cli/dist/cli.js:1530:35)
npm error     at Object.onceWrapper (node:events:639:26)
npm error     at ChildProcess.emit (node:events:536:35)
npm error     at ChildProcess._handle.onexit (node:internal/child_process:293:12)
npm error npm warn using --force Recommended protections disabled.
npm error error: rustc 1.87.0 is not supported by the following packages:
npm error   libloading@0.9.0 requires rustc 1.88.0
npm error   napi@3.8.2 requires rustc 1.88
npm error   napi@3.8.2 requires rustc 1.88
npm error   napi@3.8.2 requires rustc 1.88
npm error   napi-build@2.3.1 requires rustc 1.88
npm error   napi-derive@3.5.1 requires rustc 1.88
npm error   napi-derive-backend@5.0.1 requires rustc 1.88
npm error   napi-sys@3.2.1 requires rustc 1.88
npm error Either upgrade rustc or select compatible dependency versions with
npm error `cargo update <name>@<current-ver> --precise <compatible-ver>`
npm error where `<compatible-ver>` is the latest version supporting rustc 1.87.0
```

This updates the contributing docs to reflect the change.