### PR TITLE
Fix a typo in the JSDoc of `Math.trunc(…)`

### DIFF
--- a/internal/bundled/libs/lib.es2015.core.d.ts
+++ b/internal/bundled/libs/lib.es2015.core.d.ts
@@ -191,7 +191,7 @@ interface Math {
     hypot(...values: number[]): number;
 
     /**
-     * Returns the integral part of the a numeric expression, x, removing any fractional digits.
+     * Returns the integral part of the numeric expression x, removing any fractional digits.
      * If x is already an integer, the result is x.
      * @param x A numeric expression.
      */


### PR DESCRIPTION
fixes #2546

# What I did

- just fix a typo that would be a little weird