### PR TITLE
Allow global Symbol computed names during pseudochecker object literal serialization

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -13454,6 +13454,26 @@ func (c *Checker) getResolvedSymbolNoDiagnostics(node *ast.Node) *ast.Symbol {
 	return links.resolvedSymbolNoDiagnostics
 }
 
+func (c *Checker) isDefinitelyReferenceToGlobalSymbolObject(node *ast.Node) bool {
+	if !ast.IsPropertyAccessExpression(node) ||
+		!ast.IsIdentifier(node.Name()) ||
+		(!ast.IsPropertyAccessExpression(node.Expression()) && !ast.IsIdentifier(node.Expression())) {
+		return false
+	}
+	if node.Expression().Kind == ast.KindIdentifier {
+		if node.Expression().Text() != "Symbol" {
+			return false
+		}
+		// Exactly `Symbol.something` and `Symbol` either does not resolve or definitely resolves to the global Symbol.
+		return c.getResolvedSymbol(node.Expression()) == c.getGlobalSymbol("Symbol", ast.SymbolFlagsValue|ast.SymbolFlagsExportValue, nil /*diagnostic*/)
+	}
+	if node.Expression().Expression().Kind != ast.KindIdentifier || node.Expression().Expression().Text() != "globalThis" || node.Expression().Name().Text() != "Symbol" {
+		return false
+	}
+	// Exactly `globalThis.Symbol.something` and `globalThis` resolves to the global `globalThis`.
+	return c.getResolvedSymbol(node.Expression().Expression()) == c.globalThisSymbol
+}
+
 func (c *Checker) getCannotFindNameDiagnosticForName(node *ast.Node) *diagnostics.Message {
 	switch node.Text() {
 	case "document", "console":

--- a/internal/checker/emitresolver.go
+++ b/internal/checker/emitresolver.go
@@ -514,27 +514,9 @@ func (r *EmitResolver) IsImportRequiredByAugmentation(decl *ast.ImportDeclaratio
 }
 
 func (r *EmitResolver) IsDefinitelyReferenceToGlobalSymbolObject(node *ast.Node) bool {
-	if !ast.IsPropertyAccessExpression(node) ||
-		!ast.IsIdentifier(node.Name()) ||
-		!ast.IsPropertyAccessExpression(node.Expression()) && !ast.IsIdentifier(node.Expression()) {
-		return false
-	}
-	if node.Expression().Kind == ast.KindIdentifier {
-		if node.Expression().Text() != "Symbol" {
-			return false
-		}
-		r.checkerMu.Lock()
-		defer r.checkerMu.Unlock()
-		// Exactly `Symbol.something` and `Symbol` either does not resolve or definitely resolves to the global Symbol
-		return r.checker.getResolvedSymbol(node.Expression()) == r.checker.getGlobalSymbol("Symbol", ast.SymbolFlagsValue|ast.SymbolFlagsExportValue, nil /*diagnostic*/)
-	}
-	if node.Expression().Expression().Kind != ast.KindIdentifier || node.Expression().Expression().Text() != "globalThis" || node.Expression().Name().Text() != "Symbol" {
-		return false
-	}
 	r.checkerMu.Lock()
 	defer r.checkerMu.Unlock()
-	// Exactly `globalThis.Symbol.something` and `globalThis` resolves to the global `globalThis`
-	return r.checker.getResolvedSymbol(node.Expression().Expression()) == r.checker.globalThisSymbol
+	return r.checker.isDefinitelyReferenceToGlobalSymbolObject(node)
 }
 
 func (r *EmitResolver) RequiresAddingImplicitUndefined(declaration *ast.Node, symbol *ast.Symbol, enclosingDeclaration *ast.Node) bool {

--- a/internal/checker/nodebuilderimpl.go
+++ b/internal/checker/nodebuilderimpl.go
@@ -117,7 +117,33 @@ func newNodeBuilderImpl(ch *Checker, e *printer.EmitContext, idToSymbol map[*ast
 	if idToSymbol == nil {
 		idToSymbol = make(map[*ast.IdentifierNode]*ast.Symbol)
 	}
-	b := &NodeBuilderImpl{f: e.Factory.AsNodeFactory(), ch: ch, e: e, idToSymbol: idToSymbol, pc: pseudochecker.NewPseudoChecker(ch.strictNullChecks, ch.exactOptionalPropertyTypes)}
+	b := &NodeBuilderImpl{
+		f:          e.Factory.AsNodeFactory(),
+		ch:         ch,
+		e:          e,
+		idToSymbol: idToSymbol,
+		pc: pseudochecker.NewPseudoChecker(
+			ch.strictNullChecks,
+			ch.exactOptionalPropertyTypes,
+			func(node *ast.Node) bool {
+				if !ast.IsPropertyAccessExpression(node) ||
+					!ast.IsIdentifier(node.Name()) ||
+					(!ast.IsPropertyAccessExpression(node.Expression()) && !ast.IsIdentifier(node.Expression())) {
+					return false
+				}
+				if node.Expression().Kind == ast.KindIdentifier {
+					if node.Expression().Text() != "Symbol" {
+						return false
+					}
+					return ch.getResolvedSymbol(node.Expression()) == ch.getGlobalSymbol("Symbol", ast.SymbolFlagsValue|ast.SymbolFlagsExportValue, nil /*diagnostic*/)
+				}
+				if node.Expression().Expression().Kind != ast.KindIdentifier || node.Expression().Expression().Text() != "globalThis" || node.Expression().Name().Text() != "Symbol" {
+					return false
+				}
+				return ch.getResolvedSymbol(node.Expression().Expression()) == ch.globalThisSymbol
+			},
+		),
+	}
 	b.cloneBindingNameVisitor = ast.NewNodeVisitor(b.cloneBindingName, b.f, ast.NodeVisitorHooks{})
 	return b
 }

--- a/internal/checker/nodebuilderimpl.go
+++ b/internal/checker/nodebuilderimpl.go
@@ -125,23 +125,7 @@ func newNodeBuilderImpl(ch *Checker, e *printer.EmitContext, idToSymbol map[*ast
 		pc: pseudochecker.NewPseudoChecker(
 			ch.strictNullChecks,
 			ch.exactOptionalPropertyTypes,
-			func(node *ast.Node) bool {
-				if !ast.IsPropertyAccessExpression(node) ||
-					!ast.IsIdentifier(node.Name()) ||
-					(!ast.IsPropertyAccessExpression(node.Expression()) && !ast.IsIdentifier(node.Expression())) {
-					return false
-				}
-				if node.Expression().Kind == ast.KindIdentifier {
-					if node.Expression().Text() != "Symbol" {
-						return false
-					}
-					return ch.getResolvedSymbol(node.Expression()) == ch.getGlobalSymbol("Symbol", ast.SymbolFlagsValue|ast.SymbolFlagsExportValue, nil /*diagnostic*/)
-				}
-				if node.Expression().Expression().Kind != ast.KindIdentifier || node.Expression().Expression().Text() != "globalThis" || node.Expression().Name().Text() != "Symbol" {
-					return false
-				}
-				return ch.getResolvedSymbol(node.Expression().Expression()) == ch.globalThisSymbol
-			},
+			ch.isDefinitelyReferenceToGlobalSymbolObject,
 		),
 	}
 	b.cloneBindingNameVisitor = ast.NewNodeVisitor(b.cloneBindingName, b.f, ast.NodeVisitorHooks{})

--- a/internal/pseudochecker/checker.go
+++ b/internal/pseudochecker/checker.go
@@ -1,6 +1,8 @@
 // pseudochecker is a limited "checker" that returns pseudo-"types" of expressions - mostly those which trivially have type nodes
 package pseudochecker
 
+import "github.com/microsoft/typescript-go/internal/ast"
+
 // TODO: Late binding/symbol merging?
 // In strada, `expressionToTypeNode` used many `resolver` methods whose net effect was just
 // calling `Checker.GetMergedSymbol` on a symbol when dealing with accessors. Right now those
@@ -14,8 +16,13 @@ package pseudochecker
 type PseudoChecker struct {
 	strictNullChecks           bool
 	exactOptionalPropertyTypes bool
+	isDefinitelyReferenceToGlobalSymbolObject func(node *ast.Node) bool
 }
 
-func NewPseudoChecker(strictNullChecks bool, exactOptionalPropertyTypes bool) *PseudoChecker {
-	return &PseudoChecker{strictNullChecks: strictNullChecks, exactOptionalPropertyTypes: exactOptionalPropertyTypes}
+func NewPseudoChecker(strictNullChecks bool, exactOptionalPropertyTypes bool, isDefinitelyReferenceToGlobalSymbolObject func(node *ast.Node) bool) *PseudoChecker {
+	return &PseudoChecker{
+		strictNullChecks:           strictNullChecks,
+		exactOptionalPropertyTypes: exactOptionalPropertyTypes,
+		isDefinitelyReferenceToGlobalSymbolObject: isDefinitelyReferenceToGlobalSymbolObject,
+	}
 }

--- a/internal/pseudochecker/checker.go
+++ b/internal/pseudochecker/checker.go
@@ -14,15 +14,15 @@ import "github.com/microsoft/typescript-go/internal/ast"
 // extracting the `mergeSymbol` core checker logic into a reusable component.
 
 type PseudoChecker struct {
-	strictNullChecks           bool
-	exactOptionalPropertyTypes bool
+	strictNullChecks                          bool
+	exactOptionalPropertyTypes                bool
 	isDefinitelyReferenceToGlobalSymbolObject func(node *ast.Node) bool
 }
 
 func NewPseudoChecker(strictNullChecks bool, exactOptionalPropertyTypes bool, isDefinitelyReferenceToGlobalSymbolObject func(node *ast.Node) bool) *PseudoChecker {
 	return &PseudoChecker{
-		strictNullChecks:           strictNullChecks,
-		exactOptionalPropertyTypes: exactOptionalPropertyTypes,
+		strictNullChecks:                          strictNullChecks,
+		exactOptionalPropertyTypes:                exactOptionalPropertyTypes,
 		isDefinitelyReferenceToGlobalSymbolObject: isDefinitelyReferenceToGlobalSymbolObject,
 	}
 }

--- a/internal/pseudochecker/lookup.go
+++ b/internal/pseudochecker/lookup.go
@@ -432,7 +432,8 @@ func (ch *PseudoChecker) canGetTypeFromObjectLiteral(node *ast.ObjectLiteralExpr
 		}
 		if e.Name().Kind == ast.KindComputedPropertyName {
 			expression := e.Name().Expression()
-			if !ast.IsPrimitiveLiteralValue(expression, false) {
+			if !ast.IsPrimitiveLiteralValue(expression, false) &&
+				(ch.isDefinitelyReferenceToGlobalSymbolObject == nil || !ch.isDefinitelyReferenceToGlobalSymbolObject(expression)) {
 				return false
 			}
 		}

--- a/internal/pseudochecker/lookup.go
+++ b/internal/pseudochecker/lookup.go
@@ -433,7 +433,7 @@ func (ch *PseudoChecker) canGetTypeFromObjectLiteral(node *ast.ObjectLiteralExpr
 		if e.Name().Kind == ast.KindComputedPropertyName {
 			expression := e.Name().Expression()
 			if !ast.IsPrimitiveLiteralValue(expression, false) &&
-				(ch.isDefinitelyReferenceToGlobalSymbolObject == nil || !ch.isDefinitelyReferenceToGlobalSymbolObject(expression)) {
+				!ch.isDefinitelyReferenceToGlobalSymbolObject(expression) {
 				return false
 			}
 		}

--- a/testdata/baselines/reference/compiler/declarationEmitComputedPropertyGlobalSymbol1.js
+++ b/testdata/baselines/reference/compiler/declarationEmitComputedPropertyGlobalSymbol1.js
@@ -1,0 +1,25 @@
+//// [tests/cases/compiler/declarationEmitComputedPropertyGlobalSymbol1.ts] ////
+
+//// [declarationEmitComputedPropertyGlobalSymbol1.ts]
+export const symbolNamed = {
+    [Symbol.toStringTag]: "demo",
+    [Symbol.iterator](): IterableIterator<number> {
+        return [1, 2, 3][Symbol.iterator]();
+    },
+} as const;
+
+
+//// [declarationEmitComputedPropertyGlobalSymbol1.js]
+export const symbolNamed = {
+    [Symbol.toStringTag]: "demo",
+    [Symbol.iterator]() {
+        return [1, 2, 3][Symbol.iterator]();
+    },
+};
+
+
+//// [declarationEmitComputedPropertyGlobalSymbol1.d.ts]
+export declare const symbolNamed: {
+    readonly [Symbol.toStringTag]: "demo";
+    readonly [Symbol.iterator]: () => IterableIterator<number>;
+};

--- a/testdata/baselines/reference/compiler/declarationEmitComputedPropertyGlobalSymbol1.symbols
+++ b/testdata/baselines/reference/compiler/declarationEmitComputedPropertyGlobalSymbol1.symbols
@@ -1,0 +1,28 @@
+//// [tests/cases/compiler/declarationEmitComputedPropertyGlobalSymbol1.ts] ////
+
+=== declarationEmitComputedPropertyGlobalSymbol1.ts ===
+export const symbolNamed = {
+>symbolNamed : Symbol(symbolNamed, Decl(declarationEmitComputedPropertyGlobalSymbol1.ts, 0, 12))
+
+    [Symbol.toStringTag]: "demo",
+>[Symbol.toStringTag] : Symbol([Symbol.toStringTag], Decl(declarationEmitComputedPropertyGlobalSymbol1.ts, 0, 28))
+>Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+
+    [Symbol.iterator](): IterableIterator<number> {
+>[Symbol.iterator] : Symbol([Symbol.iterator], Decl(declarationEmitComputedPropertyGlobalSymbol1.ts, 1, 33))
+>Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
+>IterableIterator : Symbol(IterableIterator, Decl(lib.es2015.iterable.d.ts, --, --))
+
+        return [1, 2, 3][Symbol.iterator]();
+>Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
+
+    },
+} as const;
+>const : Symbol(const)
+

--- a/testdata/baselines/reference/compiler/declarationEmitComputedPropertyGlobalSymbol1.types
+++ b/testdata/baselines/reference/compiler/declarationEmitComputedPropertyGlobalSymbol1.types
@@ -1,0 +1,35 @@
+//// [tests/cases/compiler/declarationEmitComputedPropertyGlobalSymbol1.ts] ////
+
+=== declarationEmitComputedPropertyGlobalSymbol1.ts ===
+export const symbolNamed = {
+>symbolNamed : { readonly [Symbol.toStringTag]: "demo"; readonly [Symbol.iterator]: () => IterableIterator<number>; }
+>{    [Symbol.toStringTag]: "demo",    [Symbol.iterator](): IterableIterator<number> {        return [1, 2, 3][Symbol.iterator]();    },} as const : { readonly [Symbol.toStringTag]: "demo"; readonly [Symbol.iterator]: () => IterableIterator<number>; }
+>{    [Symbol.toStringTag]: "demo",    [Symbol.iterator](): IterableIterator<number> {        return [1, 2, 3][Symbol.iterator]();    },} : { readonly [Symbol.toStringTag]: "demo"; readonly [Symbol.iterator]: () => IterableIterator<number>; }
+
+    [Symbol.toStringTag]: "demo",
+>[Symbol.toStringTag] : "demo"
+>Symbol.toStringTag : unique symbol
+>Symbol : SymbolConstructor
+>toStringTag : unique symbol
+>"demo" : "demo"
+
+    [Symbol.iterator](): IterableIterator<number> {
+>[Symbol.iterator] : () => IterableIterator<number>
+>Symbol.iterator : unique symbol
+>Symbol : SymbolConstructor
+>iterator : unique symbol
+
+        return [1, 2, 3][Symbol.iterator]();
+>[1, 2, 3][Symbol.iterator]() : ArrayIterator<number>
+>[1, 2, 3][Symbol.iterator] : () => ArrayIterator<number>
+>[1, 2, 3] : number[]
+>1 : 1
+>2 : 2
+>3 : 3
+>Symbol.iterator : unique symbol
+>Symbol : SymbolConstructor
+>iterator : unique symbol
+
+    },
+} as const;
+

--- a/testdata/baselines/reference/compiler/declarationEmitComputedPropertyGlobalSymbol2.errors.txt
+++ b/testdata/baselines/reference/compiler/declarationEmitComputedPropertyGlobalSymbol2.errors.txt
@@ -1,0 +1,15 @@
+declarationEmitComputedPropertyGlobalSymbol2.ts(4,16): error TS9013: Expression type can't be inferred with --isolatedDeclarations.
+
+
+==== declarationEmitComputedPropertyGlobalSymbol2.ts (1 errors) ====
+    export const symbolNamed = {
+        [Symbol.toStringTag]: "demo",
+        [Symbol.iterator]() {
+            return [1, 2, 3][Symbol.iterator]();
+                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS9013: Expression type can't be inferred with --isolatedDeclarations.
+!!! related TS9034 declarationEmitComputedPropertyGlobalSymbol2.ts:3:5: Add a return type to the method
+!!! related TS9035 declarationEmitComputedPropertyGlobalSymbol2.ts:4:16: Add satisfies and a type assertion to this expression (satisfies T as T) to make the type explicit.
+        },
+    } as const;
+    

--- a/testdata/baselines/reference/compiler/declarationEmitComputedPropertyGlobalSymbol2.js
+++ b/testdata/baselines/reference/compiler/declarationEmitComputedPropertyGlobalSymbol2.js
@@ -1,0 +1,25 @@
+//// [tests/cases/compiler/declarationEmitComputedPropertyGlobalSymbol2.ts] ////
+
+//// [declarationEmitComputedPropertyGlobalSymbol2.ts]
+export const symbolNamed = {
+    [Symbol.toStringTag]: "demo",
+    [Symbol.iterator]() {
+        return [1, 2, 3][Symbol.iterator]();
+    },
+} as const;
+
+
+//// [declarationEmitComputedPropertyGlobalSymbol2.js]
+export const symbolNamed = {
+    [Symbol.toStringTag]: "demo",
+    [Symbol.iterator]() {
+        return [1, 2, 3][Symbol.iterator]();
+    },
+};
+
+
+//// [declarationEmitComputedPropertyGlobalSymbol2.d.ts]
+export declare const symbolNamed: {
+    readonly [Symbol.toStringTag]: "demo";
+    readonly [Symbol.iterator]: () => ArrayIterator<number>;
+};

--- a/testdata/baselines/reference/compiler/declarationEmitComputedPropertyGlobalSymbol2.symbols
+++ b/testdata/baselines/reference/compiler/declarationEmitComputedPropertyGlobalSymbol2.symbols
@@ -1,0 +1,27 @@
+//// [tests/cases/compiler/declarationEmitComputedPropertyGlobalSymbol2.ts] ////
+
+=== declarationEmitComputedPropertyGlobalSymbol2.ts ===
+export const symbolNamed = {
+>symbolNamed : Symbol(symbolNamed, Decl(declarationEmitComputedPropertyGlobalSymbol2.ts, 0, 12))
+
+    [Symbol.toStringTag]: "demo",
+>[Symbol.toStringTag] : Symbol([Symbol.toStringTag], Decl(declarationEmitComputedPropertyGlobalSymbol2.ts, 0, 28))
+>Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+
+    [Symbol.iterator]() {
+>[Symbol.iterator] : Symbol([Symbol.iterator], Decl(declarationEmitComputedPropertyGlobalSymbol2.ts, 1, 33))
+>Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
+
+        return [1, 2, 3][Symbol.iterator]();
+>Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
+
+    },
+} as const;
+>const : Symbol(const)
+

--- a/testdata/baselines/reference/compiler/declarationEmitComputedPropertyGlobalSymbol2.types
+++ b/testdata/baselines/reference/compiler/declarationEmitComputedPropertyGlobalSymbol2.types
@@ -1,0 +1,35 @@
+//// [tests/cases/compiler/declarationEmitComputedPropertyGlobalSymbol2.ts] ////
+
+=== declarationEmitComputedPropertyGlobalSymbol2.ts ===
+export const symbolNamed = {
+>symbolNamed : { readonly [Symbol.toStringTag]: "demo"; readonly [Symbol.iterator]: () => ArrayIterator<number>; }
+>{    [Symbol.toStringTag]: "demo",    [Symbol.iterator]() {        return [1, 2, 3][Symbol.iterator]();    },} as const : { readonly [Symbol.toStringTag]: "demo"; readonly [Symbol.iterator]: () => ArrayIterator<number>; }
+>{    [Symbol.toStringTag]: "demo",    [Symbol.iterator]() {        return [1, 2, 3][Symbol.iterator]();    },} : { readonly [Symbol.toStringTag]: "demo"; readonly [Symbol.iterator]: () => ArrayIterator<number>; }
+
+    [Symbol.toStringTag]: "demo",
+>[Symbol.toStringTag] : "demo"
+>Symbol.toStringTag : unique symbol
+>Symbol : SymbolConstructor
+>toStringTag : unique symbol
+>"demo" : "demo"
+
+    [Symbol.iterator]() {
+>[Symbol.iterator] : () => ArrayIterator<number>
+>Symbol.iterator : unique symbol
+>Symbol : SymbolConstructor
+>iterator : unique symbol
+
+        return [1, 2, 3][Symbol.iterator]();
+>[1, 2, 3][Symbol.iterator]() : ArrayIterator<number>
+>[1, 2, 3][Symbol.iterator] : () => ArrayIterator<number>
+>[1, 2, 3] : number[]
+>1 : 1
+>2 : 2
+>3 : 3
+>Symbol.iterator : unique symbol
+>Symbol : SymbolConstructor
+>iterator : unique symbol
+
+    },
+} as const;
+

--- a/testdata/tests/cases/compiler/declarationEmitComputedPropertyGlobalSymbol1.ts
+++ b/testdata/tests/cases/compiler/declarationEmitComputedPropertyGlobalSymbol1.ts
@@ -1,0 +1,10 @@
+// @declaration: true
+// @isolatedDeclarations: true
+// @target: es2015
+
+export const symbolNamed = {
+    [Symbol.toStringTag]: "demo",
+    [Symbol.iterator](): IterableIterator<number> {
+        return [1, 2, 3][Symbol.iterator]();
+    },
+} as const;

--- a/testdata/tests/cases/compiler/declarationEmitComputedPropertyGlobalSymbol2.ts
+++ b/testdata/tests/cases/compiler/declarationEmitComputedPropertyGlobalSymbol2.ts
@@ -1,0 +1,10 @@
+// @declaration: true
+// @isolatedDeclarations: true
+// @target: es2015
+
+export const symbolNamed = {
+    [Symbol.toStringTag]: "demo",
+    [Symbol.iterator]() {
+        return [1, 2, 3][Symbol.iterator]();
+    },
+} as const;


### PR DESCRIPTION
This change matches Strada's behavior more closely