### PR TITLE
Fixed crash when resolving declaration spaces on merged symbols resolving to export assignment

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -6774,7 +6774,6 @@ func (c *Checker) getDeclarationSpaces(node *ast.Declaration) DeclarationSpaces 
 		if !ast.IsEntityNameExpression(expression) {
 			return DeclarationSpacesExportValue
 		}
-		node = expression
 		// The below options all declare an Alias, which is allowed to merge with other values within the importing module.
 		fallthrough
 	case ast.KindImportEqualsDeclaration, ast.KindNamespaceImport, ast.KindImportClause:

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -6771,7 +6771,7 @@ func (c *Checker) getDeclarationSpaces(node *ast.Declaration) DeclarationSpaces 
 			expression = node.AsBinaryExpression().Right
 		}
 		// Export assigned entity name expressions act as aliases and should fall through, otherwise they export values.
-		if !ast.IsEntityNameExpression(expression) {
+		if !ast.IsEntityNameExpression(expression) || c.getSymbolOfDeclaration(node).Flags&ast.SymbolFlagsAlias == 0 {
 			return DeclarationSpacesExportValue
 		}
 		// The below options all declare an Alias, which is allowed to merge with other values within the importing module.

--- a/internal/fourslash/tests/diagnosticsDefaultImportMergedWithJSDocTypeAlias1_test.go
+++ b/internal/fourslash/tests/diagnosticsDefaultImportMergedWithJSDocTypeAlias1_test.go
@@ -1,0 +1,48 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestDiagnosticsDefaultImportMergedWithJSDocTypeAlias1(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `// @allowJs: true
+// @checkJs: true
+// @Filename: /lib/types.d.ts
+export interface RunnerOptions {
+  dryRun?: boolean;
+}
+
+// @Filename: /lib/runner.js
+"use strict";
+
+/**
+ * @typedef {import('./types.d.ts').RunnerOptions} RunnerOptions
+ */
+
+var EventEmitter = require("node:events").EventEmitter;
+
+class Runner extends EventEmitter {
+  constructor() { super(); }
+}
+
+module.exports = Runner;
+
+// @Filename: /lib/stats-collector.mjs
+/** @typedef {import('./runner.js')} Runner */
+
+import Runner from "./runner.js";
+
+const createStatsCollector = (runner) => runner && Runner;
+
+export { createStatsCollector };
+`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.GoToFile(t, "/lib/stats-collector.mjs")
+	f.VerifyNumberOfErrorsInCurrentFile(t, 2)
+}


### PR DESCRIPTION
fixes a crash reported here: https://github.com/microsoft/typescript-go/issues/3448#issuecomment-4283766710