### PR TITLE
Fixing encoder/decoder bugs

### DIFF
--- a/internal/api/encoder/decoder.go
+++ b/internal/api/encoder/decoder.go
@@ -1164,7 +1164,7 @@ func (d *astDecoder) createChildrenNode(kind ast.Kind, data uint32, childIndices
 		return d.factory.NewBlock(stmts, multiline), nil
 
 	case ast.KindVariableDeclarationList:
-		flags := ast.NodeFlags(definedBits) << 24
+		flags := ast.NodeFlags(definedBits)
 		var decls *ast.NodeList
 		if len(childIndices) > 0 {
 			decls = d.nodeListAt(childIndices[0])
@@ -1333,6 +1333,10 @@ func (d *astDecoder) createChildrenNode(kind ast.Kind, data uint32, childIndices
 		ast.KindNeverKeyword,
 		ast.KindIntrinsicKeyword:
 		return d.factory.NewKeywordTypeNode(kind), nil
+
+	// Keyword expressions (must be KeywordExpression, not Token, for the printer)
+	case ast.KindThisKeyword, ast.KindSuperKeyword, ast.KindImportKeyword:
+		return d.factory.NewKeywordExpression(kind), nil
 
 	// Token/keyword nodes with no children
 	default:

--- a/internal/api/encoder/decoder_test.go
+++ b/internal/api/encoder/decoder_test.go
@@ -72,6 +72,36 @@ func TestDecodeSourceFile_VariableDeclaration(t *testing.T) {
 	assert.Equal(t, decl.Initializer.AsNumericLiteral().Text, "1")
 }
 
+func TestDecodeSourceFile_VariableDeclarationListFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		code     string
+		expected ast.NodeFlags
+	}{
+		{"const", "const x = 1;", ast.NodeFlagsConst},
+		{"let", "let x = 1;", ast.NodeFlagsLet},
+		{"var", "var x = 1;", ast.NodeFlagsNone},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sf := parseSourceFile(tt.code)
+			buf, err := encoder.EncodeSourceFile(sf)
+			assert.NilError(t, err)
+
+			decoded, err := encoder.DecodeSourceFile(buf)
+			assert.NilError(t, err)
+
+			declList := decoded.Statements.Nodes[0].AsVariableStatement().DeclarationList.AsVariableDeclarationList()
+			got := declList.Flags & (ast.NodeFlagsLet | ast.NodeFlagsConst)
+			assert.Equal(t, got, tt.expected, "flags for %q: got %d, want %d", tt.code, got, tt.expected)
+		})
+	}
+}
+
 func TestDecodeSourceFile_FunctionDeclaration(t *testing.T) {
 	t.Parallel()
 	sf := parseSourceFile("function add(a: number, b: number): number { return a + b; }")
@@ -249,6 +279,24 @@ func TestDecodeSourceFile_BinaryExpression(t *testing.T) {
 	assert.Assert(t, binExpr.OperatorToken != nil)
 	assert.Equal(t, binExpr.Left.Kind, ast.KindNumericLiteral)
 	assert.Equal(t, binExpr.Right.Kind, ast.KindNumericLiteral)
+}
+
+func TestDecodeSourceFile_KeywordExpressions(t *testing.T) {
+	t.Parallel()
+	// "this" must decode as KeywordExpression, not Token, or the printer panics
+	sf := parseSourceFile("const x = this;")
+	buf, err := encoder.EncodeSourceFile(sf)
+	assert.NilError(t, err)
+
+	decoded, err := encoder.DecodeSourceFile(buf)
+	assert.NilError(t, err)
+
+	// Navigate: const x = this -> VariableStatement -> declaration -> initializer
+	decl := decoded.Statements.Nodes[0].AsVariableStatement().DeclarationList.AsVariableDeclarationList().Declarations.Nodes[0].AsVariableDeclaration()
+	thisExpr := decl.Initializer
+	assert.Equal(t, thisExpr.Kind, ast.KindThisKeyword)
+	// This would panic if decoded as Token instead of KeywordExpression
+	assert.Assert(t, thisExpr.AsKeywordExpression() != nil)
 }
 
 func BenchmarkDecodeSourceFile(b *testing.B) {

--- a/internal/api/encoder/encoder.go
+++ b/internal/api/encoder/encoder.go
@@ -918,7 +918,7 @@ func getNodeDefinedData(node *ast.Node) uint32 {
 		return uint32(boolToByte(n.ContainsOnlyTriviaWhiteSpaces)) << 24
 	case ast.KindVariableDeclarationList:
 		n := node.AsVariableDeclarationList()
-		return uint32(n.Flags & (ast.NodeFlagsLet | ast.NodeFlagsConst) << 24)
+		return (uint32(n.Flags&(ast.NodeFlagsLet|ast.NodeFlagsConst)) << 24)
 	case ast.KindImportAttributes:
 		n := node.AsImportAttributes()
 		return uint32(boolToByte(n.MultiLine))<<24 | uint32(boolToByte(n.Token == ast.KindAssertKeyword))<<25


### PR DESCRIPTION
There were 2 bugs that I came across while adding tests for extract symbol. There were fixed by copilot and here are the descriptions:

Fix binary AST decoder bugs: KeywordExpression and VariableDeclarationList flags

  Problem

  Two bugs in the Go binary AST encoder/decoder cause panics and incorrect behavior when round-tripping AST nodes through the IPC bridge (used by typeToTypeNode,
  printNode, and other JS↔Go API calls).

  1. this/super/import keywords decoded as wrong node type

  The decoder's default case creates childless nodes via NewToken(kind). However, ThisKeyword, SuperKeyword, and ImportKeyword must be created as KeywordExpression
  nodes, not Token nodes. When the printer encounters one of these and calls AsKeywordExpression(), the Go type assertion panics:

   panic: interface conversion: *ast.Node is *ast.Token, not *ast.KeywordExpression

  This is hit any time a refactoring produces code containing this, super, or import expressions that pass through the binary encode/decode path (e.g.,
  extract-constant on a callback with a this parameter type annotation).

  2. const/let flags lost on VariableDeclarationList

  The VariableDeclarationList node flags (NodeFlagsConst, NodeFlagsLet) were not properly preserved through the encode/decode round-trip, causing const declarations
  to be printed as var after decoding.

  Fix

  KeywordExpression: Added an explicit decoder case for KindThisKeyword, KindSuperKeyword, and KindImportKeyword that calls NewKeywordExpression(kind) instead of
  falling through to the default NewToken(kind) path. This mirrors the existing pattern used for KeywordTypeNode kinds.

  VariableDeclarationList flags: Encode the Let/Const node flags into the extended data field (bits 24+) so they survive the round-trip, matching how other
  boolean/flag data is encoded for nodes like JsxText and ImportAttributes.

  Tests

   - TestDecodeSourceFile_KeywordExpressions — round-trips const x = this;, verifies AsKeywordExpression() succeeds without panic
   - TestDecodeSourceFile_VariableDeclarationListFlags — round-trips const x = 1;, let x = 1;, var x = 1; and asserts correct flags on the decoded
  VariableDeclarationList

  Known remaining issue

  There is a systemic empty-NodeList encoder mask bug (not addressed in this PR) where getChildrenPropertyMask sets a bit for non-nil but empty NodeList fields (e.g.,
  Parameters on m() {}), but the visitor skips encoding empty lists. This causes subsequent children to shift to wrong slots during decode. This affects ~50+ mask
  checks in encoder.go and the JS encoder in encoder.ts, and needs a separate coordinated fix.