### PR TITLE
Don't strip release binaries

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -191,11 +191,11 @@ export const lib = task({
  * @returns {string[]}
  */
 function getReleaseBuildFlags(versionOverride) {
-    let ldflags = "-ldflags=-s -w";
+    const flags = ["-trimpath"];
     if (versionOverride) {
-        ldflags += ` -X github.com/microsoft/typescript-go/internal/core.version=${versionOverride}`;
+        flags.push(`-ldflags=-X github.com/microsoft/typescript-go/internal/core.version=${versionOverride}`);
     }
-    return ["-trimpath", ldflags];
+    return flags;
 }
 
 /**


### PR DESCRIPTION
```
-rwxr-xr-x 1 jabaile jabaile  23M Mar 31 16:37 built/local-old/tsgo*
-rw-r--r-- 1 jabaile jabaile 8.6M Mar 31 16:39 built/local-old/tsgo.tar.gz
-rwxr-xr-x 1 jabaile jabaile  33M Mar 31 16:38 built/local/tsgo*
-rw-r--r-- 1 jabaile jabaile  16M Mar 31 16:39 built/local/tsgo.tar.gz
```

This increases the size of our package by a good bit, but it would make it able for us to debug the actual shipped code and run tools like `goref` on it.

But, it is doubling the gz'd size, so...