### PR TITLE
Add nil assertion for thisType.symbol

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -29000,7 +29000,9 @@ func (c *Checker) getContextualTypeForAssignmentExpression(binary *ast.BinaryExp
 			if ast.IsPropertyAccessExpression(left) {
 				name := left.Name()
 				if ast.IsPrivateIdentifier(name) {
-					symbol = c.getPropertyOfType(thisType, binder.GetSymbolNameForPrivateIdentifier(thisType.symbol, name.Text()))
+					if thisType.symbol != nil {
+						symbol = c.getPropertyOfType(thisType, binder.GetSymbolNameForPrivateIdentifier(thisType.symbol, name.Text()))
+					}
 				} else {
 					symbol = c.getPropertyOfType(thisType, name.Text())
 				}

--- a/internal/fourslash/tests/privatePropertyOfUndefinedThis_test.go
+++ b/internal/fourslash/tests/privatePropertyOfUndefinedThis_test.go
@@ -1,0 +1,37 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestPrivatePropertyOfUndefinedThis1(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `
+// @strict: true
+this.#a = {};
+export {};
+`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineNonSuggestionDiagnostics(t)
+}
+
+func TestPrivatePropertyOfUndefinedThis2(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `
+// @strict: true
+export class C {
+    wat(this: any): boolean {
+        return this.#prop = {};
+    }
+}
+`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineNonSuggestionDiagnostics(t)
+}

--- a/testdata/baselines/reference/fourslash/syntaxandSemanticDiagnostics/privatePropertyOfUndefinedThis1.baseline
+++ b/testdata/baselines/reference/fourslash/syntaxandSemanticDiagnostics/privatePropertyOfUndefinedThis1.baseline
@@ -1,0 +1,13 @@
+// === Syntax and Semantic Diagnostics ===
+/privatePropertyOfUndefinedThis1.ts(1,1): error TS2532: Object is possibly 'undefined'.
+/privatePropertyOfUndefinedThis1.ts(1,6): error TS18016: Private identifiers are not allowed outside class bodies.
+
+
+==== /privatePropertyOfUndefinedThis1.ts (2 errors) ====
+    this.#a = {};
+    ~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+         ~~
+!!! error TS18016: Private identifiers are not allowed outside class bodies.
+    export {};
+    

--- a/testdata/baselines/reference/fourslash/syntaxandSemanticDiagnostics/privatePropertyOfUndefinedThis2.baseline
+++ b/testdata/baselines/reference/fourslash/syntaxandSemanticDiagnostics/privatePropertyOfUndefinedThis2.baseline
@@ -1,0 +1,16 @@
+// === Syntax and Semantic Diagnostics ===
+/privatePropertyOfUndefinedThis2.ts(3,9): error TS2322: Type '{}' is not assignable to type 'boolean'.
+/privatePropertyOfUndefinedThis2.ts(3,21): error TS2339: Property '#prop' does not exist on type 'any'.
+
+
+==== /privatePropertyOfUndefinedThis2.ts (2 errors) ====
+    export class C {
+        wat(this: any): boolean {
+            return this.#prop = {};
+            ~~~~~~
+!!! error TS2322: Type '{}' is not assignable to type 'boolean'.
+                        ~~~~~
+!!! error TS2339: Property '#prop' does not exist on type 'any'.
+        }
+    }
+    


### PR DESCRIPTION
`GetSymbolNameForPrivateIdentifier` requires the first parameter not to be nil, but apparently `thisType.symbol` is not always specified, e.g. when global this is used globally in a module.

Fixes #2798