### PR TITLE
Fix hover expansion for aliased default function exports

### DIFF
--- a/internal/checker/nodebuilder_hover.go
+++ b/internal/checker/nodebuilder_hover.go
@@ -451,7 +451,7 @@ func (b *NodeBuilderImpl) expandModuleDecl(symbol *ast.Symbol) *ast.Node {
 
 		// Handle alias/re-export symbols
 		if m.Flags&ast.SymbolFlagsAlias != 0 {
-			aliasDecl := core.FirstOrNil(m.Declarations)
+			aliasDecl := b.ch.getDeclarationOfAliasSymbol(m)
 			target := b.ch.getMergedSymbol(b.ch.getTargetOfAliasDeclaration(aliasDecl))
 			if target != nil {
 				// If the alias target is a local symbol (not itself an export), emit its declaration first

--- a/internal/fourslash/tests/quickInfoVerbosityNamespaceBindingWithDefaultExportedFunction1_test.go
+++ b/internal/fourslash/tests/quickInfoVerbosityNamespaceBindingWithDefaultExportedFunction1_test.go
@@ -1,0 +1,24 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestQuickInfoVerbosityNamespaceBindingWithDefaultExportedFunction1(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `// @module: esnext
+// @filename: /a.ts
+export default function fn() {}
+export { fn as default };
+// @filename: /b.ts
+import * as ns from "./a";
+
+ns/*1*/;`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineHoverWithVerbosity(t, map[string][]int{"1": {0, 1}})
+}

--- a/testdata/baselines/reference/fourslash/quickInfo/quickInfoVerbosityNamespaceBindingWithDefaultExportedFunction1.baseline
+++ b/testdata/baselines/reference/fourslash/quickInfo/quickInfoVerbosityNamespaceBindingWithDefaultExportedFunction1.baseline
@@ -1,0 +1,86 @@
+// === QuickInfo ===
+=== /b.ts ===
+// import * as ns from "./a";
+// 
+// ns;
+// ^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (alias) module "/a" {
+// |     export { default };
+// | }
+// | ```
+// | 
+// | (verbosity level: 1)
+// | ----------------------------------------------------------------------
+// ^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (alias) module "./a"
+// | ```
+// | 
+// | (verbosity level: 0)
+// | ----------------------------------------------------------------------
+[
+  {
+    "marker": {
+      "Position": 30,
+      "LSPosition": {
+        "line": 2,
+        "character": 2
+      },
+      "Name": "1",
+      "Data": {}
+    },
+    "item": {
+      "hover": {
+        "contents": {
+          "kind": "markdown",
+          "value": "```typescript\n(alias) module \"./a\"\n```\n"
+        },
+        "range": {
+          "start": {
+            "line": 2,
+            "character": 0
+          },
+          "end": {
+            "line": 2,
+            "character": 2
+          }
+        },
+        "canIncreaseVerbosity": true
+      },
+      "verbosityLevel": 0
+    }
+  },
+  {
+    "marker": {
+      "Position": 30,
+      "LSPosition": {
+        "line": 2,
+        "character": 2
+      },
+      "Name": "1",
+      "Data": {}
+    },
+    "item": {
+      "hover": {
+        "contents": {
+          "kind": "markdown",
+          "value": "```typescript\n(alias) module \"/a\" {\n    export { default };\n}\n```\n"
+        },
+        "range": {
+          "start": {
+            "line": 2,
+            "character": 0
+          },
+          "end": {
+            "line": 2,
+            "character": 2
+          }
+        }
+      },
+      "verbosityLevel": 1
+    }
+  }
+]


### PR DESCRIPTION
fixes the crash found here: https://github.com/microsoft/typescript-go/issues/3512#issuecomment-4299730772