### PR TITLE
Fix issue #3014 

### DIFF
--- a/internal/execute/tsctests/tscwatch_test.go
+++ b/internal/execute/tsctests/tscwatch_test.go
@@ -23,6 +23,13 @@ func TestWatch(t *testing.T) {
 			},
 			commandLineArgs: []string{"--watch", "--incremental"},
 		},
+		{
+			subScenario: "watch with empty files list in tsconfig",
+			files: FileMap{
+				"/home/src/workspaces/project/tsconfig.json": `{"files": []}`,
+			},
+			commandLineArgs: []string{"--watch"},
+		},
 	}
 
 	for _, test := range testCases {

--- a/internal/execute/watcher.go
+++ b/internal/execute/watcher.go
@@ -134,6 +134,8 @@ func (w *Watcher) hasErrorsInTsConfig() bool {
 }
 
 func (w *Watcher) hasBeenModified(program *compiler.Program) bool {
+	isFirstCycle := w.prevModified == nil
+
 	// checks watcher's snapshot against program file modified times
 	currState := map[string]time.Time{}
 	filesModified := w.configModified
@@ -163,5 +165,5 @@ func (w *Watcher) hasBeenModified(program *compiler.Program) bool {
 
 	// reset state for next cycle
 	w.configModified = false
-	return filesModified
+	return filesModified || isFirstCycle
 }

--- a/testdata/baselines/reference/tscWatch/commandLineWatch/watch-with-empty-files-list-in-tsconfig.js
+++ b/testdata/baselines/reference/tscWatch/commandLineWatch/watch-with-empty-files-list-in-tsconfig.js
@@ -1,0 +1,23 @@
+currentDirectory::/home/src/workspaces/project
+useCaseSensitiveFileNames::true
+Input::
+//// [/home/src/workspaces/project/tsconfig.json] *new* 
+{"files": []}
+
+tsgo --watch
+ExitStatus:: Success
+Output::
+build starting at HH:MM:SS AM
+[96mtsconfig.json[0m:[93m1[0m:[93m11[0m - [91merror[0m[90m TS18002: [0mThe 'files' list in config file '/home/src/workspaces/project/tsconfig.json' is empty.
+
+[7m1[0m {"files": []}
+[7m [0m [91m          ~~[0m
+
+
+Found 1 error in tsconfig.json[90m:1[0m
+
+build finished in d.ddds
+
+tsconfig.json::
+SemanticDiagnostics::
+Signatures::


### PR DESCRIPTION
**Problem**
When running `tsgo --watch` with a `tsconfig.json` containing an empty files array and no include rules, the compiler hung silently instead of reporting `TS18002` ("The 'files' list in config file... is empty").
This happened because the watcher polling loop (`internal/execute/watcher.go`) only triggered a build when `hasBeenModified` was `true`. On the first cycle, `prevModified` was empty, so no files appeared modified — skipping the initial build entirely and swallowing the diagnostic.

**Solution**
Treat the first execution cycle (`w.prevModified == nil`) as a modified event, ensuring the initial build always runs and configuration diagnostics are emitted correctly.

**Changes**
- `internal/execute/watcher.go` — force initial build on first cycle
- Added regression test: `watch with empty files list in tsconfig`

**Verification**
- Matches `tsc` behavior in watch mode (which correctly reports the diagnostic)
- New regression test passes with committed baseline
- `npx hereby test` passes

Fixes #3014