### PR TITLE
feat(checker): strictArrayVariance flag — invariant mutable Array<T> element type (DRAFT for post-7.0 discussion)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -112,6 +112,12 @@ Corsa no longer parses the following JSDoc tags with a specific node type. They 
 
 ## Checker
 
+### `strictArrayVariance`
+
+When `--strictArrayVariance` / `"strictArrayVariance": true` is set, relating two `Array<T>` instantiations treats `T` as **invariant** instead of covariant. Mutable tuple element positions are likewise treated as invariant at their fixed positions. That rejects unsound assignments such as passing `string[]` where `(string | number)[]` is expected, or `[string, string]` where `[string | number, string]` is expected, when the callee could mutate the argument. `ReadonlyArray<T>` and `readonly` tuples are unchanged (still covariant). The option defaults to **off** so behavior matches TypeScript 6.0 unless you opt in.
+
+When the check rejects a call or assignment, the diagnostic chain includes a dedicated hint suggesting `ReadonlyArray<T>` at the parameter type (if reads suffice), or declaring the source with the wider element type when a mutating callee is genuinely intended.
+
 ### Miscellaneous
 
 #### With `"strict": false`, Corsa no longer allows omitting arguments for parameters with type `undefined`, `unknown`, or `any`:

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -601,6 +601,7 @@ type Checker struct {
 	strictBindCallApply                         bool
 	strictPropertyInitialization                bool
 	strictBuiltinIteratorReturn                 bool
+	strictArrayVariance                         bool
 	noImplicitAny                               bool
 	noImplicitThis                              bool
 	useUnknownInCatchVariables                  bool
@@ -609,6 +610,7 @@ type Checker struct {
 	wasCanceled                                 bool
 	saveDeferredDiagnostics                     bool
 	arrayVariances                              []VarianceFlags
+	strictInvariantTupleVariances               map[int][]VarianceFlags
 	globals                                     ast.SymbolTable
 	evaluate                                    evaluator.Evaluator
 	stringLiteralTypes                          map[string]*Type
@@ -908,12 +910,17 @@ func NewChecker(program Program) (*Checker, *sync.Mutex) {
 	c.strictBindCallApply = c.compilerOptions.GetStrictOptionValue(c.compilerOptions.StrictBindCallApply)
 	c.strictPropertyInitialization = c.compilerOptions.GetStrictOptionValue(c.compilerOptions.StrictPropertyInitialization)
 	c.strictBuiltinIteratorReturn = c.compilerOptions.GetStrictOptionValue(c.compilerOptions.StrictBuiltinIteratorReturn)
+	// Off unless explicitly enabled: do not tie to `--strict` (too breaking vs TS 6.0 behavior).
+	c.strictArrayVariance = c.compilerOptions.StrictArrayVariance == core.TSTrue
 	c.noImplicitAny = c.compilerOptions.GetStrictOptionValue(c.compilerOptions.NoImplicitAny)
 	c.noImplicitThis = c.compilerOptions.GetStrictOptionValue(c.compilerOptions.NoImplicitThis)
 	c.useUnknownInCatchVariables = c.compilerOptions.GetStrictOptionValue(c.compilerOptions.UseUnknownInCatchVariables)
 	c.exactOptionalPropertyTypes = c.compilerOptions.ExactOptionalPropertyTypes == core.TSTrue
 	c.canCollectSymbolAliasAccessibilityData = c.compilerOptions.VerbatimModuleSyntax.IsFalseOrUnknown()
 	c.arrayVariances = []VarianceFlags{VarianceFlagsCovariant}
+	if c.strictArrayVariance {
+		c.strictInvariantTupleVariances = make(map[int][]VarianceFlags)
+	}
 	c.globals = make(ast.SymbolTable, countGlobalSymbols(c.files))
 	c.evaluate = evaluator.NewEvaluator(c.evaluateEntity, ast.OEKParentheses)
 	c.stringLiteralTypes = make(map[string]*Type)

--- a/internal/checker/relater.go
+++ b/internal/checker/relater.go
@@ -115,6 +115,10 @@ func (r *Relation) size() int {
 	return len(r.results)
 }
 
+// Single-element variances for global Array<T> when strictArrayVariance is enabled.
+// Treated as immutable — do not mutate.
+var invariantArrayElementVariances = []VarianceFlags{VarianceFlagsInvariant}
+
 func (c *Checker) isTypeIdenticalTo(source *Type, target *Type) bool {
 	return c.isTypeRelatedTo(source, target, c.identityRelation)
 }
@@ -1315,10 +1319,44 @@ func (c *Checker) typeCouldHaveTopLevelSingletonTypes(t *Type) bool {
 
 func (c *Checker) getVariances(t *Type) []VarianceFlags {
 	// Arrays and tuples are known to be covariant, no need to spend time computing this.
-	if t == c.globalArrayType || t == c.globalReadonlyArrayType || t.objectFlags&ObjectFlagsTuple != 0 {
+	// Mutable `Array<T>` and mutable tuples are unsound if treated covariantly when the
+	// reference may be mutated (e.g. passing `string[]` where `(string|number)[]` is
+	// expected, or `[string, string]` where `[string|number, string]` is expected, and
+	// the callee then writes). Optional strict mode treats their element parameters as
+	// invariant; `ReadonlyArray` and readonly tuples stay covariant.
+	if t == c.globalArrayType {
+		if c.strictArrayVariance {
+			return invariantArrayElementVariances
+		}
+		return c.arrayVariances
+	}
+	if t.objectFlags&ObjectFlagsTuple != 0 {
+		if c.strictArrayVariance && !t.AsTupleType().readonly {
+			return c.getStrictInvariantTupleVariances(len(t.AsInterfaceType().TypeParameters()))
+		}
+		return c.arrayVariances
+	}
+	if t == c.globalReadonlyArrayType {
 		return c.arrayVariances
 	}
 	return c.getVariancesWorker(t.symbol, t.AsInterfaceType().TypeParameters())
+}
+
+// getStrictInvariantTupleVariances returns a slice of `n` invariant variance flags.
+// The returned slice is cached per-arity on the Checker and must not be mutated.
+func (c *Checker) getStrictInvariantTupleVariances(n int) []VarianceFlags {
+	if n <= 1 {
+		return invariantArrayElementVariances[:max(n, 0):max(n, 0)]
+	}
+	if v, ok := c.strictInvariantTupleVariances[n]; ok {
+		return v
+	}
+	v := make([]VarianceFlags, n)
+	for i := range v {
+		v[i] = VarianceFlagsInvariant
+	}
+	c.strictInvariantTupleVariances[n] = v
+	return v
 }
 
 func (c *Checker) getAliasVariances(symbol *ast.Symbol) []VarianceFlags {
@@ -4144,6 +4182,18 @@ func (r *Relater) propertiesRelatedTo(source *Type, target *Type, reportErrors b
 					targetCheckType = r.c.removeMissingType(targetType, targetFlags&ElementFlagsOptional != 0)
 				}
 				related := r.isRelatedToEx(sourceType, targetCheckType, RecursionFlagsBoth, reportErrors, nil /*headMessage*/, intersectionState)
+				// Under --strictArrayVariance, mutable tuple fixed-element positions are invariant:
+				// the callee can do `xs[i] = U`, so the caller's element type must equal the target's.
+				// Only apply this check when the target tuple is mutable and both positions are fixed
+				// (required/optional); rest/variadic positions are handled via their own array/variadic
+				// paths which already go through globalArrayType variance.
+				if related != TernaryFalse &&
+					r.c.strictArrayVariance &&
+					!target.TargetTupleType().readonly &&
+					sourceFlags&ElementFlagsFixed != 0 &&
+					targetFlags&ElementFlagsFixed != 0 {
+					related &= r.isRelatedToEx(targetCheckType, sourceType, RecursionFlagsBoth, false /*reportErrors*/, nil /*headMessage*/, intersectionState)
+				}
 				if related == TernaryFalse {
 					if reportErrors && (targetArity > 1 || sourceArity > 1) {
 						if targetHasRestElement && sourcePosition >= targetStartCount && sourcePositionFromEnd >= targetEndCount && targetStartCount != sourceArity-targetEndCount-1 {
@@ -4336,6 +4386,29 @@ func (r *Relater) tryElaborateArrayLikeErrors(source *Type, target *Type, report
 		return r.c.isArrayType(source)
 	}
 	return true
+}
+
+// tryElaborateStrictArrayVarianceHint appends a user-facing hint when two
+// same-target mutable-array-like instantiations fail to relate and the
+// failure is specifically caused by `--strictArrayVariance` making the
+// element type invariant. It is a no-op when the flag is off.
+func (r *Relater) tryElaborateStrictArrayVarianceHint(source *Type, target *Type) {
+	if !r.c.strictArrayVariance {
+		return
+	}
+	if source.objectFlags&ObjectFlagsReference == 0 || target.objectFlags&ObjectFlagsReference == 0 {
+		return
+	}
+	if source.Target() != target.Target() {
+		return
+	}
+	t := source.Target()
+	isArray := t == r.c.globalArrayType
+	isMutableTuple := t.objectFlags&ObjectFlagsTuple != 0 && !t.AsTupleType().readonly
+	if !isArray && !isMutableTuple {
+		return
+	}
+	r.reportError(diagnostics.Under_strictArrayVariance_the_element_type_of_mutable_Array_and_mutable_tuples_is_invariant_Use_ReadonlyArray_at_the_parameter_type_if_reads_suffice_or_declare_the_source_as_the_wider_element_type)
 }
 
 func (r *Relater) tryElaborateErrorsForPrimitivesAndObjects(source *Type, target *Type) {
@@ -4646,6 +4719,7 @@ func (r *Relater) reportErrorResults(originalSource *Type, originalTarget *Type,
 	}
 	if source.flags&TypeFlagsObject != 0 && target.flags&TypeFlagsObject != 0 {
 		r.tryElaborateArrayLikeErrors(source, target, true /*reportErrors*/)
+		r.tryElaborateStrictArrayVarianceHint(source, target)
 	}
 	switch {
 	case source.flags&TypeFlagsObject != 0 && target.flags&TypeFlagsPrimitive != 0:

--- a/internal/core/compileroptions.go
+++ b/internal/core/compileroptions.go
@@ -97,6 +97,7 @@ type CompilerOptions struct {
 	SkipLibCheck                              Tristate                                  `json:"skipLibCheck,omitzero"`
 	StableTypeOrdering                        Tristate                                  `json:"stableTypeOrdering,omitzero"`
 	Strict                                    Tristate                                  `json:"strict,omitzero"`
+	StrictArrayVariance                       Tristate                                  `json:"strictArrayVariance,omitzero"`
 	StrictBindCallApply                       Tristate                                  `json:"strictBindCallApply,omitzero"`
 	StrictBuiltinIteratorReturn               Tristate                                  `json:"strictBuiltinIteratorReturn,omitzero"`
 	StrictFunctionTypes                       Tristate                                  `json:"strictFunctionTypes,omitzero"`

--- a/internal/core/compileroptions_strictarrayvariance_json_test.go
+++ b/internal/core/compileroptions_strictarrayvariance_json_test.go
@@ -1,0 +1,43 @@
+package core
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestCompilerOptionsJSONStrictArrayVariance(t *testing.T) {
+	t.Parallel()
+
+	t.Run("TSUnknown omits strictArrayVariance key", func(t *testing.T) {
+		t.Parallel()
+		o := CompilerOptions{Strict: TSTrue}
+		b, err := json.Marshal(&o)
+		assert.NilError(t, err)
+		assert.Assert(t, !strings.Contains(string(b), "strictArrayVariance"), "json: %s", string(b))
+	})
+
+	t.Run("TSTrue encodes and roundtrips", func(t *testing.T) {
+		t.Parallel()
+		o := CompilerOptions{StrictArrayVariance: TSTrue}
+		b, err := json.Marshal(&o)
+		assert.NilError(t, err)
+		assert.Assert(t, strings.Contains(string(b), `"strictArrayVariance":true`), "json: %s", string(b))
+		var out CompilerOptions
+		assert.NilError(t, json.Unmarshal(b, &out))
+		assert.Equal(t, TSTrue, out.StrictArrayVariance)
+	})
+
+	t.Run("TSFalse encodes and roundtrips", func(t *testing.T) {
+		t.Parallel()
+		o := CompilerOptions{StrictArrayVariance: TSFalse}
+		b, err := json.Marshal(&o)
+		assert.NilError(t, err)
+		assert.Assert(t, strings.Contains(string(b), `"strictArrayVariance":false`), "json: %s", string(b))
+		var out CompilerOptions
+		assert.NilError(t, json.Unmarshal(b, &out))
+		assert.Equal(t, TSFalse, out.StrictArrayVariance)
+	})
+}

--- a/internal/diagnostics/diagnostics_generated.go
+++ b/internal/diagnostics/diagnostics_generated.go
@@ -4308,6 +4308,10 @@ var Remove_Unused_Imports = &Message{code: 100017, category: CategoryMessage, ke
 
 var Sort_Imports = &Message{code: 100018, category: CategoryMessage, key: "Sort_Imports_100018", text: "Sort Imports"}
 
+var Treat_Array_element_types_as_invariant_when_comparing_instantiations = &Message{code: 100019, category: CategoryMessage, key: "Treat_Array_element_types_as_invariant_when_comparing_instantiations_100019", text: "Treat Array element types as invariant when comparing instantiations."}
+
+var Under_strictArrayVariance_the_element_type_of_mutable_Array_and_mutable_tuples_is_invariant_Use_ReadonlyArray_at_the_parameter_type_if_reads_suffice_or_declare_the_source_as_the_wider_element_type = &Message{code: 100020, category: CategoryError, key: "Under_strictArrayVariance_the_element_type_of_mutable_Array_and_mutable_tuples_is_invariant_Use_Read_100020", text: "Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type."}
+
 func keyToMessage(key Key) *Message {
 	switch key {
 	case "Unterminated_string_literal_1002":
@@ -8616,6 +8620,10 @@ func keyToMessage(key Key) *Message {
 		return Remove_Unused_Imports
 	case "Sort_Imports_100018":
 		return Sort_Imports
+	case "Treat_Array_element_types_as_invariant_when_comparing_instantiations_100019":
+		return Treat_Array_element_types_as_invariant_when_comparing_instantiations
+	case "Under_strictArrayVariance_the_element_type_of_mutable_Array_and_mutable_tuples_is_invariant_Use_Read_100020":
+		return Under_strictArrayVariance_the_element_type_of_mutable_Array_and_mutable_tuples_is_invariant_Use_ReadonlyArray_at_the_parameter_type_if_reads_suffice_or_declare_the_source_as_the_wider_element_type
 	default:
 		return nil
 	}

--- a/internal/diagnostics/extraDiagnosticMessages.json
+++ b/internal/diagnostics/extraDiagnosticMessages.json
@@ -126,5 +126,13 @@
     "File rename is not supported by the editor": {
         "category": "Error",
         "code": 8040
+    },
+    "Treat Array element types as invariant when comparing instantiations.": {
+        "category": "Message",
+        "code": 100019
+    },
+    "Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.": {
+        "category": "Error",
+        "code": 100020
     }
 }

--- a/internal/execute/tsc/help.go
+++ b/internal/execute/tsc/help.go
@@ -30,7 +30,9 @@ func getOptionsForHelp(commandLine *tsoptions.ParsedCommandLine) []*tsoptions.Co
 	opts = append(opts, &tsoptions.TscBuildOption)
 
 	if commandLine.CompilerOptions().All.IsTrue() {
-		slices.SortFunc(opts, func(a, b *tsoptions.CommandLineOption) int {
+		// Stable sort so options with equal names (e.g. aliases `--help, -h` and
+		// `--help, -?`) keep their declaration order.
+		slices.SortStableFunc(opts, func(a, b *tsoptions.CommandLineOption) int {
 			return strings.Compare(strings.ToLower(a.Name), strings.ToLower(b.Name))
 		})
 		return opts

--- a/internal/project/session.go
+++ b/internal/project/session.go
@@ -705,6 +705,7 @@ func (s *Session) collectProjectInfoTelemetry(project *Project) lsproto.Telemetr
 	setTristate(compilerOptions, "noImplicitThis", opts.NoImplicitThis)
 	setTristate(compilerOptions, "strictNullChecks", opts.StrictNullChecks)
 	setTristate(compilerOptions, "strictFunctionTypes", opts.StrictFunctionTypes)
+	setTristate(compilerOptions, "strictArrayVariance", opts.StrictArrayVariance)
 	setTristate(compilerOptions, "strictBindCallApply", opts.StrictBindCallApply)
 	setTristate(compilerOptions, "strictPropertyInitialization", opts.StrictPropertyInitialization)
 	setTristate(compilerOptions, "strictBuiltinIteratorReturn", opts.StrictBuiltinIteratorReturn)

--- a/internal/project/session_collect_telemetry_test.go
+++ b/internal/project/session_collect_telemetry_test.go
@@ -1,0 +1,99 @@
+package project
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/compiler"
+	"github.com/microsoft/typescript-go/internal/core"
+	"github.com/microsoft/typescript-go/internal/tsoptions"
+	"github.com/microsoft/typescript-go/internal/tspath"
+	"gotest.tools/v3/assert"
+)
+
+func TestCollectProjectInfoTelemetryStrictArrayVariance(t *testing.T) {
+	t.Parallel()
+
+	cmp := tspath.ComparePathsOptions{
+		UseCaseSensitiveFileNames: true,
+		CurrentDirectory:          "/tmp",
+	}
+
+	t.Run("true is serialized in compilerOptions", func(t *testing.T) {
+		t.Parallel()
+		co := &core.CompilerOptions{StrictArrayVariance: core.TSTrue}
+		cmd := tsoptions.NewParsedCommandLine(co, nil, cmp)
+		proj := &Project{
+			Kind:           KindConfigured,
+			configFileName: "/tmp/tsconfig.json",
+			CommandLine:    cmd,
+			Program:        &compiler.Program{},
+		}
+		var s Session
+		ev := s.collectProjectInfoTelemetry(proj)
+		assert.Assert(t, ev.ProjectInfoTelemetryEvent != nil)
+		raw := ev.ProjectInfoTelemetryEvent.Properties["compilerOptions"]
+		var m map[string]any
+		assert.NilError(t, json.Unmarshal([]byte(raw), &m))
+		assert.Equal(t, true, m["strictArrayVariance"])
+	})
+
+	t.Run("false is serialized in compilerOptions", func(t *testing.T) {
+		t.Parallel()
+		co := &core.CompilerOptions{StrictArrayVariance: core.TSFalse}
+		cmd := tsoptions.NewParsedCommandLine(co, nil, cmp)
+		proj := &Project{
+			Kind:           KindConfigured,
+			configFileName: "/tmp/tsconfig.json",
+			CommandLine:    cmd,
+			Program:        &compiler.Program{},
+		}
+		var s Session
+		ev := s.collectProjectInfoTelemetry(proj)
+		assert.Assert(t, ev.ProjectInfoTelemetryEvent != nil)
+		raw := ev.ProjectInfoTelemetryEvent.Properties["compilerOptions"]
+		var m map[string]any
+		assert.NilError(t, json.Unmarshal([]byte(raw), &m))
+		assert.Equal(t, false, m["strictArrayVariance"])
+	})
+
+	t.Run("unknown is omitted from compilerOptions", func(t *testing.T) {
+		t.Parallel()
+		co := &core.CompilerOptions{Strict: core.TSTrue}
+		cmd := tsoptions.NewParsedCommandLine(co, nil, cmp)
+		proj := &Project{
+			Kind:           KindConfigured,
+			configFileName: "/tmp/tsconfig.json",
+			CommandLine:    cmd,
+			Program:        &compiler.Program{},
+		}
+		var s Session
+		ev := s.collectProjectInfoTelemetry(proj)
+		assert.Assert(t, ev.ProjectInfoTelemetryEvent != nil)
+		raw := ev.ProjectInfoTelemetryEvent.Properties["compilerOptions"]
+		var m map[string]any
+		assert.NilError(t, json.Unmarshal([]byte(raw), &m))
+		_, ok := m["strictArrayVariance"]
+		assert.Assert(t, !ok, "strictArrayVariance should be absent when Tristate is unknown")
+	})
+
+	t.Run("jsconfig.json sets configFileName telemetry bucket", func(t *testing.T) {
+		t.Parallel()
+		co := &core.CompilerOptions{StrictArrayVariance: core.TSTrue}
+		cmd := tsoptions.NewParsedCommandLine(co, nil, cmp)
+		proj := &Project{
+			Kind:           KindConfigured,
+			configFileName: "/tmp/jsconfig.json",
+			CommandLine:    cmd,
+			Program:        &compiler.Program{},
+		}
+		var s Session
+		ev := s.collectProjectInfoTelemetry(proj)
+		assert.Assert(t, ev.ProjectInfoTelemetryEvent != nil)
+		assert.Equal(t, "jsconfig.json", ev.ProjectInfoTelemetryEvent.Properties["configFileName"])
+		raw := ev.ProjectInfoTelemetryEvent.Properties["compilerOptions"]
+		var m map[string]any
+		assert.NilError(t, json.Unmarshal([]byte(raw), &m))
+		assert.Equal(t, true, m["strictArrayVariance"])
+	})
+}

--- a/internal/testrunner/compiler_varyby_strictarrayvariance_test.go
+++ b/internal/testrunner/compiler_varyby_strictarrayvariance_test.go
@@ -1,0 +1,13 @@
+package testrunner
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestCompilerVaryByIncludesStrictArrayVariance(t *testing.T) {
+	t.Parallel()
+	_, ok := compilerVaryBy["strictarrayvariance"]
+	assert.Assert(t, ok, "strictArrayVariance must stay in compilerVaryBy so // @strictArrayVariance: ... works in compiler baselines")
+}

--- a/internal/tsoptions/decls_test.go
+++ b/internal/tsoptions/decls_test.go
@@ -74,6 +74,31 @@ func checkCompilerOptionJsonTagName(t *testing.T, field reflect.StructField, nam
 	want := name + ",omitzero"
 	got := field.Tag.Get("json")
 	if got != want {
-		t.Errorf("Field %s has json tag %s, but the option declaration has name %s", field.Name, got, want)
+		t.Errorf("Field %s has json tag %s, but the option declaration has name %s", field.Name, got, name)
 	}
+}
+
+func TestStrictArrayVarianceOptionDeclarationShape(t *testing.T) {
+	t.Parallel()
+
+	var opt *tsoptions.CommandLineOption
+	for _, o := range tsoptions.OptionsDeclarations {
+		if o.Name == "strictArrayVariance" {
+			opt = o
+			break
+		}
+	}
+	if opt == nil {
+		t.Fatal("strictArrayVariance missing from OptionsDeclarations")
+	}
+	if opt.Kind != tsoptions.CommandLineOptionTypeBoolean {
+		t.Errorf("strictArrayVariance kind = %v, want boolean", opt.Kind)
+	}
+	if opt.IsCommandLineOnly || opt.IsTSConfigOnly {
+		t.Errorf("strictArrayVariance should be a normal compiler option (CLI + tsconfig), got IsCommandLineOnly=%v IsTSConfigOnly=%v", opt.IsCommandLineOnly, opt.IsTSConfigOnly)
+	}
+	if !opt.AffectsSemanticDiagnostics || !opt.AffectsBuildInfo {
+		t.Errorf("strictArrayVariance should affect semantic diagnostics and build info, got semantic=%v buildInfo=%v", opt.AffectsSemanticDiagnostics, opt.AffectsBuildInfo)
+	}
+	// strictFlag must stay false in declscompiler.go so `--strict` does not enable this option.
 }

--- a/internal/tsoptions/declscompiler.go
+++ b/internal/tsoptions/declscompiler.go
@@ -572,6 +572,17 @@ var optionsForCompiler = []*CommandLineOption{
 		DefaultValueDescription:    diagnostics.X_true_unless_strict_is_false,
 	},
 	{
+		Name:                       "strictArrayVariance",
+		Kind:                       CommandLineOptionTypeBoolean,
+		AffectsSemanticDiagnostics: true,
+		AffectsBuildInfo:           true,
+		// strictFlag intentionally omitted: this option is explicit opt-in and is NOT implied by --strict.
+		// Guarded by strictarrayvariance_test.go: TestStrictArrayVarianceCommandLine/"strict does not enable strictArrayVariance".
+		Category:                diagnostics.Type_Checking,
+		Description:             diagnostics.Treat_Array_element_types_as_invariant_when_comparing_instantiations,
+		DefaultValueDescription: false,
+	},
+	{
 		Name:                       "strictBindCallApply",
 		Kind:                       CommandLineOptionTypeBoolean,
 		AffectsSemanticDiagnostics: true,

--- a/internal/tsoptions/parsinghelpers.go
+++ b/internal/tsoptions/parsinghelpers.go
@@ -381,6 +381,8 @@ func parseCompilerOptions(key string, value any, allOptions *core.CompilerOption
 		allOptions.StableTypeOrdering = ParseTristate(value)
 	case "strict":
 		allOptions.Strict = ParseTristate(value)
+	case "strictArrayVariance":
+		allOptions.StrictArrayVariance = ParseTristate(value)
 	case "strictBindCallApply":
 		allOptions.StrictBindCallApply = ParseTristate(value)
 	case "strictBuiltinIteratorReturn":

--- a/internal/tsoptions/strictarrayvariance_test.go
+++ b/internal/tsoptions/strictarrayvariance_test.go
@@ -1,0 +1,388 @@
+package tsoptions_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/collections"
+	"github.com/microsoft/typescript-go/internal/core"
+	"github.com/microsoft/typescript-go/internal/diagnostics"
+	"github.com/microsoft/typescript-go/internal/tspath"
+	"github.com/microsoft/typescript-go/internal/tsoptions"
+	"github.com/microsoft/typescript-go/internal/tsoptions/tsoptionstest"
+	"gotest.tools/v3/assert"
+)
+
+func parseTsconfigAtWork(t *testing.T, host *tsoptionstest.VfsParseConfigHost, jsonText string) *tsoptions.ParsedCommandLine {
+	t.Helper()
+	const basePath = "/work"
+	configFileName := "/work/tsconfig.json"
+	path := tspath.ToPath(configFileName, basePath, true)
+	parsed, parseErrs := tsoptions.ParseConfigFileTextToJson(configFileName, path, jsonText)
+	assert.Assert(t, len(parseErrs) == 0, "ParseConfigFileTextToJson: %v", parseErrs)
+	return tsoptions.ParseJsonConfigFileContent(parsed, host, basePath, nil, configFileName, nil, nil, nil)
+}
+
+func parseJsconfigAtWork(t *testing.T, host *tsoptionstest.VfsParseConfigHost, jsonText string) *tsoptions.ParsedCommandLine {
+	t.Helper()
+	const basePath = "/work"
+	configFileName := "/work/jsconfig.json"
+	path := tspath.ToPath(configFileName, basePath, true)
+	parsed, parseErrs := tsoptions.ParseConfigFileTextToJson(configFileName, path, jsonText)
+	assert.Assert(t, len(parseErrs) == 0, "ParseConfigFileTextToJson: %v", parseErrs)
+	return tsoptions.ParseJsonConfigFileContent(parsed, host, basePath, nil, configFileName, nil, nil, nil)
+}
+
+func TestStrictArrayVarianceCommandLine(t *testing.T) {
+	t.Parallel()
+
+	host := tsoptionstest.NewVFSParseConfigHost(map[string]string{
+		"/proj/0.ts": "",
+	}, "/proj", true)
+
+	t.Run("explicit false", func(t *testing.T) {
+		t.Parallel()
+		res := tsoptions.ParseCommandLine([]string{"--strictArrayVariance", "false", "0.ts"}, host)
+		assert.Assert(t, len(res.Errors) == 0, "got errors: %v", res.Errors)
+		assert.Equal(t, core.TSFalse, res.CompilerOptions().StrictArrayVariance)
+	})
+
+	t.Run("explicit true", func(t *testing.T) {
+		t.Parallel()
+		res := tsoptions.ParseCommandLine([]string{"--strictArrayVariance", "true", "0.ts"}, host)
+		assert.Assert(t, len(res.Errors) == 0, "got errors: %v", res.Errors)
+		assert.Equal(t, core.TSTrue, res.CompilerOptions().StrictArrayVariance)
+	})
+
+	t.Run("implicit true", func(t *testing.T) {
+		t.Parallel()
+		res := tsoptions.ParseCommandLine([]string{"--strictArrayVariance"}, host)
+		assert.Assert(t, len(res.Errors) == 0, "got errors: %v", res.Errors)
+		assert.Equal(t, core.TSTrue, res.CompilerOptions().StrictArrayVariance)
+	})
+
+	t.Run("strict does not enable strictArrayVariance", func(t *testing.T) {
+		t.Parallel()
+		res := tsoptions.ParseCommandLine([]string{"--strict", "0.ts"}, host)
+		assert.Assert(t, len(res.Errors) == 0, "got errors: %v", res.Errors)
+		assert.Equal(t, core.TSTrue, res.CompilerOptions().Strict)
+		assert.Equal(t, core.TSUnknown, res.CompilerOptions().StrictArrayVariance)
+	})
+
+	t.Run("non true false literal sets true and does not consume next token as flag value", func(t *testing.T) {
+		t.Parallel()
+		h := tsoptionstest.NewVFSParseConfigHost(map[string]string{
+			"/proj/0.ts":  "",
+			"/proj/maybe": "",
+		}, "/proj", true)
+		res := tsoptions.ParseCommandLine([]string{"--strictArrayVariance", "maybe", "0.ts"}, h)
+		assert.Assert(t, len(res.Errors) == 0, "got errors: %v", res.Errors)
+		assert.Equal(t, core.TSTrue, res.CompilerOptions().StrictArrayVariance)
+		assert.DeepEqual(t, []string{"maybe", "0.ts"}, res.FileNames())
+	})
+}
+
+func TestStrictArrayVarianceTsConfigJson(t *testing.T) {
+	t.Parallel()
+
+	t.Run("compilerOptions.strictArrayVariance true", func(t *testing.T) {
+		t.Parallel()
+		jsonText := `{
+  "compilerOptions": {
+    "strictArrayVariance": true
+  },
+  "files": ["a.ts"]
+}`
+		host := tsoptionstest.NewVFSParseConfigHost(map[string]string{
+			"/work/tsconfig.json": jsonText,
+			"/work/a.ts":          "",
+		}, "/work", true)
+		pc := parseTsconfigAtWork(t, host, jsonText)
+		assert.Assert(t, len(pc.Errors) == 0, "got errors: %v", pc.Errors)
+		assert.Equal(t, core.TSTrue, pc.CompilerOptions().StrictArrayVariance)
+	})
+
+	t.Run("jsconfig compilerOptions.strictArrayVariance true", func(t *testing.T) {
+		t.Parallel()
+		jsonText := `{
+  "compilerOptions": {
+    "strictArrayVariance": true
+  },
+  "files": ["a.ts"]
+}`
+		host := tsoptionstest.NewVFSParseConfigHost(map[string]string{
+			"/work/jsconfig.json": jsonText,
+			"/work/a.ts":          "",
+		}, "/work", true)
+		pc := parseJsconfigAtWork(t, host, jsonText)
+		assert.Assert(t, len(pc.Errors) == 0, "got errors: %v", pc.Errors)
+		assert.Equal(t, core.TSTrue, pc.CompilerOptions().StrictArrayVariance)
+	})
+
+	t.Run("compilerOptions.strictArrayVariance false", func(t *testing.T) {
+		t.Parallel()
+		jsonText := `{
+  "compilerOptions": {
+    "strictArrayVariance": false
+  },
+  "files": ["a.ts"]
+}`
+		host := tsoptionstest.NewVFSParseConfigHost(map[string]string{
+			"/work/tsconfig.json": jsonText,
+			"/work/a.ts":          "",
+		}, "/work", true)
+		pc := parseTsconfigAtWork(t, host, jsonText)
+		assert.Assert(t, len(pc.Errors) == 0, "got errors: %v", pc.Errors)
+		assert.Equal(t, core.TSFalse, pc.CompilerOptions().StrictArrayVariance)
+	})
+
+	t.Run("strict true does not imply strictArrayVariance", func(t *testing.T) {
+		t.Parallel()
+		jsonText := `{
+  "compilerOptions": {
+    "strict": true
+  },
+  "files": ["a.ts"]
+}`
+		host := tsoptionstest.NewVFSParseConfigHost(map[string]string{
+			"/work/tsconfig.json": jsonText,
+			"/work/a.ts":          "",
+		}, "/work", true)
+		pc := parseTsconfigAtWork(t, host, jsonText)
+		assert.Assert(t, len(pc.Errors) == 0, "got errors: %v", pc.Errors)
+		assert.Equal(t, core.TSTrue, pc.CompilerOptions().Strict)
+		assert.Equal(t, core.TSUnknown, pc.CompilerOptions().StrictArrayVariance)
+	})
+
+	t.Run("extends inherits strictArrayVariance from base", func(t *testing.T) {
+		t.Parallel()
+		baseJSON := `{"compilerOptions":{"strictArrayVariance":true}}`
+		derivedJSON := `{
+  "extends": "./base.json",
+  "compilerOptions": {},
+  "files": ["a.ts"]
+}`
+		host := tsoptionstest.NewVFSParseConfigHost(map[string]string{
+			"/work/base.json":     baseJSON,
+			"/work/tsconfig.json": derivedJSON,
+			"/work/a.ts":          "",
+		}, "/work", true)
+		pc := parseTsconfigAtWork(t, host, derivedJSON)
+		assert.Assert(t, len(pc.Errors) == 0, "got errors: %v", pc.Errors)
+		assert.Equal(t, core.TSTrue, pc.CompilerOptions().StrictArrayVariance)
+	})
+
+	t.Run("extends child strictArrayVariance overrides base", func(t *testing.T) {
+		t.Parallel()
+		baseJSON := `{"compilerOptions":{"strictArrayVariance":true}}`
+		derivedJSON := `{
+  "extends": "./base.json",
+  "compilerOptions": {
+    "strictArrayVariance": false
+  },
+  "files": ["a.ts"]
+}`
+		host := tsoptionstest.NewVFSParseConfigHost(map[string]string{
+			"/work/base.json":     baseJSON,
+			"/work/tsconfig.json": derivedJSON,
+			"/work/a.ts":          "",
+		}, "/work", true)
+		pc := parseTsconfigAtWork(t, host, derivedJSON)
+		assert.Assert(t, len(pc.Errors) == 0, "got errors: %v", pc.Errors)
+		assert.Equal(t, core.TSFalse, pc.CompilerOptions().StrictArrayVariance)
+	})
+
+	t.Run("invalid strictArrayVariance type yields diagnostics", func(t *testing.T) {
+		t.Parallel()
+		jsonText := `{
+  "compilerOptions": {
+    "strictArrayVariance": "not-a-boolean"
+  },
+  "files": ["a.ts"]
+}`
+		host := tsoptionstest.NewVFSParseConfigHost(map[string]string{
+			"/work/tsconfig.json": jsonText,
+			"/work/a.ts":          "",
+		}, "/work", true)
+		pc := parseTsconfigAtWork(t, host, jsonText)
+		assert.Assert(t, len(pc.Errors) > 0, "expected diagnostics for invalid strictArrayVariance, got none")
+		assert.Equal(t, core.TSUnknown, pc.CompilerOptions().StrictArrayVariance)
+	})
+
+	t.Run("numeric strictArrayVariance is rejected as non boolean", func(t *testing.T) {
+		t.Parallel()
+		jsonText := `{
+  "compilerOptions": {
+    "strictArrayVariance": 1
+  },
+  "files": ["a.ts"]
+}`
+		host := tsoptionstest.NewVFSParseConfigHost(map[string]string{
+			"/work/tsconfig.json": jsonText,
+			"/work/a.ts":          "",
+		}, "/work", true)
+		pc := parseTsconfigAtWork(t, host, jsonText)
+		assert.Assert(t, len(pc.Errors) > 0, "expected diagnostics for numeric strictArrayVariance, got none")
+		assert.Equal(t, core.TSUnknown, pc.CompilerOptions().StrictArrayVariance)
+	})
+}
+
+func TestStrictArrayVarianceCommandLineOverridesTsconfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("CLI false overrides tsconfig true", func(t *testing.T) {
+		t.Parallel()
+		tsconfigText := `{
+  "compilerOptions": {
+    "strictArrayVariance": true
+  },
+  "files": ["a.ts"]
+}`
+		host := tsoptionstest.NewVFSParseConfigHost(map[string]string{
+			"/work/tsconfig.json": tsconfigText,
+			"/work/a.ts":          "",
+		}, "/work", true)
+
+		cmdLine := tsoptions.ParseCommandLine([]string{"--project", "/work", "--strictArrayVariance", "false"}, host)
+		assert.Assert(t, len(cmdLine.Errors) == 0, "ParseCommandLine errors: %v", cmdLine.Errors)
+
+		rawMap, ok := cmdLine.Raw.(*collections.OrderedMap[string, any])
+		assert.Assert(t, ok, "cmdLine.Raw should be *OrderedMap[string, any]")
+		wrappedRaw := &collections.OrderedMap[string, any]{}
+		wrappedRaw.Set("compilerOptions", rawMap)
+
+		parsedConfig, diag := tsoptions.GetParsedCommandLineOfConfigFile(
+			"/work/tsconfig.json",
+			cmdLine.CompilerOptions(),
+			wrappedRaw,
+			host,
+			nil,
+		)
+		assert.Assert(t, len(diag) == 0, "GetParsedCommandLineOfConfigFile: %v", diag)
+		assert.Assert(t, len(parsedConfig.Errors) == 0, "parsed config errors: %v", parsedConfig.Errors)
+		assert.Equal(t, core.TSFalse, parsedConfig.CompilerOptions().StrictArrayVariance)
+	})
+
+	t.Run("CLI true overrides tsconfig false", func(t *testing.T) {
+		t.Parallel()
+		tsconfigText := `{
+  "compilerOptions": {
+    "strictArrayVariance": false
+  },
+  "files": ["a.ts"]
+}`
+		host := tsoptionstest.NewVFSParseConfigHost(map[string]string{
+			"/work/tsconfig.json": tsconfigText,
+			"/work/a.ts":          "",
+		}, "/work", true)
+
+		cmdLine := tsoptions.ParseCommandLine([]string{"--project", "/work", "--strictArrayVariance", "true"}, host)
+		assert.Assert(t, len(cmdLine.Errors) == 0, "ParseCommandLine errors: %v", cmdLine.Errors)
+
+		rawMap, ok := cmdLine.Raw.(*collections.OrderedMap[string, any])
+		assert.Assert(t, ok, "cmdLine.Raw should be *OrderedMap[string, any]")
+		wrappedRaw := &collections.OrderedMap[string, any]{}
+		wrappedRaw.Set("compilerOptions", rawMap)
+
+		parsedConfig, diag := tsoptions.GetParsedCommandLineOfConfigFile(
+			"/work/tsconfig.json",
+			cmdLine.CompilerOptions(),
+			wrappedRaw,
+			host,
+			nil,
+		)
+		assert.Assert(t, len(diag) == 0, "GetParsedCommandLineOfConfigFile: %v", diag)
+		assert.Assert(t, len(parsedConfig.Errors) == 0, "parsed config errors: %v", parsedConfig.Errors)
+		assert.Equal(t, core.TSTrue, parsedConfig.CompilerOptions().StrictArrayVariance)
+	})
+
+	t.Run("project without CLI flag keeps tsconfig strictArrayVariance", func(t *testing.T) {
+		t.Parallel()
+		tsconfigText := `{
+  "compilerOptions": {
+    "strictArrayVariance": true
+  },
+  "files": ["a.ts"]
+}`
+		host := tsoptionstest.NewVFSParseConfigHost(map[string]string{
+			"/work/tsconfig.json": tsconfigText,
+			"/work/a.ts":          "",
+		}, "/work", true)
+
+		cmdLine := tsoptions.ParseCommandLine([]string{"--project", "/work"}, host)
+		assert.Assert(t, len(cmdLine.Errors) == 0, "ParseCommandLine errors: %v", cmdLine.Errors)
+
+		rawMap, ok := cmdLine.Raw.(*collections.OrderedMap[string, any])
+		assert.Assert(t, ok, "cmdLine.Raw should be *OrderedMap[string, any]")
+		wrappedRaw := &collections.OrderedMap[string, any]{}
+		wrappedRaw.Set("compilerOptions", rawMap)
+
+		parsedConfig, diag := tsoptions.GetParsedCommandLineOfConfigFile(
+			"/work/tsconfig.json",
+			cmdLine.CompilerOptions(),
+			wrappedRaw,
+			host,
+			nil,
+		)
+		assert.Assert(t, len(diag) == 0, "GetParsedCommandLineOfConfigFile: %v", diag)
+		assert.Assert(t, len(parsedConfig.Errors) == 0, "parsed config errors: %v", parsedConfig.Errors)
+		assert.Equal(t, core.TSTrue, parsedConfig.CompilerOptions().StrictArrayVariance)
+	})
+
+	t.Run("project explicit jsconfig path loads strictArrayVariance", func(t *testing.T) {
+		t.Parallel()
+		jsconfigText := `{
+  "compilerOptions": {
+    "strictArrayVariance": true
+  },
+  "files": ["a.ts"]
+}`
+		host := tsoptionstest.NewVFSParseConfigHost(map[string]string{
+			"/work/jsconfig.json": jsconfigText,
+			"/work/a.ts":          "",
+		}, "/work", true)
+
+		cmdLine := tsoptions.ParseCommandLine([]string{"--project", "/work/jsconfig.json"}, host)
+		assert.Assert(t, len(cmdLine.Errors) == 0, "ParseCommandLine errors: %v", cmdLine.Errors)
+
+		rawMap, ok := cmdLine.Raw.(*collections.OrderedMap[string, any])
+		assert.Assert(t, ok, "cmdLine.Raw should be *OrderedMap[string, any]")
+		wrappedRaw := &collections.OrderedMap[string, any]{}
+		wrappedRaw.Set("compilerOptions", rawMap)
+
+		parsedConfig, diag := tsoptions.GetParsedCommandLineOfConfigFile(
+			"/work/jsconfig.json",
+			cmdLine.CompilerOptions(),
+			wrappedRaw,
+			host,
+			nil,
+		)
+		assert.Assert(t, len(diag) == 0, "GetParsedCommandLineOfConfigFile: %v", diag)
+		assert.Assert(t, len(parsedConfig.Errors) == 0, "parsed config errors: %v", parsedConfig.Errors)
+		assert.Equal(t, core.TSTrue, parsedConfig.CompilerOptions().StrictArrayVariance)
+	})
+}
+
+func TestStrictArrayVarianceParseBuildCommandLine(t *testing.T) {
+	t.Parallel()
+	host := tsoptionstest.NewVFSParseConfigHost(map[string]string{}, "/proj", true)
+
+	// `ParseBuildCommandLine` only accepts build/watch options plus an allow-listed set of
+	// compiler flags. `strictArrayVariance` is type-checking-only and must be set via
+	// tsconfig (or non-build `tsc`), matching TS "may not be used with '--build'" behavior.
+	t.Run("strictArrayVariance is rejected when parsing as build mode", func(t *testing.T) {
+		t.Parallel()
+		res := tsoptions.ParseBuildCommandLine([]string{"--strictArrayVariance", "true", "packages/a"}, host)
+		assert.Assert(t, len(res.Errors) == 1, "errors: %v", res.Errors)
+		assert.Equal(t, diagnostics.Compiler_option_0_may_not_be_used_with_build.Code(), res.Errors[0].Code())
+		assert.Equal(t, core.TSUnknown, res.CompilerOptions.StrictArrayVariance)
+	})
+}
+
+func TestStrictArrayVarianceFlipAffectsIncrementalOptionComparisons(t *testing.T) {
+	t.Parallel()
+	on := &core.CompilerOptions{StrictArrayVariance: core.TSTrue}
+	off := &core.CompilerOptions{StrictArrayVariance: core.TSFalse}
+	assert.Assert(t, tsoptions.CompilerOptionsAffectSemanticDiagnostics(on, off),
+		"incremental reuse of semantic state must not cross strictArrayVariance=false vs true")
+	assert.Assert(t, !tsoptions.CompilerOptionsAffectSemanticDiagnostics(on, on))
+}

--- a/testdata/baselines/reference/compiler/strictArrayVariance(strictarrayvariance=false).symbols
+++ b/testdata/baselines/reference/compiler/strictArrayVariance(strictarrayvariance=false).symbols
@@ -1,0 +1,270 @@
+//// [tests/cases/compiler/strictArrayVariance.ts] ////
+
+=== strictArrayVariance.ts ===
+// Mutable Array: covariant element typing is unsound when the callee mutates.
+function widen(xs: (string | number)[]) {
+>widen : Symbol(widen, Decl(strictArrayVariance.ts, 0, 0))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 1, 15))
+
+    xs.push(3);
+>xs.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 1, 15))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+}
+
+const ys: string[] = ["a"];
+>ys : Symbol(ys, Decl(strictArrayVariance.ts, 5, 5))
+
+widen(ys);
+>widen : Symbol(widen, Decl(strictArrayVariance.ts, 0, 0))
+>ys : Symbol(ys, Decl(strictArrayVariance.ts, 5, 5))
+
+// ReadonlyArray stays covariant in T; passing readonly string[] should remain ok.
+function read(xs: ReadonlyArray<string | number>) {
+>read : Symbol(read, Decl(strictArrayVariance.ts, 6, 10))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 9, 14))
+>ReadonlyArray : Symbol(ReadonlyArray, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2016.array.include.d.ts, --, --) ... and 3 more)
+
+    return xs[0];
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 9, 14))
+}
+
+const rs: readonly string[] = ["b"];
+>rs : Symbol(rs, Decl(strictArrayVariance.ts, 13, 5))
+
+read(rs);
+>read : Symbol(read, Decl(strictArrayVariance.ts, 6, 10))
+>rs : Symbol(rs, Decl(strictArrayVariance.ts, 13, 5))
+
+// `Array<T>` syntax uses the same `globalArrayType` variance as `(T)[]`.
+function idArray(xs: Array<string | number>) {
+>idArray : Symbol(idArray, Decl(strictArrayVariance.ts, 14, 9))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 17, 17))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --) ... and 4 more)
+
+    xs.push(3);
+>xs.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 17, 17))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+}
+
+const zs: Array<string> = ["c"];
+>zs : Symbol(zs, Decl(strictArrayVariance.ts, 21, 5))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --) ... and 4 more)
+
+idArray(zs);
+>idArray : Symbol(idArray, Decl(strictArrayVariance.ts, 14, 9))
+>zs : Symbol(zs, Decl(strictArrayVariance.ts, 21, 5))
+
+// Type alias to `Array<T>` should use the same variance as `Array<T>` / `(T)[]`.
+type ArrayAlias<T> = Array<T>;
+>ArrayAlias : Symbol(ArrayAlias, Decl(strictArrayVariance.ts, 22, 12))
+>T : Symbol(T, Decl(strictArrayVariance.ts, 25, 16))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --) ... and 4 more)
+>T : Symbol(T, Decl(strictArrayVariance.ts, 25, 16))
+
+function idAlias(xs: ArrayAlias<string | number>) {
+>idAlias : Symbol(idAlias, Decl(strictArrayVariance.ts, 25, 30))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 26, 17))
+>ArrayAlias : Symbol(ArrayAlias, Decl(strictArrayVariance.ts, 22, 12))
+
+    xs.push(3);
+>xs.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 26, 17))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+}
+
+const ws: ArrayAlias<string> = ["d"];
+>ws : Symbol(ws, Decl(strictArrayVariance.ts, 30, 5))
+>ArrayAlias : Symbol(ArrayAlias, Decl(strictArrayVariance.ts, 22, 12))
+
+idAlias(ws);
+>idAlias : Symbol(idAlias, Decl(strictArrayVariance.ts, 25, 30))
+>ws : Symbol(ws, Decl(strictArrayVariance.ts, 30, 5))
+
+// Mutable tuples: element positions are invariant under strictArrayVariance.
+function widenTuple(xs: [string | number, string]) {
+>widenTuple : Symbol(widenTuple, Decl(strictArrayVariance.ts, 31, 12))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 34, 20))
+
+    xs[0] = 1;
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 34, 20))
+>0 : Symbol(0)
+}
+
+const tup: [string, string] = ["x", "y"];
+>tup : Symbol(tup, Decl(strictArrayVariance.ts, 38, 5))
+
+widenTuple(tup);
+>widenTuple : Symbol(widenTuple, Decl(strictArrayVariance.ts, 31, 12))
+>tup : Symbol(tup, Decl(strictArrayVariance.ts, 38, 5))
+
+// Nested `Array<Array<U>>`: element type `U[]` is still `globalArrayType`.
+function nest(xs: (string | number)[][]) {
+>nest : Symbol(nest, Decl(strictArrayVariance.ts, 39, 16))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 42, 14))
+
+    xs[0].push(3);
+>xs[0].push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 42, 14))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+}
+
+const row: string[] = ["p"];
+>row : Symbol(row, Decl(strictArrayVariance.ts, 46, 5))
+
+const grid: string[][] = [row];
+>grid : Symbol(grid, Decl(strictArrayVariance.ts, 47, 5))
+>row : Symbol(row, Decl(strictArrayVariance.ts, 46, 5))
+
+nest(grid);
+>nest : Symbol(nest, Decl(strictArrayVariance.ts, 39, 16))
+>grid : Symbol(grid, Decl(strictArrayVariance.ts, 47, 5))
+
+// Readonly tuples use tuple variance (covariant), like ReadonlyArray.
+function rtup(xs: readonly [string | number, string]) {
+>rtup : Symbol(rtup, Decl(strictArrayVariance.ts, 48, 11))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 51, 14))
+
+    return xs[0];
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 51, 14))
+>0 : Symbol(0)
+}
+
+const rt: readonly [string, string] = ["u", "v"] as const;
+>rt : Symbol(rt, Decl(strictArrayVariance.ts, 55, 5))
+>const : Symbol(const)
+
+rtup(rt);
+>rtup : Symbol(rtup, Decl(strictArrayVariance.ts, 48, 11))
+>rt : Symbol(rt, Decl(strictArrayVariance.ts, 55, 5))
+
+// Structural assignability: object with `string[]` field to type expecting `(string | number)[]`.
+interface Hold {
+>Hold : Symbol(Hold, Decl(strictArrayVariance.ts, 56, 9))
+
+    xs: (string | number)[];
+>xs : Symbol(Hold.xs, Decl(strictArrayVariance.ts, 59, 16))
+}
+
+function mutateCell(h: Hold) {
+>mutateCell : Symbol(mutateCell, Decl(strictArrayVariance.ts, 61, 1))
+>h : Symbol(h, Decl(strictArrayVariance.ts, 63, 20))
+>Hold : Symbol(Hold, Decl(strictArrayVariance.ts, 56, 9))
+
+    h.xs.push(1);
+>h.xs.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>h.xs : Symbol(Hold.xs, Decl(strictArrayVariance.ts, 59, 16))
+>h : Symbol(h, Decl(strictArrayVariance.ts, 63, 20))
+>xs : Symbol(Hold.xs, Decl(strictArrayVariance.ts, 59, 16))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+}
+
+const cell: { xs: string[] } = { xs: ["q"] };
+>cell : Symbol(cell, Decl(strictArrayVariance.ts, 67, 5))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 67, 13))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 67, 32))
+
+mutateCell(cell);
+>mutateCell : Symbol(mutateCell, Decl(strictArrayVariance.ts, 61, 1))
+>cell : Symbol(cell, Decl(strictArrayVariance.ts, 67, 5))
+
+// Inference: generic element extraction via `infer U` still works; the instance of
+// Array<string> has its type argument inferred as `string` regardless of the flag.
+type ElemOf<T> = T extends Array<infer U> ? U : never;
+>ElemOf : Symbol(ElemOf, Decl(strictArrayVariance.ts, 68, 17))
+>T : Symbol(T, Decl(strictArrayVariance.ts, 72, 12))
+>T : Symbol(T, Decl(strictArrayVariance.ts, 72, 12))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --) ... and 4 more)
+>U : Symbol(U, Decl(strictArrayVariance.ts, 72, 38))
+>U : Symbol(U, Decl(strictArrayVariance.ts, 72, 38))
+
+type E1 = ElemOf<string[]>; // string
+>E1 : Symbol(E1, Decl(strictArrayVariance.ts, 72, 54))
+>ElemOf : Symbol(ElemOf, Decl(strictArrayVariance.ts, 68, 17))
+
+const e1: E1 = "ok";
+>e1 : Symbol(e1, Decl(strictArrayVariance.ts, 74, 5))
+>E1 : Symbol(E1, Decl(strictArrayVariance.ts, 72, 54))
+
+// Inference: a generic identity function should infer T from the argument type.
+// Under strictArrayVariance this still works because T is inferred, not constrained
+// by a widening target.
+function idGeneric<T>(xs: T[]): T[] {
+>idGeneric : Symbol(idGeneric, Decl(strictArrayVariance.ts, 74, 20))
+>T : Symbol(T, Decl(strictArrayVariance.ts, 79, 19))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 79, 22))
+>T : Symbol(T, Decl(strictArrayVariance.ts, 79, 19))
+>T : Symbol(T, Decl(strictArrayVariance.ts, 79, 19))
+
+    return xs;
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 79, 22))
+}
+
+const inferred = idGeneric(ys); // inferred: string[]
+>inferred : Symbol(inferred, Decl(strictArrayVariance.ts, 83, 5))
+>idGeneric : Symbol(idGeneric, Decl(strictArrayVariance.ts, 74, 20))
+>ys : Symbol(ys, Decl(strictArrayVariance.ts, 5, 5))
+
+const checkInferred: string[] = inferred;
+>checkInferred : Symbol(checkInferred, Decl(strictArrayVariance.ts, 84, 5))
+>inferred : Symbol(inferred, Decl(strictArrayVariance.ts, 83, 5))
+
+// Inference: when the target is wider than the source and both are mutable Array,
+// the strict flag rejects the call (same as the widen cases above) rather than
+// silently widening the inferred type argument.
+function takeWider(xs: Array<string | number>) {}
+>takeWider : Symbol(takeWider, Decl(strictArrayVariance.ts, 84, 41))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 89, 19))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --) ... and 4 more)
+
+takeWider(ys);
+>takeWider : Symbol(takeWider, Decl(strictArrayVariance.ts, 84, 41))
+>ys : Symbol(ys, Decl(strictArrayVariance.ts, 5, 5))
+
+// Spread alone does NOT widen under this flag: `[...ys]` has type `string[]`,
+// so this still errors. The diagnostic message must not suggest otherwise.
+widen([...ys]);
+>widen : Symbol(widen, Decl(strictArrayVariance.ts, 0, 0))
+>ys : Symbol(ys, Decl(strictArrayVariance.ts, 5, 5))
+
+// The primary migration target: `readonly` at the parameter boundary stays
+// covariant under the flag, so passing `string[]` to a consumer typed for
+// `readonly (string | number)[]` is still accepted.
+function readWider(xs: readonly (string | number)[]) {
+>readWider : Symbol(readWider, Decl(strictArrayVariance.ts, 94, 15))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 99, 19))
+
+    return xs.length;
+>xs.length : Symbol(ReadonlyArray.length, Decl(lib.es5.d.ts, --, --))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 99, 19))
+>length : Symbol(ReadonlyArray.length, Decl(lib.es5.d.ts, --, --))
+}
+readWider(ys);
+>readWider : Symbol(readWider, Decl(strictArrayVariance.ts, 94, 15))
+>ys : Symbol(ys, Decl(strictArrayVariance.ts, 5, 5))
+
+// Callback contravariance is orthogonal to array variance and must keep
+// working: a callback accepting the wider element type is assignable to a
+// parameter typed for the narrower one.
+function forEachString(xs: readonly string[], cb: (x: string) => void) {
+>forEachString : Symbol(forEachString, Decl(strictArrayVariance.ts, 102, 14))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 107, 23))
+>cb : Symbol(cb, Decl(strictArrayVariance.ts, 107, 45))
+>x : Symbol(x, Decl(strictArrayVariance.ts, 107, 51))
+
+    for (const x of xs) cb(x);
+>x : Symbol(x, Decl(strictArrayVariance.ts, 108, 14))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 107, 23))
+>cb : Symbol(cb, Decl(strictArrayVariance.ts, 107, 45))
+>x : Symbol(x, Decl(strictArrayVariance.ts, 108, 14))
+}
+const wideCb: (x: string | number) => void = () => {};
+>wideCb : Symbol(wideCb, Decl(strictArrayVariance.ts, 110, 5))
+>x : Symbol(x, Decl(strictArrayVariance.ts, 110, 15))
+
+forEachString(ys, wideCb);
+>forEachString : Symbol(forEachString, Decl(strictArrayVariance.ts, 102, 14))
+>ys : Symbol(ys, Decl(strictArrayVariance.ts, 5, 5))
+>wideCb : Symbol(wideCb, Decl(strictArrayVariance.ts, 110, 5))
+

