### PR TITLE
Recover from shutdown timeout in tryRestart

### DIFF
--- a/_extension/src/client.ts
+++ b/_extension/src/client.ts
@@ -273,7 +273,13 @@ export class Client implements vscode.Disposable {
 
         this.isInitialized = false;
         this.outputChannel.appendLine(`Restarting language server...`);
-        await this.client.restart();
+        try {
+            await this.client.restart();
+        }
+        catch (err) {
+            this.outputChannel.appendLine(`Graceful shutdown failed, forcing restart: ${err}`);
+            await this.client.start();
+        }
         return true;
     }
 


### PR DESCRIPTION
## Summary

Make **TypeScript Native Preview: Restart Server** succeed on the first click when the language server is hung.

Fixes #3601.

## Problem

`Client.tryRestart` in [`_extension/src/client.ts`](_extension/src/client.ts) currently calls `LanguageClient.restart()` directly. `LanguageClient.restart()` is `await this.stop(); await this.start();`. `stop()` performs an LSP graceful shutdown with a hardcoded 2-second timeout in `vscode-languageclient`. When the server is hung and doesn't answer `shutdown`/`exit` within that window, `stop()` rejects, the rejection bubbles up, and `await this.start()` is never reached — so no new process is forked. The user sees a `Stopping the server timed out` popup and has to click Restart again to actually get a new server.

## Change

Wrap `client.restart()` in `try`/`catch`. If the graceful shutdown rejects (which only happens when the server is unresponsive), fall back to a plain `client.start()`. By the time the catch runs, `vscode-languageclient` has already cleaned up its state to `Stopped` and scheduled a SIGKILL of the old process via its internal `checkProcessDied` — so `start()` cleanly forks a fresh server.

```ts
try {
    await this.client.restart();
}
catch (err) {
    this.outputChannel.appendLine(`Graceful shutdown failed, forcing restart: ${err}`);
    await this.client.start();
}
```

The behavior on the happy path (server responds to `shutdown` normally) is unchanged — `restart()` returns successfully, the catch never runs.

## Verification

Manual test using the deterministic reproduction from [#3601](https://github.com/microsoft/typescript-go/issues/3601):

1. Add `time.Sleep(5 * time.Second)` at the top of [`handleShutdown` in `internal/lsp/server.go`](internal/lsp/server.go#L1214).
2. Build (`hereby tsgo` + extension build), run extension dev host, open a TypeScript file.
3. Run **TypeScript Native Preview: Restart Server**.

**Before the fix:**
```
Restarting language server...
[error] Stopping server timed out
```
Popup appears. Server is dead. User must click Restart a second time to get a working server.

**After the fix:**
```
Restarting language server...
[error] Stopping server timed out
[info]  Graceful shutdown failed, forcing restart: Error: Stopping the server timed out
[info]  Resolved client capabilities: { ... }
```
No popup. Server is back up after a single click, with a ~2s delay (the unavoidable `vscode-languageclient` shutdown timeout).

## Scope

Per [CONTRIBUTING.md](CONTRIBUTING.md), only PRs addressing 6.0/7.0 differences or crashes are being accepted before TS 7.0 ships. This change is strictly client-side (TypeScript-only, ~5 lines, no Go-parity surface) and improves the recovery path from server crashes/hangs — it doesn't change any compiler behavior. Happy to defer if it's still considered out of scope, but flagging that the bug actively degrades the experience whenever a crash or hang does occur.
