### PR TITLE
Fixed a crash on computed property name when computing inlay hints

### DIFF
--- a/internal/fourslash/tests/inlayHintsPropertyDeclarationComputedName1_test.go
+++ b/internal/fourslash/tests/inlayHintsPropertyDeclarationComputedName1_test.go
@@ -1,0 +1,28 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/ls/lsutil"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestInlayHintsPropertyDeclarationComputedName1(t *testing.T) {
+	t.Parallel()
+
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `function foo() {
+  const sym = Symbol();
+  class C {
+    [sym] = 123;
+  }
+}`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineInlayHints(t, nil /*span*/, &lsutil.UserPreferences{
+		InlayHints: lsutil.InlayHintsPreferences{
+			IncludeInlayPropertyDeclarationTypeHints: true,
+		},
+	})
+}

--- a/internal/ls/inlay_hints.go
+++ b/internal/ls/inlay_hints.go
@@ -245,6 +245,7 @@ func (s *inlayHintState) visitVariableLikeDeclaration(decl *ast.VariableOrProper
 		hintText = b.String()
 	}
 	if !s.preferences.IncludeInlayVariableTypeHintsWhenTypeMatchesName &&
+		!ast.IsComputedPropertyName(decl.Name()) &&
 		stringutil.EquateStringCaseInsensitive(decl.Name().Text(), hintText) {
 		return
 	}

--- a/testdata/baselines/reference/fourslash/inlayHints/inlayHintsPropertyDeclarationComputedName1.baseline
+++ b/testdata/baselines/reference/fourslash/inlayHints/inlayHintsPropertyDeclarationComputedName1.baseline
@@ -1,0 +1,19 @@
+// === Inlay Hints ===
+    [sym] = 123;
+         ^
+{
+  "position": {
+    "line": 3,
+    "character": 9
+  },
+  "label": [
+    {
+      "value": ": "
+    },
+    {
+      "value": "number"
+    }
+  ],
+  "kind": 1,
+  "paddingLeft": true
+}


### PR DESCRIPTION
fixes https://github.com/microsoft/typescript-go/issues/2890