### PR TITLE
Fix hover display of default type parameters

### DIFF
--- a/internal/checker/exports.go
+++ b/internal/checker/exports.go
@@ -154,6 +154,10 @@ func (c *Checker) GetConstraintOfTypeParameter(typeParameter *Type) *Type {
 	return c.getConstraintOfTypeParameter(typeParameter)
 }
 
+func (c *Checker) GetDefaultFromTypeParameter(typeParameter *Type) *Type {
+	return c.getDefaultFromTypeParameter(typeParameter)
+}
+
 func (c *Checker) GetResolutionModeOverride(node *ast.ImportAttributes, reportErrors bool) core.ResolutionMode {
 	return c.getResolutionModeOverride(node, reportErrors)
 }

--- a/internal/fourslash/tests/quickInfoDefaultTypeParameter1_test.go
+++ b/internal/fourslash/tests/quickInfoDefaultTypeParameter1_test.go
@@ -1,0 +1,19 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestQuickInfoDefaultTypeParameter1(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `type /*1*/X</*2*/T = string> = T`
+
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyQuickInfoAt(t, "1", "type X<T = string> = T", "")
+	f.VerifyQuickInfoAt(t, "2", "(type parameter) T in type X<T = string>", "")
+}

--- a/internal/ls/hover.go
+++ b/internal/ls/hover.go
@@ -308,6 +308,11 @@ func getQuickInfoAndDeclarationAtLocation(c *checker.Checker, symbol *ast.Symbol
 					b.WriteString(" extends ")
 					b.WriteString(typeToString(cons, nil, typeFormatFlags))
 				}
+				def := c.GetDefaultFromTypeParameter(tp)
+				if def != nil {
+					b.WriteString(" = ")
+					b.WriteString(typeToString(def, nil, typeFormatFlags))
+				}
 			}
 			b.WriteString(">")
 		}


### PR DESCRIPTION
fixes https://github.com/microsoft/typescript-go/issues/3417