### PR TITLE
Fix watching files outside the workspace and realpaths symlinked into programs

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1118,7 +1118,7 @@ func (s *Server) handleInitialized(ctx context.Context, params *lsproto.Initiali
 	s.telemetryEnabled = enableTelemetry
 
 	s.session = project.NewSession(&project.SessionInit{
-		BackgroundCtx: s.backgroundCtx,
+		BackgroundCtx: lsproto.WithClientCapabilities(s.backgroundCtx, &s.clientCapabilities),
 		Options: &project.SessionOptions{
 			CurrentDirectory:       cwd,
 			DefaultLibraryPath:     s.defaultLibraryPath,

--- a/internal/project/configfileregistry.go
+++ b/internal/project/configfileregistry.go
@@ -49,13 +49,14 @@ type configFileEntry struct {
 	rootFilesWatch *WatchedFiles[PatternsAndIgnored]
 }
 
-func newConfigFileEntry(fileName string) *configFileEntry {
+func newConfigFileEntry(hasRelativePatternCapability bool, fileName string) *configFileEntry {
 	return &configFileEntry{
 		fileName:      fileName,
 		pendingReload: PendingReloadFull,
 		rootFilesWatch: NewWatchedFiles(
 			"root files for "+fileName,
 			lsproto.WatchKindCreate|lsproto.WatchKindChange|lsproto.WatchKindDelete,
+			hasRelativePatternCapability,
 			core.Identity,
 		),
 	}

--- a/internal/project/configfileregistrybuilder.go
+++ b/internal/project/configfileregistrybuilder.go
@@ -24,12 +24,13 @@ var (
 // configFileRegistry, producing a new clone with `finalize()` after
 // all changes have been made.
 type configFileRegistryBuilder struct {
-	fs                   *sourceFS
-	isOpenFile           func(tspath.Path) bool
-	extendedConfigCache  *ExtendedConfigCache
-	snapshotID           uint64
-	sessionOptions       *SessionOptions
-	customConfigFileName string
+	hasRelativePatternCapability bool
+	fs                           *sourceFS
+	isOpenFile                   func(tspath.Path) bool
+	extendedConfigCache          *ExtendedConfigCache
+	snapshotID                   uint64
+	sessionOptions               *SessionOptions
+	customConfigFileName         string
 
 	base                        *ConfigFileRegistry
 	configs                     *dirty.SyncMap[tspath.Path, *configFileEntry]
@@ -38,6 +39,7 @@ type configFileRegistryBuilder struct {
 }
 
 func newConfigFileRegistryBuilder(
+	hasRelativePatternCapability bool,
 	fs *snapshotFSBuilder,
 	oldConfigFileRegistry *ConfigFileRegistry,
 	extendedConfigCache *ExtendedConfigCache,
@@ -47,14 +49,15 @@ func newConfigFileRegistryBuilder(
 	logger *logging.LogTree,
 ) *configFileRegistryBuilder {
 	return &configFileRegistryBuilder{
-		fs:                          newSourceFS(false, fs, fs.toPath),
-		isOpenFile:                  fs.isOpenFile,
-		base:                        oldConfigFileRegistry,
-		sessionOptions:              sessionOptions,
-		extendedConfigCache:         extendedConfigCache,
-		snapshotID:                  snapshotID,
-		customConfigFileName:        customConfigFileName,
-		customConfigFileNameChanged: customConfigFileName != oldConfigFileRegistry.customConfigFileName,
+		hasRelativePatternCapability: hasRelativePatternCapability,
+		fs:                           newSourceFS(false, fs, fs.toPath),
+		isOpenFile:                   fs.isOpenFile,
+		base:                         oldConfigFileRegistry,
+		sessionOptions:               sessionOptions,
+		extendedConfigCache:          extendedConfigCache,
+		snapshotID:                   snapshotID,
+		customConfigFileName:         customConfigFileName,
+		customConfigFileNameChanged:  customConfigFileName != oldConfigFileRegistry.customConfigFileName,
 
 		configs:         dirty.NewSyncMap(oldConfigFileRegistry.configs),
 		configFileNames: dirty.NewMap(oldConfigFileRegistry.configFileNames),
@@ -233,8 +236,8 @@ func (c *configFileRegistryBuilder) updateRootFilesWatch(fileName string, entry 
 
 	slices.Sort(globs)
 	entry.rootFilesWatch = entry.rootFilesWatch.Clone(PatternsAndIgnored{
-		patterns: globs,
-		ignored:  ignored,
+		patternsInsideWorkspace: globs,
+		ignored:                 ignored,
 	})
 }
 
@@ -243,7 +246,7 @@ func (c *configFileRegistryBuilder) updateRootFilesWatch(fileName string, entry 
 // in the cache. Each `acquireConfigForProject` call that passes a `project` should be accompanied
 // by an eventual `releaseConfigForProject` call with the same project.
 func (c *configFileRegistryBuilder) acquireConfigForProject(fileName string, path tspath.Path, project *Project, logger *logging.LogTree) *tsoptions.ParsedCommandLine {
-	entry, _ := c.configs.LoadOrStore(path, newConfigFileEntry(fileName))
+	entry, _ := c.configs.LoadOrStore(path, newConfigFileEntry(c.hasRelativePatternCapability, fileName))
 	var needsRetainProject bool
 	entry.ChangeIf(
 		func(config *configFileEntry) bool {
@@ -269,7 +272,7 @@ func (c *configFileRegistryBuilder) acquireConfigForProject(fileName string, pat
 // Each `acquireConfigForFile` call that passes an `openFilePath`
 // should be accompanied by an eventual `releaseConfigForOpenFile` call with the same open file.
 func (c *configFileRegistryBuilder) acquireConfigForFile(configFileName string, configFilePath tspath.Path, filePath tspath.Path, logger *logging.LogTree) *tsoptions.ParsedCommandLine {
-	entry, _ := c.configs.LoadOrStore(configFilePath, newConfigFileEntry(configFileName))
+	entry, _ := c.configs.LoadOrStore(configFilePath, newConfigFileEntry(c.hasRelativePatternCapability, configFileName))
 	var needsRetainOpenFile bool
 	entry.ChangeIf(
 		func(config *configFileEntry) bool {

--- a/internal/project/dirty/syncmap.go
+++ b/internal/project/dirty/syncmap.go
@@ -332,7 +332,7 @@ func (m *SyncMap[K, V]) finalize(hooks FinalizationHooks[K, V]) (map[K]V, bool) 
 		if entry.delete {
 			ensureCloned()
 			if hooks.OnDelete != nil {
-				hooks.OnDelete(key, entry.original)
+				hooks.OnDelete(key, entry.value)
 			}
 			delete(result, key)
 		} else if entry.dirty {

--- a/internal/project/overlayfs.go
+++ b/internal/project/overlayfs.go
@@ -70,7 +70,8 @@ func (f *fileBase) ECMALineInfo() *sourcemap.ECMALineInfo {
 
 type diskFile struct {
 	fileBase
-	needsReload bool
+	needsReload  bool
+	realpathPath tspath.Path
 }
 
 func newDiskFile(fileName string, content string) *diskFile {
@@ -103,6 +104,7 @@ func (f *diskFile) Kind() core.ScriptKind {
 
 func (f *diskFile) Clone() *diskFile {
 	return &diskFile{
+		realpathPath: f.realpathPath,
 		fileBase: fileBase{
 			fileName: f.fileName,
 			content:  f.content,

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -152,12 +152,14 @@ func NewProject(
 	project.programFilesWatch = NewWatchedFiles(
 		"program files for "+configFileName,
 		lsproto.WatchKindCreate|lsproto.WatchKindChange|lsproto.WatchKindDelete,
+		lsproto.GetClientCapabilities(builder.ctx).Workspace.DidChangeWatchedFiles.RelativePatternSupport,
 		createResolutionLookupGlobMapper(builder.sessionOptions.CurrentDirectory, builder.sessionOptions.DefaultLibraryPath, project.currentDirectory, builder.fs.fs.UseCaseSensitiveFileNames()),
 	)
 	if builder.sessionOptions.TypingsLocation != "" {
 		project.typingsWatch = NewWatchedFiles(
 			"typings installer files",
 			lsproto.WatchKindCreate|lsproto.WatchKindChange|lsproto.WatchKindDelete,
+			lsproto.GetClientCapabilities(builder.ctx).Workspace.DidChangeWatchedFiles.RelativePatternSupport,
 			core.Identity,
 		)
 	}

--- a/internal/project/projectcollectionbuilder.go
+++ b/internal/project/projectcollectionbuilder.go
@@ -74,7 +74,7 @@ func newProjectCollectionBuilder(
 		parseCache:                         parseCache,
 		extendedConfigCache:                extendedConfigCache,
 		base:                               oldProjectCollection,
-		configFileRegistryBuilder:          newConfigFileRegistryBuilder(fs, oldConfigFileRegistry, extendedConfigCache, newSnapshotID, sessionOptions, customConfigFileName, nil),
+		configFileRegistryBuilder:          newConfigFileRegistryBuilder(lsproto.GetClientCapabilities(ctx).Workspace.DidChangeWatchedFiles.RelativePatternSupport, fs, oldConfigFileRegistry, extendedConfigCache, newSnapshotID, sessionOptions, customConfigFileName, nil),
 		newSnapshotID:                      newSnapshotID,
 		configuredProjects:                 dirty.NewSyncMap(oldProjectCollection.configuredProjects),
 		inferredProject:                    dirty.NewBox(oldProjectCollection.inferredProject),

--- a/internal/project/session.go
+++ b/internal/project/session.go
@@ -1365,6 +1365,7 @@ func (s *Session) logCacheStats(snapshot *Snapshot) {
 	s.logger.Log("\n======== Cache Statistics ========")
 	s.logger.Logf("Open file count:   %6d", len(snapshot.fs.overlays))
 	s.logger.Logf("Cached disk files: %6d", len(snapshot.fs.diskFiles))
+	s.logger.Logf("Realpath aliases:  %6d", len(snapshot.fs.nodeModulesRealpathAliases))
 	s.logger.Logf("Project count:     %6d", len(snapshot.ProjectCollection.Projects()))
 	s.logger.Logf("Config count:      %6d", len(snapshot.ConfigFileRegistry.configs))
 	if s.logger.IsVerbose() {

--- a/internal/project/session.go
+++ b/internal/project/session.go
@@ -198,6 +198,7 @@ func NewSession(init *SessionInit) *Session {
 			NewWatchedFiles(
 				"auto-import",
 				lsproto.WatchKindCreate|lsproto.WatchKindChange|lsproto.WatchKindDelete,
+				lsproto.GetClientCapabilities(init.BackgroundCtx).Workspace.DidChangeWatchedFiles.RelativePatternSupport,
 				func(nodeModulesDirs map[tspath.Path]string) PatternsAndIgnored {
 					patterns := make([]string, 0, len(nodeModulesDirs))
 					for _, dir := range nodeModulesDirs {
@@ -205,7 +206,7 @@ func NewSession(init *SessionInit) *Session {
 					}
 					slices.Sort(patterns)
 					return PatternsAndIgnored{
-						patterns: patterns,
+						patternsInsideWorkspace: patterns,
 					}
 				},
 			),
@@ -1116,12 +1117,14 @@ func updateWatch[T any](ctx context.Context, session *Session, logger logging.Lo
 	session.watchesMu.Lock()
 	defer session.watchesMu.Unlock()
 	if newWatcher != nil {
-		if id, watchers, ignored := newWatcher.Watchers(); len(watchers) > 0 {
+		w := newWatcher.Watchers()
+		watchers := append(w.WorkspaceWatchers, w.OutsideWorkspaceWatchers...)
+		if len(watchers) > 0 {
 			var newWatchers collections.OrderedMap[WatcherID, *lsproto.FileSystemWatcher]
 			for i, watcher := range watchers {
 				key := toFileSystemWatcherKey(watcher)
 				value := session.watches[key]
-				globId := WatcherID(fmt.Sprintf("%s.%d", id, i))
+				globId := WatcherID(fmt.Sprintf("%s.%d", w.WatcherID, i))
 				if value == nil {
 					value = &fileSystemWatcherValue{id: globId}
 					session.watches[key] = value
@@ -1140,14 +1143,14 @@ func updateWatch[T any](ctx context.Context, session *Session, logger logging.Lo
 					} else {
 						logger.Log(fmt.Sprintf("Updated watch: %s", id))
 					}
-					logger.Log("\t" + *watcher.GlobPattern.Pattern)
+					logger.Log("\t" + fileSystemWatcherGlobString(watcher))
 					logger.Log("")
 				}
 			}
-			if len(ignored) > 0 {
-				logger.Logf("%d paths ineligible for watching", len(ignored))
+			if len(w.IgnoredPaths) > 0 {
+				logger.Logf("%d paths ineligible for watching", len(w.IgnoredPaths))
 				if logger.IsVerbose() {
-					for path := range ignored {
+					for path := range w.IgnoredPaths {
 						logger.Log("\t" + path)
 					}
 				}
@@ -1155,7 +1158,9 @@ func updateWatch[T any](ctx context.Context, session *Session, logger logging.Lo
 		}
 	}
 	if oldWatcher != nil {
-		if _, watchers, _ := oldWatcher.Watchers(); len(watchers) > 0 {
+		w := oldWatcher.Watchers()
+		watchers := append(w.WorkspaceWatchers, w.OutsideWorkspaceWatchers...)
+		if len(watchers) > 0 {
 			var removedWatchers []WatcherID
 			for _, watcher := range watchers {
 				key := toFileSystemWatcherKey(watcher)

--- a/internal/project/session_test.go
+++ b/internal/project/session_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/microsoft/typescript-go/internal/bundled"
 	"github.com/microsoft/typescript-go/internal/core"
-	"github.com/microsoft/typescript-go/internal/glob"
 	"github.com/microsoft/typescript-go/internal/ls/lsutil"
 	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
 	"github.com/microsoft/typescript-go/internal/project"
@@ -625,28 +624,7 @@ func TestSession(t *testing.T) {
 					programBefore := lsBefore.GetProgram()
 					session.WaitForBackgroundTasks()
 
-					var xWatched bool
-				outer:
-					for _, call := range utils.Client().WatchFilesCalls() {
-						for _, watcher := range call.Watchers {
-							// On case-insensitive FS, glob patterns use lowercased paths.
-							if watcher.GlobPattern.Pattern != nil {
-								if core.Must(glob.Parse(*watcher.GlobPattern.Pattern)).Match("/home/projects/ts/x.ts") {
-									xWatched = true
-									break outer
-								}
-							} else if watcher.GlobPattern.RelativePattern != nil {
-								baseUri := string(*watcher.GlobPattern.RelativePattern.BaseUri.URI)
-								// The base URI should be a parent of the file's URI.
-								// On case-insensitive FS, paths are lowercased.
-								if strings.HasPrefix("file:///home/projects/ts/x.ts", baseUri) {
-									xWatched = true
-									break outer
-								}
-							}
-						}
-					}
-					assert.Check(t, xWatched)
+					assert.Check(t, utils.WatchesFile("/home/projects/ts/x.ts"))
 
 					err = utils.FS().WriteFile("/home/projects/TS/x.ts", `export const x = 2;`)
 					assert.NilError(t, err)
@@ -1106,6 +1084,80 @@ func TestSession(t *testing.T) {
 				t.Logf("diagnostic: %s", d.String())
 			}
 			assert.Equal(t, len(diags), 0)
+		})
+
+		t.Run("symlinked node_modules package.json change invalidates resolution", func(t *testing.T) {
+			t.Parallel()
+			// Set up a project that imports a symlinked node_modules package.
+			// The package resolves via "main" in package.json to dist/index.js.
+			files := map[string]any{
+				"/home/projects/myproject/tsconfig.json": `{
+					"compilerOptions": {
+						"noLib": true,
+						"module": "nodenext",
+						"moduleResolution": "nodenext"
+					},
+					"files": ["src/index.ts"]
+				}`,
+				"/home/projects/myproject/src/index.ts": `import { foo } from "mylib";`,
+				// The real package lives as a sibling directory
+				"/home/projects/mylib/package.json": `{
+					"name": "mylib",
+					"main": "dist/index.js"
+				}`,
+				"/home/projects/mylib/dist/index.js":   `exports.foo = function() { return 1; };`,
+				"/home/projects/mylib/dist/index.d.ts": `export declare function foo(): number;`,
+				// node_modules/mylib is a symlink to the sibling
+				"/home/projects/myproject/node_modules/mylib": vfstest.Symlink("/home/projects/mylib"),
+			}
+
+			session, utils := projecttestutil.SetupWithOptions(files, &project.SessionOptions{
+				CurrentDirectory:   "/home/projects/myproject",
+				DefaultLibraryPath: bundled.LibPath(),
+				TypingsLocation:    projecttestutil.TestTypingsLocation,
+				PositionEncoding:   lsproto.PositionEncodingKindUTF8,
+				WatchEnabled:       true,
+				LoggingEnabled:     true,
+			})
+			session.DidOpenFile(context.Background(), "file:///home/projects/myproject/src/index.ts", 1, files["/home/projects/myproject/src/index.ts"].(string), lsproto.LanguageKindTypeScript)
+
+			// Initial state: import resolves successfully via package.json main -> dist/index.d.ts
+			ls, err := session.GetLanguageService(context.Background(), "file:///home/projects/myproject/src/index.ts")
+			assert.NilError(t, err)
+			program := ls.GetProgram()
+			session.WaitForBackgroundTasks()
+			diags := program.GetSemanticDiagnostics(projecttestutil.WithRequestID(t.Context()), program.GetSourceFile("/home/projects/myproject/src/index.ts"))
+			for _, d := range diags {
+				t.Logf("initial diagnostic: %s", d.String())
+			}
+			assert.Equal(t, len(diags), 0, "import should resolve initially")
+
+			// Assert: watched file globs cover the realpath of package.json and dist/index.d.ts.
+			// With a workspace dir set, watchers use RelativePattern with a base URI.
+			assert.Check(t, utils.WatchesFile("/home/projects/mylib/package.json"), "realpath of package.json should be watched")
+			assert.Check(t, utils.WatchesFile("/home/projects/mylib/dist/index.d.ts"), "realpath of dist/index.d.ts should be watched")
+
+			// Edit package.json to remove "main" field
+			err = utils.FS().WriteFile("/home/projects/mylib/package.json", `{
+				"name": "mylib"
+			}`)
+			assert.NilError(t, err)
+
+			// Fire watch event for the realpath of the changed package.json.
+			// A real editor would fire this for the realpath since it watches realpaths.
+			session.DidChangeWatchedFiles(context.Background(), []*lsproto.FileEvent{
+				{
+					Type: lsproto.FileChangeTypeChanged,
+					Uri:  "file:///home/projects/mylib/package.json",
+				},
+			})
+
+			// After removing "main" from package.json, the import should no longer resolve.
+			ls, err = session.GetLanguageService(context.Background(), "file:///home/projects/myproject/src/index.ts")
+			assert.NilError(t, err)
+			program = ls.GetProgram()
+			diags = program.GetSemanticDiagnostics(projecttestutil.WithRequestID(t.Context()), program.GetSourceFile("/home/projects/myproject/src/index.ts"))
+			assert.Assert(t, len(diags) > 0, "import should fail after removing main from package.json")
 		})
 
 		t.Run("create file in non-existent directory", func(t *testing.T) {

--- a/internal/project/session_test.go
+++ b/internal/project/session_test.go
@@ -630,9 +630,19 @@ func TestSession(t *testing.T) {
 					for _, call := range utils.Client().WatchFilesCalls() {
 						for _, watcher := range call.Watchers {
 							// On case-insensitive FS, glob patterns use lowercased paths.
-							if core.Must(glob.Parse(*watcher.GlobPattern.Pattern)).Match("/home/projects/ts/x.ts") {
-								xWatched = true
-								break outer
+							if watcher.GlobPattern.Pattern != nil {
+								if core.Must(glob.Parse(*watcher.GlobPattern.Pattern)).Match("/home/projects/ts/x.ts") {
+									xWatched = true
+									break outer
+								}
+							} else if watcher.GlobPattern.RelativePattern != nil {
+								baseUri := string(*watcher.GlobPattern.RelativePattern.BaseUri.URI)
+								// The base URI should be a parent of the file's URI.
+								// On case-insensitive FS, paths are lowercased.
+								if strings.HasPrefix("file:///home/projects/ts/x.ts", baseUri) {
+									xWatched = true
+									break outer
+								}
 							}
 						}
 					}

--- a/internal/project/snapshot.go
+++ b/internal/project/snapshot.go
@@ -278,7 +278,7 @@ func (s *Snapshot) Clone(ctx context.Context, change SnapshotChange, overlays ma
 	}
 
 	start := time.Now()
-	fs := newSnapshotFSBuilder(session.fs.fs, s.fs.overlays, overlays, s.fs.diskFiles, s.fs.diskDirectories, session.options.PositionEncoding, s.toPath)
+	fs := newSnapshotFSBuilder(session.fs.fs, s.fs.overlays, overlays, s.fs.diskFiles, s.fs.diskDirectories, s.fs.nodeModulesRealpathAliases, session.options.PositionEncoding, s.toPath)
 	if change.fileChanges.HasExcessiveWatchEvents() {
 		invalidateStart := time.Now()
 		if change.fileChanges.InvalidateAll {
@@ -297,6 +297,7 @@ func (s *Snapshot) Clone(ctx context.Context, change SnapshotChange, overlays ma
 		}
 	} else {
 		change.fileChanges = fs.expandAndFilterWatchEvents(change.fileChanges)
+		change.fileChanges = s.fs.expandRealpathAliases(change.fileChanges)
 		fs.markDirtyFiles(change.fileChanges)
 		change.fileChanges = fs.convertOpenAndCloseToChanges(change.fileChanges)
 	}

--- a/internal/project/snapshotfs.go
+++ b/internal/project/snapshotfs.go
@@ -345,7 +345,9 @@ func (s *snapshotFSBuilder) recordRealpathAlias(fileName string, symlinkPath tsp
 	realpathPath := s.toPath(realpath)
 	if realpathPath != symlinkPath {
 		entry, _ := s.nodeModulesRealpathAliases.LoadOrStore(realpathPath, &realpathAliasSet{})
-		entry.Value().Add(symlinkPath)
+		entry.Change(func(aliasSet *realpathAliasSet) {
+			aliasSet.Add(symlinkPath)
+		})
 	}
 }
 

--- a/internal/project/snapshotfs.go
+++ b/internal/project/snapshotfs.go
@@ -29,6 +29,29 @@ var (
 	_ FileSource = (*SnapshotFS)(nil)
 )
 
+// realpathAliasSet is a thread-safe set of symlink paths that alias a single realpath.
+// It implements dirty.Cloneable so it can be used as a value in dirty.SyncMap.
+type realpathAliasSet struct {
+	mu    sync.Mutex
+	paths collections.Set[tspath.Path]
+}
+
+func (s *realpathAliasSet) Add(path tspath.Path) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.paths.Add(path)
+}
+
+func (s *realpathAliasSet) Clone() *realpathAliasSet {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	clone := &realpathAliasSet{}
+	if s.paths.Len() > 0 {
+		clone.paths = *s.paths.Clone()
+	}
+	return clone
+}
+
 type SnapshotFS struct {
 	toPath             func(fileName string) tspath.Path
 	fs                 vfs.FS
@@ -37,6 +60,10 @@ type SnapshotFS struct {
 	diskFiles          map[tspath.Path]*diskFile
 	diskDirectories    map[tspath.Path]dirty.CloneableMap[tspath.Path, string]
 	readFiles          collections.SyncMap[tspath.Path, memoizedDiskFile]
+	// nodeModulesRealpathAliases maps realpath-based keys to sets of symlink-based keys,
+	// for files inside node_modules that are accessed through directory symlinks.
+	// This allows watch events (which use realpaths) to invalidate files cached under symlink paths.
+	nodeModulesRealpathAliases map[tspath.Path]*realpathAliasSet
 }
 
 type memoizedDiskFile func() FileHandle
@@ -105,13 +132,14 @@ func (s *SnapshotFS) isFile(path tspath.Path) bool {
 }
 
 type snapshotFSBuilder struct {
-	fs                 vfs.FS
-	prevOverlays       map[tspath.Path]*Overlay
-	overlays           map[tspath.Path]*Overlay
-	overlayDirectories map[tspath.Path]map[tspath.Path]string
-	diskFiles          *dirty.SyncMap[tspath.Path, *diskFile]
-	diskDirectories    *dirty.Map[tspath.Path, dirty.CloneableMap[tspath.Path, string]]
-	toPath             func(string) tspath.Path
+	fs                         vfs.FS
+	prevOverlays               map[tspath.Path]*Overlay
+	overlays                   map[tspath.Path]*Overlay
+	overlayDirectories         map[tspath.Path]map[tspath.Path]string
+	diskFiles                  *dirty.SyncMap[tspath.Path, *diskFile]
+	diskDirectories            *dirty.Map[tspath.Path, dirty.CloneableMap[tspath.Path, string]]
+	nodeModulesRealpathAliases *dirty.SyncMap[tspath.Path, *realpathAliasSet]
+	toPath                     func(string) tspath.Path
 }
 
 func newSnapshotFSBuilder(
@@ -120,6 +148,7 @@ func newSnapshotFSBuilder(
 	overlays map[tspath.Path]*Overlay,
 	diskFiles map[tspath.Path]*diskFile,
 	diskDirectories map[tspath.Path]dirty.CloneableMap[tspath.Path, string],
+	nodeModulesRealpathAliases map[tspath.Path]*realpathAliasSet,
 	positionEncoding lsproto.PositionEncodingKind,
 	toPath func(fileName string) tspath.Path,
 ) *snapshotFSBuilder {
@@ -150,13 +179,14 @@ func newSnapshotFSBuilder(
 	}
 
 	return &snapshotFSBuilder{
-		fs:                 cachedFS,
-		prevOverlays:       prevOverlays,
-		overlays:           overlays,
-		overlayDirectories: overlayDirectories,
-		diskFiles:          dirty.NewSyncMap(diskFiles),
-		diskDirectories:    dirty.NewMap(diskDirectories),
-		toPath:             toPath,
+		fs:                         cachedFS,
+		prevOverlays:               prevOverlays,
+		overlays:                   overlays,
+		overlayDirectories:         overlayDirectories,
+		diskFiles:                  dirty.NewSyncMap(diskFiles),
+		diskDirectories:            dirty.NewMap(diskDirectories),
+		nodeModulesRealpathAliases: dirty.NewSyncMap(nodeModulesRealpathAliases),
+		toPath:                     toPath,
 	}
 }
 
@@ -221,14 +251,32 @@ func (s *snapshotFSBuilder) Finalize() (*SnapshotFS, bool) {
 		onDeletedFileOrDirectory(path)
 	}
 
+	nodeModulesRealpathAliases, aliasesChanged := s.nodeModulesRealpathAliases.Finalize()
+
+	// Prune aliases whose symlink paths no longer exist in diskFiles.
+	for realpathKey, aliasSet := range nodeModulesRealpathAliases {
+		aliasSet.mu.Lock()
+		for symlinkPath := range aliasSet.paths.Keys() {
+			if _, ok := diskFiles[symlinkPath]; !ok {
+				aliasSet.paths.Delete(symlinkPath)
+			}
+		}
+		empty := aliasSet.paths.Len() == 0
+		aliasSet.mu.Unlock()
+		if empty {
+			delete(nodeModulesRealpathAliases, realpathKey)
+		}
+	}
+
 	return &SnapshotFS{
-		fs:                 s.fs,
-		overlays:           s.overlays,
-		overlayDirectories: s.overlayDirectories,
-		diskFiles:          diskFiles,
-		diskDirectories:    core.FirstResult(s.diskDirectories.Finalize()),
-		toPath:             s.toPath,
-	}, changed
+		fs:                         s.fs,
+		overlays:                   s.overlays,
+		overlayDirectories:         s.overlayDirectories,
+		diskFiles:                  diskFiles,
+		diskDirectories:            core.FirstResult(s.diskDirectories.Finalize()),
+		nodeModulesRealpathAliases: nodeModulesRealpathAliases,
+		toPath:                     s.toPath,
+	}, changed || aliasesChanged
 }
 
 func (s *snapshotFSBuilder) isOpenFile(path tspath.Path) bool {
@@ -276,13 +324,29 @@ func (s *snapshotFSBuilder) GetAccessibleEntries(path string) vfs.Entries {
 }
 
 func (s *snapshotFSBuilder) getDiskFile(fileName string, path tspath.Path, forceReload bool) FileHandle {
-	if entry, _ := s.diskFiles.LoadOrStore(path, &diskFile{fileBase: fileBase{fileName: fileName}, needsReload: true}); entry != nil {
+	entry, loaded := s.diskFiles.LoadOrStore(path, &diskFile{fileBase: fileBase{fileName: fileName}, needsReload: true})
+	if entry != nil {
+		if !loaded && strings.Contains(string(path), "/node_modules/") {
+			s.recordRealpathAlias(fileName, path)
+		}
 		if forceReload {
 			return s.reloadEntry(entry)
 		}
 		return s.reloadEntryIfNeeded(entry)
 	}
 	return nil
+}
+
+// recordRealpathAlias checks if fileName is accessed through a symlink and, if so,
+// records a mapping from the realpath-based key to the symlink-based key.
+// This is only called for files inside node_modules where symlinks are common.
+func (s *snapshotFSBuilder) recordRealpathAlias(fileName string, symlinkPath tspath.Path) {
+	realpath := s.fs.Realpath(fileName)
+	realpathPath := s.toPath(realpath)
+	if realpathPath != symlinkPath {
+		entry, _ := s.nodeModulesRealpathAliases.LoadOrStore(realpathPath, &realpathAliasSet{})
+		entry.Value().Add(symlinkPath)
+	}
 }
 
 func (s *snapshotFSBuilder) reloadEntry(entry *dirty.SyncMapEntry[tspath.Path, *diskFile]) FileHandle {
@@ -354,10 +418,16 @@ func (s *snapshotFSBuilder) watchChangesOverlapCache(change FileChangeSummary) b
 		if _, ok := s.diskFiles.Load(path); ok {
 			return true
 		}
+		if _, ok := s.nodeModulesRealpathAliases.Load(path); ok {
+			return true
+		}
 	}
 	for uri := range change.Deleted.Keys() {
 		path := s.toPath(uri.FileName())
 		if _, ok := s.diskFiles.Load(path); ok {
+			return true
+		}
+		if _, ok := s.nodeModulesRealpathAliases.Load(path); ok {
 			return true
 		}
 	}
@@ -399,6 +469,44 @@ func (s *snapshotFSBuilder) markDirtyFiles(change FileChangeSummary) {
 			entry.Delete()
 		}
 	}
+}
+
+// expandRealpathAliases adds synthetic URIs to the Changed and Deleted sets for
+// files that were accessed through node_modules symlinks. When a watch event arrives
+// using a realpath, this expands it to include the symlink-based path so that
+// downstream consumers (markDirtyFiles, markFilesChanged) can find cached entries.
+func (s *SnapshotFS) expandRealpathAliases(change FileChangeSummary) FileChangeSummary {
+	if len(s.nodeModulesRealpathAliases) == 0 {
+		return change
+	}
+
+	var additionalChanged collections.Set[lsproto.DocumentUri]
+	for uri := range change.Changed.Keys() {
+		path := s.toPath(uri.FileName())
+		if aliases, ok := s.nodeModulesRealpathAliases[path]; ok {
+			for aliasPath := range aliases.paths.Keys() {
+				additionalChanged.Add(lsconv.FileNameToDocumentURI(string(aliasPath)))
+			}
+		}
+	}
+	for uri := range additionalChanged.Keys() {
+		change.Changed.Add(uri)
+	}
+
+	var additionalDeleted collections.Set[lsproto.DocumentUri]
+	for uri := range change.Deleted.Keys() {
+		path := s.toPath(uri.FileName())
+		if aliases, ok := s.nodeModulesRealpathAliases[path]; ok {
+			for aliasPath := range aliases.paths.Keys() {
+				additionalDeleted.Add(lsconv.FileNameToDocumentURI(string(aliasPath)))
+			}
+		}
+	}
+	for uri := range additionalDeleted.Keys() {
+		change.Deleted.Add(uri)
+	}
+
+	return change
 }
 
 // isRelevantFileName returns true if the given URI refers to a file that

--- a/internal/project/snapshotfs.go
+++ b/internal/project/snapshotfs.go
@@ -197,7 +197,7 @@ func (s *snapshotFSBuilder) FS() vfs.FS {
 func (s *snapshotFSBuilder) Finalize() (*SnapshotFS, bool) {
 	// Synchronize directory structure based on added and deleted files (including overlays)
 	var onDeletedFileOrDirectory func(path tspath.Path)
-	var deleted collections.Set[tspath.Path]
+	var deleted map[tspath.Path]*diskFile
 
 	onAddedFile := func(path tspath.Path, fileName string) {
 		childPath := path
@@ -240,33 +240,39 @@ func (s *snapshotFSBuilder) Finalize() (*SnapshotFS, bool) {
 
 	diskFiles, changed := s.diskFiles.FinalizeWith(dirty.FinalizationHooks[tspath.Path, *diskFile]{
 		OnDelete: func(key tspath.Path, value *diskFile) {
-			deleted.Add(key)
+			if deleted == nil {
+				deleted = make(map[tspath.Path]*diskFile)
+			}
+			deleted[key] = value
 		},
 		OnAdd: func(key tspath.Path, value *diskFile) {
 			onAddedFile(key, value.FileName())
 		},
 	})
 
-	for path := range deleted.Keys() {
+	for path := range deleted {
 		onDeletedFileOrDirectory(path)
 	}
 
-	nodeModulesRealpathAliases, aliasesChanged := s.nodeModulesRealpathAliases.Finalize()
-
-	// Prune aliases whose symlink paths no longer exist in diskFiles.
-	for realpathKey, aliasSet := range nodeModulesRealpathAliases {
-		aliasSet.mu.Lock()
-		for symlinkPath := range aliasSet.paths.Keys() {
-			if _, ok := diskFiles[symlinkPath]; !ok {
-				aliasSet.paths.Delete(symlinkPath)
-			}
+	// Prune deleted symlink paths from realpath alias sets before finalizing,
+	// so that empty sets are dropped during finalization.
+	for deletedPath, deletedFile := range deleted {
+		if deletedFile.realpathPath == "" {
+			continue
 		}
-		empty := aliasSet.paths.Len() == 0
-		aliasSet.mu.Unlock()
-		if empty {
-			delete(nodeModulesRealpathAliases, realpathKey)
+		if entry, ok := s.nodeModulesRealpathAliases.Load(deletedFile.realpathPath); ok {
+			entry.Locked(func(e dirty.Value[*realpathAliasSet]) {
+				e.Change(func(aliasSet *realpathAliasSet) {
+					aliasSet.paths.Delete(deletedPath)
+				})
+				if e.Value().paths.Len() == 0 {
+					e.Delete()
+				}
+			})
 		}
 	}
+
+	nodeModulesRealpathAliases, aliasesChanged := s.nodeModulesRealpathAliases.Finalize()
 
 	return &SnapshotFS{
 		fs:                         s.fs,
@@ -327,7 +333,7 @@ func (s *snapshotFSBuilder) getDiskFile(fileName string, path tspath.Path, force
 	entry, loaded := s.diskFiles.LoadOrStore(path, &diskFile{fileBase: fileBase{fileName: fileName}, needsReload: true})
 	if entry != nil {
 		if !loaded && strings.Contains(string(path), "/node_modules/") {
-			s.recordRealpathAlias(fileName, path)
+			s.recordRealpathAlias(entry, fileName, path)
 		}
 		if forceReload {
 			return s.reloadEntry(entry)
@@ -340,10 +346,13 @@ func (s *snapshotFSBuilder) getDiskFile(fileName string, path tspath.Path, force
 // recordRealpathAlias checks if fileName is accessed through a symlink and, if so,
 // records a mapping from the realpath-based key to the symlink-based key.
 // This is only called for files inside node_modules where symlinks are common.
-func (s *snapshotFSBuilder) recordRealpathAlias(fileName string, symlinkPath tspath.Path) {
-	realpath := s.fs.Realpath(fileName)
+func (s *snapshotFSBuilder) recordRealpathAlias(diskFileEntry *dirty.SyncMapEntry[tspath.Path, *diskFile], symlinkFileName string, symlinkPath tspath.Path) {
+	realpath := s.fs.Realpath(symlinkFileName)
 	realpathPath := s.toPath(realpath)
 	if realpathPath != symlinkPath {
+		diskFileEntry.Change(func(file *diskFile) {
+			file.realpathPath = realpathPath
+		})
 		entry, _ := s.nodeModulesRealpathAliases.LoadOrStore(realpathPath, &realpathAliasSet{})
 		entry.Change(func(aliasSet *realpathAliasSet) {
 			aliasSet.Add(symlinkPath)

--- a/internal/project/snapshotfs_test.go
+++ b/internal/project/snapshotfs_test.go
@@ -30,6 +30,7 @@ func TestSnapshotFSBuilder(t *testing.T) {
 			make(map[tspath.Path]*Overlay), // overlays
 			make(map[tspath.Path]*diskFile),
 			make(map[tspath.Path]dirty.CloneableMap[tspath.Path, string]),
+			nil, // nodeModulesRealpathAliases
 			lsproto.PositionEncodingKindUTF16,
 			toPath,
 		)
@@ -69,6 +70,7 @@ func TestSnapshotFSBuilder(t *testing.T) {
 			make(map[tspath.Path]*Overlay), // overlays
 			make(map[tspath.Path]*diskFile),
 			make(map[tspath.Path]dirty.CloneableMap[tspath.Path, string]),
+			nil, // nodeModulesRealpathAliases
 			lsproto.PositionEncodingKindUTF16,
 			toPath,
 		)
@@ -116,6 +118,7 @@ func TestSnapshotFSBuilder(t *testing.T) {
 			make(map[tspath.Path]*Overlay), // overlays
 			existingDiskFiles,
 			existingDirs,
+			nil, // nodeModulesRealpathAliases
 			lsproto.PositionEncodingKindUTF16,
 			toPath,
 		)
@@ -168,6 +171,7 @@ func TestSnapshotFSBuilder(t *testing.T) {
 			make(map[tspath.Path]*Overlay), // overlays
 			existingDiskFiles,
 			existingDirs,
+			nil, // nodeModulesRealpathAliases
 			lsproto.PositionEncodingKindUTF16,
 			toPath,
 		)
@@ -229,6 +233,7 @@ func TestSnapshotFSBuilder(t *testing.T) {
 			make(map[tspath.Path]*Overlay), // overlays
 			existingDiskFiles,
 			existingDirs,
+			nil, // nodeModulesRealpathAliases
 			lsproto.PositionEncodingKindUTF16,
 			toPath,
 		)
@@ -272,6 +277,7 @@ func TestSnapshotFSBuilder(t *testing.T) {
 			make(map[tspath.Path]*Overlay), // overlays
 			existingDiskFiles,
 			existingDirs,
+			nil, // nodeModulesRealpathAliases
 			lsproto.PositionEncodingKindUTF16,
 			toPath,
 		)
@@ -304,6 +310,7 @@ func TestSnapshotFSBuilder(t *testing.T) {
 			overlays,
 			make(map[tspath.Path]*diskFile),
 			make(map[tspath.Path]dirty.CloneableMap[tspath.Path, string]),
+			nil, // nodeModulesRealpathAliases
 			lsproto.PositionEncodingKindUTF16,
 			toPath,
 		)
@@ -348,6 +355,7 @@ func TestSnapshotFSBuilder(t *testing.T) {
 			make(map[tspath.Path]*Overlay), // overlays
 			existingDiskFiles,
 			existingDirs,
+			nil, // nodeModulesRealpathAliases
 			lsproto.PositionEncodingKindUTF16,
 			toPath,
 		)
@@ -434,6 +442,7 @@ func TestSnapshotFSBuilder(t *testing.T) {
 			overlays,
 			make(map[tspath.Path]*diskFile),
 			make(map[tspath.Path]dirty.CloneableMap[tspath.Path, string]),
+			nil, // nodeModulesRealpathAliases
 			lsproto.PositionEncodingKindUTF16,
 			toPath,
 		)
@@ -475,6 +484,7 @@ func TestSnapshotFSBuilder(t *testing.T) {
 			overlays,
 			make(map[tspath.Path]*diskFile),
 			make(map[tspath.Path]dirty.CloneableMap[tspath.Path, string]),
+			nil, // nodeModulesRealpathAliases
 			lsproto.PositionEncodingKindUTF16,
 			toPath,
 		)
@@ -850,6 +860,7 @@ func TestAutoImportBuilderFS(t *testing.T) {
 			make(map[tspath.Path]*Overlay),
 			make(map[tspath.Path]*diskFile),
 			make(map[tspath.Path]dirty.CloneableMap[tspath.Path, string]),
+			nil, // nodeModulesRealpathAliases
 			lsproto.PositionEncodingKindUTF16,
 			toPath,
 		)
@@ -876,5 +887,441 @@ func TestAutoImportBuilderFS(t *testing.T) {
 		// The file was cached at the symlink path, but the realpath lookup misses the cache
 		// and goes to disk where the file is now deleted. This returns nil.
 		assert.Assert(t, fh2 == nil, "File should be nil when accessed by realpath after deletion from disk")
+	})
+}
+
+func TestRealpathAliasLifecycle(t *testing.T) {
+	t.Parallel()
+
+	toPath := func(fileName string) tspath.Path {
+		return tspath.Path(fileName)
+	}
+
+	t.Run("alias recorded when reading symlinked node_modules file", func(t *testing.T) {
+		t.Parallel()
+		testFS := vfstest.FromMap(map[string]any{
+			"/project/node_modules/mylib":               vfstest.Symlink("/packages/mylib"),
+			"/packages/mylib/package.json":              `{"name": "mylib", "main": "index.js"}`,
+			"/packages/mylib/index.d.ts":                `export declare const x: number;`,
+			"/project/node_modules/nolink/package.json": `{"name": "nolink"}`,
+		}, false)
+
+		builder := newSnapshotFSBuilder(
+			testFS,
+			make(map[tspath.Path]*Overlay),
+			make(map[tspath.Path]*Overlay),
+			make(map[tspath.Path]*diskFile),
+			make(map[tspath.Path]dirty.CloneableMap[tspath.Path, string]),
+			nil,
+			lsproto.PositionEncodingKindUTF16,
+			toPath,
+		)
+
+		// Read a file through the symlink — should record an alias.
+		fh := builder.GetFile("/project/node_modules/mylib/package.json")
+		assert.Assert(t, fh != nil)
+		assert.Equal(t, fh.Content(), `{"name": "mylib", "main": "index.js"}`)
+
+		// Read a non-symlinked node_modules file — should NOT record an alias.
+		fh2 := builder.GetFile("/project/node_modules/nolink/package.json")
+		assert.Assert(t, fh2 != nil)
+
+		snapshot, _ := builder.Finalize()
+
+		// Alias exists for the symlinked file.
+		aliases, ok := snapshot.nodeModulesRealpathAliases[tspath.Path("/packages/mylib/package.json")]
+		assert.Assert(t, ok, "alias should exist for realpath of symlinked file")
+		assert.Assert(t, aliases.paths.Has(tspath.Path("/project/node_modules/mylib/package.json")))
+
+		// No alias for the non-symlinked file.
+		_, ok = snapshot.nodeModulesRealpathAliases[tspath.Path("/project/node_modules/nolink/package.json")]
+		assert.Assert(t, !ok, "no alias should exist for non-symlinked file")
+	})
+
+	t.Run("no alias recorded for files outside node_modules", func(t *testing.T) {
+		t.Parallel()
+		testFS := vfstest.FromMap(map[string]any{
+			"/project/link":       vfstest.Symlink("/elsewhere"),
+			"/elsewhere/index.ts": `export const x = 1;`,
+		}, false)
+
+		builder := newSnapshotFSBuilder(
+			testFS,
+			make(map[tspath.Path]*Overlay),
+			make(map[tspath.Path]*Overlay),
+			make(map[tspath.Path]*diskFile),
+			make(map[tspath.Path]dirty.CloneableMap[tspath.Path, string]),
+			nil,
+			lsproto.PositionEncodingKindUTF16,
+			toPath,
+		)
+
+		fh := builder.GetFile("/project/link/index.ts")
+		assert.Assert(t, fh != nil)
+
+		snapshot, _ := builder.Finalize()
+		assert.Equal(t, len(snapshot.nodeModulesRealpathAliases), 0, "no aliases for non-node_modules symlinks")
+	})
+
+	t.Run("aliases carried over across snapshots", func(t *testing.T) {
+		t.Parallel()
+		testFS := vfstest.FromMap(map[string]any{
+			"/project/node_modules/mylib":  vfstest.Symlink("/packages/mylib"),
+			"/packages/mylib/package.json": `{"name": "mylib"}`,
+		}, false)
+
+		// Build first snapshot.
+		builder1 := newSnapshotFSBuilder(
+			testFS,
+			make(map[tspath.Path]*Overlay),
+			make(map[tspath.Path]*Overlay),
+			make(map[tspath.Path]*diskFile),
+			make(map[tspath.Path]dirty.CloneableMap[tspath.Path, string]),
+			nil,
+			lsproto.PositionEncodingKindUTF16,
+			toPath,
+		)
+		builder1.GetFile("/project/node_modules/mylib/package.json")
+		snapshot1, _ := builder1.Finalize()
+
+		// Build second snapshot from the first, without reading the file again.
+		builder2 := newSnapshotFSBuilder(
+			testFS,
+			make(map[tspath.Path]*Overlay),
+			make(map[tspath.Path]*Overlay),
+			snapshot1.diskFiles,
+			snapshot1.diskDirectories,
+			snapshot1.nodeModulesRealpathAliases,
+			lsproto.PositionEncodingKindUTF16,
+			toPath,
+		)
+		snapshot2, _ := builder2.Finalize()
+
+		// Alias should still be present.
+		aliases, ok := snapshot2.nodeModulesRealpathAliases[tspath.Path("/packages/mylib/package.json")]
+		assert.Assert(t, ok, "alias should survive across snapshots")
+		assert.Assert(t, aliases.paths.Has(tspath.Path("/project/node_modules/mylib/package.json")))
+	})
+
+	t.Run("alias pruned when symlinked file is deleted", func(t *testing.T) {
+		t.Parallel()
+		testFS := vfstest.FromMap(map[string]any{
+			"/project/node_modules/mylib":  vfstest.Symlink("/packages/mylib"),
+			"/packages/mylib/package.json": `{"name": "mylib"}`,
+			"/packages/mylib/index.d.ts":   `export declare const x: number;`,
+		}, false)
+
+		// Build first snapshot — read both files.
+		builder1 := newSnapshotFSBuilder(
+			testFS,
+			make(map[tspath.Path]*Overlay),
+			make(map[tspath.Path]*Overlay),
+			make(map[tspath.Path]*diskFile),
+			make(map[tspath.Path]dirty.CloneableMap[tspath.Path, string]),
+			nil,
+			lsproto.PositionEncodingKindUTF16,
+			toPath,
+		)
+		builder1.GetFile("/project/node_modules/mylib/package.json")
+		builder1.GetFile("/project/node_modules/mylib/index.d.ts")
+		snapshot1, _ := builder1.Finalize()
+
+		// Both should be aliased under the same realpath directory but separate files.
+		_, ok := snapshot1.nodeModulesRealpathAliases[tspath.Path("/packages/mylib/package.json")]
+		assert.Assert(t, ok)
+		_, ok = snapshot1.nodeModulesRealpathAliases[tspath.Path("/packages/mylib/index.d.ts")]
+		assert.Assert(t, ok)
+
+		// Build second snapshot — delete one file via markDirtyFiles.
+		builder2 := newSnapshotFSBuilder(
+			testFS,
+			make(map[tspath.Path]*Overlay),
+			make(map[tspath.Path]*Overlay),
+			snapshot1.diskFiles,
+			snapshot1.diskDirectories,
+			snapshot1.nodeModulesRealpathAliases,
+			lsproto.PositionEncodingKindUTF16,
+			toPath,
+		)
+
+		// Simulate deletion of index.d.ts from the disk file cache.
+		if entry, ok := builder2.diskFiles.Load(tspath.Path("/project/node_modules/mylib/index.d.ts")); ok {
+			entry.Delete()
+		}
+
+		snapshot2, _ := builder2.Finalize()
+
+		// package.json alias should remain.
+		aliases, ok := snapshot2.nodeModulesRealpathAliases[tspath.Path("/packages/mylib/package.json")]
+		assert.Assert(t, ok, "package.json alias should survive")
+		assert.Assert(t, aliases.paths.Has(tspath.Path("/project/node_modules/mylib/package.json")))
+
+		// index.d.ts alias should be fully pruned (empty set → removed from map).
+		_, ok = snapshot2.nodeModulesRealpathAliases[tspath.Path("/packages/mylib/index.d.ts")]
+		assert.Assert(t, !ok, "index.d.ts alias should be pruned after deletion")
+	})
+
+	t.Run("multiple symlinks to same realpath", func(t *testing.T) {
+		t.Parallel()
+		testFS := vfstest.FromMap(map[string]any{
+			"/project/node_modules/mylib":  vfstest.Symlink("/packages/mylib"),
+			"/project/node_modules/alias":  vfstest.Symlink("/packages/mylib"),
+			"/packages/mylib/package.json": `{"name": "mylib"}`,
+		}, false)
+
+		builder := newSnapshotFSBuilder(
+			testFS,
+			make(map[tspath.Path]*Overlay),
+			make(map[tspath.Path]*Overlay),
+			make(map[tspath.Path]*diskFile),
+			make(map[tspath.Path]dirty.CloneableMap[tspath.Path, string]),
+			nil,
+			lsproto.PositionEncodingKindUTF16,
+			toPath,
+		)
+
+		// Read via both symlinks.
+		fh1 := builder.GetFile("/project/node_modules/mylib/package.json")
+		assert.Assert(t, fh1 != nil)
+		fh2 := builder.GetFile("/project/node_modules/alias/package.json")
+		assert.Assert(t, fh2 != nil)
+
+		snapshot, _ := builder.Finalize()
+
+		aliases, ok := snapshot.nodeModulesRealpathAliases[tspath.Path("/packages/mylib/package.json")]
+		assert.Assert(t, ok, "alias should exist")
+		assert.Assert(t, aliases.paths.Has(tspath.Path("/project/node_modules/mylib/package.json")))
+		assert.Assert(t, aliases.paths.Has(tspath.Path("/project/node_modules/alias/package.json")))
+	})
+
+	t.Run("multiple symlinks pruned individually", func(t *testing.T) {
+		t.Parallel()
+		testFS := vfstest.FromMap(map[string]any{
+			"/project/node_modules/mylib":  vfstest.Symlink("/packages/mylib"),
+			"/project/node_modules/alias":  vfstest.Symlink("/packages/mylib"),
+			"/packages/mylib/package.json": `{"name": "mylib"}`,
+		}, false)
+
+		// Build first snapshot – read via both symlinks.
+		builder1 := newSnapshotFSBuilder(
+			testFS,
+			make(map[tspath.Path]*Overlay),
+			make(map[tspath.Path]*Overlay),
+			make(map[tspath.Path]*diskFile),
+			make(map[tspath.Path]dirty.CloneableMap[tspath.Path, string]),
+			nil,
+			lsproto.PositionEncodingKindUTF16,
+			toPath,
+		)
+		builder1.GetFile("/project/node_modules/mylib/package.json")
+		builder1.GetFile("/project/node_modules/alias/package.json")
+		snapshot1, _ := builder1.Finalize()
+
+		// Build second snapshot – delete ONE of the symlink disk entries.
+		builder2 := newSnapshotFSBuilder(
+			testFS,
+			make(map[tspath.Path]*Overlay),
+			make(map[tspath.Path]*Overlay),
+			snapshot1.diskFiles,
+			snapshot1.diskDirectories,
+			snapshot1.nodeModulesRealpathAliases,
+			lsproto.PositionEncodingKindUTF16,
+			toPath,
+		)
+		if entry, ok := builder2.diskFiles.Load(tspath.Path("/project/node_modules/alias/package.json")); ok {
+			entry.Delete()
+		}
+		snapshot2, _ := builder2.Finalize()
+
+		// The realpath alias set should still exist, but only contain the surviving symlink.
+		aliases, ok := snapshot2.nodeModulesRealpathAliases[tspath.Path("/packages/mylib/package.json")]
+		assert.Assert(t, ok, "alias set should still exist")
+		assert.Assert(t, aliases.paths.Has(tspath.Path("/project/node_modules/mylib/package.json")), "surviving symlink should remain")
+		assert.Assert(t, !aliases.paths.Has(tspath.Path("/project/node_modules/alias/package.json")), "deleted symlink should be pruned")
+	})
+
+	t.Run("expandRealpathAliases expands change events", func(t *testing.T) {
+		t.Parallel()
+		testFS := vfstest.FromMap(map[string]any{
+			"/project/node_modules/mylib":  vfstest.Symlink("/packages/mylib"),
+			"/packages/mylib/package.json": `{"name": "mylib"}`,
+		}, false)
+
+		builder := newSnapshotFSBuilder(
+			testFS,
+			make(map[tspath.Path]*Overlay),
+			make(map[tspath.Path]*Overlay),
+			make(map[tspath.Path]*diskFile),
+			make(map[tspath.Path]dirty.CloneableMap[tspath.Path, string]),
+			nil,
+			lsproto.PositionEncodingKindUTF16,
+			toPath,
+		)
+		builder.GetFile("/project/node_modules/mylib/package.json")
+		snapshot, _ := builder.Finalize()
+
+		// Simulate a watch event on the REALPATH.
+		change := FileChangeSummary{}
+		change.Changed.Add("file:///packages/mylib/package.json")
+
+		expanded := snapshot.expandRealpathAliases(change)
+
+		// Should now also contain the symlink path.
+		assert.Assert(t, expanded.Changed.Has("file:///packages/mylib/package.json"), "original event should remain")
+		assert.Assert(t, expanded.Changed.Has("file:///project/node_modules/mylib/package.json"), "symlink event should be added")
+	})
+
+	t.Run("expandRealpathAliases expands delete events", func(t *testing.T) {
+		t.Parallel()
+		testFS := vfstest.FromMap(map[string]any{
+			"/project/node_modules/mylib":  vfstest.Symlink("/packages/mylib"),
+			"/packages/mylib/package.json": `{"name": "mylib"}`,
+		}, false)
+
+		builder := newSnapshotFSBuilder(
+			testFS,
+			make(map[tspath.Path]*Overlay),
+			make(map[tspath.Path]*Overlay),
+			make(map[tspath.Path]*diskFile),
+			make(map[tspath.Path]dirty.CloneableMap[tspath.Path, string]),
+			nil,
+			lsproto.PositionEncodingKindUTF16,
+			toPath,
+		)
+		builder.GetFile("/project/node_modules/mylib/package.json")
+		snapshot, _ := builder.Finalize()
+
+		// Simulate a delete watch event on the REALPATH.
+		change := FileChangeSummary{}
+		change.Deleted.Add("file:///packages/mylib/package.json")
+
+		expanded := snapshot.expandRealpathAliases(change)
+
+		assert.Assert(t, expanded.Deleted.Has("file:///project/node_modules/mylib/package.json"), "symlink deletion should be added")
+	})
+
+	t.Run("expandRealpathAliases is a no-op with no aliases", func(t *testing.T) {
+		t.Parallel()
+		snapshot := &SnapshotFS{
+			toPath:                     toPath,
+			nodeModulesRealpathAliases: nil,
+		}
+
+		change := FileChangeSummary{}
+		change.Changed.Add("file:///some/file.ts")
+
+		expanded := snapshot.expandRealpathAliases(change)
+		assert.Equal(t, expanded.Changed.Len(), 1)
+		assert.Assert(t, expanded.Changed.Has("file:///some/file.ts"))
+	})
+
+	t.Run("markDirtyFiles invalidates symlinked file via realpath event", func(t *testing.T) {
+		t.Parallel()
+		testFS := vfstest.FromMap(map[string]any{
+			"/project/node_modules/mylib":  vfstest.Symlink("/packages/mylib"),
+			"/packages/mylib/package.json": `{"name": "mylib", "main": "index.js"}`,
+		}, false)
+
+		// Build first snapshot — read the symlinked file.
+		builder1 := newSnapshotFSBuilder(
+			testFS,
+			make(map[tspath.Path]*Overlay),
+			make(map[tspath.Path]*Overlay),
+			make(map[tspath.Path]*diskFile),
+			make(map[tspath.Path]dirty.CloneableMap[tspath.Path, string]),
+			nil,
+			lsproto.PositionEncodingKindUTF16,
+			toPath,
+		)
+		fh := builder1.GetFile("/project/node_modules/mylib/package.json")
+		assert.Assert(t, fh != nil)
+		assert.Equal(t, fh.Content(), `{"name": "mylib", "main": "index.js"}`)
+		snapshot1, _ := builder1.Finalize()
+
+		// Modify the real file on disk.
+		err := testFS.WriteFile("/packages/mylib/package.json", `{"name": "mylib"}`)
+		assert.NilError(t, err)
+
+		// Build second snapshot — simulate realpath change event, expanded via aliases.
+		builder2 := newSnapshotFSBuilder(
+			testFS,
+			make(map[tspath.Path]*Overlay),
+			make(map[tspath.Path]*Overlay),
+			snapshot1.diskFiles,
+			snapshot1.diskDirectories,
+			snapshot1.nodeModulesRealpathAliases,
+			lsproto.PositionEncodingKindUTF16,
+			toPath,
+		)
+
+		change := FileChangeSummary{}
+		change.Changed.Add("file:///packages/mylib/package.json")
+
+		// Expand the realpath event to include the symlink path.
+		change = snapshot1.expandRealpathAliases(change)
+		// Now mark dirty — should find the file under the symlink key.
+		builder2.markDirtyFiles(change)
+
+		// Trigger reload by reading the file (simulates program construction).
+		fh = builder2.GetFile("/project/node_modules/mylib/package.json")
+		assert.Assert(t, fh != nil)
+		assert.Equal(t, fh.Content(), `{"name": "mylib"}`, "builder should serve updated content after dirty marking")
+
+		snapshot2, _ := builder2.Finalize()
+
+		// The file should have been reloaded with new content.
+		file, ok := snapshot2.diskFiles[tspath.Path("/project/node_modules/mylib/package.json")]
+		assert.Assert(t, ok, "file should still be in diskFiles")
+		assert.Equal(t, file.Content(), `{"name": "mylib"}`, "content should be updated")
+	})
+
+	t.Run("alias clone isolation between snapshots", func(t *testing.T) {
+		t.Parallel()
+		testFS := vfstest.FromMap(map[string]any{
+			"/project/node_modules/mylib":  vfstest.Symlink("/packages/mylib"),
+			"/project/node_modules/other":  vfstest.Symlink("/packages/other"),
+			"/packages/mylib/package.json": `{"name": "mylib"}`,
+			"/packages/other/package.json": `{"name": "other"}`,
+		}, false)
+
+		// Build first snapshot — read only mylib.
+		builder1 := newSnapshotFSBuilder(
+			testFS,
+			make(map[tspath.Path]*Overlay),
+			make(map[tspath.Path]*Overlay),
+			make(map[tspath.Path]*diskFile),
+			make(map[tspath.Path]dirty.CloneableMap[tspath.Path, string]),
+			nil,
+			lsproto.PositionEncodingKindUTF16,
+			toPath,
+		)
+		builder1.GetFile("/project/node_modules/mylib/package.json")
+		snapshot1, _ := builder1.Finalize()
+
+		// Build second snapshot — also read other.
+		builder2 := newSnapshotFSBuilder(
+			testFS,
+			make(map[tspath.Path]*Overlay),
+			make(map[tspath.Path]*Overlay),
+			snapshot1.diskFiles,
+			snapshot1.diskDirectories,
+			snapshot1.nodeModulesRealpathAliases,
+			lsproto.PositionEncodingKindUTF16,
+			toPath,
+		)
+		builder2.GetFile("/project/node_modules/other/package.json")
+		snapshot2, _ := builder2.Finalize()
+
+		// snapshot1 should only have mylib alias.
+		_, ok := snapshot1.nodeModulesRealpathAliases[tspath.Path("/packages/mylib/package.json")]
+		assert.Assert(t, ok, "snapshot1 should have mylib alias")
+		_, ok = snapshot1.nodeModulesRealpathAliases[tspath.Path("/packages/other/package.json")]
+		assert.Assert(t, !ok, "snapshot1 should NOT have other alias — it was added in a later snapshot")
+
+		// snapshot2 should have both.
+		_, ok = snapshot2.nodeModulesRealpathAliases[tspath.Path("/packages/mylib/package.json")]
+		assert.Assert(t, ok, "snapshot2 should have mylib alias")
+		_, ok = snapshot2.nodeModulesRealpathAliases[tspath.Path("/packages/other/package.json")]
+		assert.Assert(t, ok, "snapshot2 should have other alias")
 	})
 }

--- a/internal/project/snapshotfs_test.go
+++ b/internal/project/snapshotfs_test.go
@@ -1324,4 +1324,61 @@ func TestRealpathAliasLifecycle(t *testing.T) {
 		_, ok = snapshot2.nodeModulesRealpathAliases[tspath.Path("/packages/other/package.json")]
 		assert.Assert(t, ok, "snapshot2 should have other alias")
 	})
+
+	t.Run("adding symlink to inherited realpath key does not mutate previous snapshot", func(t *testing.T) {
+		t.Parallel()
+		testFS := vfstest.FromMap(map[string]any{
+			"/project/node_modules/mylib":  vfstest.Symlink("/packages/mylib"),
+			"/project/node_modules/alias":  vfstest.Symlink("/packages/mylib"),
+			"/packages/mylib/package.json": `{"name": "mylib"}`,
+		}, false)
+
+		// Snapshot 1: read via one symlink only.
+		builder1 := newSnapshotFSBuilder(
+			testFS,
+			make(map[tspath.Path]*Overlay),
+			make(map[tspath.Path]*Overlay),
+			make(map[tspath.Path]*diskFile),
+			make(map[tspath.Path]dirty.CloneableMap[tspath.Path, string]),
+			nil,
+			lsproto.PositionEncodingKindUTF16,
+			toPath,
+		)
+		builder1.GetFile("/project/node_modules/mylib/package.json")
+		snapshot1, _ := builder1.Finalize()
+
+		// Verify snapshot1 has exactly one alias for the realpath.
+		aliases1, ok := snapshot1.nodeModulesRealpathAliases[tspath.Path("/packages/mylib/package.json")]
+		assert.Assert(t, ok)
+		assert.Equal(t, aliases1.paths.Len(), 1)
+		assert.Assert(t, aliases1.paths.Has(tspath.Path("/project/node_modules/mylib/package.json")))
+
+		// Snapshot 2: read via the SECOND symlink, which maps to the same realpath.
+		// This exercises the case where LoadOrStore finds the key in the base map
+		// and must clone-on-write rather than mutating the shared set.
+		builder2 := newSnapshotFSBuilder(
+			testFS,
+			make(map[tspath.Path]*Overlay),
+			make(map[tspath.Path]*Overlay),
+			snapshot1.diskFiles,
+			snapshot1.diskDirectories,
+			snapshot1.nodeModulesRealpathAliases,
+			lsproto.PositionEncodingKindUTF16,
+			toPath,
+		)
+		builder2.GetFile("/project/node_modules/alias/package.json")
+		snapshot2, _ := builder2.Finalize()
+
+		// Snapshot 2 should have both symlinks.
+		aliases2, ok := snapshot2.nodeModulesRealpathAliases[tspath.Path("/packages/mylib/package.json")]
+		assert.Assert(t, ok)
+		assert.Equal(t, aliases2.paths.Len(), 2)
+		assert.Assert(t, aliases2.paths.Has(tspath.Path("/project/node_modules/mylib/package.json")))
+		assert.Assert(t, aliases2.paths.Has(tspath.Path("/project/node_modules/alias/package.json")))
+
+		// Snapshot 1 must NOT have been mutated — it should still have only one alias.
+		assert.Equal(t, aliases1.paths.Len(), 1, "snapshot1 alias set must not be mutated by snapshot2")
+		assert.Assert(t, !aliases1.paths.Has(tspath.Path("/project/node_modules/alias/package.json")),
+			"snapshot1 must not contain alias added in snapshot2")
+	})
 }

--- a/internal/project/snapshotfs_test.go
+++ b/internal/project/snapshotfs_test.go
@@ -1045,7 +1045,8 @@ func TestRealpathAliasLifecycle(t *testing.T) {
 		)
 
 		// Simulate deletion of index.d.ts from the disk file cache.
-		if entry, ok := builder2.diskFiles.Load(tspath.Path("/project/node_modules/mylib/index.d.ts")); ok {
+		var entry *dirty.SyncMapEntry[tspath.Path, *diskFile]
+		if entry, ok = builder2.diskFiles.Load(tspath.Path("/project/node_modules/mylib/index.d.ts")); ok {
 			entry.Delete()
 		}
 

--- a/internal/project/watch.go
+++ b/internal/project/watch.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/microsoft/typescript-go/internal/collections"
 	"github.com/microsoft/typescript-go/internal/core"
+	"github.com/microsoft/typescript-go/internal/ls/lsconv"
 	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
 	"github.com/microsoft/typescript-go/internal/tspath"
 )
@@ -29,19 +30,51 @@ type fileSystemWatcherValue struct {
 }
 
 type PatternsAndIgnored struct {
-	patterns []string
-	ignored  map[string]struct{}
+	directoriesOutsideWorkspace []string
+	patternsInsideWorkspace     []string
+	ignored                     map[string]struct{}
 }
 
+// toFileSystemWatcherKey produces a deduplication key for a file system watcher.
+// Note: this key is a simple string concatenation of the base and pattern, so
+// structurally different watchers (Pattern vs RelativePattern, URI vs WorkspaceFolder)
+// could theoretically collide. In practice, workspace watchers use plain Pattern
+// with filesystem paths while outside-workspace watchers use RelativePattern with
+// file:// URIs, so collisions don't occur.
 func toFileSystemWatcherKey(w *lsproto.FileSystemWatcher) fileSystemWatcherKey {
-	if w.GlobPattern.RelativePattern != nil {
-		panic("relative globs not implemented")
-	}
 	kind := w.Kind
 	if kind == nil {
 		kind = new(lsproto.WatchKindCreate | lsproto.WatchKindChange | lsproto.WatchKindDelete)
 	}
-	return fileSystemWatcherKey{pattern: *w.GlobPattern.Pattern, kind: *kind}
+	var pattern string
+	if w.GlobPattern.Pattern != nil {
+		pattern = *w.GlobPattern.Pattern
+	} else if w.GlobPattern.RelativePattern != nil {
+		var base string
+		if w.GlobPattern.RelativePattern.BaseUri.URI != nil {
+			base = string(*w.GlobPattern.RelativePattern.BaseUri.URI)
+		} else if w.GlobPattern.RelativePattern.BaseUri.WorkspaceFolder != nil {
+			panic("workspace folder-based relative patterns not implemented")
+		}
+		pattern = base + "/" + w.GlobPattern.RelativePattern.Pattern
+	}
+	return fileSystemWatcherKey{pattern: pattern, kind: *kind}
+}
+
+func fileSystemWatcherGlobString(w *lsproto.FileSystemWatcher) string {
+	if w.GlobPattern.Pattern != nil {
+		return *w.GlobPattern.Pattern
+	}
+	if w.GlobPattern.RelativePattern != nil {
+		var base string
+		if w.GlobPattern.RelativePattern.BaseUri.URI != nil {
+			base = string(*w.GlobPattern.RelativePattern.BaseUri.URI)
+		} else if w.GlobPattern.RelativePattern.BaseUri.WorkspaceFolder != nil {
+			panic("workspace folder-based relative patterns not implemented")
+		}
+		return base + "/" + w.GlobPattern.RelativePattern.Pattern
+	}
+	return ""
 }
 
 type WatcherID string
@@ -49,40 +82,52 @@ type WatcherID string
 var watcherID atomic.Uint64
 
 type WatchedFiles[T any] struct {
-	name                string
-	watchKind           lsproto.WatchKind
-	computeGlobPatterns func(input T) PatternsAndIgnored
+	name                         string
+	watchKind                    lsproto.WatchKind
+	hasRelativePatternCapability bool
+	computeGlobPatterns          func(input T) PatternsAndIgnored
 
-	mu                  sync.RWMutex
-	input               T
-	computeWatchersOnce sync.Once
-	watchers            []*lsproto.FileSystemWatcher
-	ignored             map[string]struct{}
-	id                  uint64
+	mu                       sync.RWMutex
+	input                    T
+	computeWatchersOnce      sync.Once
+	workspaceWatchers        []*lsproto.FileSystemWatcher
+	outsideWorkspaceWatchers []*lsproto.FileSystemWatcher
+	ignored                  map[string]struct{}
+	id                       uint64
 }
 
-func NewWatchedFiles[T any](name string, watchKind lsproto.WatchKind, computeGlobPatterns func(input T) PatternsAndIgnored) *WatchedFiles[T] {
+func NewWatchedFiles[T any](name string, watchKind lsproto.WatchKind, hasRelativePatternCapability bool, computeGlobPatterns func(input T) PatternsAndIgnored) *WatchedFiles[T] {
 	return &WatchedFiles[T]{
-		id:                  watcherID.Add(1),
-		name:                name,
-		watchKind:           watchKind,
-		computeGlobPatterns: computeGlobPatterns,
+		id:                           watcherID.Add(1),
+		name:                         name,
+		watchKind:                    watchKind,
+		hasRelativePatternCapability: hasRelativePatternCapability,
+		computeGlobPatterns:          computeGlobPatterns,
 	}
 }
 
-func (w *WatchedFiles[T]) Watchers() (WatcherID, []*lsproto.FileSystemWatcher, map[string]struct{}) {
+type Watchers struct {
+	WatcherID                WatcherID
+	WorkspaceWatchers        []*lsproto.FileSystemWatcher
+	OutsideWorkspaceWatchers []*lsproto.FileSystemWatcher
+	IgnoredPaths             map[string]struct{}
+}
+
+func (w *WatchedFiles[T]) Watchers() Watchers {
 	w.computeWatchersOnce.Do(func() {
 		w.mu.Lock()
 		defer w.mu.Unlock()
 		result := w.computeGlobPatterns(w.input)
-		globs := result.patterns
+		globs := result.patternsInsideWorkspace
+
 		ignored := result.ignored
 		// ignored is only used for logging and doesn't affect watcher identity
 		w.ignored = ignored
-		if !slices.EqualFunc(w.watchers, globs, func(a *lsproto.FileSystemWatcher, b string) bool {
+		changed := false
+		if !slices.EqualFunc(w.workspaceWatchers, globs, func(a *lsproto.FileSystemWatcher, b string) bool {
 			return *a.GlobPattern.Pattern == b
 		}) {
-			w.watchers = core.Map(globs, func(glob string) *lsproto.FileSystemWatcher {
+			w.workspaceWatchers = core.Map(globs, func(glob string) *lsproto.FileSystemWatcher {
 				return &lsproto.FileSystemWatcher{
 					GlobPattern: lsproto.PatternOrRelativePattern{
 						Pattern: &glob,
@@ -90,21 +135,37 @@ func (w *WatchedFiles[T]) Watchers() (WatcherID, []*lsproto.FileSystemWatcher, m
 					Kind: &w.watchKind,
 				}
 			})
+			changed = true
+		}
+		dirsOutside := result.directoriesOutsideWorkspace
+		if !slices.EqualFunc(w.outsideWorkspaceWatchers, dirsOutside, func(a *lsproto.FileSystemWatcher, b string) bool {
+			return fileSystemWatcherGlobString(a) == recursiveDirectoryGlobPattern(b, w.hasRelativePatternCapability)
+		}) {
+			w.outsideWorkspaceWatchers = core.Map(dirsOutside, func(dir string) *lsproto.FileSystemWatcher {
+				return newRecursiveDirectoryWatcher(dir, w.watchKind, w.hasRelativePatternCapability)
+			})
+			changed = true
+		}
+		if changed {
 			w.id = watcherID.Add(1)
 		}
 	})
 
 	w.mu.RLock()
 	defer w.mu.RUnlock()
-	return WatcherID(fmt.Sprintf("%s watcher %d", w.name, w.id)), w.watchers, w.ignored
+	return Watchers{
+		WatcherID:                WatcherID(fmt.Sprintf("%s watcher %d", w.name, w.id)),
+		WorkspaceWatchers:        w.workspaceWatchers,
+		OutsideWorkspaceWatchers: w.outsideWorkspaceWatchers,
+		IgnoredPaths:             w.ignored,
+	}
 }
 
 func (w *WatchedFiles[T]) ID() WatcherID {
 	if w == nil {
 		return ""
 	}
-	id, _, _ := w.Watchers()
-	return id
+	return w.Watchers().WatcherID
 }
 
 func (w *WatchedFiles[T]) Name() string {
@@ -122,11 +183,12 @@ func (w *WatchedFiles[T]) Clone(input T) *WatchedFiles[T] {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 	return &WatchedFiles[T]{
-		name:                w.name,
-		watchKind:           w.watchKind,
-		computeGlobPatterns: w.computeGlobPatterns,
-		watchers:            w.watchers,
-		input:               input,
+		name:                         w.name,
+		watchKind:                    w.watchKind,
+		hasRelativePatternCapability: w.hasRelativePatternCapability,
+		computeGlobPatterns:          w.computeGlobPatterns,
+		workspaceWatchers:            w.workspaceWatchers,
+		input:                        input,
 	}
 }
 
@@ -144,6 +206,9 @@ func createResolutionLookupGlobMapper(workspaceDirectory string, libDirectory st
 
 		if data != nil {
 			data.Range(func(path tspath.Path) bool {
+				if tspath.IsDynamicFileName(string(path)) {
+					return true
+				}
 				// Assuming all of the input paths are file paths, we can avoid
 				// duplicate work by only taking one file per dir, since their outputs
 				// will always be the same.
@@ -184,6 +249,7 @@ func createResolutionLookupGlobMapper(workspaceDirectory string, libDirectory st
 			slices.Sort(nodeModulesGlobs)
 			globs = append(globs, nodeModulesGlobs...)
 		}
+		var outsideDirs []string
 		if externalDirectories.Len() > 0 {
 			externalDirStrings := make([]string, 0, externalDirectories.Len())
 			for dir := range externalDirectories.Keys() {
@@ -197,14 +263,13 @@ func createResolutionLookupGlobMapper(workspaceDirectory string, libDirectory st
 			)
 			slices.Sort(externalDirectoryParents)
 			ignored = ignoredExternalDirs
-			for _, dir := range externalDirectoryParents {
-				globs = append(globs, getRecursiveGlobPattern(dir))
-			}
+			outsideDirs = externalDirectoryParents
 		}
 
 		return PatternsAndIgnored{
-			patterns: globs,
-			ignored:  ignored,
+			directoriesOutsideWorkspace: outsideDirs,
+			patternsInsideWorkspace:     globs,
+			ignored:                     ignored,
 		}
 	}
 }
@@ -246,12 +311,10 @@ func getTypingsLocationsGlobs(
 	if includeTypingsLocation {
 		globs[tspath.ToPath(typingsLocation, currentDirectory, useCaseSensitiveFileNames)] = getRecursiveGlobPattern(typingsLocation)
 	}
-	for _, dir := range externalDirectoryParents {
-		globs[tspath.ToPath(dir, currentDirectory, useCaseSensitiveFileNames)] = getRecursiveGlobPattern(dir)
-	}
 	return PatternsAndIgnored{
-		patterns: slices.Collect(maps.Values(globs)),
-		ignored:  ignored,
+		directoriesOutsideWorkspace: externalDirectoryParents,
+		patternsInsideWorkspace:     slices.Collect(maps.Values(globs)),
+		ignored:                     ignored,
 	}
 }
 
@@ -291,4 +354,40 @@ func perceivedOsRootLengthForWatching(pathComponents []string) int {
 
 func getRecursiveGlobPattern(directory string) string {
 	return fmt.Sprintf("%s/%s", tspath.RemoveTrailingDirectorySeparator(directory), "**/*")
+}
+
+// recursiveDirectoryGlobPattern returns the string form of a recursive watcher
+// for the given directory that would be produced by newRecursiveDirectoryWatcher.
+func recursiveDirectoryGlobPattern(directory string, useRelativePattern bool) string {
+	if useRelativePattern {
+		return string(lsconv.FileNameToDocumentURI(directory)) + "/**/*"
+	}
+	return getRecursiveGlobPattern(directory)
+}
+
+// newRecursiveDirectoryWatcher creates a FileSystemWatcher for recursively
+// watching a directory. When useRelativePattern is true, a RelativePattern with
+// a file:// base URI is used; otherwise a plain glob Pattern is used.
+func newRecursiveDirectoryWatcher(directory string, kind lsproto.WatchKind, useRelativePattern bool) *lsproto.FileSystemWatcher {
+	if useRelativePattern {
+		baseUri := lsproto.URI(lsconv.FileNameToDocumentURI(directory))
+		return &lsproto.FileSystemWatcher{
+			GlobPattern: lsproto.PatternOrRelativePattern{
+				RelativePattern: &lsproto.RelativePattern{
+					BaseUri: lsproto.WorkspaceFolderOrURI{
+						URI: &baseUri,
+					},
+					Pattern: "**/*",
+				},
+			},
+			Kind: &kind,
+		}
+	}
+	glob := getRecursiveGlobPattern(directory)
+	return &lsproto.FileSystemWatcher{
+		GlobPattern: lsproto.PatternOrRelativePattern{
+			Pattern: &glob,
+		},
+		Kind: &kind,
+	}
 }

--- a/internal/project/watch.go
+++ b/internal/project/watch.go
@@ -188,6 +188,7 @@ func (w *WatchedFiles[T]) Clone(input T) *WatchedFiles[T] {
 		hasRelativePatternCapability: w.hasRelativePatternCapability,
 		computeGlobPatterns:          w.computeGlobPatterns,
 		workspaceWatchers:            w.workspaceWatchers,
+		outsideWorkspaceWatchers:     w.outsideWorkspaceWatchers,
 		input:                        input,
 	}
 }

--- a/internal/testutil/projecttestutil/projecttestutil.go
+++ b/internal/testutil/projecttestutil/projecttestutil.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/microsoft/typescript-go/internal/bundled"
 	"github.com/microsoft/typescript-go/internal/core"
+	"github.com/microsoft/typescript-go/internal/glob"
 	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
 	"github.com/microsoft/typescript-go/internal/project"
 	"github.com/microsoft/typescript-go/internal/project/logging"
@@ -115,6 +116,29 @@ func (h *SessionUtils) ToPath(fileName string) tspath.Path {
 
 func (h *SessionUtils) FS() vfs.FS {
 	return h.fs
+}
+
+// WatchesFile reports whether any registered file watcher would match the given
+// file path. It handles both absolute glob patterns and relative patterns with
+// a base URI. On case-insensitive file systems the paths in glob patterns are
+// lowercased, so callers should pass the lowercased path.
+func (h *SessionUtils) WatchesFile(filePath string) bool {
+	fileUri := "file://" + filePath
+	for _, call := range h.client.WatchFilesCalls() {
+		for _, watcher := range call.Watchers {
+			if watcher.GlobPattern.Pattern != nil {
+				if g, err := glob.Parse(*watcher.GlobPattern.Pattern); err == nil && g.Match(filePath) {
+					return true
+				}
+			} else if watcher.GlobPattern.RelativePattern != nil {
+				baseUri := string(*watcher.GlobPattern.RelativePattern.BaseUri.URI)
+				if strings.HasPrefix(fileUri, baseUri) {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 func (h *SessionUtils) Logs() string {

--- a/internal/testutil/projecttestutil/projecttestutil.go
+++ b/internal/testutil/projecttestutil/projecttestutil.go
@@ -123,7 +123,6 @@ func (h *SessionUtils) FS() vfs.FS {
 // a base URI. On case-insensitive file systems the paths in glob patterns are
 // lowercased, so callers should pass the lowercased path.
 func (h *SessionUtils) WatchesFile(filePath string) bool {
-	fileUri := "file://" + filePath
 	for _, call := range h.client.WatchFilesCalls() {
 		for _, watcher := range call.Watchers {
 			if watcher.GlobPattern.Pattern != nil {
@@ -131,9 +130,17 @@ func (h *SessionUtils) WatchesFile(filePath string) bool {
 					return true
 				}
 			} else if watcher.GlobPattern.RelativePattern != nil {
-				baseUri := string(*watcher.GlobPattern.RelativePattern.BaseUri.URI)
-				if strings.HasPrefix(fileUri, baseUri) {
-					return true
+				rp := watcher.GlobPattern.RelativePattern
+				baseUri := string(*rp.BaseUri.URI)
+				// Convert base URI (e.g. "file:///home/projects") to a directory path
+				// with trailing separator for proper prefix matching on path boundaries.
+				baseDir := lsproto.DocumentUri(baseUri).FileName()
+				baseDir = tspath.EnsureTrailingDirectorySeparator(baseDir)
+				if strings.HasPrefix(filePath, baseDir) {
+					relativePath := filePath[len(baseDir):]
+					if g, err := glob.Parse(rp.Pattern); err == nil && g.Match(relativePath) {
+						return true
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #2686 

Contains two separate fixes, both of which are required to make `npm link`ed dependencies work:

- We’ve been registering watchers using absolute path patterns, but the LSP spec says that the value for `Pattern` is "relative to the base path." It's not clear from the spec what "the base path" is since that terminology doesn't appear anywhere else, but in practice, in VS Code, registrations we've made to absolute paths outside the editor's open directory have been silently ignored. We needed to use `RelativePattern` instead.
- We call `Realpath()` on files resolved in `node_modules` and watch their realpath locations, but when we receive a watcher notification for the realpath location, we need to reverse map that back to the symlink locations to properly update the cached file content and update programs.