### PR TITLE
Work around overzealous stack telemetry redaction

### DIFF
--- a/internal/lsp/stack_sanitizer.go
+++ b/internal/lsp/stack_sanitizer.go
@@ -11,7 +11,8 @@ import (
 // /(key|token|sig|secret|signature|password|passwd|pwd|android:value)[^a-zA-Z0-9]/i
 // as `<REDACTED: Generic Secret>`, which trips on innocuous Go frames like
 // `getSignatureHelp(`. Insert `X_X` after each trigger keyword to defeat the
-// regex; reverse with a `X_X` -> “ find-and-replace on the dashboard.
+// regex; reverse by removing the marker (replace `X_X` with the empty string)
+// on the dashboard.
 var genericSecretKeywordRegex = regexp.MustCompile(`(?i)(key|token|signature|sig|secret|password|passwd|pwd|android:value)([^a-zA-Z0-9])`)
 
 func defeatGenericSecretRegex(s string) string {

--- a/internal/lsp/stack_sanitizer.go
+++ b/internal/lsp/stack_sanitizer.go
@@ -10,10 +10,11 @@ import (
 // VS Code's telemetry pipeline redacts any string matching
 // /(key|token|sig|secret|signature|password|passwd|pwd|android:value)[^a-zA-Z0-9]/i
 // as `<REDACTED: Generic Secret>`, which trips on innocuous Go frames like
-// `getSignatureHelp(`. Insert `X_X` after each trigger keyword to defeat the
-// regex; reverse by removing the marker (replace `X_X` with the empty string)
-// on the dashboard.
-var genericSecretKeywordRegex = regexp.MustCompile(`(?i)(key|token|signature|sig|secret|password|passwd|pwd|android:value)([^a-zA-Z0-9])`)
+// `getSignatureHelp(`. Insert `X_X` after each trigger keyword that we know
+// can appear in our sanitized output, when followed by punctuation we
+// actually emit (`(`, `[`, `.`, `|`); reverse by removing the marker (replace
+// `X_X` with the empty string) on the dashboard.
+var genericSecretKeywordRegex = regexp.MustCompile(`(?i)(key|token|signature|sig|pwd)([(\[.|])`)
 
 func defeatGenericSecretRegex(s string) string {
 	return genericSecretKeywordRegex.ReplaceAllString(s, "${1}X_X${2}")

--- a/internal/lsp/stack_sanitizer.go
+++ b/internal/lsp/stack_sanitizer.go
@@ -1,10 +1,22 @@
 package lsp
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/microsoft/typescript-go/internal/core"
 )
+
+// VS Code's telemetry pipeline redacts any string matching
+// /(key|token|sig|secret|signature|password|passwd|pwd|android:value)[^a-zA-Z0-9]/i
+// as `<REDACTED: Generic Secret>`, which trips on innocuous Go frames like
+// `getSignatureHelp(`. Insert `X_X` after each trigger keyword to defeat the
+// regex; reverse with a `X_X` -> “ find-and-replace on the dashboard.
+var genericSecretKeywordRegex = regexp.MustCompile(`(?i)(key|token|signature|sig|secret|password|passwd|pwd|android:value)([^a-zA-Z0-9])`)
+
+func defeatGenericSecretRegex(s string) string {
+	return genericSecretKeywordRegex.ReplaceAllString(s, "${1}X_X${2}")
+}
 
 func sanitizeStackTrace(stack string) string {
 	// TODO: should we just look for the first '(' and
@@ -44,7 +56,7 @@ func sanitizeStackTrace(stack string) string {
 		}
 	}
 
-	return result.String()
+	return defeatGenericSecretRegex(result.String())
 }
 
 func writeSanitizedModuleOrPath(line string, result *strings.Builder) {

--- a/internal/lsp/stack_sanitizer_test.go
+++ b/internal/lsp/stack_sanitizer_test.go
@@ -41,7 +41,7 @@ github.com/microsoft/typescript-go/internal/lsp.(*Server).dispatchLoop.func1()
 created by github.com/microsoft/typescript-go/internal/lsp.(*Server).dispatchLoop in goroutine 19
         /workspaces/typescript-go/internal/lsp/server.go:438 +0x60`
 
-	baseline.Run(t, "completionsDebugStackTrace.md", sanitizedStackTraceBaselineContents(t, input), baseline.Options{
+	baseline.Run(t, "completionsDebugStackTrace.md", sanitizedStackTraceBaselineContents(t, input, sanitizeStackTrace(input)), baseline.Options{
 		Subfolder: "lsp/stackSanitizer/",
 	})
 }
@@ -78,19 +78,18 @@ github.com/microsoft/typescript-go/internal/lsp.(*Server).dispatchLoop.func1()
 created by github.com/microsoft/typescript-go/internal/lsp.(*Server).dispatchLoop in goroutine 35
 	github.com/microsoft/typescript-go/internal/lsp/server.go:438 +0x9f1`
 
-	baseline.Run(t, "completionsReleaseStackTrace.md", sanitizedStackTraceBaselineContents(t, input), baseline.Options{
+	baseline.Run(t, "completionsReleaseStackTrace.md", sanitizedStackTraceBaselineContents(t, input, sanitizeStackTrace(input)), baseline.Options{
 		Subfolder: "lsp/stackSanitizer/",
 	})
 }
 
-func sanitizedStackTraceBaselineContents(t *testing.T, input string) string {
+func sanitizedStackTraceBaselineContents(t *testing.T, input string, output string) string {
 	builder := strings.Builder{}
 	builder.WriteString("Test name: `")
 	builder.WriteString(t.Name())
 	builder.WriteString("`\n\n# Unsanitized input:\n\n````\n")
 	builder.WriteString(input)
 	builder.WriteString("\n````\n\n# Sanitized output:\n\n````\n")
-	output := sanitizeStackTrace(input)
 	builder.WriteString(output)
 	builder.WriteString("\n````\n")
 	return builder.String()
@@ -130,7 +129,7 @@ github.com/microsoft/typescript-go/internal/ls.setPwd(0x6)
 		t.Fatalf("sanitized stack trace would be redacted by VS Code's Generic Secret regex at %v: %q\nfull output:\n%s", loc, output[loc[0]:loc[1]], output)
 	}
 
-	baseline.Run(t, "genericSecretWorkaround.md", sanitizedStackTraceBaselineContents(t, input), baseline.Options{
+	baseline.Run(t, "genericSecretWorkaround.md", sanitizedStackTraceBaselineContents(t, input, output), baseline.Options{
 		Subfolder: "lsp/stackSanitizer/",
 	})
 }

--- a/internal/lsp/stack_sanitizer_test.go
+++ b/internal/lsp/stack_sanitizer_test.go
@@ -1,6 +1,7 @@
 package lsp
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
@@ -89,7 +90,47 @@ func sanitizedStackTraceBaselineContents(t *testing.T, input string) string {
 	builder.WriteString("`\n\n# Unsanitized input:\n\n````\n")
 	builder.WriteString(input)
 	builder.WriteString("\n````\n\n# Sanitized output:\n\n````\n")
-	builder.WriteString(sanitizeStackTrace(input))
+	output := sanitizeStackTrace(input)
+	builder.WriteString(output)
 	builder.WriteString("\n````\n")
 	return builder.String()
+}
+
+// Mirror of the "Generic Secret" pattern from VS Code's
+// removePropertiesWithPossibleUserInfo. If this matches the sanitized output,
+// VS Code's telemetry pipeline will replace the entire string with
+// `<REDACTED: Generic Secret>`, destroying the stack trace.
+var vscodeGenericSecretRegex = regexp.MustCompile(`(?i)(key|token|sig|secret|signature|password|passwd|pwd|android:value)[^a-zA-Z0-9]`)
+
+func TestSanitizedStackTraceDefeatsVSCodeGenericSecretRegex(t *testing.T) {
+	t.Parallel()
+
+	// Frame names contain identifiers that contain trigger keywords:
+	// `getSignatureHelp` (signature), `LookupKey` (key), `validateToken` (token),
+	// `signRequest` (sig), `loadSecretConfig` (secret), `setPwd` (pwd),
+	// and a file `signature.go`.
+	input := `goroutine 7 [running]:
+runtime/debug.Stack()
+	runtime/debug/stack.go:26 +0x5e
+github.com/microsoft/typescript-go/internal/ls.(*LanguageService).getSignatureHelp(0x1)
+	github.com/microsoft/typescript-go/internal/ls/signature.go:42 +0x10
+github.com/microsoft/typescript-go/internal/ls.LookupKey(0x2)
+	github.com/microsoft/typescript-go/internal/ls/keys.go:7 +0x10
+github.com/microsoft/typescript-go/internal/ls.validateToken(0x3)
+	github.com/microsoft/typescript-go/internal/ls/token.go:9 +0x10
+github.com/microsoft/typescript-go/internal/ls.signRequest(0x4)
+	github.com/microsoft/typescript-go/internal/ls/sig.go:11 +0x10
+github.com/microsoft/typescript-go/internal/ls.loadSecretConfig(0x5)
+	github.com/microsoft/typescript-go/internal/ls/secret.go:13 +0x10
+github.com/microsoft/typescript-go/internal/ls.setPwd(0x6)
+	github.com/microsoft/typescript-go/internal/ls/pwd.go:15 +0x10`
+
+	output := sanitizeStackTrace(input)
+	if loc := vscodeGenericSecretRegex.FindStringIndex(output); loc != nil {
+		t.Fatalf("sanitized stack trace would be redacted by VS Code's Generic Secret regex at %v: %q\nfull output:\n%s", loc, output[loc[0]:loc[1]], output)
+	}
+
+	baseline.Run(t, "genericSecretWorkaround.md", sanitizedStackTraceBaselineContents(t, input), baseline.Options{
+		Subfolder: "lsp/stackSanitizer/",
+	})
 }

--- a/internal/lsp/stack_sanitizer_test.go
+++ b/internal/lsp/stack_sanitizer_test.go
@@ -106,8 +106,7 @@ func TestSanitizedStackTraceDefeatsVSCodeGenericSecretRegex(t *testing.T) {
 
 	// Frame names contain identifiers that contain trigger keywords:
 	// `getSignatureHelp` (signature), `LookupKey` (key), `validateToken` (token),
-	// `signRequest` (sig), `loadSecretConfig` (secret), `setPwd` (pwd),
-	// and a file `signature.go`.
+	// `signRequest` (sig), `setPwd` (pwd), and a file `signature.go`.
 	input := `goroutine 7 [running]:
 runtime/debug.Stack()
 	runtime/debug/stack.go:26 +0x5e
@@ -119,10 +118,8 @@ github.com/microsoft/typescript-go/internal/ls.validateToken(0x3)
 	github.com/microsoft/typescript-go/internal/ls/token.go:9 +0x10
 github.com/microsoft/typescript-go/internal/ls.signRequest(0x4)
 	github.com/microsoft/typescript-go/internal/ls/sig.go:11 +0x10
-github.com/microsoft/typescript-go/internal/ls.loadSecretConfig(0x5)
-	github.com/microsoft/typescript-go/internal/ls/secret.go:13 +0x10
-github.com/microsoft/typescript-go/internal/ls.setPwd(0x6)
-	github.com/microsoft/typescript-go/internal/ls/pwd.go:15 +0x10`
+github.com/microsoft/typescript-go/internal/ls.setPwd(0x5)
+	github.com/microsoft/typescript-go/internal/ls/pwd.go:13 +0x10`
 
 	output := sanitizeStackTrace(input)
 	if loc := vscodeGenericSecretRegex.FindStringIndex(output); loc != nil {

--- a/testdata/baselines/reference/lsp/stackSanitizer/genericSecretWorkaround.md
+++ b/testdata/baselines/reference/lsp/stackSanitizer/genericSecretWorkaround.md
@@ -14,10 +14,8 @@ github.com/microsoft/typescript-go/internal/ls.validateToken(0x3)
 	github.com/microsoft/typescript-go/internal/ls/token.go:9 +0x10
 github.com/microsoft/typescript-go/internal/ls.signRequest(0x4)
 	github.com/microsoft/typescript-go/internal/ls/sig.go:11 +0x10
-github.com/microsoft/typescript-go/internal/ls.loadSecretConfig(0x5)
-	github.com/microsoft/typescript-go/internal/ls/secret.go:13 +0x10
-github.com/microsoft/typescript-go/internal/ls.setPwd(0x6)
-	github.com/microsoft/typescript-go/internal/ls/pwd.go:15 +0x10
+github.com/microsoft/typescript-go/internal/ls.setPwd(0x5)
+	github.com/microsoft/typescript-go/internal/ls/pwd.go:13 +0x10
 ````
 
 # Sanitized output:
@@ -33,8 +31,6 @@ typescript-go|>internal|>ls.validateTokenX_X()
 	typescript-go|>internal|>ls|>tokenX_X.go:9
 typescript-go|>internal|>ls.signRequest()
 	typescript-go|>internal|>ls|>sigX_X.go:11
-typescript-go|>internal|>ls.loadSecretConfig()
-	typescript-go|>internal|>ls|>secretX_X.go:13
 typescript-go|>internal|>ls.setPwdX_X()
-	typescript-go|>internal|>ls|>pwdX_X.go:15
+	typescript-go|>internal|>ls|>pwdX_X.go:13
 ````

--- a/testdata/baselines/reference/lsp/stackSanitizer/genericSecretWorkaround.md
+++ b/testdata/baselines/reference/lsp/stackSanitizer/genericSecretWorkaround.md
@@ -1,0 +1,40 @@
+Test name: `TestSanitizedStackTraceDefeatsVSCodeGenericSecretRegex`
+
+# Unsanitized input:
+
+````
+goroutine 7 [running]:
+runtime/debug.Stack()
+	runtime/debug/stack.go:26 +0x5e
+github.com/microsoft/typescript-go/internal/ls.(*LanguageService).getSignatureHelp(0x1)
+	github.com/microsoft/typescript-go/internal/ls/signature.go:42 +0x10
+github.com/microsoft/typescript-go/internal/ls.LookupKey(0x2)
+	github.com/microsoft/typescript-go/internal/ls/keys.go:7 +0x10
+github.com/microsoft/typescript-go/internal/ls.validateToken(0x3)
+	github.com/microsoft/typescript-go/internal/ls/token.go:9 +0x10
+github.com/microsoft/typescript-go/internal/ls.signRequest(0x4)
+	github.com/microsoft/typescript-go/internal/ls/sig.go:11 +0x10
+github.com/microsoft/typescript-go/internal/ls.loadSecretConfig(0x5)
+	github.com/microsoft/typescript-go/internal/ls/secret.go:13 +0x10
+github.com/microsoft/typescript-go/internal/ls.setPwd(0x6)
+	github.com/microsoft/typescript-go/internal/ls/pwd.go:15 +0x10
+````
+
+# Sanitized output:
+
+````
+(REDACTED FRAME)
+	(REDACTED FRAME)
+typescript-go|>internal|>ls.(*LanguageService).getSignatureHelp()
+	typescript-go|>internal|>ls|>signatureX_X.go:42
+typescript-go|>internal|>ls.LookupKeyX_X()
+	typescript-go|>internal|>ls|>keys.go:7
+typescript-go|>internal|>ls.validateTokenX_X()
+	typescript-go|>internal|>ls|>tokenX_X.go:9
+typescript-go|>internal|>ls.signRequest()
+	typescript-go|>internal|>ls|>sigX_X.go:11
+typescript-go|>internal|>ls.loadSecretConfig()
+	typescript-go|>internal|>ls|>secretX_X.go:13
+typescript-go|>internal|>ls.setPwdX_X()
+	typescript-go|>internal|>ls|>pwdX_X.go:15
+````


### PR DESCRIPTION
Work around an overzealous regex in the VS Code telemetry client that would redact the entire thing because it contains a string like `getSignature(` or `GeyKey(`.