### PR TITLE
Preserve the original parameter-list range when injecting reparsed `this` parameter

### DIFF
--- a/internal/fourslash/tests/documentHighlightJSDocThisFunctionExpressionNoCrash1_test.go
+++ b/internal/fourslash/tests/documentHighlightJSDocThisFunctionExpressionNoCrash1_test.go
@@ -1,0 +1,19 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestDocumentHighlightJSDocThisFunctionExpressionParameter(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `// @allowJs: true
+// @Filename: /a.js
+/**@this{A}*/x=function(/*m*/a){};`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineDocumentHighlights(t, nil /*preferences*/, "m")
+}

--- a/internal/parser/reparser.go
+++ b/internal/parser/reparser.go
@@ -470,7 +470,7 @@ func (p *Parser) reparseHosted(tag *ast.Node, parent *ast.Node, jsDoc *ast.Node)
 					newParams[i+1] = param
 				}
 
-				fun.FunctionLikeData().Parameters = p.newNodeList(thisParam.Loc, newParams)
+				fun.FunctionLikeData().Parameters = p.newNodeList(fun.ParameterList().Loc, newParams)
 				p.finishMutatedNode(fun)
 			}
 		}

--- a/testdata/baselines/reference/fourslash/documentHighlights/documentHighlightJSDocThisFunctionExpressionParameter.baseline.jsonc
+++ b/testdata/baselines/reference/fourslash/documentHighlights/documentHighlightJSDocThisFunctionExpressionParameter.baseline.jsonc
@@ -1,0 +1,3 @@
+// === documentHighlights ===
+// === /a.js ===
+// /**@this{A}*/x=function(/*HIGHLIGHTS*/[|a|]){};


### PR DESCRIPTION
fixes the crash found here: https://github.com/microsoft/typescript-go/issues/2964#issuecomment-3993187811