### PR TITLE
Replace regex-based HTML entity parsing with handwritten code

### DIFF
--- a/internal/transformers/jsxtransforms/jsx.go
+++ b/internal/transformers/jsxtransforms/jsx.go
@@ -917,7 +917,8 @@ func decodeEntity(entity string) (rune, bool) {
 		for _, c := range entity {
 			if base == 16 && !stringutil.IsHexDigit(c) {
 				return 0, false
-			} else if base == 10 && !stringutil.IsDigit(c) {
+			}
+			if base == 10 && !stringutil.IsDigit(c) {
 				return 0, false
 			}
 		}


### PR DESCRIPTION
I'm on a quest to eliminate regexes from the shipped code as much as possible.

This one is not trivial, but it's not too bad either when split up.