### PR TITLE
Use Go regexp for autoImportSpecifierExcludeRegexes, remove regexp2

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -338,32 +338,6 @@ BSD-3-Clause AND LicenseRef-scancode-google-patent-license-golang
 
 ---------------------------------------------------------
 
-github.com/dlclark/regexp2 v1.11.5 - MIT
-
-
-(c) 0, ca Pass. Group
-(c) 0, abc Pass. Group
-(c) 0, abac Pass. Group
-Copyright (c) Doug Clark
-(c) IgnoreCase, ABC Pass. Group
-(c) RightToLeft, abc Pass. Group
-Copyright (c) 2012 The Go Authors
-Copyright (c) Microsoft Corporation
-
-MIT License
-
-Copyright (c) <year> <copyright holders>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----------------------------------------------------------
-
----------------------------------------------------------
-
 github.com/klauspost/cpuid/v2 v2.2.10 - MIT
 
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.26
 
 require (
 	github.com/Microsoft/go-winio v0.6.2
-	github.com/dlclark/regexp2 v1.11.5
 	github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433
 	github.com/google/go-cmp v0.7.0
 	github.com/peter-evans/patience v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
-github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433 h1:vymEbVwYFP/L05h5TKQxvkXoKxNvTpjxYKdF1Nlwuao=
 github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433/go.mod h1:tphK2c80bpPhMOI4v6bIc2xWywPfbqi1Z06+RcrMkDg=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/internal/modulespecifiers/util.go
+++ b/internal/modulespecifiers/util.go
@@ -2,11 +2,11 @@ package modulespecifiers
 
 import (
 	"fmt"
+	"regexp"
 	"slices"
 	"strings"
 	"sync"
 
-	"github.com/dlclark/regexp2"
 	"github.com/microsoft/typescript-go/internal/ast"
 	"github.com/microsoft/typescript-go/internal/collections"
 	"github.com/microsoft/typescript-go/internal/core"
@@ -17,13 +17,13 @@ import (
 )
 
 type regexPatternCacheKey struct {
-	pattern string
-	opts    regexp2.RegexOptions
+	pattern         string
+	caseInsensitive bool
 }
 
 var (
 	regexPatternCacheMu sync.RWMutex
-	regexPatternCache   = make(map[regexPatternCacheKey]*regexp2.Regexp)
+	regexPatternCache   = make(map[regexPatternCacheKey]*regexp.Regexp)
 )
 
 func comparePathsByRedirect(a ModulePath, b ModulePath, useCaseSensitiveFileNames bool) int {
@@ -46,16 +46,15 @@ func IsExcludedByRegex(moduleSpecifier string, excludes []string) bool {
 		if re == nil {
 			continue
 		}
-		match, _ := re.MatchString(moduleSpecifier)
-		if match {
+		if re.MatchString(moduleSpecifier) {
 			return true
 		}
 	}
 	return false
 }
 
-func stringToRegex(pattern string) *regexp2.Regexp {
-	options := regexp2.RegexOptions(regexp2.ECMAScript)
+func stringToRegex(pattern string) *regexp.Regexp {
+	caseInsensitive := false
 
 	if len(pattern) > 2 && pattern[0] == '/' {
 		lastSlash := strings.LastIndex(pattern, "/")
@@ -75,15 +74,13 @@ func stringToRegex(pattern string) *regexp2.Regexp {
 				for _, flag := range flags {
 					switch flag {
 					case 'i':
-						options |= regexp2.IgnoreCase
-					case 'u':
-						options |= regexp2.Unicode
+						caseInsensitive = true
 					}
 				}
 			}
 		}
 	}
-	key := regexPatternCacheKey{pattern, options}
+	key := regexPatternCacheKey{pattern, caseInsensitive}
 
 	regexPatternCacheMu.RLock()
 	re, ok := regexPatternCache[key]
@@ -107,7 +104,12 @@ func stringToRegex(pattern string) *regexp2.Regexp {
 	pattern = strings.Clone(pattern)
 	key.pattern = pattern
 
-	compiled, err := regexp2.Compile(pattern, options)
+	compilePattern := pattern
+	if caseInsensitive {
+		compilePattern = "(?i:" + pattern + ")"
+	}
+
+	compiled, err := regexp.Compile(compilePattern)
 	if err != nil {
 		regexPatternCache[key] = nil
 		return nil


### PR DESCRIPTION
With #2407 merged, `autoImportSpecifierExcludeRegexes` is the only place we ever construct a regex derived from user input. We do that with `regexp2` today, to be ECMAScript compatible.

However, I just don't think people should be sticking anything complicated in there. And indeed, on GitHub, only one preference uses a regex that is not within `re2` syntax: https://github.com/reformcollective/reform-next-starter/blob/c75b23a1be762ea42ede3edf3e36d4fe1141eb43/.vscode/settings.json

I think we should drop the `regexp2` dep and just use Go's `regexp` package. This is a break for sure, but, I don't think this one feature warrants shipping an entirely separate regex engine.

Shaves 368K off our binary, so that's something I guess.