### PR TITLE
perf: remove extra func call in `getConditionalTypeInstantiation`

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -21948,7 +21948,7 @@ func (c *Checker) getConditionalTypeInstantiation(t *Type, mapper *TypeMapper, f
 		// We are instantiating a conditional type that has one or more type parameters in scope. Apply the
 		// mapper to the type parameters to produce the effective list of type arguments, and compute the
 		// instantiation cache key from the type IDs of the type arguments.
-		typeArguments := core.Map(root.outerTypeParameters, func(t *Type) *Type { return mapper.Map(t) })
+		typeArguments := core.Map(root.outerTypeParameters, mapper.Map)
 		key := getConditionalTypeKey(typeArguments, alias, forConstraint)
 		result := root.instantiations[key]
 		if result == nil {


### PR DESCRIPTION
not expecting a significant perf difference here, just a cleanup I noticed