### PR TITLE
Allow start and end positions to be in different files in `getMappedLocation`

### DIFF
--- a/internal/fourslash/tests/goToImplementationNoCrashMultiSourceDts_test.go
+++ b/internal/fourslash/tests/goToImplementationNoCrashMultiSourceDts_test.go
@@ -1,0 +1,36 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestGoToImplementationNoCrashMultiSourceDts(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	// combined.d.ts has a source map with two sources: a.ts and b.ts.
+	// The method declaration on line 1 (col 4-end) straddles a source-map boundary:
+	//   - col 4 ("method") maps to a.ts
+	//   - col 11 onwards maps to b.ts
+	const content = `
+// @Filename: /a.ts
+export {};
+// @Filename: /b.ts
+export {};
+// @Filename: /combined.d.ts
+export declare class Bar {
+    method(): void;
+}
+//# sourceMappingURL=combined.d.ts.map
+// @Filename: /combined.d.ts.map
+{"version":3,"file":"combined.d.ts","sourceRoot":"","sources":["a.ts","b.ts"],"names":[],"mappings":";IAAA,OCAA;AAAA"}
+// @Filename: /user.ts
+import { Bar } from './combined';
+declare const bar: Bar;
+bar./*impl*/method();`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineGoToImplementation(t, "impl")
+}

--- a/internal/ls/source_map.go
+++ b/internal/ls/source_map.go
@@ -2,7 +2,6 @@ package ls
 
 import (
 	"github.com/microsoft/typescript-go/internal/core"
-	"github.com/microsoft/typescript-go/internal/debug"
 	"github.com/microsoft/typescript-go/internal/ls/lsconv"
 	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
 	"github.com/microsoft/typescript-go/internal/outputpaths"
@@ -20,13 +19,14 @@ func (l *LanguageService) getMappedLocation(fileName string, fileRange core.Text
 		}
 	}
 	endPos := l.tryGetSourcePosition(fileName, core.TextPos(fileRange.End()))
-	if endPos == nil {
+	if endPos == nil || endPos.FileName != startPos.FileName {
+		// When end doesn't map (or maps to a different source file, e.g. in a .d.ts with a
+		// multi-source source map from --outFile compilation), approximate the end position.
 		endPos = &sourcemap.DocumentPosition{
 			FileName: startPos.FileName,
 			Pos:      startPos.Pos + fileRange.Len(),
 		}
 	}
-	debug.Assert(endPos.FileName == startPos.FileName, "start and end should be in same file")
 	newRange := core.NewTextRange(startPos.Pos, endPos.Pos)
 	lspRange := l.createLspRangeFromRange(newRange, l.getScript(startPos.FileName))
 	return lsproto.Location{

--- a/testdata/baselines/reference/fourslash/goToImplementation/goToImplementationNoCrashMultiSourceDts.baseline.jsonc
+++ b/testdata/baselines/reference/fourslash/goToImplementation/goToImplementationNoCrashMultiSourceDts.baseline.jsonc
@@ -1,0 +1,11 @@
+// === goToImplementation ===
+// === /combined.d.ts ===
+// <|[|export|] dec|>lare class Bar {
+//     method(): void;
+// }
+// //# sourceMappingURL=combined.d.ts.map
+
+// === /user.ts ===
+// import { Bar } from './combined';
+// declare const bar: Bar;
+// bar./*GOTO IMPL*/method();


### PR DESCRIPTION
fixes the crash found here: https://github.com/microsoft/typescript-go/issues/2988#issuecomment-4001337109