### PR TITLE
Fix hover crash in hoverExpressionWithTypeArguments

### DIFF
--- a/internal/checker/nodebuilder_hover.go
+++ b/internal/checker/nodebuilder_hover.go
@@ -565,7 +565,7 @@ func (b *NodeBuilderImpl) serializeTypeAliasForNamespace(symbol *ast.Symbol, nam
 func (b *NodeBuilderImpl) hoverExpressionWithTypeArguments(t *Type, flags ast.SymbolFlags) *ast.Node {
 	var typeArgs []*ast.Node
 	var reference *ast.Node
-	if t.Target() != nil && b.ch.IsSymbolAccessibleByFlags(t.Target().symbol, b.ctx.enclosingDeclaration, flags) {
+	if t.objectFlags&ObjectFlagsReference != 0 && t.Target() != nil && b.ch.IsSymbolAccessibleByFlags(t.Target().symbol, b.ctx.enclosingDeclaration, flags) {
 		typeArgs = core.Map(b.ch.getTypeArguments(t), func(arg *Type) *ast.Node { return b.typeToTypeNode(arg) })
 		reference = b.symbolToExpression(t.Target().symbol, ast.SymbolFlagsType)
 	} else if t.symbol != nil && b.ch.IsSymbolAccessibleByFlags(t.symbol, b.ctx.enclosingDeclaration, flags) {

--- a/internal/fourslash/tests/quickinfoVerbosityNamespaceInterfaceHeritageCrash_test.go
+++ b/internal/fourslash/tests/quickinfoVerbosityNamespaceInterfaceHeritageCrash_test.go
@@ -1,0 +1,24 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+// Regression test for crash when hovering with verbosity on a namespace
+// containing interfaces with generic heritage clauses.
+// See: https://github.com/microsoft/typescript-go/pull/3454#issuecomment-4285883568
+func TestQuickinfoVerbosityNamespaceInterfaceHeritageCrash(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `
+declare namespace NS/*1*/ {
+    interface Config extends Record<string, any> {}
+}
+`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineHoverWithVerbosity(t, map[string][]int{"1": {0, 1}})
+}

--- a/internal/fourslash/tests/quickinfoVerbosityNamespaceInterfaceHeritageIntersectionCrash_test.go
+++ b/internal/fourslash/tests/quickinfoVerbosityNamespaceInterfaceHeritageIntersectionCrash_test.go
@@ -1,0 +1,27 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+// Regression test for crash when hovering with verbosity on a namespace
+// containing an interface that extends an intersection type alias.
+// The base type resolves to an intersection (TypeFlagsIntersection),
+// causing Type.Target() to panic with "Unhandled case in Type.Target".
+// See: https://github.com/microsoft/typescript-go/issues/3466
+func TestQuickinfoVerbosityNamespaceInterfaceHeritageIntersectionCrash(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `
+declare namespace NS/*1*/ {
+    type Mixin = { a: string } & { b: number };
+    interface Config extends Mixin {}
+}
+`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineHoverWithVerbosity(t, map[string][]int{"1": {0, 1}})
+}

--- a/testdata/baselines/reference/fourslash/quickInfo/quickinfoVerbosityNamespaceInterfaceHeritageCrash.baseline
+++ b/testdata/baselines/reference/fourslash/quickInfo/quickinfoVerbosityNamespaceInterfaceHeritageCrash.baseline
@@ -1,0 +1,89 @@
+// === QuickInfo ===
+=== /quickinfoVerbosityNamespaceInterfaceHeritageCrash.ts ===
+// 
+// declare namespace NS {
+//                   ^^
+// | ----------------------------------------------------------------------
+// | ```tsx
+// | namespace NS {
+// |     interface Config extends þtype {
+// |     }
+// | }
+// | ```
+// | 
+// | (verbosity level: 1)
+// | ----------------------------------------------------------------------
+//                   ^^
+// | ----------------------------------------------------------------------
+// | ```tsx
+// | namespace NS
+// | ```
+// | 
+// | (verbosity level: 0)
+// | ----------------------------------------------------------------------
+//     interface Config extends Record<string, any> {}
+// }
+// 
+[
+  {
+    "marker": {
+      "Position": 21,
+      "LSPosition": {
+        "line": 1,
+        "character": 20
+      },
+      "Name": "1",
+      "Data": {}
+    },
+    "item": {
+      "hover": {
+        "contents": {
+          "kind": "markdown",
+          "value": "```tsx\nnamespace NS\n```\n"
+        },
+        "range": {
+          "start": {
+            "line": 1,
+            "character": 18
+          },
+          "end": {
+            "line": 1,
+            "character": 20
+          }
+        },
+        "canIncreaseVerbosity": true
+      },
+      "verbosityLevel": 0
+    }
+  },
+  {
+    "marker": {
+      "Position": 21,
+      "LSPosition": {
+        "line": 1,
+        "character": 20
+      },
+      "Name": "1",
+      "Data": {}
+    },
+    "item": {
+      "hover": {
+        "contents": {
+          "kind": "markdown",
+          "value": "```tsx\nnamespace NS {\n    interface Config extends ï¿½type {\n    }\n}\n```\n"
+        },
+        "range": {
+          "start": {
+            "line": 1,
+            "character": 18
+          },
+          "end": {
+            "line": 1,
+            "character": 20
+          }
+        }
+      },
+      "verbosityLevel": 1
+    }
+  }
+]

--- a/testdata/baselines/reference/fourslash/quickInfo/quickinfoVerbosityNamespaceInterfaceHeritageIntersectionCrash.baseline
+++ b/testdata/baselines/reference/fourslash/quickInfo/quickinfoVerbosityNamespaceInterfaceHeritageIntersectionCrash.baseline
@@ -1,0 +1,95 @@
+// === QuickInfo ===
+=== /quickinfoVerbosityNamespaceInterfaceHeritageIntersectionCrash.ts ===
+// 
+// declare namespace NS {
+//                   ^^
+// | ----------------------------------------------------------------------
+// | ```tsx
+// | namespace NS {
+// |     type Mixin = {
+// |         a: string;
+// |     } & {
+// |         b: number;
+// |     };
+// |     interface Config {
+// |     }
+// | }
+// | ```
+// | 
+// | (verbosity level: 1)
+// | ----------------------------------------------------------------------
+//                   ^^
+// | ----------------------------------------------------------------------
+// | ```tsx
+// | namespace NS
+// | ```
+// | 
+// | (verbosity level: 0)
+// | ----------------------------------------------------------------------
+//     type Mixin = { a: string } & { b: number };
+//     interface Config extends Mixin {}
+// }
+// 
+[
+  {
+    "marker": {
+      "Position": 21,
+      "LSPosition": {
+        "line": 1,
+        "character": 20
+      },
+      "Name": "1",
+      "Data": {}
+    },
+    "item": {
+      "hover": {
+        "contents": {
+          "kind": "markdown",
+          "value": "```tsx\nnamespace NS\n```\n"
+        },
+        "range": {
+          "start": {
+            "line": 1,
+            "character": 18
+          },
+          "end": {
+            "line": 1,
+            "character": 20
+          }
+        },
+        "canIncreaseVerbosity": true
+      },
+      "verbosityLevel": 0
+    }
+  },
+  {
+    "marker": {
+      "Position": 21,
+      "LSPosition": {
+        "line": 1,
+        "character": 20
+      },
+      "Name": "1",
+      "Data": {}
+    },
+    "item": {
+      "hover": {
+        "contents": {
+          "kind": "markdown",
+          "value": "```tsx\nnamespace NS {\n    type Mixin = {\n        a: string;\n    } & {\n        b: number;\n    };\n    interface Config {\n    }\n}\n```\n"
+        },
+        "range": {
+          "start": {
+            "line": 1,
+            "character": 18
+          },
+          "end": {
+            "line": 1,
+            "character": 20
+          }
+        }
+      },
+      "verbosityLevel": 1
+    }
+  }
+]


### PR DESCRIPTION
This only worked in Strada because it did a cast to `TypeReference` before using `.target` which just so happened to be undefined on the object it was using.

Fixes #3473
Fixes #3466