### PR TITLE
Clean up disk file caches more often, force GC

### DIFF
--- a/internal/project/session.go
+++ b/internal/project/session.go
@@ -3,7 +3,7 @@ package project
 import (
 	"context"
 	"fmt"
-	"runtime/debug"
+	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -426,7 +426,7 @@ func (s *Session) scheduleIdleCacheClean() {
 			cleanDiskCache: true,
 		})
 
-		debug.FreeOSMemory()
+		runtime.GC()
 	})
 }
 

--- a/internal/project/snapshot.go
+++ b/internal/project/snapshot.go
@@ -353,7 +353,7 @@ func (s *Snapshot) Clone(ctx context.Context, change SnapshotChange, overlays ma
 		}
 	}
 
-	// Clean cached disk files not touched by any open project on file open, close, save, delete,
+	// Clean cached disk files not touched by any open project on file open, close, delete,
 	// or when explicitly requested (e.g. by an idle timer).
 	shouldCleanDiskCache := change.cleanDiskCache ||
 		change.fileChanges.Opened != "" ||


### PR DESCRIPTION
A lot of the high memory usage heap profiles I've seen lately have been about half as big as the user claims they are, meaning the process is holding onto a lot more memory than Go is actively using. I'm hypothesizing that cleaning up more often will slow this process. We've also seen that agent mode sessions sometimes cause files to stay open indefinitely even without an editor tab, which eventually means that LSP textDocument/didOpen events become hard to come by, leading to a large backlog of stuff waiting to be cleaned up.

I'm also open to doing the forced GC by default / without a setting for now; thoughts?