--- a/testdata/baselines/reference/compiler/strictArrayVariance(strictarrayvariance=false).types
+++ b/testdata/baselines/reference/compiler/strictArrayVariance(strictarrayvariance=false).types
@@ -1,0 +1,304 @@
+//// [tests/cases/compiler/strictArrayVariance.ts] ////
+
+=== strictArrayVariance.ts ===
+// Mutable Array: covariant element typing is unsound when the callee mutates.
+function widen(xs: (string | number)[]) {
+>widen : (xs: (string | number)[]) => void
+>xs : (string | number)[]
+
+    xs.push(3);
+>xs.push(3) : number
+>xs.push : (...items: (string | number)[]) => number
+>xs : (string | number)[]
+>push : (...items: (string | number)[]) => number
+>3 : 3
+}
+
+const ys: string[] = ["a"];
+>ys : string[]
+>["a"] : string[]
+>"a" : "a"
+
+widen(ys);
+>widen(ys) : void
+>widen : (xs: (string | number)[]) => void
+>ys : string[]
+
+// ReadonlyArray stays covariant in T; passing readonly string[] should remain ok.
+function read(xs: ReadonlyArray<string | number>) {
+>read : (xs: ReadonlyArray<string | number>) => string | number
+>xs : readonly (string | number)[]
+
+    return xs[0];
+>xs[0] : string | number
+>xs : readonly (string | number)[]
+>0 : 0
+}
+
+const rs: readonly string[] = ["b"];
+>rs : readonly string[]
+>["b"] : string[]
+>"b" : "b"
+
+read(rs);
+>read(rs) : string | number
+>read : (xs: ReadonlyArray<string | number>) => string | number
+>rs : readonly string[]
+
+// `Array<T>` syntax uses the same `globalArrayType` variance as `(T)[]`.
+function idArray(xs: Array<string | number>) {
+>idArray : (xs: Array<string | number>) => void
+>xs : (string | number)[]
+
+    xs.push(3);
+>xs.push(3) : number
+>xs.push : (...items: (string | number)[]) => number
+>xs : (string | number)[]
+>push : (...items: (string | number)[]) => number
+>3 : 3
+}
+
+const zs: Array<string> = ["c"];
+>zs : string[]
+>["c"] : string[]
+>"c" : "c"
+
+idArray(zs);
+>idArray(zs) : void
+>idArray : (xs: Array<string | number>) => void
+>zs : string[]
+
+// Type alias to `Array<T>` should use the same variance as `Array<T>` / `(T)[]`.
+type ArrayAlias<T> = Array<T>;
+>ArrayAlias : ArrayAlias<T>
+
+function idAlias(xs: ArrayAlias<string | number>) {
+>idAlias : (xs: ArrayAlias<string | number>) => void
+>xs : ArrayAlias<string | number>
+
+    xs.push(3);
+>xs.push(3) : number
+>xs.push : (...items: (string | number)[]) => number
+>xs : ArrayAlias<string | number>
+>push : (...items: (string | number)[]) => number
+>3 : 3
+}
+
+const ws: ArrayAlias<string> = ["d"];
+>ws : ArrayAlias<string>
+>["d"] : string[]
+>"d" : "d"
+
+idAlias(ws);
+>idAlias(ws) : void
+>idAlias : (xs: ArrayAlias<string | number>) => void
+>ws : ArrayAlias<string>
+
+// Mutable tuples: element positions are invariant under strictArrayVariance.
+function widenTuple(xs: [string | number, string]) {
+>widenTuple : (xs: [string | number, string]) => void
+>xs : [string | number, string]
+
+    xs[0] = 1;
+>xs[0] = 1 : 1
+>xs[0] : string | number
+>xs : [string | number, string]
+>0 : 0
+>1 : 1
+}
+
+const tup: [string, string] = ["x", "y"];
+>tup : [string, string]
+>["x", "y"] : [string, string]
+>"x" : "x"
+>"y" : "y"
+
+widenTuple(tup);
+>widenTuple(tup) : void
+>widenTuple : (xs: [string | number, string]) => void
+>tup : [string, string]
+
+// Nested `Array<Array<U>>`: element type `U[]` is still `globalArrayType`.
+function nest(xs: (string | number)[][]) {
+>nest : (xs: (string | number)[][]) => void
+>xs : (string | number)[][]
+
+    xs[0].push(3);
+>xs[0].push(3) : number
+>xs[0].push : (...items: (string | number)[]) => number
+>xs[0] : (string | number)[]
+>xs : (string | number)[][]
+>0 : 0
+>push : (...items: (string | number)[]) => number
+>3 : 3
+}
+
+const row: string[] = ["p"];
+>row : string[]
+>["p"] : string[]
+>"p" : "p"
+
+const grid: string[][] = [row];
+>grid : string[][]
+>[row] : string[][]
+>row : string[]
+
+nest(grid);
+>nest(grid) : void
+>nest : (xs: (string | number)[][]) => void
+>grid : string[][]
+
+// Readonly tuples use tuple variance (covariant), like ReadonlyArray.
+function rtup(xs: readonly [string | number, string]) {
+>rtup : (xs: readonly [string | number, string]) => string | number
+>xs : readonly [string | number, string]
+
+    return xs[0];
+>xs[0] : string | number
+>xs : readonly [string | number, string]
+>0 : 0
+}
+
+const rt: readonly [string, string] = ["u", "v"] as const;
+>rt : readonly [string, string]
+>["u", "v"] as const : readonly ["u", "v"]
+>["u", "v"] : readonly ["u", "v"]
+>"u" : "u"
+>"v" : "v"
+
+rtup(rt);
+>rtup(rt) : string | number
+>rtup : (xs: readonly [string | number, string]) => string | number
+>rt : readonly [string, string]
+
+// Structural assignability: object with `string[]` field to type expecting `(string | number)[]`.
+interface Hold {
+    xs: (string | number)[];
+>xs : (string | number)[]
+}
+
+function mutateCell(h: Hold) {
+>mutateCell : (h: Hold) => void
+>h : Hold
+
+    h.xs.push(1);
+>h.xs.push(1) : number
+>h.xs.push : (...items: (string | number)[]) => number
+>h.xs : (string | number)[]
+>h : Hold
+>xs : (string | number)[]
+>push : (...items: (string | number)[]) => number
+>1 : 1
+}
+
+const cell: { xs: string[] } = { xs: ["q"] };
+>cell : { xs: string[]; }
+>xs : string[]
+>{ xs: ["q"] } : { xs: string[]; }
+>xs : string[]
+>["q"] : string[]
+>"q" : "q"
+
+mutateCell(cell);
+>mutateCell(cell) : void
+>mutateCell : (h: Hold) => void
+>cell : { xs: string[]; }
+
+// Inference: generic element extraction via `infer U` still works; the instance of
+// Array<string> has its type argument inferred as `string` regardless of the flag.
+type ElemOf<T> = T extends Array<infer U> ? U : never;
+>ElemOf : ElemOf<T>
+
+type E1 = ElemOf<string[]>; // string
+>E1 : string
+
+const e1: E1 = "ok";
+>e1 : string
+>"ok" : "ok"
+
+// Inference: a generic identity function should infer T from the argument type.
+// Under strictArrayVariance this still works because T is inferred, not constrained
+// by a widening target.
+function idGeneric<T>(xs: T[]): T[] {
+>idGeneric : <T>(xs: T[]) => T[]
+>xs : T[]
+
+    return xs;
+>xs : T[]
+}
+
+const inferred = idGeneric(ys); // inferred: string[]
+>inferred : string[]
+>idGeneric(ys) : string[]
+>idGeneric : <T>(xs: T[]) => T[]
+>ys : string[]
+
+const checkInferred: string[] = inferred;
+>checkInferred : string[]
+>inferred : string[]
+
+// Inference: when the target is wider than the source and both are mutable Array,
+// the strict flag rejects the call (same as the widen cases above) rather than
+// silently widening the inferred type argument.
+function takeWider(xs: Array<string | number>) {}
+>takeWider : (xs: Array<string | number>) => void
+>xs : (string | number)[]
+
+takeWider(ys);
+>takeWider(ys) : void
+>takeWider : (xs: Array<string | number>) => void
+>ys : string[]
+
+// Spread alone does NOT widen under this flag: `[...ys]` has type `string[]`,
+// so this still errors. The diagnostic message must not suggest otherwise.
+widen([...ys]);
+>widen([...ys]) : void
+>widen : (xs: (string | number)[]) => void
+>[...ys] : string[]
+>...ys : string
+>ys : string[]
+
+// The primary migration target: `readonly` at the parameter boundary stays
+// covariant under the flag, so passing `string[]` to a consumer typed for
+// `readonly (string | number)[]` is still accepted.
+function readWider(xs: readonly (string | number)[]) {
+>readWider : (xs: readonly (string | number)[]) => number
+>xs : readonly (string | number)[]
+
+    return xs.length;
+>xs.length : number
+>xs : readonly (string | number)[]
+>length : number
+}
+readWider(ys);
+>readWider(ys) : number
+>readWider : (xs: readonly (string | number)[]) => number
+>ys : string[]
+
+// Callback contravariance is orthogonal to array variance and must keep
+// working: a callback accepting the wider element type is assignable to a
+// parameter typed for the narrower one.
+function forEachString(xs: readonly string[], cb: (x: string) => void) {
+>forEachString : (xs: readonly string[], cb: (x: string) => void) => void
+>xs : readonly string[]
+>cb : (x: string) => void
+>x : string
+
+    for (const x of xs) cb(x);
+>x : string
+>xs : readonly string[]
+>cb(x) : void
+>cb : (x: string) => void
+>x : string
+}
+const wideCb: (x: string | number) => void = () => {};
+>wideCb : (x: string | number) => void
+>x : string | number
+>() => {} : () => void
+
+forEachString(ys, wideCb);
+>forEachString(ys, wideCb) : void
+>forEachString : (xs: readonly string[], cb: (x: string) => void) => void
+>ys : string[]
+>wideCb : (x: string | number) => void
+

