### PR TITLE
Add all-checks task to hereby

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -1801,8 +1801,8 @@ export const allChecks = task({
     name: "all-checks",
     description: "Runs all checks for the Go code (fourslash, lint, tests, etc.)",
     run: async () => {
-        await runTests();
         await $`npm run convertfourslash`;
+        await runTests();
         await $`npm run updatefailing`;
         await runFormat();
         await runLint();


### PR DESCRIPTION
I keep forgetting to run some of those. Not sure if there's something else I should include (the API package checks are not included on purpose, also `generate` is not something I think we need often and takes a while to run).
Ideally we'd run lint and test in parallel, but if I try and do that from the task, the output is interleaved and it's tricky to read.