### PR TITLE
Include overlays in all file systems used in snapshot building

### DIFF
--- a/internal/project/filechange.go
+++ b/internal/project/filechange.go
@@ -34,9 +34,11 @@ type FileChange struct {
 
 type FileChangeSummary struct {
 	// Only one file can be opened at a time per request
-	Opened  lsproto.DocumentUri
-	Closed  collections.Set[lsproto.DocumentUri]
-	Changed collections.Set[lsproto.DocumentUri]
+	Opened lsproto.DocumentUri
+	// Reopened is set if a close and open occurred for the same file in a single batch of changes.
+	Reopened lsproto.DocumentUri
+	Closed   collections.Set[lsproto.DocumentUri]
+	Changed  collections.Set[lsproto.DocumentUri]
 	// Only set when file watching is enabled
 	Created collections.Set[lsproto.DocumentUri]
 	// Only set when file watching is enabled
@@ -48,7 +50,7 @@ type FileChangeSummary struct {
 }
 
 func (f FileChangeSummary) IsEmpty() bool {
-	return f.Opened == "" && f.Closed.Len() == 0 && f.Changed.Len() == 0 && f.Created.Len() == 0 && f.Deleted.Len() == 0
+	return f.Opened == "" && f.Reopened == "" && f.Closed.Len() == 0 && f.Changed.Len() == 0 && f.Created.Len() == 0 && f.Deleted.Len() == 0
 }
 
 func (f FileChangeSummary) HasExcessiveWatchEvents() bool {

--- a/internal/project/overlayfs.go
+++ b/internal/project/overlayfs.go
@@ -298,13 +298,15 @@ func (fs *overlayFS) processChanges(changes []FileChange) (FileChangeSummary, ma
 		o := newOverlays[path]
 
 		if events.openChange != nil {
-			if result.Opened != "" {
+			if result.Opened != "" || result.Reopened != "" {
 				panic("can only process one file open event at a time")
 			}
 			if o != nil && o.Content() != events.openChange.Content {
 				result.Changed.Add(uri)
 			} else if o == nil {
 				result.Opened = uri
+			} else {
+				result.Reopened = uri
 			}
 			newOverlays[path] = newOverlay(
 				uri.FileName(),

--- a/internal/project/projectcollectionbuilder.go
+++ b/internal/project/projectcollectionbuilder.go
@@ -244,10 +244,10 @@ func (b *ProjectCollectionBuilder) DidChangeFiles(summary FileChangeSummary, log
 	})
 
 	// Handle opened file
-	if summary.Opened != "" {
-		fileName := summary.Opened.FileName()
-		path := b.toPath(fileName)
+	if summary.Opened != "" || summary.Reopened != "" {
 		var toRemoveProjects collections.Set[tspath.Path]
+		fileName := core.FirstNonZero(summary.Opened, summary.Reopened).FileName()
+		path := b.toPath(fileName)
 		openFileResult := b.ensureConfiguredProjectAndAncestorsForFile(fileName, path, logger)
 		b.configuredProjects.Range(func(entry *dirty.SyncMapEntry[tspath.Path, *Project]) bool {
 			toRemoveProjects.Add(entry.Key())

--- a/internal/project/snapshot.go
+++ b/internal/project/snapshot.go
@@ -339,7 +339,7 @@ func (s *Snapshot) Clone(ctx context.Context, change SnapshotChange, overlays ma
 
 	// Clean cached disk files not touched by any open project. It's not important that we do this on
 	// file open specifically, but we don't need to do it on every snapshot clone.
-	if len(change.fileChanges.Opened) != 0 {
+	if change.fileChanges.Opened != "" || change.fileChanges.Reopened != "" {
 		// The set of seen files can change only if a program was constructed (not cloned) during this snapshot.
 		if len(projectsWithNewProgramStructure) > 0 {
 			cleanFilesStart := time.Now()

--- a/testdata/baselines/reference/fourslash/state/callHierarchyAcrossProject.baseline
+++ b/testdata/baselines/reference/fourslash/state/callHierarchyAcrossProject.baseline
@@ -579,29 +579,28 @@ Open Files::
   }
 }
 
+Projects::
+  [/projects/container/compositeExec/tsconfig.json] *deleted*
+    /projects/container/lib/index.ts            
+    /projects/container/compositeExec/index.ts  
+  [/projects/container/exec/tsconfig.json] *deleted*
+    /projects/container/lib/index.ts   
+    /projects/container/exec/index.ts  
+  [/projects/container/lib/tsconfig.json] *deleted*
+    /projects/container/lib/index.ts  
+    /projects/container/lib/bar.ts    
+    /projects/container/lib/baz.ts    
+  [/projects/container/tsconfig.json] *deleted*
+  [/projects/temp/tsconfig.json] 
+    /projects/temp/temp.ts  
 Open Files::
   [/projects/temp/temp.ts] *new*
     /projects/temp/tsconfig.json  (default) 
 Config::
-  [/projects/container/compositeExec/tsconfig.json] 
-    RetainingProjects:
-      /projects/container/compositeExec/tsconfig.json  
-      /projects/container/tsconfig.json                
-  [/projects/container/exec/tsconfig.json] 
-    RetainingProjects:
-      /projects/container/exec/tsconfig.json  
-      /projects/container/tsconfig.json       
-  [/projects/container/lib/tsconfig.json] *modified*
-    RetainingProjects:
-      /projects/container/compositeExec/tsconfig.json  
-      /projects/container/exec/tsconfig.json           
-      /projects/container/lib/tsconfig.json            
-      /projects/container/tsconfig.json                
-    RetainingOpenFiles: *modified*
-      /projects/container/lib/index.ts  *deleted*
-  [/projects/container/tsconfig.json] 
-    RetainingProjects:
-      /projects/container/tsconfig.json  
+  [/projects/container/compositeExec/tsconfig.json] *deleted*
+  [/projects/container/exec/tsconfig.json] *deleted*
+  [/projects/container/lib/tsconfig.json] *deleted*
+  [/projects/container/tsconfig.json] *deleted*
   [/projects/temp/tsconfig.json] 
     RetainingProjects:
       /projects/temp/tsconfig.json  

--- a/testdata/baselines/reference/fourslash/state/codeLensAcrossProjects.baseline
+++ b/testdata/baselines/reference/fourslash/state/codeLensAcrossProjects.baseline
@@ -736,29 +736,27 @@ Open Files::
   }
 }
 
+Projects::
+  [/projects/container/compositeExec/tsconfig.json] *deleted*
+    /projects/container/lib/index.ts            
+    /projects/container/compositeExec/index.ts  
+  [/projects/container/exec/tsconfig.json] *deleted*
+    /projects/container/lib/index.ts   
+    /projects/container/exec/index.ts  
+  [/projects/container/lib/tsconfig.json] *deleted*
+    /projects/container/lib/index.ts  
+    /projects/container/lib/bar.ts    
+  [/projects/container/tsconfig.json] *deleted*
+  [/projects/temp/tsconfig.json] 
+    /projects/temp/temp.ts  
 Open Files::
   [/projects/temp/temp.ts] *new*
     /projects/temp/tsconfig.json  (default) 
 Config::
-  [/projects/container/compositeExec/tsconfig.json] 
-    RetainingProjects:
-      /projects/container/compositeExec/tsconfig.json  
-      /projects/container/tsconfig.json                
-  [/projects/container/exec/tsconfig.json] 
-    RetainingProjects:
-      /projects/container/exec/tsconfig.json  
-      /projects/container/tsconfig.json       
-  [/projects/container/lib/tsconfig.json] *modified*
-    RetainingProjects:
-      /projects/container/compositeExec/tsconfig.json  
-      /projects/container/exec/tsconfig.json           
-      /projects/container/lib/tsconfig.json            
-      /projects/container/tsconfig.json                
-    RetainingOpenFiles: *modified*
-      /projects/container/lib/index.ts  *deleted*
-  [/projects/container/tsconfig.json] 
-    RetainingProjects:
-      /projects/container/tsconfig.json  
+  [/projects/container/compositeExec/tsconfig.json] *deleted*
+  [/projects/container/exec/tsconfig.json] *deleted*
+  [/projects/container/lib/tsconfig.json] *deleted*
+  [/projects/container/tsconfig.json] *deleted*
   [/projects/temp/tsconfig.json] 
     RetainingProjects:
       /projects/temp/tsconfig.json  

--- a/testdata/baselines/reference/fourslash/state/declarationMapsRenameWithDisableSourceOfProjectReferenceRedirect.baseline
+++ b/testdata/baselines/reference/fourslash/state/declarationMapsRenameWithDisableSourceOfProjectReferenceRedirect.baseline
@@ -419,24 +419,22 @@ Open Files::
   }
 }
 
+Projects::
+  [/myproject/dependency/tsconfig.json] *deleted*
+    /myproject/dependency/FnS.ts  
+  [/myproject/main/tsconfig.json] *deleted*
+    /myproject/decls/FnS.d.ts  
+    /myproject/main/main.ts    
+  [/myproject/tsconfig.json] *deleted*
+  [/random/tsconfig.json] 
+    /random/random.ts  
 Open Files::
   [/random/random.ts] *new*
     /random/tsconfig.json  (default) 
 Config::
-  [/myproject/dependency/tsconfig.json] *modified*
-    RetainingProjects:
-      /myproject/dependency/tsconfig.json  
-      /myproject/main/tsconfig.json        
-      /myproject/tsconfig.json             
-    RetainingOpenFiles: *modified*
-      /myproject/dependency/FnS.ts  *deleted*
-  [/myproject/main/tsconfig.json] 
-    RetainingProjects:
-      /myproject/main/tsconfig.json  
-      /myproject/tsconfig.json       
-  [/myproject/tsconfig.json] 
-    RetainingProjects:
-      /myproject/tsconfig.json  
+  [/myproject/dependency/tsconfig.json] *deleted*
+  [/myproject/main/tsconfig.json] *deleted*
+  [/myproject/tsconfig.json] *deleted*
   [/random/tsconfig.json] 
     RetainingProjects:
       /random/tsconfig.json  

--- a/testdata/baselines/reference/fourslash/state/declarationMapsRenameWithProjectReferences.baseline
+++ b/testdata/baselines/reference/fourslash/state/declarationMapsRenameWithProjectReferences.baseline
@@ -273,24 +273,22 @@ Open Files::
   }
 }
 
+Projects::
+  [/myproject/dependency/tsconfig.json] *deleted*
+    /myproject/dependency/FnS.ts  
+  [/myproject/main/tsconfig.json] *deleted*
+    /myproject/dependency/FnS.ts  
+    /myproject/main/main.ts       
+  [/myproject/tsconfig.json] *deleted*
+  [/random/tsconfig.json] 
+    /random/random.ts  
 Open Files::
   [/random/random.ts] *new*
     /random/tsconfig.json  (default) 
 Config::
-  [/myproject/dependency/tsconfig.json] *modified*
-    RetainingProjects:
-      /myproject/dependency/tsconfig.json  
-      /myproject/main/tsconfig.json        
-      /myproject/tsconfig.json             
-    RetainingOpenFiles: *modified*
-      /myproject/dependency/FnS.ts  *deleted*
-  [/myproject/main/tsconfig.json] 
-    RetainingProjects:
-      /myproject/main/tsconfig.json  
-      /myproject/tsconfig.json       
-  [/myproject/tsconfig.json] 
-    RetainingProjects:
-      /myproject/tsconfig.json  
+  [/myproject/dependency/tsconfig.json] *deleted*
+  [/myproject/main/tsconfig.json] *deleted*
+  [/myproject/tsconfig.json] *deleted*
   [/random/tsconfig.json] 
     RetainingProjects:
       /random/tsconfig.json  

--- a/testdata/baselines/reference/fourslash/state/declarationMapsRenameWithSourceMaps.baseline
+++ b/testdata/baselines/reference/fourslash/state/declarationMapsRenameWithSourceMaps.baseline
@@ -399,22 +399,19 @@ Open Files::
   }
 }
 
+Projects::
+  [/myproject/dependency/tsconfig.json] *deleted*
+    /myproject/dependency/FnS.ts  
+  [/myproject/tsconfig.json] *deleted*
+  [/random/tsconfig.json] 
+    /random/random.ts  
 Open Files::
   [/random/random.ts] *new*
     /random/tsconfig.json  (default) 
 Config::
-  [/myproject/dependency/tsconfig.json] *modified*
-    RetainingProjects:
-      /myproject/dependency/tsconfig.json  
-      /myproject/tsconfig.json             
-    RetainingOpenFiles: *modified*
-      /myproject/dependency/FnS.ts  *deleted*
-  [/myproject/main/tsconfig.json] 
-    RetainingProjects:
-      /myproject/tsconfig.json  
-  [/myproject/tsconfig.json] 
-    RetainingProjects:
-      /myproject/tsconfig.json  
+  [/myproject/dependency/tsconfig.json] *deleted*
+  [/myproject/main/tsconfig.json] *deleted*
+  [/myproject/tsconfig.json] *deleted*
   [/random/tsconfig.json] 
     RetainingProjects:
       /random/tsconfig.json  

--- a/testdata/baselines/reference/fourslash/state/declarationMapsRenameWithSourceMapsNotSolution.baseline
+++ b/testdata/baselines/reference/fourslash/state/declarationMapsRenameWithSourceMapsNotSolution.baseline
@@ -428,23 +428,24 @@ Open Files::
   }
 }
 
+Projects::
+  [/myproject/dependency/tsconfig.json] *deleted*
+    /myproject/dependency/FnS.ts  
+  [/myproject/main/tsconfig.json] *deleted*
+    /myproject/decls/FnS.d.ts  
+    /myproject/main/main.ts    
+  [/myproject/tsconfig.json] *deleted*
+    /myproject/dependency/FnS.ts  
+    /myproject/main/main.ts       
+  [/random/tsconfig.json] 
+    /random/random.ts  
 Open Files::
   [/random/random.ts] *new*
     /random/tsconfig.json  (default) 
 Config::
-  [/myproject/dependency/tsconfig.json] *modified*
-    RetainingProjects:
-      /myproject/dependency/tsconfig.json  
-      /myproject/tsconfig.json             
-    RetainingOpenFiles: *modified*
-      /myproject/dependency/FnS.ts  *deleted*
-  [/myproject/main/tsconfig.json] 
-    RetainingProjects:
-      /myproject/main/tsconfig.json  
-      /myproject/tsconfig.json       
-  [/myproject/tsconfig.json] 
-    RetainingProjects:
-      /myproject/tsconfig.json  
+  [/myproject/dependency/tsconfig.json] *deleted*
+  [/myproject/main/tsconfig.json] *deleted*
+  [/myproject/tsconfig.json] *deleted*
   [/random/tsconfig.json] 
     RetainingProjects:
       /random/tsconfig.json  

--- a/testdata/baselines/reference/fourslash/state/findAllRefsProjectWithOwnFilesReferencingFileFromReferencedProject.baseline
+++ b/testdata/baselines/reference/fourslash/state/findAllRefsProjectWithOwnFilesReferencingFileFromReferencedProject.baseline
@@ -292,6 +292,16 @@ Open Files::
   }
 }
 
