### PR TITLE
Skip macOS in PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
             skip: ${{ github.event_name == 'merge_group' }}
           - os: macos-latest
             coverage: true
+            # There aren't enough macOS runners; skip in PRs and rely on main branch runs.
             skip: ${{ github.event_name == 'merge_group' || github.event_name == 'pull_request' }}
           - os: ubuntu-latest
             name: 'no submodules'


### PR DESCRIPTION
We're really struggling with macOS runners. Just skip them on PRs, leaving this testing to main. Linux coverage should be sufficient given we have no build-tag'd files that are `darwin` specific.