--- a/testdata/baselines/reference/compiler/strictArrayVariance(strictarrayvariance=true).errors.txt
+++ b/testdata/baselines/reference/compiler/strictArrayVariance(strictarrayvariance=true).errors.txt
@@ -1,0 +1,310 @@
+strictArrayVariance.ts(7,7): error TS2345: Argument of type 'string[]' is not assignable to parameter of type '(string | number)[]'.
+  Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+    Types of property 'concat' are incompatible.
+      Type '{ (...items: ConcatArray<string>[]): string[]; (...items: (string | ConcatArray<string>)[]): string[]; }' is not assignable to type '{ (...items: ConcatArray<string | number>[]): (string | number)[]; (...items: (string | number | ConcatArray<string | number>)[]): (string | number)[]; }'.
+        Types of parameters 'items' and 'items' are incompatible.
+          Type 'ConcatArray<string | number>' is not assignable to type 'ConcatArray<string>'.
+            The types returned by 'slice(...)' are incompatible between these types.
+              Type '(string | number)[]' is not assignable to type 'string[]'.
+                Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+                  The types returned by 'pop()' are incompatible between these types.
+                    Type 'string | number | undefined' is not assignable to type 'string | undefined'.
+                      Type 'number' is not assignable to type 'string'.
+strictArrayVariance.ts(23,9): error TS2345: Argument of type 'string[]' is not assignable to parameter of type '(string | number)[]'.
+  Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+    Types of property 'concat' are incompatible.
+      Type '{ (...items: ConcatArray<string>[]): string[]; (...items: (string | ConcatArray<string>)[]): string[]; }' is not assignable to type '{ (...items: ConcatArray<string | number>[]): (string | number)[]; (...items: (string | number | ConcatArray<string | number>)[]): (string | number)[]; }'.
+        Types of parameters 'items' and 'items' are incompatible.
+          Type 'ConcatArray<string | number>' is not assignable to type 'ConcatArray<string>'.
+            The types returned by 'slice(...)' are incompatible between these types.
+              Type '(string | number)[]' is not assignable to type 'string[]'.
+                Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+                  The types returned by 'pop()' are incompatible between these types.
+                    Type 'string | number | undefined' is not assignable to type 'string | undefined'.
+                      Type 'number' is not assignable to type 'string'.
+strictArrayVariance.ts(32,9): error TS2345: Argument of type 'ArrayAlias<string>' is not assignable to parameter of type 'ArrayAlias<string | number>'.
+  Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+    Types of property 'concat' are incompatible.
+      Type '{ (...items: ConcatArray<string>[]): string[]; (...items: (string | ConcatArray<string>)[]): string[]; }' is not assignable to type '{ (...items: ConcatArray<string | number>[]): (string | number)[]; (...items: (string | number | ConcatArray<string | number>)[]): (string | number)[]; }'.
+        Types of parameters 'items' and 'items' are incompatible.
+          Type 'ConcatArray<string | number>' is not assignable to type 'ConcatArray<string>'.
+            The types returned by 'slice(...)' are incompatible between these types.
+              Type '(string | number)[]' is not assignable to type 'string[]'.
+                Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+                  The types returned by 'pop()' are incompatible between these types.
+                    Type 'string | number | undefined' is not assignable to type 'string | undefined'.
+                      Type 'number' is not assignable to type 'string'.
+strictArrayVariance.ts(40,12): error TS2345: Argument of type '[string, string]' is not assignable to parameter of type '[string | number, string]'.
+  Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+    Type at position 0 in source is not compatible with type at position 0 in target.
+strictArrayVariance.ts(49,6): error TS2345: Argument of type 'string[][]' is not assignable to parameter of type '(string | number)[][]'.
+  Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+    The types returned by 'pop()' are incompatible between these types.
+      Type 'string[] | undefined' is not assignable to type '(string | number)[] | undefined'.
+        Type 'string[]' is not assignable to type '(string | number)[]'.
+          Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+            Types of property 'concat' are incompatible.
+              Type '{ (...items: ConcatArray<string>[]): string[]; (...items: (string | ConcatArray<string>)[]): string[]; }' is not assignable to type '{ (...items: ConcatArray<string | number>[]): (string | number)[]; (...items: (string | number | ConcatArray<string | number>)[]): (string | number)[]; }'.
+                Types of parameters 'items' and 'items' are incompatible.
+                  Type 'ConcatArray<string | number>' is not assignable to type 'ConcatArray<string>'.
+                    The types returned by 'slice(...)' are incompatible between these types.
+                      Type '(string | number)[]' is not assignable to type 'string[]'.
+                        Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+                          The types returned by 'pop()' are incompatible between these types.
+                            Type 'string | number | undefined' is not assignable to type 'string | undefined'.
+                              Type 'number' is not assignable to type 'string'.
+strictArrayVariance.ts(69,12): error TS2345: Argument of type '{ xs: string[]; }' is not assignable to parameter of type 'Hold'.
+  Types of property 'xs' are incompatible.
+    Type 'string[]' is not assignable to type '(string | number)[]'.
+      Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+        Types of property 'concat' are incompatible.
+          Type '{ (...items: ConcatArray<string>[]): string[]; (...items: (string | ConcatArray<string>)[]): string[]; }' is not assignable to type '{ (...items: ConcatArray<string | number>[]): (string | number)[]; (...items: (string | number | ConcatArray<string | number>)[]): (string | number)[]; }'.
+            Types of parameters 'items' and 'items' are incompatible.
+              Type 'ConcatArray<string | number>' is not assignable to type 'ConcatArray<string>'.
+                The types returned by 'slice(...)' are incompatible between these types.
+                  Type '(string | number)[]' is not assignable to type 'string[]'.
+                    Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+                      The types returned by 'pop()' are incompatible between these types.
+                        Type 'string | number | undefined' is not assignable to type 'string | undefined'.
+                          Type 'number' is not assignable to type 'string'.
+strictArrayVariance.ts(91,11): error TS2345: Argument of type 'string[]' is not assignable to parameter of type '(string | number)[]'.
+  Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+    Types of property 'concat' are incompatible.
+      Type '{ (...items: ConcatArray<string>[]): string[]; (...items: (string | ConcatArray<string>)[]): string[]; }' is not assignable to type '{ (...items: ConcatArray<string | number>[]): (string | number)[]; (...items: (string | number | ConcatArray<string | number>)[]): (string | number)[]; }'.
+        Types of parameters 'items' and 'items' are incompatible.
+          Type 'ConcatArray<string | number>' is not assignable to type 'ConcatArray<string>'.
+            The types returned by 'slice(...)' are incompatible between these types.
+              Type '(string | number)[]' is not assignable to type 'string[]'.
+                Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+                  The types returned by 'pop()' are incompatible between these types.
+                    Type 'string | number | undefined' is not assignable to type 'string | undefined'.
+                      Type 'number' is not assignable to type 'string'.
+strictArrayVariance.ts(95,7): error TS2345: Argument of type 'string[]' is not assignable to parameter of type '(string | number)[]'.
+  Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+    Types of property 'concat' are incompatible.
+      Type '{ (...items: ConcatArray<string>[]): string[]; (...items: (string | ConcatArray<string>)[]): string[]; }' is not assignable to type '{ (...items: ConcatArray<string | number>[]): (string | number)[]; (...items: (string | number | ConcatArray<string | number>)[]): (string | number)[]; }'.
+        Types of parameters 'items' and 'items' are incompatible.
+          Type 'ConcatArray<string | number>' is not assignable to type 'ConcatArray<string>'.
+            The types returned by 'slice(...)' are incompatible between these types.
+              Type '(string | number)[]' is not assignable to type 'string[]'.
+                Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+                  The types returned by 'pop()' are incompatible between these types.
+                    Type 'string | number | undefined' is not assignable to type 'string | undefined'.
+                      Type 'number' is not assignable to type 'string'.
+
+
+==== strictArrayVariance.ts (8 errors) ====
+    // Mutable Array: covariant element typing is unsound when the callee mutates.
+    function widen(xs: (string | number)[]) {
+        xs.push(3);
+    }
+    
+    const ys: string[] = ["a"];
+    widen(ys);
+          ~~
+!!! error TS2345: Argument of type 'string[]' is not assignable to parameter of type '(string | number)[]'.
+!!! error TS2345:   Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+!!! error TS2345:     Types of property 'concat' are incompatible.
+!!! error TS2345:       Type '{ (...items: ConcatArray<string>[]): string[]; (...items: (string | ConcatArray<string>)[]): string[]; }' is not assignable to type '{ (...items: ConcatArray<string | number>[]): (string | number)[]; (...items: (string | number | ConcatArray<string | number>)[]): (string | number)[]; }'.
+!!! error TS2345:         Types of parameters 'items' and 'items' are incompatible.
+!!! error TS2345:           Type 'ConcatArray<string | number>' is not assignable to type 'ConcatArray<string>'.
+!!! error TS2345:             The types returned by 'slice(...)' are incompatible between these types.
+!!! error TS2345:               Type '(string | number)[]' is not assignable to type 'string[]'.
+!!! error TS2345:                 Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+!!! error TS2345:                   The types returned by 'pop()' are incompatible between these types.
+!!! error TS2345:                     Type 'string | number | undefined' is not assignable to type 'string | undefined'.
+!!! error TS2345:                       Type 'number' is not assignable to type 'string'.
+    
+    // ReadonlyArray stays covariant in T; passing readonly string[] should remain ok.
+    function read(xs: ReadonlyArray<string | number>) {
+        return xs[0];
+    }
+    
+    const rs: readonly string[] = ["b"];
+    read(rs);
+    
+    // `Array<T>` syntax uses the same `globalArrayType` variance as `(T)[]`.
+    function idArray(xs: Array<string | number>) {
+        xs.push(3);
+    }
+    
+    const zs: Array<string> = ["c"];
+    idArray(zs);
+            ~~
+!!! error TS2345: Argument of type 'string[]' is not assignable to parameter of type '(string | number)[]'.
+!!! error TS2345:   Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+!!! error TS2345:     Types of property 'concat' are incompatible.
+!!! error TS2345:       Type '{ (...items: ConcatArray<string>[]): string[]; (...items: (string | ConcatArray<string>)[]): string[]; }' is not assignable to type '{ (...items: ConcatArray<string | number>[]): (string | number)[]; (...items: (string | number | ConcatArray<string | number>)[]): (string | number)[]; }'.
+!!! error TS2345:         Types of parameters 'items' and 'items' are incompatible.
+!!! error TS2345:           Type 'ConcatArray<string | number>' is not assignable to type 'ConcatArray<string>'.
+!!! error TS2345:             The types returned by 'slice(...)' are incompatible between these types.
+!!! error TS2345:               Type '(string | number)[]' is not assignable to type 'string[]'.
+!!! error TS2345:                 Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+!!! error TS2345:                   The types returned by 'pop()' are incompatible between these types.
+!!! error TS2345:                     Type 'string | number | undefined' is not assignable to type 'string | undefined'.
+!!! error TS2345:                       Type 'number' is not assignable to type 'string'.
+    
+    // Type alias to `Array<T>` should use the same variance as `Array<T>` / `(T)[]`.
+    type ArrayAlias<T> = Array<T>;
+    function idAlias(xs: ArrayAlias<string | number>) {
+        xs.push(3);
+    }
+    
+    const ws: ArrayAlias<string> = ["d"];
+    idAlias(ws);
+            ~~
+!!! error TS2345: Argument of type 'ArrayAlias<string>' is not assignable to parameter of type 'ArrayAlias<string | number>'.
+!!! error TS2345:   Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+!!! error TS2345:     Types of property 'concat' are incompatible.
+!!! error TS2345:       Type '{ (...items: ConcatArray<string>[]): string[]; (...items: (string | ConcatArray<string>)[]): string[]; }' is not assignable to type '{ (...items: ConcatArray<string | number>[]): (string | number)[]; (...items: (string | number | ConcatArray<string | number>)[]): (string | number)[]; }'.
+!!! error TS2345:         Types of parameters 'items' and 'items' are incompatible.
+!!! error TS2345:           Type 'ConcatArray<string | number>' is not assignable to type 'ConcatArray<string>'.
+!!! error TS2345:             The types returned by 'slice(...)' are incompatible between these types.
+!!! error TS2345:               Type '(string | number)[]' is not assignable to type 'string[]'.
+!!! error TS2345:                 Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+!!! error TS2345:                   The types returned by 'pop()' are incompatible between these types.
+!!! error TS2345:                     Type 'string | number | undefined' is not assignable to type 'string | undefined'.
+!!! error TS2345:                       Type 'number' is not assignable to type 'string'.
+    
+    // Mutable tuples: element positions are invariant under strictArrayVariance.
+    function widenTuple(xs: [string | number, string]) {
+        xs[0] = 1;
+    }
+    
+    const tup: [string, string] = ["x", "y"];
+    widenTuple(tup);
+               ~~~
+!!! error TS2345: Argument of type '[string, string]' is not assignable to parameter of type '[string | number, string]'.
+!!! error TS2345:   Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+!!! error TS2345:     Type at position 0 in source is not compatible with type at position 0 in target.
+    
+    // Nested `Array<Array<U>>`: element type `U[]` is still `globalArrayType`.
+    function nest(xs: (string | number)[][]) {
+        xs[0].push(3);
+    }
+    
+    const row: string[] = ["p"];
+    const grid: string[][] = [row];
+    nest(grid);
+         ~~~~
+!!! error TS2345: Argument of type 'string[][]' is not assignable to parameter of type '(string | number)[][]'.
+!!! error TS2345:   Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+!!! error TS2345:     The types returned by 'pop()' are incompatible between these types.
+!!! error TS2345:       Type 'string[] | undefined' is not assignable to type '(string | number)[] | undefined'.
+!!! error TS2345:         Type 'string[]' is not assignable to type '(string | number)[]'.
+!!! error TS2345:           Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+!!! error TS2345:             Types of property 'concat' are incompatible.
+!!! error TS2345:               Type '{ (...items: ConcatArray<string>[]): string[]; (...items: (string | ConcatArray<string>)[]): string[]; }' is not assignable to type '{ (...items: ConcatArray<string | number>[]): (string | number)[]; (...items: (string | number | ConcatArray<string | number>)[]): (string | number)[]; }'.
+!!! error TS2345:                 Types of parameters 'items' and 'items' are incompatible.
+!!! error TS2345:                   Type 'ConcatArray<string | number>' is not assignable to type 'ConcatArray<string>'.
+!!! error TS2345:                     The types returned by 'slice(...)' are incompatible between these types.
+!!! error TS2345:                       Type '(string | number)[]' is not assignable to type 'string[]'.
+!!! error TS2345:                         Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+!!! error TS2345:                           The types returned by 'pop()' are incompatible between these types.
+!!! error TS2345:                             Type 'string | number | undefined' is not assignable to type 'string | undefined'.
+!!! error TS2345:                               Type 'number' is not assignable to type 'string'.
+    
+    // Readonly tuples use tuple variance (covariant), like ReadonlyArray.
+    function rtup(xs: readonly [string | number, string]) {
+        return xs[0];
+    }
+    
+    const rt: readonly [string, string] = ["u", "v"] as const;
+    rtup(rt);
+    
+    // Structural assignability: object with `string[]` field to type expecting `(string | number)[]`.
+    interface Hold {
+        xs: (string | number)[];
+    }
+    
+    function mutateCell(h: Hold) {
+        h.xs.push(1);
+    }
+    
+    const cell: { xs: string[] } = { xs: ["q"] };
+    mutateCell(cell);
+               ~~~~
+!!! error TS2345: Argument of type '{ xs: string[]; }' is not assignable to parameter of type 'Hold'.
+!!! error TS2345:   Types of property 'xs' are incompatible.
+!!! error TS2345:     Type 'string[]' is not assignable to type '(string | number)[]'.
+!!! error TS2345:       Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+!!! error TS2345:         Types of property 'concat' are incompatible.
+!!! error TS2345:           Type '{ (...items: ConcatArray<string>[]): string[]; (...items: (string | ConcatArray<string>)[]): string[]; }' is not assignable to type '{ (...items: ConcatArray<string | number>[]): (string | number)[]; (...items: (string | number | ConcatArray<string | number>)[]): (string | number)[]; }'.
+!!! error TS2345:             Types of parameters 'items' and 'items' are incompatible.
+!!! error TS2345:               Type 'ConcatArray<string | number>' is not assignable to type 'ConcatArray<string>'.
+!!! error TS2345:                 The types returned by 'slice(...)' are incompatible between these types.
+!!! error TS2345:                   Type '(string | number)[]' is not assignable to type 'string[]'.
+!!! error TS2345:                     Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+!!! error TS2345:                       The types returned by 'pop()' are incompatible between these types.
+!!! error TS2345:                         Type 'string | number | undefined' is not assignable to type 'string | undefined'.
+!!! error TS2345:                           Type 'number' is not assignable to type 'string'.
+    
+    // Inference: generic element extraction via `infer U` still works; the instance of
+    // Array<string> has its type argument inferred as `string` regardless of the flag.
+    type ElemOf<T> = T extends Array<infer U> ? U : never;
+    type E1 = ElemOf<string[]>; // string
+    const e1: E1 = "ok";
+    
+    // Inference: a generic identity function should infer T from the argument type.
+    // Under strictArrayVariance this still works because T is inferred, not constrained
+    // by a widening target.
+    function idGeneric<T>(xs: T[]): T[] {
+        return xs;
+    }
+    
+    const inferred = idGeneric(ys); // inferred: string[]
+    const checkInferred: string[] = inferred;
+    
+    // Inference: when the target is wider than the source and both are mutable Array,
+    // the strict flag rejects the call (same as the widen cases above) rather than
+    // silently widening the inferred type argument.
+    function takeWider(xs: Array<string | number>) {}
+    takeWider(ys);
+              ~~
+!!! error TS2345: Argument of type 'string[]' is not assignable to parameter of type '(string | number)[]'.
+!!! error TS2345:   Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+!!! error TS2345:     Types of property 'concat' are incompatible.
+!!! error TS2345:       Type '{ (...items: ConcatArray<string>[]): string[]; (...items: (string | ConcatArray<string>)[]): string[]; }' is not assignable to type '{ (...items: ConcatArray<string | number>[]): (string | number)[]; (...items: (string | number | ConcatArray<string | number>)[]): (string | number)[]; }'.
+!!! error TS2345:         Types of parameters 'items' and 'items' are incompatible.
+!!! error TS2345:           Type 'ConcatArray<string | number>' is not assignable to type 'ConcatArray<string>'.
+!!! error TS2345:             The types returned by 'slice(...)' are incompatible between these types.
+!!! error TS2345:               Type '(string | number)[]' is not assignable to type 'string[]'.
+!!! error TS2345:                 Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+!!! error TS2345:                   The types returned by 'pop()' are incompatible between these types.
+!!! error TS2345:                     Type 'string | number | undefined' is not assignable to type 'string | undefined'.
+!!! error TS2345:                       Type 'number' is not assignable to type 'string'.
+    
+    // Spread alone does NOT widen under this flag: `[...ys]` has type `string[]`,
+    // so this still errors. The diagnostic message must not suggest otherwise.
+    widen([...ys]);
+          ~~~~~~~
+!!! error TS2345: Argument of type 'string[]' is not assignable to parameter of type '(string | number)[]'.
+!!! error TS2345:   Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+!!! error TS2345:     Types of property 'concat' are incompatible.
+!!! error TS2345:       Type '{ (...items: ConcatArray<string>[]): string[]; (...items: (string | ConcatArray<string>)[]): string[]; }' is not assignable to type '{ (...items: ConcatArray<string | number>[]): (string | number)[]; (...items: (string | number | ConcatArray<string | number>)[]): (string | number)[]; }'.
+!!! error TS2345:         Types of parameters 'items' and 'items' are incompatible.
+!!! error TS2345:           Type 'ConcatArray<string | number>' is not assignable to type 'ConcatArray<string>'.
+!!! error TS2345:             The types returned by 'slice(...)' are incompatible between these types.
+!!! error TS2345:               Type '(string | number)[]' is not assignable to type 'string[]'.
+!!! error TS2345:                 Under '--strictArrayVariance', the element type of mutable 'Array' and mutable tuples is invariant. Use 'ReadonlyArray' at the parameter type if reads suffice, or declare the source as the wider element type.
+!!! error TS2345:                   The types returned by 'pop()' are incompatible between these types.
+!!! error TS2345:                     Type 'string | number | undefined' is not assignable to type 'string | undefined'.
+!!! error TS2345:                       Type 'number' is not assignable to type 'string'.
+    
+    // The primary migration target: `readonly` at the parameter boundary stays
+    // covariant under the flag, so passing `string[]` to a consumer typed for
+    // `readonly (string | number)[]` is still accepted.
+    function readWider(xs: readonly (string | number)[]) {
+        return xs.length;
+    }
+    readWider(ys);
+    
+    // Callback contravariance is orthogonal to array variance and must keep
+    // working: a callback accepting the wider element type is assignable to a
+    // parameter typed for the narrower one.
+    function forEachString(xs: readonly string[], cb: (x: string) => void) {
+        for (const x of xs) cb(x);
+    }
+    const wideCb: (x: string | number) => void = () => {};
+    forEachString(ys, wideCb);
+    

