### PR TITLE
Add CLI and LSP attach to launch.template

### DIFF
--- a/.vscode/launch.template.json
+++ b/.vscode/launch.template.json
@@ -61,6 +61,29 @@
                 "-testDir",
                 "path_to_project_dir"
             ]
+        },
+        {
+            "name": "Launch tsgo CLI",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/cmd/tsgo",
+            "cwd": "${workspaceFolder}",
+            "args": "${input:tsgoArgs}"
+        },
+        {
+            "name": "Attach to Go process",
+            "type": "go",
+            "request": "attach",
+            "mode": "local",
+            "processId": "${command:pickGoProcess}"
+        }
+    ],
+    "inputs": [
+        {
+            "id": "tsgoArgs",
+            "type": "promptString",
+            "description": "Enter arguments for tsgo"
         }
     ]
 }


### PR DESCRIPTION
I’ve been sitting on these useful launch configurations for too long. This seems like a good time to add the attach configuration since #3516 makes it easy to get the PID of the LSP server you want to debug.

FWIW, in my own config, I use another input for all the test launchers instead of `fileBasename`, but I didn't add that here as it would surely break some people's muscle memory. But if anyone is interested:

```json5
{
    "version": "0.2.0",
    "configurations": [
        {
            "name": "Debug Test by Name",
            "type": "go",
            "request": "launch",
            "mode": "test",
            "program": "${fileDirname}",
            "env": {},
            "args": ["-test.run", "${input:testNamePattern}"]
        },
        {
            "name": "Launch submodule test",
            "type": "go",
            "request": "launch",
            "mode": "test",
            "program": "${workspaceFolder}/internal/testrunner",
            "args": [
                "-test.run",
                "TestSubmodule/${input:testNamePattern}",
            ]
        },
        {
            "name": "Launch local test",
            "type": "go",
            "request": "launch",
            "mode": "test",
            "program": "${workspaceFolder}/internal/testrunner",
            "args": [
                "-test.run",
                "TestLocal/${input:testNamePattern}",
            ]
        },
        // ...
    ],
    "inputs": [
        {
            "id": "testNamePattern",
            "type": "promptString",
            "description": "Enter a pattern matching test names to run",
            "default": "${fileBasenameNoExtension}"
        },
        // ...
    ]
}
```