+Projects::
+  [/dummy/tsconfig.json] 
+    /dummy/dummy.ts  
+  [/myproject/tsconfig-src.json] *deleted*
+    /myproject/src/helpers/functions.ts  
+    /myproject/src/main.ts               
+  [/myproject/tsconfig.json] *deleted*
+    /myproject/src/helpers/functions.ts  
+    /myproject/src/main.ts               
+    /myproject/own/main.ts               
 Open Files::
   [/dummy/dummy.ts] *new*
     /dummy/tsconfig.json  (default) 
@@ -301,17 +311,8 @@ Config::
       /dummy/tsconfig.json  
     RetainingOpenFiles:
       /dummy/dummy.ts  
-  [/myproject/tsconfig-src.json] *modified*
-    RetainingProjects:
-      /myproject/tsconfig-src.json  
-      /myproject/tsconfig.json      
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *deleted*
-  [/myproject/tsconfig.json] *modified*
-    RetainingProjects:
-      /myproject/tsconfig.json  
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *deleted*
+  [/myproject/tsconfig-src.json] *deleted*
+  [/myproject/tsconfig.json] *deleted*
 Config File Names::
   [/dummy/dummy.ts] 
     NearestConfigFileName: /dummy/tsconfig.json
@@ -344,10 +345,10 @@ Open Files::
 Projects::
   [/dummy/tsconfig.json] *deleted*
     /dummy/dummy.ts  
