### PR TITLE
Fixed completion crash on JSDoc nodes created by `reparseJSDocComment`

### DIFF
--- a/internal/fourslash/tests/completionInJSDocPropertyWithLinkNoCrash1_test.go
+++ b/internal/fourslash/tests/completionInJSDocPropertyWithLinkNoCrash1_test.go
@@ -1,0 +1,31 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestCompletionInJSDocPropertyWithLinkNoCrash1(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `
+// @allowJs: true
+// @filename: /file.js
+export function foo() {}
+
+/**
+ * @typedef MyType
+ * @property {number} [timeout] - The /*1*/timeout; defaults to {@linkcode DEFAULT}
+ */
+`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+
+	f.VerifyCompletions(t, "1", &fourslash.CompletionsExpectedList{
+		IsIncomplete: false,
+		ItemDefaults: &fourslash.CompletionsExpectedItemDefaults{CommitCharacters: &[]string{".", ",", ";"}},
+		Items:        &fourslash.CompletionsExpectedItems{},
+	})
+}

--- a/internal/parser/reparser.go
+++ b/internal/parser/reparser.go
@@ -239,6 +239,7 @@ func (p *Parser) reparseJSDocComment(node *ast.Node, tag *ast.Node) {
 	if comment := tag.CommentList(); comment != nil {
 		propJSDoc := p.factory.NewJSDoc(comment, nil)
 		p.finishReparsedNode(propJSDoc, tag)
+		propJSDoc.Parent = node
 		p.jsdocInfos = append(p.jsdocInfos, JSDocInfo{parent: node, jsDocs: []*ast.Node{propJSDoc}})
 		node.Flags |= ast.NodeFlagsHasJSDoc
 	}


### PR DESCRIPTION
Fixes a crash reported here https://github.com/microsoft/typescript-go/issues/2778#issuecomment-3894722157