### PR TITLE
Fix generate CI task flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,8 @@ jobs:
           npx hereby test >/dev/null || true
           npx hereby baseline-accept || true
           npx hereby test || true
+          npx hereby baseline-accept || true
+          npx hereby test
 
       - run: git add .
       - run: git diff --staged --exit-code --stat


### PR DESCRIPTION
We unfortunately have tests which produce baselines _after_ they fail for other reasons, so one test run is not enough.

https://github.com/microsoft/typescript-go/actions/runs/21642390137/job/62385368566