-  [/myproject/tsconfig-src.json] 
+  [/myproject/tsconfig-src.json] *new*
     /myproject/src/helpers/functions.ts  
     /myproject/src/main.ts               
-  [/myproject/tsconfig.json] 
+  [/myproject/tsconfig.json] *new*
     /myproject/src/helpers/functions.ts  
     /myproject/src/main.ts               
     /myproject/own/main.ts               
@@ -357,17 +358,17 @@ Open Files::
     /myproject/tsconfig.json      
 Config::
   [/dummy/tsconfig.json] *deleted*
-  [/myproject/tsconfig-src.json] *modified*
+  [/myproject/tsconfig-src.json] *new*
     RetainingProjects:
       /myproject/tsconfig-src.json  
       /myproject/tsconfig.json      
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *new*
-  [/myproject/tsconfig.json] *modified*
+    RetainingOpenFiles:
+      /myproject/src/main.ts  
+  [/myproject/tsconfig.json] *new*
     RetainingProjects:
       /myproject/tsconfig.json  
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *new*
+    RetainingOpenFiles:
+      /myproject/src/main.ts  
 Config File Names::
   [/dummy/dummy.ts] *deleted*
   [/myproject/src/main.ts] *new*

--- a/testdata/baselines/reference/fourslash/state/findAllRefsSolutionReferencingDefaultProjectDirectly.baseline
+++ b/testdata/baselines/reference/fourslash/state/findAllRefsSolutionReferencingDefaultProjectDirectly.baseline
@@ -248,6 +248,12 @@ Open Files::
   }
 }
 
