### PR TITLE
Fix `completionItem/resolve` auto imports crash

### DIFF
--- a/internal/fourslash/fourslash.go
+++ b/internal/fourslash/fourslash.go
@@ -969,6 +969,11 @@ func (f *FourslashTest) verifyCompletionsWorker(t *testing.T, expected *Completi
 	return list
 }
 
+func (f *FourslashTest) GetCompletions(t *testing.T, userPreferences *lsutil.UserPreferences) *lsproto.CompletionList {
+	t.Helper()
+	return f.getCompletions(t, userPreferences)
+}
+
 func (f *FourslashTest) getCompletions(t *testing.T, userPreferences *lsutil.UserPreferences) *lsproto.CompletionList {
 	t.Helper()
 	params := &lsproto.CompletionParams{
@@ -1285,6 +1290,11 @@ func (f *FourslashTest) verifyCompletionItem(t *testing.T, prefix string, actual
 	}
 
 	return ""
+}
+
+func (f *FourslashTest) ResolveCompletionItem(t *testing.T, item *lsproto.CompletionItem) *lsproto.CompletionItem {
+	t.Helper()
+	return f.resolveCompletionItem(t, item)
 }
 
 func (f *FourslashTest) resolveCompletionItem(t *testing.T, item *lsproto.CompletionItem) *lsproto.CompletionItem {

--- a/internal/fourslash/tests/completionResolveAfterEdit_test.go
+++ b/internal/fourslash/tests/completionResolveAfterEdit_test.go
@@ -1,0 +1,45 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestCompletionResolveAfterEdit(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `
+// @filename: /index.ts
+interface Point {
+	x: number;
+	y: number;
+}
+declare const p: Point;
+/*a*/
+
+// @filename: /foo.ts
+/*b*/
+`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+
+	// Step 1: Get completions at the marker.
+	f.GoToMarker(t, "a")
+	completions := f.GetCompletions(t, nil /*userPreferences*/)
+	if completions == nil || len(completions.Items) == 0 {
+		t.Fatal("Expected completions but got none")
+	}
+	firstItem := completions.Items[0]
+
+	// Step 2: Make a file change (insert a comment after marker).
+	f.GoToMarker(t, "b")
+	f.Insert(t, "1")
+
+	// Step 3: Resolve the first completion item from the original list.
+	resolved := f.ResolveCompletionItem(t, firstItem)
+	if resolved == nil {
+		t.Fatal("Expected resolved completion item but got nil")
+	}
+}

--- a/internal/ls/string_completions.go
+++ b/internal/ls/string_completions.go
@@ -2058,7 +2058,7 @@ func (l *LanguageService) stringLiteralCompletionDetails(
 		properties := completion.fromProperties
 		for _, symbol := range properties.symbols {
 			if symbol.Name == name {
-				return l.createCompletionDetailsForSymbol(item, symbol, checker, location, nil /*actions*/, docFormat)
+				return l.createCompletionDetailsForSymbol(item, symbol, checker, location, docFormat)
 			}
 		}
 	case completion.fromTypes != nil:


### PR DESCRIPTION
Fixes #2827 (and similar issue reported [here](https://github.com/microsoft/typescript-go/issues/2829#issuecomment-3924076422)).

The crash was happening because in between the completion and resolve requests, we got a snapshot update due to ATA changes, and so the snapshot used for the resolve request didn't have the auto imports data.
However, it turns out we don't need to collect auto imports for resolve requests, because to resolve completion items that come from auto imports, we use the completion item data instead of symbol information, so that's what this PR does.