### PR TITLE
adding to isTypeNode()

### DIFF
--- a/_packages/api/test/async/api.test.ts
+++ b/_packages/api/test/async/api.test.ts
@@ -30,6 +30,7 @@ import {
     isTemplateMiddle,
     isTemplateTail,
     isVariableDeclarationList,
+    type Node,
     NodeFlags,
 } from "@typescript/ast";
 import {
@@ -2012,12 +2013,12 @@ export const obj = { m: 1, s: "hi", b: true };
             const typeNode = await checker.typeToTypeNode(type);
             assert.ok(typeNode, "typeToTypeNode should return a type node");
 
-            // Verify keyword type children (NumberKeyword, StringKeyword, BooleanKeyword)
-            // pass isTypeNode — this used to crash with "Visited node failed test assertion"
-            const visited = visitEachChild(typeNode, node => node);
+            // Recursively visit to reach PropertySignature.type where isTypeNode is checked.
+            const visited = (function visit(node: Node): Node {
+                return visitEachChild(node, visit);
+            })(typeNode);
             assert.ok(visited, "visitEachChild should not throw");
 
-            // Verify isTypeNode recognizes keyword type nodes
             const kinds = [
                 SyntaxKind.NumberKeyword,
                 SyntaxKind.StringKeyword,
@@ -2026,6 +2027,20 @@ export const obj = { m: 1, s: "hi", b: true };
                 SyntaxKind.VoidKeyword,
                 SyntaxKind.UndefinedKeyword,
                 SyntaxKind.NeverKeyword,
+                SyntaxKind.UnknownKeyword,
+                SyntaxKind.BigIntKeyword,
+                SyntaxKind.ObjectKeyword,
+                SyntaxKind.SymbolKeyword,
+                SyntaxKind.IntrinsicKeyword,
+                SyntaxKind.ExpressionWithTypeArguments,
+                SyntaxKind.JSDocAllType,
+                SyntaxKind.JSDocNullableType,
+                SyntaxKind.JSDocNonNullableType,
+                SyntaxKind.JSDocOptionalType,
+                SyntaxKind.JSDocVariadicType,
+                SyntaxKind.JSDocTypeExpression,
+                SyntaxKind.JSDocTypeLiteral,
+                SyntaxKind.JSDocSignature,
             ];
             for (const kind of kinds) {
                 assert.ok(isTypeNode({ kind } as any), `isTypeNode should accept ${SyntaxKind[kind]}`);

--- a/_packages/api/test/sync/api.test.ts
+++ b/_packages/api/test/sync/api.test.ts
@@ -38,6 +38,7 @@ import {
     isTemplateMiddle,
     isTemplateTail,
     isVariableDeclarationList,
+    type Node,
     NodeFlags,
 } from "@typescript/ast";
 import {
@@ -2020,12 +2021,12 @@ export const obj = { m: 1, s: "hi", b: true };
             const typeNode = checker.typeToTypeNode(type);
             assert.ok(typeNode, "typeToTypeNode should return a type node");
 
-            // Verify keyword type children (NumberKeyword, StringKeyword, BooleanKeyword)
-            // pass isTypeNode — this used to crash with "Visited node failed test assertion"
-            const visited = visitEachChild(typeNode, node => node);
+            // Recursively visit to reach PropertySignature.type where isTypeNode is checked.
+            const visited = (function visit(node: Node): Node {
+                return visitEachChild(node, visit);
+            })(typeNode);
             assert.ok(visited, "visitEachChild should not throw");
 
-            // Verify isTypeNode recognizes keyword type nodes
             const kinds = [
                 SyntaxKind.NumberKeyword,
                 SyntaxKind.StringKeyword,
@@ -2034,6 +2035,20 @@ export const obj = { m: 1, s: "hi", b: true };
                 SyntaxKind.VoidKeyword,
                 SyntaxKind.UndefinedKeyword,
                 SyntaxKind.NeverKeyword,
+                SyntaxKind.UnknownKeyword,
+                SyntaxKind.BigIntKeyword,
+                SyntaxKind.ObjectKeyword,
+                SyntaxKind.SymbolKeyword,
+                SyntaxKind.IntrinsicKeyword,
+                SyntaxKind.ExpressionWithTypeArguments,
+                SyntaxKind.JSDocAllType,
+                SyntaxKind.JSDocNullableType,
+                SyntaxKind.JSDocNonNullableType,
+                SyntaxKind.JSDocOptionalType,
+                SyntaxKind.JSDocVariadicType,
+                SyntaxKind.JSDocTypeExpression,
+                SyntaxKind.JSDocTypeLiteral,
+                SyntaxKind.JSDocSignature,
             ];
             for (const kind of kinds) {
                 assert.ok(isTypeNode({ kind } as any), `isTypeNode should accept ${SyntaxKind[kind]}`);

--- a/_packages/ast/src/is.ts
+++ b/_packages/ast/src/is.ts
@@ -1196,7 +1196,10 @@ function isTypeNodeKind(kind: SyntaxKind): boolean {
         || kind === SyntaxKind.JSDocNullableType
         || kind === SyntaxKind.JSDocNonNullableType
         || kind === SyntaxKind.JSDocOptionalType
-        || kind === SyntaxKind.JSDocVariadicType;
+        || kind === SyntaxKind.JSDocVariadicType
+        || kind === SyntaxKind.JSDocTypeExpression
+        || kind === SyntaxKind.JSDocTypeLiteral
+        || kind === SyntaxKind.JSDocSignature;
 }
 
 export function isStatement(node: Node): node is Statement {


### PR DESCRIPTION
Bug: `isTypeNode()` in @typescript/ast only checked `kind >= FirstTypeNode && kind <= LastTypeNode` (range 183–206). Keyword type nodes like `NumberKeyword` (150), `StringKeyword` (154), `BooleanKeyword` (136) fall outside that range. When
typeToTypeNode returned a type literal with keyword-typed members (e.g. { m: number }), `visitEachChild` called `visitNode(node.type, visitor, isTypeNode)` on each PropertySignature — the test function rejected the keyword type node and
threw "Visited node failed test assertion", crashing 5 extract-symbol tests.

Fix: Updated `isTypeNode` to use an isTypeNodeKind helper matching Strada's implementation, which explicitly includes 12 keyword types (AnyKeyword, UnknownKeyword, NumberKeyword, BigIntKeyword, ObjectKeyword, BooleanKeyword, StringKeyword, SymbolKeyword, VoidKeyword, UndefinedKeyword, NeverKeyword, IntrinsicKeyword), ExpressionWithTypeArguments, and JSDoc type nodes — in addition to the existing FirstTypeNode..LastTypeNode range check.

Test: Added "visitEachChild on typeToTypeNode result with keyword types" in
the API test suite, verifying visitEachChild doesn't crash on decoded type
nodes with keyword types, and that isTypeNode accepts all keyword SyntaxKind
values.