### PR TITLE
Replace unsafe.Pointer for seen symbol tables with unique ID

### DIFF
--- a/internal/checker/symbolaccessibility.go
+++ b/internal/checker/symbolaccessibility.go
@@ -402,10 +402,10 @@ type accessibleSymbolChainContext struct {
 type symbolTableID uint64
 
 const (
-	stKindLocals  symbolTableID = 0
-	stKindExports symbolTableID = 1 << 62
-	stKindMembers symbolTableID = 2 << 62
-	stKindGlobals symbolTableID = 3 << 62
+	stKindLocals symbolTableID = iota << 62
+	stKindExports
+	stKindMembers
+	stKindGlobals
 )
 
 func symbolTableIDFromLocals(node *ast.Node) symbolTableID {


### PR DESCRIPTION
We use `reflect.ValueOf(m).UnsafePointer()` in the checker in order to have maps as map keys themselves. This is the only place we use unsafe in the checker, and theoretically going through reflect has a high cost (see https://godbolt.org/z/3jMcxY49T).

Instead of doing this, we can instead note that we always get a symbol table from some _other_ value that has an ID; a `Node` or a `Symbol`. If we use that ID (or a sentinel value) plus some metadata, we can avoid reflect and unsafe, swapping for a simple load+OR.

This seems to achieve the same goal. All tests pass.