### PR TITLE
Fixed a rescanning crash related to `JsxNamespacedName` with dashes

### DIFF
--- a/internal/format/scanner.go
+++ b/internal/format/scanner.go
@@ -114,7 +114,8 @@ func shouldRescanJsxIdentifier(node *ast.Node) bool {
 		case ast.KindJsxAttribute,
 			ast.KindJsxOpeningElement,
 			ast.KindJsxClosingElement,
-			ast.KindJsxSelfClosingElement:
+			ast.KindJsxSelfClosingElement,
+			ast.KindJsxNamespacedName:
 			// May parse an identifier like `module-layout`; that will be scanned as a keyword at first, but we should parse the whole thing to get an identifier.
 			return ast.IsKeywordKind(node.Kind) || node.Kind == ast.KindIdentifier
 		}

--- a/internal/fourslash/tests/formatDocumentNoCrashJsxNamespacedName2_test.go
+++ b/internal/fourslash/tests/formatDocumentNoCrashJsxNamespacedName2_test.go
@@ -1,0 +1,20 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestFormatDocumentNoCrashJsxNamespacedName2(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `// @Filename: /a.tsx
+const x = <A my-ns:attr="val" />;
+`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.FormatDocument(t, "")
+	f.VerifyCurrentFileContent(t, "const x = <A my-ns:attr=\"val\" />;\n")
+}


### PR DESCRIPTION
fixes a crash found here: https://github.com/microsoft/typescript-go/issues/3012#issuecomment-4015173297 (this also crashes in Strada)