### PR TITLE
Fix auto-import bucket state race and CreateProgram/UpdateProgram race

### DIFF
--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -273,9 +273,14 @@ func NewProgram(opts ProgramOptions) *Program {
 
 // Return an updated program for which it is known that only the file with the given path has changed.
 // In addition to a new program, return a boolean indicating whether the data of the old program was reused.
-func (p *Program) UpdateProgram(changedFilePath tspath.Path, newHost CompilerHost) (*Program, bool) {
+// createCheckerPool, if non-nil, overrides the CreateCheckerPool stored in the old program's options,
+// ensuring each caller uses a fresh closure and avoiding data races on captured variables.
+func (p *Program) UpdateProgram(changedFilePath tspath.Path, newHost CompilerHost, createCheckerPool func(*Program) CheckerPool) (*Program, bool) {
 	newOpts := p.opts
 	newOpts.Host = newHost
+	if createCheckerPool != nil {
+		newOpts.CreateCheckerPool = createCheckerPool
+	}
 
 	oldFile := p.filesByPath[changedFilePath]
 	newFile := newHost.GetSourceFile(oldFile.ParseOptions())

--- a/internal/fourslash/tests/autoImportSymlinkedMonorepoSourceUpdate_test.go
+++ b/internal/fourslash/tests/autoImportSymlinkedMonorepoSourceUpdate_test.go
@@ -1,0 +1,86 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+const TestAutoImportSymlinkedMonorepoSourceUpdateScenario = `
+// @Filename: /home/src/workspaces/project/tsconfig.base.json
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+	"composite": true
+  }
+}
+
+// @Filename: /home/src/workspaces/project/packages/foo/package.json
+{
+  "name": "@packages/foo",
+  "type": "module",
+  "exports": {
+    ".": {
+	  "types": "./src/index.ts",
+	  "default": "./dist/index.js"
+	}
+  }
+}
+
+// @Filename: /home/src/workspaces/project/packages/foo/tsconfig.json
+{ "extends": "../../tsconfig.base.json" }
+
+// @Filename: /home/src/workspaces/project/packages/foo/src/index.ts
+/*fooEdit*/
+
+// @Filename: /home/src/workspaces/project/packages/bar/package.json
+{
+  "name": "@packages/bar",
+  "type": "module",
+  "exports": {
+    ".": {
+	  "types": "./src/index.ts",
+	  "default": "./dist/index.js"
+	}
+  },
+  "dependencies": {
+    "@packages/foo": "*"
+  }
+}
+
+// @Filename: /home/src/workspaces/project/packages/bar/tsconfig.json
+{ "extends": "../../tsconfig.base.json" }
+
+// @Filename: /home/src/workspaces/project/packages/bar/src/index.ts
+/*fooCompletion*/
+
+// @Filename: /home/src/workspaces/project/package.json
+{ "workspaces": ["packages/*"], "type": "module" }
+
+// @link: /home/src/workspaces/project/packages/bar -> /home/src/workspaces/project/node_modules/@packages/bar
+// @link: /home/src/workspaces/project/packages/foo -> /home/src/workspaces/project/node_modules/@packages/foo
+`
+
+func TestAutoImportSymlinkedMonorepoSourceUpdate(t *testing.T) {
+	t.Parallel()
+
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, TestAutoImportSymlinkedMonorepoSourceUpdateScenario)
+
+	defer done()
+
+	// Force auto import to build the cache (no exports yet).
+	f.GoToMarker(t, "fooCompletion")
+	f.BaselineAutoImportsCompletions(t, []string{"fooCompletion"})
+
+	// Add a new export to the symlinked source package.
+	f.GoToMarker(t, "fooEdit")
+	f.Insert(t, "\nexport function foo() {}")
+
+	// The new export should appear via granular cache update.
+	f.GoToMarker(t, "fooCompletion")
+	f.BaselineAutoImportsCompletions(t, []string{"fooCompletion"})
+}

--- a/internal/ls/autoimport/registry.go
+++ b/internal/ls/autoimport/registry.go
@@ -57,9 +57,10 @@ type BucketState struct {
 	// the bucket was built. If changed, the bucket should be rebuilt.
 	fileExcludePatterns []string
 	// dirtyPackages is the set of package names that need to be re-indexed.
-	// This is used for granular updates: when a file in a project reference package
+	// This is used for granular updates: when a file in a local workspace package
 	// changes, only that package needs to be re-extracted rather than rebuilding
-	// the entire node_modules bucket. If nil, no granular updates are pending.
+	// the entire node_modules bucket.
+	// If nil, no granular updates are pending.
 	// If set but multipleFilesDirty is true, the entire bucket needs to be rebuilt.
 	dirtyPackages *collections.Set[string]
 }
@@ -98,8 +99,10 @@ type RegistryBucket struct {
 
 	// Paths maps file paths to package names. For project buckets, the package name
 	// is always empty string. For node_modules buckets, this enables reverse lookup
-	// from path to package for granular updates. Only paths eligible for granular
-	// update (project reference packages) have entries here.
+	// from path to package for granular updates. Only paths for local workspace
+	// packages (symlinked and within the workspace root) have entries here, since
+	// their realpaths are outside node_modules and need reverse lookup for dirty
+	// detection.
 	Paths map[tspath.Path]string
 	// PackageFiles maps package names to their file paths and file names.
 	// All package directory names in node_modules are keys; indexed packages have
@@ -615,8 +618,8 @@ func (b *registryBuilder) markBucketsDirty(change RegistryChange, logger *loggin
 						}
 					}
 				} else {
-					// Check if this path (possibly a realpath of a symlinked package) is in any bucket's Paths.
-					// This handles symlinked packages where the realpath doesn't contain /node_modules/.
+					// Check if this path (possibly a realpath of a workspace package) is in any bucket's Paths.
+					// This handles local workspace packages where the realpath doesn't contain /node_modules/.
 					for bucketDirPath := range cleanNodeModulesBuckets {
 						entry := core.FirstResult(b.nodeModules.Get(bucketDirPath))
 						if packageName, ok := entry.Value().Paths[path]; ok {
@@ -1184,6 +1187,7 @@ type discoveredPackage struct {
 	typesPackageJson *packagejson.InfoCacheEntry
 	typesRealpath    string
 	dirPath          tspath.Path // bucket directory path (used as extraction context)
+	isLocal          bool        // true if realpath is within the workspace root
 }
 
 // perPackageExtractionResult holds the extraction output for one physical package.
@@ -1197,7 +1201,7 @@ type perPackageExtractionResult struct {
 	statsExports                     int
 	statsUsedChecker                 int
 	skippedEntrypoints               int
-	isProjectReference               bool
+	isSymlinked                      bool
 	failedAmbientModuleLookupSources map[tspath.Path]*failedAmbientModuleLookupSource
 	failedAmbientModuleLookupTargets *collections.Set[string]
 }
@@ -1208,7 +1212,7 @@ type packageExtractionResult struct {
 	packageFiles                             map[string]map[tspath.Path]string
 	ambientModuleNames                       map[string][]string
 	entrypoints                              [][]*module.ResolvedEntrypoint
-	projectReferencePackages                 *collections.Set[string]
+	workspacePackages                        *collections.Set[string]
 	possibleFailedAmbientModuleLookupSources *collections.SyncMap[tspath.Path, *failedAmbientModuleLookupSource]
 	possibleFailedAmbientModuleLookupTargets *collections.SyncSet[string]
 	stats                                    extractorStats
@@ -1241,6 +1245,13 @@ func (b *registryBuilder) discoverBucketPackages(
 		if typesPackageJson != nil {
 			typesRealpath = b.host.FS().Realpath(typesPackageJson.PackageDirectory)
 		}
+		isLocal := realpath != "" &&
+			!strings.Contains(realpath, "/node_modules/") &&
+			tspath.ContainsPath(
+				b.host.GetCurrentDirectory(),
+				realpath,
+				tspath.ComparePathsOptions{UseCaseSensitiveFileNames: b.host.FS().UseCaseSensitiveFileNames()},
+			)
 		result = append(result, &discoveredPackage{
 			packageName:      packageName,
 			packageJson:      packageJson,
@@ -1248,6 +1259,7 @@ func (b *registryBuilder) discoverBucketPackages(
 			typesPackageJson: typesPackageJson,
 			typesRealpath:    typesRealpath,
 			dirPath:          dirPath,
+			isLocal:          isLocal,
 		})
 	}
 	return result
@@ -1309,7 +1321,6 @@ func (b *registryBuilder) extractPackage(
 			fileName = toSymlink(inputFileName)
 			realpathFileName = inputFileName
 			realpathPath = b.base.toPath(realpathFileName)
-			result.isProjectReference = true
 		}
 
 		if !seenFiles.AddIfAbsent(realpathPath) {
@@ -1318,6 +1329,7 @@ func (b *registryBuilder) extractPackage(
 		if fileName != realpathFileName {
 			symlinkPath := b.base.toPath(fileName)
 			symlinks[realpathPath] = pathAndFileName{path: symlinkPath, fileName: fileName}
+			result.isSymlinked = true
 		}
 		wg.Go(func() {
 			file := b.host.GetSourceFile(realpathFileName, realpathPath)
@@ -1377,7 +1389,7 @@ func installExtractions(
 		exports:                                  make(map[tspath.Path][]*Export),
 		packageFiles:                             make(map[string]map[tspath.Path]string),
 		ambientModuleNames:                       make(map[string][]string),
-		projectReferencePackages:                 &collections.Set[string]{},
+		workspacePackages:                        &collections.Set[string]{},
 		possibleFailedAmbientModuleLookupSources: &collections.SyncMap[tspath.Path, *failedAmbientModuleLookupSource]{},
 		possibleFailedAmbientModuleLookupTargets: &collections.SyncSet[string]{},
 	}
@@ -1407,8 +1419,8 @@ func installExtractions(
 		for target := range extraction.failedAmbientModuleLookupTargets.Keys() {
 			result.possibleFailedAmbientModuleLookupTargets.Add(target)
 		}
-		if extraction.isProjectReference {
-			result.projectReferencePackages.Add(pkg.packageName)
+		if extraction.isSymlinked && pkg.isLocal {
+			result.workspacePackages.Add(pkg.packageName)
 		}
 		result.stats.exports.Add(int32(extraction.statsExports))
 		result.stats.usedChecker.Add(int32(extraction.statsUsedChecker))
@@ -1444,9 +1456,9 @@ func (b *registryBuilder) buildNodeModulesBucket(
 	}
 
 	// Build Paths as reverse mapping from path to package name.
-	// Only include paths for packages that are project references (eligible for granular updates).
+	// Only include paths for local workspace packages (eligible for granular updates).
 	paths := make(map[tspath.Path]string)
-	for pkgName := range extraction.projectReferencePackages.Keys() {
+	for pkgName := range extraction.workspacePackages.Keys() {
 		if files, ok := extraction.packageFiles[pkgName]; ok {
 			for path := range files {
 				paths[path] = pkgName
@@ -1545,8 +1557,8 @@ func (b *registryBuilder) updateNodeModulesBucket(
 		}
 		newPaths[path] = pkgName
 	}
-	// Add paths for newly extracted project reference packages
-	for pkgName := range extraction.projectReferencePackages.Keys() {
+	// Add paths for newly extracted workspace packages
+	for pkgName := range extraction.workspacePackages.Keys() {
 		if files, ok := extraction.packageFiles[pkgName]; ok {
 			for path := range files {
 				newPaths[path] = pkgName

--- a/internal/ls/autoimport/registry.go
+++ b/internal/ls/autoimport/registry.go
@@ -65,6 +65,12 @@ type BucketState struct {
 	dirtyPackages *collections.Set[string]
 }
 
+func (b BucketState) Clone() BucketState {
+	b.fileExcludePatterns = slices.Clone(b.fileExcludePatterns)
+	b.dirtyPackages = b.dirtyPackages.Clone()
+	return b
+}
+
 func (b BucketState) Dirty() bool {
 	return b.multipleFilesDirty || b.dirtyFile != "" || b.newProgramStructure > 0 || b.dirtyPackages.Len() > 0
 }
@@ -139,7 +145,7 @@ func newRegistryBucket() *RegistryBucket {
 
 func (b *RegistryBucket) Clone() *RegistryBucket {
 	return &RegistryBucket{
-		state:                b.state,
+		state:                b.state.Clone(),
 		Paths:                b.Paths,
 		PackageFiles:         b.PackageFiles,
 		ResolvedPackageNames: b.ResolvedPackageNames,

--- a/internal/ls/autoimport/registry.go
+++ b/internal/ls/autoimport/registry.go
@@ -109,17 +109,26 @@ type RegistryBucket struct {
 	// packages (symlinked and within the workspace root) have entries here, since
 	// their realpaths are outside node_modules and need reverse lookup for dirty
 	// detection.
+	//
+	// Paths is considered immutable after the bucket is finalized.
+	// It should be fully replaced rather than mutated while changing a bucket.
 	Paths map[tspath.Path]string
 	// PackageFiles maps package names to their file paths and file names.
 	// All package directory names in node_modules are keys; indexed packages have
 	// non-nil maps with path→fileName entries, unindexed packages have nil maps.
 	// This enables efficient removal of a package's files during granular updates
 	// without iterating through all entries. Only defined for node_modules buckets.
+	//
+	// PackageFiles is considered immutable after the bucket is finalized.
+	// It should be fully replaced rather than mutated while changing a bucket.
 	PackageFiles map[string]map[tspath.Path]string
 	// ResolvedPackageNames is only defined for project buckets. It is the set of
 	// package names that were resolved from imports in the project's program files.
 	// This is passed to node_modules buckets so they include packages that are
 	// directly imported even if not listed in package.json dependencies.
+	//
+	// ResolvedPackageNames is considered immutable after the bucket is finalized.
+	// It should be fully replaced rather than mutated while changing a bucket.
 	ResolvedPackageNames *collections.Set[string]
 	// DependencyNames is only defined for node_modules buckets. It is the set of
 	// package names that will be included in the bucket if present in the directory,
@@ -127,11 +136,19 @@ type RegistryBucket struct {
 	// active programs. If nil, all packages are included because at least one open
 	// file has access to this node_modules directory without being filtered by a
 	// package.json.
+	//
+	// DependencyNames is considered immutable after the bucket is finalized.
+	// It should be fully replaced rather than mutated while changing a bucket.
 	DependencyNames *collections.Set[string]
 	// AmbientModuleNames is only defined for node_modules buckets. It is the set of
 	// ambient module names found while extracting exports in the bucket.
+	//
+	// AmbientModuleNames is considered immutable after the bucket is finalized.
+	// It should be fully replaced rather than mutated while changing a bucket.
 	AmbientModuleNames map[string][]string
-	Index              *Index[*Export]
+	// Index is considered immutable after the bucket is finalized.
+	// It should be cloned and replaced rather than mutated while changing a bucket.
+	Index *Index[*Export]
 }
 
 func newRegistryBucket() *RegistryBucket {

--- a/internal/ls/autoimport/registry_test.go
+++ b/internal/ls/autoimport/registry_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/microsoft/typescript-go/internal/bundled"
 	"github.com/microsoft/typescript-go/internal/collections"
 	"github.com/microsoft/typescript-go/internal/core"
 	"github.com/microsoft/typescript-go/internal/ls/autoimport"
@@ -498,6 +499,152 @@ export declare const otherValue: string;`,
 		stats = autoImportStats(t, session)
 		nodeModulesBucket = singleBucket(t, stats.NodeModulesBuckets)
 		assert.Equal(t, nodeModulesBucket.State.Dirty(), false, "bucket should be clean after rebuild")
+	})
+
+	t.Run("pnpm-style symlinks only grant granular updates to workspace packages", func(t *testing.T) {
+		// In pnpm, every package in node_modules is symlinked — registry packages
+		// are symlinked into node_modules/.pnpm/<pkg>@<version>/node_modules/<pkg>.
+		// Only local workspace packages (whose realpaths are outside node_modules
+		// and within the workspace root) should be eligible for granular updates.
+		// Registry packages should trigger full bucket rebuilds.
+		t.Parallel()
+		monorepoRoot := "/home/src/pnpm-monorepo"
+		projectADir := tspath.CombinePaths(monorepoRoot, "packages", "project-a")
+		projectBDir := tspath.CombinePaths(monorepoRoot, "packages", "project-b")
+		projectAIndex := tspath.CombinePaths(projectADir, "src", "index.ts")
+		projectBSrcIndex := tspath.CombinePaths(projectBDir, "src", "index.ts")
+		projectBDistIndex := tspath.CombinePaths(projectBDir, "dist", "index.d.ts")
+
+		// Simulated pnpm virtual store for a registry package (inside project-a's node_modules).
+		// In real pnpm, this would be node_modules/.pnpm/other-pkg@1.0.0/node_modules/other-pkg,
+		// but we use a simplified path to avoid creating nested node_modules buckets in tests.
+		pnpmStoreDir := tspath.CombinePaths(projectADir, "node_modules", ".pnpm-store", "other-pkg@1.0.0")
+		otherPkgIndex := tspath.CombinePaths(pnpmStoreDir, "index.d.ts")
+
+		files := map[string]any{
+			// project-b: a local workspace package
+			tspath.CombinePaths(projectBDir, "tsconfig.json"): `{
+				"compilerOptions": {
+					"composite": true,
+					"outDir": "./dist",
+					"rootDir": "./src",
+					"declaration": true,
+					"module": "esnext",
+					"strict": true
+				},
+				"include": ["src"]
+			}`,
+			tspath.CombinePaths(projectBDir, "package.json"): `{
+				"name": "project-b",
+				"version": "1.0.0",
+				"main": "dist/index.js",
+				"types": "dist/index.d.ts"
+			}`,
+			projectBSrcIndex: `export function projectBFunction(): string { return "hello"; }
+export const projectBValue: number = 42;`,
+			projectBDistIndex: `export declare function projectBFunction(): string;
+export declare const projectBValue: number;`,
+			// other-pkg: a registry package in pnpm's virtual store
+			tspath.CombinePaths(pnpmStoreDir, "package.json"): `{
+				"name": "other-pkg",
+				"version": "1.0.0",
+				"main": "index.js",
+				"types": "index.d.ts"
+			}`,
+			otherPkgIndex: `export declare function otherFunction(): void;
+export declare const otherValue: string;`,
+			// project-a: the consumer package
+			tspath.CombinePaths(projectADir, "tsconfig.json"): `{
+				"compilerOptions": {
+					"module": "esnext",
+					"strict": true,
+					"outDir": "./dist",
+					"rootDir": "./src"
+				},
+				"include": ["src"],
+				"references": [{ "path": "../project-b" }]
+			}`,
+			tspath.CombinePaths(projectADir, "package.json"): `{
+				"name": "project-a",
+				"dependencies": { "project-b": "*", "other-pkg": "*" }
+			}`,
+			projectAIndex: `console.log("hello");
+`,
+			// Symlink: local workspace package (realpath outside node_modules)
+			tspath.CombinePaths(projectADir, "node_modules", "project-b"): vfstest.Symlink(projectBDir),
+			// Symlink: pnpm-style registry package (realpath inside node_modules/.pnpm)
+			tspath.CombinePaths(projectADir, "node_modules", "other-pkg"): vfstest.Symlink(pnpmStoreDir),
+		}
+
+		session, _ := projecttestutil.SetupWithOptions(files, &project.SessionOptions{
+			CurrentDirectory:       monorepoRoot,
+			DefaultLibraryPath:     bundled.LibPath(),
+			PositionEncoding:       lsproto.PositionEncodingKindUTF8,
+			WatchEnabled:           true,
+			LoggingEnabled:         true,
+			PushDiagnosticsEnabled: true,
+		})
+		t.Cleanup(session.Close)
+		ctx := context.Background()
+
+		// Open project-a's index file and build auto-imports
+		projectAURI := lsconv.FileNameToDocumentURI(projectAIndex)
+		projectAContent := files[projectAIndex].(string)
+		session.DidOpenFile(ctx, projectAURI, 1, projectAContent, lsproto.LanguageKindTypeScript)
+		_, err := session.GetCurrentLanguageServiceWithAutoImports(ctx, projectAURI)
+		assert.NilError(t, err)
+
+		// Verify initial state: bucket is clean
+		stats := autoImportStats(t, session)
+		nodeModulesBucket := singleBucket(t, stats.NodeModulesBuckets)
+		assert.Equal(t, nodeModulesBucket.State.Dirty(), false, "bucket should be clean initially")
+
+		// Modify project-b's source file (local workspace package)
+		projectBURI := lsconv.FileNameToDocumentURI(projectBSrcIndex)
+		projectBContent := files[projectBSrcIndex].(string)
+		session.DidOpenFile(ctx, projectBURI, 1, projectBContent, lsproto.LanguageKindTypeScript)
+		session.DidChangeFile(ctx, projectBURI, 2, []lsproto.TextDocumentContentChangePartialOrWholeDocument{
+			{WholeDocument: &lsproto.TextDocumentContentChangeWholeDocument{Text: `export const projectBValue: number = 42;`}},
+		})
+
+		// project-b should get a granular update (tracked in dirtyPackages)
+		_, err = session.GetLanguageService(ctx, projectAURI)
+		assert.NilError(t, err)
+		stats = autoImportStats(t, session)
+		nodeModulesBucket = singleBucket(t, stats.NodeModulesBuckets)
+		assert.Equal(t, nodeModulesBucket.State.Dirty(), true, "bucket should be dirty after workspace package change")
+		dirtyPackages := nodeModulesBucket.State.DirtyPackages()
+		assert.Assert(t, dirtyPackages != nil, "dirty packages should be tracked for workspace package")
+		assert.Assert(t, dirtyPackages.Has("project-b"), "project-b should be in dirty packages")
+		assert.Equal(t, dirtyPackages.Len(), 1, "only project-b should be dirty")
+
+		// Rebuild to clear dirty state
+		_, err = session.GetCurrentLanguageServiceWithAutoImports(ctx, projectAURI)
+		assert.NilError(t, err)
+		stats = autoImportStats(t, session)
+		nodeModulesBucket = singleBucket(t, stats.NodeModulesBuckets)
+		assert.Equal(t, nodeModulesBucket.State.Dirty(), false, "bucket should be clean after rebuild")
+
+		// Now modify other-pkg (pnpm registry package, realpath inside node_modules/.pnpm)
+		otherPkgURI := lsconv.FileNameToDocumentURI(otherPkgIndex)
+		otherPkgContent := files[otherPkgIndex].(string)
+		session.DidOpenFile(ctx, otherPkgURI, 1, otherPkgContent, lsproto.LanguageKindTypeScript)
+		session.DidChangeFile(ctx, otherPkgURI, 2, []lsproto.TextDocumentContentChangePartialOrWholeDocument{
+			{WholeDocument: &lsproto.TextDocumentContentChangeWholeDocument{Text: `export declare function otherFunction(): void;`}},
+		})
+
+		// other-pkg should trigger a full rebuild (multipleFilesDirty), not a granular update
+		_, err = session.GetLanguageService(ctx, projectAURI)
+		assert.NilError(t, err)
+		stats = autoImportStats(t, session)
+		nodeModulesBucket = singleBucket(t, stats.NodeModulesBuckets)
+		assert.Equal(t, nodeModulesBucket.State.Dirty(), true, "bucket should be dirty after registry package change")
+		dirtyPackages = nodeModulesBucket.State.DirtyPackages()
+		// A full rebuild means dirtyPackages is nil (multipleFilesDirty takes precedence)
+		// or dirtyPackages doesn't contain "other-pkg" as a granular entry
+		if dirtyPackages != nil {
+			assert.Assert(t, !dirtyPackages.Has("other-pkg"), "other-pkg should NOT be in dirty packages (should trigger full rebuild)")
+		}
 	})
 
 	t.Run("changed fileExcludePatterns triggers bucket rebuild", func(t *testing.T) {

--- a/internal/project/autoimport.go
+++ b/internal/project/autoimport.go
@@ -87,6 +87,7 @@ func newAutoImportRegistryCloneHost(
 		projectCollection: projectCollection,
 		parseCache:        parseCache,
 		fs:                newSourceFS(false, &autoImportBuilderFS{snapshotFSBuilder: snapshotFSBuilder}, toPath),
+		currentDirectory:  currentDirectory,
 	}
 }
 

--- a/internal/project/checkerpool.go
+++ b/internal/project/checkerpool.go
@@ -42,6 +42,9 @@ func newCheckerPool(maxCheckers int, program *compiler.Program, log func(msg str
 		globalDiagCheckerCount: make([]int, maxCheckers),
 	}
 
+	if pool.log == nil {
+		pool.log = func(msg string) {}
+	}
 	pool.cond = sync.NewCond(&pool.mu)
 	return pool
 }

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -341,10 +341,8 @@ func (p *Project) CreateProgram() CreateProgramResult {
 	// CreateProgram must use its own closure so that concurrent goroutines cloning
 	// the same project never share a captured variable through a stale closure
 	// stored in the old program's options.
-	// Capture only the log function, not the entire *Project receiver.
-	log := p.log
 	createCheckerPool := func(program *compiler.Program) compiler.CheckerPool {
-		checkerPool = newCheckerPool(4, program, log)
+		checkerPool = newCheckerPool(4, program, nil)
 		return checkerPool
 	}
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -337,11 +337,22 @@ func (p *Project) CreateProgram() CreateProgramResult {
 	var checkerPool *CheckerPool
 	var newProgram *compiler.Program
 
+	// Define a fresh CreateCheckerPool closure for this call. Each invocation of
+	// CreateProgram must use its own closure so that concurrent goroutines cloning
+	// the same project never share a captured variable through a stale closure
+	// stored in the old program's options.
+	// Capture only the log function, not the entire *Project receiver.
+	log := p.log
+	createCheckerPool := func(program *compiler.Program) compiler.CheckerPool {
+		checkerPool = newCheckerPool(4, program, log)
+		return checkerPool
+	}
+
 	// Create the command line, potentially augmented with typing files
 	commandLine := p.getCommandLineWithTypingsFiles()
 
 	if p.dirtyFilePath != "" && p.Program != nil && p.Program.CommandLine() == commandLine {
-		newProgram, programCloned = p.Program.UpdateProgram(p.dirtyFilePath, p.host)
+		newProgram, programCloned = p.Program.UpdateProgram(p.dirtyFilePath, p.host, createCheckerPool)
 		if programCloned {
 			updateKind = ProgramUpdateKindCloned
 			for _, file := range newProgram.SourceFiles() {
@@ -370,10 +381,7 @@ func (p *Project) CreateProgram() CreateProgramResult {
 				Config:                      commandLine,
 				UseSourceOfProjectReference: true,
 				TypingsLocation:             typingsLocation,
-				CreateCheckerPool: func(program *compiler.Program) compiler.CheckerPool {
-					checkerPool = newCheckerPool(4, program, p.log)
-					return checkerPool
-				},
+				CreateCheckerPool:           createCheckerPool,
 			},
 		)
 	}

--- a/testdata/baselines/reference/fourslash/autoImports/autoImportSymlinkedMonorepoSourceUpdate.baseline.md
+++ b/testdata/baselines/reference/fourslash/autoImports/autoImportSymlinkedMonorepoSourceUpdate.baseline.md
@@ -1,0 +1,16 @@
+// === Auto Imports === 
+```ts
+// @FileName: /home/src/workspaces/project/packages/bar/src/index.ts
+/*fooCompletion*/
+
+```// === Auto Imports === 
+```ts
+// @FileName: /home/src/workspaces/project/packages/bar/src/index.ts
+/*fooCompletion*/
+
+``````ts
+import { foo } from "@packages/foo";
+
+
+```
+


### PR DESCRIPTION
BucketStates contained pointers that were being mutated on what should have been immutable RegistryBuckets. Added a deep clone of those fields to `(*RegistryBucket).Clone`. Other fields looked suspicious but are in fact always fully reassigned, so added some comments about that too.

Fixes the races that started showing up after #3057 

Closes #2582 again