### PR TITLE
Fix formatting crash on files with tab indentation near end of file

### DIFF
--- a/internal/format/span.go
+++ b/internal/format/span.go
@@ -890,7 +890,12 @@ func (w *formatSpanWorker) characterToColumn(startLinePosition int, characterInL
 }
 
 func (w *formatSpanWorker) indentationIsDifferent(indentationString string, startLinePosition int) bool {
-	return indentationString != w.sourceFile.Text()[startLinePosition:startLinePosition+len(indentationString)]
+	text := w.sourceFile.Text()
+	end := startLinePosition + len(indentationString)
+	if end > len(text) {
+		return true
+	}
+	return indentationString != text[startLinePosition:end]
 }
 
 func (w *formatSpanWorker) indentTriviaItems(trivia []TextRangeWithKind, commentIndentation int, indentNextTokenOrTrivia bool, indentSingleLine func(item TextRangeWithKind)) bool {

--- a/internal/fourslash/tests/formatDocumentNoCrashShortLastLine_test.go
+++ b/internal/fourslash/tests/formatDocumentNoCrashShortLastLine_test.go
@@ -1,0 +1,17 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestFormatDocumentNoCrashShortLastLine(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = "type X = {\n\tb}"
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.FormatDocument(t, "")
+}


### PR DESCRIPTION
fixes the crash found here: https://github.com/microsoft/typescript-go/issues/2945#issuecomment-3981326571