### PR TITLE
Use process.execve where it is supported

### DIFF
--- a/_packages/native-preview/bin/tsgo.js
+++ b/_packages/native-preview/bin/tsgo.js
@@ -5,6 +5,16 @@ import { execFileSync } from "node:child_process";
 
 const exe = getExePath();
 
+if (typeof process.execve === "function") {
+    // > v22.15.0
+    try {
+        process.execve(exe, [exe, ...process.argv.slice(2)]);
+    }
+    catch {
+        // not available on windows, ignore the error and fallback
+    }
+}
+
 try {
     execFileSync(exe, process.argv.slice(2), { stdio: "inherit" });
 }


### PR DESCRIPTION
Current tsgo wrapper uses execFileSync from node:child_process which keeps extra node process for no reason.
Node has experimental process.execve which solves that problem.
Docs: https://nodejs.org/docs/latest/api/process.html#processexecvefile-args-env
Note that it is still experimental and is not available on Windows at least as of right now.

This patch makes the tsgo.js wrapper use it if it is available, startup time of tsgo is still slightly slower because of the node wrapper, but at least there is no persistent node process.


Closes https://github.com/microsoft/typescript-go/issues/3238

Unlike `execFileSync` this `process.execve` takes args including argv0,
so `[exe, ...process.argv.slice(2)]` is just to set argv0 to `tsgo` instead of `tsgo.js`, it isn't really needed, it could be `process.argv.slice(1)` otherwise.

I tested that it works against node 20 and node 24 on Linux, needs testing on Windows and macOS, I can't test there.

btw on github because of whitespace diff makes it harder to see what changed here, I suggest hiding whitespace