### PR TITLE
Fix hover for optional method members in types and interfaces

### DIFF
--- a/internal/fourslash/tests/hoverOptionalMethod_test.go
+++ b/internal/fourslash/tests/hoverOptionalMethod_test.go
@@ -1,0 +1,43 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestHoverOptionalMethod(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `
+// @strict: true
+interface I {
+    bar?(): void
+}
+type T = {
+    bar?(): void
+}
+class C {
+    baz?() {}
+}
+
+declare const i: I
+declare const t: T
+declare const c: C
+
+i./*1*/bar
+t./*2*/bar
+c./*3*/baz
+`
+
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+
+	// Pre-fix (#3607): hover at /*3*/ returned an empty quickinfo because the optional
+	// method's type was `(() => void) | undefined`, which has no call signatures via
+	// getSignaturesOfType. Fall-through to `symbol.Declarations` recovers the signature.
+	f.VerifyQuickInfoAt(t, "1", "(method) I.bar(): void", "")
+	f.VerifyQuickInfoAt(t, "2", "(method) bar(): void", "")
+	f.VerifyQuickInfoAt(t, "3", "(method) C.baz(): void", "")
+}

--- a/internal/ls/hover.go
+++ b/internal/ls/hover.go
@@ -737,6 +737,18 @@ func getSymbolAtLocationForQuickInfo(c *checker.Checker, node *ast.Node) *ast.Sy
 
 func getSignaturesAtLocation(c *checker.Checker, symbol *ast.Symbol, kind checker.SignatureKind, node *ast.Node) []*checker.Signature {
 	signatures := c.GetSignaturesOfType(c.GetTypeOfSymbol(symbol), kind)
+	// Optional methods/functions (e.g. `bar?(): void`) get a `T | undefined` type, and
+	// `GetSignaturesOfType` on a union returns nothing. Recover the signatures from the
+	// function-like declarations so hover matches the required-method path.
+	if len(signatures) == 0 && kind == checker.SignatureKindCall && symbol.Flags&ast.SymbolFlagsOptional != 0 {
+		for _, decl := range symbol.Declarations {
+			if ast.IsFunctionLike(decl) {
+				if sig := c.GetSignatureFromDeclaration(decl); sig != nil {
+					signatures = append(signatures, sig)
+				}
+			}
+		}
+	}
 	if len(signatures) > 1 || len(signatures) == 1 && len(signatures[0].TypeParameters()) != 0 {
 		if callNode := getCallOrNewExpression(node); callNode != nil {
 			signature := c.GetResolvedSignature(callNode)


### PR DESCRIPTION
Closes #3607.

Hover skipped optional method members like `bar?(): void` because the call-signature lookup ran `GetSignaturesOfType(GetTypeOfSymbol(symbol))`. Optional methods carry a `T | undefined` type, signatures are not enumerated on unions, so the hover collapsed to empty for `i.bar`, `t.bar`, `c.baz`. When the lookup is empty and the symbol is optional, recover signatures from the function-like declarations so optional methods render the same as required ones.

Test fixture: `internal/fourslash/tests/hoverOptionalMethod_test.go` covers interface, type literal, and class cases.