### PR TITLE
fix: prevent wildcard pattern from overriding exact match in FindBestPatternMatch

### DIFF
--- a/internal/core/pattern.go
+++ b/internal/core/pattern.go
@@ -1,6 +1,9 @@
 package core
 
-import "strings"
+import (
+	"math"
+	"strings"
+)
 
 type Pattern struct {
 	Text      string
@@ -45,7 +48,12 @@ func FindBestPatternMatch[T any](values []T, getPattern func(v T) Pattern, candi
 		pattern := getPattern(value)
 		if (pattern.StarIndex == -1 || pattern.StarIndex > longestMatchPrefixLength) && pattern.Matches(candidate) {
 			bestPattern = value
-			longestMatchPrefixLength = pattern.StarIndex
+			if pattern.StarIndex == -1 {
+				// Exact match: use math.MaxInt so no wildcard pattern can override it.
+				longestMatchPrefixLength = math.MaxInt
+			} else {
+				longestMatchPrefixLength = pattern.StarIndex
+			}
 		}
 	}
 	return bestPattern

--- a/internal/core/pattern_test.go
+++ b/internal/core/pattern_test.go
@@ -1,0 +1,112 @@
+package core_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/core"
+	"gotest.tools/v3/assert"
+)
+
+func TestFindBestPatternMatch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("exact match beats wildcard", func(t *testing.T) {
+		t.Parallel()
+		// When both an exact pattern and a wildcard pattern match the
+		// candidate, the exact match must win regardless of iteration order.
+		type entry struct {
+			name    string
+			pattern core.Pattern
+		}
+		values := []entry{
+			{"wildcard", core.Pattern{Text: "src/foo/*", StarIndex: 8}},
+			{"exact", core.Pattern{Text: "src/foo/bar", StarIndex: -1}},
+		}
+		result := core.FindBestPatternMatch(values, func(v entry) core.Pattern { return v.pattern }, "src/foo/bar")
+		assert.Equal(t, result.name, "exact", "exact match must beat wildcard")
+	})
+
+	t.Run("exact match beats wildcard even when wildcard comes first", func(t *testing.T) {
+		t.Parallel()
+		type entry struct {
+			name    string
+			pattern core.Pattern
+		}
+		values := []entry{
+			{"exact", core.Pattern{Text: "src/foo/bar", StarIndex: -1}},
+			{"wildcard", core.Pattern{Text: "src/foo/*", StarIndex: 8}},
+		}
+		result := core.FindBestPatternMatch(values, func(v entry) core.Pattern { return v.pattern }, "src/foo/bar")
+		assert.Equal(t, result.name, "exact", "exact match must beat wildcard regardless of order")
+	})
+
+	t.Run("longer prefix wildcard beats shorter prefix wildcard", func(t *testing.T) {
+		t.Parallel()
+		type entry struct {
+			name    string
+			pattern core.Pattern
+		}
+		values := []entry{
+			{"short-prefix", core.Pattern{Text: "src/*", StarIndex: 4}},
+			{"long-prefix", core.Pattern{Text: "src/foo/*", StarIndex: 8}},
+		}
+		result := core.FindBestPatternMatch(values, func(v entry) core.Pattern { return v.pattern }, "src/foo/bar")
+		assert.Equal(t, result.name, "long-prefix", "longer prefix wildcard must win")
+	})
+
+	t.Run("no match returns zero value", func(t *testing.T) {
+		t.Parallel()
+		type entry struct {
+			name    string
+			pattern core.Pattern
+		}
+		values := []entry{
+			{"a", core.Pattern{Text: "src/*", StarIndex: 4}},
+			{"b", core.Pattern{Text: "lib/*", StarIndex: 4}},
+		}
+		result := core.FindBestPatternMatch(values, func(v entry) core.Pattern { return v.pattern }, "other/baz")
+		assert.Equal(t, result.name, "", "no match should return zero value")
+	})
+
+	t.Run("single exact match", func(t *testing.T) {
+		t.Parallel()
+		type entry struct {
+			name    string
+			pattern core.Pattern
+		}
+		values := []entry{
+			{"exact", core.Pattern{Text: "src/foo/bar", StarIndex: -1}},
+		}
+		result := core.FindBestPatternMatch(values, func(v entry) core.Pattern { return v.pattern }, "src/foo/bar")
+		assert.Equal(t, result.name, "exact")
+	})
+
+	t.Run("single wildcard match", func(t *testing.T) {
+		t.Parallel()
+		type entry struct {
+			name    string
+			pattern core.Pattern
+		}
+		values := []entry{
+			{"wildcard", core.Pattern{Text: "src/foo/*", StarIndex: 8}},
+		}
+		result := core.FindBestPatternMatch(values, func(v entry) core.Pattern { return v.pattern }, "src/foo/baz")
+		assert.Equal(t, result.name, "wildcard")
+	})
+
+	t.Run("exact match with multiple wildcards", func(t *testing.T) {
+		t.Parallel()
+		type entry struct {
+			name    string
+			pattern core.Pattern
+		}
+		values := []entry{
+			{"wc1", core.Pattern{Text: "src/*", StarIndex: 4}},
+			{"wc2", core.Pattern{Text: "src/foo/*", StarIndex: 8}},
+			{"exact", core.Pattern{Text: "src/foo/bar", StarIndex: -1}},
+			{"wc3", core.Pattern{Text: "src/foo/bar/*", StarIndex: 12}},
+		}
+		result := core.FindBestPatternMatch(values, func(v entry) core.Pattern { return v.pattern }, "src/foo/bar")
+		assert.Equal(t, result.name, "exact", "exact match must beat all wildcards")
+	})
+}


### PR DESCRIPTION
Closes #3617

## Problem

In `internal/core/pattern.go`, `FindBestPatternMatch` uses `pattern.StarIndex` as the betterness criterion when comparing matched patterns. For exact matches, `StarIndex == -1`, so after selecting an exact match, `longestMatchPrefixLength` is set to `-1`. Any subsequent wildcard pattern with `StarIndex >= 0` satisfies `pattern.StarIndex > longestMatchPrefixLength` (`N > -1`), incorrectly overriding the exact match.

**Example**: given patterns `["foo/bar" (exact), "foo/*" (StarIndex=4)]` and candidate `"foo/bar"`:
1. `"foo/bar"` matches → `longestMatchPrefixLength = -1`
2. `"foo/*"` matches → `4 > -1` = true → overrides exact match ❌

## Root Cause vs Original TypeScript

The original TypeScript uses `pattern.prefix.length` (the full text length for exact matches) as the betterness criterion — a large positive number that cannot be overridden by any wildcard. The Go port incorrectly used `pattern.StarIndex` (which is `-1` for exact matches).

## Fix

Set `longestMatchPrefixLength = math.MaxInt` when an exact match is found, so no wildcard can override it — matching the semantics of the original TypeScript.

```go
if pattern.StarIndex == -1 {
    // Exact match: use math.MaxInt so no wildcard pattern can override it.
    longestMatchPrefixLength = math.MaxInt
} else {
    longestMatchPrefixLength = pattern.StarIndex
}
```

Signed-off-by: cocoon <54054995+kuishou68@users.noreply.github.com>