### PR TITLE
Avoid crash in getReferencedSymbolsForNode on export assignments in malformed sources

### DIFF
--- a/internal/fourslash/documentHighlightMalformedAmbientModuleExportEquals_test.go
+++ b/internal/fourslash/documentHighlightMalformedAmbientModuleExportEquals_test.go
@@ -1,0 +1,24 @@
+package fourslash
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestDocumentHighlightMalformedAmbientModuleExportEquals(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+
+	const content = `// @Filename: /a.d.ts
+declare moduleu "m" {
+  interface A { x: 1 }
+  function f(): A[];
+  /*m*/export = f;
+}`
+
+	f, done := NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+
+	f.VerifyBaselineDocumentHighlights(t, nil /*preferences*/, "m")
+}

--- a/internal/fourslash/tests/documentHighlightMalformedAmbientModuleExportEquals_test.go
+++ b/internal/fourslash/tests/documentHighlightMalformedAmbientModuleExportEquals_test.go
@@ -1,8 +1,9 @@
-package fourslash
+package fourslash_test
 
 import (
 	"testing"
 
+	"github.com/microsoft/typescript-go/internal/fourslash"
 	"github.com/microsoft/typescript-go/internal/testutil"
 )
 
@@ -17,7 +18,7 @@ declare moduleu "m" {
   /*m*/export = f;
 }`
 
-	f, done := NewFourslash(t, nil /*capabilities*/, content)
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
 	defer done()
 
 	f.VerifyBaselineDocumentHighlights(t, nil /*preferences*/, "m")

--- a/internal/ls/findallreferences.go
+++ b/internal/ls/findallreferences.go
@@ -913,6 +913,9 @@ func (l *LanguageService) getReferencedSymbolsForNode(ctx context.Context, posit
 	}
 
 	if symbol.Name == ast.InternalSymbolNameExportEquals {
+		if symbol.Parent == nil {
+			return nil
+		}
 		return l.getReferencedSymbolsForModule(ctx, program, symbol.Parent, false /*excludeImportTypeOfExportEquals*/, sourceFiles, sourceFilesSet)
 	}
 

--- a/testdata/baselines/reference/fourslash/documentHighlights/documentHighlightMalformedAmbientModuleExportEquals.baseline.jsonc
+++ b/testdata/baselines/reference/fourslash/documentHighlights/documentHighlightMalformedAmbientModuleExportEquals.baseline.jsonc
@@ -1,0 +1,7 @@
+// === documentHighlights ===
+// === /a.d.ts ===
+// declare moduleu "m" {
+//   interface A { x: 1 }
+//   function f(): A[];
+//   /*HIGHLIGHTS*/export = f;
+// }


### PR DESCRIPTION
fixes https://github.com/microsoft/typescript-go/issues/3462