--- a/testdata/baselines/reference/compiler/strictArrayVariance(strictarrayvariance=true).symbols
+++ b/testdata/baselines/reference/compiler/strictArrayVariance(strictarrayvariance=true).symbols
@@ -1,0 +1,270 @@
+//// [tests/cases/compiler/strictArrayVariance.ts] ////
+
+=== strictArrayVariance.ts ===
+// Mutable Array: covariant element typing is unsound when the callee mutates.
+function widen(xs: (string | number)[]) {
+>widen : Symbol(widen, Decl(strictArrayVariance.ts, 0, 0))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 1, 15))
+
+    xs.push(3);
+>xs.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 1, 15))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+}
+
+const ys: string[] = ["a"];
+>ys : Symbol(ys, Decl(strictArrayVariance.ts, 5, 5))
+
+widen(ys);
+>widen : Symbol(widen, Decl(strictArrayVariance.ts, 0, 0))
+>ys : Symbol(ys, Decl(strictArrayVariance.ts, 5, 5))
+
+// ReadonlyArray stays covariant in T; passing readonly string[] should remain ok.
+function read(xs: ReadonlyArray<string | number>) {
+>read : Symbol(read, Decl(strictArrayVariance.ts, 6, 10))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 9, 14))
+>ReadonlyArray : Symbol(ReadonlyArray, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2016.array.include.d.ts, --, --) ... and 3 more)
+
+    return xs[0];
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 9, 14))
+}
+
+const rs: readonly string[] = ["b"];
+>rs : Symbol(rs, Decl(strictArrayVariance.ts, 13, 5))
+
+read(rs);
+>read : Symbol(read, Decl(strictArrayVariance.ts, 6, 10))
+>rs : Symbol(rs, Decl(strictArrayVariance.ts, 13, 5))
+
+// `Array<T>` syntax uses the same `globalArrayType` variance as `(T)[]`.
+function idArray(xs: Array<string | number>) {
+>idArray : Symbol(idArray, Decl(strictArrayVariance.ts, 14, 9))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 17, 17))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --) ... and 4 more)
+
+    xs.push(3);
+>xs.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 17, 17))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+}
+
+const zs: Array<string> = ["c"];
+>zs : Symbol(zs, Decl(strictArrayVariance.ts, 21, 5))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --) ... and 4 more)
+
+idArray(zs);
+>idArray : Symbol(idArray, Decl(strictArrayVariance.ts, 14, 9))
+>zs : Symbol(zs, Decl(strictArrayVariance.ts, 21, 5))
+
+// Type alias to `Array<T>` should use the same variance as `Array<T>` / `(T)[]`.
+type ArrayAlias<T> = Array<T>;
+>ArrayAlias : Symbol(ArrayAlias, Decl(strictArrayVariance.ts, 22, 12))
+>T : Symbol(T, Decl(strictArrayVariance.ts, 25, 16))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --) ... and 4 more)
+>T : Symbol(T, Decl(strictArrayVariance.ts, 25, 16))
+
+function idAlias(xs: ArrayAlias<string | number>) {
+>idAlias : Symbol(idAlias, Decl(strictArrayVariance.ts, 25, 30))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 26, 17))
+>ArrayAlias : Symbol(ArrayAlias, Decl(strictArrayVariance.ts, 22, 12))
+
+    xs.push(3);
+>xs.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 26, 17))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+}
+
+const ws: ArrayAlias<string> = ["d"];
+>ws : Symbol(ws, Decl(strictArrayVariance.ts, 30, 5))
+>ArrayAlias : Symbol(ArrayAlias, Decl(strictArrayVariance.ts, 22, 12))
+
+idAlias(ws);
+>idAlias : Symbol(idAlias, Decl(strictArrayVariance.ts, 25, 30))
+>ws : Symbol(ws, Decl(strictArrayVariance.ts, 30, 5))
+
+// Mutable tuples: element positions are invariant under strictArrayVariance.
+function widenTuple(xs: [string | number, string]) {
+>widenTuple : Symbol(widenTuple, Decl(strictArrayVariance.ts, 31, 12))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 34, 20))
+
+    xs[0] = 1;
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 34, 20))
+>0 : Symbol(0)
+}
+
+const tup: [string, string] = ["x", "y"];
+>tup : Symbol(tup, Decl(strictArrayVariance.ts, 38, 5))
+
+widenTuple(tup);
+>widenTuple : Symbol(widenTuple, Decl(strictArrayVariance.ts, 31, 12))
+>tup : Symbol(tup, Decl(strictArrayVariance.ts, 38, 5))
+
+// Nested `Array<Array<U>>`: element type `U[]` is still `globalArrayType`.
+function nest(xs: (string | number)[][]) {
+>nest : Symbol(nest, Decl(strictArrayVariance.ts, 39, 16))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 42, 14))
+
+    xs[0].push(3);
+>xs[0].push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 42, 14))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+}
+
+const row: string[] = ["p"];
+>row : Symbol(row, Decl(strictArrayVariance.ts, 46, 5))
+
+const grid: string[][] = [row];
+>grid : Symbol(grid, Decl(strictArrayVariance.ts, 47, 5))
+>row : Symbol(row, Decl(strictArrayVariance.ts, 46, 5))
+
+nest(grid);
+>nest : Symbol(nest, Decl(strictArrayVariance.ts, 39, 16))
+>grid : Symbol(grid, Decl(strictArrayVariance.ts, 47, 5))
+
+// Readonly tuples use tuple variance (covariant), like ReadonlyArray.
+function rtup(xs: readonly [string | number, string]) {
+>rtup : Symbol(rtup, Decl(strictArrayVariance.ts, 48, 11))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 51, 14))
+
+    return xs[0];
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 51, 14))
+>0 : Symbol(0)
+}
+
+const rt: readonly [string, string] = ["u", "v"] as const;
+>rt : Symbol(rt, Decl(strictArrayVariance.ts, 55, 5))
+>const : Symbol(const)
+
+rtup(rt);
+>rtup : Symbol(rtup, Decl(strictArrayVariance.ts, 48, 11))
+>rt : Symbol(rt, Decl(strictArrayVariance.ts, 55, 5))
+
+// Structural assignability: object with `string[]` field to type expecting `(string | number)[]`.
+interface Hold {
+>Hold : Symbol(Hold, Decl(strictArrayVariance.ts, 56, 9))
+
+    xs: (string | number)[];
+>xs : Symbol(Hold.xs, Decl(strictArrayVariance.ts, 59, 16))
+}
+
+function mutateCell(h: Hold) {
+>mutateCell : Symbol(mutateCell, Decl(strictArrayVariance.ts, 61, 1))
+>h : Symbol(h, Decl(strictArrayVariance.ts, 63, 20))
+>Hold : Symbol(Hold, Decl(strictArrayVariance.ts, 56, 9))
+
+    h.xs.push(1);
+>h.xs.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>h.xs : Symbol(Hold.xs, Decl(strictArrayVariance.ts, 59, 16))
+>h : Symbol(h, Decl(strictArrayVariance.ts, 63, 20))
+>xs : Symbol(Hold.xs, Decl(strictArrayVariance.ts, 59, 16))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+}
+
+const cell: { xs: string[] } = { xs: ["q"] };
+>cell : Symbol(cell, Decl(strictArrayVariance.ts, 67, 5))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 67, 13))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 67, 32))
+
+mutateCell(cell);
+>mutateCell : Symbol(mutateCell, Decl(strictArrayVariance.ts, 61, 1))
+>cell : Symbol(cell, Decl(strictArrayVariance.ts, 67, 5))
+
+// Inference: generic element extraction via `infer U` still works; the instance of
+// Array<string> has its type argument inferred as `string` regardless of the flag.
+type ElemOf<T> = T extends Array<infer U> ? U : never;
+>ElemOf : Symbol(ElemOf, Decl(strictArrayVariance.ts, 68, 17))
+>T : Symbol(T, Decl(strictArrayVariance.ts, 72, 12))
+>T : Symbol(T, Decl(strictArrayVariance.ts, 72, 12))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --) ... and 4 more)
+>U : Symbol(U, Decl(strictArrayVariance.ts, 72, 38))
+>U : Symbol(U, Decl(strictArrayVariance.ts, 72, 38))
+
+type E1 = ElemOf<string[]>; // string
+>E1 : Symbol(E1, Decl(strictArrayVariance.ts, 72, 54))
+>ElemOf : Symbol(ElemOf, Decl(strictArrayVariance.ts, 68, 17))
+
+const e1: E1 = "ok";
+>e1 : Symbol(e1, Decl(strictArrayVariance.ts, 74, 5))
+>E1 : Symbol(E1, Decl(strictArrayVariance.ts, 72, 54))
+
+// Inference: a generic identity function should infer T from the argument type.
+// Under strictArrayVariance this still works because T is inferred, not constrained
+// by a widening target.
+function idGeneric<T>(xs: T[]): T[] {
+>idGeneric : Symbol(idGeneric, Decl(strictArrayVariance.ts, 74, 20))
+>T : Symbol(T, Decl(strictArrayVariance.ts, 79, 19))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 79, 22))
+>T : Symbol(T, Decl(strictArrayVariance.ts, 79, 19))
+>T : Symbol(T, Decl(strictArrayVariance.ts, 79, 19))
+
+    return xs;
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 79, 22))
+}
+
+const inferred = idGeneric(ys); // inferred: string[]
+>inferred : Symbol(inferred, Decl(strictArrayVariance.ts, 83, 5))
+>idGeneric : Symbol(idGeneric, Decl(strictArrayVariance.ts, 74, 20))
+>ys : Symbol(ys, Decl(strictArrayVariance.ts, 5, 5))
+
+const checkInferred: string[] = inferred;
+>checkInferred : Symbol(checkInferred, Decl(strictArrayVariance.ts, 84, 5))
+>inferred : Symbol(inferred, Decl(strictArrayVariance.ts, 83, 5))
+
+// Inference: when the target is wider than the source and both are mutable Array,
+// the strict flag rejects the call (same as the widen cases above) rather than
+// silently widening the inferred type argument.
+function takeWider(xs: Array<string | number>) {}
+>takeWider : Symbol(takeWider, Decl(strictArrayVariance.ts, 84, 41))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 89, 19))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --) ... and 4 more)
+
+takeWider(ys);
+>takeWider : Symbol(takeWider, Decl(strictArrayVariance.ts, 84, 41))
+>ys : Symbol(ys, Decl(strictArrayVariance.ts, 5, 5))
+
+// Spread alone does NOT widen under this flag: `[...ys]` has type `string[]`,
+// so this still errors. The diagnostic message must not suggest otherwise.
+widen([...ys]);
+>widen : Symbol(widen, Decl(strictArrayVariance.ts, 0, 0))
+>ys : Symbol(ys, Decl(strictArrayVariance.ts, 5, 5))
+
+// The primary migration target: `readonly` at the parameter boundary stays
+// covariant under the flag, so passing `string[]` to a consumer typed for
+// `readonly (string | number)[]` is still accepted.
+function readWider(xs: readonly (string | number)[]) {
+>readWider : Symbol(readWider, Decl(strictArrayVariance.ts, 94, 15))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 99, 19))
+
+    return xs.length;
+>xs.length : Symbol(ReadonlyArray.length, Decl(lib.es5.d.ts, --, --))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 99, 19))
+>length : Symbol(ReadonlyArray.length, Decl(lib.es5.d.ts, --, --))
+}
+readWider(ys);
+>readWider : Symbol(readWider, Decl(strictArrayVariance.ts, 94, 15))
+>ys : Symbol(ys, Decl(strictArrayVariance.ts, 5, 5))
+
+// Callback contravariance is orthogonal to array variance and must keep
+// working: a callback accepting the wider element type is assignable to a
+// parameter typed for the narrower one.
+function forEachString(xs: readonly string[], cb: (x: string) => void) {
+>forEachString : Symbol(forEachString, Decl(strictArrayVariance.ts, 102, 14))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 107, 23))
+>cb : Symbol(cb, Decl(strictArrayVariance.ts, 107, 45))
+>x : Symbol(x, Decl(strictArrayVariance.ts, 107, 51))
+
+    for (const x of xs) cb(x);
+>x : Symbol(x, Decl(strictArrayVariance.ts, 108, 14))
+>xs : Symbol(xs, Decl(strictArrayVariance.ts, 107, 23))
+>cb : Symbol(cb, Decl(strictArrayVariance.ts, 107, 45))
+>x : Symbol(x, Decl(strictArrayVariance.ts, 108, 14))
+}
+const wideCb: (x: string | number) => void = () => {};
+>wideCb : Symbol(wideCb, Decl(strictArrayVariance.ts, 110, 5))
+>x : Symbol(x, Decl(strictArrayVariance.ts, 110, 15))
+
+forEachString(ys, wideCb);
+>forEachString : Symbol(forEachString, Decl(strictArrayVariance.ts, 102, 14))
+>ys : Symbol(ys, Decl(strictArrayVariance.ts, 5, 5))
+>wideCb : Symbol(wideCb, Decl(strictArrayVariance.ts, 110, 5))
+

