### PR TITLE
Fix printing of property access expressions

### DIFF
--- a/internal/ast/precedence.go
+++ b/internal/ast/precedence.go
@@ -707,7 +707,8 @@ func GetTypeNodePrecedence(n *TypeNode) TypePrecedence {
 		KindMappedType,
 		KindNamedTupleMember,
 		KindTemplateLiteralType,
-		KindImportType:
+		KindImportType,
+		KindPropertyAccessExpression:
 		return TypePrecedenceNonArray
 	default:
 		panic(fmt.Sprintf("unhandled TypeNode: %v", n.Kind))

--- a/internal/fourslash/tests/quickInfoOuterTypeParams_test.go
+++ b/internal/fourslash/tests/quickInfoOuterTypeParams_test.go
@@ -1,0 +1,30 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestQuickInfoOuterTypeParams(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `
+function namedSchemaError<Tag extends string>(tag: Tag) {
+  class NamedSchemaError extends Error {
+		public static isInstance(input: unknown) {
+			return input instanceof NamedSchemaError
+    }
+  }
+  return NamedSchemaError;
+}
+
+function t() {
+    const schemaError = namedSchemaError("MyError");
+    const isInstance = schemaError.isInst/*1*/ance({});
+}`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineHover(t)
+}

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -2325,6 +2325,8 @@ func (p *Printer) emitTypeNode(node *ast.TypeNode, precedence ast.TypePrecedence
 	case ast.KindExpressionWithTypeArguments:
 		// !!! Should this actually be considered a type?
 		p.emitExpressionWithTypeArguments(node.AsExpressionWithTypeArguments())
+	case ast.KindPropertyAccessExpression:
+		p.emitPropertyAccessExpression(node.AsPropertyAccessExpression())
 
 	case ast.KindJSDocAllType:
 		p.emitJSDocAllType(node)

--- a/testdata/baselines/reference/fourslash/quickInfo/quickInfoOuterTypeParams.baseline
+++ b/testdata/baselines/reference/fourslash/quickInfo/quickInfoOuterTypeParams.baseline
@@ -1,0 +1,53 @@
+// === QuickInfo ===
+=== /quickInfoOuterTypeParams.ts ===
+// 
+// function namedSchemaError<Tag extends string>(tag: Tag) {
+//   class NamedSchemaError extends Error {
+// 		public static isInstance(input: unknown) {
+// 			return input instanceof NamedSchemaError
+//     }
+//   }
+//   return NamedSchemaError;
+// }
+// 
+// function t() {
+//     const schemaError = namedSchemaError("MyError");
+//     const isInstance = schemaError.isInstance({});
+//                                    ^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (method) NamedSchemaError<"MyError">.isInstance(input: unknown): input is namedSchemaError<any>.NamedSchemaError
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+// }
+[
+  {
+    "marker": {
+      "Position": 338,
+      "LSPosition": {
+        "line": 12,
+        "character": 41
+      },
+      "Name": "1",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) NamedSchemaError<\"MyError\">.isInstance(input: unknown): input is namedSchemaError<any>.NamedSchemaError\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 35
+        },
+        "end": {
+          "line": 12,
+          "character": 45
+        }
+      },
+      "canIncreaseVerbosity": true
+    }
+  }
+]


### PR DESCRIPTION
Fixes https://github.com/microsoft/typescript-go/issues/3512#issuecomment-4299730639
Since #3412, we now can have a property access expression (basically anywhere?) a type node is expected when `UseInstantiationExpressions` is set (i.e. hover), so we need to handle that in the printer.