### PR TITLE
Experiment with emulating typing within editor in fourslash tests

### DIFF
--- a/internal/fourslash/fourslash.go
+++ b/internal/fourslash/fourslash.go
@@ -946,14 +946,113 @@ func (f *FourslashTest) openFile(t *testing.T, filename string) {
 		}
 	}
 	f.activeFilename = filename
-	sendNotification(t, f, lsproto.TextDocumentDidOpenInfo, &lsproto.DidOpenTextDocumentParams{
-		TextDocument: &lsproto.TextDocumentItem{
+	if f.testData.isStateBaseliningEnabled() {
+		sendNotification(t, f, lsproto.TextDocumentDidOpenInfo, &lsproto.DidOpenTextDocumentParams{
+			TextDocument: &lsproto.TextDocumentItem{
+				Uri:        lsconv.FileNameToDocumentURI(filename),
+				LanguageId: getLanguageKind(filename),
+				Text:       script.content,
+			},
+		})
+	} else {
+		f.emulateTyping(t, script, &lsproto.TextDocumentItem{
 			Uri:        lsconv.FileNameToDocumentURI(filename),
 			LanguageId: getLanguageKind(filename),
 			Text:       script.content,
+		})
+	}
+	f.baselineProjectsAfterNotification(t, filename)
+}
+
+func (f *FourslashTest) emulateTyping(t *testing.T, script *scriptInfo, origTextDoc *lsproto.TextDocumentItem) {
+	textDocCopy := *origTextDoc
+	fullText := textDocCopy.Text
+	textDocCopy.Text = ""
+	sendNotification(t, f, lsproto.TextDocumentDidOpenInfo, &lsproto.DidOpenTextDocumentParams{
+		TextDocument: &textDocCopy,
+	})
+
+	i := 0
+	for {
+		curr, runeLength := utf8.DecodeRuneInString(fullText[i:])
+		if runeLength == 0 {
+			break
+		} else if curr == utf8.RuneError {
+			t.Fatalf("Invalid UTF-8 encoding at position %d in file %s", i, textDocCopy.Uri.FileName())
+		}
+
+		currentText := fullText[:i+runeLength]
+		sendNotification(t, f, lsproto.TextDocumentDidChangeInfo, &lsproto.DidChangeTextDocumentParams{
+			TextDocument: lsproto.VersionedTextDocumentIdentifier{
+				Uri:     textDocCopy.Uri,
+				Version: int32(i + runeLength),
+			},
+			ContentChanges: []lsproto.TextDocumentContentChangePartialOrWholeDocument{
+				{
+					WholeDocument: &lsproto.TextDocumentContentChangeWholeDocument{
+						Text: currentText,
+					},
+				},
+			},
+		})
+
+		sendRequest(t, f, lsproto.TextDocumentDiagnosticInfo, &lsproto.DocumentDiagnosticParams{
+			TextDocument: lsproto.TextDocumentIdentifier{
+				Uri: textDocCopy.Uri,
+			},
+		})
+
+		switch fullText[i] {
+		case '.':
+			lineChar := f.converters.PositionToLineAndCharacter(script, core.TextPos(i))
+			line := int(lineChar.Line)
+			character := int(lineChar.Character)
+			sendRequest(t, f, lsproto.TextDocumentCompletionInfo, &lsproto.CompletionParams{
+				TextDocument: lsproto.TextDocumentIdentifier{
+					Uri: textDocCopy.Uri,
+				},
+				Position: lsproto.Position{
+					Line:      uint32(line),
+					Character: uint32(character),
+				},
+			})
+		case '(', ',', '<':
+			lineChar := f.converters.PositionToLineAndCharacter(script, core.TextPos(i))
+			line := int(lineChar.Line)
+			character := int(lineChar.Character)
+			sendRequest(t, f, lsproto.TextDocumentSignatureHelpInfo, &lsproto.SignatureHelpParams{
+				TextDocument: lsproto.TextDocumentIdentifier{
+					Uri: textDocCopy.Uri,
+				},
+				Position: lsproto.Position{
+					Line:      uint32(line),
+					Character: uint32(character),
+				},
+				Context: &lsproto.SignatureHelpContext{
+					TriggerKind:      lsproto.SignatureHelpTriggerKindTriggerCharacter,
+					TriggerCharacter: ptrTo(fullText[i : i+runeLength]),
+				},
+			})
+		}
+
+		i += runeLength
+	}
+
+	sendNotification(t, f, lsproto.TextDocumentDidChangeInfo, &lsproto.DidChangeTextDocumentParams{
+		TextDocument: lsproto.VersionedTextDocumentIdentifier{
+			Uri:     textDocCopy.Uri,
+			Version: int32(1 + 1),
+		},
+		ContentChanges: []lsproto.TextDocumentContentChangePartialOrWholeDocument{
+			{
+				WholeDocument: &lsproto.TextDocumentContentChangeWholeDocument{
+					Text: fullText,
+				},
+			},
 		},
 	})
-	f.baselineProjectsAfterNotification(t, filename)
+
+	assert.Equal(t, fullText, fullText[:i])
 }
 
 func getLanguageKind(filename string) lsproto.LanguageKind {


### PR DESCRIPTION
The fourslash test suite used to do this in the Strada codebase - maybe under a "full fidelity" mode or something along those lines. Or maybe when light mode is off. Basically, we don't ever do this anymore in Strada because it's slow to do so and the codebase is mature - but Corsa is new and could use more testing.

I don't know if I've done this right (feels easy to screw things up with rune handling), but here's some possibly-interesting things this raises:

```
TestAllowRenameOfImportPath: (errors during emulated typing)
  
  At position /c.js(Ln 0, Col 0): textDocument/diagnostic request returned error: [-32603]: no project found for URI file:///c.js

TestCompletionImportAttributes: (errors during the actual commands)
  At position /yadda(Ln 0, Col 0): textDocument/diagnostic request returned error: [-32603]: no project found for URI file:///yadda

TestAutoImportFileExcludePatterns: (errors during the actual commands)
  At marker '1': textDocument/completion request returned error: [-32603]: InternalError: panic handling request textDocument/completion: textDocument/completion returned ErrNeedsAutoImports even after enabling auto import

TestCompletionListInUnclosedTypeArguments: test timeout - most interesting(?) part of the stack looks like this:

github.com/microsoft/typescript-go/internal/astnav.FindPrecedingTokenEx.func1(0xc012a26608)
        /workspaces/typescript-go/internal/astnav/tokens.go:340 +0x9c
github.com/microsoft/typescript-go/internal/astnav.FindPrecedingTokenEx(0xc05b7e4380?, 0xea?, 0x1df0090?, 0x60?)
        /workspaces/typescript-go/internal/astnav/tokens.go:446 +0x67
github.com/microsoft/typescript-go/internal/astnav.FindPrecedingToken(...)
        /workspaces/typescript-go/internal/astnav/tokens.go:328
github.com/microsoft/typescript-go/internal/ls.findPrecedingMatchingToken(0xc04b3a5a40, 0x14, 0xc012a26608)
        /workspaces/typescript-go/internal/ls/utilities.go:1347 +0xde
github.com/microsoft/typescript-go/internal/ls.getPossibleTypeArgumentsInfo(0x0?, 0xc012a26608)
        /workspaces/typescript-go/internal/ls/utilities.go:161 +0x152
github.com/microsoft/typescript-go/internal/ls.getImmediatelyContainingArgumentInfo(0xc06b9d4ae8, 0x42?, 0xc012a26608, 0xc018fd80d0?)
        /workspaces/typescript-go/internal/ls/signaturehelp.go:890 +0x4f4
github.com/microsoft/typescript-go/internal/ls.getImmediatelyContainingArgumentOrContextualParameterInfo(0xc06b9d4ae8, 0xe9, 0xc012a26608, 0xc019644008)
        /workspaces/typescript-go/internal/ls/signaturehelp.go:790 +0x51
github.com/microsoft/typescript-go/internal/ls.getContainingArgumentInfo(0xc012a26608?, 0xc012a26608, 0xc019644008, 0x0, 0xe9)
        /workspaces/typescript-go/internal/ls/signaturehelp.go:779 +0x177
github.com/microsoft/typescript-go/internal/ls.(*LanguageService).GetSignatureHelpItems(0xc0557d3cc0, {0x1e06db0, 0xc04b9fb1a0}, 0xe9, 0xc00f4e4fc8, 0xc012a26608, 0xc063d34f40)
        /workspaces/typescript-go/internal/ls/signaturehelp.go:119 +0x1b9
```

No other fourslash test seems to fail, so I figured it wouldn't hurt to put this PR up (even in a hacky state).