### PR TITLE
Fixed a completion crash after invalid token in array literal

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -28433,6 +28433,9 @@ func (c *Checker) getContextualType(node *ast.Node, contextFlags ContextFlags) *
 	case ast.KindArrayLiteralExpression:
 		t := c.getApparentTypeOfContextualType(parent, contextFlags)
 		elementIndex := ast.IndexOfNode(parent.Elements(), node)
+		if elementIndex < 0 {
+			return nil
+		}
 		firstSpreadIndex, lastSpreadIndex := c.getSpreadIndices(parent)
 		return c.getContextualTypeForElementExpression(t, elementIndex, len(parent.Elements()), firstSpreadIndex, lastSpreadIndex)
 	case ast.KindConditionalExpression:

--- a/internal/fourslash/tests/completionInArrayLiteralAfterInvalidToken1_test.go
+++ b/internal/fourslash/tests/completionInArrayLiteralAfterInvalidToken1_test.go
@@ -1,0 +1,30 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	. "github.com/microsoft/typescript-go/internal/fourslash/tests/util"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestCompletionInArrayLiteralAfterInvalidToken1(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+
+	const content = `const pairs: Record<string, [string, string]> = {
+  a: ["x",:/*m1*/]
+};
+`
+
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+
+	f.VerifyCompletions(t, "m1", &fourslash.CompletionsExpectedList{
+		IsIncomplete: false,
+		ItemDefaults: &fourslash.CompletionsExpectedItemDefaults{
+			CommitCharacters: &DefaultCommitCharacters,
+		},
+		Items: &fourslash.CompletionsExpectedItems{},
+	})
+}


### PR DESCRIPTION
fixes a crash found here https://github.com/microsoft/typescript-go/issues/3280#issuecomment-4145864600