### PR TITLE
Speed up iofs file writes, remove writeByteOrderMark entirely

### DIFF
--- a/internal/api/callbackfs.go
+++ b/internal/api/callbackfs.go
@@ -196,8 +196,8 @@ func (fs *callbackFS) Realpath(path string) string {
 }
 
 // WriteFile implements vfs.FS - always delegates to base (no callback support).
-func (fs *callbackFS) WriteFile(path string, data string, writeByteOrderMark bool) error {
-	return fs.base.WriteFile(path, data, writeByteOrderMark)
+func (fs *callbackFS) WriteFile(path string, data string) error {
+	return fs.base.WriteFile(path, data)
 }
 
 // Remove implements vfs.FS - always delegates to base (no callback support).

--- a/internal/bundled/embed.go
+++ b/internal/bundled/embed.go
@@ -152,11 +152,11 @@ func (vfs *wrappedFS) Realpath(path string) string {
 	return vfs.fs.Realpath(path)
 }
 
-func (vfs *wrappedFS) WriteFile(path string, data string, writeByteOrderMark bool) error {
+func (vfs *wrappedFS) WriteFile(path string, data string) error {
 	if _, ok := splitPath(path); ok {
 		panic("cannot write to embedded file system")
 	}
-	return vfs.fs.WriteFile(path, data, writeByteOrderMark)
+	return vfs.fs.WriteFile(path, data)
 }
 
 func (vfs *wrappedFS) Remove(path string) error {

--- a/internal/compiler/emitHost.go
+++ b/internal/compiler/emitHost.go
@@ -116,8 +116,8 @@ func (host *emitHost) IsEmitBlocked(file string) bool {
 	return host.program.IsEmitBlocked(file)
 }
 
-func (host *emitHost) WriteFile(fileName string, text string, writeByteOrderMark bool) error {
-	return host.program.Host().FS().WriteFile(fileName, text, writeByteOrderMark)
+func (host *emitHost) WriteFile(fileName string, text string) error {
+	return host.program.Host().FS().WriteFile(fileName, text)
 }
 
 func (host *emitHost) GetEmitResolver() printer.EmitResolver {

--- a/internal/compiler/emit_test.go
+++ b/internal/compiler/emit_test.go
@@ -64,7 +64,7 @@ func BenchmarkEmitLongLines(b *testing.B) {
 			})
 
 			// Discard written files — we only care about emit performance.
-			nopWriteFile := func(fileName string, text string, writeByteOrderMark bool, data *compiler.WriteFileData) error {
+			nopWriteFile := func(fileName string, text string, data *compiler.WriteFileData) error {
 				return nil
 			}
 
@@ -118,7 +118,7 @@ func BenchmarkEmitManyFiles(b *testing.B) {
 		Host: host,
 	})
 
-	nopWriteFile := func(fileName string, text string, writeByteOrderMark bool, data *compiler.WriteFileData) error {
+	nopWriteFile := func(fileName string, text string, data *compiler.WriteFileData) error {
 		return nil
 	}
 
@@ -176,7 +176,7 @@ func BenchmarkEmitLongLinesWithLineBreaks(b *testing.B) {
 		Host: host,
 	})
 
-	nopWriteFile := func(fileName string, text string, writeByteOrderMark bool, data *compiler.WriteFileData) error {
+	nopWriteFile := func(fileName string, text string, data *compiler.WriteFileData) error {
 		return nil
 	}
 

--- a/internal/compiler/emitter.go
+++ b/internal/compiler/emitter.go
@@ -39,7 +39,7 @@ type emitter struct {
 	paths              *outputpaths.OutputPaths
 	sourceFile         *ast.SourceFile
 	emitResult         EmitResult
-	writeFile          func(fileName string, text string, writeByteOrderMark bool, data *WriteFileData) error
+	writeFile          func(fileName string, text string, data *WriteFileData) error
 }
 
 func (e *emitter) emit() {
@@ -275,7 +275,7 @@ func (e *emitter) printSourceFile(jsFilePath string, sourceMapFilePath string, s
 		// Write the source map
 		if len(sourceMapFilePath) > 0 {
 			sourceMap := sourceMapGenerator.String()
-			err := e.writeText(sourceMapFilePath, sourceMap, false /*writeByteOrderMark*/, nil)
+			err := e.writeText(sourceMapFilePath, sourceMap, nil)
 			if err != nil {
 				e.emitterDiagnostics.Add(ast.NewCompilerDiagnostic(diagnostics.Could_not_write_file_0_Colon_1, jsFilePath, err.Error()))
 			} else {
@@ -288,11 +288,14 @@ func (e *emitter) printSourceFile(jsFilePath string, sourceMapFilePath string, s
 
 	// Write the output file
 	text := e.writer.String()
+	if options.EmitBOM.IsTrue() {
+		text = stringutil.AddUTF8ByteOrderMark(text)
+	}
 	data := &WriteFileData{
 		SourceMapUrlPos: sourceMapUrlPos,
 		Diagnostics:     e.emitterDiagnostics.GetDiagnostics(),
 	}
-	err := e.writeText(jsFilePath, text, options.EmitBOM.IsTrue(), data)
+	err := e.writeText(jsFilePath, text, data)
 	skippedDtsWrite := data.SkippedDtsWrite
 	if err != nil {
 		e.emitterDiagnostics.Add(ast.NewCompilerDiagnostic(diagnostics.Could_not_write_file_0_Colon_1, jsFilePath, err.Error()))
@@ -304,11 +307,11 @@ func (e *emitter) printSourceFile(jsFilePath string, sourceMapFilePath string, s
 	e.writer.Clear()
 }
 
-func (e *emitter) writeText(fileName string, text string, writeByteOrderMark bool, data *WriteFileData) error {
+func (e *emitter) writeText(fileName string, text string, data *WriteFileData) error {
 	if e.writeFile != nil {
-		return e.writeFile(fileName, text, writeByteOrderMark, data)
+		return e.writeFile(fileName, text, data)
 	}
-	return e.host.WriteFile(fileName, text, writeByteOrderMark)
+	return e.host.WriteFile(fileName, text)
 }
 
 func shouldEmitSourceMaps(mapOptions *core.CompilerOptions, sourceFile *ast.SourceFile) bool {

--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -1394,7 +1394,7 @@ type WriteFileData struct {
 	SkippedDtsWrite bool
 }
 
-type WriteFile func(fileName string, text string, writeByteOrderMark bool, data *WriteFileData) error
+type WriteFile func(fileName string, text string, data *WriteFileData) error
 
 type EmitOptions struct {
 	TargetSourceFile *ast.SourceFile // Single file to emit. If `nil`, emits all files

--- a/internal/compiler/program_test.go
+++ b/internal/compiler/program_test.go
@@ -238,7 +238,7 @@ func TestProgram(t *testing.T) {
 			fs = bundled.WrapFS(fs)
 
 			for _, testFile := range testCase.files {
-				_ = fs.WriteFile(testFile.fileName, testFile.contents, false)
+				_ = fs.WriteFile(testFile.fileName, testFile.contents)
 			}
 
 			opts := core.CompilerOptions{Target: testCase.target}
@@ -276,7 +276,7 @@ func BenchmarkNewProgram(b *testing.B) {
 			fs = bundled.WrapFS(fs)
 
 			for _, testFile := range testCase.files {
-				_ = fs.WriteFile(testFile.fileName, testFile.contents, false)
+				_ = fs.WriteFile(testFile.fileName, testFile.contents)
 			}
 
 			opts := core.CompilerOptions{Target: testCase.target}

--- a/internal/compiler/projectreferencedtsfakinghost.go
+++ b/internal/compiler/projectreferencedtsfakinghost.go
@@ -75,7 +75,7 @@ func (fs *projectReferenceDtsFakingVfs) ReadFile(path string) (contents string, 
 }
 
 // WriteFile implements vfs.FS.
-func (fs *projectReferenceDtsFakingVfs) WriteFile(path string, data string, writeByteOrderMark bool) error {
+func (fs *projectReferenceDtsFakingVfs) WriteFile(path string, data string) error {
 	panic("should not be called by resolver")
 }
 

--- a/internal/execute/build/buildtask.go
+++ b/internal/execute/build/buildtask.go
@@ -236,8 +236,8 @@ func (t *BuildTask) compileAndEmit(orchestrator *Orchestrator, path tspath.Path)
 		ReportDiagnostic:   t.reportDiagnostic,
 		ReportErrorSummary: tsc.QuietDiagnosticsReporter,
 		Writer:             &t.result.builder,
-		WriteFile: func(fileName, text string, writeByteOrderMark bool, data *compiler.WriteFileData) error {
-			return t.writeFile(orchestrator, fileName, text, writeByteOrderMark, data)
+		WriteFile: func(fileName, text string, data *compiler.WriteFileData) error {
+			return t.writeFile(orchestrator, fileName, text, data)
 		},
 		CompileTimes:       &compileTimes,
 		Testing:            orchestrator.opts.Testing,
@@ -840,8 +840,8 @@ func (t *BuildTask) storeOutputTimeStamp(orchestrator *Orchestrator) bool {
 	return orchestrator.opts.Command.CompilerOptions.Watch.IsTrue() && !t.resolved.CompilerOptions().IsIncremental()
 }
 
-func (t *BuildTask) writeFile(orchestrator *Orchestrator, fileName string, text string, writeByteOrderMark bool, data *compiler.WriteFileData) error {
-	err := orchestrator.host.FS().WriteFile(fileName, text, writeByteOrderMark)
+func (t *BuildTask) writeFile(orchestrator *Orchestrator, fileName string, text string, data *compiler.WriteFileData) error {
+	err := orchestrator.host.FS().WriteFile(fileName, text)
 	if err == nil {
 		if data != nil && data.BuildInfo != nil {
 			t.onBuildInfoEmit(orchestrator, fileName, data.BuildInfo.(*incremental.BuildInfo), t.result.program.HasChangedDtsFile())

--- a/internal/execute/incremental/affectedfileshandler.go
+++ b/internal/execute/incremental/affectedfileshandler.go
@@ -71,7 +71,7 @@ func (h *affectedFilesHandler) computeDtsSignature(file *ast.SourceFile) string 
 	h.program.program.Emit(h.ctx, compiler.EmitOptions{
 		TargetSourceFile: file,
 		EmitOnly:         compiler.EmitOnlyForcedDts,
-		WriteFile: func(fileName string, text string, writeByteOrderMark bool, data *compiler.WriteFileData) error {
+		WriteFile: func(fileName string, text string, data *compiler.WriteFileData) error {
 			if !tspath.IsDeclarationFileName(fileName) {
 				panic("File extension for signature expected to be dts, got : " + fileName)
 			}

--- a/internal/execute/incremental/emitfileshandler.go
+++ b/internal/execute/incremental/emitfileshandler.go
@@ -176,7 +176,7 @@ func (h *emitFilesHandler) getEmitOptions(options compiler.EmitOptions) compiler
 	return compiler.EmitOptions{
 		TargetSourceFile: options.TargetSourceFile,
 		EmitOnly:         options.EmitOnly,
-		WriteFile: func(fileName string, text string, writeByteOrderMark bool, data *compiler.WriteFileData) error {
+		WriteFile: func(fileName string, text string, data *compiler.WriteFileData) error {
 			var differsOnlyInMap bool
 			if tspath.IsDeclarationFileName(fileName) {
 				if canUseIncrementalState {
@@ -210,9 +210,9 @@ func (h *emitFilesHandler) getEmitOptions(options compiler.EmitOptions) compiler
 			}
 			var err error
 			if options.WriteFile != nil {
-				err = options.WriteFile(fileName, text, writeByteOrderMark, data)
+				err = options.WriteFile(fileName, text, data)
 			} else {
-				err = h.program.program.Host().FS().WriteFile(fileName, text, writeByteOrderMark)
+				err = h.program.program.Host().FS().WriteFile(fileName, text)
 			}
 			if err == nil && differsOnlyInMap {
 				// Revert the time to original one

--- a/internal/execute/incremental/program.go
+++ b/internal/execute/incremental/program.go
@@ -304,11 +304,11 @@ func (p *Program) emitBuildInfo(ctx context.Context, options compiler.EmitOption
 		panic(fmt.Sprintf("Failed to marshal build info: %v", err))
 	}
 	if options.WriteFile != nil {
-		err = options.WriteFile(buildInfoFileName, string(text), false, &compiler.WriteFileData{
+		err = options.WriteFile(buildInfoFileName, string(text), &compiler.WriteFileData{
 			BuildInfo: buildInfo,
 		})
 	} else {
-		err = p.program.Host().FS().WriteFile(buildInfoFileName, string(text), false)
+		err = p.program.Host().FS().WriteFile(buildInfoFileName, string(text))
 	}
 	if err != nil {
 		return &compiler.EmitResult{

--- a/internal/execute/tsc.go
+++ b/internal/execute/tsc.go
@@ -54,7 +54,7 @@ func fmtMain(sys tsc.System, input, output string) tsc.ExitStatus {
 	edits := format.FormatDocument(ctx, sourceFile)
 	newText := core.ApplyBulkEdits(text, edits)
 
-	if err := sys.FS().WriteFile(output, newText, false); err != nil {
+	if err := sys.FS().WriteFile(output, newText); err != nil {
 		fmt.Fprintln(sys.Writer(), err.Error())
 		return tsc.ExitStatusNotImplemented
 	}

--- a/internal/execute/tsc/init.go
+++ b/internal/execute/tsc/init.go
@@ -22,7 +22,7 @@ func WriteConfigFile(sys System, locale locale.Locale, reportDiagnostic Diagnost
 	if sys.FS().FileExists(file) {
 		reportDiagnostic(ast.NewCompilerDiagnostic(diagnostics.A_tsconfig_json_file_is_already_defined_at_Colon_0, file))
 	} else {
-		_ = sys.FS().WriteFile(file, generateTSConfig(options, locale), false)
+		_ = sys.FS().WriteFile(file, generateTSConfig(options, locale))
 		output := []string{"\n"}
 		output = append(output, getHeader(sys, "Created a new tsconfig.json")...)
 		output = append(output, "You can learn more at https://aka.ms/tsconfig", "\n")

--- a/internal/execute/tsctests/fs.go
+++ b/internal/execute/tsctests/fs.go
@@ -50,13 +50,13 @@ func (f *testFs) readFileHandlingBuildInfo(path string) (contents string, ok boo
 	return contents, ok
 }
 
-func (f *testFs) WriteFile(path string, data string, writeByteOrderMark bool) error {
+func (f *testFs) WriteFile(path string, data string) error {
 	f.removeIgnoreLibPath(path)
 	f.writtenFiles.Add(path)
-	return f.writeFileHandlingBuildInfo(path, data, writeByteOrderMark)
+	return f.writeFileHandlingBuildInfo(path, data)
 }
 
-func (f *testFs) writeFileHandlingBuildInfo(path string, data string, writeByteOrderMark bool) error {
+func (f *testFs) writeFileHandlingBuildInfo(path string, data string) error {
 	if tspath.FileExtensionIs(path, tspath.ExtensionTsBuildInfo) {
 		var buildInfo incremental.BuildInfo
 		if err := json.Unmarshal([]byte(data), &buildInfo); err == nil {
@@ -73,7 +73,6 @@ func (f *testFs) writeFileHandlingBuildInfo(path string, data string, writeByteO
 			if err := f.WriteFile(
 				path+".readable.baseline.txt",
 				toReadableBuildInfo(&buildInfo, fsbaselineutil.SanitizeInternalSymbolName(data)),
-				false,
 			); err != nil {
 				return fmt.Errorf("testFs.WriteFile: failed to write readable build info: %w", err)
 			}
@@ -81,7 +80,7 @@ func (f *testFs) writeFileHandlingBuildInfo(path string, data string, writeByteO
 			panic("testFs.WriteFile: failed to unmarshal build info: - use underlying FS's write method if this is intended use for testcase" + err.Error())
 		}
 	}
-	return f.FS.WriteFile(path, data, writeByteOrderMark)
+	return f.FS.WriteFile(path, data)
 }
 
 // Removes `path` and all its contents. Will return the first error it encounters.

--- a/internal/execute/tsctests/sys.go
+++ b/internal/execute/tsctests/sys.go
@@ -195,7 +195,7 @@ func (s *TestSys) ensureLibPathExists(path string) {
 			s.fs.defaultLibs = &collections.SyncSet[string]{}
 		}
 		s.fs.defaultLibs.Add(path)
-		err := s.fsFromFileMap().WriteFile(path, tscDefaultLibContent, false)
+		err := s.fsFromFileMap().WriteFile(path, tscDefaultLibContent)
 		if err != nil {
 			panic("Failed to write default library file: " + err.Error())
 		}
@@ -520,8 +520,8 @@ func (s *TestSys) baselineFSwithDiff(baseline io.Writer) {
 	s.fsDiffer.BaselineFSwithDiff(baseline)
 }
 
-func (s *TestSys) writeFileNoError(path string, content string, writeByteOrderMark bool) {
-	if err := s.fsFromFileMap().WriteFile(path, content, writeByteOrderMark); err != nil {
+func (s *TestSys) writeFileNoError(path string, content string) {
+	if err := s.fsFromFileMap().WriteFile(path, content); err != nil {
 		panic(err)
 	}
 }
@@ -541,28 +541,28 @@ func (s *TestSys) readFileNoError(path string) string {
 }
 
 func (s *TestSys) renameFileNoError(oldPath string, newPath string) {
-	s.writeFileNoError(newPath, s.readFileNoError(oldPath), false)
+	s.writeFileNoError(newPath, s.readFileNoError(oldPath))
 	s.removeNoError(oldPath)
 }
 
 func (s *TestSys) replaceFileText(path string, oldText string, newText string) {
 	content := s.readFileNoError(path)
 	content = strings.Replace(content, oldText, newText, 1)
-	s.writeFileNoError(path, content, false)
+	s.writeFileNoError(path, content)
 }
 
 func (s *TestSys) replaceFileTextAll(path string, oldText string, newText string) {
 	content := s.readFileNoError(path)
 	content = strings.ReplaceAll(content, oldText, newText)
-	s.writeFileNoError(path, content, false)
+	s.writeFileNoError(path, content)
 }
 
 func (s *TestSys) appendFile(path string, text string) {
 	content := s.readFileNoError(path)
-	s.writeFileNoError(path, content+text, false)
+	s.writeFileNoError(path, content+text)
 }
 
 func (s *TestSys) prependFile(path string, text string) {
 	content := s.readFileNoError(path)
-	s.writeFileNoError(path, text+content, false)
+	s.writeFileNoError(path, text+content)
 }

--- a/internal/execute/tsctests/tsc_test.go
+++ b/internal/execute/tsctests/tsc_test.go
@@ -981,7 +981,6 @@ func TestTscExtends(t *testing.T) {
 								"types": [],
 							},
 						}`),
-						false,
 					)
 				},
 			},
@@ -1443,7 +1442,7 @@ func TestTscIncremental(t *testing.T) {
 				{
 					caption: "Add new file and update main file",
 					edit: func(sys *TestSys) {
-						sys.writeFileNoError(`/home/src/workspaces/project/src/newFile.ts`, "function foo() { return 20; }", false)
+						sys.writeFileNoError(`/home/src/workspaces/project/src/newFile.ts`, "function foo() { return 20; }")
 						sys.prependFile(
 							`/home/src/workspaces/project/src/main.ts`,
 							`/// <reference path="./newFile.ts"/>
@@ -1455,7 +1454,7 @@ func TestTscIncremental(t *testing.T) {
 				{
 					caption: "Write file that could not be resolved",
 					edit: func(sys *TestSys) {
-						sys.writeFileNoError(`/home/src/workspaces/project/src/fileNotFound.ts`, "function something2() { return 20; }", false)
+						sys.writeFileNoError(`/home/src/workspaces/project/src/fileNotFound.ts`, "function something2() { return 20; }")
 					},
 				},
 				{
@@ -1542,7 +1541,7 @@ func TestTscIncremental(t *testing.T) {
 				{
 					caption: "Modify imports used in global file",
 					edit: func(sys *TestSys) {
-						sys.writeFileNoError("/home/src/workspaces/project/constants.ts", "export default 2;", false)
+						sys.writeFileNoError("/home/src/workspaces/project/constants.ts", "export default 2;")
 					},
 					expectedDiff: "Currently there is issue with d.ts emit for export default = 1 to widen in dts which is why we are not re-computing errors and results in incorrect error reporting",
 				},
@@ -1568,7 +1567,7 @@ func TestTscIncremental(t *testing.T) {
 				{
 					caption: "Modify imports used in global file",
 					edit: func(sys *TestSys) {
-						sys.writeFileNoError("/home/src/workspaces/project/constants.ts", "export default 2;", false)
+						sys.writeFileNoError("/home/src/workspaces/project/constants.ts", "export default 2;")
 					},
 					expectedDiff: "Currently there is issue with d.ts emit for export default = 1 to widen in dts which is why we are not re-computing errors and results in incorrect error reporting",
 				},
@@ -2736,7 +2735,7 @@ func TestTscModuleResolution(t *testing.T) {
 				{
 					caption: "add the alternateResult in @types",
 					edit: func(sys *TestSys) {
-						sys.writeFileNoError("/home/src/projects/project/node_modules/@types/bar/index.d.ts", getTscModuleResolutionAlternateResultDts("bar"), false)
+						sys.writeFileNoError("/home/src/projects/project/node_modules/@types/bar/index.d.ts", getTscModuleResolutionAlternateResultDts("bar"))
 					},
 					// !!! repopulateInfo on diagnostics not yet implemented
 					expectedDiff: "Currently we arent repopulating error chain so errors will be different",
@@ -2744,31 +2743,31 @@ func TestTscModuleResolution(t *testing.T) {
 				{
 					caption: "add the alternateResult in package/types",
 					edit: func(sys *TestSys) {
-						sys.writeFileNoError("/home/src/projects/project/node_modules/foo/index.d.ts", getTscModuleResolutionAlternateResultDts("foo"), false)
+						sys.writeFileNoError("/home/src/projects/project/node_modules/foo/index.d.ts", getTscModuleResolutionAlternateResultDts("foo"))
 					},
 				},
 				{
 					caption: "update package.json from @types so error is fixed",
 					edit: func(sys *TestSys) {
-						sys.writeFileNoError("/home/src/projects/project/node_modules/@types/bar/package.json", getTscModuleResolutionAlternateResultAtTypesPackageJson("bar" /*addTypesCondition*/, true), false)
+						sys.writeFileNoError("/home/src/projects/project/node_modules/@types/bar/package.json", getTscModuleResolutionAlternateResultAtTypesPackageJson("bar" /*addTypesCondition*/, true))
 					},
 				},
 				{
 					caption: "update package.json so error is fixed",
 					edit: func(sys *TestSys) {
-						sys.writeFileNoError("/home/src/projects/project/node_modules/foo/package.json", getTscModuleResolutionAlternateResultPackageJson("foo" /*addTypes*/, true /*addTypesCondition*/, true), false)
+						sys.writeFileNoError("/home/src/projects/project/node_modules/foo/package.json", getTscModuleResolutionAlternateResultPackageJson("foo" /*addTypes*/, true /*addTypesCondition*/, true))
 					},
 				},
 				{
 					caption: "update package.json from @types so error is introduced",
 					edit: func(sys *TestSys) {
-						sys.writeFileNoError("/home/src/projects/project/node_modules/@types/bar2/package.json", getTscModuleResolutionAlternateResultAtTypesPackageJson("bar2" /*addTypesCondition*/, false), false)
+						sys.writeFileNoError("/home/src/projects/project/node_modules/@types/bar2/package.json", getTscModuleResolutionAlternateResultAtTypesPackageJson("bar2" /*addTypesCondition*/, false))
 					},
 				},
 				{
 					caption: "update package.json so error is introduced",
 					edit: func(sys *TestSys) {
-						sys.writeFileNoError("/home/src/projects/project/node_modules/foo2/package.json", getTscModuleResolutionAlternateResultPackageJson("foo2" /*addTypes*/, true /*addTypesCondition*/, false), false)
+						sys.writeFileNoError("/home/src/projects/project/node_modules/foo2/package.json", getTscModuleResolutionAlternateResultPackageJson("foo2" /*addTypes*/, true /*addTypesCondition*/, false))
 					},
 				},
 				{
@@ -2790,7 +2789,7 @@ func TestTscModuleResolution(t *testing.T) {
 				{
 					caption: "add the alternateResult in @types",
 					edit: func(sys *TestSys) {
-						sys.writeFileNoError("/home/src/projects/project/node_modules/@types/bar2/index.d.ts", getTscModuleResolutionAlternateResultDts("bar2"), false)
+						sys.writeFileNoError("/home/src/projects/project/node_modules/@types/bar2/index.d.ts", getTscModuleResolutionAlternateResultDts("bar2"))
 					},
 					// !!! repopulateInfo on diagnostics not yet implemented
 					expectedDiff: "Currently we arent repopulating error chain so errors will be different",
@@ -2798,7 +2797,7 @@ func TestTscModuleResolution(t *testing.T) {
 				{
 					caption: "add the ndoe10Result in package/types",
 					edit: func(sys *TestSys) {
-						sys.writeFileNoError("/home/src/projects/project/node_modules/foo2/index.d.ts", getTscModuleResolutionAlternateResultDts("foo2"), false)
+						sys.writeFileNoError("/home/src/projects/project/node_modules/foo2/index.d.ts", getTscModuleResolutionAlternateResultDts("foo2"))
 					},
 				},
 			},
@@ -3055,13 +3054,13 @@ func TestTscNoCheck(t *testing.T) {
 		fixErrorNoCheck := &tscEdit{
 			caption: "Fix `a` error with noCheck",
 			edit: func(sys *TestSys) {
-				sys.writeFileNoError("/home/src/workspaces/project/a.ts", `export const a = "hello";`, false)
+				sys.writeFileNoError("/home/src/workspaces/project/a.ts", `export const a = "hello";`)
 			},
 		}
 		addErrorNoCheck := &tscEdit{
 			caption: "Introduce error with noCheck",
 			edit: func(sys *TestSys) {
-				sys.writeFileNoError("/home/src/workspaces/project/a.ts", scenario.aText, false)
+				sys.writeFileNoError("/home/src/workspaces/project/a.ts", scenario.aText)
 			},
 		}
 		return &tscInput{
@@ -3093,7 +3092,7 @@ func TestTscNoCheck(t *testing.T) {
 				{
 					caption: "Add file with error",
 					edit: func(sys *TestSys) {
-						sys.writeFileNoError("/home/src/workspaces/project/c.ts", `export const c: number = "hello";`, false)
+						sys.writeFileNoError("/home/src/workspaces/project/c.ts", `export const c: number = "hello";`)
 					},
 					commandLineArgs: commandLineArgs,
 				},
@@ -3216,7 +3215,7 @@ func TestTscNoEmit(t *testing.T) {
 					{
 						caption: "Fix error",
 						edit: func(sys *TestSys) {
-							sys.writeFileNoError("/home/src/projects/project/a.ts", fixedATsContent, false)
+							sys.writeFileNoError("/home/src/projects/project/a.ts", fixedATsContent)
 						},
 					},
 					noChange,
@@ -3228,7 +3227,7 @@ func TestTscNoEmit(t *testing.T) {
 					{
 						caption: "Introduce error",
 						edit: func(sys *TestSys) {
-							sys.writeFileNoError("/home/src/projects/project/a.ts", scenario.aText, false)
+							sys.writeFileNoError("/home/src/projects/project/a.ts", scenario.aText)
 						},
 					},
 					{
@@ -3253,7 +3252,7 @@ func TestTscNoEmit(t *testing.T) {
 					{
 						caption: "Fix error",
 						edit: func(sys *TestSys) {
-							sys.writeFileNoError("/home/src/projects/project/a.ts", fixedATsContent, false)
+							sys.writeFileNoError("/home/src/projects/project/a.ts", fixedATsContent)
 						},
 					},
 					{
@@ -3271,7 +3270,7 @@ func TestTscNoEmit(t *testing.T) {
 					{
 						caption: "Introduce error",
 						edit: func(sys *TestSys) {
-							sys.writeFileNoError("/home/src/projects/project/a.ts", scenario.aText, false)
+							sys.writeFileNoError("/home/src/projects/project/a.ts", scenario.aText)
 						},
 					},
 					{
@@ -3547,13 +3546,13 @@ func TestTscNoEmit(t *testing.T) {
 				{
 					caption: "No change",
 					edit: func(sys *TestSys) {
-						sys.writeFileNoError(`/user/username/projects/myproject/a.js`, sys.readFileNoError(`/user/username/projects/myproject/a.js`), false)
+						sys.writeFileNoError(`/user/username/projects/myproject/a.js`, sys.readFileNoError(`/user/username/projects/myproject/a.js`))
 					},
 				},
 				{
 					caption: "change",
 					edit: func(sys *TestSys) {
-						sys.writeFileNoError(`/user/username/projects/myproject/a.js`, "const x = 10;", false)
+						sys.writeFileNoError(`/user/username/projects/myproject/a.js`, "const x = 10;")
 					},
 				},
 			},
@@ -3632,7 +3631,7 @@ func TestTscNoEmitOnError(t *testing.T) {
 				{
 					caption: "Fix error",
 					edit: func(sys *TestSys) {
-						sys.writeFileNoError("/user/username/projects/noEmitOnError/src/main.ts", scenario.fixedErrorContent, false)
+						sys.writeFileNoError("/user/username/projects/noEmitOnError/src/main.ts", scenario.fixedErrorContent)
 					},
 				},
 				noChange,
@@ -3678,7 +3677,7 @@ func TestTscNoEmitOnError(t *testing.T) {
 				edits = append(edits, &tscEdit{
 					caption: scenario.subScenario,
 					edit: func(sys *TestSys) {
-						sys.writeFileNoError(`/user/username/projects/noEmitOnError/src/main.ts`, scenario.mainErrorContent, false)
+						sys.writeFileNoError(`/user/username/projects/noEmitOnError/src/main.ts`, scenario.mainErrorContent)
 					},
 				})
 			}
@@ -3686,19 +3685,19 @@ func TestTscNoEmitOnError(t *testing.T) {
 				&tscEdit{
 					caption: "No Change",
 					edit: func(sys *TestSys) {
-						sys.writeFileNoError(`/user/username/projects/noEmitOnError/src/main.ts`, sys.readFileNoError(`/user/username/projects/noEmitOnError/src/main.ts`), false)
+						sys.writeFileNoError(`/user/username/projects/noEmitOnError/src/main.ts`, sys.readFileNoError(`/user/username/projects/noEmitOnError/src/main.ts`))
 					},
 				},
 				&tscEdit{
 					caption: "Fix " + scenario.subScenario,
 					edit: func(sys *TestSys) {
-						sys.writeFileNoError("/user/username/projects/noEmitOnError/src/main.ts", scenario.fixedErrorContent, false)
+						sys.writeFileNoError("/user/username/projects/noEmitOnError/src/main.ts", scenario.fixedErrorContent)
 					},
 				},
 				&tscEdit{
 					caption: "No Change",
 					edit: func(sys *TestSys) {
-						sys.writeFileNoError(`/user/username/projects/noEmitOnError/src/main.ts`, sys.readFileNoError(`/user/username/projects/noEmitOnError/src/main.ts`), false)
+						sys.writeFileNoError(`/user/username/projects/noEmitOnError/src/main.ts`, sys.readFileNoError(`/user/username/projects/noEmitOnError/src/main.ts`))
 					},
 				},
 			)

--- a/internal/execute/tsctests/tscbuild_test.go
+++ b/internal/execute/tsctests/tscbuild_test.go
@@ -391,7 +391,7 @@ func TestBuildConfigFileErrors(t *testing.T) {
 									"a.ts",
 									"b.ts"
 								]
-							}`), false)
+							}`))
 					},
 				},
 			},
@@ -449,7 +449,7 @@ func TestBuildConfigFileErrors(t *testing.T) {
 									"a.ts",
 									"b.ts"
 								]
-							}`), false)
+							}`))
 					},
 				},
 			},
@@ -718,7 +718,7 @@ func TestBuildDemoProject(t *testing.T) {
 									"rootDir": "."
 								},
 							}
-						`), false)
+						`))
 					},
 				},
 			},
@@ -1930,7 +1930,7 @@ func TestBuildProgramUpdates(t *testing.T) {
 								tags() { }
 								private p = 12
 							};
-						`), false)
+						`))
 					},
 				},
 				{
@@ -1969,7 +1969,7 @@ func TestBuildProgramUpdates(t *testing.T) {
 								tags() { }
 								private p = 12
 							};
-						`), false)
+						`))
 					},
 				},
 				{
@@ -2006,7 +2006,6 @@ func TestBuildProgramUpdates(t *testing.T) {
 									"noUnusedParameters": false,
 								},
 							}`),
-							false,
 						)
 					},
 				},
@@ -2088,7 +2087,7 @@ func TestBuildProgramUpdates(t *testing.T) {
                             "compilerOptions": {
 								"strict": true
 							}
-                        }`), false)
+                        }`))
 					},
 				},
 				{
@@ -2098,7 +2097,7 @@ func TestBuildProgramUpdates(t *testing.T) {
 						{
                             "extends": "./alpha.tsconfig.json",
                             "compilerOptions": { "strict": false }
-                        }`), false)
+                        }`))
 					},
 				},
 				{
@@ -2108,13 +2107,13 @@ func TestBuildProgramUpdates(t *testing.T) {
 						{
                             "extends": "./alpha.tsconfig.json",
                             "files": ["other.ts"]
-                        }`), false)
+                        }`))
 					},
 				},
 				{
 					caption: "update aplha config",
 					edit: func(sys *TestSys) {
-						sys.writeFileNoError("/user/username/projects/project/alpha.tsconfig.json", "{}", false)
+						sys.writeFileNoError("/user/username/projects/project/alpha.tsconfig.json", "{}")
 					},
 				},
 				{
@@ -2123,7 +2122,7 @@ func TestBuildProgramUpdates(t *testing.T) {
 						sys.writeFileNoError("/user/username/projects/project/extendsConfig2.tsconfig.json", stringtestutil.Dedent(`
 						{
                             "compilerOptions": { "strictNullChecks": true }
-                        }`), false)
+                        }`))
 					},
 				},
 				{
@@ -2134,7 +2133,7 @@ func TestBuildProgramUpdates(t *testing.T) {
                             "extends": ["./extendsConfig1.tsconfig.json", "./extendsConfig2.tsconfig.json"],
                             "compilerOptions": { "composite": false },
                             "files": ["other2.ts"],
-                        }`), false)
+                        }`))
 					},
 				},
 				{
@@ -2206,7 +2205,7 @@ func TestBuildProgramUpdates(t *testing.T) {
                                 },
                             ],
                             "files": [],
-                        }`), false)
+                        }`))
 					},
 				},
 			},
@@ -3224,13 +3223,13 @@ class someClass2 { }`,
 			{
 				caption: "Change to new File and build core",
 				edit: func(sys *TestSys) {
-					sys.writeFileNoError("/user/username/projects/sample1/core/newfile.ts", `export const newFileConst = 30;`, false)
+					sys.writeFileNoError("/user/username/projects/sample1/core/newfile.ts", `export const newFileConst = 30;`)
 				},
 			},
 			{
 				caption: "Change to new File and build core",
 				edit: func(sys *TestSys) {
-					sys.writeFileNoError("/user/username/projects/sample1/core/newfile.ts", "\nexport class someClass2 { }", false)
+					sys.writeFileNoError("/user/username/projects/sample1/core/newfile.ts", "\nexport class someClass2 { }")
 				},
 			},
 		}
@@ -3377,7 +3376,7 @@ class someClass2 { }`,
 					// Update a file in the leaf node (tests), only it should rebuild the last one
 					caption: "Only builds the leaf node project",
 					edit: func(sys *TestSys) {
-						sys.writeFileNoError("/user/username/projects/sample1/tests/index.ts", "const m = 10;", false)
+						sys.writeFileNoError("/user/username/projects/sample1/tests/index.ts", "const m = 10;")
 					},
 				},
 				{
@@ -3517,7 +3516,7 @@ class someClass2 { }`,
 						sys.writeFileNoError("/user/username/projects/sample1/tests/tsconfig.base.json", stringtestutil.Dedent(`
 						{
 							"compilerOptions": { }
-						}`), false)
+						}`))
 					},
 				},
 			},
@@ -3779,7 +3778,7 @@ class someClass2 { }`,
 				{
 					caption: "Write logic",
 					edit: func(sys *TestSys) {
-						sys.writeFileNoError("/user/username/projects/sample1/logic/tsconfig.json", getLogicConfig(), false)
+						sys.writeFileNoError("/user/username/projects/sample1/logic/tsconfig.json", getLogicConfig())
 					},
 				},
 			},
@@ -3817,7 +3816,7 @@ class someClass2 { }`,
 				{
 					caption: "Add new file",
 					edit: func(sys *TestSys) {
-						sys.writeFileNoError("/user/username/projects/sample1/core/file3.ts", `export const y = 10;`, false)
+						sys.writeFileNoError("/user/username/projects/sample1/core/file3.ts", `export const y = 10;`)
 					},
 				},
 				noChange,
@@ -3841,7 +3840,7 @@ class someClass2 { }`,
 				{
 					caption: "Add new file",
 					edit: func(sys *TestSys) {
-						sys.writeFileNoError("/user/username/projects/sample1/core/file3.ts", `export const y = 10;`, false)
+						sys.writeFileNoError("/user/username/projects/sample1/core/file3.ts", `export const y = 10;`)
 					},
 				},
 				noChange,

--- a/internal/execute/tsctests/tscwatch_test.go
+++ b/internal/execute/tsctests/tscwatch_test.go
@@ -71,22 +71,22 @@ func noEmitWatchTestInput(
 		},
 		edits: []*tscEdit{
 			newTscEdit("fix error", func(sys *TestSys) {
-				sys.writeFileNoError("/home/src/workspaces/project/a.ts", `const a = "hello";`, false)
+				sys.writeFileNoError("/home/src/workspaces/project/a.ts", `const a = "hello";`)
 			}),
 			newTscEdit("emit after fixing error", func(sys *TestSys) {
-				sys.writeFileNoError("/home/src/workspaces/project/tsconfig.json", toTsconfig("", optionString), false)
+				sys.writeFileNoError("/home/src/workspaces/project/tsconfig.json", toTsconfig("", optionString))
 			}),
 			newTscEdit("no emit run after fixing error", func(sys *TestSys) {
-				sys.writeFileNoError("/home/src/workspaces/project/tsconfig.json", toTsconfig(noEmitOpt, optionString), false)
+				sys.writeFileNoError("/home/src/workspaces/project/tsconfig.json", toTsconfig(noEmitOpt, optionString))
 			}),
 			newTscEdit("introduce error", func(sys *TestSys) {
-				sys.writeFileNoError("/home/src/workspaces/project/a.ts", aText, false)
+				sys.writeFileNoError("/home/src/workspaces/project/a.ts", aText)
 			}),
 			newTscEdit("emit when error", func(sys *TestSys) {
-				sys.writeFileNoError("/home/src/workspaces/project/tsconfig.json", toTsconfig("", optionString), false)
+				sys.writeFileNoError("/home/src/workspaces/project/tsconfig.json", toTsconfig("", optionString))
 			}),
 			newTscEdit("no emit run when error", func(sys *TestSys) {
-				sys.writeFileNoError("/home/src/workspaces/project/tsconfig.json", toTsconfig(noEmitOpt, optionString), false)
+				sys.writeFileNoError("/home/src/workspaces/project/tsconfig.json", toTsconfig(noEmitOpt, optionString))
 			}),
 		},
 	}

--- a/internal/ls/autoimport/registry_test.go
+++ b/internal/ls/autoimport/registry_test.go
@@ -161,7 +161,7 @@ export const bar = 2;`,
 
 		fs := sessionUtils.FS()
 		updatePackageJSON := func(content string) {
-			assert.NilError(t, fs.WriteFile(packageJSON.FileName(), content, false))
+			assert.NilError(t, fs.WriteFile(packageJSON.FileName(), content))
 			session.DidChangeWatchedFiles(ctx, []*lsproto.FileEvent{
 				{Type: lsproto.FileChangeTypeChanged, Uri: packageJSON.URI()},
 			})

--- a/internal/printer/emithost.go
+++ b/internal/printer/emithost.go
@@ -15,7 +15,7 @@ type EmitHost interface {
 	GetCurrentDirectory() string
 	CommonSourceDirectory() string
 	IsEmitBlocked(file string) bool
-	WriteFile(fileName string, text string, writeByteOrderMark bool) error
+	WriteFile(fileName string, text string) error
 	GetEmitModuleFormatOfFile(file ast.HasFileName) core.ModuleKind
 	GetEmitResolver() EmitResolver
 	GetProjectReferenceFromSource(path tspath.Path) *tsoptions.SourceOutputAndProjectReference

--- a/internal/project/ata/ata.go
+++ b/internal/project/ata/ata.go
@@ -469,7 +469,7 @@ func (ti *TypingsInstaller) ensureTypingsLocationExists(fs vfs.FS, logger loggin
 
 	if !fs.FileExists(npmConfigPath) {
 		logger.Log(fmt.Sprintf("ATA:: Npm config file: '%s' is missing, creating new one...", npmConfigPath))
-		err := fs.WriteFile(npmConfigPath, "{ \"private\": true }", false)
+		err := fs.WriteFile(npmConfigPath, "{ \"private\": true }")
 		if err != nil {
 			logger.Log(fmt.Sprintf("ATA:: Npm config file write failed: %v", err))
 		}

--- a/internal/project/ata/ata_test.go
+++ b/internal/project/ata/ata_test.go
@@ -377,7 +377,6 @@ func TestATA(t *testing.T) {
 		assert.NilError(t, utils.FS().WriteFile(
 			"/user/username/projects/project/package.json",
 			`{ "dependencies": { "commander": "0.0.2" } }`,
-			false,
 		))
 		session.DidChangeWatchedFiles(context.Background(), []*lsproto.FileEvent{{
 			Type: lsproto.FileChangeTypeChanged,

--- a/internal/project/bulkcache_test.go
+++ b/internal/project/bulkcache_test.go
@@ -64,10 +64,10 @@ func TestBulkCacheInvalidation(t *testing.T) {
 				"types": ["node"]
 			},
 			"include": ["src/**/*"]
-		}`, false)
+		}`)
 			assert.NilError(t, err)
 			// Update fs.d.ts in node_modules
-			err = utils.FS().WriteFile("/project/node_modules/@types/node/fs.d.ts", "new text", false)
+			err = utils.FS().WriteFile("/project/node_modules/@types/node/fs.d.ts", "new text")
 			assert.NilError(t, err)
 
 			// Process the excessive node_modules changes
@@ -139,10 +139,10 @@ func TestBulkCacheInvalidation(t *testing.T) {
 				"types": ["node"]
 			},
 			"include": ["src/**/*"]
-		}`, false)
+		}`)
 			assert.NilError(t, err)
 			// Add root file
-			err = utils.FS().WriteFile("/project/src/rootFile.ts", `console.log("root file")`, false)
+			err = utils.FS().WriteFile("/project/src/rootFile.ts", `console.log("root file")`)
 			assert.NilError(t, err)
 
 			session.DidChangeWatchedFiles(context.Background(), fileEvents)
@@ -199,7 +199,7 @@ func TestBulkCacheInvalidation(t *testing.T) {
 				"strict": false,
 				"target": "esnext"
 			}
-		}`, false)
+		}`)
 		assert.NilError(t, err)
 
 		// Create excessive changes to trigger bulk invalidation
@@ -244,7 +244,7 @@ func TestBulkCacheInvalidation(t *testing.T) {
 			"strict": true
 		},
 		"include": ["src/**/*"]
-	}`, false)
+	}`)
 			assert.NilError(t, err)
 
 			// Process the changes
@@ -309,7 +309,7 @@ func TestBulkCacheInvalidation(t *testing.T) {
 				"strict": true
 			},
 			"include": ["src/**/*"]
-		}`, false)
+		}`)
 		assert.NilError(t, err)
 
 		// Create excessive changes in dist folder only

--- a/internal/project/configfilechanges_test.go
+++ b/internal/project/configfilechanges_test.go
@@ -34,7 +34,7 @@ func TestConfigFileChanges(t *testing.T) {
 		session, utils := projecttestutil.Setup(files)
 		session.DidOpenFile(context.Background(), "file:///src/index.ts", 1, files["/src/index.ts"].(string), lsproto.LanguageKindTypeScript)
 
-		err := utils.FS().WriteFile("/src/tsconfig.json", `{"extends": "../tsconfig.base.json", "compilerOptions": {"target": "esnext"}, "references": [{"path": "../utils"}]}`, false /*writeByteOrderMark*/)
+		err := utils.FS().WriteFile("/src/tsconfig.json", `{"extends": "../tsconfig.base.json", "compilerOptions": {"target": "esnext"}, "references": [{"path": "../utils"}]}`)
 		assert.NilError(t, err)
 		session.DidChangeWatchedFiles(context.Background(), []*lsproto.FileEvent{
 			{
@@ -53,7 +53,7 @@ func TestConfigFileChanges(t *testing.T) {
 		session, utils := projecttestutil.Setup(files)
 		session.DidOpenFile(context.Background(), "file:///src/index.ts", 1, files["/src/index.ts"].(string), lsproto.LanguageKindTypeScript)
 
-		err := utils.FS().WriteFile("/tsconfig.base.json", `{"compilerOptions": {"strict": false}}`, false /*writeByteOrderMark*/)
+		err := utils.FS().WriteFile("/tsconfig.base.json", `{"compilerOptions": {"strict": false}}`)
 		assert.NilError(t, err)
 		session.DidChangeWatchedFiles(context.Background(), []*lsproto.FileEvent{
 			{
@@ -72,7 +72,7 @@ func TestConfigFileChanges(t *testing.T) {
 		session, utils := projecttestutil.Setup(files)
 		session.DidOpenFile(context.Background(), "file:///src/index.ts", 1, files["/src/index.ts"].(string), lsproto.LanguageKindTypeScript)
 
-		err := utils.FS().WriteFile("/tsconfig.more-base.json", `{"compilerOptions": {"verbatimModuleSyntax": true}}`, false /*writeByteOrderMark*/)
+		err := utils.FS().WriteFile("/tsconfig.more-base.json", `{"compilerOptions": {"verbatimModuleSyntax": true}}`)
 		assert.NilError(t, err)
 		session.DidChangeWatchedFiles(context.Background(), []*lsproto.FileEvent{
 			{
@@ -93,7 +93,7 @@ func TestConfigFileChanges(t *testing.T) {
 		snapshotBefore, release := session.Snapshot()
 		defer release()
 
-		err := utils.FS().WriteFile("/utils/tsconfig.json", `{"compilerOptions": {"composite": true, "target": "esnext"}}`, false /*writeByteOrderMark*/)
+		err := utils.FS().WriteFile("/utils/tsconfig.json", `{"compilerOptions": {"composite": true, "target": "esnext"}}`)
 		assert.NilError(t, err)
 		session.DidChangeWatchedFiles(context.Background(), []*lsproto.FileEvent{
 			{
@@ -136,7 +136,7 @@ func TestConfigFileChanges(t *testing.T) {
 		session, utils := projecttestutil.Setup(files)
 		session.DidOpenFile(context.Background(), "file:///src/subfolder/foo.ts", 1, files["/src/subfolder/foo.ts"].(string), lsproto.LanguageKindTypeScript)
 
-		err := utils.FS().WriteFile("/src/subfolder/tsconfig.json", `{}`, false /*writeByteOrderMark*/)
+		err := utils.FS().WriteFile("/src/subfolder/tsconfig.json", `{}`)
 		assert.NilError(t, err)
 		session.DidChangeWatchedFiles(context.Background(), []*lsproto.FileEvent{
 			{
@@ -189,7 +189,7 @@ func TestConfigFileChanges(t *testing.T) {
 		session.DidOpenFile(context.Background(), "file:///src/index.ts", 1, missingBaseFiles["/src/index.ts"].(string), lsproto.LanguageKindTypeScript)
 
 		// Create the previously-missing base config file that is extended by /src/tsconfig.json
-		err := utils.FS().WriteFile("/tsconfig.base.json", `{"compilerOptions": {"strict": true}}`, false /*writeByteOrderMark*/)
+		err := utils.FS().WriteFile("/tsconfig.base.json", `{"compilerOptions": {"strict": true}}`)
 		assert.NilError(t, err)
 		session.DidChangeWatchedFiles(context.Background(), []*lsproto.FileEvent{
 			{

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -70,7 +70,7 @@ func TestProjectProgramUpdateKind(t *testing.T) {
 		session.DidOpenFile(context.Background(), "file:///src/index.ts", 1, files["/src/index.ts"].(string), lsproto.LanguageKindTypeScript)
 		_, err := session.GetLanguageService(context.Background(), lsproto.DocumentUri("file:///src/index.ts"))
 		assert.NilError(t, err)
-		err = utils.FS().WriteFile("/src/tsconfig.json", `{"compilerOptions": {"strict": false}}`, false)
+		err = utils.FS().WriteFile("/src/tsconfig.json", `{"compilerOptions": {"strict": false}}`)
 		assert.NilError(t, err)
 		session.DidChangeWatchedFiles(context.Background(), []*lsproto.FileEvent{{Uri: lsproto.DocumentUri("file:///src/tsconfig.json"), Type: lsproto.FileChangeTypeChanged}})
 		_, err = session.GetLanguageService(context.Background(), lsproto.DocumentUri("file:///src/index.ts"))
@@ -93,7 +93,7 @@ func TestProjectProgramUpdateKind(t *testing.T) {
 		_, err := session.GetLanguageService(context.Background(), lsproto.DocumentUri("file:///src/index.ts"))
 		assert.NilError(t, err)
 		content := "export const y = 2;"
-		err = utils.FS().WriteFile("/src/newfile.ts", content, false)
+		err = utils.FS().WriteFile("/src/newfile.ts", content)
 		assert.NilError(t, err)
 		session.DidChangeWatchedFiles(context.Background(), []*lsproto.FileEvent{{Uri: lsproto.DocumentUri("file:///src/newfile.ts"), Type: lsproto.FileChangeTypeCreated}})
 		session.DidOpenFile(context.Background(), "file:///src/newfile.ts", 1, content, lsproto.LanguageKindTypeScript)
@@ -267,7 +267,7 @@ func TestPushDiagnostics(t *testing.T) {
 		initialCallCount := len(utils.Client().PublishDiagnosticsCalls())
 
 		// Change the tsconfig to remove baseUrl
-		err = utils.FS().WriteFile("/src/tsconfig.json", `{"compilerOptions": {}}`, false)
+		err = utils.FS().WriteFile("/src/tsconfig.json", `{"compilerOptions": {}}`)
 		assert.NilError(t, err)
 		session.DidChangeWatchedFiles(context.Background(), []*lsproto.FileEvent{{Uri: lsproto.DocumentUri("file:///src/tsconfig.json"), Type: lsproto.FileChangeTypeChanged}})
 		_, err = session.GetLanguageService(context.Background(), lsproto.DocumentUri("file:///src/index.ts"))

--- a/internal/project/projectcollectionbuilder_test.go
+++ b/internal/project/projectcollectionbuilder_test.go
@@ -603,7 +603,7 @@ func TestProjectCollectionBuilder(t *testing.T) {
 			"imports": {
 				"#utils": "./src/nonexistent.ts"
 			}
-		}`, false)
+		}`)
 		assert.NilError(t, err)
 		session.DidChangeWatchedFiles(context.Background(), []*lsproto.FileEvent{
 			{

--- a/internal/project/projectlifetime_test.go
+++ b/internal/project/projectlifetime_test.go
@@ -245,7 +245,7 @@ func TestProjectLifetime(t *testing.T) {
 		assert.Assert(t, snapshot.ProjectCollection.ConfiguredProject(tspath.Path("/home/projects/ts/p1/tsconfig.json")) == nil)
 
 		// Simulate file move: create src/index.ts on disk
-		err := utils.FS().WriteFile("/home/projects/TS/p1/src/index.ts", files["/home/projects/TS/p1/index.ts"].(string), false)
+		err := utils.FS().WriteFile("/home/projects/TS/p1/src/index.ts", files["/home/projects/TS/p1/index.ts"].(string))
 		assert.NilError(t, err)
 		err = utils.FS().Remove("/home/projects/TS/p1/index.ts")
 		assert.NilError(t, err)
@@ -316,7 +316,7 @@ func TestProjectLifetime(t *testing.T) {
 
 		// Simulate tsconfig.json move: create tsconfig.json at parent level, delete from src/
 		tsconfigContent := files["/home/projects/TS/p1/src/tsconfig.json"].(string)
-		err := utils.FS().WriteFile("/home/projects/TS/p1/tsconfig.json", tsconfigContent, false)
+		err := utils.FS().WriteFile("/home/projects/TS/p1/tsconfig.json", tsconfigContent)
 		assert.NilError(t, err)
 		err = utils.FS().Remove("/home/projects/TS/p1/src/tsconfig.json")
 		assert.NilError(t, err)
@@ -385,7 +385,7 @@ func TestProjectLifetime(t *testing.T) {
 		// - Create a new file y.ts on disk
 		err = utils.FS().Remove("/home/projects/TS/p1/src/x.ts")
 		assert.NilError(t, err)
-		err = utils.FS().WriteFile("/home/projects/TS/p1/src/y.ts", `export const y = 2;`, false)
+		err = utils.FS().WriteFile("/home/projects/TS/p1/src/y.ts", `export const y = 2;`)
 		assert.NilError(t, err)
 
 		// Send both events in a single batch

--- a/internal/project/projectreferencesprogram_test.go
+++ b/internal/project/projectreferencesprogram_test.go
@@ -281,7 +281,7 @@ func TestProjectReferencesProgram(t *testing.T) {
 		assert.Equal(t, len(snapshot.ProjectCollection.Projects()), 1)
 		programBefore := snapshot.ProjectCollection.Projects()[0].Program
 
-		err := utils.FS().WriteFile("/user/username/projects/myproject/dependency/fns2.ts", `export const x = 2;`, false)
+		err := utils.FS().WriteFile("/user/username/projects/myproject/dependency/fns2.ts", `export const x = 2;`)
 		assert.NilError(t, err)
 		session.DidChangeWatchedFiles(context.Background(), []*lsproto.FileEvent{
 			{

--- a/internal/project/session_test.go
+++ b/internal/project/session_test.go
@@ -278,7 +278,7 @@ func TestSession(t *testing.T) {
 					"strict": true
 				},
 				"include": ["./**/*"]
-			}`, false)
+			}`)
 			assert.NilError(t, err)
 
 			session.DidChangeWatchedFiles(context.Background(), []*lsproto.FileEvent{
@@ -315,7 +315,7 @@ func TestSession(t *testing.T) {
 				program := ls.GetProgram()
 				assert.Check(t, program.GetSourceFile("/home/projects/TS/p1/src/x.ts") == nil)
 
-				err = utils.FS().WriteFile("/home/projects/TS/p1/src/x.ts", "", false)
+				err = utils.FS().WriteFile("/home/projects/TS/p1/src/x.ts", "")
 				assert.NilError(t, err)
 
 				session.DidOpenFile(context.Background(), "file:///home/projects/TS/p1/src/x.ts", 1, "", lsproto.LanguageKindTypeScript)
@@ -349,7 +349,7 @@ func TestSession(t *testing.T) {
 				program := ls.GetProgram()
 				assert.Check(t, program.GetSourceFile("/home/projects/TS/p1/src/x.ts") == nil)
 
-				err = utils.FS().WriteFile("/home/projects/TS/p1/src/x.ts", "", false)
+				err = utils.FS().WriteFile("/home/projects/TS/p1/src/x.ts", "")
 				assert.NilError(t, err)
 
 				session.DidOpenFile(context.Background(), "file:///home/projects/TS/p1/src/x.ts", 1, "", lsproto.LanguageKindTypeScript)
@@ -524,7 +524,7 @@ func TestSession(t *testing.T) {
 			assert.NilError(t, err)
 			programBefore := lsBefore.GetProgram()
 
-			err = utils.FS().WriteFile("/home/projects/TS/p1/src/x.ts", `export const x = 2;`, false)
+			err = utils.FS().WriteFile("/home/projects/TS/p1/src/x.ts", `export const x = 2;`)
 			assert.NilError(t, err)
 
 			session.DidChangeWatchedFiles(context.Background(), []*lsproto.FileEvent{
@@ -551,7 +551,7 @@ func TestSession(t *testing.T) {
 			assert.NilError(t, err)
 			programBefore := lsBefore.GetProgram()
 
-			err = utils.FS().WriteFile("/home/projects/TS/p1/src/x.ts", `export const x = 2;`, false)
+			err = utils.FS().WriteFile("/home/projects/TS/p1/src/x.ts", `export const x = 2;`)
 			assert.NilError(t, err)
 
 			session.DidChangeWatchedFiles(context.Background(), []*lsproto.FileEvent{
@@ -610,7 +610,7 @@ func TestSession(t *testing.T) {
 					}
 					assert.Check(t, xWatched)
 
-					err = utils.FS().WriteFile("/home/projects/TS/x.ts", `export const x = 2;`, false)
+					err = utils.FS().WriteFile("/home/projects/TS/x.ts", `export const x = 2;`)
 					assert.NilError(t, err)
 
 					session.DidChangeWatchedFiles(context.Background(), []*lsproto.FileEvent{
@@ -655,7 +655,7 @@ func TestSession(t *testing.T) {
 					"noLib": false,
 					"strict": true
 				}
-			}`, false)
+			}`)
 			assert.NilError(t, err)
 
 			session.DidChangeWatchedFiles(context.Background(), []*lsproto.FileEvent{
@@ -784,7 +784,7 @@ func TestSession(t *testing.T) {
 			assert.Equal(t, len(program.GetSemanticDiagnostics(projecttestutil.WithRequestID(t.Context()), program.GetSourceFile("/home/projects/TS/p1/src/index.ts"))), 1)
 
 			// Add the missing file
-			err = utils.FS().WriteFile("/home/projects/TS/p1/src/y.ts", `export const y = 1;`, false)
+			err = utils.FS().WriteFile("/home/projects/TS/p1/src/y.ts", `export const y = 1;`)
 			assert.NilError(t, err)
 
 			session.DidChangeWatchedFiles(context.Background(), []*lsproto.FileEvent{
@@ -824,7 +824,7 @@ func TestSession(t *testing.T) {
 			assert.Equal(t, len(program.GetSemanticDiagnostics(projecttestutil.WithRequestID(t.Context()), program.GetSourceFile("/home/projects/TS/p1/src/index.ts"))), 1)
 
 			// Add a new file through failed lookup watch
-			err = utils.FS().WriteFile("/home/projects/TS/p1/src/z.ts", `export const z = 1;`, false)
+			err = utils.FS().WriteFile("/home/projects/TS/p1/src/z.ts", `export const z = 1;`)
 			assert.NilError(t, err)
 
 			session.DidChangeWatchedFiles(context.Background(), []*lsproto.FileEvent{
@@ -864,7 +864,7 @@ func TestSession(t *testing.T) {
 			assert.Equal(t, len(program.GetSemanticDiagnostics(projecttestutil.WithRequestID(t.Context()), program.GetSourceFile("/home/projects/TS/p1/src/index.ts"))), 1)
 
 			// Add a new file through wildcard watch
-			err = utils.FS().WriteFile("/home/projects/TS/p1/src/a.ts", `const a = 1;`, false)
+			err = utils.FS().WriteFile("/home/projects/TS/p1/src/a.ts", `const a = 1;`)
 			assert.NilError(t, err)
 
 			session.DidChangeWatchedFiles(context.Background(), []*lsproto.FileEvent{

--- a/internal/project/snapshotfs.go
+++ b/internal/project/snapshotfs.go
@@ -470,7 +470,7 @@ func (fs *sourceFS) WalkDir(root string, walkFn vfs.WalkDirFunc) error {
 }
 
 // WriteFile implements vfs.FS.
-func (fs *sourceFS) WriteFile(path string, data string, writeByteOrderMark bool) error {
+func (fs *sourceFS) WriteFile(path string, data string) error {
 	panic("unimplemented")
 }
 

--- a/internal/stringutil/util.go
+++ b/internal/stringutil/util.go
@@ -202,17 +202,10 @@ func RemoveByteOrderMark(text string) string {
 }
 
 func AddUTF8ByteOrderMark(text string) string {
-	if bom := GetUTF8ByteOrderMark(text); bom != "" {
-		return bom + text
+	if getByteOrderMarkLength(text) == 0 {
+		return "\xEF\xBB\xBF" + text
 	}
 	return text
-}
-
-func GetUTF8ByteOrderMark(text string) string {
-	if getByteOrderMarkLength(text) == 0 {
-		return "\xEF\xBB\xBF"
-	}
-	return ""
 }
 
 func StripQuotes(name string) string {

--- a/internal/testutil/harnessutil/recorderfs.go
+++ b/internal/testutil/harnessutil/recorderfs.go
@@ -4,7 +4,6 @@ import (
 	"slices"
 	"sync"
 
-	"github.com/microsoft/typescript-go/internal/stringutil"
 	"github.com/microsoft/typescript-go/internal/vfs"
 )
 
@@ -19,14 +18,11 @@ func NewOutputRecorderFS(fs vfs.FS) vfs.FS {
 	return &OutputRecorderFS{FS: fs}
 }
 
-func (fs *OutputRecorderFS) WriteFile(path string, data string, writeByteOrderMark bool) error {
-	if err := fs.FS.WriteFile(path, data, writeByteOrderMark); err != nil {
+func (fs *OutputRecorderFS) WriteFile(path string, data string) error {
+	if err := fs.FS.WriteFile(path, data); err != nil {
 		return err
 	}
 	path = fs.Realpath(path)
-	if writeByteOrderMark {
-		data = stringutil.AddUTF8ByteOrderMark(data)
-	}
 	fs.outputsMut.Lock()
 	defer fs.outputsMut.Unlock()
 	if index, ok := fs.outputsMap[path]; ok {

--- a/internal/testutil/projecttestutil/projecttestutil.go
+++ b/internal/testutil/projecttestutil/projecttestutil.go
@@ -74,7 +74,7 @@ func (h *SessionUtils) SetupNpmExecutorForTypingsInstaller() {
 
 		if lenNpmInstallArgs == 3 && npmInstallArgs[2] == "types-registry@latest" {
 			// Write typings file
-			err := h.fs.WriteFile(cwd+"/node_modules/types-registry/index.json", h.createTypesRegistryFileContent(), false)
+			err := h.fs.WriteFile(cwd+"/node_modules/types-registry/index.json", h.createTypesRegistryFileContent())
 			return nil, err
 		}
 
@@ -100,7 +100,7 @@ func (h *SessionUtils) SetupNpmExecutorForTypingsInstaller() {
 			if !ok {
 				return nil, fmt.Errorf("content not provided for %s", packageBaseName)
 			}
-			err := h.fs.WriteFile(cwd+"/node_modules/@types/"+packageBaseName+"/index.d.ts", content, false)
+			err := h.fs.WriteFile(cwd+"/node_modules/@types/"+packageBaseName+"/index.d.ts", content)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/vfs/cachedvfs/cachedvfs.go
+++ b/internal/vfs/cachedvfs/cachedvfs.go
@@ -145,6 +145,6 @@ func (fsys *FS) WalkDir(root string, walkFn vfs.WalkDirFunc) error {
 	return fsys.fs.WalkDir(root, walkFn)
 }
 
-func (fsys *FS) WriteFile(path string, data string, writeByteOrderMark bool) error {
-	return fsys.fs.WriteFile(path, data, writeByteOrderMark)
+func (fsys *FS) WriteFile(path string, data string) error {
+	return fsys.fs.WriteFile(path, data)
 }

--- a/internal/vfs/cachedvfs/cachedvfs_test.go
+++ b/internal/vfs/cachedvfs/cachedvfs_test.go
@@ -320,32 +320,31 @@ func TestWriteFile(t *testing.T) {
 	underlying := createMockFS()
 	cached := cachedvfs.From(underlying)
 
-	_ = cached.WriteFile("/some/path/file.txt", "new content", false)
+	_ = cached.WriteFile("/some/path/file.txt", "new content")
 	assert.Equal(t, 1, len(underlying.WriteFileCalls()))
 
-	_ = cached.WriteFile("/some/path/file.txt", "another content", true)
+	_ = cached.WriteFile("/some/path/file.txt", "another content")
 	assert.Equal(t, 2, len(underlying.WriteFileCalls()))
 
 	cached.ClearCache()
-	_ = cached.WriteFile("/some/path/file.txt", "third content", false)
+	_ = cached.WriteFile("/some/path/file.txt", "third content")
 	assert.Equal(t, 3, len(underlying.WriteFileCalls()))
 
 	call := underlying.WriteFileCalls()[2]
 	assert.Equal(t, "/some/path/file.txt", call.Path)
 	assert.Equal(t, "third content", call.Data)
-	assert.Equal(t, false, call.WriteByteOrderMark)
 
 	cached.DisableAndClearCache()
-	_ = cached.WriteFile("/some/path/file.txt", "fourth content", false)
+	_ = cached.WriteFile("/some/path/file.txt", "fourth content")
 	assert.Equal(t, 4, len(underlying.WriteFileCalls()))
 
-	_ = cached.WriteFile("/some/path/file.txt", "fifth content", true)
+	_ = cached.WriteFile("/some/path/file.txt", "fifth content")
 	assert.Equal(t, 5, len(underlying.WriteFileCalls()))
 
 	cached.Enable()
-	_ = cached.WriteFile("/some/path/file.txt", "sixth content", false)
+	_ = cached.WriteFile("/some/path/file.txt", "sixth content")
 	assert.Equal(t, 6, len(underlying.WriteFileCalls()))
 
-	_ = cached.WriteFile("/some/path/file.txt", "seventh content", true)
+	_ = cached.WriteFile("/some/path/file.txt", "seventh content")
 	assert.Equal(t, 7, len(underlying.WriteFileCalls()))
 }

--- a/internal/vfs/iovfs/iofs.go
+++ b/internal/vfs/iovfs/iofs.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/microsoft/typescript-go/internal/stringutil"
 	"github.com/microsoft/typescript-go/internal/tspath"
 	"github.com/microsoft/typescript-go/internal/vfs"
 	"github.com/microsoft/typescript-go/internal/vfs/internal"
@@ -60,19 +59,13 @@ func From(fsys fs.FS, useCaseSensitiveFileNames bool) FsWithSys {
 		}
 	}
 
-	var writeFile func(path string, content string, writeByteOrderMark bool) error
+	var writeFile func(path string, content string) error
 	var mkdirAll func(path string) error
 	var remove func(path string) error
 	var chtimes func(path string, aTime time.Time, mTime time.Time) error
 	if fsys, ok := fsys.(WritableFS); ok {
-		writeFile = func(path string, content string, writeByteOrderMark bool) error {
+		writeFile = func(path string, content string) error {
 			rest, _ := strings.CutPrefix(path, "/")
-			if writeByteOrderMark {
-				// Strada uses \uFEFF because NodeJS requires it, but substitutes it with the correct BOM based on the
-				// output encoding. \uFEFF is actually the BOM for big-endian UTF-16. For UTF-8 the actual BOM is
-				// \xEF\xBB\xBF.
-				content = stringutil.AddUTF8ByteOrderMark(content)
-			}
 			return fsys.WriteFile(rest, content, 0o666)
 		}
 		mkdirAll = func(path string) error {
@@ -88,7 +81,7 @@ func From(fsys fs.FS, useCaseSensitiveFileNames bool) FsWithSys {
 			return fsys.Chtimes(rest, aTime, mTime)
 		}
 	} else {
-		writeFile = func(string, string, bool) error {
+		writeFile = func(string, string) error {
 			panic("writeFile not supported")
 		}
 		mkdirAll = func(string) error {
@@ -135,7 +128,7 @@ type ioFS struct {
 
 	useCaseSensitiveFileNames bool
 	realpath                  func(path string) (string, error)
-	writeFile                 func(path string, content string, writeByteOrderMark bool) error
+	writeFile                 func(path string, content string) error
 	mkdirAll                  func(path string) error
 	remove                    func(path string) error
 	chtimes                   func(path string, aTime time.Time, mTime time.Time) error
@@ -194,15 +187,15 @@ func (vfs *ioFS) Realpath(path string) string {
 	return realpath
 }
 
-func (vfs *ioFS) WriteFile(path string, content string, writeByteOrderMark bool) error {
+func (vfs *ioFS) WriteFile(path string, content string) error {
 	_ = internal.RootLength(path) // Assert path is rooted
-	if err := vfs.writeFile(path, content, writeByteOrderMark); err == nil {
+	if err := vfs.writeFile(path, content); err == nil {
 		return nil
 	}
 	if err := vfs.mkdirAll(tspath.GetDirectoryPath(tspath.NormalizePath(path))); err != nil {
 		return err
 	}
-	return vfs.writeFile(path, content, writeByteOrderMark)
+	return vfs.writeFile(path, content)
 }
 
 func (vfs *ioFS) FSys() fs.FS {

--- a/internal/vfs/osvfs/os.go
+++ b/internal/vfs/osvfs/os.go
@@ -10,7 +10,6 @@ import (
 	"unicode"
 
 	"github.com/microsoft/typescript-go/internal/core"
-	"github.com/microsoft/typescript-go/internal/stringutil"
 	"github.com/microsoft/typescript-go/internal/tspath"
 	"github.com/microsoft/typescript-go/internal/vfs"
 	"github.com/microsoft/typescript-go/internal/vfs/internal"
@@ -131,7 +130,7 @@ func osFSRealpath(path string) string {
 
 var writeSema = make(chan struct{}, 32)
 
-func (vfs *osFS) writeFile(path string, content string, writeByteOrderMark bool) error {
+func (vfs *osFS) writeFile(path string, content string) error {
 	writeSema <- struct{}{}
 	defer func() { <-writeSema }()
 
@@ -140,14 +139,6 @@ func (vfs *osFS) writeFile(path string, content string, writeByteOrderMark bool)
 		return err
 	}
 	defer file.Close()
-
-	if writeByteOrderMark {
-		if bom := stringutil.GetUTF8ByteOrderMark(content); bom != "" {
-			if _, err := file.WriteString(bom); err != nil {
-				return err
-			}
-		}
-	}
 
 	if _, err := file.WriteString(content); err != nil {
 		return err
@@ -160,15 +151,15 @@ func (vfs *osFS) ensureDirectoryExists(directoryPath string) error {
 	return os.MkdirAll(directoryPath, 0o777)
 }
 
-func (vfs *osFS) WriteFile(path string, content string, writeByteOrderMark bool) error {
+func (vfs *osFS) WriteFile(path string, content string) error {
 	_ = internal.RootLength(path) // Assert path is rooted
-	if err := vfs.writeFile(path, content, writeByteOrderMark); err == nil {
+	if err := vfs.writeFile(path, content); err == nil {
 		return nil
 	}
 	if err := vfs.ensureDirectoryExists(tspath.GetDirectoryPath(tspath.NormalizePath(path))); err != nil {
 		return err
 	}
-	return vfs.writeFile(path, content, writeByteOrderMark)
+	return vfs.writeFile(path, content)
 }
 
 func (vfs *osFS) Remove(path string) error {

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -20,7 +20,7 @@ type FS interface {
 	// If the file fails to be read, ok will be false.
 	ReadFile(path string) (contents string, ok bool)
 
-	WriteFile(path string, data string, writeByteOrderMark bool) error
+	WriteFile(path string, data string) error
 
 	// Removes `path` and all its contents. Will return the first error it encounters.
 	Remove(path string) error

--- a/internal/vfs/vfs_test.go
+++ b/internal/vfs/vfs_test.go
@@ -24,7 +24,7 @@ func BenchmarkReadFile(b *testing.B) {
 	const smallData = "hello, world"
 	tmpdir := tspath.NormalizeSlashes(b.TempDir())
 	osSmallDataPath := tspath.CombinePaths(tmpdir, "foo.ts")
-	err := osFS.WriteFile(osSmallDataPath, smallData, false)
+	err := osFS.WriteFile(osSmallDataPath, smallData)
 	assert.NilError(b, err)
 
 	tests := []bench{

--- a/internal/vfs/vfsmock/mock_generated.go
+++ b/internal/vfs/vfsmock/mock_generated.go
@@ -50,7 +50,7 @@ var _ vfs.FS = &FSMock{}
 //			WalkDirFunc: func(root string, walkFn vfs.WalkDirFunc) error {
 //				panic("mock out the WalkDir method")
 //			},
-//			WriteFileFunc: func(path string, data string, writeByteOrderMark bool) error {
+//			WriteFileFunc: func(path string, data string) error {
 //				panic("mock out the WriteFile method")
 //			},
 //		}
@@ -91,7 +91,7 @@ type FSMock struct {
 	WalkDirFunc func(root string, walkFn vfs.WalkDirFunc) error
 
 	// WriteFileFunc mocks the WriteFile method.
-	WriteFileFunc func(path string, data string, writeByteOrderMark bool) error
+	WriteFileFunc func(path string, data string) error
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -154,8 +154,6 @@ type FSMock struct {
 			Path string
 			// Data is the data argument value.
 			Data string
-			// WriteByteOrderMark is the writeByteOrderMark argument value.
-			WriteByteOrderMark bool
 		}
 	}
 	lockChtimes                   sync.RWMutex
@@ -496,23 +494,21 @@ func (mock *FSMock) WalkDirCalls() []struct {
 }
 
 // WriteFile calls WriteFileFunc.
-func (mock *FSMock) WriteFile(path string, data string, writeByteOrderMark bool) error {
+func (mock *FSMock) WriteFile(path string, data string) error {
 	if mock.WriteFileFunc == nil {
 		panic("FSMock.WriteFileFunc: method is nil but FS.WriteFile was just called")
 	}
 	callInfo := struct {
-		Path               string
-		Data               string
-		WriteByteOrderMark bool
+		Path string
+		Data string
 	}{
-		Path:               path,
-		Data:               data,
-		WriteByteOrderMark: writeByteOrderMark,
+		Path: path,
+		Data: data,
 	}
 	mock.lockWriteFile.Lock()
 	mock.calls.WriteFile = append(mock.calls.WriteFile, callInfo)
 	mock.lockWriteFile.Unlock()
-	return mock.WriteFileFunc(path, data, writeByteOrderMark)
+	return mock.WriteFileFunc(path, data)
 }
 
 // WriteFileCalls gets all the calls that were made to WriteFile.
@@ -520,14 +516,12 @@ func (mock *FSMock) WriteFile(path string, data string, writeByteOrderMark bool)
 //
 //	len(mockedFS.WriteFileCalls())
 func (mock *FSMock) WriteFileCalls() []struct {
-	Path               string
-	Data               string
-	WriteByteOrderMark bool
+	Path string
+	Data string
 } {
 	var calls []struct {
-		Path               string
-		Data               string
-		WriteByteOrderMark bool
+		Path string
+		Data string
 	}
 	mock.lockWriteFile.RLock()
 	calls = mock.calls.WriteFile

--- a/internal/vfs/vfstest/vfstest_test.go
+++ b/internal/vfs/vfstest/vfstest_test.go
@@ -202,21 +202,21 @@ func TestWritableFS(t *testing.T) {
 
 	fs := FromMap[any](nil, false)
 
-	err := fs.WriteFile("/foo/bar/baz", "hello, world", false)
+	err := fs.WriteFile("/foo/bar/baz", "hello, world")
 	assert.NilError(t, err)
 
 	content, ok := fs.ReadFile("/foo/bar/baz")
 	assert.Assert(t, ok)
 	assert.Equal(t, content, "hello, world")
 
-	err = fs.WriteFile("/foo/bar/baz", "goodbye, world", false)
+	err = fs.WriteFile("/foo/bar/baz", "goodbye, world")
 	assert.NilError(t, err)
 
 	content, ok = fs.ReadFile("/foo/bar/baz")
 	assert.Assert(t, ok)
 	assert.Equal(t, content, "goodbye, world")
 
-	err = fs.WriteFile("/foo/bar/baz/oops", "goodbye, world", false)
+	err = fs.WriteFile("/foo/bar/baz/oops", "goodbye, world")
 	assert.ErrorContains(t, err, `mkdir "foo/bar/baz": path exists but is not a directory`)
 }
 
@@ -224,13 +224,13 @@ func TestWritableFSDelete(t *testing.T) {
 	t.Parallel()
 	fs := FromMap[any](nil, false)
 
-	_ = fs.WriteFile("/foo/bar/file.ts", "remove", false)
+	_ = fs.WriteFile("/foo/bar/file.ts", "remove")
 	assert.Assert(t, fs.FileExists("/foo/bar/file.ts"))
 	err := fs.Remove("/foo/bar/file.ts")
 	assert.NilError(t, err)
 	assert.Assert(t, !fs.FileExists("/foo/bar/file.ts"))
 
-	_ = fs.WriteFile("/foo/bar/test/remove2.ts", "remove2", false)
+	_ = fs.WriteFile("/foo/bar/test/remove2.ts", "remove2")
 	assert.Assert(t, fs.DirectoryExists("/foo/bar/test"))
 	err = fs.Remove("/foo/bar/test")
 	assert.NilError(t, err)
@@ -243,7 +243,7 @@ func TestWritableFSDelete(t *testing.T) {
 	err = fs.Remove("/foo/bar/file.ts")
 	assert.NilError(t, err)
 
-	_ = fs.WriteFile("/foo/barbar", "remove2", false)
+	_ = fs.WriteFile("/foo/barbar", "remove2")
 	_ = fs.Remove("/foo/bar")
 	assert.Assert(t, fs.FileExists("/foo/barbar"))
 }
@@ -254,7 +254,7 @@ func TestStress(t *testing.T) {
 	fs := FromMap[any](nil, false)
 
 	ops := []func(){
-		func() { _ = fs.WriteFile("/foo/bar/baz.txt", "hello, world", false) },
+		func() { _ = fs.WriteFile("/foo/bar/baz.txt", "hello, world") },
 		func() { fs.ReadFile("/foo/bar/baz.txt") },
 		func() { fs.DirectoryExists("/foo/bar") },
 		func() { fs.FileExists("/foo/bar") },
@@ -617,7 +617,7 @@ func TestWritableFSSymlink(t *testing.T) {
 		"/d/existing.ts":     "hello, world",
 	}, false)
 
-	err := fs.WriteFile("/some/dirlink/file.ts", "hello, world", false)
+	err := fs.WriteFile("/some/dirlink/file.ts", "hello, world")
 	assert.NilError(t, err)
 
 	content, ok := fs.ReadFile("/some/dirlink/file.ts")
@@ -628,14 +628,14 @@ func TestWritableFSSymlink(t *testing.T) {
 	assert.Assert(t, ok)
 	assert.Equal(t, content, "hello, world")
 
-	err = fs.WriteFile("/some/dirlink/file.ts", "goodbye, world", false)
+	err = fs.WriteFile("/some/dirlink/file.ts", "goodbye, world")
 	assert.NilError(t, err)
 
 	content, ok = fs.ReadFile("/some/dirlink/file.ts")
 	assert.Assert(t, ok)
 	assert.Equal(t, content, "goodbye, world")
 
-	err = fs.WriteFile("/other.ts", "hello, world", false)
+	err = fs.WriteFile("/other.ts", "hello, world")
 	assert.NilError(t, err)
 
 	content, ok = fs.ReadFile("/other.ts")
@@ -646,18 +646,18 @@ func TestWritableFSSymlink(t *testing.T) {
 	assert.Assert(t, ok)
 	assert.Equal(t, content, "hello, world")
 
-	err = fs.WriteFile("/some/dirlink", "hello, world", false)
+	err = fs.WriteFile("/some/dirlink", "hello, world")
 	assert.Error(t, err, `write "some/dirlink": path exists but is not a regular file`)
 
 	// Can't write inside a broken dir symlink
-	err = fs.WriteFile("/brokenlink/file.ts", "hello, world", false)
+	err = fs.WriteFile("/brokenlink/file.ts", "hello, world")
 	assert.Error(t, err, `broken symlink "brokenlink" -> "does/not/exist"`)
 
-	err = fs.WriteFile("/brokenlink/also/wrong/file.ts", "hello, world", false)
+	err = fs.WriteFile("/brokenlink/also/wrong/file.ts", "hello, world")
 	assert.Error(t, err, `broken symlink "brokenlink" -> "does/not/exist"`)
 
 	// But we can write to a broken file symlink
-	err = fs.WriteFile("/brokenlink", "hello, world", false)
+	err = fs.WriteFile("/brokenlink", "hello, world")
 	assert.NilError(t, err)
 	content, ok = fs.ReadFile("/brokenlink")
 	assert.Assert(t, ok)
@@ -677,7 +677,7 @@ func TestWritableFSSymlinkChain(t *testing.T) {
 		"/d/existing.ts": "hello, world",
 	}, false)
 
-	err := fs.WriteFile("/a/foo/bar/new.ts", "this is new.ts", false)
+	err := fs.WriteFile("/a/foo/bar/new.ts", "this is new.ts")
 	assert.NilError(t, err)
 	content, ok := fs.ReadFile("/a/foo/bar/new.ts")
 	assert.Assert(t, ok)
@@ -700,7 +700,7 @@ func TestWritableFSSymlinkChainNotDir(t *testing.T) {
 		"/d": "hello, world",
 	}, false)
 
-	err := fs.WriteFile("/a/foo/bar/new.ts", "this is new.ts", false)
+	err := fs.WriteFile("/a/foo/bar/new.ts", "this is new.ts")
 	assert.Error(t, err, `mkdir "d": path exists but is not a directory`)
 }
 
@@ -732,7 +732,7 @@ func TestWritableFSSymlinkDelete(t *testing.T) {
 	assert.Assert(t, !fs.DirectoryExists("/c"))
 	assert.Assert(t, !fs.DirectoryExists("/d"))
 	assert.Assert(t, !fs.FileExists("/d/again.ts"))
-	err = fs.WriteFile("/d/again.ts", "d exists again", false)
+	err = fs.WriteFile("/d/again.ts", "d exists again")
 	assert.NilError(t, err)
 	assert.Assert(t, fs.DirectoryExists("/b"))
 	assert.Assert(t, fs.DirectoryExists("/c"))
@@ -745,7 +745,7 @@ func TestWritableFSSymlinkDelete(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, !fs.FileExists("/brokenlink"))
 	assert.Assert(t, !fs.DirectoryExists("/brokenlink"))
-	err = fs.WriteFile("/does/not/exist", "hello, world", false)
+	err = fs.WriteFile("/does/not/exist", "hello, world")
 	assert.NilError(t, err)
 	assert.Assert(t, fs.FileExists("/brokenlink"))
 }

--- a/internal/vfs/wrapvfs/wrapvfs.go
+++ b/internal/vfs/wrapvfs/wrapvfs.go
@@ -10,7 +10,7 @@ type Replacements struct {
 	UseCaseSensitiveFileNames func() bool
 	FileExists                func(string) bool
 	ReadFile                  func(string) (string, bool)
-	WriteFile                 func(string, string, bool) error
+	WriteFile                 func(string, string) error
 	Remove                    func(string) error
 	Chtimes                   func(string, time.Time, time.Time) error
 	DirectoryExists           func(string) bool
@@ -57,11 +57,11 @@ func (w *wrappedFS) ReadFile(path string) (contents string, ok bool) {
 }
 
 // WriteFile implements [vfs.FS].
-func (w *wrappedFS) WriteFile(path string, data string, writeByteOrderMark bool) error {
+func (w *wrappedFS) WriteFile(path string, data string) error {
 	if w.replacements.WriteFile != nil {
-		return w.replacements.WriteFile(path, data, writeByteOrderMark)
+		return w.replacements.WriteFile(path, data)
 	}
-	return w.fs.WriteFile(path, data, writeByteOrderMark)
+	return w.fs.WriteFile(path, data)
 }
 
 // Remove implements [vfs.FS].


### PR DESCRIPTION
While looking at https://github.com/microsoft/typescript-go/pull/1551, I realized that the signature could just change to accept a string. Then, reading further exposed the fact that our OS FS was not writing the correct BOM when asked.

I then contemplated why we even had `writeByteOrderMark` at all, and just decided to remove it entirely.

The reason it existed in JS was because we never directly added the BOM to written files. Instead, just before writing, we added a special string to the front and Node would automatically convert it into a BOM. Now, we don't need to do this. We can just add the BOM in the emit phase before we hand the contents to the FS (but after we generate source maps).