### PR TITLE
Add nil check in `getAllExportsForSymbol`

### DIFF
--- a/internal/ls/autoimport/import_adder.go
+++ b/internal/ls/autoimport/import_adder.go
@@ -362,8 +362,10 @@ func (adder *importAdder) getNewImportEntry(moduleSpecifier string, importKind l
 func (adder *importAdder) getAllExportsForSymbol(
 	symbol *ast.Symbol,
 ) []*Export {
-	exportId := SymbolToExport(symbol, adder.checker).ExportID
-	return adder.view.SearchByExportID(exportId)
+	if export := SymbolToExport(symbol, adder.checker); export != nil {
+		return adder.view.SearchByExportID(export.ExportID)
+	}
+	return nil
 }
 
 func TypeToAutoImportableTypeNode(


### PR DESCRIPTION
Fixes the crash described [here](https://github.com/microsoft/typescript-go/issues/2829#issuecomment-3924076793).