### PR TITLE
Fix for a snapshot update with a nil CommandLine

### DIFF
--- a/internal/api/proto.go
+++ b/internal/api/proto.go
@@ -393,7 +393,7 @@ type ProjectResponse struct {
 }
 
 func NewProjectResponse(p *project.Project) *ProjectResponse {
-	var rootFiles []string
+	rootFiles := []string{}
 	var opts *core.CompilerOptions
 	if p.CommandLine != nil {
 		rootFiles = p.CommandLine.FileNames()

--- a/internal/api/proto.go
+++ b/internal/api/proto.go
@@ -393,11 +393,17 @@ type ProjectResponse struct {
 }
 
 func NewProjectResponse(p *project.Project) *ProjectResponse {
+	var rootFiles []string
+	var opts *core.CompilerOptions
+	if p.CommandLine != nil {
+		rootFiles = p.CommandLine.FileNames()
+		opts = p.CommandLine.CompilerOptions()
+	}
 	return &ProjectResponse{
 		Id:              ProjectHandle(p),
 		ConfigFileName:  p.Name(),
-		RootFiles:       p.CommandLine.FileNames(),
-		CompilerOptions: p.CommandLine.CompilerOptions(),
+		RootFiles:       rootFiles,
+		CompilerOptions: opts,
 	}
 }
 

--- a/internal/api/proto_test.go
+++ b/internal/api/proto_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/microsoft/typescript-go/internal/api"
 	"github.com/microsoft/typescript-go/internal/json"
+	"github.com/microsoft/typescript-go/internal/project"
 	"gotest.tools/v3/assert"
 )
 
@@ -57,4 +58,13 @@ func TestDocumentIdentifierUnmarshalJSON(t *testing.T) {
 			assert.Equal(t, string(d.URI), tt.uri)
 		})
 	}
+}
+
+func TestNewProjectResponse_NilCommandLine(t *testing.T) {
+	t.Parallel()
+	p := &project.Project{}
+	resp := api.NewProjectResponse(p)
+	assert.Assert(t, resp != nil)
+	assert.DeepEqual(t, resp.RootFiles, []string{})
+	assert.Assert(t, resp.CompilerOptions == nil)
 }


### PR DESCRIPTION
Found this while testing code actions on the typescript repo.  NewProjectResponse panics when a project has a nil CommandLine. It was hard to add a test for this, but adding a nil check fixed the panic.