### PR TITLE
Fix file counts, jsx in project telemetry

### DIFF
--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -1054,7 +1054,7 @@ func (p *Program) verifyCompilerOptions() {
 			createDiagnosticForOptionName(diagnostics.Option_0_cannot_be_specified_with_option_1, "reactNamespace", "jsxFactory")
 		}
 		if options.Jsx == core.JsxEmitReactJSX || options.Jsx == core.JsxEmitReactJSXDev {
-			createDiagnosticForOptionName(diagnostics.Option_0_cannot_be_specified_when_option_jsx_is_1, "jsxFactory", tsoptions.InverseJsxOptionMap.GetOrZero(options.Jsx))
+			createDiagnosticForOptionName(diagnostics.Option_0_cannot_be_specified_when_option_jsx_is_1, "jsxFactory", options.Jsx.String())
 		}
 		if parser.ParseIsolatedEntityName(options.JsxFactory) == nil {
 			createOptionValueDiagnostic("jsxFactory", diagnostics.Invalid_value_for_jsxFactory_0_is_not_a_valid_identifier_or_qualified_name, options.JsxFactory)
@@ -1068,7 +1068,7 @@ func (p *Program) verifyCompilerOptions() {
 			createDiagnosticForOptionName(diagnostics.Option_0_cannot_be_specified_without_specifying_option_1, "jsxFragmentFactory", "jsxFactory")
 		}
 		if options.Jsx == core.JsxEmitReactJSX || options.Jsx == core.JsxEmitReactJSXDev {
-			createDiagnosticForOptionName(diagnostics.Option_0_cannot_be_specified_when_option_jsx_is_1, "jsxFragmentFactory", tsoptions.InverseJsxOptionMap.GetOrZero(options.Jsx))
+			createDiagnosticForOptionName(diagnostics.Option_0_cannot_be_specified_when_option_jsx_is_1, "jsxFragmentFactory", options.Jsx.String())
 		}
 		if parser.ParseIsolatedEntityName(options.JsxFragmentFactory) == nil {
 			createOptionValueDiagnostic("jsxFragmentFactory", diagnostics.Invalid_value_for_jsxFragmentFactory_0_is_not_a_valid_identifier_or_qualified_name, options.JsxFragmentFactory)
@@ -1077,13 +1077,13 @@ func (p *Program) verifyCompilerOptions() {
 
 	if options.ReactNamespace != "" {
 		if options.Jsx == core.JsxEmitReactJSX || options.Jsx == core.JsxEmitReactJSXDev {
-			createDiagnosticForOptionName(diagnostics.Option_0_cannot_be_specified_when_option_jsx_is_1, "reactNamespace", tsoptions.InverseJsxOptionMap.GetOrZero(options.Jsx))
+			createDiagnosticForOptionName(diagnostics.Option_0_cannot_be_specified_when_option_jsx_is_1, "reactNamespace", options.Jsx.String())
 		}
 	}
 
 	if options.JsxImportSource != "" {
 		if options.Jsx == core.JsxEmitReact {
-			createDiagnosticForOptionName(diagnostics.Option_0_cannot_be_specified_when_option_jsx_is_1, "jsxImportSource", tsoptions.InverseJsxOptionMap.GetOrZero(options.Jsx))
+			createDiagnosticForOptionName(diagnostics.Option_0_cannot_be_specified_when_option_jsx_is_1, "jsxImportSource", options.Jsx.String())
 		}
 	}
 

--- a/internal/core/compileroptions.go
+++ b/internal/core/compileroptions.go
@@ -457,6 +457,10 @@ func (m ModuleResolutionKind) String() string {
 	switch m {
 	case ModuleResolutionKindUnknown:
 		panic("should not use zero value of ModuleResolutionKind")
+	case ModuleResolutionKindClassic:
+		return "Classic"
+	case ModuleResolutionKindNode10:
+		return "Node10"
 	case ModuleResolutionKindNode16:
 		return "Node16"
 	case ModuleResolutionKindNodeNext:
@@ -529,3 +533,22 @@ const (
 	JsxEmitReactJSX    JsxEmit = 4
 	JsxEmitReactJSXDev JsxEmit = 5
 )
+
+func (j JsxEmit) String() string {
+	switch j {
+	case JsxEmitNone:
+		panic("should not use zero value of JsxEmit")
+	case JsxEmitPreserve:
+		return "preserve"
+	case JsxEmitReactNative:
+		return "react-native"
+	case JsxEmitReact:
+		return "react"
+	case JsxEmitReactJSX:
+		return "react-jsx"
+	case JsxEmitReactJSXDev:
+		return "react-jsxdev"
+	default:
+		panic("unhandled case in JsxEmit.String")
+	}
+}

--- a/internal/project/session.go
+++ b/internal/project/session.go
@@ -706,7 +706,7 @@ func (s *Session) collectProjectInfoTelemetry(project *Project) lsproto.Telemetr
 		compilerOptions["moduleResolution"] = name
 	}
 	if opts.Jsx != core.JsxEmitNone {
-		compilerOptions["jsx"] = fmt.Sprintf("%d", opts.Jsx)
+		compilerOptions["jsx"] = jsxEmitName(opts.Jsx)
 	}
 	if b, err := json.Marshal(compilerOptions); err == nil {
 		props["compilerOptions"] = string(b)
@@ -746,9 +746,8 @@ func boolTelemetry(v bool) string {
 func countFileStats(sourceFiles []*ast.SourceFile) *lsproto.ProjectInfoTelemetryMeasurements {
 	var stats lsproto.ProjectInfoTelemetryMeasurements
 	for _, sf := range sourceFiles {
-		fileName := sf.FileName()
 		size := float64(sf.End())
-		switch core.GetScriptKindFromFileName(fileName) {
+		switch sf.ScriptKind {
 		case core.ScriptKindJS:
 			stats.JsFileCount++
 			stats.JsFileSize += size
@@ -756,7 +755,7 @@ func countFileStats(sourceFiles []*ast.SourceFile) *lsproto.ProjectInfoTelemetry
 			stats.JsxFileCount++
 			stats.JsxFileSize += size
 		case core.ScriptKindTS:
-			if tspath.IsDeclarationFileName(fileName) {
+			if tspath.IsDeclarationFileName(sf.FileName()) {
 				stats.DtsFileCount++
 				stats.DtsFileSize += size
 			} else {
@@ -785,6 +784,23 @@ func moduleResolutionKindName(kind core.ModuleResolutionKind) string {
 		return "NodeNext"
 	case core.ModuleResolutionKindBundler:
 		return "Bundler"
+	default:
+		return ""
+	}
+}
+
+func jsxEmitName(jsx core.JsxEmit) string {
+	switch jsx {
+	case core.JsxEmitPreserve:
+		return "preserve"
+	case core.JsxEmitReactNative:
+		return "react-native"
+	case core.JsxEmitReact:
+		return "react"
+	case core.JsxEmitReactJSX:
+		return "react-jsx"
+	case core.JsxEmitReactJSXDev:
+		return "react-jsxdev"
 	default:
 		return ""
 	}

--- a/internal/project/session.go
+++ b/internal/project/session.go
@@ -702,11 +702,11 @@ func (s *Session) collectProjectInfoTelemetry(project *Project) lsproto.Telemetr
 	if opts.Module != core.ModuleKindNone {
 		compilerOptions["module"] = opts.Module.String()
 	}
-	if name := moduleResolutionKindName(opts.ModuleResolution); name != "" {
-		compilerOptions["moduleResolution"] = name
+	if opts.ModuleResolution != core.ModuleResolutionKindUnknown {
+		compilerOptions["moduleResolution"] = opts.ModuleResolution.String()
 	}
 	if opts.Jsx != core.JsxEmitNone {
-		compilerOptions["jsx"] = jsxEmitName(opts.Jsx)
+		compilerOptions["jsx"] = opts.Jsx.String()
 	}
 	if b, err := json.Marshal(compilerOptions); err == nil {
 		props["compilerOptions"] = string(b)
@@ -768,42 +768,6 @@ func countFileStats(sourceFiles []*ast.SourceFile) *lsproto.ProjectInfoTelemetry
 		}
 	}
 	return &stats
-}
-
-func moduleResolutionKindName(kind core.ModuleResolutionKind) string {
-	switch kind {
-	case core.ModuleResolutionKindUnknown:
-		return ""
-	case core.ModuleResolutionKindClassic:
-		return "Classic"
-	case core.ModuleResolutionKindNode10:
-		return "Node10"
-	case core.ModuleResolutionKindNode16:
-		return "Node16"
-	case core.ModuleResolutionKindNodeNext:
-		return "NodeNext"
-	case core.ModuleResolutionKindBundler:
-		return "Bundler"
-	default:
-		return ""
-	}
-}
-
-func jsxEmitName(jsx core.JsxEmit) string {
-	switch jsx {
-	case core.JsxEmitPreserve:
-		return "preserve"
-	case core.JsxEmitReactNative:
-		return "react-native"
-	case core.JsxEmitReact:
-		return "react"
-	case core.JsxEmitReactJSX:
-		return "react-jsx"
-	case core.JsxEmitReactJSXDev:
-		return "react-jsxdev"
-	default:
-		return ""
-	}
 }
 
 func (s *Session) Snapshot() *Snapshot {

--- a/internal/tsoptions/enummaps.go
+++ b/internal/tsoptions/enummaps.go
@@ -199,17 +199,6 @@ var jsxOptionMap = collections.NewOrderedMapFromList([]collections.MapEntry[stri
 	{Key: "react", Value: core.JsxEmitReact},
 })
 
-var InverseJsxOptionMap = collections.NewOrderedMapFromList(func() []collections.MapEntry[core.JsxEmit, string] {
-	entries := make([]collections.MapEntry[core.JsxEmit, string], 0, jsxOptionMap.Size())
-	for key, value := range jsxOptionMap.Entries() {
-		entries = append(entries, collections.MapEntry[core.JsxEmit, string]{
-			Key:   value.(core.JsxEmit),
-			Value: key,
-		})
-	}
-	return entries
-}())
-
 var newLineOptionMap = collections.NewOrderedMapFromList([]collections.MapEntry[string, any]{
 	{Key: "crlf", Value: core.NewLineKindCRLF},
 	{Key: "lf", Value: core.NewLineKindLF},


### PR DESCRIPTION
We need to count files based on what their file says they are. This doesn't fix the missing JS thing but is a problem.

Then, fix the JSX value to send a string.