### PR TITLE
fix(3140): align typeParameters grammar check with Strada

### DIFF
--- a/internal/checker/grammarchecks.go
+++ b/internal/checker/grammarchecks.go
@@ -779,9 +779,8 @@ func (c *Checker) checkGrammarArrowFunction(node *ast.Node, file *ast.SourceFile
 	typeParameters := arrowFunc.TypeParameters
 	if typeParameters != nil {
 		typeParamNodes := typeParameters.Nodes
-		if len(typeParamNodes) == 0 ||
-			len(typeParamNodes) == 1 && typeParamNodes[0].AsTypeParameter().Constraint == nil ||
-			typeParameters.HasTrailingComma() {
+		hasConstraint := len(typeParamNodes) > 0 && typeParamNodes[0].AsTypeParameter().Constraint != nil
+		if !(len(typeParamNodes) > 1 || typeParameters.HasTrailingComma() || hasConstraint) {
 			if tspath.FileExtensionIsOneOf(file.FileName(), []string{tspath.ExtensionMts, tspath.ExtensionCts}) {
 				// TODO(danielr): should we return early here?
 				c.grammarErrorOnNode(typeParameters.Nodes[0], diagnostics.This_syntax_is_reserved_in_files_with_the_mts_or_cts_extension_Add_a_trailing_comma_or_explicit_constraint)

--- a/testdata/baselines/reference/compiler/genericArrowFunctionInEsmExtensionFile.errors.txt
+++ b/testdata/baselines/reference/compiler/genericArrowFunctionInEsmExtensionFile.errors.txt
@@ -1,0 +1,15 @@
+a.mts(6,12): error TS7060: This syntax is reserved in files with the .mts or .cts extension. Add a trailing comma or explicit constraint.
+
+
+==== a.mts (1 errors) ====
+    // @see https://github.com/microsoft/TypeScript/issues/44442
+    const a = <T,>(arg: T): T => {
+      return arg;
+    };
+    
+    const b = <T>(arg: T): T => {
+               ~
+!!! error TS7060: This syntax is reserved in files with the .mts or .cts extension. Add a trailing comma or explicit constraint.
+      return arg;
+    };
+    

--- a/testdata/baselines/reference/compiler/genericArrowFunctionInEsmExtensionFile.js
+++ b/testdata/baselines/reference/compiler/genericArrowFunctionInEsmExtensionFile.js
@@ -1,0 +1,22 @@
+//// [tests/cases/compiler/genericArrowFunctionInEsmExtensionFile.ts] ////
+
+//// [a.mts]
+// @see https://github.com/microsoft/TypeScript/issues/44442
+const a = <T,>(arg: T): T => {
+  return arg;
+};
+
+const b = <T>(arg: T): T => {
+  return arg;
+};
+
+
+//// [a.mjs]
+// @see https://github.com/microsoft/TypeScript/issues/44442
+const a = (arg) => {
+    return arg;
+};
+const b = (arg) => {
+    return arg;
+};
+export {};

--- a/testdata/baselines/reference/compiler/genericArrowFunctionInEsmExtensionFile.symbols
+++ b/testdata/baselines/reference/compiler/genericArrowFunctionInEsmExtensionFile.symbols
@@ -1,0 +1,28 @@
+//// [tests/cases/compiler/genericArrowFunctionInEsmExtensionFile.ts] ////
+
+=== a.mts ===
+// @see https://github.com/microsoft/TypeScript/issues/44442
+const a = <T,>(arg: T): T => {
+>a : Symbol(a, Decl(a.mts, 1, 5))
+>T : Symbol(T, Decl(a.mts, 1, 11))
+>arg : Symbol(arg, Decl(a.mts, 1, 15))
+>T : Symbol(T, Decl(a.mts, 1, 11))
+>T : Symbol(T, Decl(a.mts, 1, 11))
+
+  return arg;
+>arg : Symbol(arg, Decl(a.mts, 1, 15))
+
+};
+
+const b = <T>(arg: T): T => {
+>b : Symbol(b, Decl(a.mts, 5, 5))
+>T : Symbol(T, Decl(a.mts, 5, 11))
+>arg : Symbol(arg, Decl(a.mts, 5, 14))
+>T : Symbol(T, Decl(a.mts, 5, 11))
+>T : Symbol(T, Decl(a.mts, 5, 11))
+
+  return arg;
+>arg : Symbol(arg, Decl(a.mts, 5, 14))
+
+};
+

--- a/testdata/baselines/reference/compiler/genericArrowFunctionInEsmExtensionFile.types
+++ b/testdata/baselines/reference/compiler/genericArrowFunctionInEsmExtensionFile.types
@@ -1,0 +1,24 @@
+//// [tests/cases/compiler/genericArrowFunctionInEsmExtensionFile.ts] ////
+
+=== a.mts ===
+// @see https://github.com/microsoft/TypeScript/issues/44442
+const a = <T,>(arg: T): T => {
+>a : <T>(arg: T) => T
+><T,>(arg: T): T => {  return arg;} : <T>(arg: T) => T
+>arg : T
+
+  return arg;
+>arg : T
+
+};
+
+const b = <T>(arg: T): T => {
+>b : <T>(arg: T) => T
+><T>(arg: T): T => {  return arg;} : <T>(arg: T) => T
+>arg : T
+
+  return arg;
+>arg : T
+
+};
+

--- a/testdata/tests/cases/compiler/genericArrowFunctionInEsmExtensionFile.ts
+++ b/testdata/tests/cases/compiler/genericArrowFunctionInEsmExtensionFile.ts
@@ -1,0 +1,11 @@
+// @module: nodenext
+// @filename: a.mts
+
+// @see https://github.com/microsoft/TypeScript/issues/44442
+const a = <T,>(arg: T): T => {
+  return arg;
+};
+
+const b = <T>(arg: T): T => {
+  return arg;
+};


### PR DESCRIPTION
Fixes #3140

---

```ts
if (node.typeParameters && !(length(node.typeParameters) > 1 || node.typeParameters.hasTrailingComma || node.typeParameters[0].constraint)) {}

```