### PR TITLE
Fix package.json file watching

### DIFF
--- a/internal/project/projectcollectionbuilder.go
+++ b/internal/project/projectcollectionbuilder.go
@@ -1018,12 +1018,12 @@ func (b *ProjectCollectionBuilder) markFilesChanged(entry dirty.Value[*Project],
 
 			dirtyFilePath = p.dirtyFilePath
 			for _, path := range paths {
+				if _, ok := p.affectingLocationsWatch.input[path]; ok {
+					dirty = true
+					dirtyFilePath = ""
+					break
+				}
 				if changeType == lsproto.FileChangeTypeCreated {
-					if _, ok := p.affectingLocationsWatch.input[path]; ok {
-						dirty = true
-						dirtyFilePath = ""
-						break
-					}
 					if _, ok := p.failedLookupsWatch.input[path]; ok {
 						dirty = true
 						dirtyFilePath = ""


### PR DESCRIPTION
The affecting locations check was accidentally grouped with the failed locations check, which was only reacting to created files. Affecting locations (usually package.json) already exist, so should react to any change type.