### PR TITLE
Hide skipped tests in CI too

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -556,7 +556,8 @@ const baselineTrackingEnabled = isTypeScriptSubmoduleCloned() && ![
 
 const goTestSumFlags = [
     "--format-hide-empty-pkg",
-    ...(!isCI ? ["--hide-summary", "skipped"] : []),
+    "--hide-summary",
+    "skipped",
 ];
 
 /**


### PR DESCRIPTION
I'm tired of scrolling through thousands of skipped tests to find the erroring output. Skip these in CI too. I don't think anyone has ever read the skipped list.