### PR TITLE
Fix dedupe/redirect nondeterminism

### DIFF
--- a/internal/modulespecifiers/specifiers.go
+++ b/internal/modulespecifiers/specifiers.go
@@ -208,6 +208,11 @@ func getAllModulePathsWorker(
 		allFileNames[p.FileName] = p
 	}
 
+	useCaseSensitiveFileNames := info.UseCaseSensitiveFileNames
+	comparePaths := func(a, b ModulePath) int {
+		return comparePathsByRedirect(a, b, useCaseSensitiveFileNames)
+	}
+
 	// Sort by paths closest to importing file Name directory
 	sortedPaths := make([]ModulePath, 0, len(paths))
 	for directory := info.SourceDirectory; len(allFileNames) != 0; {
@@ -220,7 +225,7 @@ func getAllModulePathsWorker(
 			}
 		}
 		if len(pathsInDirectory) > 0 {
-			slices.SortFunc(pathsInDirectory, comparePathsByRedirectAndNumberOfDirectorySeparators)
+			slices.SortFunc(pathsInDirectory, comparePaths)
 			sortedPaths = append(sortedPaths, pathsInDirectory...)
 		}
 		newDirectory := tspath.GetDirectoryPath(directory)
@@ -231,7 +236,7 @@ func getAllModulePathsWorker(
 	}
 	if len(allFileNames) > 0 {
 		remainingPaths := slices.Collect(maps.Values(allFileNames))
-		slices.SortFunc(remainingPaths, comparePathsByRedirectAndNumberOfDirectorySeparators)
+		slices.SortFunc(remainingPaths, comparePaths)
 		sortedPaths = append(sortedPaths, remainingPaths...)
 	}
 	return sortedPaths

--- a/internal/modulespecifiers/specifiers.go
+++ b/internal/modulespecifiers/specifiers.go
@@ -220,7 +220,7 @@ func getAllModulePathsWorker(
 			}
 		}
 		if len(pathsInDirectory) > 0 {
-			slices.SortStableFunc(pathsInDirectory, comparePathsByRedirectAndNumberOfDirectorySeparators)
+			slices.SortFunc(pathsInDirectory, comparePathsByRedirectAndNumberOfDirectorySeparators)
 			sortedPaths = append(sortedPaths, pathsInDirectory...)
 		}
 		newDirectory := tspath.GetDirectoryPath(directory)
@@ -231,7 +231,7 @@ func getAllModulePathsWorker(
 	}
 	if len(allFileNames) > 0 {
 		remainingPaths := slices.Collect(maps.Values(allFileNames))
-		slices.SortStableFunc(remainingPaths, comparePathsByRedirectAndNumberOfDirectorySeparators)
+		slices.SortFunc(remainingPaths, comparePathsByRedirectAndNumberOfDirectorySeparators)
 		sortedPaths = append(sortedPaths, remainingPaths...)
 	}
 	return sortedPaths

--- a/internal/modulespecifiers/util.go
+++ b/internal/modulespecifiers/util.go
@@ -28,7 +28,10 @@ var (
 
 func comparePathsByRedirectAndNumberOfDirectorySeparators(a ModulePath, b ModulePath) int {
 	if a.IsRedirect == b.IsRedirect {
-		return strings.Count(a.FileName, "/") - strings.Count(b.FileName, "/")
+		if c := strings.Count(a.FileName, "/") - strings.Count(b.FileName, "/"); c != 0 {
+			return c
+		}
+		return strings.Compare(a.FileName, b.FileName)
 	}
 	if a.IsRedirect {
 		return 1

--- a/internal/modulespecifiers/util.go
+++ b/internal/modulespecifiers/util.go
@@ -26,12 +26,9 @@ var (
 	regexPatternCache   = make(map[regexPatternCacheKey]*regexp2.Regexp)
 )
 
-func comparePathsByRedirectAndNumberOfDirectorySeparators(a ModulePath, b ModulePath) int {
+func comparePathsByRedirect(a ModulePath, b ModulePath, useCaseSensitiveFileNames bool) int {
 	if a.IsRedirect == b.IsRedirect {
-		if c := strings.Count(a.FileName, "/") - strings.Count(b.FileName, "/"); c != 0 {
-			return c
-		}
-		return strings.Compare(a.FileName, b.FileName)
+		return tspath.ComparePaths(a.FileName, b.FileName, tspath.ComparePathsOptions{UseCaseSensitiveFileNames: useCaseSensitiveFileNames})
 	}
 	if a.IsRedirect {
 		return 1


### PR DESCRIPTION
Noticed this in #1604 (and in other CI jobs with dedupes). Without this, redirected / deduplicated files randomly swap ordering because the inputs are randomly ordered.

The comparison change is the real fix, but I have also removed the stable sorts since that is misleading; `allFileNames` is a map!