### PR TITLE
Remove redundant JSDoc flag checks

### DIFF
--- a/internal/ast/utilities.go
+++ b/internal/ast/utilities.go
@@ -2942,10 +2942,8 @@ func IsParameterPropertyModifier(kind Kind) bool {
 }
 
 func ForEachChildAndJSDoc(node *Node, sourceFile *SourceFile, v Visitor) bool {
-	if node.Flags&NodeFlagsHasJSDoc != 0 {
-		if visitNodes(v, node.JSDoc(sourceFile)) {
-			return true
-		}
+	if visitNodes(v, node.JSDoc(sourceFile)) {
+		return true
 	}
 	return node.ForEachChild(v)
 }

--- a/internal/astnav/tokens.go
+++ b/internal/astnav/tokens.go
@@ -282,13 +282,11 @@ func VisitEachChildAndJSDoc(
 	visitNodes func(*ast.NodeList, *ast.NodeVisitor) *ast.NodeList,
 ) {
 	visitor := getNodeVisitor(visitNode, visitNodes)
-	if node.Flags&ast.NodeFlagsHasJSDoc != 0 {
-		for _, jsdoc := range node.JSDoc(sourceFile) {
-			if visitor.Hooks.VisitNode != nil {
-				visitor.Hooks.VisitNode(jsdoc, visitor)
-			} else {
-				visitor.VisitNode(jsdoc)
-			}
+	for _, jsdoc := range node.JSDoc(sourceFile) {
+		if visitor.Hooks.VisitNode != nil {
+			visitor.Hooks.VisitNode(jsdoc, visitor)
+		} else {
+			visitor.VisitNode(jsdoc)
 		}
 	}
 	node.VisitEachChild(visitor)

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -2173,13 +2173,11 @@ func (c *Checker) checkSourceElement(node *ast.Node) bool {
 }
 
 func (c *Checker) checkSourceElementWorker(node *ast.Node) {
-	if node.Flags&ast.NodeFlagsHasJSDoc != 0 {
-		for _, jsdoc := range node.EagerJSDoc(nil) {
-			c.checkJSDocComments(jsdoc)
-			if tags := jsdoc.AsJSDoc().Tags; tags != nil {
-				for _, tag := range tags.Nodes {
-					c.checkJSDocComments(tag)
-				}
+	for _, jsdoc := range node.EagerJSDoc(nil) {
+		c.checkJSDocComments(jsdoc)
+		if tags := jsdoc.AsJSDoc().Tags; tags != nil {
+			for _, tag := range tags.Nodes {
+				c.checkJSDocComments(tag)
 			}
 		}
 	}

--- a/internal/ls/selectionranges.go
+++ b/internal/ls/selectionranges.go
@@ -196,10 +196,8 @@ func getSmartSelectionRange(l *LanguageService, sourceFile *ast.SourceFile, pos 
 		}
 
 		// Visit JSDoc nodes first if they exist
-		if current.Flags&ast.NodeFlagsHasJSDoc != 0 {
-			for _, jsdoc := range current.JSDoc(sourceFile) {
-				visit(jsdoc)
-			}
+		for _, jsdoc := range current.JSDoc(sourceFile) {
+			visit(jsdoc)
 		}
 
 		tempVisitor := ast.NewNodeVisitor(visit, nil, ast.NodeVisitorHooks{


### PR DESCRIPTION
These are redundant; `JSDoc` and `EagerJSDoc` both check this and return nil.