### PR TITLE
Remap JS type nodes in declaration emit to TS constructs or fallback to serialization

### DIFF
--- a/internal/checker/emitresolver.go
+++ b/internal/checker/emitresolver.go
@@ -1222,3 +1222,12 @@ func (r *EmitResolver) GetPropertiesOfContainerFunction(node *ast.Node) []*ast.S
 	}
 	return r.checker.getPropertiesOfType(r.checker.getTypeOfSymbol(s))
 }
+
+func (r *EmitResolver) TryJSTypeNodeToTypeNode(emitContext *printer.EmitContext, typeNode *ast.Node, enclosingDeclaration *ast.Node, flags nodebuilder.Flags, internalFlags nodebuilder.InternalFlags, tracker nodebuilder.SymbolTracker) *ast.Node {
+	typeNode = emitContext.ParseNode(typeNode)
+	r.checkerMu.Lock()
+	defer r.checkerMu.Unlock()
+
+	requestNodeBuilder := NewNodeBuilder(r.checker, emitContext) // TODO: cache per-context
+	return requestNodeBuilder.TryJSTypeNodeToTypeNode(typeNode, enclosingDeclaration, flags, internalFlags, tracker)
+}

--- a/internal/checker/nodebuilder.go
+++ b/internal/checker/nodebuilder.go
@@ -266,6 +266,11 @@ func (b *NodeBuilder) TypeToTypeNode(typ *Type, enclosingDeclaration *ast.Node, 
 	return b.exitContext(b.impl.typeToTypeNode(typ))
 }
 
