### PR TITLE
Fix race on snapshot in DidOpenFile

### DIFF
--- a/internal/project/session.go
+++ b/internal/project/session.go
@@ -245,6 +245,8 @@ func (s *Session) InitializeWithUserConfig(config *lsutil.UserConfig) {
 
 func (s *Session) DidOpenFile(ctx context.Context, uri lsproto.DocumentUri, version int32, content string, languageKind lsproto.LanguageKind) {
 	s.cancelDiagnosticsRefresh()
+	s.snapshotUpdateMu.Lock()
+	defer s.snapshotUpdateMu.Unlock()
 	s.pendingFileChangesMu.Lock()
 	s.pendingFileChanges = append(s.pendingFileChanges, FileChange{
 		Kind:         FileChangeKindOpen,


### PR DESCRIPTION
All other funcs locked on `snapshotUpdateMu` when doing `UpdateSnapshot`, but this did not. I think is the root cause of this flake:

https://github.com/microsoft/typescript-go/actions/runs/21879194209/job/63156565973

```
=== Failed
=== FAIL: internal/project TestRefCountingCaches/parseCache/unchanged_program_does_not_over-ref (0.37s)

=== FAIL: internal/project TestRefCountingCaches/parseCache (0.99s)

=== FAIL: internal/project TestRefCountingCaches (25.98s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x172270a]

goroutine 19035 [running]:
testing.tRunner.func1.2({0x189c680, 0x35e9b90})
	/home/runner/.local/share/microsoft-go/go1.25.7-1/src/testing/testing.go:1872 +0x237
testing.tRunner.func1()
	/home/runner/.local/share/microsoft-go/go1.25.7-1/src/testing/testing.go:1875 +0x35b
panic({0x189c680?, 0x35e9b90?})
	/home/runner/.local/share/microsoft-go/go1.25.7-1/src/runtime/panic.go:783 +0x132
github.com/microsoft/typescript-go/internal/project.(*snapshotFSBuilder).convertOpenAndCloseToChanges(0xc006ed9640, {{0x1ac8f11, 0x13}, {0x0, 0x0}, {0xc001920210}, {0x0}, {0x0}, {0x0}, 0x0})
	/home/runner/work/typescript-go/typescript-go/internal/project/snapshotfs.go:366 +0x44a
github.com/microsoft/typescript-go/internal/project.(*Snapshot).Clone(0xc00a954280, {0x221da48, 0x364a1a0}, {{{0xc0080d1510, 0x1, 0x1}, {0x0, 0x0, 0x0}, 0x0, ...}, ...}, ...)
	/home/runner/work/typescript-go/typescript-go/internal/project/snapshot.go:292 +0x8d7
github.com/microsoft/typescript-go/internal/project.(*Session).UpdateSnapshot(0xc00185e280, {0x221da48, 0x364a1a0}, 0xc0019201e0, {{{0xc0080d1510, 0x1, 0x1}, {0x0, 0x0, 0x0}, ...}, ...})
	/home/runner/work/typescript-go/typescript-go/internal/project/session.go:560 +0x15d
github.com/microsoft/typescript-go/internal/project.(*Session).DidOpenFile(0xc00185e280, {0x221da48, 0x364a1a0}, {0x1ac8f11, 0x13}, 0x1, {0x0, 0x0}, {0x1ac2230, 0xa})
	/home/runner/work/typescript-go/typescript-go/internal/project/session.go:258 +0x49e
github.com/microsoft/typescript-go/internal/project.TestRefCountingCaches.func2.3(0xc0007a7880)
	/home/runner/work/typescript-go/typescript-go/internal/project/refcountcache_test.go:165 +0xad3
testing.tRunner(0xc0007a7880, 0xc0079c5998)
	/home/runner/.local/share/microsoft-go/go1.25.7-1/src/testing/testing.go:1934 +0xea
created by testing.(*T).Run in goroutine 129
	/home/runner/.local/share/microsoft-go/go1.25.7-1/src/testing/testing.go:1997 +0x465
```