### PR TITLE
Remove nondeterminism in container generation

### DIFF
--- a/internal/checker/symbolaccessibility.go
+++ b/internal/checker/symbolaccessibility.go
@@ -136,26 +136,26 @@ func (c *Checker) getWithAlternativeContainers(container *ast.Symbol, symbol *as
 	}
 	// we potentially have a symbol which is a member of the instance side of something - look for a variable in scope with the container's type
 	// which may be acting like a namespace (eg, `Symbol` acts like a namespace when looking up `Symbol.toStringTag`)
-	var firstVariableMatch *ast.Symbol
+	var variableMatches []*ast.Symbol
 	if (meaning == ast.SymbolFlagsValue &&
 		container.Flags&leftMeaning == 0) &&
 		container.Flags&ast.SymbolFlagsType != 0 &&
 		c.getDeclaredTypeOfSymbol(container).flags&TypeFlagsObject != 0 {
 		c.someSymbolTableInScope(enclosingDeclaration, func(t ast.SymbolTable, _ symbolTableID, _ bool, _ bool, _ *ast.Node) bool {
+			found := false
 			for _, s := range t {
 				if s.Flags&leftMeaning != 0 && c.getTypeOfSymbol(s) == c.getDeclaredTypeOfSymbol(container) {
-					firstVariableMatch = s
-					return true
+					variableMatches = append(variableMatches, s)
+					found = true
 				}
 			}
-			return false
+			return found
 		})
+		c.sortSymbols(variableMatches)
 	}
 
 	var res []*ast.Symbol
-	if firstVariableMatch != nil {
-		res = append(res, firstVariableMatch)
-	}
+	res = append(res, variableMatches...)
 	res = append(res, additionalContainers...)
 	res = append(res, container)
 	if objectLiteralContainer != nil {


### PR DESCRIPTION
Per [this comment](https://github.com/microsoft/typescript-go/pull/3152#issuecomment-4085530742)

Unfortunately, it makes the worst case, exhaustively traversing the global table, the guaranteed case (if we end up looking at the globals - we won't if there's a more local match, and local symbol tables are generally small, so exhaustive isn't bad), since we need to find all possible references to sort them.

We also mentioned having a deferred-sorted globals list to potentially look at to keep the early-bail behavior in a stable way, but that itself is gonna be costly to make, and, because it's unclear how many symbols fall back to globals here, I'm not even sure that's worth it. Certainly, there's nothing in our test suite this affects the printback of. This is the kinda thing I'd prefer only to start tweaking in a big way with perf numbers to back it up, so I know I'm not introducing complexity for negative gain.

I double checked the other `someSymbolTableInScope` calls - they all either only do `[]` accesses, or collect all possible refs and sort them (see `trySymbolTable`), so this one seems like the odd duck out right now in terms of handling unsorted maps well.