### PR TITLE
Fix document highlights for require property destructuring

### DIFF
--- a/internal/fourslash/tests/documentHighlightRequirePropertyDestructure1_test.go
+++ b/internal/fourslash/tests/documentHighlightRequirePropertyDestructure1_test.go
@@ -1,0 +1,20 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestDocumentHighlightRequirePropertyDestructure1(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `// @allowJs: true
+// @Filename: /a.js
+const { a } = require("m").f;
+a/*m*/;`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineDocumentHighlights(t, nil /*preferences*/, "m")
+}

--- a/internal/ls/importTracker.go
+++ b/internal/ls/importTracker.go
@@ -565,8 +565,14 @@ func getImportOrExportSymbol(node *ast.Node, symbol *ast.Symbol, checker *checke
 		if !isNodeImport(node) {
 			return nil
 		}
-		// A symbol being imported is always an alias. So get what that aliases to find the local symbol.
-		importedSymbol := checker.GetImmediateAliasedSymbol(symbol)
+		// JS destructuring from `require(...)` is import-like for references, but the binding element
+		// itself is still a local variable symbol rather than an alias.
+		var importedSymbol *ast.Symbol
+		if symbol.Flags&ast.SymbolFlagsAlias != 0 {
+			importedSymbol = checker.GetImmediateAliasedSymbol(symbol)
+		} else {
+			importedSymbol = getPropertySymbolOfObjectBindingPatternWithoutPropertyName(symbol, checker)
+		}
 		if importedSymbol == nil {
 			return nil
 		}

--- a/testdata/baselines/reference/fourslash/documentHighlights/documentHighlightRequirePropertyDestructure1.baseline.jsonc
+++ b/testdata/baselines/reference/fourslash/documentHighlights/documentHighlightRequirePropertyDestructure1.baseline.jsonc
@@ -1,0 +1,4 @@
+// === documentHighlights ===
+// === /a.js ===
+// const { [|a|] } = require("m").f;
+// [|a|]/*HIGHLIGHTS*/;


### PR DESCRIPTION
Fixes a crash found here: https://github.com/microsoft/typescript-go/issues/3256#issuecomment-4140021456