### PR TITLE
Fix panic in organizeImports for .d.ts files with unused imports matching module augmentations

### DIFF
--- a/internal/fourslash/tests/organizeImports_dtsUnusedImportWithAugmentation_test.go
+++ b/internal/fourslash/tests/organizeImports_dtsUnusedImportWithAugmentation_test.go
@@ -1,0 +1,38 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestOrganizeImports_dtsUnusedImportWithAugmentation(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `// @Filename: /styled-patch.d.ts
+import * as styledComponents from 'styled-components';
+
+declare module 'styled-components' {
+    interface ThemedStyledComponentsModule {
+        keyframes(): Keyframes;
+    }
+}
+// @Filename: /node_modules/styled-components/index.d.ts
+export interface Keyframes {}
+export interface ThemedStyledComponentsModule {}`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyOrganizeImports(t,
+		`import 'styled-components';
+
+declare module 'styled-components' {
+    interface ThemedStyledComponentsModule {
+        keyframes(): Keyframes;
+    }
+}`,
+		lsproto.CodeActionKindSourceOrganizeImports,
+		nil,
+	)
+}

--- a/internal/ls/organizeimports.go
+++ b/internal/ls/organizeimports.go
@@ -295,11 +295,12 @@ func removeUnusedImports(oldImports []*ast.Statement, sourceFile *ast.SourceFile
 			if hasModuleDeclarationMatchingSpecifier(sourceFile, moduleSpecifier) {
 				if sourceFile.IsDeclarationFile {
 					importDeclNode := importDecl.AsImportDeclaration()
-					newImportDecl := factory.NewImportDeclaration(
+					newImportDecl := factory.UpdateImportDeclaration(
+						importDeclNode,
 						importDeclNode.Modifiers(),
 						nil, // no import clause
 						importDeclNode.ModuleSpecifier,
-						nil, // no attributes
+						importDeclNode.Attributes,
 					)
 					usedImports = append(usedImports, newImportDecl)
 				} else {


### PR DESCRIPTION
fixes a crash reported in https://github.com/microsoft/typescript-go/issues/2778#issuecomment-3894722100