### PR TITLE
Share package.json cache and skip collecting failed lookup locations in auto-imports

### DIFF
--- a/internal/ls/autoimport/util.go
+++ b/internal/ls/autoimport/util.go
@@ -264,10 +264,10 @@ func (rh *resolutionHost) FS() vfs.FS {
 	return rh.fs
 }
 
-func getModuleResolver(host RegistryCloneHost, realpath func(string) string, packageJsonCache *packagejson.InfoCache) *module.Resolver {
+func getModuleResolver(host RegistryCloneHost, realpath func(string) string, opts module.ResolverOptions) *module.Resolver {
 	rh := &resolutionHost{
 		fs:               wrapvfs.Wrap(host.FS(), wrapvfs.Replacements{Realpath: realpath}),
 		currentDirectory: host.GetCurrentDirectory(),
 	}
-	return module.NewResolverWithPackageJsonCache(rh, core.EmptyCompilerOptions, "", "", packageJsonCache)
+	return module.NewResolverWithOptions(rh, core.EmptyCompilerOptions, "", "", opts)
 }

--- a/internal/module/resolver.go
+++ b/internal/module/resolver.go
@@ -69,15 +69,16 @@ type resolutionState struct {
 	tracer   *tracer
 
 	// request fields
-	name                        string
-	containingDirectory         string
-	isConfigLookup              bool
-	features                    NodeResolutionFeatures
-	esmMode                     bool
-	conditions                  []string
-	extensions                  extensions
-	compilerOptions             *core.CompilerOptions
-	resolvePackageDirectoryOnly bool
+	name                          string
+	containingDirectory           string
+	isConfigLookup                bool
+	skipCollectingLookupLocations bool
+	features                      NodeResolutionFeatures
+	esmMode                       bool
+	conditions                    []string
+	extensions                    extensions
+	compilerOptions               *core.CompilerOptions
+	resolvePackageDirectoryOnly   bool
 
 	// state fields
 	candidateIsFromPackageJsonField bool
@@ -110,6 +111,8 @@ func newResolutionState(
 		resolver:            resolver,
 		tracer:              traceBuilder,
 	}
+
+	state.skipCollectingLookupLocations = resolver.skipCollectingLookupLocations
 
 	if isTypeReferenceDirective {
 		state.extensions = extensionsDeclaration
@@ -151,11 +154,17 @@ func GetCompilerOptionsWithRedirect(compilerOptions *core.CompilerOptions, redir
 
 type Resolver struct {
 	caches
-	host            ResolutionHost
-	compilerOptions *core.CompilerOptions
-	typingsLocation string
-	projectName     string
+	host                          ResolutionHost
+	compilerOptions               *core.CompilerOptions
+	typingsLocation               string
+	projectName                   string
+	skipCollectingLookupLocations bool
 	// reportDiagnostic: DiagnosticReporter
+}
+
+type ResolverOptions struct {
+	PackageJsonCache              *packagejson.InfoCache
+	SkipCollectingLookupLocations bool
 }
 
 func NewResolver(
@@ -173,22 +182,26 @@ func NewResolver(
 	}
 }
 
-func NewResolverWithPackageJsonCache(
+func NewResolverWithOptions(
 	host ResolutionHost,
-	options *core.CompilerOptions,
+	compilerOptions *core.CompilerOptions,
 	typingsLocation string,
 	projectName string,
-	packageJsonCache *packagejson.InfoCache,
+	opts ResolverOptions,
 ) *Resolver {
-	return &Resolver{
-		host: host,
-		caches: caches{
-			packageJsonInfoCache: packageJsonCache,
-		},
-		compilerOptions: options,
-		typingsLocation: typingsLocation,
-		projectName:     projectName,
+	r := &Resolver{
+		host:                          host,
+		compilerOptions:               compilerOptions,
+		typingsLocation:               typingsLocation,
+		projectName:                   projectName,
+		skipCollectingLookupLocations: opts.SkipCollectingLookupLocations,
 	}
+	if opts.PackageJsonCache != nil {
+		r.packageJsonInfoCache = opts.PackageJsonCache
+	} else {
+		r.caches = newCaches(host.GetCurrentDirectory(), host.FS().UseCaseSensitiveFileNames(), compilerOptions)
+	}
+	return r
 }
 
 func (r *Resolver) newTraceBuilder() *tracer {
@@ -1514,8 +1527,20 @@ func (r *resolutionState) tryFileLookup(fileName string, onlyRecordFailures bool
 			r.tracer.write(diagnostics.File_0_does_not_exist, fileName)
 		}
 	}
-	r.failedLookupLocations = append(r.failedLookupLocations, fileName)
+	r.recordFailedLookup(fileName)
 	return false
+}
+
+func (r *resolutionState) recordFailedLookup(location string) {
+	if !r.skipCollectingLookupLocations {
+		r.failedLookupLocations = append(r.failedLookupLocations, location)
+	}
+}
+
+func (r *resolutionState) recordAffectingLocation(location string) {
+	if !r.skipCollectingLookupLocations {
+		r.affectingLocations = append(r.affectingLocations, location)
+	}
 }
 
 func (r *resolutionState) loadNodeModuleFromDirectory(extensions extensions, candidate string, onlyRecordFailures bool, considerPackageJson bool) *resolved {
@@ -1671,7 +1696,7 @@ func (r *resolutionState) getPackageFile(extensions extensions, packageInfo *pac
 func (r *resolutionState) getPackageJsonInfo(packageDirectory string, onlyRecordFailures bool) *packagejson.InfoCacheEntry {
 	packageJsonPath := tspath.CombinePaths(packageDirectory, "package.json")
 	if onlyRecordFailures {
-		r.failedLookupLocations = append(r.failedLookupLocations, packageJsonPath)
+		r.recordFailedLookup(packageJsonPath)
 		return nil
 	}
 
@@ -1680,7 +1705,7 @@ func (r *resolutionState) getPackageJsonInfo(packageDirectory string, onlyRecord
 			if r.tracer != nil {
 				r.tracer.write(diagnostics.File_0_exists_according_to_earlier_cached_lookups, packageJsonPath)
 			}
-			r.affectingLocations = append(r.affectingLocations, packageJsonPath)
+			r.recordAffectingLocation(packageJsonPath)
 			if existing.PackageDirectory == packageDirectory {
 				return existing
 			}
@@ -1694,7 +1719,7 @@ func (r *resolutionState) getPackageJsonInfo(packageDirectory string, onlyRecord
 			if existing.DirectoryExists && r.tracer != nil {
 				r.tracer.write(diagnostics.File_0_does_not_exist_according_to_earlier_cached_lookups, packageJsonPath)
 			}
-			r.failedLookupLocations = append(r.failedLookupLocations, packageJsonPath)
+			r.recordFailedLookup(packageJsonPath)
 			return nil
 		}
 	}
@@ -1716,7 +1741,7 @@ func (r *resolutionState) getPackageJsonInfo(packageDirectory string, onlyRecord
 			},
 		}
 		result = r.resolver.packageJsonInfoCache.Set(packageJsonPath, result)
-		r.affectingLocations = append(r.affectingLocations, packageJsonPath)
+		r.recordAffectingLocation(packageJsonPath)
 		return result
 	} else {
 		if directoryExists && r.tracer != nil {
@@ -1726,7 +1751,7 @@ func (r *resolutionState) getPackageJsonInfo(packageDirectory string, onlyRecord
 			PackageDirectory: packageDirectory,
 			DirectoryExists:  directoryExists,
 		})
-		r.failedLookupLocations = append(r.failedLookupLocations, packageJsonPath)
+		r.recordFailedLookup(packageJsonPath)
 	}
 	return nil
 }
@@ -2075,7 +2100,7 @@ func (e *ResolvedEntrypoint) SymlinkOrRealpath() string {
 func (r *Resolver) GetEntrypointsFromPackageJsonInfo(packageJson *packagejson.InfoCacheEntry, packageName string) *ResolvedEntrypoints {
 	extensions := extensionsTypeScript | extensionsDeclaration
 	features := NodeResolutionFeaturesAll
-	state := &resolutionState{resolver: r, extensions: extensions, features: features, compilerOptions: r.compilerOptions}
+	state := &resolutionState{resolver: r, extensions: extensions, features: features, compilerOptions: r.compilerOptions, skipCollectingLookupLocations: r.skipCollectingLookupLocations}
 	if packageJson.Exists() && packageJson.Contents.Exports.IsPresent() {
 		entrypoints := state.loadEntrypointsFromExportMap(packageJson, packageName, packageJson.Contents.Exports)
 		return &ResolvedEntrypoints{


### PR DESCRIPTION
#2780 shows a lot of allocations going to package.json parsing. I can't repro myself, but based on the profile and the report that the problem started after #2502, I think this is probably it. The failed lookup locations are also not used by auto-imports, so that should be an additional small win. I tried invoking completions in a file in Signal-Desktop as a random benchmark, and this brought total allocs down from 0.78 GB to 0.75 GB. Not huge, but maybe there's a pathological case I haven't been able to repro. Worth a try!

