### PR TITLE
Fix external package realpath during auto-import collection

### DIFF
--- a/internal/ls/autoimport/util.go
+++ b/internal/ls/autoimport/util.go
@@ -239,21 +239,51 @@ func addPackageJsonDependencies(contents *packagejson.PackageJson, deps *collect
 }
 
 // getPackageRealpathFuncs returns functions to transform between symlink and realpath for files within a package.
-// It calls FS.Realpath once per package directory and uses string replacement for files,
-// avoiding expensive realpath syscalls for each file.
+// It calls FS.Realpath once per package directory and uses prefix substitution for files within that directory,
+// avoiding expensive realpath syscalls for each file. For files outside the package (e.g. re-exported
+// dependencies reached through node_modules symlinks), it resolves the file's directory realpath once,
+// finds the symlink boundary (the package root where the symlink lives), and caches that prefix mapping.
+// All subsequent files under the same symlinked package directory use prefix substitution with no syscalls.
 func getPackageRealpathFuncs(fs vfs.FS, packageDir string) (toRealpath, toSymlink func(string) string) {
 	realPackageDir := fs.Realpath(packageDir)
-	if realPackageDir == packageDir {
-		// Not a symlink, both directions are identity
-		return core.Identity, core.Identity
-	}
-	// Package is symlinked; derive paths by replacing the prefix
+	isSymlinked := realPackageDir != packageDir
+	// Cache of package-directory-level symlink→realpath prefix mappings for
+	// external packages encountered via re-exports. Keyed by the node_modules
+	// package directory (e.g. "/app/node_modules/dep"), so all files under
+	// that package reuse a single realpath lookup.
+	dirCache := make(map[string]string)
 	toRealpath = func(fileName string) string {
-		if after, ok := strings.CutPrefix(fileName, packageDir); ok {
-			return realPackageDir + after
+		// Fast path: files within the package use prefix substitution.
+		if isSymlinked {
+			if after, ok := strings.CutPrefix(fileName, packageDir); ok {
+				return realPackageDir + after
+			}
 		}
-		return fileName
+		// Files outside the package (e.g. re-exports into symlinked deps):
+		// find the node_modules package directory, resolve it once, and cache.
+		pkgDir := module.ParseNodeModuleFromPath(fileName, false /*isFolder*/)
+		if pkgDir == "" {
+			return fileName
+		}
+		if realDir, ok := dirCache[pkgDir]; ok {
+			if realDir == pkgDir {
+				return fileName
+			}
+			return realDir + fileName[len(pkgDir):]
+		}
+		realDir := fs.Realpath(pkgDir)
+		dirCache[pkgDir] = realDir
+		if realDir == pkgDir {
+			return fileName
+		}
+		return realDir + fileName[len(pkgDir):]
 	}
+	if !isSymlinked {
+		return toRealpath, core.Identity
+	}
+	// toSymlink only handles files within the package directory (reversing the
+	// packageDir→realPackageDir substitution). It does not handle arbitrary external
+	// paths; callers should only use it for files known to be within the package.
 	toSymlink = func(fileName string) string {
 		if after, ok := strings.CutPrefix(fileName, realPackageDir); ok {
 			return packageDir + after

--- a/internal/ls/autoimport/util_test.go
+++ b/internal/ls/autoimport/util_test.go
@@ -3,6 +3,9 @@ package autoimport
 import (
 	"reflect"
 	"testing"
+
+	"github.com/microsoft/typescript-go/internal/vfs/vfstest"
+	"gotest.tools/v3/assert"
 )
 
 func TestWordIndices(t *testing.T) {
@@ -87,4 +90,89 @@ func TestWordIndices(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGetPackageRealpathFuncs_FollowsNodeModulesSymlinks tests that toRealpath correctly
+// follows symlinks for files outside the package directory (e.g. node_modules entries).
+// Without this, the module resolver uses unresolved symlink paths as cache keys, causing
+// the same file to be loaded multiple times and triggering massive memory usage when
+// barrel files re-export from many symlinked packages (issue #2780).
+func TestGetPackageRealpathFuncs_FollowsNodeModulesSymlinks(t *testing.T) {
+	t.Parallel()
+
+	// Simulate a layout where the package directory is itself a symlink (e.g. Bazel's
+	// convenience symlinks or pnpm's virtual store):
+	//   /symlink-bin/pkg/              -> symlink to /real/bin/pkg/
+	//   /real/bin/pkg/node_modules/dep -> symlink to /real/dep/
+	//
+	// When toRealpath is used as the module resolver's Realpath, it must follow
+	// the node_modules symlink so that /real/bin/pkg/node_modules/dep/index.d.ts
+	// resolves to /real/dep/index.d.ts — otherwise the same dep file gets different
+	// cache keys depending on which path it was reached through.
+	fs := vfstest.FromMap(map[string]any{
+		"/symlink-bin/pkg":               vfstest.Symlink("/real/bin/pkg"),
+		"/real/bin/pkg/index.d.ts":       "export declare const a: number;",
+		"/real/bin/pkg/node_modules/dep": vfstest.Symlink("/real/dep"),
+		"/real/dep/index.d.ts":           "export declare const b: number;",
+	}, true)
+
+	toRealpath, _ := getPackageRealpathFuncs(fs, "/symlink-bin/pkg")
+
+	// Files inside the package should be converted via string replacement (fast path).
+	assert.Equal(t,
+		toRealpath("/symlink-bin/pkg/index.d.ts"),
+		"/real/bin/pkg/index.d.ts",
+		"package files should be converted via prefix replacement",
+	)
+
+	// Files outside the package (e.g. node_modules symlinks) should be resolved via
+	// fs.Realpath so the cache key is the canonical realpath, not the symlink path.
+	assert.Equal(t,
+		toRealpath("/real/bin/pkg/node_modules/dep/index.d.ts"),
+		"/real/dep/index.d.ts",
+		"node_modules symlinks must be followed so the same file gets a consistent cache key",
+	)
+}
+
+// TestGetPackageRealpathFuncs_DuplicateCacheKeys demonstrates how the broken toRealpath
+// causes the same physical file to get different cache keys when reached through different
+// symlink paths. In pnpm/Bazel monorepos, multiple packages may have node_modules symlinks
+// that point to the same physical dependency. Because toRealpath doesn't follow symlinks
+// for files outside the package directory, each path is treated as distinct, leading to
+// duplicate file loads and memory bloat (issue #2780).
+func TestGetPackageRealpathFuncs_DuplicateCacheKeys(t *testing.T) {
+	t.Parallel()
+
+	// Simulate two packages (app-a, app-b) that each have a node_modules symlink to
+	// the same shared dependency. This is a typical pnpm/Bazel layout:
+	//   /workspace/packages/app-a/              -> symlink to /store/app-a/
+	//   /workspace/packages/app-b/              -> symlink to /store/app-b/
+	//   /store/app-a/node_modules/shared-lib    -> symlink to /store/shared-lib/
+	//   /store/app-b/node_modules/shared-lib    -> symlink to /store/shared-lib/
+	fs := vfstest.FromMap(map[string]any{
+		"/workspace/packages/app-a":            vfstest.Symlink("/store/app-a"),
+		"/workspace/packages/app-b":            vfstest.Symlink("/store/app-b"),
+		"/store/app-a/index.d.ts":              "export declare const a: number;",
+		"/store/app-b/index.d.ts":              "export declare const b: number;",
+		"/store/app-a/node_modules/shared-lib": vfstest.Symlink("/store/shared-lib"),
+		"/store/app-b/node_modules/shared-lib": vfstest.Symlink("/store/shared-lib"),
+		"/store/shared-lib/index.d.ts":         "export declare const shared: string;",
+	}, true)
+
+	toRealpathA, _ := getPackageRealpathFuncs(fs, "/workspace/packages/app-a")
+	toRealpathB, _ := getPackageRealpathFuncs(fs, "/workspace/packages/app-b")
+
+	sharedFileViaA := "/store/app-a/node_modules/shared-lib/index.d.ts"
+	sharedFileViaB := "/store/app-b/node_modules/shared-lib/index.d.ts"
+
+	resolvedA := toRealpathA(sharedFileViaA)
+	resolvedB := toRealpathB(sharedFileViaB)
+
+	// Both should resolve to the same canonical realpath so the module resolver
+	// uses a single cache key for the shared dependency, avoiding duplicate loads.
+	expectedRealpath := "/store/shared-lib/index.d.ts"
+	assert.Equal(t, resolvedA, expectedRealpath,
+		"app-a's toRealpath should follow the node_modules symlink to the realpath")
+	assert.Equal(t, resolvedB, expectedRealpath,
+		"app-b's toRealpath should follow the node_modules symlink to the realpath")
 }

--- a/internal/ls/autoimport/util_test.go
+++ b/internal/ls/autoimport/util_test.go
@@ -110,10 +110,11 @@ func TestGetPackageRealpathFuncs_FollowsNodeModulesSymlinks(t *testing.T) {
 	// resolves to /real/dep/index.d.ts — otherwise the same dep file gets different
 	// cache keys depending on which path it was reached through.
 	fs := vfstest.FromMap(map[string]any{
-		"/symlink-bin/pkg":               vfstest.Symlink("/real/bin/pkg"),
-		"/real/bin/pkg/index.d.ts":       "export declare const a: number;",
-		"/real/bin/pkg/node_modules/dep": vfstest.Symlink("/real/dep"),
-		"/real/dep/index.d.ts":           "export declare const b: number;",
+		"/symlink-bin/pkg":                vfstest.Symlink("/real/bin/pkg"),
+		"/real/bin/pkg/index.d.ts":        "export declare const a: number;",
+		"/real/bin/pkg/node_modules/dep":  vfstest.Symlink("/real/dep"),
+		"/real/dep/index.d.ts":            "export declare const b: number;",
+		"/real/dep/src/utils/helper.d.ts": "export declare const c: number;",
 	}, true)
 
 	toRealpath, _ := getPackageRealpathFuncs(fs, "/symlink-bin/pkg")
@@ -131,6 +132,14 @@ func TestGetPackageRealpathFuncs_FollowsNodeModulesSymlinks(t *testing.T) {
 		toRealpath("/real/bin/pkg/node_modules/dep/index.d.ts"),
 		"/real/dep/index.d.ts",
 		"node_modules symlinks must be followed so the same file gets a consistent cache key",
+	)
+
+	// Files in subdirectories of an already-resolved external package should
+	// use the cached prefix mapping without additional realpath calls.
+	assert.Equal(t,
+		toRealpath("/real/bin/pkg/node_modules/dep/src/utils/helper.d.ts"),
+		"/real/dep/src/utils/helper.d.ts",
+		"subdirectories of a resolved external package should use cached prefix mapping",
 	)
 }
 
@@ -175,4 +184,32 @@ func TestGetPackageRealpathFuncs_DuplicateCacheKeys(t *testing.T) {
 		"app-a's toRealpath should follow the node_modules symlink to the realpath")
 	assert.Equal(t, resolvedB, expectedRealpath,
 		"app-b's toRealpath should follow the node_modules symlink to the realpath")
+}
+
+// TestGetPackageRealpathFuncs_NonSymlinkedPackageWithSymlinkedDeps tests that even when the
+// package directory itself is NOT a symlink, toRealpath still follows symlinks for files
+// outside the package (e.g. re-exports reaching into symlinked node_modules dependencies).
+func TestGetPackageRealpathFuncs_NonSymlinkedPackageWithSymlinkedDeps(t *testing.T) {
+	t.Parallel()
+
+	fs := vfstest.FromMap(map[string]any{
+		"/real/my-pkg/index.d.ts":       "export declare const a: number;",
+		"/real/my-pkg/node_modules/dep": vfstest.Symlink("/real/dep"),
+		"/real/dep/index.d.ts":          "export declare const b: number;",
+	}, true)
+
+	toRealpath, _ := getPackageRealpathFuncs(fs, "/real/my-pkg")
+
+	// Files inside the (non-symlinked) package should be returned unchanged.
+	assert.Equal(t,
+		toRealpath("/real/my-pkg/index.d.ts"),
+		"/real/my-pkg/index.d.ts",
+	)
+
+	// Files outside the package reached via symlinked node_modules should still be resolved.
+	assert.Equal(t,
+		toRealpath("/real/my-pkg/node_modules/dep/index.d.ts"),
+		"/real/dep/index.d.ts",
+		"symlinked deps must be resolved even when the package dir itself is not a symlink",
+	)
 }


### PR DESCRIPTION
To avoid hitting the file system as much during auto-imports, we use a heuristic and assume that individual files inside node_modules are never symlinked; only entire package directories are symlinked. We build a `realpath` implementation that does prefix substitution to infer the realpath of each individual package file from the symlink/realpath relationship of its package directory. This function didn't account for the possibility that it could be called on files in _other_ packages, which can happen if a node_modules file does `export * from "some-other-package"`. The exports originating in `some-other-package` were being keyed under their symlink path, which can be duplicated many times over in some layouts.

The fix is to use the package directory symlink heuristic for each unique package directory encountered while extracting a single package. If package `foo` contains its own exports, plus some re-exports from `bar` and `baz`, `fs.Realpath()` will be called only three times between any number of exports originating from those three packages.

Thanks @shinichy for the investigation and the test case!

Closes #2780