--- a/testdata/baselines/reference/compiler/strictArrayVariance(strictarrayvariance=true).types
+++ b/testdata/baselines/reference/compiler/strictArrayVariance(strictarrayvariance=true).types
@@ -1,0 +1,304 @@
+//// [tests/cases/compiler/strictArrayVariance.ts] ////
+
+=== strictArrayVariance.ts ===
+// Mutable Array: covariant element typing is unsound when the callee mutates.
+function widen(xs: (string | number)[]) {
+>widen : (xs: (string | number)[]) => void
+>xs : (string | number)[]
+
+    xs.push(3);
+>xs.push(3) : number
+>xs.push : (...items: (string | number)[]) => number
+>xs : (string | number)[]
+>push : (...items: (string | number)[]) => number
+>3 : 3
+}
+
+const ys: string[] = ["a"];
+>ys : string[]
+>["a"] : string[]
+>"a" : "a"
+
+widen(ys);
+>widen(ys) : void
+>widen : (xs: (string | number)[]) => void
+>ys : string[]
+
+// ReadonlyArray stays covariant in T; passing readonly string[] should remain ok.
+function read(xs: ReadonlyArray<string | number>) {
+>read : (xs: ReadonlyArray<string | number>) => string | number
+>xs : readonly (string | number)[]
+
+    return xs[0];
+>xs[0] : string | number
+>xs : readonly (string | number)[]
+>0 : 0
+}
+
+const rs: readonly string[] = ["b"];
+>rs : readonly string[]
+>["b"] : string[]
+>"b" : "b"
+
+read(rs);
+>read(rs) : string | number
+>read : (xs: ReadonlyArray<string | number>) => string | number
+>rs : readonly string[]
+
+// `Array<T>` syntax uses the same `globalArrayType` variance as `(T)[]`.
+function idArray(xs: Array<string | number>) {
+>idArray : (xs: Array<string | number>) => void
+>xs : (string | number)[]
+
+    xs.push(3);
+>xs.push(3) : number
+>xs.push : (...items: (string | number)[]) => number
+>xs : (string | number)[]
+>push : (...items: (string | number)[]) => number
+>3 : 3
+}
+
+const zs: Array<string> = ["c"];
+>zs : string[]
+>["c"] : string[]
+>"c" : "c"
+
+idArray(zs);
+>idArray(zs) : void
+>idArray : (xs: Array<string | number>) => void
+>zs : string[]
+
+// Type alias to `Array<T>` should use the same variance as `Array<T>` / `(T)[]`.
+type ArrayAlias<T> = Array<T>;
+>ArrayAlias : ArrayAlias<T>
+
+function idAlias(xs: ArrayAlias<string | number>) {
+>idAlias : (xs: ArrayAlias<string | number>) => void
+>xs : ArrayAlias<string | number>
+
+    xs.push(3);
+>xs.push(3) : number
+>xs.push : (...items: (string | number)[]) => number
+>xs : ArrayAlias<string | number>
+>push : (...items: (string | number)[]) => number
+>3 : 3
+}
+
+const ws: ArrayAlias<string> = ["d"];
+>ws : ArrayAlias<string>
+>["d"] : string[]
+>"d" : "d"
+
+idAlias(ws);
+>idAlias(ws) : void
+>idAlias : (xs: ArrayAlias<string | number>) => void
+>ws : ArrayAlias<string>
+
+// Mutable tuples: element positions are invariant under strictArrayVariance.
+function widenTuple(xs: [string | number, string]) {
+>widenTuple : (xs: [string | number, string]) => void
+>xs : [string | number, string]
+
+    xs[0] = 1;
+>xs[0] = 1 : 1
+>xs[0] : string | number
+>xs : [string | number, string]
+>0 : 0
+>1 : 1
+}
+
+const tup: [string, string] = ["x", "y"];
+>tup : [string, string]
+>["x", "y"] : [string, string]
+>"x" : "x"
+>"y" : "y"
+
+widenTuple(tup);
+>widenTuple(tup) : void
+>widenTuple : (xs: [string | number, string]) => void
+>tup : [string, string]
+
+// Nested `Array<Array<U>>`: element type `U[]` is still `globalArrayType`.
+function nest(xs: (string | number)[][]) {
+>nest : (xs: (string | number)[][]) => void
+>xs : (string | number)[][]
+
+    xs[0].push(3);
+>xs[0].push(3) : number
+>xs[0].push : (...items: (string | number)[]) => number
+>xs[0] : (string | number)[]
+>xs : (string | number)[][]
+>0 : 0
+>push : (...items: (string | number)[]) => number
+>3 : 3
+}
+
+const row: string[] = ["p"];
+>row : string[]
+>["p"] : string[]
+>"p" : "p"
+
+const grid: string[][] = [row];
+>grid : string[][]
+>[row] : string[][]
+>row : string[]
+
+nest(grid);
+>nest(grid) : void
+>nest : (xs: (string | number)[][]) => void
+>grid : string[][]
+
+// Readonly tuples use tuple variance (covariant), like ReadonlyArray.
+function rtup(xs: readonly [string | number, string]) {
+>rtup : (xs: readonly [string | number, string]) => string | number
+>xs : readonly [string | number, string]
+
+    return xs[0];
+>xs[0] : string | number
+>xs : readonly [string | number, string]
+>0 : 0
+}
+
+const rt: readonly [string, string] = ["u", "v"] as const;
+>rt : readonly [string, string]
+>["u", "v"] as const : readonly ["u", "v"]
+>["u", "v"] : readonly ["u", "v"]
+>"u" : "u"
+>"v" : "v"
+
+rtup(rt);
+>rtup(rt) : string | number
+>rtup : (xs: readonly [string | number, string]) => string | number
+>rt : readonly [string, string]
+
+// Structural assignability: object with `string[]` field to type expecting `(string | number)[]`.
+interface Hold {
+    xs: (string | number)[];
+>xs : (string | number)[]
+}
+
+function mutateCell(h: Hold) {
+>mutateCell : (h: Hold) => void
+>h : Hold
+
+    h.xs.push(1);
+>h.xs.push(1) : number
+>h.xs.push : (...items: (string | number)[]) => number
+>h.xs : (string | number)[]
+>h : Hold
+>xs : (string | number)[]
+>push : (...items: (string | number)[]) => number
+>1 : 1
+}
+
+const cell: { xs: string[] } = { xs: ["q"] };
+>cell : { xs: string[]; }
+>xs : string[]
+>{ xs: ["q"] } : { xs: string[]; }
+>xs : string[]
+>["q"] : string[]
+>"q" : "q"
+
+mutateCell(cell);
+>mutateCell(cell) : void
+>mutateCell : (h: Hold) => void
+>cell : { xs: string[]; }
+
+// Inference: generic element extraction via `infer U` still works; the instance of
+// Array<string> has its type argument inferred as `string` regardless of the flag.
+type ElemOf<T> = T extends Array<infer U> ? U : never;
+>ElemOf : ElemOf<T>
+
+type E1 = ElemOf<string[]>; // string
+>E1 : string
+
+const e1: E1 = "ok";
+>e1 : string
+>"ok" : "ok"
+
+// Inference: a generic identity function should infer T from the argument type.
+// Under strictArrayVariance this still works because T is inferred, not constrained
+// by a widening target.
+function idGeneric<T>(xs: T[]): T[] {
+>idGeneric : <T>(xs: T[]) => T[]
+>xs : T[]
+
+    return xs;
+>xs : T[]
+}
+
+const inferred = idGeneric(ys); // inferred: string[]
+>inferred : string[]
+>idGeneric(ys) : string[]
+>idGeneric : <T>(xs: T[]) => T[]
+>ys : string[]
+
+const checkInferred: string[] = inferred;
+>checkInferred : string[]
+>inferred : string[]
+
+// Inference: when the target is wider than the source and both are mutable Array,
+// the strict flag rejects the call (same as the widen cases above) rather than
+// silently widening the inferred type argument.
+function takeWider(xs: Array<string | number>) {}
+>takeWider : (xs: Array<string | number>) => void
+>xs : (string | number)[]
+
+takeWider(ys);
+>takeWider(ys) : void
+>takeWider : (xs: Array<string | number>) => void
+>ys : string[]
+
+// Spread alone does NOT widen under this flag: `[...ys]` has type `string[]`,
+// so this still errors. The diagnostic message must not suggest otherwise.
+widen([...ys]);
+>widen([...ys]) : void
+>widen : (xs: (string | number)[]) => void
+>[...ys] : string[]
+>...ys : string
+>ys : string[]
+
+// The primary migration target: `readonly` at the parameter boundary stays
+// covariant under the flag, so passing `string[]` to a consumer typed for
+// `readonly (string | number)[]` is still accepted.
+function readWider(xs: readonly (string | number)[]) {
+>readWider : (xs: readonly (string | number)[]) => number
+>xs : readonly (string | number)[]
+
+    return xs.length;
+>xs.length : number
+>xs : readonly (string | number)[]
+>length : number
+}
+readWider(ys);
+>readWider(ys) : number
+>readWider : (xs: readonly (string | number)[]) => number
+>ys : string[]
+
+// Callback contravariance is orthogonal to array variance and must keep
+// working: a callback accepting the wider element type is assignable to a
+// parameter typed for the narrower one.
+function forEachString(xs: readonly string[], cb: (x: string) => void) {
+>forEachString : (xs: readonly string[], cb: (x: string) => void) => void
+>xs : readonly string[]
+>cb : (x: string) => void
+>x : string
+
+    for (const x of xs) cb(x);
+>x : string
+>xs : readonly string[]
+>cb(x) : void
+>cb : (x: string) => void
+>x : string
+}
+const wideCb: (x: string | number) => void = () => {};
+>wideCb : (x: string | number) => void
+>x : string | number
+>() => {} : () => void
+
+forEachString(ys, wideCb);
+>forEachString(ys, wideCb) : void
+>forEachString : (xs: readonly string[], cb: (x: string) => void) => void
+>ys : string[]
+>wideCb : (x: string | number) => void
+

