### PR TITLE
Remove "open a PR" from agent instructions

### DIFF
--- a/.github/agents/issue-investigator.md
+++ b/.github/agents/issue-investigator.md
@@ -3,7 +3,7 @@ name: Issue Investigator
 description: An expert at reproducing, investigating, and diagnosing issues
 ---
 
-Investigate the provided issue or problem description and open a PR with your investigation notes included as an additional markdown file. If you discover the solution, you can try fixing it, but your top priority is reproducing the problem and determining the root cause.
+Investigate the provided issue or problem description, logging your investigation notes in a markdown file. If you discover the solution, you can try fixing it, but your top priority is reproducing the problem and determining the root cause.
 
 First try to reproduce by making a test case using existing test infrastructure, but if you can't reproduce that way, you can add a temporary test project in a separate directory and use any means necessary to reproduce. Just make sure to commit your reproduction so someone can pick up your line of investigation if needed.
 

--- a/.github/agents/strada-corsa-port.md
+++ b/.github/agents/strada-corsa-port.md
@@ -19,4 +19,4 @@ Instructions
   - Tip: to run a single baseline test from the submodule, run go test ./internal/testrunner -run '^TestSubmodule/NAME_OF_TEST_FILE'
   - Run npx hereby baseline-accept to adopt the baseline changes.
   - Run git diff 'testdata/**/*.diff'. If your change is correct, these diff files will be reduced or completely deleted.
-- Iterate until you are satisfied with your change. Commit everything, including the baseline changes in testdata, and open a PR.
+- Iterate until you are satisfied with your change. Commit everything, including the baseline changes in testdata.


### PR DESCRIPTION
These agent instructions were written for CCA, when opening a PR was the automatic and only possible outcome. Now, when using Copilot CLI or local agent mode, Copilot can decide to spawn subagents using these instructions, causing those subagents to use the GitHub API to open a PR _as you_, when you perhaps only intended to be working and investigating locally.

#3272 was opened by the issue-investigator subagent even though my user instructions are

> You must never speak as me in public fora. This includes using `gh` to create PRs, comment on issues, etc. You may commit code, but you must co-sign the commit with the 'Co-authored-by' trailer. Do not push unless asked.

and my _actual prompt_ said “You may commit but not push”!!!