### PR TITLE
perf: add TSGO_BINARY env var and fast-path sibling check in getExePath

### DIFF
--- a/_packages/native-preview/lib/getExePath.js
+++ b/_packages/native-preview/lib/getExePath.js
@@ -4,6 +4,16 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 export default function getExePath() {
+    // Allow users to bypass resolution entirely. Useful in monorepos where
+    // import.meta.resolve is slow across many separate tsgo invocations.
+    const envPath = process.env.TSGO_BINARY;
+    if (envPath) {
+        if (!fs.existsSync(envPath)) {
+            throw new Error("TSGO_BINARY points to non-existent file: " + envPath);
+        }
+        return envPath;
+    }
+
     const __dirname = path.dirname(fileURLToPath(import.meta.url));
     const normalizedDirname = __dirname.replace(/\\/g, "/");
 
@@ -20,24 +30,34 @@ export default function getExePath() {
         exeDir = path.resolve(__dirname, "..", "..", expectedPackage, "lib");
     }
     else {
-        // We're actually running from an installed package.
+        // We're running from an installed package.
+        // Fast path: check the sibling package at the standard npm layout first.
+        // This avoids calling import.meta.resolve, which can be slow in large
+        // monorepos where many tsgo invocations happen as separate processes.
         const platformPackageName = "@typescript/" + expectedPackage;
-        try {
-            if (typeof import.meta.resolve === "undefined") {
-                // v16.20.1
-                const require = module.createRequire(import.meta.url);
-                const packageJson = require.resolve(platformPackageName + "/package.json");
-                exeDir = path.join(path.dirname(packageJson), "lib");
-            }
-            else {
-                // v20.6.0, v18.19.0
-                const packageJson = import.meta.resolve(platformPackageName + "/package.json");
-                const packageJsonPath = fileURLToPath(packageJson);
-                exeDir = path.join(path.dirname(packageJsonPath), "lib");
-            }
+        const siblingDir = path.resolve(__dirname, "..", "..", expectedPackage, "lib");
+        const siblingExe = path.join(siblingDir, process.platform === "win32" ? "tsgo.exe" : "tsgo");
+        if (fs.existsSync(siblingExe)) {
+            exeDir = siblingDir;
         }
-        catch (e) {
-            throw new Error("Unable to resolve " + platformPackageName + ". Either your platform is unsupported, or you are missing the package on disk.");
+        else {
+            try {
+                if (typeof import.meta.resolve === "undefined") {
+                    // v16.20.1
+                    const require = module.createRequire(import.meta.url);
+                    const packageJson = require.resolve(platformPackageName + "/package.json");
+                    exeDir = path.join(path.dirname(packageJson), "lib");
+                }
+                else {
+                    // v20.6.0, v18.19.0
+                    const packageJson = import.meta.resolve(platformPackageName + "/package.json");
+                    const packageJsonPath = fileURLToPath(packageJson);
+                    exeDir = path.join(path.dirname(packageJsonPath), "lib");
+                }
+            }
+            catch (e) {
+                throw new Error("Unable to resolve " + platformPackageName + ". Either your platform is unsupported, or you are missing the package on disk.");
+            }
         }
     }
 

--- a/_packages/native-preview/lib/getExePath.js
+++ b/_packages/native-preview/lib/getExePath.js
@@ -8,8 +8,18 @@ export default function getExePath() {
     // import.meta.resolve is slow across many separate tsgo invocations.
     const envPath = process.env.TSGO_BINARY;
     if (envPath) {
-        if (!fs.existsSync(envPath)) {
-            throw new Error("TSGO_BINARY points to non-existent file: " + envPath);
+        let envStat;
+        try {
+            envStat = fs.statSync(envPath);
+        }
+        catch {
+            throw new Error("TSGO_BINARY points to non-existent path: " + envPath);
+        }
+        if (!envStat.isFile()) {
+            throw new Error("TSGO_BINARY does not point to a file: " + envPath);
+        }
+        if (process.platform === "win32" && envPath.length >= 248) {
+            return "\\\\?\\" + envPath;
         }
         return envPath;
     }


### PR DESCRIPTION
Fixes the performance issue raised in #2836 where `import.meta.resolve` is called on every separate tsgo invocation in large monorepos.

Two changes in `getExePath.js`:

**1. `TSGO_BINARY` environment variable**

If set, the function returns that path immediately and skips all resolution. This is useful for monorepo setups where users want to hardcode the binary location (e.g. in their shell config or CI environment). It also works as a diagnostic tool to verify whether path resolution is the actual bottleneck.

```
TSGO_BINARY=/path/to/tsgo npx tsgo ...
```

If the path does not exist, a clear error is thrown rather than silently failing.

**2. Fast-path sibling check before `import.meta.resolve`**

In the installed package branch, the code now checks if the platform binary exists at the predictable sibling location (`../../{expectedPackage}/lib/`) using a single `fs.existsSync` call before falling back to `import.meta.resolve`. This covers the standard npm/yarn layout where both `@typescript/native-preview` and `@typescript/native-preview-{platform}-{arch}` sit side by side under `node_modules/@typescript/`. If the sibling is not found there (e.g. unusual hoisting), it falls through to the existing `import.meta.resolve` logic unchanged.

The path calculation is the same as the one already used in the `built/npm` branch, so it is not new math.

**Testing**

I wrote a local test suite covering these cases before opening this PR:

- `TSGO_BINARY` pointing to a real file returns it correctly
- `TSGO_BINARY` pointing to a missing file throws with a clear message
- Sibling path math resolves to the correct absolute path given a simulated `node_modules/@typescript/native-preview/lib` directory
- Sibling exe found via fast path when the fake binary is present
- Fast path absent falls through cleanly (no error from the fast path itself)
- Source path (`/_packages/native-preview/lib`) detection still works
- Built-npm path (`/built/npm/native-preview/lib`) detection still works

All 7 tests passed on Node 22.