### PR TITLE
Remove accidental method pointer

### DIFF
--- a/internal/project/projectcollectionbuilder.go
+++ b/internal/project/projectcollectionbuilder.go
@@ -29,6 +29,7 @@ type ProjectCollectionBuilder struct {
 	sessionOptions      *SessionOptions
 	parseCache          *ParseCache
 	extendedConfigCache *ExtendedConfigCache
+	toPath              func(fileName string) tspath.Path
 
 	ctx                                context.Context
 	fs                                 *snapshotFSBuilder
@@ -61,6 +62,7 @@ func newProjectCollectionBuilder(
 	return &ProjectCollectionBuilder{
 		ctx:                                ctx,
 		fs:                                 fs,
+		toPath:                             fs.toPath,
 		compilerOptionsForInferredProjects: compilerOptionsForInferredProjects,
 		sessionOptions:                     sessionOptions,
 		parseCache:                         parseCache,
@@ -903,10 +905,6 @@ func (b *ProjectCollectionBuilder) findOrCreateProject(
 	}
 	entry, _ := b.configuredProjects.LoadOrStore(configFilePath, NewConfiguredProject(configFileName, configFilePath, b, logger))
 	return entry
-}
-
-func (b *ProjectCollectionBuilder) toPath(fileName string) tspath.Path {
-	return tspath.ToPath(fileName, b.sessionOptions.CurrentDirectory, b.fs.fs.UseCaseSensitiveFileNames())
 }
 
 func (b *ProjectCollectionBuilder) updateInferredProjectRoots(rootFileNames []string, logger *logging.LogTree) bool {


### PR DESCRIPTION
Fixes #2239 

When I started writing the snapshot system, I initially passed around a reference to the static options that contain `currentDirectory` and `useCaseSensitiveFileNames` and let individual types define toPath for themselves, passing those things to `tspath.ToPath()`. When that started to get too repetitive, I refactored to make a single `toPath func(string) tspath.Path` at the top of `NewSession` and passed it around to everything. But I forgot to remove one instance of the `toPath` method. In #2390, I ended up storing that method pointer on `*compilerHost` in an otherwise uninteresting change. When I wrote that line, I thought it was a func-typed property, because that's how it is on every other type around there, but it was actually a method retaining the entire `*projectCollectionBuilder`.