### PR TITLE
Speed up iofs file writes, fix BOM

### DIFF
--- a/internal/stringutil/util.go
+++ b/internal/stringutil/util.go
@@ -202,10 +202,17 @@ func RemoveByteOrderMark(text string) string {
 }
 
 func AddUTF8ByteOrderMark(text string) string {
-	if getByteOrderMarkLength(text) == 0 {
-		return "\xEF\xBB\xBF" + text
+	if bom := GetUTF8ByteOrderMark(text); bom != "" {
+		return bom + text
 	}
 	return text
+}
+
+func GetUTF8ByteOrderMark(text string) string {
+	if getByteOrderMarkLength(text) == 0 {
+		return "\xEF\xBB\xBF"
+	}
+	return ""
 }
 
 func StripQuotes(name string) string {

--- a/internal/vfs/iovfs/iofs.go
+++ b/internal/vfs/iovfs/iofs.go
@@ -19,7 +19,7 @@ type RealpathFS interface {
 
 type WritableFS interface {
 	fs.FS
-	WriteFile(path string, data []byte, perm fs.FileMode) error
+	WriteFile(path string, data string, perm fs.FileMode) error
 	MkdirAll(path string, perm fs.FileMode) error
 	// Removes `path` and all its contents. Will return the first error it encounters.
 	Remove(path string) error
@@ -73,7 +73,7 @@ func From(fsys fs.FS, useCaseSensitiveFileNames bool) FsWithSys {
 				// \xEF\xBB\xBF.
 				content = stringutil.AddUTF8ByteOrderMark(content)
 			}
-			return fsys.WriteFile(rest, []byte(content), 0o666)
+			return fsys.WriteFile(rest, content, 0o666)
 		}
 		mkdirAll = func(path string) error {
 			rest, _ := strings.CutPrefix(path, "/")

--- a/internal/vfs/osvfs/os.go
+++ b/internal/vfs/osvfs/os.go
@@ -10,6 +10,7 @@ import (
 	"unicode"
 
 	"github.com/microsoft/typescript-go/internal/core"
+	"github.com/microsoft/typescript-go/internal/stringutil"
 	"github.com/microsoft/typescript-go/internal/tspath"
 	"github.com/microsoft/typescript-go/internal/vfs"
 	"github.com/microsoft/typescript-go/internal/vfs/internal"
@@ -141,8 +142,10 @@ func (vfs *osFS) writeFile(path string, content string, writeByteOrderMark bool)
 	defer file.Close()
 
 	if writeByteOrderMark {
-		if _, err := file.WriteString("\uFEFF"); err != nil {
-			return err
+		if bom := stringutil.GetUTF8ByteOrderMark(content); bom != "" {
+			if _, err := file.WriteString(bom); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/vfs/vfstest/vfstest.go
+++ b/internal/vfs/vfstest/vfstest.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"testing/fstest"
 	"time"
+	"unsafe"
 
 	"github.com/microsoft/typescript-go/internal/tspath"
 	"github.com/microsoft/typescript-go/internal/vfs"
@@ -498,7 +499,7 @@ func (m *MapFS) MkdirAll(path string, perm fs.FileMode) error {
 	return m.mkdirAll(path, perm)
 }
 
-func (m *MapFS) WriteFile(path string, data []byte, perm fs.FileMode) error {
+func (m *MapFS) WriteFile(path string, data string, perm fs.FileMode) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -526,7 +527,7 @@ func (m *MapFS) WriteFile(path string, data []byte, perm fs.FileMode) error {
 	}
 
 	m.setEntry(path, cp, fstest.MapFile{
-		Data:    data,
+		Data:    unsafe.Slice(unsafe.StringData(data), len(data)),
 		ModTime: m.clock.Now(),
 		Mode:    perm &^ umask,
 	})


### PR DESCRIPTION
Closes #1551

While looking at #1551, I realized that the signature could just change. Then, reading further exposed the fact that our OS FS was not writing the correct BOM when asked. So, fix that too.