### PR TITLE
Fix regression causing untitled files to crash

### DIFF
--- a/internal/project/session_test.go
+++ b/internal/project/session_test.go
@@ -153,6 +153,44 @@ func TestSession(t *testing.T) {
 			assert.Equal(t, programAfter.GetSourceFile("/home/projects/TS/p1/src/x.ts").Text(), "export const x = 2;")
 		})
 
+		t.Run("update untitled file", func(t *testing.T) {
+			t.Parallel()
+			session, _ := projecttestutil.Setup(defaultFiles)
+
+			session.DidOpenFile(context.Background(), "untitled:Untitled-1", 1, "let x = 1;", lsproto.LanguageKindTypeScript)
+
+			lsBefore, err := session.GetLanguageService(context.Background(), "untitled:Untitled-1")
+			assert.NilError(t, err)
+			programBefore := lsBefore.GetProgram()
+			untitledFileName := lsproto.DocumentUri("untitled:Untitled-1").FileName()
+			assert.Equal(t, programBefore.GetSourceFile(untitledFileName).Text(), "let x = 1;")
+
+			session.DidChangeFile(context.Background(), "untitled:Untitled-1", 2, []lsproto.TextDocumentContentChangePartialOrWholeDocument{
+				{
+					Partial: new(lsproto.TextDocumentContentChangePartial{
+						Range: lsproto.Range{
+							Start: lsproto.Position{
+								Line:      0,
+								Character: 8,
+							},
+							End: lsproto.Position{
+								Line:      0,
+								Character: 9,
+							},
+						},
+						Text: "2",
+					}),
+				},
+			})
+
+			lsAfter, err := session.GetLanguageService(context.Background(), "untitled:Untitled-1")
+			assert.NilError(t, err)
+			programAfter := lsAfter.GetProgram()
+
+			assert.Check(t, programAfter != programBefore)
+			assert.Equal(t, programAfter.GetSourceFile(untitledFileName).Text(), "let x = 2;")
+		})
+
 		t.Run("unchanged source files are reused", func(t *testing.T) {
 			t.Parallel()
 			session, _ := projecttestutil.Setup(defaultFiles)

--- a/internal/project/snapshotfs.go
+++ b/internal/project/snapshotfs.go
@@ -404,15 +404,23 @@ func (s *snapshotFSBuilder) markDirtyFiles(change FileChangeSummary) {
 	}
 }
 
-// hasRelevantWatchExtension returns true if the given path ends with a file
-// extension relevant to TypeScript compilation. This is used to quickly filter
-// out watch events for files that cannot affect the project.
-func hasRelevantWatchExtension(path string) bool {
-	i := strings.LastIndexByte(path, '.')
+// isRelevantFileName returns true if the given URI refers to a file that
+// could affect the project: it has a TypeScript-relevant extension, is a
+// dynamic (e.g. untitled) file, or is currently open as an overlay.
+func (s *snapshotFSBuilder) isRelevantFileName(uri lsproto.DocumentUri) bool {
+	fileName := uri.FileName()
+	if tspath.IsDynamicFileName(fileName) {
+		return true
+	}
+	path := s.toPath(fileName)
+	if _, ok := s.overlays[path]; ok {
+		return true
+	}
+	i := strings.LastIndexByte(string(path), '.')
 	if i < 0 {
 		return false
 	}
-	switch path[i:] {
+	switch string(path)[i:] {
 	case ".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts", ".json":
 		return true
 	}
@@ -430,7 +438,7 @@ func (s *snapshotFSBuilder) expandAndFilterWatchEvents(change FileChangeSummary)
 			path := s.toPath(uri.FileName())
 			if _, ok := s.diskDirectories.Get(path); ok {
 				s.collectFilesRecursive(path, &filteredDeleted)
-			} else if hasRelevantWatchExtension(string(path)) {
+			} else if s.isRelevantFileName(uri) {
 				filteredDeleted.Add(uri)
 			}
 		}
@@ -440,7 +448,7 @@ func (s *snapshotFSBuilder) expandAndFilterWatchEvents(change FileChangeSummary)
 	if change.Changed.Len() > 0 {
 		var filteredChanged collections.Set[lsproto.DocumentUri]
 		for uri := range change.Changed.Keys() {
-			if hasRelevantWatchExtension(string(s.toPath(uri.FileName()))) {
+			if s.isRelevantFileName(uri) {
 				filteredChanged.Add(uri)
 			}
 		}


### PR DESCRIPTION
Silly thing in #3095 caused changes to untitled files to be filtered out (because they don't have file extensions, so look like a spurious watch change to a random file) and shockingly we didn't have coverage for that 😬. Now we both look for untitled file patterns when filtering events out and never ignore anything that's tracked as an open file.