### PR TITLE
support quick info and go to definition on mapped keys

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -20397,6 +20397,7 @@ func (c *Checker) resolveMappedTypeMembers(t *Type) {
 				}
 				prop := c.newSymbol(ast.SymbolFlagsProperty|core.IfElse(isOptional, ast.SymbolFlagsOptional, 0), propName)
 				prop.CheckFlags = lateFlag | ast.CheckFlagsMapped | core.IfElse(isReadonly, ast.CheckFlagsReadonly, 0) | core.IfElse(stripOptional, ast.CheckFlagsStripOptional, 0)
+				prop.Parent = mappedType.symbol
 				valueLinks := c.valueSymbolLinks.Get(prop)
 				valueLinks.containingType = t
 				valueLinks.nameType = propNameType

--- a/internal/checker/services.go
+++ b/internal/checker/services.go
@@ -408,6 +408,14 @@ func (c *Checker) GetMappedTypeSymbolOfProperty(symbol *ast.Symbol) *ast.Symbol 
 	return nil
 }
 
+// GetMappedSyntheticOrigin returns the syntheticOrigin of a mapped symbol (the original property it was derived from).
+func (c *Checker) GetMappedSyntheticOrigin(symbol *ast.Symbol) *ast.Symbol {
+	if symbol.CheckFlags&ast.CheckFlagsMapped != 0 && c.mappedSymbolLinks.Has(symbol) {
+		return c.mappedSymbolLinks.Get(symbol).syntheticOrigin
+	}
+	return nil
+}
+
 func (c *Checker) getImmediateRootSymbols(symbol *ast.Symbol) []*ast.Symbol {
 	if symbol.CheckFlags&ast.CheckFlagsSynthetic != 0 {
 		return core.MapNonNil(

--- a/internal/fourslash/tests/goToDefinitionMappedType2_test.go
+++ b/internal/fourslash/tests/goToDefinitionMappedType2_test.go
@@ -1,0 +1,32 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestGoToDefinitionMappedType2(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `interface Foo {
+    /*def*/property: string
+}
+
+type JustMapIt<T> = {[P in keyof T]: 0}
+type MapItWithRemap<T> = {[P in keyof T as P extends string ? ` + "`mapped_${P}`" + ` : never]: 0}
+
+{
+    let gotoDef!: JustMapIt<Foo>
+    gotoDef.property
+}
+
+{
+    let gotoDef!: MapItWithRemap<Foo>
+    gotoDef.[|/*ref*/mapped_property|]
+}`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineGoToDefinition(t, true, "ref")
+}

--- a/internal/fourslash/tests/goToDefinitionMappedType3_test.go
+++ b/internal/fourslash/tests/goToDefinitionMappedType3_test.go
@@ -1,0 +1,41 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestGoToDefinitionMappedType3(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `interface Source {
+  /*def*/alpha: number;
+  beta: string;
+}
+
+// Transforming interface field names with a suffix
+type Transformed<T> = {
+  [K in keyof T as ` + "`${K & string}Suffix`" + `]: () => T[K];
+};
+
+type Result = Transformed<Source>;
+/*
+  Expected:
+  {
+    alphaSuffix: () => number;
+    betaSuffix: () => string;
+  }
+  */
+
+const obj: Result = {
+  alphaSuffix: () => 42,
+  betaSuffix: () => "hello",
+};
+
+obj.[|/*ref*/alphaSuffix|]();`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineGoToDefinition(t, true, "ref")
+}

--- a/internal/fourslash/tests/quickInfoMappedType2_test.go
+++ b/internal/fourslash/tests/quickInfoMappedType2_test.go
@@ -1,0 +1,34 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestQuickInfoMappedType2(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	// Tests that @inheritDoc on a MappedTypeNode causes hover to show documentation.
+	// TODO: once @inheritDoc resolution is fully implemented, the expected documentation
+	// should be "desc on Getters\nhello" (combined from the mapped type and the source property).
+	const content = `type ToGet<T> = T extends string ? ` + "`get${Capitalize<T>}`" + ` : never;
+type Getters<T> = /** @inheritDoc desc on Getters */ { 
+    [P in keyof T as ToGet<P>]: () => T[P]
+};
+
+type Y = {
+    /** hello  */
+    d: string;
+}
+
+type T50 = Getters<Y>;  // { getFoo: () => string, getBar: () => number }
+
+declare let y: T50;
+y.get/*3*/D;`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	// Current Go behavior: shows the raw @inheritDoc tag text from the mapped type declaration.
+	f.VerifyQuickInfoAt(t, "3", "(property) getD: () => string", "\n\n*@inheritDoc* \u2014 desc on Getters ")
+}

--- a/internal/fourslash/tests/quickInfoMappedType2_test.go
+++ b/internal/fourslash/tests/quickInfoMappedType2_test.go
@@ -23,7 +23,7 @@ type Y = {
     d: string;
 }
 
-type T50 = Getters<Y>;  // { getFoo: () => string, getBar: () => number }
+type T50 = Getters<Y>;
 
 declare let y: T50;
 y.get/*3*/D;`

--- a/internal/fourslash/tests/quickInfoMappedType3_test.go
+++ b/internal/fourslash/tests/quickInfoMappedType3_test.go
@@ -1,0 +1,58 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestQuickInfoMappedType3(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `type Getters<Type> =  /** @inheritDoc desc on Getters */  {
+  [Property in keyof Type as ` + "`" + `get${Capitalize<
+    string & Property
+  >}` + "`" + `]: () => Type[Property];
+};
+
+interface Person {
+  // ✅ When hovering here, the documentation is displayed, as it should.
+  /**
+   * Person's name.
+   * @example "John Doe"
+   */
+  name: string;
+
+  // ✅ When hovering here, the documentation is displayed, as it should.
+  /**
+   * Person's Age.
+   * @example 30
+   */
+  age: number;
+
+  // ✅ When hovering here, the documentation is displayed, as it should.
+  /**
+   * Person's Location.
+   * @example "Brazil"
+   */
+  location: string;
+}
+
+type LazyPerson = Getters<Person>;
+
+const me: LazyPerson = {
+  // ❌ When hovering here, the documentation is NOT displayed.
+  /*1*/getName: () => "Jake Carter",
+  // ❌ When hovering here, the documentation is NOT displayed.
+  /*2*/getAge: () => 35,
+  // ❌ When hovering here, the documentation is NOT displayed.
+  /*3*/getLocation: () => "United States",
+};
+
+// ❌ When hovering here, the documentation is NOT displayed.
+me./*4*/getName();`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineHover(t)
+}

--- a/internal/fourslash/tests/quickInfoMappedType3_test.go
+++ b/internal/fourslash/tests/quickInfoMappedType3_test.go
@@ -42,15 +42,15 @@ interface Person {
 type LazyPerson = Getters<Person>;
 
 const me: LazyPerson = {
-  // ❌ When hovering here, the documentation is NOT displayed.
+  // ✅ When hovering here, the documentation is displayed, as it should.
   /*1*/getName: () => "Jake Carter",
-  // ❌ When hovering here, the documentation is NOT displayed.
+  // ✅ When hovering here, the documentation is displayed, as it should.
   /*2*/getAge: () => 35,
-  // ❌ When hovering here, the documentation is NOT displayed.
+  // ✅ When hovering here, the documentation is displayed, as it should.
   /*3*/getLocation: () => "United States",
 };
 
-// ❌ When hovering here, the documentation is NOT displayed.
+// ✅ When hovering here, the documentation is displayed, as it should.
 me./*4*/getName();`
 	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
 	defer done()

--- a/internal/fourslash/tests/quickInfoMappedType4_test.go
+++ b/internal/fourslash/tests/quickInfoMappedType4_test.go
@@ -1,0 +1,32 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestQuickInfoMappedType4(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `type ToGet<T> = T extends string ? ` + "`get${Capitalize<T>}`" + ` : never;
+type Getters<T> = { 
+    /** @inheritDoc desc on Getters */
+    [P in keyof T as ToGet<P>]: () => T[P]
+    
+     };
+
+type Y = {
+    /** hello  */
+    d: string;
+}
+
+type T50 = Getters<Y>;  // { getFoo: () => string, getBar: () => number }
+
+declare let y: T50;
+y.get/*3*/D;`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyQuickInfoAt(t, "3", "(property) getD: () => string", "")
+}

--- a/internal/fourslash/tests/quickInfoMappedType4_test.go
+++ b/internal/fourslash/tests/quickInfoMappedType4_test.go
@@ -22,7 +22,7 @@ type Y = {
     d: string;
 }
 
-type T50 = Getters<Y>;  // { getFoo: () => string, getBar: () => number }
+type T50 = Getters<Y>;
 
 declare let y: T50;
 y.get/*3*/D;`

--- a/internal/ls/definition.go
+++ b/internal/ls/definition.go
@@ -264,6 +264,12 @@ func getDeclarationsFromLocation(c *checker.Checker, node *ast.Node) []*ast.Node
 		if len(symbol.Declarations) > 0 {
 			return symbol.Declarations
 		}
+		// For mapped type properties with no declarations, fall back to syntheticOrigin declarations
+		if symbol.CheckFlags&ast.CheckFlagsMapped != 0 {
+			if syntheticOrigin := c.GetMappedSyntheticOrigin(symbol); syntheticOrigin != nil && len(syntheticOrigin.Declarations) > 0 {
+				return syntheticOrigin.Declarations
+			}
+		}
 	}
 	if indexInfos := c.GetIndexSignaturesAtLocation(node); len(indexInfos) != 0 {
 		return indexInfos

--- a/internal/ls/hover.go
+++ b/internal/ls/hover.go
@@ -71,6 +71,19 @@ func (l *LanguageService) getQuickInfoAndDocumentationForSymbol(c *checker.Check
 
 func (l *LanguageService) getDocumentationFromDeclaration(c *checker.Checker, symbol *ast.Symbol, declaration *ast.Node, location *ast.Node, contentFormat lsproto.MarkupKind, commentOnly bool) string {
 	if declaration == nil {
+		// For mapped type symbols with @inheritDoc on the mapped type, synthesize documentation
+		// from the mapped type's declarations and the syntheticOrigin's declarations.
+		if symbol != nil && symbol.CheckFlags&ast.CheckFlagsMapped != 0 &&
+			symbol.Parent != nil && len(symbol.Parent.Declarations) > 0 &&
+			core.Some(symbol.Parent.Declarations, hasJSDocInheritDocTag) {
+			syntheticOrigin := c.GetMappedSyntheticOrigin(symbol)
+			var decls []*ast.Node
+			decls = append(decls, symbol.Parent.Declarations...)
+			if syntheticOrigin != nil {
+				decls = append(decls, syntheticOrigin.Declarations...)
+			}
+			return l.getDocumentationFromDeclarations(c, decls, location, contentFormat, commentOnly)
+		}
 		return ""
 	}
 
@@ -185,6 +198,35 @@ func (l *LanguageService) getDocumentationFromDeclaration(c *checker.Checker, sy
 		}
 	}
 	return b.String()
+}
+
+// hasJSDocInheritDocTag reports whether the given node has a @inheritDoc JSDoc tag.
+func hasJSDocInheritDocTag(node *ast.Node) bool {
+	for _, jsdoc := range node.JSDoc(nil) {
+		if jsdoc.Kind != ast.KindJSDoc {
+			continue
+		}
+		tags := jsdoc.AsJSDoc().Tags
+		if tags == nil {
+			continue
+		}
+		for _, tag := range tags.Nodes {
+			if tag.Kind == ast.KindJSDocTag && tag.TagName().Text() == "inheritDoc" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// getDocumentationFromDeclarations gets documentation from the first declaration in decls that has JSDoc.
+func (l *LanguageService) getDocumentationFromDeclarations(c *checker.Checker, decls []*ast.Node, location *ast.Node, contentFormat lsproto.MarkupKind, commentOnly bool) string {
+	for _, decl := range decls {
+		if s := l.getDocumentationFromDeclaration(c, nil, decl, location, contentFormat, commentOnly); s != "" {
+			return s
+		}
+	}
+	return ""
 }
 
 func getCommentText(comments []*ast.Node) string {

--- a/internal/ls/hover.go
+++ b/internal/ls/hover.go
@@ -71,8 +71,8 @@ func (l *LanguageService) getQuickInfoAndDocumentationForSymbol(c *checker.Check
 
 func (l *LanguageService) getDocumentationFromDeclaration(c *checker.Checker, symbol *ast.Symbol, declaration *ast.Node, location *ast.Node, contentFormat lsproto.MarkupKind, commentOnly bool) string {
 	if declaration == nil {
-		// For mapped type symbols with @inheritDoc on the mapped type, synthesize documentation
-		// from the mapped type's declarations and the syntheticOrigin's declarations.
+		// For mapped type symbols with @inheritDoc on the mapped type, collect documentation
+		// by considering the mapped type's declarations and the syntheticOrigin's declarations.
 		if symbol != nil && symbol.CheckFlags&ast.CheckFlagsMapped != 0 &&
 			symbol.Parent != nil && len(symbol.Parent.Declarations) > 0 &&
 			core.Some(symbol.Parent.Declarations, hasJSDocInheritDocTag) {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -3120,6 +3120,7 @@ func (p *Parser) nextIsStartOfMappedType() bool {
 
 func (p *Parser) parseMappedType() *ast.Node {
 	pos := p.nodePos()
+	hasJSDoc := p.jsdocScannerInfo()
 	p.parseExpected(ast.KindOpenBraceToken)
 	var readonlyToken *ast.Node // ReadonlyKeyword | PlusToken | MinusToken
 	if p.token == ast.KindReadonlyKeyword || p.token == ast.KindPlusToken || p.token == ast.KindMinusToken {
@@ -3146,7 +3147,9 @@ func (p *Parser) parseMappedType() *ast.Node {
 	p.parseSemicolon()
 	members := p.parseList(PCTypeMembers, (*Parser).parseTypeMember)
 	p.parseExpected(ast.KindCloseBraceToken)
-	return p.finishNode(p.factory.NewMappedTypeNode(readonlyToken, typeParameter, nameType, questionToken, typeNode, members), pos)
+	result := p.finishNode(p.factory.NewMappedTypeNode(readonlyToken, typeParameter, nameType, questionToken, typeNode, members), pos)
+	p.withJSDoc(result, hasJSDoc)
+	return result
 }
 
 func (p *Parser) parseMappedTypeParameter() *ast.Node {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -3120,7 +3120,7 @@ func (p *Parser) nextIsStartOfMappedType() bool {
 
 func (p *Parser) parseMappedType() *ast.Node {
 	pos := p.nodePos()
-	hasJSDoc := p.jsdocScannerInfo()
+	jsdocInfo := p.jsdocScannerInfo()
 	p.parseExpected(ast.KindOpenBraceToken)
 	var readonlyToken *ast.Node // ReadonlyKeyword | PlusToken | MinusToken
 	if p.token == ast.KindReadonlyKeyword || p.token == ast.KindPlusToken || p.token == ast.KindMinusToken {
@@ -3148,7 +3148,7 @@ func (p *Parser) parseMappedType() *ast.Node {
 	members := p.parseList(PCTypeMembers, (*Parser).parseTypeMember)
 	p.parseExpected(ast.KindCloseBraceToken)
 	result := p.finishNode(p.factory.NewMappedTypeNode(readonlyToken, typeParameter, nameType, questionToken, typeNode, members), pos)
-	p.withJSDoc(result, hasJSDoc)
+	p.withJSDoc(result, jsdocInfo)
 	return result
 }
 

--- a/internal/parser/utilities.go
+++ b/internal/parser/utilities.go
@@ -27,7 +27,7 @@ func tokenIsIdentifierOrKeywordOrGreaterThan(token ast.Kind) bool {
 
 func GetJSDocCommentRanges(f *ast.NodeFactory, commentRanges []ast.CommentRange, node *ast.Node, text string) []ast.CommentRange {
 	switch node.Kind {
-	case ast.KindParameter, ast.KindTypeParameter, ast.KindFunctionExpression, ast.KindArrowFunction, ast.KindParenthesizedExpression, ast.KindVariableDeclaration, ast.KindExportSpecifier:
+	case ast.KindParameter, ast.KindTypeParameter, ast.KindFunctionExpression, ast.KindArrowFunction, ast.KindParenthesizedExpression, ast.KindVariableDeclaration, ast.KindExportSpecifier, ast.KindMappedType:
 		for commentRange := range scanner.GetTrailingCommentRanges(f, text, node.Pos()) {
 			commentRanges = append(commentRanges, commentRange)
 		}

--- a/testdata/baselines/reference/fourslash/goToDefinition/goToDefinitionMappedType2.baseline.jsonc
+++ b/testdata/baselines/reference/fourslash/goToDefinition/goToDefinitionMappedType2.baseline.jsonc
@@ -1,0 +1,15 @@
+// === goToDefinition ===
+// === /goToDefinitionMappedType2.ts ===
+// interface Foo {
+//     <|[|property|]: string|>
+// }
+// 
+// type JustMapIt<T> = {[P in keyof T]: 0}
+// --- (line: 6) skipped ---
+
+// --- (line: 11) skipped ---
+// 
+// {
+//     let gotoDef!: MapItWithRemap<Foo>
+//     gotoDef./*GOTO DEF*/mapped_property
+// }

--- a/testdata/baselines/reference/fourslash/goToDefinition/goToDefinitionMappedType3.baseline.jsonc
+++ b/testdata/baselines/reference/fourslash/goToDefinition/goToDefinitionMappedType3.baseline.jsonc
@@ -1,0 +1,14 @@
+// === goToDefinition ===
+// === /goToDefinitionMappedType3.ts ===
+// interface Source {
+//   <|[|alpha|]: number;|>
+//   beta: string;
+// }
+// 
+// --- (line: 6) skipped ---
+
+// --- (line: 21) skipped ---
+//   betaSuffix: () => "hello",
+// };
+// 
+// obj./*GOTO DEF*/alphaSuffix();

--- a/testdata/baselines/reference/fourslash/quickInfo/quickInfoMappedType3.baseline
+++ b/testdata/baselines/reference/fourslash/quickInfo/quickInfoMappedType3.baseline
@@ -1,0 +1,190 @@
+// === QuickInfo ===
+=== /quickInfoMappedType3.ts ===
+// type Getters<Type> =  /** @inheritDoc desc on Getters */  {
+//   [Property in keyof Type as `get${Capitalize<
+//     string & Property
+//   >}`]: () => Type[Property];
+// };
+// 
+// interface Person {
+//   // ✅ When hovering here, the documentation is displayed, as it should.
+//   /**
+//    * Person's name.
+//    * @example "John Doe"
+//    */
+//   name: string;
+// 
+//   // ✅ When hovering here, the documentation is displayed, as it should.
+//   /**
+//    * Person's Age.
+//    * @example 30
+//    */
+//   age: number;
+// 
+//   // ✅ When hovering here, the documentation is displayed, as it should.
+//   /**
+//    * Person's Location.
+//    * @example "Brazil"
+//    */
+//   location: string;
+// }
+// 
+// type LazyPerson = Getters<Person>;
+// 
+// const me: LazyPerson = {
+//   // ❌ When hovering here, the documentation is NOT displayed.
+//   getName: () => "Jake Carter",
+//   ^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```tsx
+// | (property) getName: () => string
+// | ```
+// | 
+// | 
+// | *@inheritDoc* — desc on Getters 
+// | ----------------------------------------------------------------------
+//   // ❌ When hovering here, the documentation is NOT displayed.
+//   getAge: () => 35,
+//   ^^^^^^
+// | ----------------------------------------------------------------------
+// | ```tsx
+// | (property) getAge: () => number
+// | ```
+// | 
+// | 
+// | *@inheritDoc* — desc on Getters 
+// | ----------------------------------------------------------------------
+//   // ❌ When hovering here, the documentation is NOT displayed.
+//   getLocation: () => "United States",
+//   ^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```tsx
+// | (property) getLocation: () => string
+// | ```
+// | 
+// | 
+// | *@inheritDoc* — desc on Getters 
+// | ----------------------------------------------------------------------
+// };
+// 
+// // ❌ When hovering here, the documentation is NOT displayed.
+// me.getName();
+//    ^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```tsx
+// | (property) getName: () => string
+// | ```
+// | 
+// | 
+// | *@inheritDoc* — desc on Getters 
+// | ----------------------------------------------------------------------
+[
+  {
+    "marker": {
+      "Position": 755,
+      "LSPosition": {
+        "line": 33,
+        "character": 2
+      },
+      "Name": "1",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```tsx\n(property) getName: () => string\n```\n\n\n*@inheritDoc* — desc on Getters "
+      },
+      "range": {
+        "start": {
+          "line": 33,
+          "character": 2
+        },
+        "end": {
+          "line": 33,
+          "character": 9
+        }
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 852,
+      "LSPosition": {
+        "line": 35,
+        "character": 2
+      },
+      "Name": "2",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```tsx\n(property) getAge: () => number\n```\n\n\n*@inheritDoc* — desc on Getters "
+      },
+      "range": {
+        "start": {
+          "line": 35,
+          "character": 2
+        },
+        "end": {
+          "line": 35,
+          "character": 8
+        }
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 937,
+      "LSPosition": {
+        "line": 37,
+        "character": 2
+      },
+      "Name": "3",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```tsx\n(property) getLocation: () => string\n```\n\n\n*@inheritDoc* — desc on Getters "
+      },
+      "range": {
+        "start": {
+          "line": 37,
+          "character": 2
+        },
+        "end": {
+          "line": 37,
+          "character": 13
+        }
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 1043,
+      "LSPosition": {
+        "line": 41,
+        "character": 3
+      },
+      "Name": "4",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```tsx\n(property) getName: () => string\n```\n\n\n*@inheritDoc* — desc on Getters "
+      },
+      "range": {
+        "start": {
+          "line": 41,
+          "character": 3
+        },
+        "end": {
+          "line": 41,
+          "character": 10
+        }
+      }
+    }
+  }
+]

--- a/testdata/baselines/reference/fourslash/quickInfo/quickInfoMappedType3.baseline
+++ b/testdata/baselines/reference/fourslash/quickInfo/quickInfoMappedType3.baseline
@@ -81,7 +81,7 @@
 [
   {
     "marker": {
-      "Position": 755,
+      "Position": 765,
       "LSPosition": {
         "line": 33,
         "character": 2
@@ -108,7 +108,7 @@
   },
   {
     "marker": {
-      "Position": 852,
+      "Position": 872,
       "LSPosition": {
         "line": 35,
         "character": 2
@@ -135,7 +135,7 @@
   },
   {
     "marker": {
-      "Position": 937,
+      "Position": 967,
       "LSPosition": {
         "line": 37,
         "character": 2
@@ -162,7 +162,7 @@
   },
   {
     "marker": {
-      "Position": 1043,
+      "Position": 1083,
       "LSPosition": {
         "line": 41,
         "character": 3

--- a/testdata/baselines/reference/fourslash/quickInfo/quickInfoMappedType3.baseline
+++ b/testdata/baselines/reference/fourslash/quickInfo/quickInfoMappedType3.baseline
@@ -32,7 +32,7 @@
 // type LazyPerson = Getters<Person>;
 // 
 // const me: LazyPerson = {
-//   // ❌ When hovering here, the documentation is NOT displayed.
+//   // ✅ When hovering here, the documentation is displayed, as it should.
 //   getName: () => "Jake Carter",
 //   ^^^^^^^
 // | ----------------------------------------------------------------------
@@ -43,7 +43,7 @@
 // | 
 // | *@inheritDoc* — desc on Getters 
 // | ----------------------------------------------------------------------
-//   // ❌ When hovering here, the documentation is NOT displayed.
+//   // ✅ When hovering here, the documentation is displayed, as it should.
 //   getAge: () => 35,
 //   ^^^^^^
 // | ----------------------------------------------------------------------
@@ -54,7 +54,7 @@
 // | 
 // | *@inheritDoc* — desc on Getters 
 // | ----------------------------------------------------------------------
-//   // ❌ When hovering here, the documentation is NOT displayed.
+//   // ✅ When hovering here, the documentation is displayed, as it should.
 //   getLocation: () => "United States",
 //   ^^^^^^^^^^^
 // | ----------------------------------------------------------------------
@@ -67,7 +67,7 @@
 // | ----------------------------------------------------------------------
 // };
 // 
-// // ❌ When hovering here, the documentation is NOT displayed.
+// // ✅ When hovering here, the documentation is displayed, as it should.
 // me.getName();
 //    ^^^^^^^
 // | ----------------------------------------------------------------------


### PR DESCRIPTION
Fixes microsoft/TypeScript#50715
Fixes microsoft/TypeScript#56019
Fixes microsoft/TypeScript#61094

**Fixes:**
- https://github.com/microsoft/TypeScript/issues/50715
- https://github.com/microsoft/TypeScript/issues/56019
- https://github.com/microsoft/TypeScript/issues/61094

This was originally implemented in https://github.com/microsoft/TypeScript/pull/61061 (migrated here).