### PR TITLE
Reuse fileloader task data when atomic store fails

### DIFF
--- a/internal/compiler/filesparser.go
+++ b/internal/compiler/filesparser.go
@@ -191,6 +191,26 @@ type filesParser struct {
 	maxDepth       int
 }
 
+var parseTaskDataPool = sync.Pool{
+	New: func() any {
+		return &parseTaskData{
+			tasks: make(map[string]*parseTask, 1),
+		}
+	},
+}
+
+func getParseTaskData(task *parseTask) *parseTaskData {
+	td := parseTaskDataPool.Get().(*parseTaskData)
+	td.tasks[task.normalizedFilePath] = task
+	td.lowestDepth = math.MaxInt
+	return td
+}
+
+func putParseTaskData(td *parseTaskData) {
+	clear(td.tasks)
+	parseTaskDataPool.Put(td)
+}
+
 type parseTaskData struct {
 	// map of tasks by file casing
 	tasks           map[string]*parseTask
@@ -208,10 +228,11 @@ func (w *filesParser) parse(loader *fileLoader, tasks []*parseTask) {
 func (w *filesParser) start(loader *fileLoader, tasks []*parseTask, depth int) {
 	for i, task := range tasks {
 		task.path = loader.toPath(task.normalizedFilePath)
-		data, loaded := w.taskDataByPath.LoadOrStore(task.path, &parseTaskData{
-			tasks:       map[string]*parseTask{task.normalizedFilePath: task},
-			lowestDepth: math.MaxInt,
-		})
+		candidate := getParseTaskData(task)
+		data, loaded := w.taskDataByPath.LoadOrStore(task.path, candidate)
+		if loaded {
+			putParseTaskData(candidate)
+		}
 
 		w.wg.Queue(func() {
 			data.mu.Lock()


### PR DESCRIPTION
We use an atomic store to create a file's loader data. If this fails, we throw away the struct and map. This is a waste! We can totally use that for the next file. Stick these into a global sync.Pool, clearing the map (basically free for this small of a map) for later reuse.

The results for the `testrunner` package:

### Summary (flat)

| Metric              | Before      | After     | Reduction |
|----------------------|-------------|-----------|-----------|
| **alloc_objects**    | 4,264,897   | 879,354   | **-79%**  |
| **alloc_space**      | 443 MB      | 80.5 MB   | **-82%**  |

### Line-level breakdown (flat)

| Line                          | Before (objects) | After (objects) | Before (bytes) | After (bytes) |
|-------------------------------|------------------|-----------------|----------------|---------------|
| `LoadOrStore` / struct alloc  | 1,054,132        | 0               | 96.5 MB        | 0             |
| `map[string]*parseTask{...}`  | 2,162,094        | 0               | 250.5 MB       | 0             |
| `wg.Queue` closure            | 1,048,671        | 879,354         | 96 MB          | 80.5 MB       |