### PR TITLE
Fixed a call hierarchy crash in arrow prop declaration in exported default class

### DIFF
--- a/internal/fourslash/tests/callHierarchyInPropDeclarationOfExportedDefaultClass1_test.go
+++ b/internal/fourslash/tests/callHierarchyInPropDeclarationOfExportedDefaultClass1_test.go
@@ -1,0 +1,25 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestCallHierarchyInPropDeclarationOfExportedDefaultClass1(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `// @Filename: /main.ts
+export default class {
+  onSave = () => {
+    const values = [];
+    values./*m1*/push(1);
+  };
+}
+`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.GoToMarker(t, "m1")
+	f.VerifyBaselineCallHierarchy(t)
+}

--- a/internal/ls/callhierarchy.go
+++ b/internal/ls/callhierarchy.go
@@ -258,7 +258,7 @@ func getCallHierarchyItemContainerName(node *ast.Node) string {
 				}
 			}
 		}
-		if ast.IsModuleBlock(parent.Parent.Parent.Parent) {
+		if parent.Parent.Parent != nil && parent.Parent.Parent.Parent != nil && ast.IsModuleBlock(parent.Parent.Parent.Parent) {
 			modParent := parent.Parent.Parent.Parent.Parent
 			if ast.IsModuleDeclaration(modParent) {
 				if name := modParent.Name(); name != nil && ast.IsIdentifier(name) {

--- a/testdata/baselines/reference/fourslash/callHierarchy/callHierarchyInPropDeclarationOfExportedDefaultClass1.callHierarchy.txt
+++ b/testdata/baselines/reference/fourslash/callHierarchy/callHierarchyInPropDeclarationOfExportedDefaultClass1.callHierarchy.txt
@@ -1,0 +1,50 @@
+// === Call Hierarchy ===
+╭ name: push
+├ kind: method
+├ file: bundled:///libs/lib.es5.d.ts
+├ span:
+│ ╭ bundled:///libs/lib.es5.d.ts:1341:5-1345:33
+│ │ 1341:     /**
+│ │           ^^^
+│ │ 1342:      * Appends new elements to the end of an array, and returns the new length of the array.
+│ │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ │ 1343:      * @param items New elements to add to the array.
+│ │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ │ 1344:      */
+│ │       ^^^^^^^
+│ │ 1345:     push(...items: T[]): number;
+│ │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ ╰
+├ selectionSpan:
+│ ╭ bundled:///libs/lib.es5.d.ts:1345:5-1345:9
+│ │ 1345:     push(...items: T[]): number;
+│ │           ^^^^
+│ ╰
+├ incoming:
+│ ╭ from:
+│ │ ╭ name: onSave
+│ │ ├ kind: function
+│ │ ├ file: /main.ts
+│ │ ├ span:
+│ │ │ ╭ /main.ts:2:12-5:4
+│ │ │ │ 2:   onSave = () => {
+│ │ │ │               ^^^^^^^
+│ │ │ │ 3:     const values = [];
+│ │ │ │    ^^^^^^^^^^^^^^^^^^^^^^
+│ │ │ │ 4:     values.push(1);
+│ │ │ │    ^^^^^^^^^^^^^^^^^^^
+│ │ │ │ 5:   };
+│ │ │ │    ^^^
+│ │ │ ╰
+│ │ ├ selectionSpan:
+│ │ │ ╭ /main.ts:2:3-2:9
+│ │ │ │ 2:   onSave = () => {
+│ │ │ │      ^^^^^^
+│ │ │ ╰
+│ │ ╰ incoming: none
+│ ├ fromSpans:
+│ │ ╭ /main.ts:4:12-4:16
+│ │ │ 4:     values.push(1);
+│ │ │               ^^^^
+│ ╰ ╰
+╰ outgoing: none


### PR DESCRIPTION
fixes a crash found here https://github.com/microsoft/typescript-go/issues/3281#issuecomment-4145960697