### PR TITLE
Provide more accurate rename range in `prepareRename` LSP response

### DIFF
--- a/internal/ls/rename.go
+++ b/internal/ls/rename.go
@@ -363,7 +363,7 @@ func getRenameInfoError(ctx context.Context, message *diagnostics.Message) Renam
 }
 
 func getRenameInfoSuccess(node *ast.Node, sourceFile *ast.SourceFile, displayName string, converters *lsconv.Converters) RenameInfo {
-	start := node.Pos()
+	start := astnav.GetStartOfNode(node, sourceFile, false /*includeJSDoc*/)
 	end := node.End()
 	if ast.IsStringLiteralLike(node) {
 		// Exclude the quotes


### PR DESCRIPTION
Strada [uses `node.getStart`](https://github.com/microsoft/TypeScript/blob/55423abe4d029017f19b6e4c32097591994836b4/src/services/rename.ts#L220), while Corsa uses `node.Pos`. This causes the `textDocument/prepareRename` method to return a range with leading trivia. As a result, that range doesn't match the one later returned returned by `textDocument/rename`.