+Projects::
+  [/dummy/tsconfig.json] 
+    /dummy/dummy.ts  
+  [/myproject/tsconfig-src.json] *deleted*
+    /myproject/src/helpers/functions.ts  
+    /myproject/src/main.ts               
 Open Files::
   [/dummy/dummy.ts] *new*
     /dummy/tsconfig.json  (default) 
@@ -257,14 +263,8 @@ Config::
       /dummy/tsconfig.json  
     RetainingOpenFiles:
       /dummy/dummy.ts  
-  [/myproject/tsconfig-src.json] *modified*
-    RetainingProjects:
-      /myproject/tsconfig-src.json  
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *deleted*
-  [/myproject/tsconfig.json] *modified*
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *deleted*
+  [/myproject/tsconfig-src.json] *deleted*
+  [/myproject/tsconfig.json] *deleted*
 Config File Names::
   [/dummy/dummy.ts] 
     NearestConfigFileName: /dummy/tsconfig.json
@@ -297,7 +297,7 @@ Open Files::
 Projects::
   [/dummy/tsconfig.json] *deleted*
     /dummy/dummy.ts  
-  [/myproject/tsconfig-src.json] 
+  [/myproject/tsconfig-src.json] *new*
     /myproject/src/helpers/functions.ts  
     /myproject/src/main.ts               
 Open Files::
