### PR TITLE
Add deprecation suggestion and code fix for computed enum member names

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -23272,15 +23272,22 @@ func (c *Checker) computeEnumMemberValues(node *ast.Node) {
 }
 
 func (c *Checker) computeEnumMemberValue(member *ast.Node, autoValue jsnum.Number, previous *ast.Node) evaluator.Result {
+	errorReported := false
 	if ast.IsComputedNonLiteralName(member.Name()) {
+		errorReported = true
 		c.error(member.Name(), diagnostics.Computed_property_names_are_not_allowed_in_enums)
 	} else if ast.IsBigIntLiteral(member.Name()) {
+		errorReported = true
 		c.error(member.Name(), diagnostics.An_enum_member_cannot_have_a_numeric_name)
 	} else {
 		text := ast.GetTextOfPropertyName(member.Name())
 		if isNumericLiteralName(text) && !ast.IsInfinityOrNaNString(text) {
+			errorReported = true
 			c.error(member.Name(), diagnostics.An_enum_member_cannot_have_a_numeric_name)
 		}
+	}
+	if !errorReported && ast.IsComputedPropertyName(member.Name()) {
+		c.suggestionDiagnostics.Add(createDiagnosticForNode(member.Name(), diagnostics.Using_a_string_literal_as_an_enum_member_name_via_a_computed_property_is_deprecated_Use_a_simple_string_literal_instead))
 	}
 	if member.Initializer() != nil {
 		return c.computeConstantEnumMemberValue(member)

--- a/internal/diagnostics/diagnostics_generated.go
+++ b/internal/diagnostics/diagnostics_generated.go
@@ -928,6 +928,8 @@ var X_await_using_declarations_are_not_allowed_in_ambient_contexts = &Message{co
 
 var Ignore_the_tsconfig_found_and_build_with_commandline_options_and_files = &Message{code: 1549, category: CategoryMessage, key: "Ignore_the_tsconfig_found_and_build_with_commandline_options_and_files_1549", text: "Ignore the tsconfig found and build with commandline options and files."}
 
+var Using_a_string_literal_as_an_enum_member_name_via_a_computed_property_is_deprecated_Use_a_simple_string_literal_instead = &Message{code: 1550, category: CategorySuggestion, key: "Using_a_string_literal_as_an_enum_member_name_via_a_computed_property_is_deprecated_Use_a_simple_str_1550", text: "Using a string literal as an enum member name via a computed property is deprecated. Use a simple string literal instead.", reportsDeprecated: true}
+
 var The_types_of_0_are_incompatible_between_these_types = &Message{code: 2200, category: CategoryError, key: "The_types_of_0_are_incompatible_between_these_types_2200", text: "The types of '{0}' are incompatible between these types."}
 
 var The_types_returned_by_0_are_incompatible_between_these_types = &Message{code: 2201, category: CategoryError, key: "The_types_returned_by_0_are_incompatible_between_these_types_2201", text: "The types returned by '{0}' are incompatible between these types."}
@@ -4254,6 +4256,10 @@ var Add_resolution_mode_import_attribute = &Message{code: 95196, category: Categ
 
 var Add_resolution_mode_import_attribute_to_all_type_only_imports_that_need_it = &Message{code: 95197, category: CategoryMessage, key: "Add_resolution_mode_import_attribute_to_all_type_only_imports_that_need_it_95197", text: "Add 'resolution-mode' import attribute to all type-only imports that need it"}
 
+var Remove_unnecessary_computed_property_name_syntax = &Message{code: 95198, category: CategoryMessage, key: "Remove_unnecessary_computed_property_name_syntax_95198", text: "Remove unnecessary computed property name syntax"}
+
+var Remove_all_unnecessary_computed_property_name_syntax = &Message{code: 95199, category: CategoryMessage, key: "Remove_all_unnecessary_computed_property_name_syntax_95199", text: "Remove all unnecessary computed property name syntax"}
+
 var Do_not_print_diagnostics = &Message{code: 100000, category: CategoryMessage, key: "Do_not_print_diagnostics_100000", text: "Do not print diagnostics."}
 
 var Run_in_single_threaded_mode = &Message{code: 100001, category: CategoryMessage, key: "Run_in_single_threaded_mode_100001", text: "Run in single threaded mode."}
@@ -5206,6 +5212,8 @@ func keyToMessage(key Key) *Message {
 		return X_await_using_declarations_are_not_allowed_in_ambient_contexts
 	case "Ignore_the_tsconfig_found_and_build_with_commandline_options_and_files_1549":
 		return Ignore_the_tsconfig_found_and_build_with_commandline_options_and_files
+	case "Using_a_string_literal_as_an_enum_member_name_via_a_computed_property_is_deprecated_Use_a_simple_str_1550":
+		return Using_a_string_literal_as_an_enum_member_name_via_a_computed_property_is_deprecated_Use_a_simple_string_literal_instead
 	case "The_types_of_0_are_incompatible_between_these_types_2200":
 		return The_types_of_0_are_incompatible_between_these_types
 	case "The_types_returned_by_0_are_incompatible_between_these_types_2201":
@@ -8532,6 +8540,10 @@ func keyToMessage(key Key) *Message {
 		return Add_resolution_mode_import_attribute
 	case "Add_resolution_mode_import_attribute_to_all_type_only_imports_that_need_it_95197":
 		return Add_resolution_mode_import_attribute_to_all_type_only_imports_that_need_it
+	case "Remove_unnecessary_computed_property_name_syntax_95198":
+		return Remove_unnecessary_computed_property_name_syntax
+	case "Remove_all_unnecessary_computed_property_name_syntax_95199":
+		return Remove_all_unnecessary_computed_property_name_syntax
 	case "Do_not_print_diagnostics_100000":
 		return Do_not_print_diagnostics
 	case "Run_in_single_threaded_mode_100001":

--- a/internal/diagnostics/extraDiagnosticMessages.json
+++ b/internal/diagnostics/extraDiagnosticMessages.json
@@ -75,6 +75,11 @@
         "category": "Message",
         "code": 1549
     },
+    "Using a string literal as an enum member name via a computed property is deprecated. Use a simple string literal instead.": {
+        "category": "Suggestion",
+        "code": 1550,
+        "reportsDeprecated": true
+    },
     "tsconfig.json is present but will not be loaded if files are specified on commandline. Use '--ignoreConfig' to skip this error.": {
         "category": "Error",
         "code": 5112
@@ -90,5 +95,13 @@
     "Deduplicate packages with the same name and version.": {
         "category": "Message",
         "code": 100011
+    },
+    "Remove unnecessary computed property name syntax": {
+        "category": "Message",
+        "code": 95198
+    },
+    "Remove all unnecessary computed property name syntax": {
+        "category": "Message",
+        "code": 95199
     }
 }

--- a/internal/fourslash/tests/manual/codeFixEnumComputedPropertyName_test.go
+++ b/internal/fourslash/tests/manual/codeFixEnumComputedPropertyName_test.go
@@ -1,0 +1,25 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestCodeFixEnumComputedPropertyName(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = "// @Filename: test.ts\n" +
+		"enum CHAR {\n" +
+		"    ['\\t']/*1*/ = 0x09,\n" +
+		"}"
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.GoToMarker(t, "1")
+	f.VerifyImportFixAtPosition(t, []string{
+		"enum CHAR {\n" +
+			"    \"\\t\" = 0x09,\n" +
+			"}",
+	}, nil /*preferences*/)
+}

--- a/internal/fourslash/tests/manual/enumComputedPropertyNameDeprecated_test.go
+++ b/internal/fourslash/tests/manual/enumComputedPropertyNameDeprecated_test.go
@@ -1,0 +1,57 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	. "github.com/microsoft/typescript-go/internal/fourslash/tests/util"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestEnumComputedPropertyNameDeprecated(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = "// @strict: true\n" +
+		"// @Filename: a.ts\n" +
+		"enum CHAR {\n" +
+		"    [|['\\t']|] = 0x09,\n" +
+		"    [|['\\n']|] = 0x0A,\n" +
+		"    [|[`\\r`]|] = 0x0D,\n" +
+		"    'space' = 0x20,\n" +
+		"}\n\n" +
+		"enum NoWarning {\n" +
+		"    A = 1,\n" +
+		"    B = 2,\n" +
+		"    \"quoted\" = 3,\n" +
+		"}"
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+
+	ranges := f.Ranges()
+	if len(ranges) != 3 {
+		t.Fatalf("Expected 3 ranges, got %d", len(ranges))
+	}
+
+	message := "Using a string literal as an enum member name via a computed property is deprecated. Use a simple string literal instead."
+	f.VerifySuggestionDiagnostics(t, []*lsproto.Diagnostic{
+		{
+			Code:    &lsproto.IntegerOrString{Integer: PtrTo[int32](1550)},
+			Message: message,
+			Range:   ranges[0].LSRange,
+			Tags:    &[]lsproto.DiagnosticTag{lsproto.DiagnosticTagDeprecated},
+		},
+		{
+			Code:    &lsproto.IntegerOrString{Integer: PtrTo[int32](1550)},
+			Message: message,
+			Range:   ranges[1].LSRange,
+			Tags:    &[]lsproto.DiagnosticTag{lsproto.DiagnosticTagDeprecated},
+		},
+		{
+			Code:    &lsproto.IntegerOrString{Integer: PtrTo[int32](1550)},
+			Message: message,
+			Range:   ranges[2].LSRange,
+			Tags:    &[]lsproto.DiagnosticTag{lsproto.DiagnosticTagDeprecated},
+		},
+	})
+}

--- a/internal/ls/codeactions.go
+++ b/internal/ls/codeactions.go
@@ -44,6 +44,7 @@ type CombinedCodeActions struct {
 // codeFixProviders is the list of all registered code fix providers
 var codeFixProviders = []*CodeFixProvider{
 	ImportFixProvider,
+	computedEnumMemberNameFixProvider,
 	// Add more code fix providers here as they are implemented
 }
 

--- a/internal/ls/codeactions_computed_enum_member_name.go
+++ b/internal/ls/codeactions_computed_enum_member_name.go
@@ -1,0 +1,75 @@
+package ls
+
+import (
+	"context"
+
+	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/astnav"
+	"github.com/microsoft/typescript-go/internal/diagnostics"
+	"github.com/microsoft/typescript-go/internal/locale"
+	"github.com/microsoft/typescript-go/internal/ls/change"
+)
+
+var computedEnumMemberNameFixErrorCodes = []int32{
+	diagnostics.Using_a_string_literal_as_an_enum_member_name_via_a_computed_property_is_deprecated_Use_a_simple_string_literal_instead.Code(),
+}
+
+const computedEnumMemberNameFixID = "convertComputedEnumMemberName"
+
+var computedEnumMemberNameFixProvider = &CodeFixProvider{
+	ErrorCodes:     computedEnumMemberNameFixErrorCodes,
+	GetCodeActions: getComputedEnumMemberNameCodeActions,
+	FixIds:         []string{computedEnumMemberNameFixID},
+}
+
+type computedEnumMemberNameInfo struct {
+	computedName *ast.Node
+	literalText  string
+}
+
+func getComputedEnumMemberNameCodeActions(ctx context.Context, fixContext *CodeFixContext) ([]CodeAction, error) {
+	info := getComputedEnumMemberNameInfo(fixContext.SourceFile, fixContext.Span.Pos())
+	if info == nil {
+		return nil, nil
+	}
+
+	tracker := change.NewTracker(ctx, fixContext.Program.Options(), fixContext.LS.FormatOptions(), fixContext.LS.converters)
+	tracker.ReplaceNode(
+		fixContext.SourceFile,
+		info.computedName,
+		tracker.NodeFactory.NewStringLiteral(info.literalText, ast.TokenFlagsNone),
+		nil,
+	)
+
+	locale := locale.FromContext(ctx)
+	description := diagnostics.Remove_unnecessary_computed_property_name_syntax.Localize(locale)
+	return []CodeAction{{
+		Description: description,
+		Changes:     tracker.GetChanges()[fixContext.SourceFile.FileName()],
+	}}, nil
+}
+
+func getComputedEnumMemberNameInfo(sourceFile *ast.SourceFile, pos int) *computedEnumMemberNameInfo {
+	token := astnav.GetTokenAtPosition(sourceFile, pos)
+	node := token
+	for node != nil && !ast.IsComputedPropertyName(node) {
+		node = node.Parent
+	}
+
+	if node == nil || !ast.IsComputedPropertyName(node) {
+		return nil
+	}
+	if node.Parent == nil || !ast.IsEnumMember(node.Parent) {
+		return nil
+	}
+
+	expression := node.AsComputedPropertyName().Expression
+	if !ast.IsStringLiteralLike(expression) {
+		return nil
+	}
+
+	return &computedEnumMemberNameInfo{
+		computedName: node,
+		literalText:  expression.Text(),
+	}
+}


### PR DESCRIPTION
## Summary

Add a deprecation warning for computed property names in enum members (e.g., `["key"]` or `` [`key`] ``), along with a quick fix to convert them to simple string literals.

- Fix: microsoft/typescript#42468

## Background

As discussed in microsoft/typescript#42468 and microsoft/typescript#62649, TypeScript currently allows computed property names with literal expressions in enums:

```typescript
enum CHAR {
    ['\t'] = 0x09,  // allowed, but semantically equivalent to '\t' = 0x09
    [`\r`] = 0x0D,
}
```

This syntax is:
- Rarely used in practice
- Not supported by Babel or typescript-eslint
- Semantically redundant — only literal expressions are allowed, so ['key'] is always equivalent to 'key'

## Approach
To avoid breaking existing code, this PR takes a gradual deprecation approach:

1. Phase 1 (this PR): Add a suggestion diagnostic marking this syntax as deprecated, with an auto-fix
2. Phase 2 (future): Disallow this syntax entirely

## Changes
- Add suggestion diagnostic (code 1550) for literal computed property names in enums
- Add quick fix: "Remove unnecessary computed property name syntax"
- Add "Fix All" support for batch conversion