### PR TITLE
Fix rename panic on unresolved reexports

### DIFF
--- a/internal/fourslash/tests/renameUnresolvedReexport1_test.go
+++ b/internal/fourslash/tests/renameUnresolvedReexport1_test.go
@@ -1,0 +1,22 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestRenameUnresolvedReexport1(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `// @Filename: /a.ts
+export { [|jsonSchema|] } from "@internal/ai-sdk-v4";
+// @Filename: /b.ts
+import { jsonSchema } from "./a";
+`
+
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineRename(t, nil /*preferences*/, f.Ranges()[0])
+}

--- a/internal/ls/rename.go
+++ b/internal/ls/rename.go
@@ -326,7 +326,7 @@ func (l *LanguageService) getTextForRename(originalNode *ast.Node, entry *Refere
 			} else {
 				originalSymbol = ch.GetSymbolAtLocation(originalNode)
 			}
-			if slices.Contains(originalSymbol.Declarations, parent) {
+			if originalSymbol != nil && slices.Contains(originalSymbol.Declarations, parent) {
 				return name + " as " + newText
 			}
 			return newText

--- a/testdata/baselines/reference/fourslash/findRenameLocations/renameUnresolvedReexport1.baseline.jsonc
+++ b/testdata/baselines/reference/fourslash/findRenameLocations/renameUnresolvedReexport1.baseline.jsonc
@@ -1,0 +1,7 @@
+// === findRenameLocations ===
+// === /a.ts ===
+// export { /*START PREFIX*/jsonSchema as /*RENAME*/[|jsonSchemaRENAME|] } from "@internal/ai-sdk-v4";
+
+// === /b.ts ===
+// import { [|jsonSchemaRENAME|] } from "./a";
+// 


### PR DESCRIPTION
fixes the crash reported here: https://github.com/microsoft/typescript-go/issues/3599#issuecomment-4317050073