@@ -305,14 +305,14 @@ Open Files::
     /myproject/tsconfig-src.json  (default) 
 Config::
   [/dummy/tsconfig.json] *deleted*
-  [/myproject/tsconfig-src.json] *modified*
+  [/myproject/tsconfig-src.json] *new*
     RetainingProjects:
       /myproject/tsconfig-src.json  
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *new*
-  [/myproject/tsconfig.json] *modified*
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *new*
+    RetainingOpenFiles:
+      /myproject/src/main.ts  
+  [/myproject/tsconfig.json] *new*
+    RetainingOpenFiles:
+      /myproject/src/main.ts  
 Config File Names::
   [/dummy/dummy.ts] *deleted*
   [/myproject/src/main.ts] *new*

--- a/testdata/baselines/reference/fourslash/state/findAllRefsSolutionReferencingDefaultProjectIndirectly.baseline
+++ b/testdata/baselines/reference/fourslash/state/findAllRefsSolutionReferencingDefaultProjectIndirectly.baseline
@@ -413,6 +413,12 @@ Open Files::
   }
 }
 
+Projects::
+  [/dummy/tsconfig.json] 
+    /dummy/dummy.ts  
+  [/myproject/tsconfig-src.json] *deleted*
+    /myproject/src/helpers/functions.ts  
+    /myproject/src/main.ts               
 Open Files::
   [/dummy/dummy.ts] *new*
     /dummy/tsconfig.json  (default) 
@@ -422,20 +428,10 @@ Config::
       /dummy/tsconfig.json  
     RetainingOpenFiles:
       /dummy/dummy.ts  
-  [/myproject/tsconfig-indirect1.json] *modified*
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *deleted*
-  [/myproject/tsconfig-indirect2.json] *modified*
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *deleted*
-  [/myproject/tsconfig-src.json] *modified*
-    RetainingProjects:
-      /myproject/tsconfig-src.json  
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *deleted*
-  [/myproject/tsconfig.json] *modified*
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *deleted*
+  [/myproject/tsconfig-indirect1.json] *deleted*
+  [/myproject/tsconfig-indirect2.json] *deleted*
+  [/myproject/tsconfig-src.json] *deleted*
+  [/myproject/tsconfig.json] *deleted*
 Config File Names::
   [/dummy/dummy.ts] 
     NearestConfigFileName: /dummy/tsconfig.json
@@ -468,7 +464,7 @@ Open Files::
 Projects::
   [/dummy/tsconfig.json] *deleted*
     /dummy/dummy.ts  
-  [/myproject/tsconfig-src.json] 
+  [/myproject/tsconfig-src.json] *new*
     /myproject/src/helpers/functions.ts  
     /myproject/src/main.ts               
 Open Files::
