### PR TITLE
Fix retrieval of named children in JS RemoteNode

### DIFF
--- a/_packages/api/src/node.ts
+++ b/_packages/api/src/node.ts
@@ -555,8 +555,12 @@ export class RemoteNode extends RemoteNodeBase implements Node {
         // Counting the 1s gives us the number of *missing properties* before the `order`th property. If every property
         // were present, we would have `parameters = children[5]`, but since `postfixToken` and `astersiskToken` are
         // missing, we have `parameters = children[5 - 2]`.
-        const propertyIndex = order - popcount8[~(mask | ((0xff << order) & 0xff)) & 0xff];
-        return this.getOrCreateChildAtNodeIndex(this.index + 1 + propertyIndex);
+        let propertyIndex = order - popcount8[~(mask | ((0xff << order) & 0xff)) & 0xff];
+        let childIndex = this.index + 1;
+        for (let i = 0; i < propertyIndex; i++) {
+            childIndex = this.view.getUint32(this.offsetNodes + childIndex * NODE_LEN + NODE_OFFSET_NEXT, true);
+        }
+        return this.getOrCreateChildAtNodeIndex(childIndex);
     }
 
     __print(): string {

--- a/_packages/api/test/async/api.test.ts
+++ b/_packages/api/test/async/api.test.ts
@@ -16,7 +16,9 @@ import { createVirtualFileSystem } from "@typescript/api/fs";
 import type { FileSystem } from "@typescript/api/fs";
 import {
     cast,
+    isBinaryExpression,
     isCallExpression,
+    isExpressionStatement,
     isImportDeclaration,
     isNamedImports,
     isReturnStatement,
@@ -25,6 +27,7 @@ import {
     isTemplateHead,
     isTemplateMiddle,
     isTemplateTail,
+    SyntaxKind,
 } from "@typescript/ast";
 import assert from "node:assert";
 import {
@@ -138,6 +141,23 @@ describe("SourceFile", () => {
         finally {
             await api.close();
         }
+    });
+
+    test("node named children", async () => {
+        const api = spawnAPI({
+            "/tsconfig.json": "{}",
+            "/src/index.ts": "foo.bar === baz",
+        });
+        const snapshot = await api.updateSnapshot({ openProject: "/tsconfig.json" });
+        const project = snapshot.getProject("/tsconfig.json")!;
+        const sourceFile = await project.program.getSourceFile("/src/index.ts");
+
+        assert.ok(sourceFile);
+        assert.equal(sourceFile.statements[0].kind, SyntaxKind.ExpressionStatement);
+        const expr = cast(sourceFile.statements[0], isExpressionStatement).expression;
+        assert.equal(expr.kind, SyntaxKind.BinaryExpression);
+        const operator = cast(expr, isBinaryExpression).operatorToken;
+        assert.equal(operator.kind, SyntaxKind.EqualsEqualsEqualsToken);
     });
 
     test("extended data", async () => {

--- a/_packages/api/test/sync/api.test.ts
+++ b/_packages/api/test/sync/api.test.ts
@@ -24,7 +24,9 @@ import {
 } from "@typescript/api/sync";
 import {
     cast,
+    isBinaryExpression,
     isCallExpression,
+    isExpressionStatement,
     isImportDeclaration,
     isNamedImports,
     isReturnStatement,
@@ -33,6 +35,7 @@ import {
     isTemplateHead,
     isTemplateMiddle,
     isTemplateTail,
+    SyntaxKind,
 } from "@typescript/ast";
 import assert from "node:assert";
 import {
@@ -146,6 +149,23 @@ describe("SourceFile", () => {
         finally {
             api.close();
         }
+    });
+
+    test("node named children", () => {
+        const api = spawnAPI({
+            "/tsconfig.json": "{}",
+            "/src/index.ts": "foo.bar === baz",
+        });
+        const snapshot = api.updateSnapshot({ openProject: "/tsconfig.json" });
+        const project = snapshot.getProject("/tsconfig.json")!;
+        const sourceFile = project.program.getSourceFile("/src/index.ts");
+
+        assert.ok(sourceFile);
+        assert.equal(sourceFile.statements[0].kind, SyntaxKind.ExpressionStatement);
+        const expr = cast(sourceFile.statements[0], isExpressionStatement).expression;
+        assert.equal(expr.kind, SyntaxKind.BinaryExpression);
+        const operator = cast(expr, isBinaryExpression).operatorToken;
+        assert.equal(operator.kind, SyntaxKind.EqualsEqualsEqualsToken);
     });
 
     test("extended data", () => {


### PR DESCRIPTION
```typescript
foo.bar === baz
```

In binary AST nodes are encoded in this order:

- `ExpressionStatement`
- `BinaryExpression`
- `PropertyAccessExpression`
- `Identifier`
- `Identifier`
- `EqualsEqualsEqualsToken`
- `Identifier`

On `main`:

We're trying to read `.operatorToken` of `BinaryExpression`, `propertyIndex` is 1, `getNamedChild('operatorToken')` returns `BinaryExpression.index + 1 + 1`th node. It returns  an `Identifier`.

In this PR:


We're trying to read `.operatorToken` of `BinaryExpression`, `propertyIndex` is 1, we iterate over the immediate child nodes and jump straight to their sibling nodes using their `.next` value. `getNamedChild('operatorToken')` returns an `EqualsEqualsEqualsToken`.