### PR TITLE
Miscellaneous extension improvements

### DIFF
--- a/_extension/package.json
+++ b/_extension/package.json
@@ -137,12 +137,6 @@
                 "category": "TypeScript Native Preview"
             },
             {
-                "command": "typescript.native-preview.selectVersion",
-                "title": "Select Version",
-                "enablement": "typescript.native-preview.serverRunning",
-                "category": "TypeScript Native Preview"
-            },
-            {
                 "command": "typescript.native-preview.goToSourceDefinition",
                 "title": "Go to Source Definition",
                 "enablement": "typescript.native-preview.serverRunning",

--- a/_extension/package.json
+++ b/_extension/package.json
@@ -68,6 +68,25 @@
                             "experimental"
                         ]
                     },
+                    "typescript.native-preview.additionalTsdkLocations": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "default": [],
+                        "description": "Additional paths to tsgo binary directories or @typescript/native-preview packages that should appear in the version selector.",
+                        "tags": [
+                            "experimental"
+                        ]
+                    },
+                    "typescript.native-preview.showPID": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Show the language server process ID in the status bar.",
+                        "tags": [
+                            "experimental"
+                        ]
+                    },
                     "typescript.native-preview.goMemLimit": {
                         "type": "string",
                         "description": "Set GOMEMLIMIT for the language server (e.g., '2048MiB', '4GiB'). See https://pkg.go.dev/runtime#hdr-Environment_Variables for more information.",
@@ -114,6 +133,12 @@
             {
                 "command": "typescript.native-preview.reportIssue",
                 "title": "Report Issue",
+                "enablement": "typescript.native-preview.serverRunning",
+                "category": "TypeScript Native Preview"
+            },
+            {
+                "command": "typescript.native-preview.selectVersion",
+                "title": "Select Version",
                 "enablement": "typescript.native-preview.serverRunning",
                 "category": "TypeScript Native Preview"
             },

--- a/_extension/package.json
+++ b/_extension/package.json
@@ -79,10 +79,10 @@
                             "experimental"
                         ]
                     },
