### PR TITLE
Fixed a formatting crash caused by misinterpretation of tokens in reparsed node lists

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -179,7 +179,6 @@ func cloneNode(updated *Node, original *Node, hooks NodeFactoryHooks) *Node {
 
 type NodeList struct {
 	Loc   core.TextRange
-	Flags NodeFlags
 	Nodes []*Node
 }
 

--- a/internal/format/span.go
+++ b/internal/format/span.go
@@ -447,7 +447,7 @@ func (w *formatSpanWorker) processChildNodes(
 
 	// node range is outside the target range - do not dive inside
 	if !w.originalRange.Overlaps(nodes.Loc) {
-		if nodes.End() < w.originalRange.Pos() && nodes.Flags&ast.NodeFlagsReparsed == 0 {
+		if nodes.End() < w.originalRange.Pos() && (len(nodes.Nodes) == 0 || nodes.Nodes[0].Flags&ast.NodeFlagsReparsed == 0) {
 			w.formattingScanner.skipToEndOf(&nodes.Loc)
 		}
 		return

--- a/internal/parser/reparser.go
+++ b/internal/parser/reparser.go
@@ -11,12 +11,6 @@ func (p *Parser) finishReparsedNode(node *ast.Node, locationNode *ast.Node) {
 	p.overrideParentInImmediateChildren(node)
 }
 
-func (p *Parser) newReparsedNodeList(loc core.TextRange, nodes []*ast.Node) *ast.NodeList {
-	list := p.newNodeList(loc, nodes)
-	list.Flags = ast.NodeFlagsReparsed
-	return list
-}
-
 func (p *Parser) finishMutatedNode(node *ast.Node) {
 	p.overrideParentInImmediateChildren(node)
 }
@@ -195,7 +189,7 @@ func (p *Parser) reparseJSDocSignature(jsSignature *ast.Node, fun *ast.Node, jsD
 		parameters = append(parameters, parameter)
 		p.reparseJSDocComment(parameter, param)
 	}
-	signature.FunctionLikeData().Parameters = p.newReparsedNodeList(jsSignature.AsJSDocSignature().Parameters.Loc, parameters)
+	signature.FunctionLikeData().Parameters = p.newNodeList(jsSignature.AsJSDocSignature().Parameters.Loc, parameters)
 
 	if jsSignature.Type() != nil && jsSignature.Type().TypeExpression() != nil {
 		signature.FunctionLikeData().Type = p.addDeepCloneReparse(jsSignature.Type().TypeExpression().Type())
@@ -230,7 +224,7 @@ func (p *Parser) reparseJSDocTypeLiteral(t *ast.TypeNode) *ast.Node {
 			properties = append(properties, property)
 			p.reparseJSDocComment(property, prop)
 		}
-		t = p.factory.NewTypeLiteralNode(p.newReparsedNodeList(jstypeliteral.Loc, properties))
+		t = p.factory.NewTypeLiteralNode(p.newNodeList(jstypeliteral.Loc, properties))
 		if isArrayType {
 			p.finishReparsedNode(t, jstypeliteral.AsNode())
 			t = p.factory.NewArrayTypeNode(t)
@@ -306,7 +300,7 @@ func (p *Parser) gatherTypeParameters(j *ast.Node, tagWithTypeParameters *ast.No
 	if len(typeParameters) == 0 {
 		return nil
 	} else {
-		return p.newReparsedNodeList(core.NewTextRange(pos, endPos), typeParameters)
+		return p.newNodeList(core.NewTextRange(pos, endPos), typeParameters)
 	}
 }
 
@@ -535,13 +529,13 @@ func (p *Parser) reparseHosted(tag *ast.Node, parent *ast.Node, jsDoc *ast.Node)
 					return
 				}
 			}
-			typesList := p.newReparsedNodeList(implementsTag.ClassName.Loc, p.nodeSlicePool.NewSlice1(p.addDeepCloneReparse(implementsTag.ClassName)))
+			typesList := p.newNodeList(implementsTag.ClassName.Loc, p.nodeSlicePool.NewSlice1(p.addDeepCloneReparse(implementsTag.ClassName)))
 
 			heritageClause := p.factory.NewHeritageClause(ast.KindImplementsKeyword, typesList)
 			p.finishReparsedNode(heritageClause, implementsTag.ClassName)
 
 			if class.HeritageClauses == nil {
-				heritageClauses := p.newReparsedNodeList(implementsTag.ClassName.Loc, p.nodeSlicePool.NewSlice1(heritageClause))
+				heritageClauses := p.newNodeList(implementsTag.ClassName.Loc, p.nodeSlicePool.NewSlice1(heritageClause))
 				class.HeritageClauses = heritageClauses
 			} else {
 				class.HeritageClauses.Nodes = append(class.HeritageClauses.Nodes, heritageClause)
@@ -561,7 +555,7 @@ func (p *Parser) reparseHosted(tag *ast.Node, parent *ast.Node, jsDoc *ast.Node)
 						for i, arg := range source.TypeArguments.Nodes {
 							newArguments[i] = p.addDeepCloneReparse(arg)
 						}
-						target.TypeArguments = p.newReparsedNodeList(source.TypeArguments.Loc, newArguments)
+						target.TypeArguments = p.newNodeList(source.TypeArguments.Loc, newArguments)
 						p.finishMutatedNode(target.AsNode())
 					}
 				}


### PR DESCRIPTION
fixes the crash reported here: https://github.com/microsoft/typescript-go/issues/3025#issuecomment-4020210407