@@ -476,20 +472,20 @@ Open Files::
     /myproject/tsconfig-src.json  (default) 
 Config::
   [/dummy/tsconfig.json] *deleted*
-  [/myproject/tsconfig-indirect1.json] *modified*
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *new*
-  [/myproject/tsconfig-indirect2.json] *modified*
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *new*
-  [/myproject/tsconfig-src.json] *modified*
+  [/myproject/tsconfig-indirect1.json] *new*
+    RetainingOpenFiles:
+      /myproject/src/main.ts  
+  [/myproject/tsconfig-indirect2.json] *new*
+    RetainingOpenFiles:
+      /myproject/src/main.ts  
+  [/myproject/tsconfig-src.json] *new*
     RetainingProjects:
       /myproject/tsconfig-src.json  
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *new*
-  [/myproject/tsconfig.json] *modified*
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *new*
+    RetainingOpenFiles:
+      /myproject/src/main.ts  
+  [/myproject/tsconfig.json] *new*
+    RetainingOpenFiles:
+      /myproject/src/main.ts  
 Config File Names::
   [/dummy/dummy.ts] *deleted*
   [/myproject/src/main.ts] *new*

--- a/testdata/baselines/reference/fourslash/state/findAllRefsSolutionReferencingDefaultProjectIndirectlyThroughDisableReferencedProjectLoad.baseline
+++ b/testdata/baselines/reference/fourslash/state/findAllRefsSolutionReferencingDefaultProjectIndirectlyThroughDisableReferencedProjectLoad.baseline
@@ -420,15 +420,9 @@ Config::
       /dummy/tsconfig.json  
     RetainingOpenFiles:
       /dummy/dummy.ts  
-  [/myproject/tsconfig-indirect1.json] *modified*
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *deleted*
-  [/myproject/tsconfig-indirect2.json] *modified*
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *deleted*
-  [/myproject/tsconfig.json] *modified*
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *deleted*
+  [/myproject/tsconfig-indirect1.json] *deleted*
+  [/myproject/tsconfig-indirect2.json] *deleted*
+  [/myproject/tsconfig.json] *deleted*
 Config File Names::
   [/dummy/dummy.ts] 
     NearestConfigFileName: /dummy/tsconfig.json
@@ -469,15 +463,15 @@ Open Files::
     /dev/null/inferred  (default) 
 Config::
   [/dummy/tsconfig.json] *deleted*
-  [/myproject/tsconfig-indirect1.json] *modified*
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *new*
-  [/myproject/tsconfig-indirect2.json] *modified*
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *new*
-  [/myproject/tsconfig.json] *modified*
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *new*
+  [/myproject/tsconfig-indirect1.json] *new*
+    RetainingOpenFiles:
+      /myproject/src/main.ts  
+  [/myproject/tsconfig-indirect2.json] *new*
+    RetainingOpenFiles:
+      /myproject/src/main.ts  
+  [/myproject/tsconfig.json] *new*
+    RetainingOpenFiles:
+      /myproject/src/main.ts  
 Config File Names::
   [/dummy/dummy.ts] *deleted*
   [/myproject/src/main.ts] *new*

--- a/testdata/baselines/reference/fourslash/state/findAllRefsSolutionReferencingDefaultProjectIndirectlyThroughDisableReferencedProjectLoadInOneButWithoutItInAnother.baseline
+++ b/testdata/baselines/reference/fourslash/state/findAllRefsSolutionReferencingDefaultProjectIndirectlyThroughDisableReferencedProjectLoadInOneButWithoutItInAnother.baseline
@@ -414,6 +414,12 @@ Open Files::
   }
 }
 
+Projects::
+  [/dummy/tsconfig.json] 
+    /dummy/dummy.ts  
+  [/myproject/tsconfig-src.json] *deleted*
+    /myproject/src/helpers/functions.ts  
+    /myproject/src/main.ts               
 Open Files::
   [/dummy/dummy.ts] *new*
     /dummy/tsconfig.json  (default) 
@@ -423,20 +429,10 @@ Config::
       /dummy/tsconfig.json  
     RetainingOpenFiles:
       /dummy/dummy.ts  
