### PR TITLE
Fixes a crash when requesting implementations on a tripleslash directive

### DIFF
--- a/internal/fourslash/tests/goToImplementationNoCrashTripleSlashRef_test.go
+++ b/internal/fourslash/tests/goToImplementationNoCrashTripleSlashRef_test.go
@@ -1,0 +1,20 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestGoToImplementationNoCrashTripleSlashRef(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `// @Filename: /node_modules/@types/mymod/index.d.ts
+export declare function foo(): void;
+// @Filename: /main.d.ts
+/// <reference types="/*m*/mymod" />`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineGoToImplementation(t, "m")
+}

--- a/internal/ls/findallreferences.go
+++ b/internal/ls/findallreferences.go
@@ -594,7 +594,7 @@ func (l *LanguageService) provideSymbolsAndEntries(ctx context.Context, uri lspr
 	position := int(l.converters.LineAndCharacterToPosition(sourceFile, documentPosition))
 
 	node := astnav.GetTouchingPropertyName(sourceFile, position)
-	if isRename && !isNodeEligibleForRename(node) {
+	if isRename && !isNodeEligibleForRename(node) || implementations && ast.IsSourceFile(node) {
 		return SymbolAndEntriesData{OriginalNode: node, Position: position}, false
 	}
 

--- a/testdata/baselines/reference/fourslash/goToImplementation/goToImplementationNoCrashTripleSlashRef.baseline.jsonc
+++ b/testdata/baselines/reference/fourslash/goToImplementation/goToImplementationNoCrashTripleSlashRef.baseline.jsonc
@@ -1,0 +1,3 @@
+// === goToImplementation ===
+// === /main.d.ts ===
+// /// <reference types="/*GOTO IMPL*/mymod" />


### PR DESCRIPTION
Fixes a crash found here: https://github.com/microsoft/typescript-go/issues/2945#issuecomment-3981326421