--- a/testdata/baselines/reference/tsc/commandLine/help-all.js
+++ b/testdata/baselines/reference/tsc/commandLine/help-all.js
@@ -286,6 +286,11 @@ Enable all strict type-checking options.
 type: boolean
 default: true
 
+[94m--strictArrayVariance[39m
+Treat Array element types as invariant when comparing instantiations.
+type: boolean
+default: false
+
 [94m--strictBindCallApply[39m
 Check that the arguments for 'bind', 'call', and 'apply' methods match the original function.
 type: boolean

--- a/testdata/tests/cases/compiler/strictArrayVariance.ts
+++ b/testdata/tests/cases/compiler/strictArrayVariance.ts
@@ -1,0 +1,116 @@
+// @strict: true
+// @strictArrayVariance: true, false
+// @noEmit: true
+
+// Mutable Array: covariant element typing is unsound when the callee mutates.
+function widen(xs: (string | number)[]) {
+    xs.push(3);
+}
+
+const ys: string[] = ["a"];
+widen(ys);
+
+// ReadonlyArray stays covariant in T; passing readonly string[] should remain ok.
+function read(xs: ReadonlyArray<string | number>) {
+    return xs[0];
+}
+
+const rs: readonly string[] = ["b"];
+read(rs);
+
+// `Array<T>` syntax uses the same `globalArrayType` variance as `(T)[]`.
+function idArray(xs: Array<string | number>) {
+    xs.push(3);
+}
+
+const zs: Array<string> = ["c"];
+idArray(zs);
+
+// Type alias to `Array<T>` should use the same variance as `Array<T>` / `(T)[]`.
+type ArrayAlias<T> = Array<T>;
+function idAlias(xs: ArrayAlias<string | number>) {
+    xs.push(3);
+}
+
+const ws: ArrayAlias<string> = ["d"];
+idAlias(ws);
+
+// Mutable tuples: element positions are invariant under strictArrayVariance.
+function widenTuple(xs: [string | number, string]) {
+    xs[0] = 1;
+}
+
+const tup: [string, string] = ["x", "y"];
+widenTuple(tup);
+
+// Nested `Array<Array<U>>`: element type `U[]` is still `globalArrayType`.
+function nest(xs: (string | number)[][]) {
+    xs[0].push(3);
+}
+
+const row: string[] = ["p"];
+const grid: string[][] = [row];
+nest(grid);
+
+// Readonly tuples use tuple variance (covariant), like ReadonlyArray.
+function rtup(xs: readonly [string | number, string]) {
+    return xs[0];
+}
+
+const rt: readonly [string, string] = ["u", "v"] as const;
+rtup(rt);
+
+// Structural assignability: object with `string[]` field to type expecting `(string | number)[]`.
+interface Hold {
+    xs: (string | number)[];
+}
+
+function mutateCell(h: Hold) {
+    h.xs.push(1);
+}
+
+const cell: { xs: string[] } = { xs: ["q"] };
+mutateCell(cell);
+
+// Inference: generic element extraction via `infer U` still works; the instance of
+// Array<string> has its type argument inferred as `string` regardless of the flag.
+type ElemOf<T> = T extends Array<infer U> ? U : never;
+type E1 = ElemOf<string[]>; // string
+const e1: E1 = "ok";
+
+// Inference: a generic identity function should infer T from the argument type.
+// Under strictArrayVariance this still works because T is inferred, not constrained
+// by a widening target.
+function idGeneric<T>(xs: T[]): T[] {
+    return xs;
+}
+
+const inferred = idGeneric(ys); // inferred: string[]
+const checkInferred: string[] = inferred;
+
+// Inference: when the target is wider than the source and both are mutable Array,
+// the strict flag rejects the call (same as the widen cases above) rather than
+// silently widening the inferred type argument.
+function takeWider(xs: Array<string | number>) {}
+takeWider(ys);
+
+// Spread alone does NOT widen under this flag: `[...ys]` has type `string[]`,
+// so this still errors. The diagnostic message must not suggest otherwise.
+widen([...ys]);
+
+// The primary migration target: `readonly` at the parameter boundary stays
+// covariant under the flag, so passing `string[]` to a consumer typed for
+// `readonly (string | number)[]` is still accepted.
+function readWider(xs: readonly (string | number)[]) {
+    return xs.length;
+}
+readWider(ys);
+
+// Callback contravariance is orthogonal to array variance and must keep
+// working: a callback accepting the wider element type is assignable to a
+// parameter typed for the narrower one.
+function forEachString(xs: readonly string[], cb: (x: string) => void) {
+    for (const x of xs) cb(x);
+}
+const wideCb: (x: string | number) => void = () => {};
+forEachString(ys, wideCb);


### PR DESCRIPTION
> 🚧 **Draft — filed under the `CONTRIBUTING.md` 7.0-freeze policy for discussion only.** Not requesting merge in the 7.0 cycle. Tracking issue: #3576.

## Summary

- New compiler option `strictArrayVariance` — default **off**, **not** implied by `--strict`.
- Under the flag, the element type parameter of `globalArrayType` and mutable tuple element positions are treated as **invariant** when relating instantiations.
- `ReadonlyArray<T>` and readonly tuples remain **covariant** — no change to the read-only view.

## Motivation

Mutable `Array<T>` is covariant in `T` today, which is unsound when a callee can mutate through the reference:

```ts
function widen(xs: (string | number)[]) { xs.push(3); }
const ys: string[] = ["a"];
widen(ys); // accepted; the callee mutates `ys` to hold a number
```

Full design discussion, the `lib.dom.d.ts` adoption blocker, and maintainer questions live on the tracking issue (#3576).

## Implementation notes

- `internal/checker/checker.go` — `arrayVariances` keeps its single covariant slot; a per-`Checker` cache of invariant tuple variances (`strictInvariantTupleVariances`) is populated on demand when the flag is on.
- `internal/checker/relater.go` — `getVariances` returns invariant variances for `globalArrayType` and mutable tuple targets when `c.compilerOptions.StrictArrayVariance == core.TSTrue`. `tryElaborateStrictArrayVarianceHint` emits the dedicated diagnostic.
- `internal/tsoptions/declscompiler.go` — option declaration; `strictFlag` **intentionally omitted** (not implied by `--strict`). An inline comment points at the test that pins that behavior.
- `internal/diagnostics/extraDiagnosticMessages.json` — adds the option-description message (100019) and the dedicated hint (100020). The hint text points at `ReadonlyArray<T>` or a wider source declaration — **not** at `[...arr]`, because bare spread does not widen under contextual typing.
- `internal/project/session.go` — telemetry capture for the new option, mirroring existing `strict*` handling.

## Test plan

- [x] `go test ./internal/checker/...`
- [x] `go test ./internal/tsoptions/...`
- [x] `go test ./internal/core/...`
- [x] `go test ./internal/project/...`
- [x] `go test ./internal/testrunner/...` (incl. `TestLocal/strictArrayVariance.ts_strictarrayvariance={true,false}`)
- [x] Manual UX reproduction: `widen(ys)` accepted with `--strict`; rejected with `--strict --strictArrayVariance` carrying the new hint.

Baselines regenerated via `hereby baseline-accept`. The compiler test case (`testdata/tests/cases/compiler/strictArrayVariance.ts`) covers: mutable `T[]` widening, `ReadonlyArray` preservation, `Array<T>` syntax, type-alias to `Array<T>`, mutable tuples, nested arrays, structural assignment through a containing object, inference via `infer U` and generic identity functions, the readonly-parameter migration target, callback contravariance, and documents that bare `[...arr]` does **not** widen.

## Migration notes

For code that needs to keep compiling under the flag:

- **Prefer `ReadonlyArray<T>` / `readonly T[]` at parameter boundaries** if reads suffice. This is the primary migration target and is exercised by the test case.
- If the callee genuinely needs to mutate, **declare the source with the wider element type from the start**.
- Bare `[...arr]` does not widen — contextual typing preserves the spread's source type. Do not advertise it as a workaround.

## Known gaps / open questions

See the tracking issue #3576. The largest is the `lib.dom.d.ts` adoption blocker: types like `HTMLCollectionOf<T>` extending `HTMLCollectionBase` fail under invariance, so users cannot turn the flag on in projects that import DOM types without a coordinated lib pass.

## Cross-links

- Tracking issue: #3576
- Podcast context (linked, not relied on for the technical case): <https://youtu.be/urYhuK6m_O4?t=3622>
