### PR TITLE
Fixed a signature help crash related to tagged template calls

### DIFF
--- a/internal/fourslash/tests/signatureHelpMalformedTaggedTemplateNoCrash1_test.go
+++ b/internal/fourslash/tests/signatureHelpMalformedTaggedTemplateNoCrash1_test.go
@@ -1,0 +1,25 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestSignatureHelpMalformedTaggedTemplateNoCrash1(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+
+	const content = "`${1}\n/*m1*/\n// ``\n"
+
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+
+	f.GoToMarker(t, "m1")
+	f.VerifyNoSignatureHelpWithContext(t, &lsproto.SignatureHelpContext{
+		TriggerKind: lsproto.SignatureHelpTriggerKindInvoked,
+		IsRetrigger: false,
+	})
+}

--- a/internal/ls/signaturehelp.go
+++ b/internal/ls/signaturehelp.go
@@ -867,7 +867,7 @@ func getImmediatelyContainingArgumentInfo(node *ast.Node, position int, sourceFi
 		}
 
 		spanIndex := ast.IndexOfNode(templateSpan.Parent.AsTemplateExpression().TemplateSpans.Nodes, templateSpan)
-		argumentIndex := getArgumentIndexForTemplatePiece(spanIndex, templateSpan, position, sourceFile)
+		argumentIndex := getArgumentIndexForTemplatePiece(spanIndex, node, position, sourceFile)
 
 		return getArgumentListInfoForTemplate(tagExpression.AsTaggedTemplateExpression(), argumentIndex, sourceFile)
 	} else if ast.IsJsxOpeningLikeElement(parent) {


### PR DESCRIPTION
fixes a crash found here: https://github.com/microsoft/typescript-go/issues/3099#issuecomment-4064180276