### PR TITLE
Mark file as changed when didOpen content differs from disk content

### DIFF
--- a/internal/lsp/server_semantictokens_test.go
+++ b/internal/lsp/server_semantictokens_test.go
@@ -1,0 +1,90 @@
+package lsp_test
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/bundled"
+	"github.com/microsoft/typescript-go/internal/lsp"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
+	"github.com/microsoft/typescript-go/internal/testutil/lsptestutil"
+	"github.com/microsoft/typescript-go/internal/vfs/vfstest"
+	"gotest.tools/v3/assert"
+)
+
+// TestSemanticTokensCRLF reproduces a crash where semantic tokens panics with
+// "token spans multiple lines" when the editor opens a file with CRLF line endings
+// but the project originally loaded the file from disk with LF line endings.
+//
+// The SourceFile AST keeps positions from the LF text, but the converter's
+// line map is recomputed from the CRLF overlay, causing a mismatch.
+func TestSemanticTokensCRLF(t *testing.T) {
+	t.Parallel()
+	if !bundled.Embedded {
+		t.Skip("bundled files are not embedded")
+	}
+
+	// Enough lines so the cumulative \r\n vs \n offset difference
+	// causes an LF-based position to land on a \r in the CRLF text.
+	fileOnDisk := "var x\nvar x\nvar x\nvar x\nvar x\nvar x\nconst a = 1\n"
+	fileFromEditor := strings.ReplaceAll(fileOnDisk, "\n", "\r\n")
+
+	files := map[string]string{
+		"/home/projects/tsconfig.json": `{}`,
+		"/home/projects/test.ts":       fileOnDisk,
+		"/home/projects/other.ts":      "export {}",
+	}
+	fs := bundled.WrapFS(vfstest.FromMap(files, false))
+
+	onServerRequest := func(_ context.Context, req *lsproto.RequestMessage) *lsproto.ResponseMessage {
+		if req.Method == lsproto.MethodClientRegisterCapability || req.Method == lsproto.MethodClientUnregisterCapability {
+			return &lsproto.ResponseMessage{ID: req.ID, JSONRPC: req.JSONRPC, Result: lsproto.Null{}}
+		}
+		return nil
+	}
+
+	client, closeClient := lsptestutil.NewLSPClient(t, lsp.ServerOptions{
+		Err: io.Discard, Cwd: "/home/projects", FS: fs, DefaultLibraryPath: bundled.LibPath(),
+	}, onServerRequest)
+	t.Cleanup(func() { _ = closeClient() })
+
+	initMsg, _, ok := lsptestutil.SendRequest(t, client, lsproto.InitializeInfo, &lsproto.InitializeParams{
+		Capabilities: &lsproto.ClientCapabilities{
+			TextDocument: &lsproto.TextDocumentClientCapabilities{
+				SemanticTokens: &lsproto.SemanticTokensClientCapabilities{
+					TokenTypes:     []string{"namespace", "type", "class", "enum", "interface", "struct", "typeParameter", "parameter", "variable", "property", "enumMember", "event", "function", "method", "macro", "keyword", "modifier", "comment", "string", "number", "regexp", "operator", "decorator"},
+					TokenModifiers: []string{"declaration", "definition", "readonly", "static", "deprecated", "abstract", "async", "modification", "documentation", "defaultLibrary", "local"},
+				},
+			},
+		},
+	})
+	assert.Assert(t, ok && initMsg.AsResponse().Error == nil, "Initialize failed")
+	lsptestutil.SendNotification(t, client, lsproto.InitializedInfo, &lsproto.InitializedParams{})
+	<-client.Server.InitComplete()
+
+	// Open another project file to force the project to load test.ts from disk (LF).
+	otherUri := lsproto.DocumentUri("file:///home/projects/other.ts")
+	lsptestutil.SendNotification(t, client, lsproto.TextDocumentDidOpenInfo, &lsproto.DidOpenTextDocumentParams{
+		TextDocument: &lsproto.TextDocumentItem{Uri: otherUri, LanguageId: "typescript", Text: files["/home/projects/other.ts"]},
+	})
+	msg1, _, _ := lsptestutil.SendRequest(t, client, lsproto.TextDocumentSemanticTokensFullInfo, &lsproto.SemanticTokensParams{
+		TextDocument: lsproto.TextDocumentIdentifier{Uri: otherUri},
+	})
+	assert.Assert(t, msg1.AsResponse().Error == nil, "Initial request failed")
+
+	// Open test.ts with CRLF content; the project already parsed it from disk (LF).
+	uri := lsproto.DocumentUri("file:///home/projects/test.ts")
+	lsptestutil.SendNotification(t, client, lsproto.TextDocumentDidOpenInfo, &lsproto.DidOpenTextDocumentParams{
+		TextDocument: &lsproto.TextDocumentItem{Uri: uri, LanguageId: "typescript", Text: fileFromEditor},
+	})
+
+	// This panics: AST positions are LF-based but the line map is CRLF-based.
+	msg, _, _ := lsptestutil.SendRequest(t, client, lsproto.TextDocumentSemanticTokensFullInfo, &lsproto.SemanticTokensParams{
+		TextDocument: lsproto.TextDocumentIdentifier{Uri: uri},
+	})
+	if msg.AsResponse().Error != nil {
+		t.Fatalf("Semantic tokens request failed: %s", msg.AsResponse().Error.Message)
+	}
+}

