### PR TITLE
Fixed a crash related to a dynamic `import()` of an UMD module

### DIFF
--- a/internal/fourslash/tests/goToImplementationNoCrashUMDWithDynamicImport_test.go
+++ b/internal/fourslash/tests/goToImplementationNoCrashUMDWithDynamicImport_test.go
@@ -1,0 +1,21 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestGoToImplementationNoCrashUMDWithDynamicImport(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `// @Filename: /lib.d.ts
+export as namespace Lib;
+export interface /*1*/IFoo {}
+// @Filename: /user.ts
+const p = import('./lib');`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineGoToImplementation(t, "1")
+}

--- a/internal/ls/importTracker.go
+++ b/internal/ls/importTracker.go
@@ -171,7 +171,11 @@ func getImportersForExport(
 	// Adds a module and all of its transitive dependencies as possible indirect users
 	var addIndirectUser func(*ast.Node, bool)
 	addIndirectUser = func(sourceFileLike *ast.Node, addTransitiveDependencies bool) {
-		debug.Assert(!isAvailableThroughGlobal)
+		// When isAvailableThroughGlobal, getIndirectUsers already returns all source files,
+		// so indirectUserDeclarations is never consulted. Nothing to do here.
+		if isAvailableThroughGlobal {
+			return
+		}
 		if !markSeenIndirectUser(sourceFileLike) {
 			return
 		}

--- a/testdata/baselines/reference/fourslash/goToImplementation/goToImplementationNoCrashUMDWithDynamicImport.baseline.jsonc
+++ b/testdata/baselines/reference/fourslash/goToImplementation/goToImplementationNoCrashUMDWithDynamicImport.baseline.jsonc
@@ -1,0 +1,4 @@
+// === goToImplementation ===
+// === /lib.d.ts ===
+// export as namespace Lib;
+// export interface /*GOTO IMPL*/IFoo {}


### PR DESCRIPTION
fixes a crash found here https://github.com/microsoft/typescript-go/issues/2988#issuecomment-4001335927