### PR TITLE
Don’t use request context for sending responses

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -430,7 +430,6 @@ func (s *Server) dispatchLoop(ctx context.Context) error {
 					delete(s.pendingClientRequests, *req.ID)
 					s.pendingClientRequestsMu.Unlock()
 				}
-
 			}
 
 			if isBlockingMethod(req.Method) {


### PR DESCRIPTION
In #2499, we started checking for context cancelation during sending responses as a way to ensure we don’t get stuck trying to write a message to a client that has exited. If the context is canceled, we would bail out returning an error, but that error would eventually be ignored. Ignoring the error is a problem, but the big problem was that we were checking the _request_ context during sending. If the request was canceled, we would try to send an error response saying the request was canceled, but we would fail to send it since the context was canceled. This left the client perpetually waiting for our response and never asking for new errors.

Fixes #2557 