+func (b *NodeBuilder) TryJSTypeNodeToTypeNode(node *ast.Node, enclosingDeclaration *ast.Node, flags nodebuilder.Flags, internalFlags nodebuilder.InternalFlags, tracker nodebuilder.SymbolTracker) *ast.Node {
+	b.enterContext(enclosingDeclaration, flags, internalFlags, tracker)
+	return b.exitContext(b.impl.tryJSTypeNodeToTypeNode(node))
+}
+
 // var _ NodeBuilderInterface = NewNodeBuilderAPI(nil, nil)
 
 func NewNodeBuilder(ch *Checker, e *printer.EmitContext) *NodeBuilder {

--- a/internal/checker/nodecopy.go
+++ b/internal/checker/nodecopy.go
@@ -17,6 +17,10 @@ func (b *NodeBuilderImpl) reuseNode(node *ast.Node) *ast.Node {
 	return b.tryReuseExistingNodeHelper(node)
 }
 
+func (b *NodeBuilderImpl) tryJSTypeNodeToTypeNode(node *ast.Node) *ast.Node {
+	return b.reuseNode(node)
+}
+
 // a wrapper around `reuseNode` that handles renaming `new` to `"new"` so we don't accidentally emit constructor signatures when we don't mean to
 func (b *NodeBuilderImpl) reuseName(node *ast.Node) *ast.Node {
 	res := b.reuseNode(node)

--- a/internal/printer/emitresolver.go
+++ b/internal/printer/emitresolver.go
@@ -122,4 +122,5 @@ type EmitResolver interface {
 	CreateLiteralConstValue(emitContext *EmitContext, node *ast.Node, tracker nodebuilder.SymbolTracker) *ast.Node
 	CreateTypeOfExpression(emitContext *EmitContext, expression *ast.Node, enclosingDeclaration *ast.Node, flags nodebuilder.Flags, internalFlags nodebuilder.InternalFlags, tracker nodebuilder.SymbolTracker) *ast.Node
 	CreateLateBoundIndexSignatures(emitContext *EmitContext, container *ast.Node, enclosingDeclaration *ast.Node, flags nodebuilder.Flags, internalFlags nodebuilder.InternalFlags, tracker nodebuilder.SymbolTracker) []*ast.Node
+	TryJSTypeNodeToTypeNode(emitContext *EmitContext, typeNode *ast.Node, enclosingDeclaration *ast.Node, flags nodebuilder.Flags, internalFlags nodebuilder.InternalFlags, tracker nodebuilder.SymbolTracker) *ast.Node
 }

--- a/internal/transformers/declarations/transform.go
+++ b/internal/transformers/declarations/transform.go
@@ -1205,7 +1205,17 @@ func (tx *DeclarationTransformer) ensureType(node *ast.Node, ignorePrivate bool)
 	// Should be removed createTypeOfDeclaration will actually now reuse the existing annotation so there is no real need to duplicate type walking
 	// Left in for now to minimize diff during syntactic type node builder refactor
 	if !ast.IsExportAssignment(node) && !ast.IsBindingElement(node) && node.Type() != nil && (!ast.IsParameterDeclaration(node) || !tx.resolver.RequiresAddingImplicitUndefined(node, nil, tx.enclosingDeclaration)) {
-		return tx.Visitor().Visit(node.Type())
+		if tx.state.currentSourceFile.IsJS() {
+			// JS types have a heap of constructs we can't directly emit into .d.ts files; the node builder contains logic to remap those where possible, so we invoke it here
+			// In strada we always built js declarations symbolically, so all js type nodes went through this postprocessing
+			res := tx.resolver.TryJSTypeNodeToTypeNode(tx.EmitContext(), node.Type(), tx.enclosingDeclaration, declarationEmitNodeBuilderFlags, declarationEmitInternalNodeBuilderFlags, tx.tracker)
+			if res != nil {
+				return res
+			}
+			// otherwise, fall back to full serialization
+		} else {
+			return tx.Visitor().Visit(node.Type())
+		}
 	}
 
 	oldErrorNameNode := tx.state.errorNameNode

--- a/testdata/baselines/reference/submodule/conformance/jsDeclarationsClassStatic(target=es2015).js
+++ b/testdata/baselines/reference/submodule/conformance/jsDeclarationsClassStatic(target=es2015).js
@@ -63,7 +63,7 @@ declare const Strings: {
 export = Handler;
 export { Strings };
 export type HandlerOptions = {
-    name: String;
+    name: string;
 };
 /**
  * @typedef {Object} HandlerOptions

--- a/testdata/baselines/reference/submodule/conformance/jsDeclarationsClassStatic(target=es2015).js.diff
+++ b/testdata/baselines/reference/submodule/conformance/jsDeclarationsClassStatic(target=es2015).js.diff
@@ -21,8 +21,6 @@
 -    /**
 -     * Should be able to export a type alias at the same time.
 -     */
--    name: string;
--};
 +    var statische: () => void;
 +}
 +declare const Strings: {
@@ -32,8 +30,8 @@
 +export = Handler;
 +export { Strings };
 +export type HandlerOptions = {
-+    name: String;
-+};
+     name: string;
+ };
 +/**
 + * @typedef {Object} HandlerOptions
 + * @property {String} name

--- a/testdata/baselines/reference/submodule/conformance/jsDeclarationsExportDefinePropertyEmit.js
+++ b/testdata/baselines/reference/submodule/conformance/jsDeclarationsExportDefinePropertyEmit.js
@@ -149,7 +149,7 @@ export { _exported_4 as "f" };
 declare function g(a: {
     x: string;
 }, b: {
-    y: typeof module.exports.b;
+    y: () => void;
 }): void | "";
 declare const _exported_5: typeof g;
 export { _exported_5 as "g" };
@@ -160,7 +160,7 @@ export { _exported_5 as "g" };
 declare function hh(a: {
     x: string;
 }, b: {
-    y: typeof module.exports.b;
+    y: () => void;
 }): void | "";
 declare const _exported_6: typeof hh;
 export { _exported_6 as "h" };
@@ -182,9 +182,7 @@ out/index.d.ts(4,25): error TS18057: String literal import and export names are 
 out/index.d.ts(12,25): error TS18057: String literal import and export names are not supported when the '--module' flag is set to 'es2015' or 'es2020'.
 out/index.d.ts(21,25): error TS18057: String literal import and export names are not supported when the '--module' flag is set to 'es2015' or 'es2020'.
 out/index.d.ts(28,25): error TS18057: String literal import and export names are not supported when the '--module' flag is set to 'es2015' or 'es2020'.
-out/index.d.ts(36,15): error TS2591: Cannot find name 'module'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
 out/index.d.ts(39,25): error TS18057: String literal import and export names are not supported when the '--module' flag is set to 'es2015' or 'es2020'.
-out/index.d.ts(47,15): error TS2591: Cannot find name 'module'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
 out/index.d.ts(50,25): error TS18057: String literal import and export names are not supported when the '--module' flag is set to 'es2015' or 'es2020'.
 out/index.d.ts(52,25): error TS18057: String literal import and export names are not supported when the '--module' flag is set to 'es2015' or 'es2020'.
 out/index.d.ts(54,25): error TS18057: String literal import and export names are not supported when the '--module' flag is set to 'es2015' or 'es2020'.
@@ -192,7 +190,7 @@ out/index.d.ts(56,25): error TS18057: String literal import and export names are
 out/index.d.ts(58,26): error TS18057: String literal import and export names are not supported when the '--module' flag is set to 'es2015' or 'es2020'.
 
 
-==== out/index.d.ts (13 errors) ====
+==== out/index.d.ts (11 errors) ====
     declare const _exported: () => void;
     export { _exported as "a" };
                           ~~~
@@ -238,9 +236,7 @@ out/index.d.ts(58,26): error TS18057: String literal import and export names are
     declare function g(a: {
         x: string;
     }, b: {
-        y: typeof module.exports.b;
-                  ~~~~~~
-!!! error TS2591: Cannot find name 'module'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
+        y: () => void;
     }): void | "";
     declare const _exported_5: typeof g;
     export { _exported_5 as "g" };
@@ -253,9 +249,7 @@ out/index.d.ts(58,26): error TS18057: String literal import and export names are
     declare function hh(a: {
         x: string;
     }, b: {
-        y: typeof module.exports.b;
-                  ~~~~~~
-!!! error TS2591: Cannot find name 'module'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
+        y: () => void;
     }): void | "";
     declare const _exported_6: typeof hh;
     export { _exported_6 as "h" };

--- a/testdata/baselines/reference/submodule/conformance/jsDeclarationsExportDefinePropertyEmit.js.diff
+++ b/testdata/baselines/reference/submodule/conformance/jsDeclarationsExportDefinePropertyEmit.js.diff
@@ -48,7 +48,7 @@
 +declare function g(a: {
 +    x: string;
 +}, b: {
-+    y: typeof module.exports.b;
++    y: () => void;
 +}): void | "";
 +declare const _exported_5: typeof g;
 +export { _exported_5 as "g" };
@@ -59,7 +59,7 @@
 +declare function hh(a: {
 +    x: string;
 +}, b: {
-+    y: typeof module.exports.b;
++    y: () => void;
 +}): void | "";
 +declare const _exported_6: typeof hh;
 +export { _exported_6 as "h" };
@@ -81,9 +81,7 @@
 +out/index.d.ts(12,25): error TS18057: String literal import and export names are not supported when the '--module' flag is set to 'es2015' or 'es2020'.
 +out/index.d.ts(21,25): error TS18057: String literal import and export names are not supported when the '--module' flag is set to 'es2015' or 'es2020'.
 +out/index.d.ts(28,25): error TS18057: String literal import and export names are not supported when the '--module' flag is set to 'es2015' or 'es2020'.
-+out/index.d.ts(36,15): error TS2591: Cannot find name 'module'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
 +out/index.d.ts(39,25): error TS18057: String literal import and export names are not supported when the '--module' flag is set to 'es2015' or 'es2020'.
-+out/index.d.ts(47,15): error TS2591: Cannot find name 'module'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
 +out/index.d.ts(50,25): error TS18057: String literal import and export names are not supported when the '--module' flag is set to 'es2015' or 'es2020'.
 +out/index.d.ts(52,25): error TS18057: String literal import and export names are not supported when the '--module' flag is set to 'es2015' or 'es2020'.
 +out/index.d.ts(54,25): error TS18057: String literal import and export names are not supported when the '--module' flag is set to 'es2015' or 'es2020'.
@@ -91,7 +89,7 @@
 +out/index.d.ts(58,26): error TS18057: String literal import and export names are not supported when the '--module' flag is set to 'es2015' or 'es2020'.
 +
 +
-+==== out/index.d.ts (13 errors) ====
++==== out/index.d.ts (11 errors) ====
 +    declare const _exported: () => void;
 +    export { _exported as "a" };
 +                          ~~~
@@ -161,9 +159,7 @@
 +    declare function g(a: {
 +        x: string;
 +    }, b: {
-+        y: typeof module.exports.b;
-+                  ~~~~~~
-+!!! error TS2591: Cannot find name 'module'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
++        y: () => void;
 +    }): void | "";
 +    declare const _exported_5: typeof g;
 +    export { _exported_5 as "g" };
@@ -176,9 +172,7 @@
 +    declare function hh(a: {
 +        x: string;
 +    }, b: {
-+        y: typeof module.exports.b;
-+                  ~~~~~~
-+!!! error TS2591: Cannot find name 'module'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
++        y: () => void;
 +    }): void | "";
 +    declare const _exported_6: typeof hh;
 +    export { _exported_6 as "h" };

--- a/testdata/baselines/reference/submodule/conformance/jsDeclarationsFunctionsCjs.js
+++ b/testdata/baselines/reference/submodule/conformance/jsDeclarationsFunctionsCjs.js
@@ -127,7 +127,7 @@ export declare var f: <T>(a: T) => T;
 declare function g(a: {
     x: string;
 }, b: {
-    y: typeof module.exports.b;
+    y: () => void;
 }): void | "";
 export { g };
 /**
@@ -137,7 +137,7 @@ export { g };
 declare function hh(a: {
     x: string;
 }, b: {
-    y: typeof module.exports.b;
+    y: () => void;
 }): void | "";
 export { hh as h };
 export declare var i: () => void;

--- a/testdata/baselines/reference/submodule/conformance/jsDeclarationsFunctionsCjs.js.diff
+++ b/testdata/baselines/reference/submodule/conformance/jsDeclarationsFunctionsCjs.js.diff
@@ -42,7 +42,7 @@
 -        (): void;
 -        cat: string;
 -    };
-+    y: typeof module.exports.b;
++    y: () => void;
  }): void | "";
 +export { g };
  /**
@@ -56,7 +56,7 @@
 -        (): void;
 -        cat: string;
 -    };
-+    y: typeof module.exports.b;
++    y: () => void;
  }): void | "";
 -export { hh as h, i as ii, j as jj };
 +export { hh as h };

--- a/testdata/baselines/reference/submodule/conformance/jsDeclarationsImportAliasExposedWithinNamespace.js
+++ b/testdata/baselines/reference/submodule/conformance/jsDeclarationsImportAliasExposedWithinNamespace.js
@@ -59,7 +59,7 @@ export {testFn, testFnTypes};
  * @global
  * @type {Object<string,*>}
  */
-declare const myTypes: Object<string, any>;
+declare const myTypes: Record<string, any>;
 export type myTypes = string | RegExp | Array<string | RegExp>;
 export type myTypes = {
     prop1: myTypes.typeA;
@@ -80,7 +80,7 @@ export { myTypes };
  * @global
  * @type {Object<string,*>}
  */
-declare const testFnTypes: Object<string, any>;
+declare const testFnTypes: Record<string, any>;
 export type testFnTypes = boolean | myTypes.typeC;
 /** @typedef {boolean|myTypes.typeC} testFnTypes.input */
 /**

--- a/testdata/baselines/reference/submodule/conformance/jsDeclarationsImportAliasExposedWithinNamespace.js.diff
+++ b/testdata/baselines/reference/submodule/conformance/jsDeclarationsImportAliasExposedWithinNamespace.js.diff
@@ -25,7 +25,7 @@
   */
 -export const myTypes: {
 -    [x: string]: any;
-+declare const myTypes: Object<string, any>;
++declare const myTypes: Record<string, any>;
 +export type myTypes = string | RegExp | Array<string | RegExp>;
 +export type myTypes = {
 +    prop1: myTypes.typeA;
@@ -49,7 +49,7 @@
 + * @global
 + * @type {Object<string,*>}
 + */
-+declare const testFnTypes: Object<string, any>;
++declare const testFnTypes: Record<string, any>;
 +export type testFnTypes = boolean | myTypes.typeC;
  /** @typedef {boolean|myTypes.typeC} testFnTypes.input */
  /**

--- a/testdata/baselines/reference/submodule/conformance/jsDeclarationsImportAliasExposedWithinNamespaceCjs.js
+++ b/testdata/baselines/reference/submodule/conformance/jsDeclarationsImportAliasExposedWithinNamespaceCjs.js
@@ -59,7 +59,7 @@ module.exports = {testFn, testFnTypes};
  * @global
  * @type {Object<string,*>}
  */
-declare const myTypes: Object<string, any>;
+declare const myTypes: Record<string, any>;
 export type myTypes = string | RegExp | Array<string | RegExp>;
 export type myTypes = {
     prop1: myTypes.typeA;

--- a/testdata/baselines/reference/submodule/conformance/jsDeclarationsImportAliasExposedWithinNamespaceCjs.js.diff
+++ b/testdata/baselines/reference/submodule/conformance/jsDeclarationsImportAliasExposedWithinNamespaceCjs.js.diff
@@ -6,7 +6,7 @@
   */
 -export const myTypes: {
 -    [x: string]: any;
-+declare const myTypes: Object<string, any>;
++declare const myTypes: Record<string, any>;
 +export type myTypes = string | RegExp | Array<string | RegExp>;
 +export type myTypes = {
 +    prop1: myTypes.typeA;

--- a/testdata/baselines/reference/submodule/conformance/jsDeclarationsJSDocRedirectedLookups.js
+++ b/testdata/baselines/reference/submodule/conformance/jsDeclarationsJSDocRedirectedLookups.js
@@ -63,17 +63,17 @@
 
 
 //// [index.d.ts]
-/** @type {String} */ declare const a: String;
-/** @type {Number} */ declare const b: Number;
-/** @type {Boolean} */ declare const c: Boolean;
-/** @type {Void} */ declare const d: Void;
-/** @type {Undefined} */ declare const e: Undefined;
-/** @type {Null} */ declare const f: Null;
+/** @type {String} */ declare const a: string;
+/** @type {Number} */ declare const b: number;
+/** @type {Boolean} */ declare const c: boolean;
+/** @type {Void} */ declare const d: void;
+/** @type {Undefined} */ declare const e: undefined;
+/** @type {Null} */ declare const f: null;
 /** @type {Function} */ declare const g: Function;
-/** @type {function} */ declare const h: function;
-/** @type {array} */ declare const i: array;
-/** @type {promise} */ declare const j: promise;
-/** @type {Object<string, string>} */ declare const k: Object<string, string>;
+/** @type {function} */ declare const h: Function;
+/** @type {array} */ declare const i: any[];
+/** @type {promise} */ declare const j: Promise<any>;
+/** @type {Object<string, string>} */ declare const k: Record<string, string>;
 /** @type {class} */ declare const l: class;
 /** @type {bool} */ declare const m: bool;
 /** @type {int} */ declare const n: int;

--- a/testdata/baselines/reference/submodule/conformance/jsDeclarationsJSDocRedirectedLookups.js.diff
+++ b/testdata/baselines/reference/submodule/conformance/jsDeclarationsJSDocRedirectedLookups.js.diff
@@ -1,32 +1,13 @@
 --- old.jsDeclarationsJSDocRedirectedLookups.js
 +++ new.jsDeclarationsJSDocRedirectedLookups.js
-@@= skipped -62, +62 lines =@@
-
-
- //// [index.d.ts]
--/** @type {String} */ declare const a: string;
--/** @type {Number} */ declare const b: number;
--/** @type {Boolean} */ declare const c: boolean;
--/** @type {Void} */ declare const d: void;
--/** @type {Undefined} */ declare const e: undefined;
--/** @type {Null} */ declare const f: null;
-+/** @type {String} */ declare const a: String;
-+/** @type {Number} */ declare const b: Number;
-+/** @type {Boolean} */ declare const c: Boolean;
-+/** @type {Void} */ declare const d: Void;
-+/** @type {Undefined} */ declare const e: Undefined;
-+/** @type {Null} */ declare const f: Null;
- /** @type {Function} */ declare const g: Function;
--/** @type {function} */ declare const h: Function;
--/** @type {array} */ declare const i: any[];
--/** @type {promise} */ declare const j: Promise<any>;
+@@= skipped -72, +72 lines =@@
+ /** @type {function} */ declare const h: Function;
+ /** @type {array} */ declare const i: any[];
+ /** @type {promise} */ declare const j: Promise<any>;
 -/** @type {Object<string, string>} */ declare const k: {
 -    [x: string]: string;
 -};
-+/** @type {function} */ declare const h: function;
-+/** @type {array} */ declare const i: array;
-+/** @type {promise} */ declare const j: promise;
-+/** @type {Object<string, string>} */ declare const k: Object<string, string>;
++/** @type {Object<string, string>} */ declare const k: Record<string, string>;
  /** @type {class} */ declare const l: class;
  /** @type {bool} */ declare const m: bool;
  /** @type {int} */ declare const n: int;

--- a/testdata/baselines/reference/submodule/conformance/jsDeclarationsMissingTypeParameters(target=es2015).js
+++ b/testdata/baselines/reference/submodule/conformance/jsDeclarationsMissingTypeParameters(target=es2015).js
@@ -50,7 +50,7 @@ function w() { return null; }
 declare function x(y?: Array | undefined): void;
 /** @param {function (Array)} func Invoked
  */
-declare function y(func: function): void;
+declare function y(func: Function): void;
 /**
  * @return {(Array.<> | null)} list of devices
  */

--- a/testdata/baselines/reference/submodule/conformance/jsDeclarationsMissingTypeParameters(target=es2015).js.diff
+++ b/testdata/baselines/reference/submodule/conformance/jsDeclarationsMissingTypeParameters(target=es2015).js.diff
@@ -9,7 +9,7 @@
  /** @param {function (Array)} func Invoked
   */
 -declare function y(func: (arg0: any[]) => any): void;
-+declare function y(func: function): void;
++declare function y(func: Function): void;
  /**
   * @return {(Array.<> | null)} list of devices
   */

--- a/testdata/baselines/reference/submodule/conformance/jsDeclarationsRestArgsWithThisTypeInJSDocFunction(target=es2015).js
+++ b/testdata/baselines/reference/submodule/conformance/jsDeclarationsRestArgsWithThisTypeInJSDocFunction(target=es2015).js
@@ -23,5 +23,5 @@ export declare class Clazz {
     /**
      * @param {function(this:Object, ...*):*} functionDeclaration
      */
-    method(functionDeclaration: function): void;
+    method(functionDeclaration: Function): void;
 }

--- a/testdata/baselines/reference/submodule/conformance/jsDeclarationsRestArgsWithThisTypeInJSDocFunction(target=es2015).js.diff
+++ b/testdata/baselines/reference/submodule/conformance/jsDeclarationsRestArgsWithThisTypeInJSDocFunction(target=es2015).js.diff
@@ -10,5 +10,5 @@
       * @param {function(this:Object, ...*):*} functionDeclaration
       */
 -    method(functionDeclaration: (this: Object, ...args: any[]) => any): void;
-+    method(functionDeclaration: function): void;
++    method(functionDeclaration: Function): void;
  }

--- a/testdata/baselines/reference/submodule/conformance/jsDeclarationsReusesExistingNodesMappingJSDocTypes.js
+++ b/testdata/baselines/reference/submodule/conformance/jsDeclarationsReusesExistingNodesMappingJSDocTypes.js
@@ -50,7 +50,7 @@ exports.h = null;
 
 //// [index.d.ts]
 /** @type {?} */
-export declare const a:  | null;
+export declare const a: any | null;
 /** @type {*} */
 export declare const b: any;
 /** @type {string?} */
@@ -60,8 +60,8 @@ export declare const d: string | undefined;
 /** @type {string!} */
 export declare const e: string;
 /** @type {function(string, number): object} */
-export declare const f: function;
+export declare const f: Function;
 /** @type {function(new: object, string, number)} */
-export declare const g: function;
+export declare const g: Function;
 /** @type {Object.<string, number>} */
-export declare const h: Object<string, number>;
+export declare const h: Record<string, number>;

--- a/testdata/baselines/reference/submodule/conformance/jsDeclarationsReusesExistingNodesMappingJSDocTypes.js.diff
+++ b/testdata/baselines/reference/submodule/conformance/jsDeclarationsReusesExistingNodesMappingJSDocTypes.js.diff
@@ -5,7 +5,7 @@
  //// [index.d.ts]
  /** @type {?} */
 -export const a: unknown;
-+export declare const a:  | null;
++export declare const a: any | null;
  /** @type {*} */
 -export const b: any;
 +export declare const b: any;
@@ -20,12 +20,12 @@
 +export declare const e: string;
  /** @type {function(string, number): object} */
 -export const f: (arg0: string, arg1: number) => object;
-+export declare const f: function;
++export declare const f: Function;
  /** @type {function(new: object, string, number)} */
 -export const g: new (arg1: string, arg2: number) => object;
-+export declare const g: function;
++export declare const g: Function;
  /** @type {Object.<string, number>} */
 -export const h: {
 -    [x: string]: number;
 -};
-+export declare const h: Object<string, number>;
++export declare const h: Record<string, number>;

--- a/testdata/baselines/reference/submodule/conformance/recursiveTypeReferences2.js
+++ b/testdata/baselines/reference/submodule/conformance/recursiveTypeReferences2.js
@@ -65,16 +65,12 @@ type JsonRecord = {
 };
 type Json = boolean | number | string | null | JsonRecord | JsonArray | readonly [];
 type XMLObject<T> = {
-    $A: {
-        [K in keyof T]?: XMLObject<T[K]>[];
-    };
-    $O: {
-        [K in keyof T]?: {
-            $$?: Record<string, string>;
-        } & (T[K] extends string ? {
-            $: string;
-        } : XMLObject<T[K]>);
-    };
+    $A: { [K in keyof T]?: XMLObject<T[K]>[]; };
+    $O: { [K in keyof T]?: {
+        $$?: Record<string, string>;
+    } & (T[K] extends string ? {
+        $: string;
+    } : XMLObject<T[K]>); };
     $$?: Record<string, string>;
 } & {
     [K in keyof T]?: (T[K] extends string ? string : XMLObject<T[K]>);

--- a/testdata/baselines/reference/submodule/conformance/recursiveTypeReferences2.js.diff
+++ b/testdata/baselines/reference/submodule/conformance/recursiveTypeReferences2.js.diff
@@ -10,16 +10,12 @@
 +};
 +type Json = boolean | number | string | null | JsonRecord | JsonArray | readonly [];
 +type XMLObject<T> = {
-+    $A: {
-+        [K in keyof T]?: XMLObject<T[K]>[];
-+    };
-+    $O: {
-+        [K in keyof T]?: {
-+            $$?: Record<string, string>;
-+        } & (T[K] extends string ? {
-+            $: string;
-+        } : XMLObject<T[K]>);
-+    };
++    $A: { [K in keyof T]?: XMLObject<T[K]>[]; };
++    $O: { [K in keyof T]?: {
++        $$?: Record<string, string>;
++    } & (T[K] extends string ? {
++        $: string;
++    } : XMLObject<T[K]>); };
 +    $$?: Record<string, string>;
 +} & {
 +    [K in keyof T]?: (T[K] extends string ? string : XMLObject<T[K]>);
@@ -27,7 +23,7 @@
  /**
   * @template T
   * @typedef {{
-@@= skipped -22, +42 lines =@@
+@@= skipped -22, +38 lines =@@
  declare const p: XMLObject<{
      foo: string;
  }>;

--- a/testdata/baselines/reference/submodule/conformance/thisPropertyAssignmentInherited.js
+++ b/testdata/baselines/reference/submodule/conformance/thisPropertyAssignmentInherited.js
@@ -28,7 +28,7 @@ export declare class Element {
     /**
      * @returns {String}
      */
-    get textContent(): String;
+    get textContent(): string;
     set textContent(x: string);
     cloneNode(): this;
 }

--- a/testdata/baselines/reference/submodule/conformance/thisPropertyAssignmentInherited.js.diff
+++ b/testdata/baselines/reference/submodule/conformance/thisPropertyAssignmentInherited.js.diff
@@ -10,8 +10,7 @@
      /**
       * @returns {String}
       */
--    get textContent(): string;
-+    get textContent(): String;
+     get textContent(): string;
 +    set textContent(x: string);
      cloneNode(): this;
  }

--- a/testdata/baselines/reference/submodule/conformance/thisTag2.js
+++ b/testdata/baselines/reference/submodule/conformance/thisTag2.js
@@ -14,20 +14,4 @@ export function f2() {}
 /** @this {string} */
 export declare function f1(this: string): void;
 /** @this */
-export declare function f2(this: ): void;
-
-
-//// [DtsFileErrors]
-
-
-a.d.ts(4,34): error TS1110: Type expected.
-
-
-==== a.d.ts (1 errors) ====
-    /** @this {string} */
-    export declare function f1(this: string): void;
-    /** @this */
-    export declare function f2(this: ): void;
-                                     ~
-!!! error TS1110: Type expected.
-    
+export declare function f2(this: any): void;

--- a/testdata/baselines/reference/submodule/conformance/thisTag2.js.diff
+++ b/testdata/baselines/reference/submodule/conformance/thisTag2.js.diff
@@ -8,20 +8,4 @@
 +export declare function f1(this: string): void;
  /** @this */
 -export function f2(this: any): void;
-+export declare function f2(this: ): void;
-+
-+
-+//// [DtsFileErrors]
-+
-+
-+a.d.ts(4,34): error TS1110: Type expected.
-+
-+
-+==== a.d.ts (1 errors) ====
-+    /** @this {string} */
-+    export declare function f1(this: string): void;
-+    /** @this */
-+    export declare function f2(this: ): void;
-+                                     ~
-+!!! error TS1110: Type expected.
-+    
++export declare function f2(this: any): void;


### PR DESCRIPTION
Fixes part 1 (the bug part) of #2533 and handles #3402 as a side-effect.

With the reparser-focused approach, this was generally supposed to be getting handled in the reparser stage (if we supported them) - the js node remapping logic in the node builder was ported just because some bits of it were still port-able (and it's harmless to keep), so is what I'll say is "partially ported" compared to strada, since a ton of jsdoc node kinds were (and still are) outright missing, highlighting that we're in some weird middleground place right now where the AST isn't exactly like strada's, but nor is it fully handled upfront like we'd originally proposed for corsa.

Rather than deferring to that node builder logic like this, IMO, it'd be better to perform *all* these js-ts type node remappings at parse/reparse time, but since we're only doing a light touch of reparsing right now (object and signature types), this is where we're at, where some remapping logic lives in the parser/reparser so the checker can leverage it, and some in `nodecopy` for emit.