### PR TITLE
Improve asynchronous transfer performance

### DIFF
--- a/_packages/api/src/async/client.ts
+++ b/_packages/api/src/async/client.ts
@@ -148,7 +148,7 @@ export class Client {
         const response = await this.apiRequest<{ data: string; } | null>(method, params);
         if (!response) return undefined;
         const buffer = Buffer.from(response.data, "base64");
-        return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength).slice();
+        return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
     }
 
     async close(): Promise<void> {

--- a/_packages/api/src/node/node.ts
+++ b/_packages/api/src/node/node.ts
@@ -111,7 +111,7 @@ export class RemoteNodeBase {
     }
 
     protected getFileText(start: number, end: number): string {
-        return this.sourceFile._decoder.decode(new Uint8Array(this.view.buffer, this.sourceFile._offsetStringTable + start, end - start));
+        return this.sourceFile._decoder.decode(new Uint8Array(this.view.buffer, this.view.byteOffset + this.sourceFile._offsetStringTable + start, end - start));
     }
 
     protected get sourceFile(): RemoteSourceFile {
@@ -324,7 +324,7 @@ export class RemoteNode extends RemoteNodeBase implements Node {
         const start = this.view.getUint32(offsetStringTableOffsets + index * 4, true);
         const end = this.view.getUint32(offsetStringTableOffsets + (index + 1) * 4, true);
         const offsetStringTable = this.sourceFile._offsetStringTable;
-        const text = new Uint8Array(this.view.buffer, offsetStringTable + start, end - start);
+        const text = new Uint8Array(this.view.buffer, this.view.byteOffset + offsetStringTable + start, end - start);
         return this.sourceFile._decoder.decode(text);
     }
 


### PR DESCRIPTION
This has little impact on throughput, but reduces JS-side memory usage by 10%-20% in tests.

before 
```
PS F:\git\typescript-go\_packages\api> node .\test\async\api.bench.ts --filter "transfer"
┌─────────┬───────────────────────┬────────────────────┬───────────────────┬────────────────────────┬────────────────────────┬─────────┐
│ (index) │ Task name             │ Latency avg (ns)   │ Latency med (ns)  │ Throughput avg (ops/s) │ Throughput med (ops/s) │ Samples │
├─────────┼───────────────────────┼────────────────────┼───────────────────┼────────────────────────┼────────────────────────┼─────────┤
│ 0       │ 'transfer debug.ts'   │ '705.56 ± 2.63%'   │ '600.00 ± 100.00' │ '1523007 ± 0.02%'      │ '1666667 ± 238095'     │ 1417306 │
│ 1       │ 'transfer program.ts' │ '745.17 ± 9.87%'   │ '700.00 ± 100.00' │ '1500905 ± 0.02%'      │ '1428571 ± 178571'     │ 1341980 │
│ 2       │ 'transfer checker.ts' │ '2245.0 ± 127.15%' │ '700.00 ± 100.00' │ '1420808 ± 0.04%'      │ '1428571 ± 178571'     │ 445442  │
└─────────┴───────────────────────┴────────────────────┴───────────────────┴────────────────────────┴────────────────────────┴─────────┘
```
after
```
PS F:\git\typescript-go\_packages\api> node .\test\async\api.bench.ts --filter "transfer"
┌─────────┬───────────────────────┬───────────────────┬───────────────────┬────────────────────────┬────────────────────────┬─────────┐
│ (index) │ Task name             │ Latency avg (ns)  │ Latency med (ns)  │ Throughput avg (ops/s) │ Throughput med (ops/s) │ Samples │
├─────────┼───────────────────────┼───────────────────┼───────────────────┼────────────────────────┼────────────────────────┼─────────┤
│ 0       │ 'transfer debug.ts'   │ '695.11 ± 0.61%'  │ '600.00 ± 100.00' │ '1529490 ± 0.02%'      │ '1666667 ± 238095'     │ 1438630 │
│ 1       │ 'transfer program.ts' │ '708.53 ± 1.24%'  │ '700.00 ± 100.00' │ '1510814 ± 0.02%'      │ '1428571 ± 238095'     │ 1411376 │
│ 2       │ 'transfer checker.ts' │ '755.92 ± 13.15%' │ '700.00 ± 100.00' │ '1519659 ± 0.02%'      │ '1428571 ± 238095'     │ 1322886 │
└─────────┴───────────────────────┴───────────────────┴───────────────────┴────────────────────────┴────────────────────────┴─────────┘
```
before
```
PS F:\git\typescript-go\_packages\api> node .\test\async\api.bench.ts --filter "transfer" --singleIteration
┌─────────┬───────────────────────┬─────────────────────┬────────────────────┬────────────────────────┬────────────────────────┬─────────┐
│ (index) │ Task name             │ Latency avg (ns)    │ Latency med (ns)   │ Throughput avg (ops/s) │ Throughput med (ops/s) │ Samples │
├─────────┼───────────────────────┼─────────────────────┼────────────────────┼────────────────────────┼────────────────────────┼─────────┤
│ 0       │ 'transfer debug.ts'   │ '13761400 ± 0.00%'  │ '13761400 ± 0.00'  │ '73 ± 0.00%'           │ '73 ± 0'               │ 1       │
│ 1       │ 'transfer program.ts' │ '54559000 ± 0.00%'  │ '54559000 ± 0.00'  │ '18 ± 0.00%'           │ '18 ± 0'               │ 1       │
│ 2       │ 'transfer checker.ts' │ '579572700 ± 0.00%' │ '579572700 ± 0.00' │ '2 ± 0.00%'            │ '2 ± 0'                │ 1       │
└─────────┴───────────────────────┴─────────────────────┴────────────────────┴────────────────────────┴────────────────────────┴─────────┘
```
after
```
PS F:\git\typescript-go\_packages\api> node .\test\async\api.bench.ts --filter "transfer" --singleIteration   
┌─────────┬───────────────────────┬────────────────────┬───────────────────┬────────────────────────┬────────────────────────┬─────────┐
│ (index) │ Task name             │ Latency avg (ns)   │ Latency med (ns)  │ Throughput avg (ops/s) │ Throughput med (ops/s) │ Samples │
├─────────┼───────────────────────┼────────────────────┼───────────────────┼────────────────────────┼────────────────────────┼─────────┤
│ 0       │ 'transfer debug.ts'   │ '2066900 ± 0.00%'  │ '2066900 ± 0.00'  │ '484 ± 0.00%'          │ '484 ± 0'              │ 1       │
│ 1       │ 'transfer program.ts' │ '5550500 ± 0.00%'  │ '5550500 ± 0.00'  │ '180 ± 0.00%'          │ '180 ± 0'              │ 1       │
│ 2       │ 'transfer checker.ts' │ '68797900 ± 0.00%' │ '68797900 ± 0.00' │ '15 ± 0.00%'           │ '15 ± 0'               │ 1       │
└─────────┴───────────────────────┴────────────────────┴───────────────────┴────────────────────────┴────────────────────────┴─────────┘
```