### PR TITLE
[LSP] Process file deletions against tsconfig `includes`

### DIFF
--- a/internal/project/projectcollectionbuilder.go
+++ b/internal/project/projectcollectionbuilder.go
@@ -292,7 +292,7 @@ func (b *ProjectCollectionBuilder) DidChangeFiles(summary FileChangeSummary, log
 			retainProjectAndReferences(project)
 
 			// Retain all the ancestor projects
-			b.configFileRegistryBuilder.forEachConfigFileNameFor(openFile, openFilePath, func(configFileName string) {
+			b.configFileRegistryBuilder.forEachConfigFileNameFor(openFilePath, func(configFileName string) {
 				if ancestor := b.findOrCreateProject(configFileName, b.toPath(configFileName), projectLoadKindFind, logger); ancestor != nil {
 					retainProjectAndReferences(ancestor.Value())
 				}

--- a/internal/project/session_test.go
+++ b/internal/project/session_test.go
@@ -3,6 +3,7 @@ package project_test
 import (
 	"context"
 	"maps"
+	"slices"
 	"strings"
 	"testing"
 
@@ -676,6 +677,7 @@ func TestSession(t *testing.T) {
 			ls, err := session.GetLanguageService(context.Background(), "file:///home/projects/TS/p1/src/index.ts")
 			assert.NilError(t, err)
 			program := ls.GetProgram()
+			assert.Check(t, slices.Contains(program.CommandLine().ParsedConfig.FileNames, "/home/projects/TS/p1/src/x.ts"))
 			assert.Equal(t, len(program.GetSemanticDiagnostics(projecttestutil.WithRequestID(t.Context()), program.GetSourceFile("/home/projects/TS/p1/src/index.ts"))), 0)
 
 			err = utils.FS().Remove("/home/projects/TS/p1/src/x.ts")
@@ -691,8 +693,16 @@ func TestSession(t *testing.T) {
 			ls, err = session.GetLanguageService(context.Background(), "file:///home/projects/TS/p1/src/index.ts")
 			assert.NilError(t, err)
 			program = ls.GetProgram()
+			// File name is still in the command line, was explicitly included
+			assert.Check(t, slices.Contains(program.CommandLine().ParsedConfig.FileNames, "/home/projects/TS/p1/src/x.ts"))
 			assert.Equal(t, len(program.GetSemanticDiagnostics(projecttestutil.WithRequestID(t.Context()), program.GetSourceFile("/home/projects/TS/p1/src/index.ts"))), 1)
 			assert.Check(t, program.GetSourceFile("/home/projects/TS/p1/src/x.ts") == nil)
+
+			// Open file to trigger cleanup
+			session.DidOpenFile(context.Background(), "untitled:Untitled-1", 1, "", lsproto.LanguageKindTypeScript)
+			snapshot, release := session.Snapshot()
+			defer release()
+			assert.Check(t, snapshot.GetFile("/home/projects/TS/p1/src/x.ts") == nil)
 		})
 
 		t.Run("delete wildcard included file", func(t *testing.T) {
@@ -713,6 +723,7 @@ func TestSession(t *testing.T) {
 			ls, err := session.GetLanguageService(context.Background(), "file:///home/projects/TS/p1/src/x.ts")
 			assert.NilError(t, err)
 			program := ls.GetProgram()
+			assert.Check(t, slices.Contains(program.CommandLine().ParsedConfig.FileNames, "/home/projects/TS/p1/src/index.ts"))
 			assert.Equal(t, len(program.GetSemanticDiagnostics(projecttestutil.WithRequestID(t.Context()), program.GetSourceFile("/home/projects/TS/p1/src/x.ts"))), 0)
 
 			err = utils.FS().Remove("/home/projects/TS/p1/src/index.ts")
@@ -728,7 +739,15 @@ func TestSession(t *testing.T) {
 			ls, err = session.GetLanguageService(context.Background(), "file:///home/projects/TS/p1/src/x.ts")
 			assert.NilError(t, err)
 			program = ls.GetProgram()
+			// File name is gone from the command line, was originally included via wildcard
+			assert.Check(t, !slices.Contains(program.CommandLine().ParsedConfig.FileNames, "/home/projects/TS/p1/src/index.ts"))
 			assert.Equal(t, len(program.GetSemanticDiagnostics(projecttestutil.WithRequestID(t.Context()), program.GetSourceFile("/home/projects/TS/p1/src/x.ts"))), 1)
+
+			// Open file to trigger cleanup
+			session.DidOpenFile(context.Background(), "untitled:Untitled-1", 1, "", lsproto.LanguageKindTypeScript)
+			snapshot, release := session.Snapshot()
+			defer release()
+			assert.Check(t, snapshot.GetFile("/home/projects/TS/p1/src/index.ts") == nil)
 		})
 
 		t.Run("create explicitly included file", func(t *testing.T) {


### PR DESCRIPTION
We weren't triggering tsconfig file name reloads in response to watcher deletion events that match `includes` wildcards, so we were holding onto source files that should have been deleted for too long.