### PR TITLE
Drop scriptKind out of scanner entirely

### DIFF
--- a/_packages/ast/src/scanner.ts
+++ b/_packages/ast/src/scanner.ts
@@ -2,7 +2,6 @@ import { CharacterCodes } from "#enums/characterCodes";
 import { CommentDirectiveType } from "#enums/commentDirectiveType";
 import { LanguageVariant } from "#enums/languageVariant";
 import { RegularExpressionFlags } from "#enums/regularExpressionFlags";
-import { ScriptKind } from "#enums/scriptKind";
 import { ScriptTarget } from "#enums/scriptTarget";
 import { SyntaxKind } from "#enums/syntaxKind";
 import { TokenFlags } from "#enums/tokenFlags";
@@ -80,7 +79,6 @@ export interface Scanner {
     clearCommentDirectives(): void;
     setText(text: string | undefined, start?: number, length?: number): void;
     setLanguageVariant(variant: LanguageVariant): void;
-    setScriptKind(scriptKind: ScriptKind): void;
     resetTokenState(pos: number): void;
     setSkipJsDocLeadingAsterisks(skip: boolean): void;
     lookAhead<T>(callback: () => T): T;
@@ -916,8 +914,6 @@ export function createScanner(
     var commentDirectives: CommentDirective[] | undefined;
     var skipJsDocLeadingAsterisks = 0;
 
-    var scriptKind: ScriptKind = ScriptKind.Unknown;
-
     setText(text, start, length);
 
     var scanner: Scanner = {
@@ -961,7 +957,6 @@ export function createScanner(
         clearCommentDirectives,
         setText,
         setLanguageVariant,
-        setScriptKind,
         resetTokenState,
         setSkipJsDocLeadingAsterisks,
         tryScan,
@@ -2519,10 +2514,6 @@ export function createScanner(
 
     function setLanguageVariant(variant: LanguageVariant) {
         languageVariant = variant;
-    }
-
-    function setScriptKind(kind: ScriptKind) {
-        scriptKind = kind;
     }
 
     function resetTokenState(position: number) {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -247,7 +247,6 @@ func (p *Parser) initializeState(opts ast.SourceFileParseOptions, sourceText str
 	p.scanner.SetText(p.sourceText)
 	p.scanner.SetOnError(p.scanError)
 	p.scanner.SetLanguageVariant(p.languageVariant)
-	p.scanner.SetScriptKind(p.scriptKind)
 }
 
 func (p *Parser) scanError(message *diagnostics.Message, pos int, length int, args ...any) {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -214,7 +214,6 @@ type Scanner struct {
 	languageVariant core.LanguageVariant
 	onError         ErrorCallback
 	skipTrivia      bool
-	scriptKind      core.ScriptKind
 	ScannerState
 
 	containsNonASCII bool
@@ -408,10 +407,6 @@ func (s *Scanner) SetText(text string) {
 
 func (s *Scanner) SetOnError(errorCallback ErrorCallback) {
 	s.onError = errorCallback
-}
-
-func (s *Scanner) SetScriptKind(scriptKind core.ScriptKind) {
-	s.scriptKind = scriptKind
 }
 
 func (s *Scanner) SetLanguageVariant(languageVariant core.LanguageVariant) {


### PR DESCRIPTION
This isn't needed at all anymore, after we dropped JSDocParsingMode et al.