### PR TITLE
Do not reuse input expression nodes to generate type nodes for contextually typed const array literal expressions

### DIFF
--- a/testdata/baselines/reference/submodule/compiler/declarationEmitPropertyNumericStringKey.js.diff
+++ b/testdata/baselines/reference/submodule/compiler/declarationEmitPropertyNumericStringKey.js.diff
@@ -1,0 +1,11 @@
+--- old.declarationEmitPropertyNumericStringKey.js
++++ new.declarationEmitPropertyNumericStringKey.js
+@@= skipped -27, +27 lines =@@
+
+ //// [declarationEmitPropertyNumericStringKey.d.ts]
+ declare const STATUS: {
+-    readonly "404": "not found";
++    readonly ["404"]: "not found";
+ };
+ declare const hundredStr = "100";
+ declare const obj: {

--- a/testdata/baselines/reference/submodule/conformance/constAssertions.js.diff
+++ b/testdata/baselines/reference/submodule/conformance/constAssertions.js.diff
@@ -1,0 +1,53 @@
+--- old.constAssertions.js
++++ new.constAssertions.js
+@@= skipped -213, +213 lines =@@
+
+
+ //// [constAssertions.d.ts]
+-declare let v1: "abc";
+-declare let v2: "abc";
++declare let v1: 'abc';
++declare let v2: `abc`;
+ declare let v3: 10;
+ declare let v4: -10;
+ declare let v5: 10;
+@@= skipped -9, +9 lines =@@
+ declare let v7: -10n;
+ declare let v8: true;
+ declare let v9: false;
+-declare let c1: "abc";
+-declare let c2: "abc";
++declare let c1: 'abc';
++declare let c2: `abc`;
+ declare let c3: 10;
+ declare let c4: -10;
+ declare let c5: 10;
+@@= skipped -13, +13 lines =@@
+ declare let vc1: "abc";
+ declare let a1: readonly [];
+ declare let a2: readonly [1, 2, 3];
+-declare let a3: readonly [10, "hello", true];
++declare let a3: readonly [10, 'hello', true];
+ declare let a4: readonly [1, 2, 3];
+ declare let a5: number[];
+ declare let a6: readonly number[];
+@@= skipped -65, +65 lines =@@
+     };
+ };
+ declare let q1: 10;
+-declare let q2: "abc";
++declare let q2: 'abc';
+ declare let q3: true;
+ declare let q4: readonly [1, 2, 3];
+ declare let q5: {
+@@= skipped -11, +11 lines =@@
+ declare let e1: "abc";
+ declare let e2: 0 | 1;
+ declare let e3: 1;
+-declare let t1: "foo";
+-declare let t2: "bar";
++declare let t1: 'foo';
++declare let t2: 'bar';
+ declare let t3: "foo-bar";
+ declare let t4: "(foo)-(bar)";
+ declare function ff1(x: 'foo' | 'bar', y: 1 | 2): "bar-1" | "bar-2" | "foo-1" | "foo-2";

--- a/testdata/baselines/reference/submoduleAccepted/compiler/declarationEmitClassMemberWithComputedPropertyName.js.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/declarationEmitClassMemberWithComputedPropertyName.js.diff
@@ -1,0 +1,14 @@
+--- old.declarationEmitClassMemberWithComputedPropertyName.js
++++ new.declarationEmitClassMemberWithComputedPropertyName.js
+@@= skipped -57, +57 lines =@@
+
+ //// [declarationEmitClassMemberWithComputedPropertyName.d.ts]
+ declare const k1: unique symbol;
+-declare const k2: "foo";
++declare const k2: 'foo';
+ declare const k3: unique symbol;
+-declare const k4: "prop";
++declare const k4: 'prop';
+ declare class Foo {
+     static [k1](): number;
+     [k1](): string;

--- a/testdata/baselines/reference/submoduleAccepted/compiler/discriminatedUnionWithIndexSignature.types.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/discriminatedUnionWithIndexSignature.types.diff
@@ -1,0 +1,17 @@
+--- old.discriminatedUnionWithIndexSignature.types
++++ new.discriminatedUnionWithIndexSignature.types
+@@= skipped -39, +39 lines =@@
+
+ const withAsConst: MapOrSingleton = {
+ >withAsConst : MapOrSingleton
+->{    1: {        type: 'text' as const,    },} : { 1: { type: "text"; }; }
++>{    1: {        type: 'text' as const,    },} : { 1: { type: 'text'; }; }
+
+     1: {
+->1 : { type: "text"; }
+->{        type: 'text' as const,    } : { type: "text"; }
++>1 : { type: 'text'; }
++>{        type: 'text' as const,    } : { type: 'text'; }
+
+         type: 'text' as const,
+ >type : "text"

--- a/testdata/baselines/reference/submoduleAccepted/compiler/narrowingNoInfer1.types.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/narrowingNoInfer1.types.diff
@@ -1,0 +1,39 @@
+--- old.narrowingNoInfer1.types
++++ new.narrowingNoInfer1.types
+@@= skipped -68, +68 lines =@@
+ test2({ type: 'a' as const }, { type: 'b' as const }, (thing) => {
+ >test2({ type: 'a' as const }, { type: 'b' as const }, (thing) => {  if (thing.type === "a") {    thing;  } else {    thing;  }}) : void
+ >test2 : <T1, T2>(a: T1, b: T2, cb: (thing: NoInfer<T1> | NoInfer<T2>) => void) => void
+->{ type: 'a' as const } : { type: "a"; }
++>{ type: 'a' as const } : { type: 'a'; }
+ >type : "a"
+ >'a' as const : "a"
+ >'a' : "a"
+->{ type: 'b' as const } : { type: "b"; }
++>{ type: 'b' as const } : { type: 'b'; }
+ >type : "b"
+ >'b' as const : "b"
+ >'b' : "b"
+->(thing) => {  if (thing.type === "a") {    thing;  } else {    thing;  }} : (thing: NoInfer<{ type: "a"; }> | NoInfer<{ type: "b"; }>) => void
+->thing : NoInfer<{ type: "a"; }> | NoInfer<{ type: "b"; }>
++>(thing) => {  if (thing.type === "a") {    thing;  } else {    thing;  }} : (thing: NoInfer<{ type: 'a'; }> | NoInfer<{ type: 'b'; }>) => void
++>thing : NoInfer<{ type: 'a'; }> | NoInfer<{ type: 'b'; }>
+
+   if (thing.type === "a") {
+ >thing.type === "a" : boolean
+ >thing.type : "a" | "b"
+->thing : NoInfer<{ type: "a"; }> | NoInfer<{ type: "b"; }>
++>thing : NoInfer<{ type: 'a'; }> | NoInfer<{ type: 'b'; }>
+ >type : "a" | "b"
+ >"a" : "a"
+
+     thing;
+->thing : NoInfer<{ type: "a"; }>
++>thing : NoInfer<{ type: 'a'; }>
+
+   } else {
+     thing;
+->thing : NoInfer<{ type: "b"; }>
++>thing : NoInfer<{ type: 'b'; }>
+   }
+ });


### PR DESCRIPTION
Since their `readonly` state requires checking to know.

Fixes #3192

Had to tune up the pseudochecker's `isContextuallyTyped` a bit (note: this was a port from strada, strada's `expressionToTypeNode`'s `isContextuallyTyped` is similarly wrong as the old version) to get this to work.