### PR TITLE
Don't bundle extension package.json, read from extension context

### DIFF
--- a/_extension/src/util.ts
+++ b/_extension/src/util.ts
@@ -1,8 +1,5 @@
 import * as path from "path";
 import * as vscode from "vscode";
-import packageJson from "../package.json";
-
-const version = packageJson.version;
 
 export const aiConnectionString = "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255";
 
@@ -68,7 +65,7 @@ export async function getExe(context: vscode.ExtensionContext): Promise<ExeInfo>
 
     return {
         path: getBuiltinExePath(context),
-        version,
+        version: context.extension.packageJSON.version,
     };
 }
 


### PR DESCRIPTION
This was bundled before we updated info for publish.