### PR TITLE
2x speedup of binary AST encoding

### DIFF
--- a/internal/api/encoder/encoder.go
+++ b/internal/api/encoder/encoder.go
@@ -354,12 +354,7 @@ func EncodeSourceFile(sourceFile *ast.SourceFile) ([]byte, error) {
 
 func appendUint32s(buf []byte, values ...uint32) []byte {
 	for _, value := range values {
-		var err error
-		if buf, err = binary.Append(buf, binary.LittleEndian, value); err != nil {
-			// The only error binary.Append can return is for values that are not fixed-size.
-			// This can never happen here, since we are always appending uint32.
-			panic(fmt.Sprintf("failed to append uint32: %v", err))
-		}
+		buf = binary.LittleEndian.AppendUint32(buf, value)
 	}
 	return buf
 }


### PR DESCRIPTION
`binary.Append` [uses a `data.(type)` switch internally](https://github.com/golang/go/blob/6435bf46c17dccb2eb5f7bab7dd8aa4972252b21/src/encoding/binary/binary.go#L472), but we always know we're appending a `uint32`, so there's no need to consult runtime type metadata. 

On `main`:

```
$ go test -bench .
goos: linux
goarch: amd64
pkg: github.com/microsoft/typescript-go/internal/api/encoder
cpu: AMD Ryzen 7 5800H with Radeon Graphics
BenchmarkEncodeSourceFile-16                  33          35284493 ns/op
PASS
ok      github.com/microsoft/typescript-go/internal/api/encoder 1.234s
```

This PR:

```
$ go test -bench .
goos: linux
goarch: amd64
pkg: github.com/microsoft/typescript-go/internal/api/encoder
cpu: AMD Ryzen 7 5800H with Radeon Graphics
BenchmarkEncodeSourceFile-16                  68          16876151 ns/op
PASS
ok      github.com/microsoft/typescript-go/internal/api/encoder 1.217s
```