### PR TITLE
Fix rename crash on quoted single-character property names

### DIFF
--- a/internal/fourslash/tests/renameQuotedSingleCharacterPropertyName1_test.go
+++ b/internal/fourslash/tests/renameQuotedSingleCharacterPropertyName1_test.go
@@ -1,0 +1,21 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestRenameQuotedSingleCharacterPropertyName1(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = "" +
+		"\n" +
+		"const obj = {\n" +
+		"  \"'\"/**/: 1,\n" +
+		"}\n"
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineRename(t, nil /*preferences*/, "")
+}

--- a/internal/stringutil/util.go
+++ b/internal/stringutil/util.go
@@ -219,6 +219,9 @@ func AddUTF8ByteOrderMark(text string) string {
 }
 
 func StripQuotes(name string) string {
+	if len(name) < 2 {
+		return name
+	}
 	firstChar, _ := utf8.DecodeRuneInString(name)
 	lastChar, _ := utf8.DecodeLastRuneInString(name)
 	if firstChar == lastChar && (firstChar == '\'' || firstChar == '"' || firstChar == '`') {

--- a/testdata/baselines/reference/fourslash/findRenameLocations/renameQuotedSingleCharacterPropertyName1.baseline.jsonc
+++ b/testdata/baselines/reference/fourslash/findRenameLocations/renameQuotedSingleCharacterPropertyName1.baseline.jsonc
@@ -1,0 +1,6 @@
+// === findRenameLocations ===
+// === /renameQuotedSingleCharacterPropertyName1.ts ===
+// const obj = {
+//   "[|'RENAME|]"/*RENAME*/: 1,
+// }
+// 


### PR DESCRIPTION
fixes a crash found here: https://github.com/microsoft/typescript-go/issues/3280#issuecomment-4145864512