### PR TITLE
Reenable semantic tokens

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1101,17 +1101,17 @@ func (s *Server) handleInitialize(ctx context.Context, params *lsproto.Initializ
 					},
 				},
 			},
-			// SemanticTokensProvider: &lsproto.SemanticTokensOptionsOrRegistrationOptions{
-			// 	Options: &lsproto.SemanticTokensOptions{
-			// 		Legend: ls.SemanticTokensLegend(s.clientCapabilities.TextDocument.SemanticTokens),
-			// 		Full: &lsproto.BooleanOrSemanticTokensFullDelta{
-			// 			Boolean: new(true),
-			// 		},
-			// 		Range: &lsproto.BooleanOrEmptyObject{
-			// 			Boolean: new(true),
-			// 		},
-			// 	},
-			// },
+			SemanticTokensProvider: &lsproto.SemanticTokensOptionsOrRegistrationOptions{
+				Options: &lsproto.SemanticTokensOptions{
+					Legend: ls.SemanticTokensLegend(s.clientCapabilities.TextDocument.SemanticTokens),
+					Full: &lsproto.BooleanOrSemanticTokensFullDelta{
+						Boolean: new(true),
+					},
+					Range: &lsproto.BooleanOrEmptyObject{
+						Boolean: new(true),
+					},
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
The desync-based crashes should be fixed, so reenable this.