--- a/internal/project/session_test.go
+++ b/internal/project/session_test.go
@@ -113,6 +113,50 @@ func TestSession(t *testing.T) {
 		})
 	})
 
+	t.Run("watchChange and didOpen in same batch rebuilds program", func(t *testing.T) {
+		t.Parallel()
+		files := map[string]any{
+			"/home/projects/TS/p1/tsconfig.json": `{
+				"compilerOptions": {
+					"noLib": true,
+					"strict": true
+				}
+			}`,
+			"/home/projects/TS/p1/src/a.ts": "export const a = 1;\n",
+			"/home/projects/TS/p1/src/b.ts": "export const b = 1;\n",
+		}
+		session, utils := projecttestutil.Setup(files)
+		oldContent := files["/home/projects/TS/p1/src/a.ts"].(string)
+
+		// Open b.ts to create the project; a.ts is included via tsconfig.
+		session.DidOpenFile(context.Background(), "file:///home/projects/TS/p1/src/b.ts", 1, files["/home/projects/TS/p1/src/b.ts"].(string), lsproto.LanguageKindTypeScript)
+
+		// Verify a.ts is in the program with the original content.
+		ls, err := session.GetLanguageService(context.Background(), "file:///home/projects/TS/p1/src/b.ts")
+		assert.NilError(t, err)
+		assert.Equal(t, ls.GetProgram().GetSourceFile("/home/projects/TS/p1/src/a.ts").Text(), oldContent)
+
+		// Modify a.ts on disk (simulate a build tool or git checkout).
+		newContent := "export const a = 2;\nexport const extra = true;\n"
+		err = utils.FS().WriteFile("/home/projects/TS/p1/src/a.ts", newContent)
+		assert.NilError(t, err)
+
+		// Queue a watch event for the disk change (not flushed yet).
+		session.DidChangeWatchedFiles(context.Background(), []*lsproto.FileEvent{
+			{Type: lsproto.FileChangeTypeChanged, Uri: "file:///home/projects/TS/p1/src/a.ts"},
+		})
+
+		// Open a.ts in the editor—flushes both watch event and didOpen together.
+		// Before the fix, processChanges would discard the watch event,
+		// leaving the project with a stale SourceFile and a mismatched line map.
+		session.DidOpenFile(context.Background(), "file:///home/projects/TS/p1/src/a.ts", 1, newContent, lsproto.LanguageKindTypeScript)
+
+		// The program's SourceFile must reflect the overlay (new) content.
+		ls, err = session.GetLanguageService(context.Background(), "file:///home/projects/TS/p1/src/a.ts")
+		assert.NilError(t, err)
+		assert.Equal(t, ls.GetProgram().GetSourceFile("/home/projects/TS/p1/src/a.ts").Text(), newContent)
+	})
+
 	t.Run("DidChangeFile", func(t *testing.T) {
 		t.Parallel()
 		t.Run("update file and program", func(t *testing.T) {

--- a/internal/project/snapshotfs.go
+++ b/internal/project/snapshotfs.go
@@ -600,6 +600,14 @@ func (s *snapshotFSBuilder) convertOpenAndCloseToChanges(change FileChangeSummar
 		path := s.toPath(change.Opened.FileName())
 		if entry, ok := s.diskFiles.Load(path); !ok || entry.Original() == nil {
 			change.Created.Add(change.Opened)
+		} else if overlay, ok := s.overlays[path]; ok {
+			// When a watch event and a didOpen for the same file arrive in the same
+			// batch, processChanges gives the open priority and discards the watch
+			// event. If the overlay content differs from what the program last saw
+			// (the original disk file), mark it as Changed so the project rebuilds.
+			if diskFile := entry.Original(); diskFile != nil && overlay.Hash() != diskFile.Hash() {
+				change.Changed.Add(change.Opened)
+			}
 		}
 	}
 	for uri := range change.Closed.Keys() {

--- a/internal/project/snapshotfs.go
+++ b/internal/project/snapshotfs.go
@@ -601,10 +601,10 @@ func (s *snapshotFSBuilder) convertOpenAndCloseToChanges(change FileChangeSummar
 		if entry, ok := s.diskFiles.Load(path); !ok || entry.Original() == nil {
 			change.Created.Add(change.Opened)
 		} else if overlay, ok := s.overlays[path]; ok {
-			// When a watch event and a didOpen for the same file arrive in the same
-			// batch, processChanges gives the open priority and discards the watch
-			// event. If the overlay content differs from what the program last saw
-			// (the original disk file), mark it as Changed so the project rebuilds.
+			// The file already exists in the program, but the overlay content from
+			// didOpen may differ from what was originally read from disk (e.g. the
+			// editor normalizes line endings, or the file changed on disk since the
+			// project was loaded). Mark it as Changed so the project rebuilds.
 			if diskFile := entry.Original(); diskFile != nil && overlay.Hash() != diskFile.Hash() {
 				change.Changed.Add(change.Opened)
 			}


### PR DESCRIPTION
This is one possible way #3441 could have broken.

(This bug was introduced in #2549)

Fixes #3470 (i tested, yay)