### PR TITLE
Fixed a go-to-implementations crash related to reexported type-only namespace

### DIFF
--- a/internal/fourslash/tests/goToImplementationReexportedTypeOnlyNamespace1_test.go
+++ b/internal/fourslash/tests/goToImplementationReexportedTypeOnlyNamespace1_test.go
@@ -1,0 +1,32 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestGoToImplementationReexportedTypeOnlyNamespace1(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `
+// @Filename: /node_modules/@typescript-eslint/types/index.d.ts
+export * as TSESTree from './generated/ast-spec';
+
+// @Filename: /node_modules/@typescript-eslint/types/generated/ast-spec.d.ts
+export interface BaseNode {}
+
+// @Filename: /node_modules/@typescript-eslint/utils/index.d.ts
+export { TSESTree } from '@typescript-eslint/types';
+
+// @Filename: /src/check-license.ts
+import type {TSE/*impl*/STree} from '@typescript-eslint/utils';
+
+let node: TSESTree.Node | undefined;
+export default node;
+`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineGoToImplementation(t, "impl")
+}

--- a/internal/fourslash/tests/goToImplementationReexportedTypeOnlyNamespace2_test.go
+++ b/internal/fourslash/tests/goToImplementationReexportedTypeOnlyNamespace2_test.go
@@ -1,0 +1,32 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestGoToImplementationReexportedTypeOnlyNamespace2(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `
+// @Filename: /node_modules/@typescript-eslint/types/index.d.ts
+export type * as TSESTree from './generated/ast-spec';
+
+// @Filename: /node_modules/@typescript-eslint/types/generated/ast-spec.d.ts
+export interface BaseNode {}
+
+// @Filename: /node_modules/@typescript-eslint/utils/index.d.ts
+export { TSESTree } from '@typescript-eslint/types';
+
+// @Filename: /src/check-license.ts
+import type {TSE/*impl*/STree} from '@typescript-eslint/utils';
+
+let node: TSESTree.Node | undefined;
+export default node;
+`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineGoToImplementation(t, "impl")
+}

--- a/internal/fourslash/tests/goToImplementationReexportedTypeOnlyNamespace3_test.go
+++ b/internal/fourslash/tests/goToImplementationReexportedTypeOnlyNamespace3_test.go
@@ -1,0 +1,33 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestGoToImplementationReexportedTypeOnlyNamespace3(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `
+// @Filename: /node_modules/@typescript-eslint/types/index.d.ts
+export * as TSESTree from './generated/ast-spec';
+export type * as TSESTree from './generated/ast-spec';
+
+// @Filename: /node_modules/@typescript-eslint/types/generated/ast-spec.d.ts
+export interface BaseNode {}
+
+// @Filename: /node_modules/@typescript-eslint/utils/index.d.ts
+export { TSESTree } from '@typescript-eslint/types';
+
+// @Filename: /src/check-license.ts
+import type {TSE/*impl*/STree} from '@typescript-eslint/utils';
+
+let node: TSESTree.Node | undefined;
+export default node;
+`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineGoToImplementation(t, "impl")
+}

--- a/internal/ls/utilities.go
+++ b/internal/ls/utilities.go
@@ -377,7 +377,7 @@ func isObjectBindingElementWithoutPropertyName(bindingElement *ast.Node) bool {
 }
 
 func isRightSideOfPropertyAccess(node *ast.Node) bool {
-	return node.Parent.Kind == ast.KindPropertyAccessExpression && node.Parent.Name() == node
+	return node.Parent != nil && node.Parent.Kind == ast.KindPropertyAccessExpression && node.Parent.Name() == node
 }
 
 func isStaticSymbol(symbol *ast.Symbol) bool {

--- a/testdata/baselines/reference/fourslash/goToImplementation/goToImplementationReexportedTypeOnlyNamespace1.baseline.jsonc
+++ b/testdata/baselines/reference/fourslash/goToImplementation/goToImplementationReexportedTypeOnlyNamespace1.baseline.jsonc
@@ -1,0 +1,11 @@
+// === goToImplementation ===
+// === /node_modules/@typescript-eslint/utils/index.d.ts ===
+// <|export { [|TSESTree|] } from '@typescript-eslint/types';|>
+// 
+
+// === /src/check-license.ts ===
+// import type {TSE/*GOTO IMPL*/STree} from '@typescript-eslint/utils';
+// 
+// let node: TSESTree.Node | undefined;
+// export default node;
+// 

--- a/testdata/baselines/reference/fourslash/goToImplementation/goToImplementationReexportedTypeOnlyNamespace2.baseline.jsonc
+++ b/testdata/baselines/reference/fourslash/goToImplementation/goToImplementationReexportedTypeOnlyNamespace2.baseline.jsonc
@@ -1,0 +1,11 @@
+// === goToImplementation ===
+// === /node_modules/@typescript-eslint/utils/index.d.ts ===
+// <|export { [|TSESTree|] } from '@typescript-eslint/types';|>
+// 
+
+// === /src/check-license.ts ===
+// import type {TSE/*GOTO IMPL*/STree} from '@typescript-eslint/utils';
+// 
+// let node: TSESTree.Node | undefined;
+// export default node;
+// 

--- a/testdata/baselines/reference/fourslash/goToImplementation/goToImplementationReexportedTypeOnlyNamespace3.baseline.jsonc
+++ b/testdata/baselines/reference/fourslash/goToImplementation/goToImplementationReexportedTypeOnlyNamespace3.baseline.jsonc
@@ -1,0 +1,11 @@
+// === goToImplementation ===
+// === /node_modules/@typescript-eslint/utils/index.d.ts ===
+// <|export { [|TSESTree|] } from '@typescript-eslint/types';|>
+// 
+
+// === /src/check-license.ts ===
+// import type {TSE/*GOTO IMPL*/STree} from '@typescript-eslint/utils';
+// 
+// let node: TSESTree.Node | undefined;
+// export default node;
+// 


### PR DESCRIPTION
fixes the crash found here: https://github.com/microsoft/typescript-go/issues/3187#issuecomment-4101731639