### PR TITLE
Avoid constructing empty `extends` clauses in hovers

### DIFF
--- a/internal/checker/nodebuilder_hover.go
+++ b/internal/checker/nodebuilder_hover.go
@@ -136,8 +136,15 @@ func (b *NodeBuilderImpl) expandClassDecl(symbol *ast.Symbol) *ast.Node {
 	// Heritage clauses
 	var heritageClauses []*ast.Node
 	if len(baseTypes) > 0 {
-		extendsTypes := core.Map(baseTypes, func(bt *Type) *ast.Node { return b.hoverExpressionWithTypeArguments(bt, ast.SymbolFlagsValue) })
-		heritageClauses = append(heritageClauses, b.f.NewHeritageClause(ast.KindExtendsKeyword, b.f.NewNodeList(extendsTypes)))
+		var extendsTypes []*ast.Node
+		for _, t := range baseTypes {
+			if expr := b.hoverExpressionWithTypeArguments(t, ast.SymbolFlagsValue); expr != nil {
+				extendsTypes = append(extendsTypes, expr)
+			}
+		}
+		if len(extendsTypes) > 0 {
+			heritageClauses = append(heritageClauses, b.f.NewHeritageClause(ast.KindExtendsKeyword, b.f.NewNodeList(extendsTypes)))
+		}
 	}
 	if impls := b.getImplementsTypes(classType); len(impls) > 0 {
 		var implExprs []*ast.Node

--- a/internal/checker/nodebuilder_hover.go
+++ b/internal/checker/nodebuilder_hover.go
@@ -136,23 +136,17 @@ func (b *NodeBuilderImpl) expandClassDecl(symbol *ast.Symbol) *ast.Node {
 	// Heritage clauses
 	var heritageClauses []*ast.Node
 	if len(baseTypes) > 0 {
-		var extendsTypes []*ast.Node
-		for _, t := range baseTypes {
-			if expr := b.hoverExpressionWithTypeArguments(t, ast.SymbolFlagsValue); expr != nil {
-				extendsTypes = append(extendsTypes, expr)
-			}
-		}
+		extendsTypes := core.MapNonNil(baseTypes, func(t *Type) *ast.Node {
+			return b.hoverExpressionWithTypeArguments(t, ast.SymbolFlagsValue)
+		})
 		if len(extendsTypes) > 0 {
 			heritageClauses = append(heritageClauses, b.f.NewHeritageClause(ast.KindExtendsKeyword, b.f.NewNodeList(extendsTypes)))
 		}
 	}
 	if impls := b.getImplementsTypes(classType); len(impls) > 0 {
-		var implExprs []*ast.Node
-		for _, t := range impls {
-			if expr := b.hoverExpressionWithTypeArguments(t, ast.SymbolFlagsType); expr != nil {
-				implExprs = append(implExprs, expr)
-			}
-		}
+		implExprs := core.MapNonNil(impls, func(t *Type) *ast.Node {
+			return b.hoverExpressionWithTypeArguments(t, ast.SymbolFlagsType)
+		})
 		if len(implExprs) > 0 {
 			heritageClauses = append(heritageClauses, b.f.NewHeritageClause(ast.KindImplementsKeyword, b.f.NewNodeList(implExprs)))
 		}

--- a/internal/fourslash/tests/quickinfoVerbosityClassWithMixinBase_test.go
+++ b/internal/fourslash/tests/quickinfoVerbosityClassWithMixinBase_test.go
@@ -11,8 +11,10 @@ func TestQuickinfoVerbosityClassWithMixinBase1(t *testing.T) {
 	t.Parallel()
 	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
 
-	// Expanded hover serializes Derived's generated class declaration,
-	// including the class heritage clause for a constructor returning an intersection.
+	// Expanded hover serializes Derived's generated class declaration.
+	// Not every base type was serializable (e.g. Mixin did not produce a Node in the `extends` clause).
+	// That would end up creating an `extends` clause with a nil base type,
+	// which would cause issues when we'd print out the constructed node.
 	const content = `
 class Base {}
 

--- a/internal/fourslash/tests/quickinfoVerbosityClassWithMixinBase_test.go
+++ b/internal/fourslash/tests/quickinfoVerbosityClassWithMixinBase_test.go
@@ -13,7 +13,7 @@ func TestQuickinfoVerbosityClassWithMixinBase1(t *testing.T) {
 
 	// Expanded hover serializes Derived's generated class declaration.
 	// Not every base type was serializable (e.g. Mixin did not produce a Node in the `extends` clause).
-	// That would end up creating an `extends` clause with a nil base type,
+	// That would end up creating an `extends` clause with nil in place of an actual base node,
 	// which would cause issues when we'd print out the constructed node.
 	const content = `
 class Base {}

--- a/internal/fourslash/tests/quickinfoVerbosityClassWithMixinBase_test.go
+++ b/internal/fourslash/tests/quickinfoVerbosityClassWithMixinBase_test.go
@@ -7,20 +7,18 @@ import (
 	"github.com/microsoft/typescript-go/internal/testutil"
 )
 
-func TestQuickinfoVerbosityNamespaceClassHeritageCrash(t *testing.T) {
+func TestQuickinfoVerbosityClassWithMixinBase1(t *testing.T) {
 	t.Parallel()
 	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
 
-	// Expanded namespace hover serializes Derived's generated class declaration,
+	// Expanded hover serializes Derived's generated class declaration,
 	// including the class heritage clause for a constructor returning an intersection.
 	const content = `
 class Base {}
 
 declare const Mixin: new () => Base & { mixed: string };
 
-declare namespace NS/*1*/ {
-    class Derived extends Mixin {}
-}
+class Derived/*1*/ extends Mixin {}
 `
 	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
 	defer done()

--- a/internal/fourslash/tests/quickinfoVerbosityNamespaceClassHeritageCrash_test.go
+++ b/internal/fourslash/tests/quickinfoVerbosityNamespaceClassHeritageCrash_test.go
@@ -1,0 +1,29 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestQuickinfoVerbosityNamespaceClassHeritageCrash(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+
+	// Expanded namespace hover serializes Derived's generated class declaration,
+	// including the class heritage clause for a constructor returning an intersection.
+	const content = `
+class Base {}
+
+declare const Mixin: new () => Base & { mixed: string };
+
+declare namespace NS/*1*/ {
+    class Derived extends Mixin {}
+}
+`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+
+	f.VerifyBaselineHoverWithVerbosity(t, map[string][]int{"1": {0, 1}})
+}

--- a/testdata/baselines/reference/fourslash/quickInfo/quickinfoVerbosityClassWithMixinBase1.baseline
+++ b/testdata/baselines/reference/fourslash/quickInfo/quickinfoVerbosityClassWithMixinBase1.baseline
@@ -1,0 +1,89 @@
+// === QuickInfo ===
+=== /quickinfoVerbosityClassWithMixinBase1.ts ===
+// 
+// class Base {}
+// 
+// declare const Mixin: new () => Base & { mixed: string };
+// 
+// class Derived extends Mixin {}
+//       ^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | class Derived {
+// | }
+// | ```
+// | 
+// | (verbosity level: 1)
+// | ----------------------------------------------------------------------
+//       ^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | class Derived
+// | ```
+// | 
+// | (verbosity level: 0)
+// | ----------------------------------------------------------------------
+// 
+[
+  {
+    "marker": {
+      "Position": 87,
+      "LSPosition": {
+        "line": 5,
+        "character": 13
+      },
+      "Name": "1",
+      "Data": {}
+    },
+    "item": {
+      "hover": {
+        "contents": {
+          "kind": "markdown",
+          "value": "```typescript\nclass Derived\n```\n"
+        },
+        "range": {
+          "start": {
+            "line": 5,
+            "character": 6
+          },
+          "end": {
+            "line": 5,
+            "character": 13
+          }
+        },
+        "canIncreaseVerbosity": true
+      },
+      "verbosityLevel": 0
+    }
+  },
+  {
+    "marker": {
+      "Position": 87,
+      "LSPosition": {
+        "line": 5,
+        "character": 13
+      },
+      "Name": "1",
+      "Data": {}
+    },
+    "item": {
+      "hover": {
+        "contents": {
+          "kind": "markdown",
+          "value": "```typescript\nclass Derived {\n}\n```\n"
+        },
+        "range": {
+          "start": {
+            "line": 5,
+            "character": 6
+          },
+          "end": {
+            "line": 5,
+            "character": 13
+          }
+        }
+      },
+      "verbosityLevel": 1
+    }
+  }
+]


### PR DESCRIPTION
Fixes #3506