### PR TITLE
Remove install-extension task

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -60,8 +60,6 @@ const { values: rawOptions } = parseArgs({
         debug: { type: "boolean" },
         dirty: { type: "boolean" },
 
-        insiders: { type: "boolean" },
-
         setPrerelease: { type: "string" },
         forRelease: { type: "boolean" },
 
@@ -1509,27 +1507,4 @@ export const nativePreview = task({
     run: options.forRelease ? async () => {
         throw new Error("This task should not be run in release builds.");
     } : undefined,
-});
-
-export const installExtension = task({
-    name: "install-extension",
-    hiddenFromTaskList: true,
-    dependencies: options.forRelease ? undefined : [packNativePreviewExtensions],
-    run: async () => {
-        if (options.forRelease) {
-            throw new Error("This task should not be run in release builds.");
-        }
-
-        const platforms = nativePreviewPlatforms();
-        const myPlatform = platforms.find(p => p.nodeOs === process.platform && p.nodeArch === process.arch);
-        if (!myPlatform) {
-            throw new Error(`No platform found for ${process.platform}-${process.arch}`);
-        }
-
-        await $`${options.insiders ? "code-insiders" : "code"} --install-extension ${myPlatform.extensions[0].vsixPath}`;
-        console.log(pc.yellowBright("\nExtension installed. ") + "To enable this extension, set:\n");
-        console.log(pc.whiteBright(`    "typescript.experimental.useTsgo": true\n`));
-        console.log("To configure the extension to use built/local instead of its bundled tsgo, set:\n");
-        console.log(pc.whiteBright(`    "typescript.native-preview.tsdk": "${path.join(__dirname, "built", "local")}"\n`));
-    },
 });


### PR DESCRIPTION
I don't think any of us are using it, and it creates strange scenarios.

I think it's fine to have either the full release, or just the launch task. Not "I have installed some weird vsix locally".