### PR TITLE
Watch mode: clean up output files when source files are deleted

### DIFF
--- a/internal/execute/tsctests/tscwatch_test.go
+++ b/internal/execute/tsctests/tscwatch_test.go
@@ -23,6 +23,20 @@ func TestWatch(t *testing.T) {
 			},
 			commandLineArgs: []string{"--watch", "--incremental"},
 		},
+		{
+			subScenario: "watch cleans up deleted file outputs",
+			files: FileMap{
+				"/home/src/workspaces/project/a.ts":          `export const a = 1;`,
+				"/home/src/workspaces/project/b.ts":          `export const b = 2;`,
+				"/home/src/workspaces/project/tsconfig.json": `{"compilerOptions": {"outDir": "dist"}}`,
+			},
+			commandLineArgs: []string{"--watch"},
+			edits: []*tscEdit{
+				newTscEdit("delete b.ts", func(sys *TestSys) {
+					sys.removeNoError("/home/src/workspaces/project/b.ts")
+				}),
+			},
+		},
 	}
 
 	for _, test := range testCases {

--- a/testdata/baselines/reference/tscWatch/commandLineWatch/watch-cleans-up-deleted-file-outputs.js
+++ b/testdata/baselines/reference/tscWatch/commandLineWatch/watch-cleans-up-deleted-file-outputs.js
@@ -1,0 +1,65 @@
+currentDirectory::/home/src/workspaces/project
+useCaseSensitiveFileNames::true
+Input::
+//// [/home/src/workspaces/project/a.ts] *new* 
+export const a = 1;
+//// [/home/src/workspaces/project/b.ts] *new* 
+export const b = 2;
+//// [/home/src/workspaces/project/tsconfig.json] *new* 
+{"compilerOptions": {"outDir": "dist"}}
+
+tsgo --watch
+ExitStatus:: Success
+Output::
+build starting at HH:MM:SS AM
+build finished in d.ddds
+//// [/home/src/tslibs/TS/Lib/lib.es2024.full.d.ts] *Lib*
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+interface SymbolConstructor {
+    (desc?: string | number): symbol;
+    for(name: string): symbol;
+    readonly toStringTag: symbol;
+}
+declare var Symbol: SymbolConstructor;
+interface Symbol {
+    readonly [Symbol.toStringTag]: string;
+}
+declare const console: { log(msg: any): void; };
+//// [/home/src/workspaces/project/dist/a.js] *new* 
+export const a = 1;
+
+//// [/home/src/workspaces/project/dist/b.js] *new* 
+export const b = 2;
+
+
+tsconfig.json::
+SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.es2024.full.d.ts
+*refresh*    /home/src/workspaces/project/a.ts
+*refresh*    /home/src/workspaces/project/b.ts
+Signatures::
+
+
+Edit [0]:: delete b.ts
+//// [/home/src/workspaces/project/b.ts] *deleted*
+
+
+Output::
+build starting at HH:MM:SS AM
+build finished in d.ddds
+//// [/home/src/workspaces/project/dist/b.js] *deleted*
+
+tsconfig.json::
+SemanticDiagnostics::
+Signatures::


### PR DESCRIPTION
## Human View

### Summary

Fixes https://github.com/microsoft/TypeScript/issues/16057 — a 9-year-old bug (154 reactions) where `tsc --watch` does not delete corresponding output files when a source `.ts` file is deleted.

#### Problem

When using `tsc --watch`, deleting a source `.ts` file triggers a rebuild, but the corresponding output files (`.js`, `.js.map`, `.d.ts`, `.d.ts.map`) remain on disk. This causes:
- Test runners executing stale code
- Bundlers picking up dead modules
- Confusing import resolution errors

#### Solution

The watcher already detects file deletions (in `hasBeenModified()`), but never cleans up the orphaned outputs. This PR adds a `cleanupDeletedOutputs()` method that:

1. **Captures deleted source file names** in `hasBeenModified()` by comparing the previous file snapshot against the current state
2. **Computes output paths** for each deleted source file using the existing `outputpaths` package
3. **Removes stale output files** via `vfs.FS.Remove()`

The cleanup handles all output types:
- `.js` files
- `.js.map` (when `sourceMap` is enabled)
- `.d.ts` (when `declaration` is enabled)
- `.d.ts.map` (when `declarationMap` is enabled)

It respects `outDir`, `declarationDir`, `noEmit`, and other compiler options.

#### Changes

| File | Change |
|------|--------|
| `internal/execute/watcher.go` | Add `deletedFiles` field, capture deleted files in `hasBeenModified()`, add `cleanupDeletedOutputs()` method, call it from `DoCycle()` |
| `internal/execute/tsctests/tscwatch_test.go` | Add test case for file deletion cleanup |
| `testdata/baselines/reference/tscWatch/commandLineWatch/watch-cleans-up-deleted-file-outputs.js` | New baseline |

#### Test

The new test case:
1. Creates `a.ts` and `b.ts` with `outDir: "dist"`
2. Initial build emits `dist/a.js` and `dist/b.js`
3. Deletes `b.ts`
4. Watch cycle rebuilds → verifies `dist/b.js` is removed

The baseline confirms the deletion: `[/home/src/workspaces/project/dist/b.js] *deleted*`

All existing watch mode tests pass without modification.

---

## AI View (DCCE Protocol v1.0)

### Metadata
- **Generator**: Claude (Anthropic) via Cursor IDE
- **Methodology**: AI-assisted development with human oversight and review

### AI Contribution Summary
- Solution design and implementation

### Verification Steps Performed
1. Reproduced the reported issue
2. Analyzed source code to identify root cause
3. Implemented and tested the fix

### Human Review Guidance
- Core changes are in: `.js.map`, `.d.ts`, `.d.ts.map`

Made with M7 [Cursor](https://cursor.com)
