### PR TITLE
Add missing IsNodeType functions

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -3001,6 +3001,10 @@ func (node *DoStatement) computeSubtreeFacts() SubtreeFacts {
 		propagateSubtreeFacts(node.Expression)
 }
 
+func IsDoStatement(node *Node) bool {
+	return node.Kind == KindDoStatement
+}
+
 // WhileStatement
 
 type WhileStatement struct {
@@ -3038,6 +3042,10 @@ func (node *WhileStatement) Clone(f NodeFactoryCoercible) *Node {
 
 func (node *WhileStatement) computeSubtreeFacts() SubtreeFacts {
 	return propagateSubtreeFacts(node.Expression) | propagateSubtreeFacts(node.Statement)
+}
+
+func IsWhileStatement(node *Node) bool {
+	return node.Kind == KindWhileStatement
 }
 
 // ForStatement
@@ -3182,6 +3190,10 @@ func (node *BreakStatement) Clone(f NodeFactoryCoercible) *Node {
 	return cloneNode(f.AsNodeFactory().NewBreakStatement(node.Label), node.AsNode(), f.AsNodeFactory().hooks)
 }
 
+func IsBreakStatement(node *Node) bool {
+	return node.Kind == KindBreakStatement
+}
+
 // ContinueStatement
 
 type ContinueStatement struct {
@@ -3212,6 +3224,10 @@ func (node *ContinueStatement) VisitEachChild(v *NodeVisitor) *Node {
 
 func (node *ContinueStatement) Clone(f NodeFactoryCoercible) *Node {
 	return cloneNode(f.AsNodeFactory().NewContinueStatement(node.Label), node.AsNode(), f.AsNodeFactory().hooks)
+}
+
+func IsContinueStatement(node *Node) bool {
+	return node.Kind == KindContinueStatement
 }
 
 // ReturnStatement
@@ -3294,6 +3310,10 @@ func (node *WithStatement) computeSubtreeFacts() SubtreeFacts {
 	return propagateSubtreeFacts(node.Expression) | propagateSubtreeFacts(node.Statement)
 }
 
+func IsWithStatement(node *Node) bool {
+	return node.Kind == KindWithStatement
+}
+
 // SwitchStatement
 
 type SwitchStatement struct {
@@ -3374,6 +3394,10 @@ func (node *CaseBlock) Clone(f NodeFactoryCoercible) *Node {
 
 func (node *CaseBlock) computeSubtreeFacts() SubtreeFacts {
 	return propagateNodeListSubtreeFacts(node.Clauses, propagateSubtreeFacts)
+}
+
+func IsCaseBlock(node *Node) bool {
+	return node.Kind == KindCaseBlock
 }
 
 // CaseOrDefaultClause
@@ -3577,6 +3601,10 @@ func (f *NodeFactory) NewDebuggerStatement() *Node {
 
 func (node *DebuggerStatement) Clone(f NodeFactoryCoercible) *Node {
 	return cloneNode(f.AsNodeFactory().NewDebuggerStatement(), node.AsNode(), f.AsNodeFactory().hooks)
+}
+
+func IsDebuggerStatement(node *Node) bool {
+	return node.Kind == KindDebuggerStatement
 }
 
 // LabeledStatement
@@ -4074,6 +4102,10 @@ func (node *MissingDeclaration) VisitEachChild(v *NodeVisitor) *Node {
 
 func (node *MissingDeclaration) Clone(f NodeFactoryCoercible) *Node {
 	return cloneNode(f.AsNodeFactory().NewMissingDeclaration(node.Modifiers()), node.AsNode(), f.AsNodeFactory().hooks)
+}
+
+func IsMissingDeclaration(node *Node) bool {
+	return node.Kind == KindMissingDeclaration
 }
 
 // FunctionDeclaration
@@ -6033,6 +6065,10 @@ func (node *SemicolonClassElement) Clone(f NodeFactoryCoercible) *Node {
 	return cloneNode(f.AsNodeFactory().NewSemicolonClassElement(), node.AsNode(), f.AsNodeFactory().hooks)
 }
 
+func IsSemicolonClassElement(node *Node) bool {
+	return node.Kind == KindSemicolonClassElement
+}
+
 // ClassStaticBlockDeclaration
 
 type ClassStaticBlockDeclaration struct {
@@ -6258,6 +6294,10 @@ func (node *NoSubstitutionTemplateLiteral) Clone(f NodeFactoryCoercible) *Node {
 	return cloneNode(f.AsNodeFactory().NewNoSubstitutionTemplateLiteral(node.Text, node.TemplateFlags), node.AsNode(), f.AsNodeFactory().hooks)
 }
 
+func IsNoSubstitutionTemplateLiteral(node *Node) bool {
+	return node.Kind == KindNoSubstitutionTemplateLiteral
+}
+
 // BinaryExpression
 
 type BinaryExpression struct {
@@ -6396,6 +6436,10 @@ func (node *PostfixUnaryExpression) Clone(f NodeFactoryCoercible) *Node {
 
 func (node *PostfixUnaryExpression) computeSubtreeFacts() SubtreeFacts {
 	return propagateSubtreeFacts(node.Operand)
+}
+
+func IsPostfixUnaryExpression(node *Node) bool {
+	return node.Kind == KindPostfixUnaryExpression
 }
 
 // YieldExpression
@@ -6619,6 +6663,10 @@ func (node *AsExpression) computeSubtreeFacts() SubtreeFacts {
 
 func (node *AsExpression) propagateSubtreeFacts() SubtreeFacts {
 	return node.SubtreeFacts() & ^SubtreeExclusionsOuterExpression
+}
+
+func IsAsExpression(node *Node) bool {
+	return node.Kind == KindAsExpression
 }
 
 // SatisfiesExpression
@@ -7533,6 +7581,10 @@ func (node *DeleteExpression) computeSubtreeFacts() SubtreeFacts {
 	return propagateSubtreeFacts(node.Expression)
 }
 
+func IsDeleteExpression(node *Node) bool {
+	return node.Kind == KindDeleteExpression
+}
+
 // TypeOfExpression
 
 type TypeOfExpression struct {
@@ -7691,6 +7743,10 @@ func (node *TypeAssertion) propagateSubtreeFacts() SubtreeFacts {
 	return node.SubtreeFacts() & ^SubtreeExclusionsOuterExpression
 }
 
+func IsTypeAssertionExpression(node *Node) bool {
+	return node.Kind == KindTypeAssertionExpression
+}
+
 // TypeNodeBase
 
 type TypeNodeBase struct {
@@ -7748,6 +7804,10 @@ func (node *UnionTypeNode) VisitEachChild(v *NodeVisitor) *Node {
 
 func (node *UnionTypeNode) Clone(f NodeFactoryCoercible) *Node {
 	return cloneNode(f.AsNodeFactory().NewUnionTypeNode(node.Types), node.AsNode(), f.AsNodeFactory().hooks)
+}
+
+func IsUnionTypeNode(node *Node) bool {
+	return node.Kind == KindUnionType
 }
 
 // IntersectionTypeNode
@@ -7928,6 +7988,10 @@ func (node *ArrayTypeNode) VisitEachChild(v *NodeVisitor) *Node {
 
 func (node *ArrayTypeNode) Clone(f NodeFactoryCoercible) *Node {
 	return cloneNode(f.AsNodeFactory().NewArrayTypeNode(node.ElementType), node.AsNode(), f.AsNodeFactory().hooks)
+}
+
+func IsArrayTypeNode(node *Node) bool {
+	return node.Kind == KindArrayType
 }
 
 // IndexedAccessTypeNode
@@ -8230,6 +8294,10 @@ func (node *ImportAttribute) computeSubtreeFacts() SubtreeFacts {
 
 func (node *ImportAttribute) Name() *ImportAttributeName {
 	return node.name
+}
+
+func IsImportAttribute(node *Node) bool {
+	return node.Kind == KindImportAttribute
 }
 
 // ImportAttributes
@@ -8834,6 +8902,10 @@ func (node *TemplateLiteralTypeNode) VisitEachChild(v *NodeVisitor) *Node {
 
 func (node *TemplateLiteralTypeNode) Clone(f NodeFactoryCoercible) *Node {
 	return cloneNode(f.AsNodeFactory().NewTemplateLiteralTypeNode(node.Head, node.TemplateSpans), node.AsNode(), f.AsNodeFactory().hooks)
+}
+
+func IsTemplateLiteralTypeNode(node *Node) bool {
+	return node.Kind == KindTemplateLiteralType
 }
 
 // TemplateLiteralTypeSpan
@@ -9486,7 +9558,13 @@ func (node *SyntaxList) Clone(f NodeFactoryCoercible) *Node {
 	return cloneNode(f.AsNodeFactory().NewSyntaxList(node.Children), node.AsNode(), f.AsNodeFactory().hooks)
 }
 
-/// JSDoc ///
+func IsSyntaxList(node *Node) bool {
+	return node.Kind == KindSyntaxList
+}
+
+/// JSDoc nodes ///
+
+// JSDoc
 
 type JSDoc struct {
 	NodeBase
@@ -9535,7 +9613,8 @@ type JSDocCommentBase struct {
 	text []string
 }
 
-// JSDoc comments
+// JSDocText
+
 type JSDocText struct {
 	JSDocCommentBase
 }
@@ -9550,6 +9629,12 @@ func (f *NodeFactory) NewJSDocText(text []string) *Node {
 func (node *JSDocText) Clone(f NodeFactoryCoercible) *Node {
 	return cloneNode(f.AsNodeFactory().NewJSDocText(node.text), node.AsNode(), f.AsNodeFactory().hooks)
 }
+
+func IsJSDocText(node *Node) bool {
+	return node.Kind == KindJSDocText
+}
+
+// JSDocLink
 
 type JSDocLink struct {
 	JSDocCommentBase
@@ -9587,6 +9672,12 @@ func (node *JSDocLink) Name() *DeclarationName {
 	return node.name
 }
 
+func IsJSDocLink(node *Node) bool {
+	return node.Kind == KindJSDocLink
+}
+
+// JSDocLinkPlain
+
 type JSDocLinkPlain struct {
 	JSDocCommentBase
 	name *Node // optional (should only be EntityName)
@@ -9623,6 +9714,12 @@ func (node *JSDocLinkPlain) Name() *DeclarationName {
 	return node.name
 }
 
+func IsJSDocLinkPlain(node *Node) bool {
+	return node.Kind == KindJSDocLinkPlain
+}
+
+// JSDocLinkCode
+
 type JSDocLinkCode struct {
 	JSDocCommentBase
 	name *Node // optional (should only be EntityName)
@@ -9657,6 +9754,10 @@ func (node *JSDocLinkCode) Clone(f NodeFactoryCoercible) *Node {
 
 func (node *JSDocLinkCode) Name() *DeclarationName {
 	return node.name
+}
+
+func IsJSDocLinkCode(node *Node) bool {
+	return node.Kind == KindJSDocLinkCode
 }
 
 // JSDocTypeExpression
@@ -9782,6 +9883,10 @@ func (node *JSDocAllType) Clone(f NodeFactoryCoercible) *Node {
 	return cloneNode(f.AsNodeFactory().NewJSDocAllType(), node.AsNode(), f.AsNodeFactory().hooks)
 }
 
+func IsJSDocAllType(node *Node) bool {
+	return node.Kind == KindJSDocAllType
+}
+
 // JSDocVariadicType
 
 type JSDocVariadicType struct {
@@ -9814,6 +9919,10 @@ func (node *JSDocVariadicType) Clone(f NodeFactoryCoercible) *Node {
 	return cloneNode(f.AsNodeFactory().NewJSDocVariadicType(node.Type), node.AsNode(), f.AsNodeFactory().hooks)
 }
 
+func IsJSDocVariadicType(node *Node) bool {
+	return node.Kind == KindJSDocVariadicType
+}
+
 // JSDocOptionalType
 
 type JSDocOptionalType struct {
@@ -9844,6 +9953,10 @@ func (node *JSDocOptionalType) VisitEachChild(v *NodeVisitor) *Node {
 
 func (node *JSDocOptionalType) Clone(f NodeFactoryCoercible) *Node {
 	return cloneNode(f.AsNodeFactory().NewJSDocOptionalType(node.Type), node.AsNode(), f.AsNodeFactory().hooks)
+}
+
+func IsJSDocOptionalType(node *Node) bool {
+	return node.Kind == KindJSDocOptionalType
 }
 
 // JSDocTypeTag
@@ -9885,6 +9998,7 @@ func IsJSDocTypeTag(node *Node) bool {
 }
 
 // JSDocUnknownTag
+
 type JSDocUnknownTag struct {
 	JSDocTagBase
 }
@@ -9920,6 +10034,7 @@ func IsJSDocUnknownTag(node *Node) bool {
 }
 
 // JSDocTemplateTag
+
 type JSDocTemplateTag struct {
 	JSDocTagBase
 	Constraint     *Node
@@ -9959,6 +10074,7 @@ func IsJSDocTemplateTag(n *Node) bool {
 }
 
 // JSDocParameterOrPropertyTag
+
 type JSDocParameterOrPropertyTag struct {
 	JSDocTagBase
 	name           *EntityName
@@ -10032,6 +10148,7 @@ func IsJSDocPropertyTag(node *Node) bool {
 }
 
 // JSDocReturnTag
+
 type JSDocReturnTag struct {
 	JSDocTagBase
 	TypeExpression *TypeNode
@@ -10069,6 +10186,7 @@ func IsJSDocReturnTag(node *Node) bool {
 }
 
 // JSDocPublicTag
+
 type JSDocPublicTag struct {
 	JSDocTagBase
 }
@@ -10099,7 +10217,12 @@ func (node *JSDocPublicTag) Clone(f NodeFactoryCoercible) *Node {
 	return cloneNode(f.AsNodeFactory().NewJSDocPublicTag(node.TagName, node.Comment), node.AsNode(), f.AsNodeFactory().hooks)
 }
 
+func IsJSDocPublicTag(node *Node) bool {
+	return node.Kind == KindJSDocPublicTag
+}
+
 // JSDocPrivateTag
+
 type JSDocPrivateTag struct {
 	JSDocTagBase
 }
@@ -10130,7 +10253,12 @@ func (node *JSDocPrivateTag) Clone(f NodeFactoryCoercible) *Node {
 	return cloneNode(f.AsNodeFactory().NewJSDocPrivateTag(node.TagName, node.Comment), node.AsNode(), f.AsNodeFactory().hooks)
 }
 
+func IsJSDocPrivateTag(node *Node) bool {
+	return node.Kind == KindJSDocPrivateTag
+}
+
 // JSDocProtectedTag
+
 type JSDocProtectedTag struct {
 	JSDocTagBase
 }
@@ -10161,7 +10289,12 @@ func (node *JSDocProtectedTag) Clone(f NodeFactoryCoercible) *Node {
 	return cloneNode(f.AsNodeFactory().NewJSDocProtectedTag(node.TagName, node.Comment), node.AsNode(), f.AsNodeFactory().hooks)
 }
 
+func IsJSDocProtectedTag(node *Node) bool {
+	return node.Kind == KindJSDocProtectedTag
+}
+
 // JSDocReadonlyTag
+
 type JSDocReadonlyTag struct {
 	JSDocTagBase
 }
@@ -10192,7 +10325,12 @@ func (node *JSDocReadonlyTag) Clone(f NodeFactoryCoercible) *Node {
 	return cloneNode(f.AsNodeFactory().NewJSDocReadonlyTag(node.TagName, node.Comment), node.AsNode(), f.AsNodeFactory().hooks)
 }
 
+func IsJSDocReadonlyTag(node *Node) bool {
+	return node.Kind == KindJSDocReadonlyTag
+}
+
 // JSDocOverrideTag
+
 type JSDocOverrideTag struct {
 	JSDocTagBase
 }
@@ -10223,7 +10361,12 @@ func (node *JSDocOverrideTag) Clone(f NodeFactoryCoercible) *Node {
 	return cloneNode(f.AsNodeFactory().NewJSDocOverrideTag(node.TagName, node.Comment), node.AsNode(), f.AsNodeFactory().hooks)
 }
 
+func IsJSDocOverrideTag(node *Node) bool {
+	return node.Kind == KindJSDocOverrideTag
+}
+
 // JSDocDeprecatedTag
+
 type JSDocDeprecatedTag struct {
 	JSDocTagBase
 }
@@ -10259,6 +10402,7 @@ func IsJSDocDeprecatedTag(node *Node) bool {
 }
 
 // JSDocSeeTag
+
 type JSDocSeeTag struct {
 	JSDocTagBase
 	NameExpression *TypeNode
@@ -10291,7 +10435,12 @@ func (node *JSDocSeeTag) Clone(f NodeFactoryCoercible) *Node {
 	return cloneNode(f.AsNodeFactory().NewJSDocSeeTag(node.TagName, node.NameExpression, node.Comment), node.AsNode(), f.AsNodeFactory().hooks)
 }
 
+func IsJSDocSeeTag(node *Node) bool {
+	return node.Kind == KindJSDocSeeTag
+}
+
 // JSDocImplementsTag
+
 type JSDocImplementsTag struct {
 	JSDocTagBase
 	ClassName *Expression
@@ -10329,6 +10478,7 @@ func IsJSDocImplementsTag(node *Node) bool {
 }
 
 // JSDocAugmentsTag
+
 type JSDocAugmentsTag struct {
 	JSDocTagBase
 	ClassName *Expression
@@ -10366,6 +10516,7 @@ func IsJSDocAugmentsTag(node *Node) bool {
 }
 
 // JSDocSatisfiesTag
+
 type JSDocSatisfiesTag struct {
 	JSDocTagBase
 	TypeExpression *TypeNode
@@ -10398,7 +10549,12 @@ func (node *JSDocSatisfiesTag) Clone(f NodeFactoryCoercible) *Node {
 	return cloneNode(f.AsNodeFactory().NewJSDocSatisfiesTag(node.TagName, node.TypeExpression, node.Comment), node.AsNode(), f.AsNodeFactory().hooks)
 }
 
+func IsJSDocSatisfiesTag(node *Node) bool {
+	return node.Kind == KindJSDocSatisfiesTag
+}
+
 // JSDocThisTag
+
 type JSDocThisTag struct {
 	JSDocTagBase
 	TypeExpression *TypeNode
@@ -10431,7 +10587,12 @@ func (node *JSDocThisTag) Clone(f NodeFactoryCoercible) *Node {
 	return cloneNode(f.AsNodeFactory().NewJSDocThisTag(node.TagName, node.TypeExpression, node.Comment), node.AsNode(), f.AsNodeFactory().hooks)
 }
 
+func IsJSDocThisTag(node *Node) bool {
+	return node.Kind == KindJSDocThisTag
+}
+
 // JSDocImportTag
+
 type JSDocImportTag struct {
 	JSDocTagBase
 	ImportClause    *Declaration
@@ -10473,6 +10634,7 @@ func IsJSDocImportTag(node *Node) bool {
 }
 
 // JSDocCallbackTag
+
 type JSDocCallbackTag struct {
 	JSDocTagBase
 	FullName       *Node
@@ -10514,6 +10676,7 @@ func IsJSDocCallbackTag(node *Node) bool {
 }
 
 // JSDocOverloadTag
+
 type JSDocOverloadTag struct {
 	JSDocTagBase
 	TypeExpression *TypeNode
@@ -10546,7 +10709,12 @@ func (node *JSDocOverloadTag) Clone(f NodeFactoryCoercible) *Node {
 	return cloneNode(f.AsNodeFactory().NewJSDocOverloadTag(node.TagName, node.TypeExpression, node.Comment), node.AsNode(), f.AsNodeFactory().hooks)
 }
 
+func IsJSDocOverloadTag(node *Node) bool {
+	return node.Kind == KindJSDocOverloadTag
+}
+
 // JSDocTypedefTag
+
 type JSDocTypedefTag struct {
 	JSDocTagBase
 	TypeExpression *Node
@@ -10591,6 +10759,7 @@ func IsJSDocTypedefTag(node *Node) bool {
 }
 
 // JSDocTypeLiteral
+
 type JSDocTypeLiteral struct {
 	TypeNodeBase
 	DeclarationBase
@@ -10630,6 +10799,7 @@ func IsJSDocTypeLiteral(node *Node) bool {
 }
 
 // JSDocSignature
+
 type JSDocSignature struct {
 	TypeNodeBase
 	FunctionLikeBase
@@ -10667,6 +10837,7 @@ func IsJSDocSignature(node *Node) bool {
 }
 
 // JSDocNameReference
+
 type JSDocNameReference struct {
 	TypeNodeBase
 	name *EntityName


### PR DESCRIPTION
Adds all missing `IsNodeType` functions in `ast.go` for consistency.

Also normalizes comments before a `Node` block.
