### PR TITLE
Handle numbers in tsconfig parsing

### DIFF
--- a/internal/tsoptions/parsinghelpers.go
+++ b/internal/tsoptions/parsinghelpers.go
@@ -63,6 +63,10 @@ func parseNumber(value any) *int {
 	if num, ok := value.(int); ok {
 		return &num
 	}
+	if num, ok := value.(float64); ok {
+		n := int(num)
+		return &n
+	}
 	return nil
 }
 

--- a/testdata/baselines/reference/config/tsconfigParsing/parses tsconfig with compilerOptions, files, include, and exclude with json api.js
+++ b/testdata/baselines/reference/config/tsconfigParsing/parses tsconfig with compilerOptions, files, include, and exclude with json api.js
@@ -49,6 +49,7 @@ CompilerOptions::
   },
   "strict": true,
   "target": 4,
+  "maxNodeModuleJsDepth": 1,
   "configFilePath": "/apath/tsconfig.json",
   "pathsBasePath": "/apath"
 }

--- a/testdata/baselines/reference/config/tsconfigParsing/parses tsconfig with compilerOptions, files, include, and exclude with jsonSourceFile api.js
+++ b/testdata/baselines/reference/config/tsconfigParsing/parses tsconfig with compilerOptions, files, include, and exclude with jsonSourceFile api.js
@@ -49,6 +49,7 @@ CompilerOptions::
   },
   "strict": true,
   "target": 4,
+  "maxNodeModuleJsDepth": 1,
   "configFilePath": "/apath/tsconfig.json",
   "pathsBasePath": "/apath"
 }


### PR DESCRIPTION
This has never worked and we have never noticed because `maxNodeModuleJsDepth` is actually our only `int` compiler option that isn't a new one like `--checkers`. Wow!

Fixes #3493