### PR TITLE
fix: nil pointer deref when accessing module exports in name resolver

### DIFF
--- a/internal/binder/nameresolver.go
+++ b/internal/binder/nameresolver.go
@@ -141,7 +141,7 @@ loop:
 				if nameNotFoundMessage != nil && r.CompilerOptions.GetIsolatedModules() && location.Flags&ast.NodeFlagsAmbient == 0 && ast.GetSourceFileOfNode(location) != ast.GetSourceFileOfNode(result.ValueDeclaration) {
 					isolatedModulesLikeFlagName := core.IfElse(r.CompilerOptions.VerbatimModuleSyntax == core.TSTrue, "verbatimModuleSyntax", "isolatedModules")
 					r.error(originalLocation, diagnostics.Cannot_access_0_from_another_file_without_qualification_when_1_is_enabled_Use_2_instead,
-						name, isolatedModulesLikeFlagName, r.getSymbolOfDeclaration(location).Name+"."+name)
+						name, isolatedModulesLikeFlagName, enumSymbol.Name+"."+name)
 				}
 				break loop
 			}


### PR DESCRIPTION
Strada has optional chaining here to account for the case where `Symbol` is nil. Corsa doesn't which can cause a bug in some scenarios

https://github.com/microsoft/typescript/blob/5e4281fdf21da7c282ceaf016440992e1fad2565/src/compiler/utilities.ts#L11603
https://github.com/microsoft/typescript/blob/5e4281fdf21da7c282ceaf016440992e1fad2565/src/compiler/utilities.ts#L11647


https://github.com/oxc-project/tsgolint/issues/810, https://github.com/oxc-project/tsgolint/pull/812


I'm not sure if it's possible to write a test case for this - I think only tsgolint exposes this. Let me know if this is a hard requirement, and I can simply patch this in tsgolint.