### PR TITLE
Set GODEBUG=tracebackancestors in testing

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -531,7 +531,7 @@ function goTestFlags(taskName) {
 
 function getGODEBUG() {
     const key = "tracebackancestors";
-    const setting = `${key}=5`;
+    const setting = `${key}=10`;
     const existing = process.env.GODEBUG ?? "";
     if (!existing) return setting;
     if (existing.includes(`${key}=`)) return existing;


### PR DESCRIPTION
This GODEBUG option has the runtime record the current stack trace each time a goroutine starts, producing a better stack trace.

For example, in #3058, CI says:

```
panic: program not found in counter

goroutine 19771 [running]:
github.com/microsoft/typescript-go/internal/project.(*programCounter).Deref(0x3a80d8084de0, 0x3a80d63a7b08)
<snip>
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 19769
	/Users/runner/go/pkg/mod/golang.org/x/sync@v0.19.0/errgroup/errgroup.go:78 +0x90
```


But, if you set `tracebackancestors` higher, you get:

```
goroutine 3965858 [running]:
github.com/microsoft/typescript-go/internal/project.(*programCounter).Deref(0xf815248f770, 0xf8155274488)
        /home/jabaile/work/TypeScript-go/internal/project/programcounter.go:28 +0x150
<snip>
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 3964288
        /home/jabaile/go/pkg/mod/golang.org/x/sync@v0.19.0/errgroup/errgroup.go:78 +0x95
[originating from goroutine 3964288]:
golang.org/x/sync/errgroup.(*Group).Go(...)
        /home/jabaile/go/pkg/mod/golang.org/x/sync@v0.19.0/errgroup/errgroup.go:102 +0x95
<snip>
created by golang.org/x/sync/errgroup.(*Group).Go
        /home/jabaile/go/pkg/mod/golang.org/x/sync@v0.19.0/errgroup/errgroup.go:78 +0x95
[originating from goroutine 3926176]:
golang.org/x/sync/errgroup.(*Group).Go(...)
        /home/jabaile/go/pkg/mod/golang.org/x/sync@v0.19.0/errgroup/errgroup.go:102 +0x95
<snip>
github.com/microsoft/typescript-go/internal/fourslash/tests/manual_test.TestPathCompletionsPackageJsonImportsWildcard2(...)
        /home/jabaile/work/TypeScript-go/internal/fourslash/tests/manual/pathCompletionsPackageJsonImportsWildcard2_test.go:32 +0x7f
testing.tRunner(...)
```

Which actually says which test did it!

There's a runtime cost to this, paid on every `go` statement. In my testing, I couldn't measure much difference.