### PR TITLE
Record (and possibly rewind) JSDoc info, create JSDoc cache separately

### DIFF
--- a/internal/parser/jsdoc.go
+++ b/internal/parser/jsdoc.go
@@ -31,12 +31,6 @@ func (p *Parser) withJSDoc(node *ast.Node, hasJSDoc bool) []*ast.Node {
 	if !hasJSDoc {
 		return nil
 	}
-
-	if p.jsdocCache == nil {
-		p.jsdocCache = make(map[*ast.Node][]*ast.Node, strings.Count(p.sourceText, "/**"))
-	} else if _, ok := p.jsdocCache[node]; ok {
-		panic("tried to set JSDoc on a node with existing JSDoc")
-	}
 	// Should only be called once per node
 	p.hasDeprecatedTag = false
 	ranges := GetJSDocCommentRanges(&p.factory, p.jsdocCommentRangesSpace, node, p.sourceText)
@@ -61,7 +55,7 @@ func (p *Parser) withJSDoc(node *ast.Node, hasJSDoc bool) []*ast.Node {
 		if p.scriptKind == core.ScriptKindJS || p.scriptKind == core.ScriptKindJSX {
 			p.reparseTags(node, jsdoc)
 		}
-		p.jsdocCache[node] = jsdoc
+		p.jsdocInfos = append(p.jsdocInfos, JSDocInfo{parent: node, jsDocs: jsdoc})
 		return jsdoc
 	}
 	return nil

--- a/internal/parser/reparser.go
+++ b/internal/parser/reparser.go
@@ -96,7 +96,7 @@ func (p *Parser) reparseUnhosted(tag *ast.Node, parent *ast.Node, jsDoc *ast.Nod
 		}
 		typeAlias.AsTypeAliasDeclaration().Type = t
 		p.finishReparsedNode(typeAlias, tag)
-		p.jsdocCache[typeAlias] = []*ast.Node{jsDoc}
+		p.jsdocInfos = append(p.jsdocInfos, JSDocInfo{parent: typeAlias, jsDocs: []*ast.Node{jsDoc}})
 		typeAlias.Flags |= ast.NodeFlagsHasJSDoc
 		p.reparseList = append(p.reparseList, typeAlias)
 	case ast.KindJSDocCallbackTag:
@@ -108,7 +108,7 @@ func (p *Parser) reparseUnhosted(tag *ast.Node, parent *ast.Node, jsDoc *ast.Nod
 		typeAlias := p.factory.NewJSTypeAliasDeclaration(nil, p.addDeepCloneReparse(callbackTag.FullName), nil, functionType)
 		typeAlias.AsTypeAliasDeclaration().TypeParameters = p.gatherTypeParameters(jsDoc, tag)
 		p.finishReparsedNode(typeAlias, tag)
-		p.jsdocCache[typeAlias] = []*ast.Node{jsDoc}
+		p.jsdocInfos = append(p.jsdocInfos, JSDocInfo{parent: typeAlias, jsDocs: []*ast.Node{jsDoc}})
 		typeAlias.Flags |= ast.NodeFlagsHasJSDoc
 		p.reparseList = append(p.reparseList, typeAlias)
 	case ast.KindJSDocImportTag:
@@ -239,7 +239,7 @@ func (p *Parser) reparseJSDocComment(node *ast.Node, tag *ast.Node) {
 	if comment := tag.CommentList(); comment != nil {
 		propJSDoc := p.factory.NewJSDoc(comment, nil)
 		p.finishReparsedNode(propJSDoc, tag)
-		p.jsdocCache[node] = []*ast.Node{propJSDoc}
+		p.jsdocInfos = append(p.jsdocInfos, JSDocInfo{parent: node, jsDocs: []*ast.Node{propJSDoc}})
 		node.Flags |= ast.NodeFlagsHasJSDoc
 	}
 }


### PR DESCRIPTION
This PR is a follow-up to #2795 that records (and possibly rewinds) JSDoc comment occurrences and creates the JSDoc cache as a separate step when finalizing a source file object.

No tests associated with this PR as all it does is eliminate speculatively parsed and discarded JSDoc objects from the JSDoc cache.