-  [/myproject/tsconfig-indirect1.json] *modified*
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *deleted*
-  [/myproject/tsconfig-indirect2.json] *modified*
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *deleted*
-  [/myproject/tsconfig-src.json] *modified*
-    RetainingProjects:
-      /myproject/tsconfig-src.json  
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *deleted*
-  [/myproject/tsconfig.json] *modified*
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *deleted*
+  [/myproject/tsconfig-indirect1.json] *deleted*
+  [/myproject/tsconfig-indirect2.json] *deleted*
+  [/myproject/tsconfig-src.json] *deleted*
+  [/myproject/tsconfig.json] *deleted*
 Config File Names::
   [/dummy/dummy.ts] 
     NearestConfigFileName: /dummy/tsconfig.json
@@ -469,7 +465,7 @@ Open Files::
 Projects::
   [/dummy/tsconfig.json] *deleted*
     /dummy/dummy.ts  
-  [/myproject/tsconfig-src.json] 
+  [/myproject/tsconfig-src.json] *new*
     /myproject/src/helpers/functions.ts  
     /myproject/src/main.ts               
 Open Files::
@@ -477,20 +473,20 @@ Open Files::
     /myproject/tsconfig-src.json  (default) 
 Config::
   [/dummy/tsconfig.json] *deleted*
-  [/myproject/tsconfig-indirect1.json] *modified*
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *new*
-  [/myproject/tsconfig-indirect2.json] *modified*
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *new*
-  [/myproject/tsconfig-src.json] *modified*
+  [/myproject/tsconfig-indirect1.json] *new*
+    RetainingOpenFiles:
+      /myproject/src/main.ts  
+  [/myproject/tsconfig-indirect2.json] *new*
+    RetainingOpenFiles:
+      /myproject/src/main.ts  
+  [/myproject/tsconfig-src.json] *new*
     RetainingProjects:
       /myproject/tsconfig-src.json  
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *new*
-  [/myproject/tsconfig.json] *modified*
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *new*
+    RetainingOpenFiles:
+      /myproject/src/main.ts  
+  [/myproject/tsconfig.json] *new*
+    RetainingOpenFiles:
+      /myproject/src/main.ts  
 Config File Names::
   [/dummy/dummy.ts] *deleted*
   [/myproject/src/main.ts] *new*

--- a/testdata/baselines/reference/fourslash/state/findAllRefsSolutionWithDisableReferencedProjectLoadReferencingDefaultProjectDirectly.baseline
+++ b/testdata/baselines/reference/fourslash/state/findAllRefsSolutionWithDisableReferencedProjectLoadReferencingDefaultProjectDirectly.baseline
@@ -256,9 +256,7 @@ Config::
       /dummy/tsconfig.json  
     RetainingOpenFiles:
       /dummy/dummy.ts  
-  [/myproject/tsconfig.json] *modified*
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *deleted*
+  [/myproject/tsconfig.json] *deleted*
 Config File Names::
   [/dummy/dummy.ts] 
     NearestConfigFileName: /dummy/tsconfig.json
@@ -299,9 +297,9 @@ Open Files::
     /dev/null/inferred  (default) 
 Config::
   [/dummy/tsconfig.json] *deleted*
-  [/myproject/tsconfig.json] *modified*
-    RetainingOpenFiles: *modified*
-      /myproject/src/main.ts  *new*
+  [/myproject/tsconfig.json] *new*
+    RetainingOpenFiles:
+      /myproject/src/main.ts  
 Config File Names::
   [/dummy/dummy.ts] *deleted*
   [/myproject/src/main.ts] *new*

--- a/testdata/baselines/reference/fourslash/state/implementationsAcrossProjects.baseline
+++ b/testdata/baselines/reference/fourslash/state/implementationsAcrossProjects.baseline
@@ -318,29 +318,27 @@ Open Files::
   }
 }
 
+Projects::
+  [/projects/container/compositeExec/tsconfig.json] *deleted*
+    /projects/container/lib/index.ts            
+    /projects/container/compositeExec/index.ts  
+  [/projects/container/exec/tsconfig.json] *deleted*
+    /projects/container/lib/index.ts   
+    /projects/container/exec/index.ts  
+  [/projects/container/lib/tsconfig.json] *deleted*
+    /projects/container/lib/index.ts  
+    /projects/container/lib/bar.ts    
+  [/projects/container/tsconfig.json] *deleted*
+  [/projects/temp/tsconfig.json] 
+    /projects/temp/temp.ts  
 Open Files::
   [/projects/temp/temp.ts] *new*
     /projects/temp/tsconfig.json  (default) 
 Config::
