### PR TITLE
Preallocate symbols in getSuggestionForSymbolNameLookup

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -1696,8 +1696,7 @@ func (c *Checker) getSuggestionForSymbolNameLookup(symbols ast.SymbolTable, name
 	if symbol != nil {
 		return symbol
 	}
-	allSymbols := make([]*ast.Symbol, 0, len(symbols))
-	allSymbols = slices.AppendSeq(allSymbols, maps.Values(symbols))
+	allSymbols := slices.AppendSeq(make([]*ast.Symbol, 0, len(symbols)), maps.Values(symbols))
 	if meaning&ast.SymbolFlagsGlobalLookup != 0 {
 		for _, s := range []string{"stringString", "numberNumber", "booleanBoolean", "objectObject", "bigintBigInt", "symbolSymbol"} {
 			if _, ok := symbols[s[len(s)/2:]]; ok {


### PR DESCRIPTION
I was doing some investigation in https://github.com/oxc-project/tsgolint/issues/797 (see that issue for CPU profiles) and noticed there was a significant slowdown between our latest version (0.17) and the previous version (0.16).

One contributing factor to this slowness seemed to be the `getSuggestionForSymbolNameLookup` method, which showed up in more profile samples in the new version, essentially doubling the time spent there. I'm not sure why that is the case though, I didn't look into it too deeply.

One seemingly simple optimization would be to pre-allocate this `allSymbols` array rather than letting `slices.Collect` allocate it as initially empty and naturally re-allocate as it pushes more elements. This should at least speed up this function a little bit. I don't know the best way to benchmark this in `typescript-go` (happy to benchmark it if you have a suggestion on that), but downstream in `tsgolint` this seemed to improve the overall lint time for running a single rule alone by about 3%.

