### PR TITLE
Ensure request cancel is always called

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -490,8 +490,8 @@ func (s *Server) dispatchLoop(ctx context.Context) error {
 		case req := <-s.requestQueue:
 			s.lastRequestTimeMs.Store(time.Now().UnixMilli())
 			requestCtx := locale.WithLocale(ctx, s.locale)
+			var cancel context.CancelFunc
 			if req.ID != nil {
-				var cancel context.CancelFunc
 				requestCtx, cancel = context.WithCancel(core.WithRequestID(requestCtx, req.ID.String()))
 				s.pendingClientRequestsMu.Lock()
 				s.pendingClientRequests[*req.ID] = pendingClientRequest{
@@ -517,6 +517,7 @@ func (s *Server) dispatchLoop(ctx context.Context) error {
 
 			removeRequest := func() {
 				if req.ID != nil {
+					defer cancel()
 					s.pendingClientRequestsMu.Lock()
 					defer s.pendingClientRequestsMu.Unlock()
 					delete(s.pendingClientRequests, *req.ID)

--- a/internal/project/session.go
+++ b/internal/project/session.go
@@ -382,6 +382,7 @@ func (s *Session) ScheduleDiagnosticsRefresh() {
 
 	// Enqueue the debounced diagnostics refresh
 	s.backgroundQueue.Enqueue(debounceCtx, func(ctx context.Context) {
+		defer cancel()
 		// Sleep for the debounce delay
 		select {
 		case <-time.After(s.options.DebounceDelay):


### PR DESCRIPTION
This appears to be the root cause of #3423. The cancel function from `WithCancel`, `WithTimeout`, etc, _must_ be called no matter what. Normally, this is deferred, but this is trickier code because of how we need to order requests and do cancellation out-of-band.