### PR TITLE
Suppress process.execve warning on windows

### DIFF
--- a/_packages/native-preview/bin/tsgo.js
+++ b/_packages/native-preview/bin/tsgo.js
@@ -5,13 +5,13 @@ import { execFileSync } from "node:child_process";
 
 const exe = getExePath();
 
-if (typeof process.execve === "function") {
+if (process.platform !== "win32" && typeof process.execve === "function") {
     // > v22.15.0
     try {
         process.execve(exe, [exe, ...process.argv.slice(2)]);
     }
     catch {
-        // not available on windows, ignore the error and fallback
+        // may not be available, ignore the error and fallback
     }
 }
 


### PR DESCRIPTION
I noticed that as on windows process.execve first needs to run before fallback it will still emit a warning there <https://github.com/nodejs/node/blob/38647b388bbf5d350f8febe77a6674ec0d0607c5/lib/internal/process/per_thread.js#L283>

This one:
```
› tsgo --version
Version 7.0.0-dev.20260327.2
(node:1457628) ExperimentalWarning: process.execve is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
```

Even though it is technically unused.

Probably makes sense to gate that code based on platform anyways, and keep try catch for future compat.

On linux that warning seems to be swallowed and not emitted as process is replaced before node emits a warning, which is interesting...

@jakebailey what do you think?