-                    "typescript.native-preview.showPID": {
+                    "typescript.native-preview.showDebugInfo": {
                         "type": "boolean",
                         "default": false,
-                        "description": "Show the language server process ID in the status bar.",
+                        "description": "Show debug information (PID, executable path) in the server menu.",
                         "tags": [
                             "experimental"
                         ]

--- a/_extension/src/client.ts
+++ b/_extension/src/client.ts
@@ -80,6 +80,7 @@ export class Client implements vscode.Disposable {
                 sendNotification: sendNotificationMiddleware,
                 provideHover: () => undefined,
             },
+            diagnosticCollectionName: "typescript",
             diagnosticPullOptions: {
                 onChange: true,
                 onSave: true,

--- a/_extension/src/client.ts
+++ b/_extension/src/client.ts
@@ -248,6 +248,10 @@ export class Client implements vscode.Disposable {
         return this.exe;
     }
 
+    get serverPid(): number | undefined {
+        return (this.client as any)?._serverProcess?.pid;
+    }
+
     /**
      * Initialize an API session and return the socket path for connecting.
      * This allows other extensions to get a direct connection to the API server.

--- a/_extension/src/extension.ts
+++ b/_extension/src/extension.ts
@@ -12,7 +12,10 @@ import {
 } from "./util";
 
 import { TelemetryReporter as VSCodeTelemetryReporter } from "@vscode/extension-telemetry";
-import { SessionManager } from "./session";
+import {
+    promptUseWorkspaceVersion,
+    SessionManager,
+} from "./session";
 import { createTelemetryReporter } from "./telemetryReporting";
 
 export interface ExtensionAPI {
@@ -110,6 +113,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<Extens
     }
 
     await sessionManager.start(context);
+
+    // Prompt user to use workspace version if one is detected and they haven't opted in yet.
+    promptUseWorkspaceVersion(context);
 
     function onLanguageServerInitialized(listener: () => void): vscode.Disposable {
         if (sessionManager.currentSession?.client.isInitialized) {

--- a/_extension/src/extension.ts
+++ b/_extension/src/extension.ts
@@ -115,7 +115,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<Extens
     await sessionManager.start(context);
 
     // Prompt user to use workspace version if one is detected and they haven't opted in yet.
-    await promptUseWorkspaceVersion(context);
+    promptUseWorkspaceVersion(context).catch(err => {
+        output.appendLine(`Error prompting to use workspace version: ${err}`);
+    });
 
     function onLanguageServerInitialized(listener: () => void): vscode.Disposable {
         if (sessionManager.currentSession?.client.isInitialized) {

--- a/_extension/src/extension.ts
+++ b/_extension/src/extension.ts
@@ -115,7 +115,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Extens
     await sessionManager.start(context);
 
     // Prompt user to use workspace version if one is detected and they haven't opted in yet.
-    promptUseWorkspaceVersion(context);
+    await promptUseWorkspaceVersion(context);
 
     function onLanguageServerInitialized(listener: () => void): vscode.Disposable {
         if (sessionManager.currentSession?.client.isInitialized) {

--- a/_extension/src/session.ts
+++ b/_extension/src/session.ts
@@ -1,3 +1,4 @@
+import * as path from "path";
 import * as vscode from "vscode";
 import { ActiveJsTsEditorTracker } from "./activeJsTsEditorTracker";
 import { Client } from "./client";
@@ -6,7 +7,10 @@ import { ManagedFileContextManager } from "./managedFileContext";
 import { ProjectStatus } from "./projectStatus";
 import { setupStatusBar } from "./statusBar";
 import { TelemetryReporter } from "./telemetryReporting";
-import { getExe } from "./util";
+import {
+    getExe,
+    useWorkspaceTsdkStorageKey,
+} from "./util";
 
 /**
  * SessionManager's lifetime is equal to that of the extension. It is responsible
@@ -55,7 +59,7 @@ export class SessionManager implements vscode.Disposable {
             this.outputChannel.appendLine("Restarting TypeScript Native Preview...");
             await this.currentSession.dispose();
         }
-        this.currentSession = new Session(this.outputChannel, this.traceOutputChannel, this.initializedEventEmitter, this.telemetryReporter);
+        this.currentSession = new Session(context, this.outputChannel, this.traceOutputChannel, this.initializedEventEmitter, this.telemetryReporter);
         return this.currentSession.start(context);
     }
 
@@ -91,12 +95,14 @@ export class SessionManager implements vscode.Disposable {
 class Session implements vscode.Disposable {
     client: Client;
     private disposables: vscode.Disposable[] = [];
+    private context: vscode.ExtensionContext;
     private outputChannel: vscode.LogOutputChannel;
     private traceOutputChannel: vscode.LogOutputChannel;
     private telemetryReporter: TelemetryReporter;
     private initializedEventEmitter: vscode.EventEmitter<void>;
 
     constructor(
+        context: vscode.ExtensionContext,
         outputChannel: vscode.LogOutputChannel,
         traceOutputChannel: vscode.LogOutputChannel,
         initializedEventEmitter: vscode.EventEmitter<void>,
@@ -104,6 +110,7 @@ class Session implements vscode.Disposable {
     ) {
         this.client = new Client(outputChannel, traceOutputChannel, initializedEventEmitter, telemetryReporter);
         this.disposables.push(this.client);
+        this.context = context;
         this.outputChannel = outputChannel;
         this.traceOutputChannel = traceOutputChannel;
         this.telemetryReporter = telemetryReporter;
@@ -114,7 +121,7 @@ class Session implements vscode.Disposable {
     async start(context: vscode.ExtensionContext): Promise<void> {
         const exe = await getExe(context);
         await this.client.start(exe);
-        this.disposables.push(setupStatusBar(exe.version));
+        this.disposables.push(setupStatusBar(exe.version, this.client.serverPid));
 
         // Set up active editor tracker and UI features
         const activeEditorTracker = new ActiveJsTsEditorTracker();
@@ -150,6 +157,7 @@ class Session implements vscode.Disposable {
         }));
 
         this.disposables.push(vscode.commands.registerCommand("typescript.native-preview.selectVersion", async () => {
+            await promptSelectVersion(this.context, this.outputChannel);
         }));
 
         this.disposables.push(vscode.commands.registerCommand("typescript.native-preview.showMenu", showCommands));
@@ -270,6 +278,11 @@ async function showCommands(): Promise<void> {
             command: "typescript.native-preview.reportIssue",
         },
         {
+            label: "$(versions) Select Version",
+            description: "Choose between bundled and workspace versions",
+            command: "typescript.native-preview.selectVersion",
+        },
+        {
             label: "$(stop-circle) Disable TypeScript Native Preview",
             description: "Switch back to the built-in TypeScript extension",
             command: "typescript.native-preview.disable",
@@ -282,6 +295,162 @@ async function showCommands(): Promise<void> {
 
     if (selected) {
         await vscode.commands.executeCommand(selected.command);
+    }
+}
+
+interface VersionQuickPickItem extends vscode.QuickPickItem {
+    run(): Promise<void>;
+}
+
+interface DetectedVersion {
+    label: string;
+    version: string;
+    tsdkPath: string;
+}
+
+async function findWorkspaceNativePreviewPackages(): Promise<DetectedVersion[]> {
+    const results: DetectedVersion[] = [];
+    for (const folder of vscode.workspace.workspaceFolders ?? []) {
+        const packagePath = vscode.Uri.joinPath(folder.uri, "node_modules", "@typescript", "native-preview");
+        try {
+            const packageJsonPath = vscode.Uri.joinPath(packagePath, "package.json");
+            const raw = await vscode.workspace.fs.readFile(packageJsonPath);
+            const packageJson = JSON.parse(new TextDecoder().decode(raw));
+            results.push({
+                label: folder.name,
+                version: packageJson.version ?? "unknown",
+                tsdkPath: path.posix.join("node_modules", "@typescript", "native-preview"),
+            });
+        }
+        catch {
+            // No @typescript/native-preview in this folder
+        }
+    }
+    return results;
+}
+
+async function promptSelectVersion(context: vscode.ExtensionContext, outputChannel: vscode.LogOutputChannel): Promise<void> {
+    const config = vscode.workspace.getConfiguration("typescript.native-preview");
+    const currentTsdk = config.get<string>("tsdk") ?? "";
+    const useWorkspaceTsdk = context.workspaceState.get<boolean>(useWorkspaceTsdkStorageKey, false);
+    const workspaceVersions = await findWorkspaceNativePreviewPackages();
+    const isUsingBundled = !currentTsdk || !useWorkspaceTsdk;
+    const bundledVersion = context.extension.packageJSON.version as string;
+    const items: VersionQuickPickItem[] = [];
+
+    // Bundled version
+    items.push({
+        label: (isUsingBundled ? "• " : "") + "Use Bundled Version",
+        description: bundledVersion,
+        detail: context.asAbsolutePath("lib"),
+        run: async () => {
+            await context.workspaceState.update(useWorkspaceTsdkStorageKey, false);
+            await config.update("tsdk", undefined, vscode.ConfigurationTarget.Workspace);
+            outputChannel.appendLine("Switched to bundled tsgo version.");
+        },
+    });
+
+    // Workspace versions
+    if (vscode.workspace.isTrusted) {
+        for (const wsVersion of workspaceVersions) {
+            const isActive = !isUsingBundled && currentTsdk.endsWith("@typescript/native-preview");
+            items.push({
+                label: (isActive ? "• " : "") + "Use Workspace Version",
+                description: wsVersion.version,
+                detail: wsVersion.tsdkPath,
+                run: async () => {
+                    await context.workspaceState.update(useWorkspaceTsdkStorageKey, true);
+                    await config.update("tsdk", wsVersion.tsdkPath, vscode.ConfigurationTarget.Workspace);
+                    outputChannel.appendLine(`Switched to workspace tsgo version (${wsVersion.version}).`);
+                },
+            });
+        }
+    }
+    else if (workspaceVersions.length > 0) {
+        items.push({
+            label: "",
+            kind: vscode.QuickPickItemKind.Separator,
+            run: async () => {},
+        });
+        items.push({
+            label: "$(lock) Manage Workspace Trust to select a workspace version",
+            run: async () => {
+                await vscode.commands.executeCommand("workbench.trust.manage");
+            },
+        });
+    }
+
+    // Additional tsdk locations from settings
+    const additionalLocations = config.get<string[]>("additionalTsdkLocations", []);
+    if (additionalLocations.length > 0) {
+        items.push({
+            label: "",
+            kind: vscode.QuickPickItemKind.Separator,
+            run: async () => {},
+        });
+        for (const loc of additionalLocations) {
+            const isActive = !isUsingBundled && currentTsdk === loc;
+            items.push({
+                label: (isActive ? "• " : "") + "Use Custom Version",
+                detail: loc,
+                run: async () => {
+                    await context.workspaceState.update(useWorkspaceTsdkStorageKey, true);
+                    await config.update("tsdk", loc, vscode.ConfigurationTarget.Workspace);
+                    outputChannel.appendLine(`Switched to custom tsgo version at ${loc}.`);
+                },
+            });
+        }
+    }
+
+    const selected = await vscode.window.showQuickPick<VersionQuickPickItem>(items, {
+        placeHolder: "Select the TypeScript Native Preview version to use",
+    });
+
+    if (selected) {
+        await selected.run();
+        // Restart server to pick up the new version
+        await vscode.commands.executeCommand("typescript.native-preview.restart");
+    }
+}
+
+/**
+ * If the workspace has `@typescript/native-preview` installed and the user
+ * hasn't already opted in or dismissed the prompt, ask whether they'd like
+ * to use the workspace version.
+ */
+export async function promptUseWorkspaceVersion(context: vscode.ExtensionContext): Promise<void> {
+    if (!vscode.workspace.isTrusted) return;
+
+    const useWorkspaceTsdk = context.workspaceState.get<boolean>(useWorkspaceTsdkStorageKey, false);
+    if (useWorkspaceTsdk) return; // already opted in
+
+    const suppressKey = "typescript.native-preview.suppressPromptWorkspaceTsdk";
+    if (context.workspaceState.get<boolean>(suppressKey, false)) return;
+
+    const workspaceVersions = await findWorkspaceNativePreviewPackages();
+    if (workspaceVersions.length === 0) return;
+
+    const wsVersion = workspaceVersions[0];
+    const allow = "Allow";
+    const dismiss = "Dismiss";
+    const suppress = "Never in this Workspace";
+
+    const result = await vscode.window.showInformationMessage(
+        `This workspace contains a TypeScript Native Preview version (${wsVersion.version}). Would you like to use the workspace version?`,
+        allow,
+        dismiss,
+        suppress,
+    );
+
+    if (result === allow) {
+        if (!vscode.workspace.isTrusted) return;
+        await context.workspaceState.update(useWorkspaceTsdkStorageKey, true);
+        const config = vscode.workspace.getConfiguration("typescript.native-preview");
+        await config.update("tsdk", wsVersion.tsdkPath, vscode.ConfigurationTarget.Workspace);
+        await vscode.commands.executeCommand("typescript.native-preview.restart");
+    }
+    else if (result === suppress) {
+        await context.workspaceState.update(suppressKey, true);
     }
 }
 

--- a/_extension/src/session.ts
+++ b/_extension/src/session.ts
@@ -121,7 +121,7 @@ class Session implements vscode.Disposable {
     async start(context: vscode.ExtensionContext): Promise<void> {
         const exe = await getExe(context);
         await this.client.start(exe);
-        this.disposables.push(setupStatusBar(exe.version, this.client.serverPid));
+        this.disposables.push(setupStatusBar(exe.version));
 
         // Set up active editor tracker and UI features
         const activeEditorTracker = new ActiveJsTsEditorTracker();
@@ -156,11 +156,13 @@ class Session implements vscode.Disposable {
             this.traceOutputChannel.show();
         }));
 
-        this.disposables.push(vscode.commands.registerCommand("typescript.native-preview.selectVersion", async () => {
+        this.disposables.push(vscode.commands.registerCommand("typescript.selectTypeScriptVersion", async () => {
             await promptSelectVersion(this.context, this.outputChannel);
         }));
 
-        this.disposables.push(vscode.commands.registerCommand("typescript.native-preview.showMenu", showCommands));
+        this.disposables.push(vscode.commands.registerCommand("typescript.native-preview.showMenu", () => {
+            showCommands(this.client);
+        }));
 
         this.disposables.push(vscode.commands.registerCommand("typescript.native-preview.reportIssue", () => {
             this.telemetryReporter.sendTelemetryEvent("command.reportIssue");
@@ -255,8 +257,15 @@ class Session implements vscode.Disposable {
     }
 }
 
-async function showCommands(): Promise<void> {
-    const commands: readonly { label: string; description: string; command: string; }[] = [
+async function showCommands(client: Client): Promise<void> {
+    interface CommandItem {
+        label: string;
+        description?: string;
+        kind?: vscode.QuickPickItemKind;
+        command?: string;
+        action?: () => Promise<void>;
+    }
+    const commands: CommandItem[] = [
         {
             label: "$(refresh) Restart Server",
             description: "Restart the TypeScript Native Preview language server",
@@ -280,7 +289,7 @@ async function showCommands(): Promise<void> {
         {
             label: "$(versions) Select Version",
             description: "Choose between bundled and workspace versions",
-            command: "typescript.native-preview.selectVersion",
+            command: "typescript.selectTypeScriptVersion",
         },
         {
             label: "$(stop-circle) Disable TypeScript Native Preview",
@@ -289,12 +298,44 @@ async function showCommands(): Promise<void> {
         },
     ];
 
+    const showDebugInfo = vscode.workspace.getConfiguration("typescript.native-preview").get<boolean>("showDebugInfo", false);
+    if (showDebugInfo) {
+        const exe = client.getCurrentExe();
+        const pid = client.serverPid;
+        commands.push({ label: "", kind: vscode.QuickPickItemKind.Separator });
+        if (exe) {
+            commands.push({
+                label: `Executable`,
+                description: exe.path,
+                action: async () => {
+                    await vscode.env.clipboard.writeText(exe.path);
+                    vscode.window.showInformationMessage("Executable path copied to clipboard.");
+                },
+            });
+        }
+        if (pid) {
+            commands.push({
+                label: `PID`,
+                description: `${pid}`,
+                action: async () => {
+                    await vscode.env.clipboard.writeText(`${pid}`);
+                    vscode.window.showInformationMessage("Server PID copied to clipboard.");
+                },
+            });
+        }
+    }
+
     const selected = await vscode.window.showQuickPick(commands, {
         placeHolder: "TypeScript Native Preview Commands",
     });
 
     if (selected) {
-        await vscode.commands.executeCommand(selected.command);
+        if (selected.action) {
+            await selected.action();
+        }
+        else if (selected.command) {
+            await vscode.commands.executeCommand(selected.command);
+        }
     }
 }
 

--- a/_extension/src/session.ts
+++ b/_extension/src/session.ts
@@ -8,6 +8,7 @@ import { ProjectStatus } from "./projectStatus";
 import { setupStatusBar } from "./statusBar";
 import { TelemetryReporter } from "./telemetryReporting";
 import {
+    getBuiltinExePath,
     getExe,
     useWorkspaceTsdkStorageKey,
 } from "./util";
@@ -157,7 +158,7 @@ class Session implements vscode.Disposable {
         }));
 
         this.disposables.push(vscode.commands.registerCommand("typescript.selectTypeScriptVersion", async () => {
-            await promptSelectVersion(this.context, this.outputChannel);
+            await promptSelectVersion(this.context, this.client, this.outputChannel);
         }));
 
         this.disposables.push(vscode.commands.registerCommand("typescript.native-preview.showMenu", () => {
@@ -360,7 +361,7 @@ async function findWorkspaceNativePreviewPackages(): Promise<DetectedVersion[]> 
             results.push({
                 label: folder.name,
                 version: packageJson.version ?? "unknown",
-                tsdkPath: path.posix.join("node_modules", "@typescript", "native-preview"),
+                tsdkPath: path.normalize(packagePath.fsPath),
             });
         }
         catch {
@@ -370,18 +371,16 @@ async function findWorkspaceNativePreviewPackages(): Promise<DetectedVersion[]> 
     return results;
 }
 
-async function promptSelectVersion(context: vscode.ExtensionContext, outputChannel: vscode.LogOutputChannel): Promise<void> {
+async function promptSelectVersion(context: vscode.ExtensionContext, client: Client, outputChannel: vscode.LogOutputChannel): Promise<void> {
     const config = vscode.workspace.getConfiguration("typescript.native-preview");
-    const currentTsdk = config.get<string>("tsdk") ?? "";
-    const useWorkspaceTsdk = context.workspaceState.get<boolean>(useWorkspaceTsdkStorageKey, false);
+    const currentExePath = client.getCurrentExe()?.path;
     const workspaceVersions = await findWorkspaceNativePreviewPackages();
-    const isUsingBundled = !currentTsdk || !useWorkspaceTsdk;
     const bundledVersion = context.extension.packageJSON.version as string;
     const items: VersionQuickPickItem[] = [];
 
     // Bundled version
     items.push({
-        label: (isUsingBundled ? "• " : "") + "Use Bundled Version",
+        label: (currentExePath === getBuiltinExePath(context) ? "• " : "") + "Use Bundled Version",
         description: bundledVersion,
         detail: context.asAbsolutePath("lib"),
         run: async () => {
@@ -394,7 +393,7 @@ async function promptSelectVersion(context: vscode.ExtensionContext, outputChann
     // Workspace versions
     if (vscode.workspace.isTrusted) {
         for (const wsVersion of workspaceVersions) {
-            const isActive = !isUsingBundled && currentTsdk.endsWith("@typescript/native-preview");
+            const isActive = currentExePath === wsVersion.tsdkPath;
             items.push({
                 label: (isActive ? "• " : "") + "Use Workspace Version",
                 description: wsVersion.version,
@@ -430,7 +429,7 @@ async function promptSelectVersion(context: vscode.ExtensionContext, outputChann
             run: async () => {},
         });
         for (const loc of additionalLocations) {
-            const isActive = !isUsingBundled && currentTsdk === loc;
+            const isActive = currentExePath === loc;
             items.push({
                 label: (isActive ? "• " : "") + "Use Custom Version",
                 detail: loc,

--- a/_extension/src/session.ts
+++ b/_extension/src/session.ts
@@ -10,6 +10,7 @@ import { TelemetryReporter } from "./telemetryReporting";
 import {
     getBuiltinExePath,
     getExe,
+    resolveTsdkPathToExe,
     useWorkspaceTsdkStorageKey,
 } from "./util";
 
@@ -348,25 +349,21 @@ interface DetectedVersion {
     label: string;
     version: string;
     tsdkPath: string;
+    exePath: string;
 }
 
 async function findWorkspaceNativePreviewPackages(): Promise<DetectedVersion[]> {
     const results: DetectedVersion[] = [];
     for (const folder of vscode.workspace.workspaceFolders ?? []) {
         const packagePath = vscode.Uri.joinPath(folder.uri, "node_modules", "@typescript", "native-preview");
-        try {
-            const packageJsonPath = vscode.Uri.joinPath(packagePath, "package.json");
-            const raw = await vscode.workspace.fs.readFile(packageJsonPath);
-            const packageJson = JSON.parse(new TextDecoder().decode(raw));
-            results.push({
-                label: folder.name,
-                version: packageJson.version ?? "unknown",
-                tsdkPath: path.normalize(packagePath.fsPath),
-            });
-        }
-        catch {
-            // No @typescript/native-preview in this folder
-        }
+        const resolved = await resolveTsdkPathToExe(path.normalize(packagePath.fsPath));
+        if (!resolved) continue;
+        results.push({
+            label: folder.name,
+            version: resolved?.version ?? "unknown",
+            tsdkPath: path.normalize(packagePath.fsPath),
+            exePath: resolved?.path ?? "",
+        });
     }
     return results;
 }
@@ -374,15 +371,16 @@ async function findWorkspaceNativePreviewPackages(): Promise<DetectedVersion[]> 
 async function promptSelectVersion(context: vscode.ExtensionContext, client: Client, outputChannel: vscode.LogOutputChannel): Promise<void> {
     const config = vscode.workspace.getConfiguration("typescript.native-preview");
     const currentExePath = client.getCurrentExe()?.path;
+    const builtinExe = await getBuiltinExePath(context);
     const workspaceVersions = await findWorkspaceNativePreviewPackages();
     const bundledVersion = context.extension.packageJSON.version as string;
     const items: VersionQuickPickItem[] = [];
 
     // Bundled version
     items.push({
-        label: (currentExePath === getBuiltinExePath(context) ? "• " : "") + "Use Bundled Version",
+        label: (currentExePath === builtinExe.path ? "• " : "") + "Use Bundled Version",
         description: bundledVersion,
-        detail: context.asAbsolutePath("lib"),
+        detail: builtinExe.path,
         run: async () => {
             await context.workspaceState.update(useWorkspaceTsdkStorageKey, false);
             await config.update("tsdk", undefined, vscode.ConfigurationTarget.Workspace);
@@ -429,10 +427,15 @@ async function promptSelectVersion(context: vscode.ExtensionContext, client: Cli
             run: async () => {},
         });
         for (const loc of additionalLocations) {
-            const isActive = currentExePath === loc;
+            const resolved = await resolveTsdkPathToExe(loc);
+            if (!resolved) continue;
+            if (resolved.path === builtinExe.path) continue;
+            if (workspaceVersions.some(ws => ws.exePath === resolved.path)) continue;
+            const isActive = currentExePath === resolved.path;
             items.push({
                 label: (isActive ? "• " : "") + "Use Custom Version",
-                detail: loc,
+                description: resolved.version,
+                detail: resolved.path,
                 run: async () => {
                     await context.workspaceState.update(useWorkspaceTsdkStorageKey, true);
                     await config.update("tsdk", loc, vscode.ConfigurationTarget.Workspace);

--- a/_extension/src/statusBar.ts
+++ b/_extension/src/statusBar.ts
@@ -1,14 +1,34 @@
 import * as vscode from "vscode";
 import { jsTsLanguageModes } from "./util";
 
-export function setupStatusBar(version: string): vscode.Disposable {
+export function setupStatusBar(version: string, pid?: number): vscode.Disposable {
     const statusItem = vscode.languages.createLanguageStatusItem("typescript.native-preview.status", jsTsLanguageModes);
     statusItem.name = "TypeScript Native Preview";
-    statusItem.text = `$(beaker) tsgo ${version}`;
+
+    function updateText() {
+        const showPID = vscode.workspace.getConfiguration("typescript.native-preview").get<boolean>("showPID", false);
+        statusItem.text = showPID && pid
+            ? `$(beaker) tsgo ${version} (PID: ${pid})`
+            : `$(beaker) tsgo ${version}`;
+    }
+    updateText();
+
     statusItem.detail = "TypeScript Native Preview Language Server";
     statusItem.command = {
         title: "Show Menu",
         command: "typescript.native-preview.showMenu",
     };
-    return statusItem;
+
+    const configListener = vscode.workspace.onDidChangeConfiguration(e => {
+        if (e.affectsConfiguration("typescript.native-preview.showPID")) {
+            updateText();
+        }
+    });
+
+    return {
+        dispose() {
+            statusItem.dispose();
+            configListener.dispose();
+        },
+    };
 }

--- a/_extension/src/statusBar.ts
+++ b/_extension/src/statusBar.ts
@@ -1,34 +1,14 @@
 import * as vscode from "vscode";
 import { jsTsLanguageModes } from "./util";
 
-export function setupStatusBar(version: string, pid?: number): vscode.Disposable {
+export function setupStatusBar(version: string): vscode.Disposable {
     const statusItem = vscode.languages.createLanguageStatusItem("typescript.native-preview.status", jsTsLanguageModes);
     statusItem.name = "TypeScript Native Preview";
-
-    function updateText() {
-        const showPID = vscode.workspace.getConfiguration("typescript.native-preview").get<boolean>("showPID", false);
-        statusItem.text = showPID && pid
-            ? `$(beaker) tsgo ${version} (PID: ${pid})`
-            : `$(beaker) tsgo ${version}`;
-    }
-    updateText();
-
+    statusItem.text = `$(beaker) tsgo ${version}`;
     statusItem.detail = "TypeScript Native Preview Language Server";
     statusItem.command = {
         title: "Show Menu",
         command: "typescript.native-preview.showMenu",
     };
-
-    const configListener = vscode.workspace.onDidChangeConfiguration(e => {
-        if (e.affectsConfiguration("typescript.native-preview.showPID")) {
-            updateText();
-        }
-    });
-
-    return {
-        dispose() {
-            statusItem.dispose();
-            configListener.dispose();
-        },
-    };
+    return statusItem;
 }

--- a/_extension/src/util.ts
+++ b/_extension/src/util.ts
@@ -1,3 +1,5 @@
+import { exec } from "child_process";
+import { get } from "http";
 import * as path from "path";
 import * as vscode from "vscode";
 
@@ -37,8 +39,20 @@ export interface ExeInfo {
     version: string;
 }
 
-export function getBuiltinExePath(context: vscode.ExtensionContext): string {
-    return context.asAbsolutePath(path.join("./lib", `tsgo${process.platform === "win32" ? ".exe" : ""}`));
+export async function getBuiltinExePath(context: vscode.ExtensionContext): Promise<{ path: string; version: string; }> {
+    if (context.extensionMode === vscode.ExtensionMode.Development) {
+        const exeName = `tsgo${process.platform === "win32" ? ".exe" : ""}`;
+        const exe = context.asAbsolutePath(path.join("../", "built", "local", exeName));
+        try {
+            await vscode.workspace.fs.stat(vscode.Uri.file(exe));
+            return { path: exe, version: "(local)" };
+        }
+        catch {}
+    }
+    return {
+        path: context.asAbsolutePath(path.join("./lib", `tsgo${process.platform === "win32" ? ".exe" : ""}`)),
+        version: context.extension.packageJSON.version,
+    };
 }
 
 function workspaceResolve(relativePath: string): vscode.Uri {
@@ -56,50 +70,46 @@ export const useWorkspaceTsdkStorageKey = "typescript.native-preview.useWorkspac
 
 export async function getExe(context: vscode.ExtensionContext): Promise<ExeInfo> {
     const config = vscode.workspace.getConfiguration("typescript.native-preview");
-    const exeName = `tsgo${process.platform === "win32" ? ".exe" : ""}`;
 
-    let exe = config.get<string>("tsdk");
+    let tsdk = config.get<string>("tsdk");
     const exeInspection = config.inspect<string>("tsdk");
 
     // If tsdk is set at the workspace level, require the user to have
     // explicitly opted in via the version picker (stored in workspace state).
-    if (exe && (exeInspection?.workspaceValue !== undefined || exeInspection?.workspaceFolderValue !== undefined)) {
+    if (tsdk && (exeInspection?.workspaceValue !== undefined || exeInspection?.workspaceFolderValue !== undefined)) {
         const useWorkspaceTsdk = context.workspaceState.get<boolean>(useWorkspaceTsdkStorageKey, false);
         if (!useWorkspaceTsdk) {
-            exe = exeInspection.globalValue;
+            tsdk = exeInspection.globalValue;
         }
     }
 
-    if (exe) {
-        if (exe.endsWith("/@typescript/native-preview")) {
-            try {
-                const packagePath = workspaceResolve(exe);
-                const packageJsonPath = vscode.Uri.joinPath(packagePath, "package.json");
-                const packageJson = JSON.parse(await vscode.workspace.fs.readFile(packageJsonPath).then(buffer => buffer.toString()));
-                const getExePath = (await import(vscode.Uri.joinPath(packagePath, "lib", "getExePath.js").toString())).default;
-                return { path: getExePath(), version: packageJson.version };
-            }
-            catch {}
+    if (tsdk) {
+        const exe = await resolveTsdkPathToExe(tsdk);
+        if (exe) {
+            return exe;
         }
+    }
+
+    return getBuiltinExePath(context);
+}
+
+export async function resolveTsdkPathToExe(tsdkPath: string): Promise<{ path: string; version: string; } | undefined> {
+    if (tsdkPath.endsWith("/@typescript/native-preview")) {
         try {
-            const exePath = workspaceResolve(path.join(exe, exeName));
-            await vscode.workspace.fs.stat(exePath);
-            return { path: exePath.fsPath, version: "(local)" };
+            const packagePath = workspaceResolve(tsdkPath);
+            const packageJsonPath = vscode.Uri.joinPath(packagePath, "package.json");
+            const packageJson = JSON.parse(await vscode.workspace.fs.readFile(packageJsonPath).then(buffer => buffer.toString()));
+            const getExePath = (await import(vscode.Uri.joinPath(packagePath, "lib", "getExePath.js").toString())).default;
+            return { path: getExePath(), version: packageJson.version };
         }
         catch {}
     }
-
-    exe = context.asAbsolutePath(path.join("../", "built", "local", exeName));
     try {
-        await vscode.workspace.fs.stat(vscode.Uri.file(exe));
-        return { path: exe, version: "(local)" };
+        const exePath = workspaceResolve(path.join(tsdkPath, `tsgo${process.platform === "win32" ? ".exe" : ""}`));
+        await vscode.workspace.fs.stat(exePath);
+        return { path: exePath.fsPath, version: "(local)" };
     }
     catch {}
-
-    return {
-        path: getBuiltinExePath(context),
-        version: context.extension.packageJSON.version,
-    };
 }
 
 export function getLanguageForUri(uri: vscode.Uri): string | undefined {

--- a/_extension/src/util.ts
+++ b/_extension/src/util.ts
@@ -54,32 +54,19 @@ function workspaceResolve(relativePath: string): vscode.Uri {
 
 export const useWorkspaceTsdkStorageKey = "typescript.native-preview.useWorkspaceTsdk";
 
-/**
- * Returns true if the `tsdk` setting is only set at the workspace level
- * (i.e., not explicitly set at the user/global level).
- */
-function isTsdkWorkspaceLevelOnly(): boolean {
-    const config = vscode.workspace.getConfiguration("typescript.native-preview");
-    const inspection = config.inspect<string>("tsdk");
-    if (!inspection) return false;
-    // If the user explicitly set it at the global level, it's trusted.
-    if (inspection.globalValue !== undefined) return false;
-    // Otherwise it's workspace-level only (could be committed by anyone).
-    return inspection.workspaceValue !== undefined || inspection.workspaceFolderValue !== undefined;
-}
-
 export async function getExe(context: vscode.ExtensionContext): Promise<ExeInfo> {
     const config = vscode.workspace.getConfiguration("typescript.native-preview");
     const exeName = `tsgo${process.platform === "win32" ? ".exe" : ""}`;
 
     let exe = config.get<string>("tsdk");
+    const exeInspection = config.inspect<string>("tsdk");
 
-    // If tsdk is only set at the workspace level, require the user to have
+    // If tsdk is set at the workspace level, require the user to have
     // explicitly opted in via the version picker (stored in workspace state).
-    if (exe && isTsdkWorkspaceLevelOnly()) {
+    if (exe && (exeInspection?.workspaceValue !== undefined || exeInspection?.workspaceFolderValue !== undefined)) {
         const useWorkspaceTsdk = context.workspaceState.get<boolean>(useWorkspaceTsdkStorageKey, false);
         if (!useWorkspaceTsdk) {
-            exe = undefined;
+            exe = exeInspection.globalValue;
         }
     }
 

--- a/_extension/src/util.ts
+++ b/_extension/src/util.ts
@@ -52,11 +52,37 @@ function workspaceResolve(relativePath: string): vscode.Uri {
     return vscode.Uri.file(relativePath);
 }
 
+export const useWorkspaceTsdkStorageKey = "typescript.native-preview.useWorkspaceTsdk";
+
+/**
+ * Returns true if the `tsdk` setting is only set at the workspace level
+ * (i.e., not explicitly set at the user/global level).
+ */
+function isTsdkWorkspaceLevelOnly(): boolean {
+    const config = vscode.workspace.getConfiguration("typescript.native-preview");
+    const inspection = config.inspect<string>("tsdk");
+    if (!inspection) return false;
+    // If the user explicitly set it at the global level, it's trusted.
+    if (inspection.globalValue !== undefined) return false;
+    // Otherwise it's workspace-level only (could be committed by anyone).
+    return inspection.workspaceValue !== undefined || inspection.workspaceFolderValue !== undefined;
+}
+
 export async function getExe(context: vscode.ExtensionContext): Promise<ExeInfo> {
     const config = vscode.workspace.getConfiguration("typescript.native-preview");
     const exeName = `tsgo${process.platform === "win32" ? ".exe" : ""}`;
 
     let exe = config.get<string>("tsdk");
+
+    // If tsdk is only set at the workspace level, require the user to have
+    // explicitly opted in via the version picker (stored in workspace state).
+    if (exe && isTsdkWorkspaceLevelOnly()) {
+        const useWorkspaceTsdk = context.workspaceState.get<boolean>(useWorkspaceTsdkStorageKey, false);
+        if (!useWorkspaceTsdk) {
+            exe = undefined;
+        }
+    }
+
     if (exe) {
         if (exe.endsWith("/@typescript/native-preview")) {
             try {


### PR DESCRIPTION
## Version picker with persistent preference

- Ports the "Select TypeScript Version" command handler from the built-in TypeScript extension, which prior to this PR results in an error if you're using the native preview. This automates setting/changing your workspace setting’s `typescript.native-preview.tsdk` value.

- Like the built-in extension, upon discovering a workspace tsdk setting, we now prompt one time to ask if you want to use it, and save the preference.

  <img width="485" height="155" alt="Screenshot 2026-04-22 at 1 00 53 PM" src="https://github.com/user-attachments/assets/49e0c8e9-e0a1-4865-b665-5821596d48e0" />

- A new `typescript.native-preview.additionalTsdkLocations` setting adds to the pick list. This is a selfish feature because it's always annoying as a developer working on TypeScript to swap to a workspace-installed version via the UI and then not be able to switch back to your local clone without manually typing it into the settings file. I added my local build to my user preferences so it will always show up in the UI for me.

  <img width="639" height="209" alt="Screenshot 2026-04-22 at 1 14 30 PM" src="https://github.com/user-attachments/assets/00599ff2-ec74-4eaf-a055-14cee91198fd" />

## Adds PID and binary path location to server menu with a setting

If you enable `typescript.native-preview.showDebugInfo`, clicking on the tsgo status item menu shows:

<img width="631" height="240" alt="Screenshot 2026-04-22 at 1 14 21 PM" src="https://github.com/user-attachments/assets/5e20e746-c890-4345-bdb3-f526d7bf92c5" />

I'm constantly guessing which `tsgo` process to attach to for debugging. (Selecting the item copies the value to the clipboard.)

## Fix diagnostic collection owner name

Per request from @mjbvz