### PR TITLE
Fix go to implementation crash on invalid CJS shorthand exports

### DIFF
--- a/internal/fourslash/tests/goToImplementationReachingNonExistentExport1_test.go
+++ b/internal/fourslash/tests/goToImplementationReachingNonExistentExport1_test.go
@@ -1,0 +1,27 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestGoToImplementationReachingNonExistentExport1(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `
+// @Filename: /github.ts
+export { transformRecordedData };
+
+// @Filename: /gitGateway.ts
+import { transformRecordedData as transformGitHub } from './github';
+
+const methods = { github: {
+    transformData: /*impl*/transformGitHub,
+}};
+`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineGoToImplementation(t, "impl")
+}

--- a/internal/fourslash/tests/goToImplementationReachingNonExistentExport2_test.go
+++ b/internal/fourslash/tests/goToImplementationReachingNonExistentExport2_test.go
@@ -1,0 +1,30 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestGoToImplementationReachingNonExistentExport2(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `
+// @allowJs: true
+// @checkJs: true
+
+// @Filename: /github.js
+module.exports = { transformRecordedData };
+
+// @Filename: /gitGateway.js
+const { transformRecordedData: transformGitHub } = require('./github');
+
+const methods = { github: {
+    transformData: /*impl*/transformGitHub,
+}};
+`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineGoToImplementation(t, "impl")
+}

--- a/internal/fourslash/tests/goToImplementationReachingNonExistentExport3_test.go
+++ b/internal/fourslash/tests/goToImplementationReachingNonExistentExport3_test.go
@@ -1,0 +1,30 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestGoToImplementationReachingNonExistentExport3(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `
+// @allowJs: true
+// @checkJs: true
+
+// @Filename: /github.js
+export { transformRecordedData };
+
+// @Filename: /gitGateway.js
+import { transformRecordedData as transformGitHub } from './github';
+
+const methods = { github: {
+    transformData: /*impl*/transformGitHub,
+}};
+`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineGoToImplementation(t, "impl")
+}

--- a/internal/ls/importTracker.go
+++ b/internal/ls/importTracker.go
@@ -578,6 +578,9 @@ func getImportOrExportSymbol(node *ast.Node, symbol *ast.Symbol, checker *checke
 		}
 		// Search on the local symbol in the exporting module, not the exported symbol.
 		importedSymbol = skipExportSpecifierSymbol(importedSymbol, checker)
+		if importedSymbol == nil {
+			return nil
+		}
 		// Similarly, skip past the symbol for 'export ='
 		if importedSymbol.Name == "export=" {
 			importedSymbol = getExportEqualsLocalSymbol(importedSymbol, checker)
@@ -672,7 +675,7 @@ func skipExportSpecifierSymbol(symbol *ast.Symbol, checker *checker.Checker) *as
 			// Export of form 'module.exports.propName = expr';
 			return checker.GetSymbolAtLocation(declaration)
 		case ast.IsShorthandPropertyAssignment(declaration) && ast.IsBinaryExpression(declaration.Parent.Parent) && ast.GetAssignmentDeclarationKind(declaration.Parent.Parent) == ast.JSDeclarationKindModuleExports:
-			return core.OrElse(checker.GetExportSpecifierLocalTargetSymbol(declaration.Name()), symbol)
+			return checker.GetExportSpecifierLocalTargetSymbol(declaration.Name())
 		}
 	}
 	return symbol

--- a/internal/ls/importTracker.go
+++ b/internal/ls/importTracker.go
@@ -672,7 +672,7 @@ func skipExportSpecifierSymbol(symbol *ast.Symbol, checker *checker.Checker) *as
 			// Export of form 'module.exports.propName = expr';
 			return checker.GetSymbolAtLocation(declaration)
 		case ast.IsShorthandPropertyAssignment(declaration) && ast.IsBinaryExpression(declaration.Parent.Parent) && ast.GetAssignmentDeclarationKind(declaration.Parent.Parent) == ast.JSDeclarationKindModuleExports:
-			return checker.GetExportSpecifierLocalTargetSymbol(declaration.Name())
+			return core.OrElse(checker.GetExportSpecifierLocalTargetSymbol(declaration.Name()), symbol)
 		}
 	}
 	return symbol

--- a/testdata/baselines/reference/fourslash/goToImplementation/goToImplementationReachingNonExistentExport1.baseline.jsonc
+++ b/testdata/baselines/reference/fourslash/goToImplementation/goToImplementationReachingNonExistentExport1.baseline.jsonc
@@ -1,0 +1,8 @@
+// === goToImplementation ===
+// === /gitGateway.ts ===
+// import { transformRecordedData as transformGitHub } from './github';
+// 
+// const methods = { github: {
+//     transformData: /*GOTO IMPL*/transformGitHub,
+// }};
+// 

--- a/testdata/baselines/reference/fourslash/goToImplementation/goToImplementationReachingNonExistentExport2.baseline.jsonc
+++ b/testdata/baselines/reference/fourslash/goToImplementation/goToImplementationReachingNonExistentExport2.baseline.jsonc
@@ -1,0 +1,8 @@
+// === goToImplementation ===
+// === /gitGateway.js ===
+// const { transformRecordedData: transformGitHub } = require('./github');
+// 
+// const methods = { github: {
+//     transformData: /*GOTO IMPL*/transformGitHub,
+// }};
+// 

--- a/testdata/baselines/reference/fourslash/goToImplementation/goToImplementationReachingNonExistentExport3.baseline.jsonc
+++ b/testdata/baselines/reference/fourslash/goToImplementation/goToImplementationReachingNonExistentExport3.baseline.jsonc
@@ -1,0 +1,8 @@
+// === goToImplementation ===
+// === /gitGateway.js ===
+// import { transformRecordedData as transformGitHub } from './github';
+// 
+// const methods = { github: {
+//     transformData: /*GOTO IMPL*/transformGitHub,
+// }};
+// 


### PR DESCRIPTION
fixes the crash reported here: https://github.com/microsoft/typescript-go/issues/3593#issuecomment-4316621438