### PR TITLE
Log runtime/metrics on UpdateSnapshot

### DIFF
--- a/internal/project/session.go
+++ b/internal/project/session.go
@@ -3,8 +3,8 @@ package project
 import (
 	"context"
 	"fmt"
-	gometrics "runtime/metrics"
 	"runtime"
+	gometrics "runtime/metrics"
 	"slices"
 	"strings"
 	"sync"
@@ -867,7 +867,7 @@ func (s *Session) logProjectChanges(oldSnapshot *Snapshot, newSnapshot *Snapshot
 
 var runtimeMetricsSamples = sync.OnceValue(func() []gometrics.Sample {
 	descs := gometrics.All()
-	samples := make([]gometrics.Sample, 0, len(descs))
+	var samples []gometrics.Sample
 	for _, desc := range descs {
 		name := desc.Name
 		if strings.HasPrefix(name, "/memory/") || strings.HasPrefix(name, "/gc/") {


### PR DESCRIPTION
Could help us diagnose some memory problems.