-  [/projects/container/compositeExec/tsconfig.json] 
-    RetainingProjects:
-      /projects/container/compositeExec/tsconfig.json  
-      /projects/container/tsconfig.json                
-  [/projects/container/exec/tsconfig.json] 
-    RetainingProjects:
-      /projects/container/exec/tsconfig.json  
-      /projects/container/tsconfig.json       
-  [/projects/container/lib/tsconfig.json] *modified*
-    RetainingProjects:
-      /projects/container/compositeExec/tsconfig.json  
-      /projects/container/exec/tsconfig.json           
-      /projects/container/lib/tsconfig.json            
-      /projects/container/tsconfig.json                
-    RetainingOpenFiles: *modified*
-      /projects/container/lib/index.ts  *deleted*
-  [/projects/container/tsconfig.json] 
-    RetainingProjects:
-      /projects/container/tsconfig.json  
+  [/projects/container/compositeExec/tsconfig.json] *deleted*
+  [/projects/container/exec/tsconfig.json] *deleted*
+  [/projects/container/lib/tsconfig.json] *deleted*
+  [/projects/container/tsconfig.json] *deleted*
   [/projects/temp/tsconfig.json] 
     RetainingProjects:
       /projects/temp/tsconfig.json  

--- a/testdata/baselines/reference/fourslash/state/renameAncestorProjectRefMangement.baseline
+++ b/testdata/baselines/reference/fourslash/state/renameAncestorProjectRefMangement.baseline
@@ -230,18 +230,19 @@ Open Files::
   }
 }
 
+Projects::
+  [/projects/container/compositeExec/tsconfig.json] *deleted*
+    /projects/container/lib/index.ts            
+    /projects/container/compositeExec/index.ts  
+  [/projects/container/tsconfig.json] *deleted*
+  [/projects/temp/tsconfig.json] 
+    /projects/temp/temp.ts  
 Open Files::
   [/projects/temp/temp.ts] *new*
     /projects/temp/tsconfig.json  (default) 
 Config::
-  [/projects/container/compositeExec/tsconfig.json] *modified*
-    RetainingProjects:
-      /projects/container/compositeExec/tsconfig.json  
-    RetainingOpenFiles: *modified*
-      /projects/container/compositeExec/index.ts  *deleted*
-  [/projects/container/lib/tsconfig.json] 
-    RetainingProjects:
-      /projects/container/compositeExec/tsconfig.json  
+  [/projects/container/compositeExec/tsconfig.json] *deleted*
+  [/projects/container/lib/tsconfig.json] *deleted*
   [/projects/temp/tsconfig.json] 
     RetainingProjects:
       /projects/temp/tsconfig.json  


### PR DESCRIPTION
@sheetalkamat pointed out that the fix in https://github.com/microsoft/typescript-go/pull/2456 was a little backwards, and that was because we never used the overlay-augmented file system in determining root files for tsconfigs; we were only using the on-disk file system. We were also a little inconsistent about converting opens/closes to creates/deletes; we wouldn't process a deletion for an open file (good), but we didn't simulate a creation event for an open that we had never seen before (bad), and we also weren't simulating a deletion for the closure of an open file that no longer exists on disk (bad).

This fixes #1983 (at least one very common reproduction of it; I'm optimistic). What was happening was:

1. Do a `git switch` or `mv` a file or do something that batches a deletion of a file currently open in your editor with the creation of a new file that matches the `include` of the same tsconfig.json as the deleted open file.
2. We would ignore the deletion event since the file remains open. However, the creation event would cause the file names for the impacted tsconfig.json to be reevaluated.
3. The file system used to reevaluate file names for the tsconfig.json was a cache in front of the disk, and the cache did still contain the deleted but open file since we ignored the deletion event, _but_ that file system delegated its `GetAccessibleEntries` (read directory) to the underlying OS file system, so the deleted file would get dropped from the tsconfig's root files.

To make matters even more confusing, _program construction_ always used the overlay file system, so if the deleted but open file was _imported_ by another program file, program construction _would_ find that file and include it, and everything would work—this is why the error was a little tricky to reproduce. You needed an open file that was a root of a tsconfig and not included in the program any other way.

This PR makes the following changes:

1. Overlays are included in the file system used everywhere throughout snapshot building
2. That file system properly implements `GetAccessibleEntries` so overlays appear in directory reads whether they actually exist on disk or not.
3. After Session makes a `FileChangeSummary` of opens/closes/creates/deletes/changes, that summary is compared against the previous snapshot's file system to convert opens/closes to creates/deletes.
4. I pulled #2515 into this PR; we were missing some deletions

The directory structure that enables (2) will also directly enable us to fix #2506 and the directory deletion file watcher issue, but I left those fixes out of this PR to keep the scope smaller.

