### PR TITLE
Sort index types by indexFlags, not flags again

### DIFF
--- a/internal/checker/utilities.go
+++ b/internal/checker/utilities.go
@@ -491,7 +491,7 @@ func CompareTypes(t1, t2 *Type) int {
 		if c := CompareTypes(t1.AsIndexType().target, t2.AsIndexType().target); c != 0 {
 			return c
 		}
-		if c := int(t1.AsIndexType().flags) - int(t2.AsIndexType().flags); c != 0 {
+		if c := int(t1.AsIndexType().indexFlags) - int(t2.AsIndexType().indexFlags); c != 0 {
 			return c
 		}
 	case t1.flags&TypeFlagsIndexedAccess != 0:


### PR DESCRIPTION
Copilot caught this when comparing the code I wrote for Strada. 

comparing `.flags` here seems wrong; we already know the flags are equal by this point. `.indexFlags` seems like what it was meant to be.