### PR TITLE
perf: Make `NodeArray` no longer inherit from `Array`

### DIFF
--- a/_packages/native-preview/src/api/node/encoder.ts
+++ b/_packages/native-preview/src/api/node/encoder.ts
@@ -207,7 +207,7 @@ function getChildPropertiesForNode(node: Node): readonly (string | undefined)[] 
 
 // Returns whether a value is a NodeArray (array-like with pos and end).
 function isNodeArray(value: any): value is NodeArray<Node> {
-    return Array.isArray(value) && typeof (value as any).pos === "number" && typeof (value as any).end === "number";
+    return Symbol.iterator in value && typeof (value as any).pos === "number" && typeof (value as any).end === "number";
 }
 
 /**

--- a/_packages/native-preview/src/api/node/node.generated.ts
+++ b/_packages/native-preview/src/api/node/node.generated.ts
@@ -34,8 +34,9 @@ import {
     NODE_OFFSET_POS,
 } from "./protocol.ts";
 
-export class RemoteNodeList extends Array<RemoteNode> implements NodeArray<RemoteNode> {
+export class RemoteNodeList implements NodeArray<RemoteNode> {
     parent: RemoteNode;
+    length: number;
     hasTrailingComma?: boolean;
     transformFlags: number = 0;
     protected view: DataView;
@@ -61,70 +62,12 @@ export class RemoteNodeList extends Array<RemoteNode> implements NodeArray<Remot
     private sourceFile: SourceFileInfo;
 
     constructor(view: DataView, index: number, parent: RemoteNode, sourceFile: SourceFileInfo, offsetNodes: number) {
-        super();
         this.view = view;
         this.index = index;
         this.parent = parent;
         this.sourceFile = sourceFile;
         this._byteIndex = offsetNodes + index * NODE_LEN;
         this.length = this.data;
-
-        const length = this.length;
-        for (let i = 16; i < length; i++) {
-            Object.defineProperty(this, i, {
-                get() {
-                    return this.at(i);
-                },
-            });
-        }
-    }
-    get 0(): RemoteNode {
-        return this.at(0);
-    }
-    get 1(): RemoteNode {
-        return this.at(1);
-    }
-    get 2(): RemoteNode {
-        return this.at(2);
-    }
-    get 3(): RemoteNode {
-        return this.at(3);
-    }
-    get 4(): RemoteNode {
-        return this.at(4);
-    }
-    get 5(): RemoteNode {
-        return this.at(5);
-    }
-    get 6(): RemoteNode {
-        return this.at(6);
-    }
-    get 7(): RemoteNode {
-        return this.at(7);
-    }
-    get 8(): RemoteNode {
-        return this.at(8);
-    }
-    get 9(): RemoteNode {
-        return this.at(9);
-    }
-    get 10(): RemoteNode {
-        return this.at(10);
-    }
-    get 11(): RemoteNode {
-        return this.at(11);
-    }
-    get 12(): RemoteNode {
-        return this.at(12);
-    }
-    get 13(): RemoteNode {
-        return this.at(13);
-    }
-    get 14(): RemoteNode {
-        return this.at(14);
-    }
-    get 15(): RemoteNode {
-        return this.at(15);
     }
 
     *[Symbol.iterator](): ArrayIterator<RemoteNode> {

--- a/_packages/native-preview/src/ast/ast.generated.ts
+++ b/_packages/native-preview/src/ast/ast.generated.ts
@@ -1145,7 +1145,7 @@ export interface JsxText extends ExpressionBase, LiteralLikeNodeBase {
 }
 export interface SyntaxList extends NodeBase {
     readonly kind: SyntaxKind.SyntaxList;
-    readonly children: readonly Node[];
+    readonly children: NodeArray<Node>;
 }
 export interface JSDoc extends NodeBase {
     readonly kind: SyntaxKind.JSDoc;
@@ -1327,7 +1327,7 @@ export interface SyntheticReferenceExpression extends ExpressionBase {
 }
 export interface JSDocTypeLiteral extends JSDocTypeBase, DeclarationBase {
     readonly kind: SyntaxKind.JSDocTypeLiteral;
-    readonly jsdocPropertyTags?: readonly JSDocTag[];
+    readonly jsdocPropertyTags?: NodeArray<JSDocTag>;
     readonly isArrayType: boolean;
 }
 

--- a/_packages/native-preview/src/ast/ast.ts
+++ b/_packages/native-preview/src/ast/ast.ts
@@ -36,9 +36,12 @@ export interface ReadonlyTextRange {
     readonly end: number;
 }
 
-export interface NodeArray<T extends Node> extends ReadonlyArray<T>, ReadonlyTextRange {
+export interface NodeArray<T extends Node> extends ReadonlyTextRange {
     hasTrailingComma?: boolean;
     transformFlags: number;
+    length: number;
+    at(index: number): T;
+    [Symbol.iterator](): IterableIterator<T>;
 }
 
 export interface Node extends ReadonlyTextRange {

--- a/_packages/native-preview/src/ast/astnav.ts
+++ b/_packages/native-preview/src/ast/astnav.ts
@@ -216,7 +216,7 @@ function getTokenAtPositionImpl(
                     if (nodes.end === position && includePrecedingTokenAtEndPosition !== undefined) {
                         state.left = nodes.end;
                         nodeAfterLeft = undefined;
-                        state.prevSubtree = nodes[nodes.length - 1];
+                        state.prevSubtree = nodes.at(nodes.length - 1);
                     }
                     else if (nodes.end <= position) {
                         state.left = nodes.end;
@@ -227,8 +227,8 @@ function getTokenAtPositionImpl(
                             state.left = node.end;
                             nodeAfterLeft = undefined;
                             for (let i = middle + 1; i < arr.length; i++) {
-                                if (!(arr[i].flags & NodeFlags.Reparsed)) {
-                                    nodeAfterLeft = arr[i];
+                                if (!(arr.at(i).flags & NodeFlags.Reparsed)) {
+                                    nodeAfterLeft = arr.at(i);
                                     break;
                                 }
                             }
@@ -374,14 +374,14 @@ function findPrecedingTokenImpl(sourceFile: SourceFile, position: number, startN
                 }
                 if (nodes.length > 0 && !skipSingleCommentChildrenImpl) {
                     const index = binarySearchForPrecedingToken(nodes, position);
-                    if (index >= 0 && !(nodes[index].flags & NodeFlags.Reparsed)) {
-                        foundChild = nodes[index];
+                    if (index >= 0 && !(nodes.at(index).flags & NodeFlags.Reparsed)) {
+                        foundChild = nodes.at(index);
                     }
                     const lookupIndex = index >= 0 ? index - 1 : nodes.length - 1;
                     for (let i = lookupIndex; i >= 0; i--) {
-                        if (!(nodes[i].flags & NodeFlags.Reparsed)) {
+                        if (!(nodes.at(i).flags & NodeFlags.Reparsed)) {
                             if (prevChild === undefined) {
-                                prevChild = nodes[i];
+                                prevChild = nodes.at(i);
                             }
                             break;
                         }
@@ -479,7 +479,7 @@ function findRightmostValidToken(sourceFile: SourceFile, endPos: number, contain
                 if (nodes.length > 0 && !skipSingleCommentChildren) {
                     hasChildren = true;
                     for (let i = nodes.length - 1; i >= 0; i--) {
-                        const node = nodes[i];
+                        const node = nodes.at(i);
                         if (node.flags & NodeFlags.Reparsed) continue;
                         if (node.end > endPos || getTokenPosOfNode(node, sourceFile) >= position) continue;
                         if (isValidPrecedingNode(node, sourceFile)) {
@@ -574,7 +574,7 @@ function isJSDocCommentChildKind(kind: SyntaxKind): boolean {
 }
 
 function isJSDocSingleCommentNodeList(nodes: NodeArray<Node>): boolean {
-    return nodes.length === 1 && isJSDocCommentChildKind(nodes[0].kind);
+    return nodes.length === 1 && isJSDocCommentChildKind(nodes.at(0).kind);
 }
 
 function getScannerForSourceFile(sourceFile: SourceFile, pos: number) {
@@ -616,22 +616,22 @@ function binarySearchNodeList(
     let hi = nodes.length - 1;
     while (lo <= hi) {
         const mid = (lo + hi) >>> 1;
-        const node = nodes[mid];
+        const node = nodes.at(mid);
         if (node.flags & NodeFlags.Reparsed) {
             // Skip reparsed nodes: try to find a non-reparsed node nearby
             let found = false;
             for (let i = mid + 1; i <= hi; i++) {
-                if (!(nodes[i].flags & NodeFlags.Reparsed)) {
-                    const cmp = testNode(nodes[i]);
+                if (!(nodes.at(i).flags & NodeFlags.Reparsed)) {
+                    const cmp = testNode(nodes.at(i));
                     if (cmp < 0) {
-                        onLeft(nodes[i], i, nodes);
+                        onLeft(nodes.at(i), i, nodes);
                         lo = i + 1;
                     }
                     else if (cmp > 0) {
                         hi = i - 1;
                     }
                     else {
-                        onMatch(nodes[i]);
+                        onMatch(nodes.at(i));
                         return;
                     }
                     found = true;
@@ -664,13 +664,13 @@ function binarySearchForPrecedingToken(nodes: NodeArray<Node>, position: number)
     let result = -1;
     while (lo <= hi) {
         const mid = (lo + hi) >>> 1;
-        const node = nodes[mid];
+        const node = nodes.at(mid);
         if (node.flags & NodeFlags.Reparsed) {
             lo = mid + 1;
             continue;
         }
         if (position < node.end) {
-            if (mid === 0 || position >= nodes[mid - 1].end) {
+            if (mid === 0 || position >= nodes.at(mid - 1).end) {
                 result = mid;
                 break;
             }

--- a/_packages/native-preview/src/ast/clone.ts
+++ b/_packages/native-preview/src/ast/clone.ts
@@ -105,12 +105,13 @@ export function getSynthesizedDeepClones<T extends Node>(nodes: NodeArray<T>, in
 export function getSynthesizedDeepClones<T extends Node>(nodes: NodeArray<T> | undefined, includeTrivia?: boolean): NodeArray<T> | undefined;
 export function getSynthesizedDeepClones<T extends Node>(nodes: NodeArray<T> | undefined, includeTrivia = true): NodeArray<T> | undefined {
     if (nodes) {
-        const cloned = createNodeArray(
-            Array.from(nodes).map(n => getSynthesizedDeepClone(n, includeTrivia)),
-            nodes.pos,
-            nodes.end,
-        );
-        return cloned;
+        const cloned = new Array(nodes.length) as T[] & { pos: number; end: number; };
+        cloned.pos = nodes.pos;
+        cloned.end = nodes.end;
+        for (let i = 0; i < nodes.length; i++) {
+            cloned[i] = getSynthesizedDeepClone(nodes.at(i), includeTrivia);
+        }
+        return cloned as unknown as NodeArray<T>;
     }
     return nodes;
 }

--- a/_packages/native-preview/src/ast/clone.ts
+++ b/_packages/native-preview/src/ast/clone.ts
@@ -14,11 +14,6 @@ import {
 } from "./factory.generated.ts";
 import { visitEachChild } from "./visitor.ts";
 
-function isArray(value: any): value is readonly unknown[] {
-    // See: https://github.com/microsoft/TypeScript/issues/17002
-    return Array.isArray(value);
-}
-
 function forEachChildRecursively<T>(rootNode: Node, cbNode: (node: Node, parent: Node) => T | "skip" | undefined, cbNodes?: (nodes: NodeArray<Node>, parent: Node) => T | "skip" | undefined): T | undefined {
     const queue: (Node | NodeArray<Node>)[] = gatherPossibleChildren(rootNode);
     const parents: Node[] = []; // tracks parent references for elements in queue
@@ -28,7 +23,7 @@ function forEachChildRecursively<T>(rootNode: Node, cbNode: (node: Node, parent:
     while (queue.length !== 0) {
         const current = queue.pop()!;
         const parent = parents.pop()!;
-        if (isArray(current)) {
+        if (Symbol.iterator in current) {
             if (cbNodes) {
                 const res = cbNodes(current, parent);
                 if (res) {
@@ -37,7 +32,7 @@ function forEachChildRecursively<T>(rootNode: Node, cbNode: (node: Node, parent:
                 }
             }
             for (let i = current.length - 1; i >= 0; --i) {
-                queue.push(current[i]);
+                queue.push(current.at(i));
                 parents.push(parent);
             }
         }
@@ -111,7 +106,7 @@ export function getSynthesizedDeepClones<T extends Node>(nodes: NodeArray<T> | u
 export function getSynthesizedDeepClones<T extends Node>(nodes: NodeArray<T> | undefined, includeTrivia = true): NodeArray<T> | undefined {
     if (nodes) {
         const cloned = createNodeArray(
-            nodes.map(n => getSynthesizedDeepClone(n, includeTrivia)),
+            Array.from(nodes).map(n => getSynthesizedDeepClone(n, includeTrivia)),
             nodes.pos,
             nodes.end,
         );

--- a/_packages/native-preview/src/ast/factory.generated.ts
+++ b/_packages/native-preview/src/ast/factory.generated.ts
@@ -671,11 +671,11 @@ export class NodeObject {
     }
 }
 
-function isNodeArray<T extends Node>(array: readonly T[]): array is NodeArray<T> {
+function isNodeArray<T extends Node>(array: readonly T[] | NodeArray<T>): array is NodeArray<T> {
     return "pos" in array && "end" in array;
 }
 
-export function createNodeArray<T extends Node>(elements: readonly T[], pos: number = -1, end: number = -1): NodeArray<T> {
+export function createNodeArray<T extends Node>(elements: readonly T[] | NodeArray<T>, pos: number = -1, end: number = -1): NodeArray<T> {
     if (isNodeArray(elements)) return elements;
     const arr = elements.slice() as unknown as NodeArray<T> & { pos: number; end: number; };
     arr.pos = pos;
@@ -1725,7 +1725,7 @@ export function createSwitchStatement(expression: Expression, caseBlock: CaseBlo
     }) as unknown as SwitchStatement;
 }
 
-export function createCaseBlock(clauses: readonly CaseOrDefaultClause[]): CaseBlock {
+export function createCaseBlock(clauses: readonly CaseOrDefaultClause[] | NodeArray<CaseOrDefaultClause>): CaseBlock {
     return new NodeObject(SyntaxKind.CaseBlock, {
         clauses: createNodeArray(clauses),
     }) as unknown as CaseBlock;
@@ -1769,14 +1769,14 @@ export function createExpressionStatement(expression: Expression): ExpressionSta
     }) as unknown as ExpressionStatement;
 }
 
-export function createBlock(statements: readonly Statement[], multiLine?: boolean): Block {
+export function createBlock(statements: readonly Statement[] | NodeArray<Statement>, multiLine?: boolean): Block {
     return new NodeObject(SyntaxKind.Block, {
         statements: createNodeArray(statements),
         multiLine,
     }) as unknown as Block;
 }
 
-export function createVariableStatement(modifiers: readonly ModifierLike[] | undefined, declarationList: VariableDeclarationList): VariableStatement {
+export function createVariableStatement(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, declarationList: VariableDeclarationList): VariableStatement {
     return new NodeObject(SyntaxKind.VariableStatement, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         declarationList,
@@ -1792,7 +1792,7 @@ export function createVariableDeclaration(name: BindingName, exclamationToken?: 
     }) as unknown as VariableDeclaration;
 }
 
-export function createVariableDeclarationList(declarations: readonly VariableDeclaration[], flags: NodeFlags): VariableDeclarationList {
+export function createVariableDeclarationList(declarations: readonly VariableDeclaration[] | NodeArray<VariableDeclaration>, flags: NodeFlags): VariableDeclarationList {
     const node = new NodeObject(SyntaxKind.VariableDeclarationList, {
         declarations: createNodeArray(declarations),
     }) as unknown as VariableDeclarationList;
@@ -1800,7 +1800,7 @@ export function createVariableDeclarationList(declarations: readonly VariableDec
     return node;
 }
 
-export function createParameterDeclaration(modifiers: readonly ModifierLike[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: BindingName, questionToken?: QuestionToken, type?: TypeNode, initializer?: Expression): ParameterDeclaration {
+export function createParameterDeclaration(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, dotDotDotToken: DotDotDotToken | undefined, name: BindingName, questionToken?: QuestionToken, type?: TypeNode, initializer?: Expression): ParameterDeclaration {
     return new NodeObject(SyntaxKind.Parameter, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         dotDotDotToken,
@@ -1820,13 +1820,13 @@ export function createBindingElement(dotDotDotToken?: DotDotDotToken, propertyNa
     }) as unknown as BindingElement;
 }
 
-export function createMissingDeclaration(modifiers?: readonly ModifierLike[]): MissingDeclaration {
+export function createMissingDeclaration(modifiers?: readonly ModifierLike[] | NodeArray<ModifierLike>): MissingDeclaration {
     return new NodeObject(SyntaxKind.MissingDeclaration, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
     }) as unknown as MissingDeclaration;
 }
 
-export function createFunctionDeclaration(modifiers: readonly ModifierLike[] | undefined, asteriskToken: AsteriskToken | undefined, name: Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type?: TypeNode, body?: FunctionBody): FunctionDeclaration {
+export function createFunctionDeclaration(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, asteriskToken: AsteriskToken | undefined, name: Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, parameters: readonly ParameterDeclaration[] | NodeArray<ParameterDeclaration>, type?: TypeNode, body?: FunctionBody): FunctionDeclaration {
     return new NodeObject(SyntaxKind.FunctionDeclaration, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         asteriskToken,
@@ -1838,7 +1838,7 @@ export function createFunctionDeclaration(modifiers: readonly ModifierLike[] | u
     }) as unknown as FunctionDeclaration;
 }
 
-export function createClassDeclaration(modifiers: readonly ModifierLike[] | undefined, name: Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, heritageClauses: readonly HeritageClause[] | undefined, members: readonly ClassElement[]): ClassDeclaration {
+export function createClassDeclaration(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, heritageClauses: readonly HeritageClause[] | NodeArray<HeritageClause> | undefined, members: readonly ClassElement[] | NodeArray<ClassElement>): ClassDeclaration {
     return new NodeObject(SyntaxKind.ClassDeclaration, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         name,
@@ -1848,7 +1848,7 @@ export function createClassDeclaration(modifiers: readonly ModifierLike[] | unde
     }) as unknown as ClassDeclaration;
 }
 
-export function createClassExpression(modifiers: readonly ModifierLike[] | undefined, name: Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, heritageClauses: readonly HeritageClause[] | undefined, members: readonly ClassElement[]): ClassExpression {
+export function createClassExpression(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, heritageClauses: readonly HeritageClause[] | NodeArray<HeritageClause> | undefined, members: readonly ClassElement[] | NodeArray<ClassElement>): ClassExpression {
     return new NodeObject(SyntaxKind.ClassExpression, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         name,
@@ -1858,14 +1858,14 @@ export function createClassExpression(modifiers: readonly ModifierLike[] | undef
     }) as unknown as ClassExpression;
 }
 
-export function createHeritageClause(token: SyntaxKind.ExtendsKeyword | SyntaxKind.ImplementsKeyword, types: readonly ExpressionWithTypeArguments[]): HeritageClause {
+export function createHeritageClause(token: SyntaxKind.ExtendsKeyword | SyntaxKind.ImplementsKeyword, types: readonly ExpressionWithTypeArguments[] | NodeArray<ExpressionWithTypeArguments>): HeritageClause {
     return new NodeObject(SyntaxKind.HeritageClause, {
         token,
         types: createNodeArray(types),
     }) as unknown as HeritageClause;
 }
 
-export function createInterfaceDeclaration(modifiers: readonly ModifierLike[] | undefined, name: Identifier, typeParameters: readonly TypeParameterDeclaration[] | undefined, heritageClauses: readonly HeritageClause[] | undefined, members: readonly TypeElement[]): InterfaceDeclaration {
+export function createInterfaceDeclaration(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: Identifier, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, heritageClauses: readonly HeritageClause[] | NodeArray<HeritageClause> | undefined, members: readonly TypeElement[] | NodeArray<TypeElement>): InterfaceDeclaration {
     return new NodeObject(SyntaxKind.InterfaceDeclaration, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         name,
@@ -1875,7 +1875,7 @@ export function createInterfaceDeclaration(modifiers: readonly ModifierLike[] | 
     }) as unknown as InterfaceDeclaration;
 }
 
-export function createTypeAliasDeclaration(modifiers: readonly ModifierLike[] | undefined, name: Identifier, typeParameters: readonly TypeParameterDeclaration[] | undefined, type: TypeNode): TypeAliasDeclaration {
+export function createTypeAliasDeclaration(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: Identifier, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, type: TypeNode): TypeAliasDeclaration {
     return new NodeObject(SyntaxKind.TypeAliasDeclaration, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         name,
@@ -1891,7 +1891,7 @@ export function createEnumMember(name: PropertyName, initializer?: Expression): 
     }) as unknown as EnumMember;
 }
 
-export function createEnumDeclaration(modifiers: readonly ModifierLike[] | undefined, name: Identifier, members: readonly EnumMember[]): EnumDeclaration {
+export function createEnumDeclaration(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: Identifier, members: readonly EnumMember[] | NodeArray<EnumMember>): EnumDeclaration {
     return new NodeObject(SyntaxKind.EnumDeclaration, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         name,
@@ -1899,7 +1899,7 @@ export function createEnumDeclaration(modifiers: readonly ModifierLike[] | undef
     }) as unknown as EnumDeclaration;
 }
 
-export function createModuleBlock(statements: readonly Statement[]): ModuleBlock {
+export function createModuleBlock(statements: readonly Statement[] | NodeArray<Statement>): ModuleBlock {
     return new NodeObject(SyntaxKind.ModuleBlock, {
         statements: createNodeArray(statements),
     }) as unknown as ModuleBlock;
@@ -1913,7 +1913,7 @@ export function createNotEmittedTypeElement(): NotEmittedTypeElement {
     return new NodeObject(SyntaxKind.NotEmittedTypeElement, undefined) as unknown as NotEmittedTypeElement;
 }
 
-export function createImportDeclaration(modifiers: readonly ModifierLike[] | undefined, importClause: ImportClause | undefined, moduleSpecifier: Expression, attributes?: ImportAttributes): ImportDeclaration {
+export function createImportDeclaration(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, importClause: ImportClause | undefined, moduleSpecifier: Expression, attributes?: ImportAttributes): ImportDeclaration {
     return new NodeObject(SyntaxKind.ImportDeclaration, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         importClause,
@@ -1934,13 +1934,13 @@ export function createNamespaceImport(name: Identifier): NamespaceImport {
     }) as unknown as NamespaceImport;
 }
 
-export function createNamedImports(elements: readonly ImportSpecifier[]): NamedImports {
+export function createNamedImports(elements: readonly ImportSpecifier[] | NodeArray<ImportSpecifier>): NamedImports {
     return new NodeObject(SyntaxKind.NamedImports, {
         elements: createNodeArray(elements),
     }) as unknown as NamedImports;
 }
 
-export function createExportAssignment(modifiers: readonly ModifierLike[] | undefined, isExportEquals: boolean = false, type: TypeNode, expression: Expression): ExportAssignment {
+export function createExportAssignment(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, isExportEquals: boolean = false, type: TypeNode, expression: Expression): ExportAssignment {
     return new NodeObject(SyntaxKind.ExportAssignment, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         isExportEquals,
@@ -1949,7 +1949,7 @@ export function createExportAssignment(modifiers: readonly ModifierLike[] | unde
     }) as unknown as ExportAssignment;
 }
 
-export function createNamespaceExportDeclaration(modifiers: readonly ModifierLike[] | undefined, name: Identifier): NamespaceExportDeclaration {
+export function createNamespaceExportDeclaration(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: Identifier): NamespaceExportDeclaration {
     return new NodeObject(SyntaxKind.NamespaceExportDeclaration, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         name,
@@ -1962,7 +1962,7 @@ export function createNamespaceExport(name: ModuleExportName): NamespaceExport {
     }) as unknown as NamespaceExport;
 }
 
-export function createNamedExports(elements: readonly ExportSpecifier[]): NamedExports {
+export function createNamedExports(elements: readonly ExportSpecifier[] | NodeArray<ExportSpecifier>): NamedExports {
     return new NodeObject(SyntaxKind.NamedExports, {
         elements: createNodeArray(elements),
     }) as unknown as NamedExports;
@@ -1976,7 +1976,7 @@ export function createExportSpecifier(isTypeOnly: boolean = false, propertyName:
     }) as unknown as ExportSpecifier;
 }
 
-export function createCallSignatureDeclaration(typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type?: TypeNode): CallSignatureDeclaration {
+export function createCallSignatureDeclaration(typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, parameters: readonly ParameterDeclaration[] | NodeArray<ParameterDeclaration>, type?: TypeNode): CallSignatureDeclaration {
     return new NodeObject(SyntaxKind.CallSignature, {
         typeParameters: typeParameters ? createNodeArray(typeParameters) : undefined,
         parameters: createNodeArray(parameters),
@@ -1984,7 +1984,7 @@ export function createCallSignatureDeclaration(typeParameters: readonly TypePara
     }) as unknown as CallSignatureDeclaration;
 }
 
-export function createConstructSignatureDeclaration(typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type?: TypeNode): ConstructSignatureDeclaration {
+export function createConstructSignatureDeclaration(typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, parameters: readonly ParameterDeclaration[] | NodeArray<ParameterDeclaration>, type?: TypeNode): ConstructSignatureDeclaration {
     return new NodeObject(SyntaxKind.ConstructSignature, {
         typeParameters: typeParameters ? createNodeArray(typeParameters) : undefined,
         parameters: createNodeArray(parameters),
@@ -1992,7 +1992,7 @@ export function createConstructSignatureDeclaration(typeParameters: readonly Typ
     }) as unknown as ConstructSignatureDeclaration;
 }
 
-export function createConstructorDeclaration(modifiers: readonly ModifierLike[] | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type?: TypeNode, body?: FunctionBody): ConstructorDeclaration {
+export function createConstructorDeclaration(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, parameters: readonly ParameterDeclaration[] | NodeArray<ParameterDeclaration>, type?: TypeNode, body?: FunctionBody): ConstructorDeclaration {
     return new NodeObject(SyntaxKind.Constructor, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         typeParameters: typeParameters ? createNodeArray(typeParameters) : undefined,
@@ -2002,7 +2002,7 @@ export function createConstructorDeclaration(modifiers: readonly ModifierLike[] 
     }) as unknown as ConstructorDeclaration;
 }
 
-export function createGetAccessorDeclaration(modifiers: readonly ModifierLike[] | undefined, name: PropertyName, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type?: TypeNode, body?: FunctionBody): GetAccessorDeclaration {
+export function createGetAccessorDeclaration(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: PropertyName, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, parameters: readonly ParameterDeclaration[] | NodeArray<ParameterDeclaration>, type?: TypeNode, body?: FunctionBody): GetAccessorDeclaration {
     return new NodeObject(SyntaxKind.GetAccessor, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         name,
@@ -2013,7 +2013,7 @@ export function createGetAccessorDeclaration(modifiers: readonly ModifierLike[] 
     }) as unknown as GetAccessorDeclaration;
 }
 
-export function createSetAccessorDeclaration(modifiers: readonly ModifierLike[] | undefined, name: PropertyName, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type?: TypeNode, body?: FunctionBody): SetAccessorDeclaration {
+export function createSetAccessorDeclaration(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: PropertyName, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, parameters: readonly ParameterDeclaration[] | NodeArray<ParameterDeclaration>, type?: TypeNode, body?: FunctionBody): SetAccessorDeclaration {
     return new NodeObject(SyntaxKind.SetAccessor, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         name,
@@ -2024,7 +2024,7 @@ export function createSetAccessorDeclaration(modifiers: readonly ModifierLike[] 
     }) as unknown as SetAccessorDeclaration;
 }
 
-export function createIndexSignatureDeclaration(modifiers: readonly ModifierLike[] | undefined, parameters: readonly ParameterDeclaration[], type: TypeNode): IndexSignatureDeclaration {
+export function createIndexSignatureDeclaration(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, parameters: readonly ParameterDeclaration[] | NodeArray<ParameterDeclaration>, type: TypeNode): IndexSignatureDeclaration {
     return new NodeObject(SyntaxKind.IndexSignature, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         parameters: createNodeArray(parameters),
@@ -2032,7 +2032,7 @@ export function createIndexSignatureDeclaration(modifiers: readonly ModifierLike
     }) as unknown as IndexSignatureDeclaration;
 }
 
-export function createMethodSignatureDeclaration(modifiers: readonly ModifierLike[] | undefined, name: PropertyName, postfixToken: QuestionToken | ExclamationToken | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type?: TypeNode): MethodSignatureDeclaration {
+export function createMethodSignatureDeclaration(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: PropertyName, postfixToken: QuestionToken | ExclamationToken | undefined, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, parameters: readonly ParameterDeclaration[] | NodeArray<ParameterDeclaration>, type?: TypeNode): MethodSignatureDeclaration {
     return new NodeObject(SyntaxKind.MethodSignature, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         name,
@@ -2043,7 +2043,7 @@ export function createMethodSignatureDeclaration(modifiers: readonly ModifierLik
     }) as unknown as MethodSignatureDeclaration;
 }
 
-export function createMethodDeclaration(modifiers: readonly ModifierLike[] | undefined, asteriskToken: AsteriskToken | undefined, name: PropertyName, postfixToken: QuestionToken | ExclamationToken | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type?: TypeNode, body?: FunctionBody): MethodDeclaration {
+export function createMethodDeclaration(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, asteriskToken: AsteriskToken | undefined, name: PropertyName, postfixToken: QuestionToken | ExclamationToken | undefined, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, parameters: readonly ParameterDeclaration[] | NodeArray<ParameterDeclaration>, type?: TypeNode, body?: FunctionBody): MethodDeclaration {
     return new NodeObject(SyntaxKind.MethodDeclaration, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         asteriskToken,
@@ -2056,7 +2056,7 @@ export function createMethodDeclaration(modifiers: readonly ModifierLike[] | und
     }) as unknown as MethodDeclaration;
 }
 
-export function createPropertySignatureDeclaration(modifiers: readonly ModifierLike[] | undefined, name: PropertyName, postfixToken: QuestionToken | ExclamationToken | undefined, type: TypeNode, initializer: Expression): PropertySignatureDeclaration {
+export function createPropertySignatureDeclaration(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: PropertyName, postfixToken: QuestionToken | ExclamationToken | undefined, type: TypeNode, initializer: Expression): PropertySignatureDeclaration {
     return new NodeObject(SyntaxKind.PropertySignature, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         name,
@@ -2066,7 +2066,7 @@ export function createPropertySignatureDeclaration(modifiers: readonly ModifierL
     }) as unknown as PropertySignatureDeclaration;
 }
 
-export function createPropertyDeclaration(modifiers: readonly ModifierLike[] | undefined, name: PropertyName, postfixToken?: QuestionToken | ExclamationToken, type?: TypeNode, initializer?: Expression): PropertyDeclaration {
+export function createPropertyDeclaration(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: PropertyName, postfixToken?: QuestionToken | ExclamationToken, type?: TypeNode, initializer?: Expression): PropertyDeclaration {
     return new NodeObject(SyntaxKind.PropertyDeclaration, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         name,
@@ -2080,7 +2080,7 @@ export function createSemicolonClassElement(): SemicolonClassElement {
     return new NodeObject(SyntaxKind.SemicolonClassElement, undefined) as unknown as SemicolonClassElement;
 }
 
-export function createClassStaticBlockDeclaration(modifiers: readonly ModifierLike[] | undefined, body: Block): ClassStaticBlockDeclaration {
+export function createClassStaticBlockDeclaration(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, body: Block): ClassStaticBlockDeclaration {
     return new NodeObject(SyntaxKind.ClassStaticBlockDeclaration, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         body,
@@ -2130,7 +2130,7 @@ export function createNoSubstitutionTemplateLiteral(text: string, templateFlags:
     }) as unknown as NoSubstitutionTemplateLiteral;
 }
 
-export function createBinaryExpression(modifiers: readonly ModifierLike[] | undefined, left: Expression, type: TypeNode | undefined, operatorToken: BinaryOperatorToken, right: Expression): BinaryExpression {
+export function createBinaryExpression(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, left: Expression, type: TypeNode | undefined, operatorToken: BinaryOperatorToken, right: Expression): BinaryExpression {
     return new NodeObject(SyntaxKind.BinaryExpression, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         left,
@@ -2161,7 +2161,7 @@ export function createYieldExpression(asteriskToken?: AsteriskToken, expression?
     }) as unknown as YieldExpression;
 }
 
-export function createArrowFunction(modifiers: readonly ModifierLike[] | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type: TypeNode | undefined, equalsGreaterThanToken: EqualsGreaterThanToken, body: ConciseBody): ArrowFunction {
+export function createArrowFunction(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, parameters: readonly ParameterDeclaration[] | NodeArray<ParameterDeclaration>, type: TypeNode | undefined, equalsGreaterThanToken: EqualsGreaterThanToken, body: ConciseBody): ArrowFunction {
     return new NodeObject(SyntaxKind.ArrowFunction, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         typeParameters: typeParameters ? createNodeArray(typeParameters) : undefined,
@@ -2172,7 +2172,7 @@ export function createArrowFunction(modifiers: readonly ModifierLike[] | undefin
     }) as unknown as ArrowFunction;
 }
 
-export function createFunctionExpression(modifiers: readonly ModifierLike[] | undefined, asteriskToken: AsteriskToken | undefined, name: Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type: TypeNode | undefined, body: FunctionBody): FunctionExpression {
+export function createFunctionExpression(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, asteriskToken: AsteriskToken | undefined, name: Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, parameters: readonly ParameterDeclaration[] | NodeArray<ParameterDeclaration>, type: TypeNode | undefined, body: FunctionBody): FunctionExpression {
     return new NodeObject(SyntaxKind.FunctionExpression, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         asteriskToken,
@@ -2228,7 +2228,7 @@ export function createElementAccessExpression(expression: Expression, questionDo
     return node;
 }
 
-export function createCallExpression(expression: Expression, questionDotToken: QuestionDotToken | undefined, typeArguments: readonly TypeNode[] | undefined, arguments_: readonly Expression[], flags: NodeFlags): CallExpression {
+export function createCallExpression(expression: Expression, questionDotToken: QuestionDotToken | undefined, typeArguments: readonly TypeNode[] | NodeArray<TypeNode> | undefined, arguments_: readonly Expression[] | NodeArray<Expression>, flags: NodeFlags): CallExpression {
     const node = new NodeObject(SyntaxKind.CallExpression, {
         expression,
         questionDotToken,
@@ -2239,7 +2239,7 @@ export function createCallExpression(expression: Expression, questionDotToken: Q
     return node;
 }
 
-export function createNewExpression(expression: Expression, typeArguments?: readonly TypeNode[], arguments_?: readonly Expression[]): NewExpression {
+export function createNewExpression(expression: Expression, typeArguments?: readonly TypeNode[] | NodeArray<TypeNode>, arguments_?: readonly Expression[] | NodeArray<Expression>): NewExpression {
     return new NodeObject(SyntaxKind.NewExpression, {
         expression,
         typeArguments: typeArguments ? createNodeArray(typeArguments) : undefined,
@@ -2268,7 +2268,7 @@ export function createSpreadElement(expression: Expression): SpreadElement {
     }) as unknown as SpreadElement;
 }
 
-export function createTemplateExpression(head: TemplateHead, templateSpans: readonly TemplateSpan[]): TemplateExpression {
+export function createTemplateExpression(head: TemplateHead, templateSpans: readonly TemplateSpan[] | NodeArray<TemplateSpan>): TemplateExpression {
     return new NodeObject(SyntaxKind.TemplateExpression, {
         head,
         templateSpans: createNodeArray(templateSpans),
@@ -2282,7 +2282,7 @@ export function createTemplateSpan(expression: Expression, literal: TemplateMidd
     }) as unknown as TemplateSpan;
 }
 
-export function createTaggedTemplateExpression(tag: Expression, questionDotToken: QuestionDotToken, typeArguments: readonly TypeNode[] | undefined, template: TemplateLiteral, flags: NodeFlags): TaggedTemplateExpression {
+export function createTaggedTemplateExpression(tag: Expression, questionDotToken: QuestionDotToken, typeArguments: readonly TypeNode[] | NodeArray<TypeNode> | undefined, template: TemplateLiteral, flags: NodeFlags): TaggedTemplateExpression {
     const node = new NodeObject(SyntaxKind.TaggedTemplateExpression, {
         tag,
         questionDotToken,
@@ -2299,14 +2299,14 @@ export function createParenthesizedExpression(expression: Expression): Parenthes
     }) as unknown as ParenthesizedExpression;
 }
 
-export function createArrayLiteralExpression(elements: readonly Expression[], multiLine?: boolean): ArrayLiteralExpression {
+export function createArrayLiteralExpression(elements: readonly Expression[] | NodeArray<Expression>, multiLine?: boolean): ArrayLiteralExpression {
     return new NodeObject(SyntaxKind.ArrayLiteralExpression, {
         elements: createNodeArray(elements),
         multiLine,
     }) as unknown as ArrayLiteralExpression;
 }
 
-export function createObjectLiteralExpression(properties: readonly ObjectLiteralElementLike[], multiLine?: boolean): ObjectLiteralExpression {
+export function createObjectLiteralExpression(properties: readonly ObjectLiteralElementLike[] | NodeArray<ObjectLiteralElementLike>, multiLine?: boolean): ObjectLiteralExpression {
     return new NodeObject(SyntaxKind.ObjectLiteralExpression, {
         properties: createNodeArray(properties),
         multiLine,
@@ -2319,7 +2319,7 @@ export function createSpreadAssignment(expression: Expression): SpreadAssignment
     }) as unknown as SpreadAssignment;
 }
 
-export function createPropertyAssignment(modifiers: readonly ModifierLike[] | undefined, name: PropertyName, postfixToken: QuestionToken | ExclamationToken | undefined, type: TypeNode, initializer: Expression): PropertyAssignment {
+export function createPropertyAssignment(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: PropertyName, postfixToken: QuestionToken | ExclamationToken | undefined, type: TypeNode, initializer: Expression): PropertyAssignment {
     return new NodeObject(SyntaxKind.PropertyAssignment, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         name,
@@ -2329,7 +2329,7 @@ export function createPropertyAssignment(modifiers: readonly ModifierLike[] | un
     }) as unknown as PropertyAssignment;
 }
 
-export function createShorthandPropertyAssignment(modifiers: readonly ModifierLike[] | undefined, name: PropertyName, postfixToken: QuestionToken | ExclamationToken | undefined, type: TypeNode, equalsToken?: EqualsToken, objectAssignmentInitializer?: Expression): ShorthandPropertyAssignment {
+export function createShorthandPropertyAssignment(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: PropertyName, postfixToken: QuestionToken | ExclamationToken | undefined, type: TypeNode, equalsToken?: EqualsToken, objectAssignmentInitializer?: Expression): ShorthandPropertyAssignment {
     return new NodeObject(SyntaxKind.ShorthandPropertyAssignment, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         name,
@@ -2375,13 +2375,13 @@ export function createKeywordTypeNode<TKind extends KeywordTypeSyntaxKind>(kind:
     return new NodeObject(kind, undefined) as unknown as KeywordTypeNode<TKind>;
 }
 
-export function createUnionTypeNode(types: readonly TypeNode[]): UnionTypeNode {
+export function createUnionTypeNode(types: readonly TypeNode[] | NodeArray<TypeNode>): UnionTypeNode {
     return new NodeObject(SyntaxKind.UnionType, {
         types: createNodeArray(types),
     }) as unknown as UnionTypeNode;
 }
 
-export function createIntersectionTypeNode(types: readonly TypeNode[]): IntersectionTypeNode {
+export function createIntersectionTypeNode(types: readonly TypeNode[] | NodeArray<TypeNode>): IntersectionTypeNode {
     return new NodeObject(SyntaxKind.IntersectionType, {
         types: createNodeArray(types),
     }) as unknown as IntersectionTypeNode;
@@ -2422,14 +2422,14 @@ export function createIndexedAccessTypeNode(objectType: TypeNode, indexType: Typ
     }) as unknown as IndexedAccessTypeNode;
 }
 
-export function createTypeReferenceNode(typeName: EntityName, typeArguments?: readonly TypeNode[]): TypeReferenceNode {
+export function createTypeReferenceNode(typeName: EntityName, typeArguments?: readonly TypeNode[] | NodeArray<TypeNode>): TypeReferenceNode {
     return new NodeObject(SyntaxKind.TypeReference, {
         typeName,
         typeArguments: typeArguments ? createNodeArray(typeArguments) : undefined,
     }) as unknown as TypeReferenceNode;
 }
 
-export function createExpressionWithTypeArguments(expression: Expression, typeArguments?: readonly TypeNode[]): ExpressionWithTypeArguments {
+export function createExpressionWithTypeArguments(expression: Expression, typeArguments?: readonly TypeNode[] | NodeArray<TypeNode>): ExpressionWithTypeArguments {
     return new NodeObject(SyntaxKind.ExpressionWithTypeArguments, {
         expression,
         typeArguments: typeArguments ? createNodeArray(typeArguments) : undefined,
@@ -2461,7 +2461,7 @@ export function createImportAttribute(name: ImportAttributeName, value: Expressi
     }) as unknown as ImportAttribute;
 }
 
-export function createImportAttributes(token: SyntaxKind.WithKeyword | SyntaxKind.AssertKeyword, attributes: readonly ImportAttribute[], multiLine?: boolean): ImportAttributes {
+export function createImportAttributes(token: SyntaxKind.WithKeyword | SyntaxKind.AssertKeyword, attributes: readonly ImportAttribute[] | NodeArray<ImportAttribute>, multiLine?: boolean): ImportAttributes {
     return new NodeObject(SyntaxKind.ImportAttributes, {
         token,
         attributes: createNodeArray(attributes),
@@ -2469,14 +2469,14 @@ export function createImportAttributes(token: SyntaxKind.WithKeyword | SyntaxKin
     }) as unknown as ImportAttributes;
 }
 
-export function createTypeQueryNode(exprName: EntityName, typeArguments?: readonly TypeNode[]): TypeQueryNode {
+export function createTypeQueryNode(exprName: EntityName, typeArguments?: readonly TypeNode[] | NodeArray<TypeNode>): TypeQueryNode {
     return new NodeObject(SyntaxKind.TypeQuery, {
         exprName,
         typeArguments: typeArguments ? createNodeArray(typeArguments) : undefined,
     }) as unknown as TypeQueryNode;
 }
 
-export function createMappedTypeNode(readonlyToken: ReadonlyKeyword | PlusToken | MinusToken | undefined, typeParameter: TypeParameterDeclaration, nameType?: TypeNode, questionToken?: QuestionToken | PlusToken | MinusToken, type?: TypeNode, members?: readonly TypeElement[]): MappedTypeNode {
+export function createMappedTypeNode(readonlyToken: ReadonlyKeyword | PlusToken | MinusToken | undefined, typeParameter: TypeParameterDeclaration, nameType?: TypeNode, questionToken?: QuestionToken | PlusToken | MinusToken, type?: TypeNode, members?: readonly TypeElement[] | NodeArray<TypeElement>): MappedTypeNode {
     return new NodeObject(SyntaxKind.MappedType, {
         readonlyToken,
         typeParameter,
@@ -2487,13 +2487,13 @@ export function createMappedTypeNode(readonlyToken: ReadonlyKeyword | PlusToken 
     }) as unknown as MappedTypeNode;
 }
 
-export function createTypeLiteralNode(members: readonly TypeElement[]): TypeLiteralNode {
+export function createTypeLiteralNode(members: readonly TypeElement[] | NodeArray<TypeElement>): TypeLiteralNode {
     return new NodeObject(SyntaxKind.TypeLiteral, {
         members: createNodeArray(members),
     }) as unknown as TypeLiteralNode;
 }
 
-export function createTupleTypeNode(elements: readonly TypeNode[]): TupleTypeNode {
+export function createTupleTypeNode(elements: readonly TypeNode[] | NodeArray<TypeNode>): TupleTypeNode {
     return new NodeObject(SyntaxKind.TupleType, {
         elements: createNodeArray(elements),
     }) as unknown as TupleTypeNode;
@@ -2526,7 +2526,7 @@ export function createParenthesizedTypeNode(type: TypeNode): ParenthesizedTypeNo
     }) as unknown as ParenthesizedTypeNode;
 }
 
-export function createFunctionTypeNode(typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type?: TypeNode): FunctionTypeNode {
+export function createFunctionTypeNode(typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, parameters: readonly ParameterDeclaration[] | NodeArray<ParameterDeclaration>, type?: TypeNode): FunctionTypeNode {
     return new NodeObject(SyntaxKind.FunctionType, {
         typeParameters: typeParameters ? createNodeArray(typeParameters) : undefined,
         parameters: createNodeArray(parameters),
@@ -2534,7 +2534,7 @@ export function createFunctionTypeNode(typeParameters: readonly TypeParameterDec
     }) as unknown as FunctionTypeNode;
 }
 
-export function createConstructorTypeNode(modifiers: readonly ModifierLike[] | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type?: TypeNode): ConstructorTypeNode {
+export function createConstructorTypeNode(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, parameters: readonly ParameterDeclaration[] | NodeArray<ParameterDeclaration>, type?: TypeNode): ConstructorTypeNode {
     return new NodeObject(SyntaxKind.ConstructorType, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         typeParameters: typeParameters ? createNodeArray(typeParameters) : undefined,
@@ -2567,7 +2567,7 @@ export function createTemplateTail(text: string, rawText: string, templateFlags:
     }) as unknown as TemplateTail;
 }
 
-export function createTemplateLiteralTypeNode(head: TemplateHead, templateSpans: readonly TemplateLiteralTypeSpan[]): TemplateLiteralTypeNode {
+export function createTemplateLiteralTypeNode(head: TemplateHead, templateSpans: readonly TemplateLiteralTypeSpan[] | NodeArray<TemplateLiteralTypeSpan>): TemplateLiteralTypeNode {
     return new NodeObject(SyntaxKind.TemplateLiteralType, {
         head,
         templateSpans: createNodeArray(templateSpans),
@@ -2595,7 +2595,7 @@ export function createPartiallyEmittedExpression(expression: Expression): Partia
     }) as unknown as PartiallyEmittedExpression;
 }
 
-export function createJsxElement(openingElement: JsxOpeningElement, children: readonly JsxChild[], closingElement: JsxClosingElement): JsxElement {
+export function createJsxElement(openingElement: JsxOpeningElement, children: readonly JsxChild[] | NodeArray<JsxChild>, closingElement: JsxClosingElement): JsxElement {
     return new NodeObject(SyntaxKind.JsxElement, {
         openingElement,
         children: createNodeArray(children),
@@ -2603,7 +2603,7 @@ export function createJsxElement(openingElement: JsxOpeningElement, children: re
     }) as unknown as JsxElement;
 }
 
-export function createJsxAttributes(properties: readonly JsxAttributeLike[]): JsxAttributes {
+export function createJsxAttributes(properties: readonly JsxAttributeLike[] | NodeArray<JsxAttributeLike>): JsxAttributes {
     return new NodeObject(SyntaxKind.JsxAttributes, {
         properties: createNodeArray(properties),
     }) as unknown as JsxAttributes;
@@ -2616,7 +2616,7 @@ export function createJsxNamespacedName(namespace: Identifier, name: Identifier)
     }) as unknown as JsxNamespacedName;
 }
 
-export function createJsxOpeningElement(tagName: JsxTagNameExpression, typeArguments: readonly TypeNode[] | undefined, attributes: JsxAttributes): JsxOpeningElement {
+export function createJsxOpeningElement(tagName: JsxTagNameExpression, typeArguments: readonly TypeNode[] | NodeArray<TypeNode> | undefined, attributes: JsxAttributes): JsxOpeningElement {
     return new NodeObject(SyntaxKind.JsxOpeningElement, {
         tagName,
         typeArguments: typeArguments ? createNodeArray(typeArguments) : undefined,
@@ -2624,7 +2624,7 @@ export function createJsxOpeningElement(tagName: JsxTagNameExpression, typeArgum
     }) as unknown as JsxOpeningElement;
 }
 
-export function createJsxSelfClosingElement(tagName: JsxTagNameExpression, typeArguments: readonly TypeNode[] | undefined, attributes: JsxAttributes): JsxSelfClosingElement {
+export function createJsxSelfClosingElement(tagName: JsxTagNameExpression, typeArguments: readonly TypeNode[] | NodeArray<TypeNode> | undefined, attributes: JsxAttributes): JsxSelfClosingElement {
     return new NodeObject(SyntaxKind.JsxSelfClosingElement, {
         tagName,
         typeArguments: typeArguments ? createNodeArray(typeArguments) : undefined,
@@ -2632,7 +2632,7 @@ export function createJsxSelfClosingElement(tagName: JsxTagNameExpression, typeA
     }) as unknown as JsxSelfClosingElement;
 }
 
-export function createJsxFragment(openingFragment: JsxOpeningFragment, children: readonly JsxChild[], closingFragment: JsxClosingFragment): JsxFragment {
+export function createJsxFragment(openingFragment: JsxOpeningFragment, children: readonly JsxChild[] | NodeArray<JsxChild>, closingFragment: JsxClosingFragment): JsxFragment {
     return new NodeObject(SyntaxKind.JsxFragment, {
         openingFragment,
         children: createNodeArray(children),
@@ -2681,13 +2681,13 @@ export function createJsxText(text: string, containsOnlyTriviaWhiteSpaces?: bool
     }) as unknown as JsxText;
 }
 
-export function createSyntaxList(children: readonly Node[]): SyntaxList {
+export function createSyntaxList(children: readonly Node[] | NodeArray<Node>): SyntaxList {
     return new NodeObject(SyntaxKind.SyntaxList, {
         children,
     }) as unknown as SyntaxList;
 }
 
-export function createJSDoc(comment: readonly JSDocComment[], tags?: readonly JSDocTag[]): JSDoc {
+export function createJSDoc(comment: readonly JSDocComment[] | NodeArray<JSDocComment>, tags?: readonly JSDocTag[] | NodeArray<JSDocTag>): JSDoc {
     return new NodeObject(SyntaxKind.JSDoc, {
         comment: createNodeArray(comment),
         tags: tags ? createNodeArray(tags) : undefined,
@@ -2728,7 +2728,7 @@ export function createJSDocOptionalType(type: TypeNode): JSDocOptionalType {
     }) as unknown as JSDocOptionalType;
 }
 
-export function createJSDocTypeTag(tagName: Identifier, typeExpression: Node, comment?: readonly JSDocComment[]): JSDocTypeTag {
+export function createJSDocTypeTag(tagName: Identifier, typeExpression: Node, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocTypeTag {
     return new NodeObject(SyntaxKind.JSDocTypeTag, {
         tagName,
         typeExpression,
@@ -2736,14 +2736,14 @@ export function createJSDocTypeTag(tagName: Identifier, typeExpression: Node, co
     }) as unknown as JSDocTypeTag;
 }
 
-export function createJSDocUnknownTag(tagName: Identifier, comment?: readonly JSDocComment[]): JSDocUnknownTag {
+export function createJSDocUnknownTag(tagName: Identifier, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocUnknownTag {
     return new NodeObject(SyntaxKind.JSDocUnknownTag, {
         tagName,
         comment: comment ? createNodeArray(comment) : undefined,
     }) as unknown as JSDocUnknownTag;
 }
 
-export function createJSDocTemplateTag(tagName: Identifier, constraint: Node, typeParameters: readonly TypeParameterDeclaration[], comment?: readonly JSDocComment[]): JSDocTemplateTag {
+export function createJSDocTemplateTag(tagName: Identifier, constraint: Node, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration>, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocTemplateTag {
     return new NodeObject(SyntaxKind.JSDocTemplateTag, {
         tagName,
         constraint,
@@ -2752,7 +2752,7 @@ export function createJSDocTemplateTag(tagName: Identifier, constraint: Node, ty
     }) as unknown as JSDocTemplateTag;
 }
 
-export function createJSDocReturnTag(tagName: Identifier, typeExpression?: TypeNode, comment?: readonly JSDocComment[]): JSDocReturnTag {
+export function createJSDocReturnTag(tagName: Identifier, typeExpression?: TypeNode, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocReturnTag {
     return new NodeObject(SyntaxKind.JSDocReturnTag, {
         tagName,
         typeExpression,
@@ -2760,49 +2760,49 @@ export function createJSDocReturnTag(tagName: Identifier, typeExpression?: TypeN
     }) as unknown as JSDocReturnTag;
 }
 
-export function createJSDocPublicTag(tagName: Identifier, comment?: readonly JSDocComment[]): JSDocPublicTag {
+export function createJSDocPublicTag(tagName: Identifier, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocPublicTag {
     return new NodeObject(SyntaxKind.JSDocPublicTag, {
         tagName,
         comment: comment ? createNodeArray(comment) : undefined,
     }) as unknown as JSDocPublicTag;
 }
 
-export function createJSDocPrivateTag(tagName: Identifier, comment?: readonly JSDocComment[]): JSDocPrivateTag {
+export function createJSDocPrivateTag(tagName: Identifier, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocPrivateTag {
     return new NodeObject(SyntaxKind.JSDocPrivateTag, {
         tagName,
         comment: comment ? createNodeArray(comment) : undefined,
     }) as unknown as JSDocPrivateTag;
 }
 
-export function createJSDocProtectedTag(tagName: Identifier, comment?: readonly JSDocComment[]): JSDocProtectedTag {
+export function createJSDocProtectedTag(tagName: Identifier, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocProtectedTag {
     return new NodeObject(SyntaxKind.JSDocProtectedTag, {
         tagName,
         comment: comment ? createNodeArray(comment) : undefined,
     }) as unknown as JSDocProtectedTag;
 }
 
-export function createJSDocReadonlyTag(tagName: Identifier, comment?: readonly JSDocComment[]): JSDocReadonlyTag {
+export function createJSDocReadonlyTag(tagName: Identifier, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocReadonlyTag {
     return new NodeObject(SyntaxKind.JSDocReadonlyTag, {
         tagName,
         comment: comment ? createNodeArray(comment) : undefined,
     }) as unknown as JSDocReadonlyTag;
 }
 
-export function createJSDocOverrideTag(tagName: Identifier, comment?: readonly JSDocComment[]): JSDocOverrideTag {
+export function createJSDocOverrideTag(tagName: Identifier, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocOverrideTag {
     return new NodeObject(SyntaxKind.JSDocOverrideTag, {
         tagName,
         comment: comment ? createNodeArray(comment) : undefined,
     }) as unknown as JSDocOverrideTag;
 }
 
-export function createJSDocDeprecatedTag(tagName: Identifier, comment?: readonly JSDocComment[]): JSDocDeprecatedTag {
+export function createJSDocDeprecatedTag(tagName: Identifier, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocDeprecatedTag {
     return new NodeObject(SyntaxKind.JSDocDeprecatedTag, {
         tagName,
         comment: comment ? createNodeArray(comment) : undefined,
     }) as unknown as JSDocDeprecatedTag;
 }
 
-export function createJSDocSeeTag(tagName: Identifier, nameExpression: TypeNode, comment?: readonly JSDocComment[]): JSDocSeeTag {
+export function createJSDocSeeTag(tagName: Identifier, nameExpression: TypeNode, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocSeeTag {
     return new NodeObject(SyntaxKind.JSDocSeeTag, {
         tagName,
         nameExpression,
@@ -2810,7 +2810,7 @@ export function createJSDocSeeTag(tagName: Identifier, nameExpression: TypeNode,
     }) as unknown as JSDocSeeTag;
 }
 
-export function createJSDocImplementsTag(tagName: Identifier, className: ExpressionWithTypeArguments, comment?: readonly JSDocComment[]): JSDocImplementsTag {
+export function createJSDocImplementsTag(tagName: Identifier, className: ExpressionWithTypeArguments, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocImplementsTag {
     return new NodeObject(SyntaxKind.JSDocImplementsTag, {
         tagName,
         className,
@@ -2818,7 +2818,7 @@ export function createJSDocImplementsTag(tagName: Identifier, className: Express
     }) as unknown as JSDocImplementsTag;
 }
 
-export function createJSDocAugmentsTag(tagName: Identifier, className: ExpressionWithTypeArguments, comment?: readonly JSDocComment[]): JSDocAugmentsTag {
+export function createJSDocAugmentsTag(tagName: Identifier, className: ExpressionWithTypeArguments, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocAugmentsTag {
     return new NodeObject(SyntaxKind.JSDocAugmentsTag, {
         tagName,
         className,
@@ -2826,7 +2826,7 @@ export function createJSDocAugmentsTag(tagName: Identifier, className: Expressio
     }) as unknown as JSDocAugmentsTag;
 }
 
-export function createJSDocSatisfiesTag(tagName: Identifier, typeExpression: TypeNode, comment?: readonly JSDocComment[]): JSDocSatisfiesTag {
+export function createJSDocSatisfiesTag(tagName: Identifier, typeExpression: TypeNode, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocSatisfiesTag {
     return new NodeObject(SyntaxKind.JSDocSatisfiesTag, {
         tagName,
         typeExpression,
@@ -2834,7 +2834,7 @@ export function createJSDocSatisfiesTag(tagName: Identifier, typeExpression: Typ
     }) as unknown as JSDocSatisfiesTag;
 }
 
-export function createJSDocThrowsTag(tagName: Identifier, typeExpression?: TypeNode, comment?: readonly JSDocComment[]): JSDocThrowsTag {
+export function createJSDocThrowsTag(tagName: Identifier, typeExpression?: TypeNode, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocThrowsTag {
     return new NodeObject(SyntaxKind.JSDocThrowsTag, {
         tagName,
         typeExpression,
@@ -2842,7 +2842,7 @@ export function createJSDocThrowsTag(tagName: Identifier, typeExpression?: TypeN
     }) as unknown as JSDocThrowsTag;
 }
 
-export function createJSDocThisTag(tagName: Identifier, typeExpression: TypeNode, comment?: readonly JSDocComment[]): JSDocThisTag {
+export function createJSDocThisTag(tagName: Identifier, typeExpression: TypeNode, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocThisTag {
     return new NodeObject(SyntaxKind.JSDocThisTag, {
         tagName,
         typeExpression,
@@ -2850,7 +2850,7 @@ export function createJSDocThisTag(tagName: Identifier, typeExpression: TypeNode
     }) as unknown as JSDocThisTag;
 }
 
-export function createJSDocImportTag(tagName: Identifier, importClause: ImportClause | undefined, moduleSpecifier: Expression, attributes?: ImportAttributes, comment?: readonly JSDocComment[]): JSDocImportTag {
+export function createJSDocImportTag(tagName: Identifier, importClause: ImportClause | undefined, moduleSpecifier: Expression, attributes?: ImportAttributes, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocImportTag {
     return new NodeObject(SyntaxKind.JSDocImportTag, {
         tagName,
         importClause,
@@ -2860,7 +2860,7 @@ export function createJSDocImportTag(tagName: Identifier, importClause: ImportCl
     }) as unknown as JSDocImportTag;
 }
 
-export function createJSDocCallbackTag(tagName: Identifier, typeExpression: TypeNode, fullName?: Node, comment?: readonly JSDocComment[]): JSDocCallbackTag {
+export function createJSDocCallbackTag(tagName: Identifier, typeExpression: TypeNode, fullName?: Node, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocCallbackTag {
     return new NodeObject(SyntaxKind.JSDocCallbackTag, {
         tagName,
         typeExpression,
@@ -2869,7 +2869,7 @@ export function createJSDocCallbackTag(tagName: Identifier, typeExpression: Type
     }) as unknown as JSDocCallbackTag;
 }
 
-export function createJSDocOverloadTag(tagName: Identifier, typeExpression: TypeNode, comment?: readonly JSDocComment[]): JSDocOverloadTag {
+export function createJSDocOverloadTag(tagName: Identifier, typeExpression: TypeNode, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocOverloadTag {
     return new NodeObject(SyntaxKind.JSDocOverloadTag, {
         tagName,
         typeExpression,
@@ -2877,7 +2877,7 @@ export function createJSDocOverloadTag(tagName: Identifier, typeExpression: Type
     }) as unknown as JSDocOverloadTag;
 }
 
-export function createJSDocTypedefTag(tagName: Identifier, typeExpression?: Node, name?: Identifier, comment?: readonly JSDocComment[]): JSDocTypedefTag {
+export function createJSDocTypedefTag(tagName: Identifier, typeExpression?: Node, name?: Identifier, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocTypedefTag {
     return new NodeObject(SyntaxKind.JSDocTypedefTag, {
         tagName,
         typeExpression,
@@ -2886,7 +2886,7 @@ export function createJSDocTypedefTag(tagName: Identifier, typeExpression?: Node
     }) as unknown as JSDocTypedefTag;
 }
 
-export function createJSDocSignature(typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type?: TypeNode): JSDocSignature {
+export function createJSDocSignature(typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, parameters: readonly ParameterDeclaration[] | NodeArray<ParameterDeclaration>, type?: TypeNode): JSDocSignature {
     return new NodeObject(SyntaxKind.JSDocSignature, {
         typeParameters: typeParameters ? createNodeArray(typeParameters) : undefined,
         parameters: createNodeArray(parameters),
@@ -2900,7 +2900,7 @@ export function createJSDocNameReference(name: EntityName): JSDocNameReference {
     }) as unknown as JSDocNameReference;
 }
 
-export function createModuleDeclaration(modifiers: readonly ModifierLike[] | undefined, keyword: SyntaxKind.ModuleKeyword | SyntaxKind.NamespaceKeyword, name: ModuleName, body?: ModuleBody): ModuleDeclaration {
+export function createModuleDeclaration(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, keyword: SyntaxKind.ModuleKeyword | SyntaxKind.NamespaceKeyword, name: ModuleName, body?: ModuleBody): ModuleDeclaration {
     return new NodeObject(SyntaxKind.ModuleDeclaration, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         keyword,
@@ -2909,7 +2909,7 @@ export function createModuleDeclaration(modifiers: readonly ModifierLike[] | und
     }) as unknown as ModuleDeclaration;
 }
 
-export function createImportEqualsDeclaration(modifiers: readonly ModifierLike[] | undefined, isTypeOnly: boolean = false, name: Identifier, moduleReference: ModuleReference): ImportEqualsDeclaration {
+export function createImportEqualsDeclaration(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, isTypeOnly: boolean = false, name: Identifier, moduleReference: ModuleReference): ImportEqualsDeclaration {
     return new NodeObject(SyntaxKind.ImportEqualsDeclaration, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         isTypeOnly,
@@ -2918,7 +2918,7 @@ export function createImportEqualsDeclaration(modifiers: readonly ModifierLike[]
     }) as unknown as ImportEqualsDeclaration;
 }
 
-export function createExportDeclaration(modifiers?: readonly ModifierLike[], isTypeOnly?: boolean, exportClause?: NamedExportBindings, moduleSpecifier?: Expression, attributes?: ImportAttributes): ExportDeclaration {
+export function createExportDeclaration(modifiers?: readonly ModifierLike[] | NodeArray<ModifierLike>, isTypeOnly?: boolean, exportClause?: NamedExportBindings, moduleSpecifier?: Expression, attributes?: ImportAttributes): ExportDeclaration {
     return new NodeObject(SyntaxKind.ExportDeclaration, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         isTypeOnly,
@@ -2928,7 +2928,7 @@ export function createExportDeclaration(modifiers?: readonly ModifierLike[], isT
     }) as unknown as ExportDeclaration;
 }
 
-export function createImportTypeNode(isTypeOf: boolean = false, argument: TypeNode, attributes?: ImportAttributes, qualifier?: EntityName, typeArguments?: readonly TypeNode[]): ImportTypeNode {
+export function createImportTypeNode(isTypeOf: boolean = false, argument: TypeNode, attributes?: ImportAttributes, qualifier?: EntityName, typeArguments?: readonly TypeNode[] | NodeArray<TypeNode>): ImportTypeNode {
     return new NodeObject(SyntaxKind.ImportType, {
         isTypeOf,
         argument,
@@ -2981,7 +2981,7 @@ export function createJSDocLinkCode(name: EntityName | undefined, text: readonly
     }) as unknown as JSDocLinkCode;
 }
 
-export function createTypeParameterDeclaration(modifiers: readonly ModifierLike[] | undefined, name: Identifier, constraint?: TypeNode, expression?: Expression, defaultType?: TypeNode): TypeParameterDeclaration {
+export function createTypeParameterDeclaration(modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: Identifier, constraint?: TypeNode, expression?: Expression, defaultType?: TypeNode): TypeParameterDeclaration {
     return new NodeObject(SyntaxKind.TypeParameter, {
         modifiers: modifiers ? createNodeArray(modifiers) : undefined,
         name,
@@ -2998,7 +2998,7 @@ export function createSyntheticReferenceExpression(expression: Expression, thisA
     }) as unknown as SyntheticReferenceExpression;
 }
 
-export function createJSDocTypeLiteral(jsdocPropertyTags?: readonly JSDocTag[], isArrayType?: boolean): JSDocTypeLiteral {
+export function createJSDocTypeLiteral(jsdocPropertyTags?: readonly JSDocTag[] | NodeArray<JSDocTag>, isArrayType?: boolean): JSDocTypeLiteral {
     return new NodeObject(SyntaxKind.JSDocTypeLiteral, {
         jsdocPropertyTags,
         isArrayType,
@@ -3023,33 +3023,33 @@ export function createForOfStatement(awaitModifier: AwaitKeyword | undefined, in
     }) as unknown as ForOfStatement;
 }
 
-export function createCaseClause(expression: Expression, statements: readonly Statement[]): CaseClause {
+export function createCaseClause(expression: Expression, statements: readonly Statement[] | NodeArray<Statement>): CaseClause {
     return new NodeObject(SyntaxKind.CaseClause, {
         expression,
         statements: createNodeArray(statements),
     }) as unknown as CaseClause;
 }
 
-export function createDefaultClause(expression: Expression, statements: readonly Statement[]): DefaultClause {
+export function createDefaultClause(expression: Expression, statements: readonly Statement[] | NodeArray<Statement>): DefaultClause {
     return new NodeObject(SyntaxKind.DefaultClause, {
         expression,
         statements: createNodeArray(statements),
     }) as unknown as DefaultClause;
 }
 
-export function createObjectBindingPattern(elements: readonly BindingElement[]): ObjectBindingPattern {
+export function createObjectBindingPattern(elements: readonly BindingElement[] | NodeArray<BindingElement>): ObjectBindingPattern {
     return new NodeObject(SyntaxKind.ObjectBindingPattern, {
         elements: createNodeArray(elements),
     }) as unknown as ObjectBindingPattern;
 }
 
-export function createArrayBindingPattern(elements: readonly BindingElement[]): ArrayBindingPattern {
+export function createArrayBindingPattern(elements: readonly BindingElement[] | NodeArray<BindingElement>): ArrayBindingPattern {
     return new NodeObject(SyntaxKind.ArrayBindingPattern, {
         elements: createNodeArray(elements),
     }) as unknown as ArrayBindingPattern;
 }
 
-export function createJSDocParameterTag(tagName: Identifier, name: EntityName, isBracketed: boolean, typeExpression: TypeNode | undefined, isNameFirst: boolean, comment: readonly JSDocComment[] | undefined): JSDocParameterTag {
+export function createJSDocParameterTag(tagName: Identifier, name: EntityName, isBracketed: boolean, typeExpression: TypeNode | undefined, isNameFirst: boolean, comment: readonly JSDocComment[] | NodeArray<JSDocComment> | undefined): JSDocParameterTag {
     return new NodeObject(SyntaxKind.JSDocParameterTag, {
         tagName,
         name,
@@ -3060,7 +3060,7 @@ export function createJSDocParameterTag(tagName: Identifier, name: EntityName, i
     }) as unknown as JSDocParameterTag;
 }
 
-export function createJSDocPropertyTag(tagName: Identifier, name: EntityName, isBracketed: boolean, typeExpression: TypeNode | undefined, isNameFirst: boolean, comment: readonly JSDocComment[] | undefined): JSDocPropertyTag {
+export function createJSDocPropertyTag(tagName: Identifier, name: EntityName, isBracketed: boolean, typeExpression: TypeNode | undefined, isNameFirst: boolean, comment: readonly JSDocComment[] | NodeArray<JSDocComment> | undefined): JSDocPropertyTag {
     return new NodeObject(SyntaxKind.JSDocPropertyTag, {
         tagName,
         name,
@@ -3119,7 +3119,7 @@ export function updateSwitchStatement(node: SwitchStatement, expression: Express
     return node.expression !== expression || node.caseBlock !== caseBlock ? createSwitchStatement(expression, caseBlock) : node;
 }
 
-export function updateCaseBlock(node: CaseBlock, clauses: readonly CaseOrDefaultClause[]): CaseBlock {
+export function updateCaseBlock(node: CaseBlock, clauses: readonly CaseOrDefaultClause[] | NodeArray<CaseOrDefaultClause>): CaseBlock {
     return node.clauses !== clauses ? createCaseBlock(clauses) : node;
 }
 
@@ -3143,11 +3143,11 @@ export function updateExpressionStatement(node: ExpressionStatement, expression:
     return node.expression !== expression ? createExpressionStatement(expression) : node;
 }
 
-export function updateBlock(node: Block, statements: readonly Statement[]): Block {
+export function updateBlock(node: Block, statements: readonly Statement[] | NodeArray<Statement>): Block {
     return node.statements !== statements ? createBlock(statements, node.multiLine) : node;
 }
 
-export function updateVariableStatement(node: VariableStatement, modifiers: readonly ModifierLike[] | undefined, declarationList: VariableDeclarationList): VariableStatement {
+export function updateVariableStatement(node: VariableStatement, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, declarationList: VariableDeclarationList): VariableStatement {
     return node.modifiers !== modifiers || node.declarationList !== declarationList ? createVariableStatement(modifiers, declarationList) : node;
 }
 
@@ -3155,11 +3155,11 @@ export function updateVariableDeclaration(node: VariableDeclaration, name: Bindi
     return node.name !== name || node.exclamationToken !== exclamationToken || node.type !== type || node.initializer !== initializer ? createVariableDeclaration(name, exclamationToken, type, initializer) : node;
 }
 
-export function updateVariableDeclarationList(node: VariableDeclarationList, declarations: readonly VariableDeclaration[]): VariableDeclarationList {
+export function updateVariableDeclarationList(node: VariableDeclarationList, declarations: readonly VariableDeclaration[] | NodeArray<VariableDeclaration>): VariableDeclarationList {
     return node.declarations !== declarations ? createVariableDeclarationList(declarations, node.flags) : node;
 }
 
-export function updateParameterDeclaration(node: ParameterDeclaration, modifiers: readonly ModifierLike[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: BindingName, questionToken?: QuestionToken, type?: TypeNode, initializer?: Expression): ParameterDeclaration {
+export function updateParameterDeclaration(node: ParameterDeclaration, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, dotDotDotToken: DotDotDotToken | undefined, name: BindingName, questionToken?: QuestionToken, type?: TypeNode, initializer?: Expression): ParameterDeclaration {
     return node.modifiers !== modifiers || node.dotDotDotToken !== dotDotDotToken || node.name !== name || node.questionToken !== questionToken || node.type !== type || node.initializer !== initializer ? createParameterDeclaration(modifiers, dotDotDotToken, name, questionToken, type, initializer) : node;
 }
 
@@ -3167,31 +3167,31 @@ export function updateBindingElement(node: BindingElement, dotDotDotToken?: DotD
     return node.dotDotDotToken !== dotDotDotToken || node.propertyName !== propertyName || node.name !== name || node.initializer !== initializer ? createBindingElement(dotDotDotToken, propertyName, name, initializer) : node;
 }
 
-export function updateMissingDeclaration(node: MissingDeclaration, modifiers?: readonly ModifierLike[]): MissingDeclaration {
+export function updateMissingDeclaration(node: MissingDeclaration, modifiers?: readonly ModifierLike[] | NodeArray<ModifierLike>): MissingDeclaration {
     return node.modifiers !== modifiers ? createMissingDeclaration(modifiers) : node;
 }
 
-export function updateFunctionDeclaration(node: FunctionDeclaration, modifiers: readonly ModifierLike[] | undefined, asteriskToken: AsteriskToken | undefined, name: Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type?: TypeNode, body?: FunctionBody): FunctionDeclaration {
+export function updateFunctionDeclaration(node: FunctionDeclaration, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, asteriskToken: AsteriskToken | undefined, name: Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, parameters: readonly ParameterDeclaration[] | NodeArray<ParameterDeclaration>, type?: TypeNode, body?: FunctionBody): FunctionDeclaration {
     return node.modifiers !== modifiers || node.asteriskToken !== asteriskToken || node.name !== name || node.typeParameters !== typeParameters || node.parameters !== parameters || node.type !== type || node.body !== body ? createFunctionDeclaration(modifiers, asteriskToken, name, typeParameters, parameters, type, body) : node;
 }
 
-export function updateClassDeclaration(node: ClassDeclaration, modifiers: readonly ModifierLike[] | undefined, name: Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, heritageClauses: readonly HeritageClause[] | undefined, members: readonly ClassElement[]): ClassDeclaration {
+export function updateClassDeclaration(node: ClassDeclaration, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, heritageClauses: readonly HeritageClause[] | NodeArray<HeritageClause> | undefined, members: readonly ClassElement[] | NodeArray<ClassElement>): ClassDeclaration {
     return node.modifiers !== modifiers || node.name !== name || node.typeParameters !== typeParameters || node.heritageClauses !== heritageClauses || node.members !== members ? createClassDeclaration(modifiers, name, typeParameters, heritageClauses, members) : node;
 }
 
-export function updateClassExpression(node: ClassExpression, modifiers: readonly ModifierLike[] | undefined, name: Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, heritageClauses: readonly HeritageClause[] | undefined, members: readonly ClassElement[]): ClassExpression {
+export function updateClassExpression(node: ClassExpression, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, heritageClauses: readonly HeritageClause[] | NodeArray<HeritageClause> | undefined, members: readonly ClassElement[] | NodeArray<ClassElement>): ClassExpression {
     return node.modifiers !== modifiers || node.name !== name || node.typeParameters !== typeParameters || node.heritageClauses !== heritageClauses || node.members !== members ? createClassExpression(modifiers, name, typeParameters, heritageClauses, members) : node;
 }
 
-export function updateHeritageClause(node: HeritageClause, types: readonly ExpressionWithTypeArguments[]): HeritageClause {
+export function updateHeritageClause(node: HeritageClause, types: readonly ExpressionWithTypeArguments[] | NodeArray<ExpressionWithTypeArguments>): HeritageClause {
     return node.types !== types ? createHeritageClause(node.token, types) : node;
 }
 
-export function updateInterfaceDeclaration(node: InterfaceDeclaration, modifiers: readonly ModifierLike[] | undefined, name: Identifier, typeParameters: readonly TypeParameterDeclaration[] | undefined, heritageClauses: readonly HeritageClause[] | undefined, members: readonly TypeElement[]): InterfaceDeclaration {
+export function updateInterfaceDeclaration(node: InterfaceDeclaration, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: Identifier, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, heritageClauses: readonly HeritageClause[] | NodeArray<HeritageClause> | undefined, members: readonly TypeElement[] | NodeArray<TypeElement>): InterfaceDeclaration {
     return node.modifiers !== modifiers || node.name !== name || node.typeParameters !== typeParameters || node.heritageClauses !== heritageClauses || node.members !== members ? createInterfaceDeclaration(modifiers, name, typeParameters, heritageClauses, members) : node;
 }
 
-export function updateTypeAliasDeclaration(node: TypeAliasDeclaration, modifiers: readonly ModifierLike[] | undefined, name: Identifier, typeParameters: readonly TypeParameterDeclaration[] | undefined, type: TypeNode): TypeAliasDeclaration {
+export function updateTypeAliasDeclaration(node: TypeAliasDeclaration, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: Identifier, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, type: TypeNode): TypeAliasDeclaration {
     return node.modifiers !== modifiers || node.name !== name || node.typeParameters !== typeParameters || node.type !== type ? createTypeAliasDeclaration(modifiers, name, typeParameters, type) : node;
 }
 
@@ -3199,15 +3199,15 @@ export function updateEnumMember(node: EnumMember, name: PropertyName, initializ
     return node.name !== name || node.initializer !== initializer ? createEnumMember(name, initializer) : node;
 }
 
-export function updateEnumDeclaration(node: EnumDeclaration, modifiers: readonly ModifierLike[] | undefined, name: Identifier, members: readonly EnumMember[]): EnumDeclaration {
+export function updateEnumDeclaration(node: EnumDeclaration, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: Identifier, members: readonly EnumMember[] | NodeArray<EnumMember>): EnumDeclaration {
     return node.modifiers !== modifiers || node.name !== name || node.members !== members ? createEnumDeclaration(modifiers, name, members) : node;
 }
 
-export function updateModuleBlock(node: ModuleBlock, statements: readonly Statement[]): ModuleBlock {
+export function updateModuleBlock(node: ModuleBlock, statements: readonly Statement[] | NodeArray<Statement>): ModuleBlock {
     return node.statements !== statements ? createModuleBlock(statements) : node;
 }
 
-export function updateImportDeclaration(node: ImportDeclaration, modifiers: readonly ModifierLike[] | undefined, importClause: ImportClause | undefined, moduleSpecifier: Expression, attributes?: ImportAttributes): ImportDeclaration {
+export function updateImportDeclaration(node: ImportDeclaration, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, importClause: ImportClause | undefined, moduleSpecifier: Expression, attributes?: ImportAttributes): ImportDeclaration {
     return node.modifiers !== modifiers || node.importClause !== importClause || node.moduleSpecifier !== moduleSpecifier || node.attributes !== attributes ? createImportDeclaration(modifiers, importClause, moduleSpecifier, attributes) : node;
 }
 
@@ -3219,15 +3219,15 @@ export function updateNamespaceImport(node: NamespaceImport, name: Identifier): 
     return node.name !== name ? createNamespaceImport(name) : node;
 }
 
-export function updateNamedImports(node: NamedImports, elements: readonly ImportSpecifier[]): NamedImports {
+export function updateNamedImports(node: NamedImports, elements: readonly ImportSpecifier[] | NodeArray<ImportSpecifier>): NamedImports {
     return node.elements !== elements ? createNamedImports(elements) : node;
 }
 
-export function updateExportAssignment(node: ExportAssignment, modifiers: readonly ModifierLike[] | undefined, type: TypeNode, expression: Expression): ExportAssignment {
+export function updateExportAssignment(node: ExportAssignment, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, type: TypeNode, expression: Expression): ExportAssignment {
     return node.modifiers !== modifiers || node.type !== type || node.expression !== expression ? createExportAssignment(modifiers, node.isExportEquals, type, expression) : node;
 }
 
-export function updateNamespaceExportDeclaration(node: NamespaceExportDeclaration, modifiers: readonly ModifierLike[] | undefined, name: Identifier): NamespaceExportDeclaration {
+export function updateNamespaceExportDeclaration(node: NamespaceExportDeclaration, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: Identifier): NamespaceExportDeclaration {
     return node.modifiers !== modifiers || node.name !== name ? createNamespaceExportDeclaration(modifiers, name) : node;
 }
 
@@ -3235,7 +3235,7 @@ export function updateNamespaceExport(node: NamespaceExport, name: ModuleExportN
     return node.name !== name ? createNamespaceExport(name) : node;
 }
 
-export function updateNamedExports(node: NamedExports, elements: readonly ExportSpecifier[]): NamedExports {
+export function updateNamedExports(node: NamedExports, elements: readonly ExportSpecifier[] | NodeArray<ExportSpecifier>): NamedExports {
     return node.elements !== elements ? createNamedExports(elements) : node;
 }
 
@@ -3243,51 +3243,51 @@ export function updateExportSpecifier(node: ExportSpecifier, propertyName: Modul
     return node.propertyName !== propertyName || node.name !== name ? createExportSpecifier(node.isTypeOnly, propertyName, name) : node;
 }
 
-export function updateCallSignatureDeclaration(node: CallSignatureDeclaration, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type?: TypeNode): CallSignatureDeclaration {
+export function updateCallSignatureDeclaration(node: CallSignatureDeclaration, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, parameters: readonly ParameterDeclaration[] | NodeArray<ParameterDeclaration>, type?: TypeNode): CallSignatureDeclaration {
     return node.typeParameters !== typeParameters || node.parameters !== parameters || node.type !== type ? createCallSignatureDeclaration(typeParameters, parameters, type) : node;
 }
 
-export function updateConstructSignatureDeclaration(node: ConstructSignatureDeclaration, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type?: TypeNode): ConstructSignatureDeclaration {
+export function updateConstructSignatureDeclaration(node: ConstructSignatureDeclaration, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, parameters: readonly ParameterDeclaration[] | NodeArray<ParameterDeclaration>, type?: TypeNode): ConstructSignatureDeclaration {
     return node.typeParameters !== typeParameters || node.parameters !== parameters || node.type !== type ? createConstructSignatureDeclaration(typeParameters, parameters, type) : node;
 }
 
-export function updateConstructorDeclaration(node: ConstructorDeclaration, modifiers: readonly ModifierLike[] | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type?: TypeNode, body?: FunctionBody): ConstructorDeclaration {
+export function updateConstructorDeclaration(node: ConstructorDeclaration, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, parameters: readonly ParameterDeclaration[] | NodeArray<ParameterDeclaration>, type?: TypeNode, body?: FunctionBody): ConstructorDeclaration {
     return node.modifiers !== modifiers || node.typeParameters !== typeParameters || node.parameters !== parameters || node.type !== type || node.body !== body ? createConstructorDeclaration(modifiers, typeParameters, parameters, type, body) : node;
 }
 
-export function updateGetAccessorDeclaration(node: GetAccessorDeclaration, modifiers: readonly ModifierLike[] | undefined, name: PropertyName, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type?: TypeNode, body?: FunctionBody): GetAccessorDeclaration {
+export function updateGetAccessorDeclaration(node: GetAccessorDeclaration, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: PropertyName, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, parameters: readonly ParameterDeclaration[] | NodeArray<ParameterDeclaration>, type?: TypeNode, body?: FunctionBody): GetAccessorDeclaration {
     return node.modifiers !== modifiers || node.name !== name || node.typeParameters !== typeParameters || node.parameters !== parameters || node.type !== type || node.body !== body ? createGetAccessorDeclaration(modifiers, name, typeParameters, parameters, type, body) : node;
 }
 
-export function updateSetAccessorDeclaration(node: SetAccessorDeclaration, modifiers: readonly ModifierLike[] | undefined, name: PropertyName, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type?: TypeNode, body?: FunctionBody): SetAccessorDeclaration {
+export function updateSetAccessorDeclaration(node: SetAccessorDeclaration, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: PropertyName, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, parameters: readonly ParameterDeclaration[] | NodeArray<ParameterDeclaration>, type?: TypeNode, body?: FunctionBody): SetAccessorDeclaration {
     return node.modifiers !== modifiers || node.name !== name || node.typeParameters !== typeParameters || node.parameters !== parameters || node.type !== type || node.body !== body ? createSetAccessorDeclaration(modifiers, name, typeParameters, parameters, type, body) : node;
 }
 
-export function updateIndexSignatureDeclaration(node: IndexSignatureDeclaration, modifiers: readonly ModifierLike[] | undefined, parameters: readonly ParameterDeclaration[], type: TypeNode): IndexSignatureDeclaration {
+export function updateIndexSignatureDeclaration(node: IndexSignatureDeclaration, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, parameters: readonly ParameterDeclaration[] | NodeArray<ParameterDeclaration>, type: TypeNode): IndexSignatureDeclaration {
     return node.modifiers !== modifiers || node.parameters !== parameters || node.type !== type ? createIndexSignatureDeclaration(modifiers, parameters, type) : node;
 }
 
-export function updateMethodSignatureDeclaration(node: MethodSignatureDeclaration, modifiers: readonly ModifierLike[] | undefined, name: PropertyName, postfixToken: QuestionToken | ExclamationToken | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type?: TypeNode): MethodSignatureDeclaration {
+export function updateMethodSignatureDeclaration(node: MethodSignatureDeclaration, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: PropertyName, postfixToken: QuestionToken | ExclamationToken | undefined, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, parameters: readonly ParameterDeclaration[] | NodeArray<ParameterDeclaration>, type?: TypeNode): MethodSignatureDeclaration {
     return node.modifiers !== modifiers || node.name !== name || node.postfixToken !== postfixToken || node.typeParameters !== typeParameters || node.parameters !== parameters || node.type !== type ? createMethodSignatureDeclaration(modifiers, name, postfixToken, typeParameters, parameters, type) : node;
 }
 
-export function updateMethodDeclaration(node: MethodDeclaration, modifiers: readonly ModifierLike[] | undefined, asteriskToken: AsteriskToken | undefined, name: PropertyName, postfixToken: QuestionToken | ExclamationToken | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type?: TypeNode, body?: FunctionBody): MethodDeclaration {
+export function updateMethodDeclaration(node: MethodDeclaration, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, asteriskToken: AsteriskToken | undefined, name: PropertyName, postfixToken: QuestionToken | ExclamationToken | undefined, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, parameters: readonly ParameterDeclaration[] | NodeArray<ParameterDeclaration>, type?: TypeNode, body?: FunctionBody): MethodDeclaration {
     return node.modifiers !== modifiers || node.asteriskToken !== asteriskToken || node.name !== name || node.postfixToken !== postfixToken || node.typeParameters !== typeParameters || node.parameters !== parameters || node.type !== type || node.body !== body ? createMethodDeclaration(modifiers, asteriskToken, name, postfixToken, typeParameters, parameters, type, body) : node;
 }
 
-export function updatePropertySignatureDeclaration(node: PropertySignatureDeclaration, modifiers: readonly ModifierLike[] | undefined, name: PropertyName, postfixToken: QuestionToken | ExclamationToken | undefined, type: TypeNode, initializer: Expression): PropertySignatureDeclaration {
+export function updatePropertySignatureDeclaration(node: PropertySignatureDeclaration, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: PropertyName, postfixToken: QuestionToken | ExclamationToken | undefined, type: TypeNode, initializer: Expression): PropertySignatureDeclaration {
     return node.modifiers !== modifiers || node.name !== name || node.postfixToken !== postfixToken || node.type !== type || node.initializer !== initializer ? createPropertySignatureDeclaration(modifiers, name, postfixToken, type, initializer) : node;
 }
 
-export function updatePropertyDeclaration(node: PropertyDeclaration, modifiers: readonly ModifierLike[] | undefined, name: PropertyName, postfixToken?: QuestionToken | ExclamationToken, type?: TypeNode, initializer?: Expression): PropertyDeclaration {
+export function updatePropertyDeclaration(node: PropertyDeclaration, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: PropertyName, postfixToken?: QuestionToken | ExclamationToken, type?: TypeNode, initializer?: Expression): PropertyDeclaration {
     return node.modifiers !== modifiers || node.name !== name || node.postfixToken !== postfixToken || node.type !== type || node.initializer !== initializer ? createPropertyDeclaration(modifiers, name, postfixToken, type, initializer) : node;
 }
 
-export function updateClassStaticBlockDeclaration(node: ClassStaticBlockDeclaration, modifiers: readonly ModifierLike[] | undefined, body: Block): ClassStaticBlockDeclaration {
+export function updateClassStaticBlockDeclaration(node: ClassStaticBlockDeclaration, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, body: Block): ClassStaticBlockDeclaration {
     return node.modifiers !== modifiers || node.body !== body ? createClassStaticBlockDeclaration(modifiers, body) : node;
 }
 
-export function updateBinaryExpression(node: BinaryExpression, modifiers: readonly ModifierLike[] | undefined, left: Expression, type: TypeNode | undefined, operatorToken: BinaryOperatorToken, right: Expression): BinaryExpression {
+export function updateBinaryExpression(node: BinaryExpression, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, left: Expression, type: TypeNode | undefined, operatorToken: BinaryOperatorToken, right: Expression): BinaryExpression {
     return node.modifiers !== modifiers || node.left !== left || node.type !== type || node.operatorToken !== operatorToken || node.right !== right ? createBinaryExpression(modifiers, left, type, operatorToken, right) : node;
 }
 
@@ -3303,11 +3303,11 @@ export function updateYieldExpression(node: YieldExpression, asteriskToken?: Ast
     return node.asteriskToken !== asteriskToken || node.expression !== expression ? createYieldExpression(asteriskToken, expression) : node;
 }
 
-export function updateArrowFunction(node: ArrowFunction, modifiers: readonly ModifierLike[] | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type: TypeNode | undefined, equalsGreaterThanToken: EqualsGreaterThanToken, body: ConciseBody): ArrowFunction {
+export function updateArrowFunction(node: ArrowFunction, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, parameters: readonly ParameterDeclaration[] | NodeArray<ParameterDeclaration>, type: TypeNode | undefined, equalsGreaterThanToken: EqualsGreaterThanToken, body: ConciseBody): ArrowFunction {
     return node.modifiers !== modifiers || node.typeParameters !== typeParameters || node.parameters !== parameters || node.type !== type || node.equalsGreaterThanToken !== equalsGreaterThanToken || node.body !== body ? createArrowFunction(modifiers, typeParameters, parameters, type, equalsGreaterThanToken, body) : node;
 }
 
-export function updateFunctionExpression(node: FunctionExpression, modifiers: readonly ModifierLike[] | undefined, asteriskToken: AsteriskToken | undefined, name: Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type: TypeNode | undefined, body: FunctionBody): FunctionExpression {
+export function updateFunctionExpression(node: FunctionExpression, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, asteriskToken: AsteriskToken | undefined, name: Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, parameters: readonly ParameterDeclaration[] | NodeArray<ParameterDeclaration>, type: TypeNode | undefined, body: FunctionBody): FunctionExpression {
     return node.modifiers !== modifiers || node.asteriskToken !== asteriskToken || node.name !== name || node.typeParameters !== typeParameters || node.parameters !== parameters || node.type !== type || node.body !== body ? createFunctionExpression(modifiers, asteriskToken, name, typeParameters, parameters, type, body) : node;
 }
 
@@ -3331,11 +3331,11 @@ export function updateElementAccessExpression(node: ElementAccessExpression, exp
     return node.expression !== expression || node.questionDotToken !== questionDotToken || node.argumentExpression !== argumentExpression ? createElementAccessExpression(expression, questionDotToken, argumentExpression, node.flags) : node;
 }
 
-export function updateCallExpression(node: CallExpression, expression: Expression, questionDotToken: QuestionDotToken | undefined, typeArguments: readonly TypeNode[] | undefined, arguments_: readonly Expression[]): CallExpression {
+export function updateCallExpression(node: CallExpression, expression: Expression, questionDotToken: QuestionDotToken | undefined, typeArguments: readonly TypeNode[] | NodeArray<TypeNode> | undefined, arguments_: readonly Expression[] | NodeArray<Expression>): CallExpression {
     return node.expression !== expression || node.questionDotToken !== questionDotToken || node.typeArguments !== typeArguments || node.arguments !== arguments_ ? createCallExpression(expression, questionDotToken, typeArguments, arguments_, node.flags) : node;
 }
 
-export function updateNewExpression(node: NewExpression, expression: Expression, typeArguments?: readonly TypeNode[], arguments_?: readonly Expression[]): NewExpression {
+export function updateNewExpression(node: NewExpression, expression: Expression, typeArguments?: readonly TypeNode[] | NodeArray<TypeNode>, arguments_?: readonly Expression[] | NodeArray<Expression>): NewExpression {
     return node.expression !== expression || node.typeArguments !== typeArguments || node.arguments !== arguments_ ? createNewExpression(expression, typeArguments, arguments_) : node;
 }
 
@@ -3351,7 +3351,7 @@ export function updateSpreadElement(node: SpreadElement, expression: Expression)
     return node.expression !== expression ? createSpreadElement(expression) : node;
 }
 
-export function updateTemplateExpression(node: TemplateExpression, head: TemplateHead, templateSpans: readonly TemplateSpan[]): TemplateExpression {
+export function updateTemplateExpression(node: TemplateExpression, head: TemplateHead, templateSpans: readonly TemplateSpan[] | NodeArray<TemplateSpan>): TemplateExpression {
     return node.head !== head || node.templateSpans !== templateSpans ? createTemplateExpression(head, templateSpans) : node;
 }
 
@@ -3359,7 +3359,7 @@ export function updateTemplateSpan(node: TemplateSpan, expression: Expression, l
     return node.expression !== expression || node.literal !== literal ? createTemplateSpan(expression, literal) : node;
 }
 
-export function updateTaggedTemplateExpression(node: TaggedTemplateExpression, tag: Expression, questionDotToken: QuestionDotToken, typeArguments: readonly TypeNode[] | undefined, template: TemplateLiteral): TaggedTemplateExpression {
+export function updateTaggedTemplateExpression(node: TaggedTemplateExpression, tag: Expression, questionDotToken: QuestionDotToken, typeArguments: readonly TypeNode[] | NodeArray<TypeNode> | undefined, template: TemplateLiteral): TaggedTemplateExpression {
     return node.tag !== tag || node.questionDotToken !== questionDotToken || node.typeArguments !== typeArguments || node.template !== template ? createTaggedTemplateExpression(tag, questionDotToken, typeArguments, template, node.flags) : node;
 }
 
@@ -3367,11 +3367,11 @@ export function updateParenthesizedExpression(node: ParenthesizedExpression, exp
     return node.expression !== expression ? createParenthesizedExpression(expression) : node;
 }
 
-export function updateArrayLiteralExpression(node: ArrayLiteralExpression, elements: readonly Expression[]): ArrayLiteralExpression {
+export function updateArrayLiteralExpression(node: ArrayLiteralExpression, elements: readonly Expression[] | NodeArray<Expression>): ArrayLiteralExpression {
     return node.elements !== elements ? createArrayLiteralExpression(elements, node.multiLine) : node;
 }
 
-export function updateObjectLiteralExpression(node: ObjectLiteralExpression, properties: readonly ObjectLiteralElementLike[]): ObjectLiteralExpression {
+export function updateObjectLiteralExpression(node: ObjectLiteralExpression, properties: readonly ObjectLiteralElementLike[] | NodeArray<ObjectLiteralElementLike>): ObjectLiteralExpression {
     return node.properties !== properties ? createObjectLiteralExpression(properties, node.multiLine) : node;
 }
 
@@ -3379,11 +3379,11 @@ export function updateSpreadAssignment(node: SpreadAssignment, expression: Expre
     return node.expression !== expression ? createSpreadAssignment(expression) : node;
 }
 
-export function updatePropertyAssignment(node: PropertyAssignment, modifiers: readonly ModifierLike[] | undefined, name: PropertyName, postfixToken: QuestionToken | ExclamationToken | undefined, type: TypeNode, initializer: Expression): PropertyAssignment {
+export function updatePropertyAssignment(node: PropertyAssignment, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: PropertyName, postfixToken: QuestionToken | ExclamationToken | undefined, type: TypeNode, initializer: Expression): PropertyAssignment {
     return node.modifiers !== modifiers || node.name !== name || node.postfixToken !== postfixToken || node.type !== type || node.initializer !== initializer ? createPropertyAssignment(modifiers, name, postfixToken, type, initializer) : node;
 }
 
-export function updateShorthandPropertyAssignment(node: ShorthandPropertyAssignment, modifiers: readonly ModifierLike[] | undefined, name: PropertyName, postfixToken: QuestionToken | ExclamationToken | undefined, type: TypeNode, equalsToken?: EqualsToken, objectAssignmentInitializer?: Expression): ShorthandPropertyAssignment {
+export function updateShorthandPropertyAssignment(node: ShorthandPropertyAssignment, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: PropertyName, postfixToken: QuestionToken | ExclamationToken | undefined, type: TypeNode, equalsToken?: EqualsToken, objectAssignmentInitializer?: Expression): ShorthandPropertyAssignment {
     return node.modifiers !== modifiers || node.name !== name || node.postfixToken !== postfixToken || node.type !== type || node.equalsToken !== equalsToken || node.objectAssignmentInitializer !== objectAssignmentInitializer ? createShorthandPropertyAssignment(modifiers, name, postfixToken, type, equalsToken, objectAssignmentInitializer) : node;
 }
 
@@ -3407,11 +3407,11 @@ export function updateTypeAssertion(node: TypeAssertion, type: TypeNode, express
     return node.type !== type || node.expression !== expression ? createTypeAssertion(type, expression) : node;
 }
 
-export function updateUnionTypeNode(node: UnionTypeNode, types: readonly TypeNode[]): UnionTypeNode {
+export function updateUnionTypeNode(node: UnionTypeNode, types: readonly TypeNode[] | NodeArray<TypeNode>): UnionTypeNode {
     return node.types !== types ? createUnionTypeNode(types) : node;
 }
 
-export function updateIntersectionTypeNode(node: IntersectionTypeNode, types: readonly TypeNode[]): IntersectionTypeNode {
+export function updateIntersectionTypeNode(node: IntersectionTypeNode, types: readonly TypeNode[] | NodeArray<TypeNode>): IntersectionTypeNode {
     return node.types !== types ? createIntersectionTypeNode(types) : node;
 }
 
@@ -3435,11 +3435,11 @@ export function updateIndexedAccessTypeNode(node: IndexedAccessTypeNode, objectT
     return node.objectType !== objectType || node.indexType !== indexType ? createIndexedAccessTypeNode(objectType, indexType) : node;
 }
 
-export function updateTypeReferenceNode(node: TypeReferenceNode, typeName: EntityName, typeArguments?: readonly TypeNode[]): TypeReferenceNode {
+export function updateTypeReferenceNode(node: TypeReferenceNode, typeName: EntityName, typeArguments?: readonly TypeNode[] | NodeArray<TypeNode>): TypeReferenceNode {
     return node.typeName !== typeName || node.typeArguments !== typeArguments ? createTypeReferenceNode(typeName, typeArguments) : node;
 }
 
-export function updateExpressionWithTypeArguments(node: ExpressionWithTypeArguments, expression: Expression, typeArguments?: readonly TypeNode[]): ExpressionWithTypeArguments {
+export function updateExpressionWithTypeArguments(node: ExpressionWithTypeArguments, expression: Expression, typeArguments?: readonly TypeNode[] | NodeArray<TypeNode>): ExpressionWithTypeArguments {
     return node.expression !== expression || node.typeArguments !== typeArguments ? createExpressionWithTypeArguments(expression, typeArguments) : node;
 }
 
@@ -3455,23 +3455,23 @@ export function updateImportAttribute(node: ImportAttribute, name: ImportAttribu
     return node.name !== name || node.value !== value ? createImportAttribute(name, value) : node;
 }
 
-export function updateImportAttributes(node: ImportAttributes, attributes: readonly ImportAttribute[]): ImportAttributes {
+export function updateImportAttributes(node: ImportAttributes, attributes: readonly ImportAttribute[] | NodeArray<ImportAttribute>): ImportAttributes {
     return node.attributes !== attributes ? createImportAttributes(node.token, attributes, node.multiLine) : node;
 }
 
-export function updateTypeQueryNode(node: TypeQueryNode, exprName: EntityName, typeArguments?: readonly TypeNode[]): TypeQueryNode {
+export function updateTypeQueryNode(node: TypeQueryNode, exprName: EntityName, typeArguments?: readonly TypeNode[] | NodeArray<TypeNode>): TypeQueryNode {
     return node.exprName !== exprName || node.typeArguments !== typeArguments ? createTypeQueryNode(exprName, typeArguments) : node;
 }
 
-export function updateMappedTypeNode(node: MappedTypeNode, readonlyToken: ReadonlyKeyword | PlusToken | MinusToken | undefined, typeParameter: TypeParameterDeclaration, nameType?: TypeNode, questionToken?: QuestionToken | PlusToken | MinusToken, type?: TypeNode, members?: readonly TypeElement[]): MappedTypeNode {
+export function updateMappedTypeNode(node: MappedTypeNode, readonlyToken: ReadonlyKeyword | PlusToken | MinusToken | undefined, typeParameter: TypeParameterDeclaration, nameType?: TypeNode, questionToken?: QuestionToken | PlusToken | MinusToken, type?: TypeNode, members?: readonly TypeElement[] | NodeArray<TypeElement>): MappedTypeNode {
     return node.readonlyToken !== readonlyToken || node.typeParameter !== typeParameter || node.nameType !== nameType || node.questionToken !== questionToken || node.type !== type || node.members !== members ? createMappedTypeNode(readonlyToken, typeParameter, nameType, questionToken, type, members) : node;
 }
 
-export function updateTypeLiteralNode(node: TypeLiteralNode, members: readonly TypeElement[]): TypeLiteralNode {
+export function updateTypeLiteralNode(node: TypeLiteralNode, members: readonly TypeElement[] | NodeArray<TypeElement>): TypeLiteralNode {
     return node.members !== members ? createTypeLiteralNode(members) : node;
 }
 
-export function updateTupleTypeNode(node: TupleTypeNode, elements: readonly TypeNode[]): TupleTypeNode {
+export function updateTupleTypeNode(node: TupleTypeNode, elements: readonly TypeNode[] | NodeArray<TypeNode>): TupleTypeNode {
     return node.elements !== elements ? createTupleTypeNode(elements) : node;
 }
 
@@ -3491,15 +3491,15 @@ export function updateParenthesizedTypeNode(node: ParenthesizedTypeNode, type: T
     return node.type !== type ? createParenthesizedTypeNode(type) : node;
 }
 
-export function updateFunctionTypeNode(node: FunctionTypeNode, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type?: TypeNode): FunctionTypeNode {
+export function updateFunctionTypeNode(node: FunctionTypeNode, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, parameters: readonly ParameterDeclaration[] | NodeArray<ParameterDeclaration>, type?: TypeNode): FunctionTypeNode {
     return node.typeParameters !== typeParameters || node.parameters !== parameters || node.type !== type ? createFunctionTypeNode(typeParameters, parameters, type) : node;
 }
 
-export function updateConstructorTypeNode(node: ConstructorTypeNode, modifiers: readonly ModifierLike[] | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type?: TypeNode): ConstructorTypeNode {
+export function updateConstructorTypeNode(node: ConstructorTypeNode, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, parameters: readonly ParameterDeclaration[] | NodeArray<ParameterDeclaration>, type?: TypeNode): ConstructorTypeNode {
     return node.modifiers !== modifiers || node.typeParameters !== typeParameters || node.parameters !== parameters || node.type !== type ? createConstructorTypeNode(modifiers, typeParameters, parameters, type) : node;
 }
 
-export function updateTemplateLiteralTypeNode(node: TemplateLiteralTypeNode, head: TemplateHead, templateSpans: readonly TemplateLiteralTypeSpan[]): TemplateLiteralTypeNode {
+export function updateTemplateLiteralTypeNode(node: TemplateLiteralTypeNode, head: TemplateHead, templateSpans: readonly TemplateLiteralTypeSpan[] | NodeArray<TemplateLiteralTypeSpan>): TemplateLiteralTypeNode {
     return node.head !== head || node.templateSpans !== templateSpans ? createTemplateLiteralTypeNode(head, templateSpans) : node;
 }
 
@@ -3515,11 +3515,11 @@ export function updatePartiallyEmittedExpression(node: PartiallyEmittedExpressio
     return node.expression !== expression ? createPartiallyEmittedExpression(expression) : node;
 }
 
-export function updateJsxElement(node: JsxElement, openingElement: JsxOpeningElement, children: readonly JsxChild[], closingElement: JsxClosingElement): JsxElement {
+export function updateJsxElement(node: JsxElement, openingElement: JsxOpeningElement, children: readonly JsxChild[] | NodeArray<JsxChild>, closingElement: JsxClosingElement): JsxElement {
     return node.openingElement !== openingElement || node.children !== children || node.closingElement !== closingElement ? createJsxElement(openingElement, children, closingElement) : node;
 }
 
-export function updateJsxAttributes(node: JsxAttributes, properties: readonly JsxAttributeLike[]): JsxAttributes {
+export function updateJsxAttributes(node: JsxAttributes, properties: readonly JsxAttributeLike[] | NodeArray<JsxAttributeLike>): JsxAttributes {
     return node.properties !== properties ? createJsxAttributes(properties) : node;
 }
 
@@ -3527,15 +3527,15 @@ export function updateJsxNamespacedName(node: JsxNamespacedName, namespace: Iden
     return node.namespace !== namespace || node.name !== name ? createJsxNamespacedName(namespace, name) : node;
 }
 
-export function updateJsxOpeningElement(node: JsxOpeningElement, tagName: JsxTagNameExpression, typeArguments: readonly TypeNode[] | undefined, attributes: JsxAttributes): JsxOpeningElement {
+export function updateJsxOpeningElement(node: JsxOpeningElement, tagName: JsxTagNameExpression, typeArguments: readonly TypeNode[] | NodeArray<TypeNode> | undefined, attributes: JsxAttributes): JsxOpeningElement {
     return node.tagName !== tagName || node.typeArguments !== typeArguments || node.attributes !== attributes ? createJsxOpeningElement(tagName, typeArguments, attributes) : node;
 }
 
-export function updateJsxSelfClosingElement(node: JsxSelfClosingElement, tagName: JsxTagNameExpression, typeArguments: readonly TypeNode[] | undefined, attributes: JsxAttributes): JsxSelfClosingElement {
+export function updateJsxSelfClosingElement(node: JsxSelfClosingElement, tagName: JsxTagNameExpression, typeArguments: readonly TypeNode[] | NodeArray<TypeNode> | undefined, attributes: JsxAttributes): JsxSelfClosingElement {
     return node.tagName !== tagName || node.typeArguments !== typeArguments || node.attributes !== attributes ? createJsxSelfClosingElement(tagName, typeArguments, attributes) : node;
 }
 
-export function updateJsxFragment(node: JsxFragment, openingFragment: JsxOpeningFragment, children: readonly JsxChild[], closingFragment: JsxClosingFragment): JsxFragment {
+export function updateJsxFragment(node: JsxFragment, openingFragment: JsxOpeningFragment, children: readonly JsxChild[] | NodeArray<JsxChild>, closingFragment: JsxClosingFragment): JsxFragment {
     return node.openingFragment !== openingFragment || node.children !== children || node.closingFragment !== closingFragment ? createJsxFragment(openingFragment, children, closingFragment) : node;
 }
 
@@ -3555,11 +3555,11 @@ export function updateJsxExpression(node: JsxExpression, dotDotDotToken?: DotDot
     return node.dotDotDotToken !== dotDotDotToken || node.expression !== expression ? createJsxExpression(dotDotDotToken, expression) : node;
 }
 
-export function updateSyntaxList(node: SyntaxList, children: readonly Node[]): SyntaxList {
+export function updateSyntaxList(node: SyntaxList, children: readonly Node[] | NodeArray<Node>): SyntaxList {
     return node.children !== children ? createSyntaxList(children) : node;
 }
 
-export function updateJSDoc(node: JSDoc, comment: readonly JSDocComment[], tags?: readonly JSDocTag[]): JSDoc {
+export function updateJSDoc(node: JSDoc, comment: readonly JSDocComment[] | NodeArray<JSDocComment>, tags?: readonly JSDocTag[] | NodeArray<JSDocTag>): JSDoc {
     return node.comment !== comment || node.tags !== tags ? createJSDoc(comment, tags) : node;
 }
 
@@ -3583,87 +3583,87 @@ export function updateJSDocOptionalType(node: JSDocOptionalType, type: TypeNode)
     return node.type !== type ? createJSDocOptionalType(type) : node;
 }
 
-export function updateJSDocTypeTag(node: JSDocTypeTag, tagName: Identifier, typeExpression: Node, comment?: readonly JSDocComment[]): JSDocTypeTag {
+export function updateJSDocTypeTag(node: JSDocTypeTag, tagName: Identifier, typeExpression: Node, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocTypeTag {
     return node.tagName !== tagName || node.typeExpression !== typeExpression || node.comment !== comment ? createJSDocTypeTag(tagName, typeExpression, comment) : node;
 }
 
-export function updateJSDocUnknownTag(node: JSDocUnknownTag, tagName: Identifier, comment?: readonly JSDocComment[]): JSDocUnknownTag {
+export function updateJSDocUnknownTag(node: JSDocUnknownTag, tagName: Identifier, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocUnknownTag {
     return node.tagName !== tagName || node.comment !== comment ? createJSDocUnknownTag(tagName, comment) : node;
 }
 
-export function updateJSDocTemplateTag(node: JSDocTemplateTag, tagName: Identifier, constraint: Node, typeParameters: readonly TypeParameterDeclaration[], comment?: readonly JSDocComment[]): JSDocTemplateTag {
+export function updateJSDocTemplateTag(node: JSDocTemplateTag, tagName: Identifier, constraint: Node, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration>, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocTemplateTag {
     return node.tagName !== tagName || node.constraint !== constraint || node.typeParameters !== typeParameters || node.comment !== comment ? createJSDocTemplateTag(tagName, constraint, typeParameters, comment) : node;
 }
 
-export function updateJSDocReturnTag(node: JSDocReturnTag, tagName: Identifier, typeExpression?: TypeNode, comment?: readonly JSDocComment[]): JSDocReturnTag {
+export function updateJSDocReturnTag(node: JSDocReturnTag, tagName: Identifier, typeExpression?: TypeNode, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocReturnTag {
     return node.tagName !== tagName || node.typeExpression !== typeExpression || node.comment !== comment ? createJSDocReturnTag(tagName, typeExpression, comment) : node;
 }
 
-export function updateJSDocPublicTag(node: JSDocPublicTag, tagName: Identifier, comment?: readonly JSDocComment[]): JSDocPublicTag {
+export function updateJSDocPublicTag(node: JSDocPublicTag, tagName: Identifier, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocPublicTag {
     return node.tagName !== tagName || node.comment !== comment ? createJSDocPublicTag(tagName, comment) : node;
 }
 
-export function updateJSDocPrivateTag(node: JSDocPrivateTag, tagName: Identifier, comment?: readonly JSDocComment[]): JSDocPrivateTag {
+export function updateJSDocPrivateTag(node: JSDocPrivateTag, tagName: Identifier, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocPrivateTag {
     return node.tagName !== tagName || node.comment !== comment ? createJSDocPrivateTag(tagName, comment) : node;
 }
 
-export function updateJSDocProtectedTag(node: JSDocProtectedTag, tagName: Identifier, comment?: readonly JSDocComment[]): JSDocProtectedTag {
+export function updateJSDocProtectedTag(node: JSDocProtectedTag, tagName: Identifier, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocProtectedTag {
     return node.tagName !== tagName || node.comment !== comment ? createJSDocProtectedTag(tagName, comment) : node;
 }
 
-export function updateJSDocReadonlyTag(node: JSDocReadonlyTag, tagName: Identifier, comment?: readonly JSDocComment[]): JSDocReadonlyTag {
+export function updateJSDocReadonlyTag(node: JSDocReadonlyTag, tagName: Identifier, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocReadonlyTag {
     return node.tagName !== tagName || node.comment !== comment ? createJSDocReadonlyTag(tagName, comment) : node;
 }
 
-export function updateJSDocOverrideTag(node: JSDocOverrideTag, tagName: Identifier, comment?: readonly JSDocComment[]): JSDocOverrideTag {
+export function updateJSDocOverrideTag(node: JSDocOverrideTag, tagName: Identifier, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocOverrideTag {
     return node.tagName !== tagName || node.comment !== comment ? createJSDocOverrideTag(tagName, comment) : node;
 }
 
-export function updateJSDocDeprecatedTag(node: JSDocDeprecatedTag, tagName: Identifier, comment?: readonly JSDocComment[]): JSDocDeprecatedTag {
+export function updateJSDocDeprecatedTag(node: JSDocDeprecatedTag, tagName: Identifier, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocDeprecatedTag {
     return node.tagName !== tagName || node.comment !== comment ? createJSDocDeprecatedTag(tagName, comment) : node;
 }
 
-export function updateJSDocSeeTag(node: JSDocSeeTag, tagName: Identifier, nameExpression: TypeNode, comment?: readonly JSDocComment[]): JSDocSeeTag {
+export function updateJSDocSeeTag(node: JSDocSeeTag, tagName: Identifier, nameExpression: TypeNode, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocSeeTag {
     return node.tagName !== tagName || node.nameExpression !== nameExpression || node.comment !== comment ? createJSDocSeeTag(tagName, nameExpression, comment) : node;
 }
 
-export function updateJSDocImplementsTag(node: JSDocImplementsTag, tagName: Identifier, className: ExpressionWithTypeArguments, comment?: readonly JSDocComment[]): JSDocImplementsTag {
+export function updateJSDocImplementsTag(node: JSDocImplementsTag, tagName: Identifier, className: ExpressionWithTypeArguments, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocImplementsTag {
     return node.tagName !== tagName || node.className !== className || node.comment !== comment ? createJSDocImplementsTag(tagName, className, comment) : node;
 }
 
-export function updateJSDocAugmentsTag(node: JSDocAugmentsTag, tagName: Identifier, className: ExpressionWithTypeArguments, comment?: readonly JSDocComment[]): JSDocAugmentsTag {
+export function updateJSDocAugmentsTag(node: JSDocAugmentsTag, tagName: Identifier, className: ExpressionWithTypeArguments, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocAugmentsTag {
     return node.tagName !== tagName || node.className !== className || node.comment !== comment ? createJSDocAugmentsTag(tagName, className, comment) : node;
 }
 
-export function updateJSDocSatisfiesTag(node: JSDocSatisfiesTag, tagName: Identifier, typeExpression: TypeNode, comment?: readonly JSDocComment[]): JSDocSatisfiesTag {
+export function updateJSDocSatisfiesTag(node: JSDocSatisfiesTag, tagName: Identifier, typeExpression: TypeNode, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocSatisfiesTag {
     return node.tagName !== tagName || node.typeExpression !== typeExpression || node.comment !== comment ? createJSDocSatisfiesTag(tagName, typeExpression, comment) : node;
 }
 
-export function updateJSDocThrowsTag(node: JSDocThrowsTag, tagName: Identifier, typeExpression?: TypeNode, comment?: readonly JSDocComment[]): JSDocThrowsTag {
+export function updateJSDocThrowsTag(node: JSDocThrowsTag, tagName: Identifier, typeExpression?: TypeNode, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocThrowsTag {
     return node.tagName !== tagName || node.typeExpression !== typeExpression || node.comment !== comment ? createJSDocThrowsTag(tagName, typeExpression, comment) : node;
 }
 
-export function updateJSDocThisTag(node: JSDocThisTag, tagName: Identifier, typeExpression: TypeNode, comment?: readonly JSDocComment[]): JSDocThisTag {
+export function updateJSDocThisTag(node: JSDocThisTag, tagName: Identifier, typeExpression: TypeNode, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocThisTag {
     return node.tagName !== tagName || node.typeExpression !== typeExpression || node.comment !== comment ? createJSDocThisTag(tagName, typeExpression, comment) : node;
 }
 
-export function updateJSDocImportTag(node: JSDocImportTag, tagName: Identifier, importClause: ImportClause | undefined, moduleSpecifier: Expression, attributes?: ImportAttributes, comment?: readonly JSDocComment[]): JSDocImportTag {
+export function updateJSDocImportTag(node: JSDocImportTag, tagName: Identifier, importClause: ImportClause | undefined, moduleSpecifier: Expression, attributes?: ImportAttributes, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocImportTag {
     return node.tagName !== tagName || node.importClause !== importClause || node.moduleSpecifier !== moduleSpecifier || node.attributes !== attributes || node.comment !== comment ? createJSDocImportTag(tagName, importClause, moduleSpecifier, attributes, comment) : node;
 }
 
-export function updateJSDocCallbackTag(node: JSDocCallbackTag, tagName: Identifier, typeExpression: TypeNode, fullName?: Node, comment?: readonly JSDocComment[]): JSDocCallbackTag {
+export function updateJSDocCallbackTag(node: JSDocCallbackTag, tagName: Identifier, typeExpression: TypeNode, fullName?: Node, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocCallbackTag {
     return node.tagName !== tagName || node.typeExpression !== typeExpression || node.fullName !== fullName || node.comment !== comment ? createJSDocCallbackTag(tagName, typeExpression, fullName, comment) : node;
 }
 
-export function updateJSDocOverloadTag(node: JSDocOverloadTag, tagName: Identifier, typeExpression: TypeNode, comment?: readonly JSDocComment[]): JSDocOverloadTag {
+export function updateJSDocOverloadTag(node: JSDocOverloadTag, tagName: Identifier, typeExpression: TypeNode, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocOverloadTag {
     return node.tagName !== tagName || node.typeExpression !== typeExpression || node.comment !== comment ? createJSDocOverloadTag(tagName, typeExpression, comment) : node;
 }
 
-export function updateJSDocTypedefTag(node: JSDocTypedefTag, tagName: Identifier, typeExpression?: Node, name?: Identifier, comment?: readonly JSDocComment[]): JSDocTypedefTag {
+export function updateJSDocTypedefTag(node: JSDocTypedefTag, tagName: Identifier, typeExpression?: Node, name?: Identifier, comment?: readonly JSDocComment[] | NodeArray<JSDocComment>): JSDocTypedefTag {
     return node.tagName !== tagName || node.typeExpression !== typeExpression || node.name !== name || node.comment !== comment ? createJSDocTypedefTag(tagName, typeExpression, name, comment) : node;
 }
 
-export function updateJSDocSignature(node: JSDocSignature, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type?: TypeNode): JSDocSignature {
+export function updateJSDocSignature(node: JSDocSignature, typeParameters: readonly TypeParameterDeclaration[] | NodeArray<TypeParameterDeclaration> | undefined, parameters: readonly ParameterDeclaration[] | NodeArray<ParameterDeclaration>, type?: TypeNode): JSDocSignature {
     return node.typeParameters !== typeParameters || node.parameters !== parameters || node.type !== type ? createJSDocSignature(typeParameters, parameters, type) : node;
 }
 
@@ -3671,19 +3671,19 @@ export function updateJSDocNameReference(node: JSDocNameReference, name: EntityN
     return node.name !== name ? createJSDocNameReference(name) : node;
 }
 
-export function updateModuleDeclaration(node: ModuleDeclaration, modifiers: readonly ModifierLike[] | undefined, name: ModuleName, body?: ModuleBody): ModuleDeclaration {
+export function updateModuleDeclaration(node: ModuleDeclaration, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: ModuleName, body?: ModuleBody): ModuleDeclaration {
     return node.modifiers !== modifiers || node.name !== name || node.body !== body ? createModuleDeclaration(modifiers, node.keyword, name, body) : node;
 }
 
-export function updateImportEqualsDeclaration(node: ImportEqualsDeclaration, modifiers: readonly ModifierLike[] | undefined, name: Identifier, moduleReference: ModuleReference): ImportEqualsDeclaration {
+export function updateImportEqualsDeclaration(node: ImportEqualsDeclaration, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: Identifier, moduleReference: ModuleReference): ImportEqualsDeclaration {
     return node.modifiers !== modifiers || node.name !== name || node.moduleReference !== moduleReference ? createImportEqualsDeclaration(modifiers, node.isTypeOnly, name, moduleReference) : node;
 }
 
-export function updateExportDeclaration(node: ExportDeclaration, modifiers?: readonly ModifierLike[], exportClause?: NamedExportBindings, moduleSpecifier?: Expression, attributes?: ImportAttributes): ExportDeclaration {
+export function updateExportDeclaration(node: ExportDeclaration, modifiers?: readonly ModifierLike[] | NodeArray<ModifierLike>, exportClause?: NamedExportBindings, moduleSpecifier?: Expression, attributes?: ImportAttributes): ExportDeclaration {
     return node.modifiers !== modifiers || node.exportClause !== exportClause || node.moduleSpecifier !== moduleSpecifier || node.attributes !== attributes ? createExportDeclaration(modifiers, node.isTypeOnly, exportClause, moduleSpecifier, attributes) : node;
 }
 
-export function updateImportTypeNode(node: ImportTypeNode, argument: TypeNode, attributes?: ImportAttributes, qualifier?: EntityName, typeArguments?: readonly TypeNode[]): ImportTypeNode {
+export function updateImportTypeNode(node: ImportTypeNode, argument: TypeNode, attributes?: ImportAttributes, qualifier?: EntityName, typeArguments?: readonly TypeNode[] | NodeArray<TypeNode>): ImportTypeNode {
     return node.argument !== argument || node.attributes !== attributes || node.qualifier !== qualifier || node.typeArguments !== typeArguments ? createImportTypeNode(node.isTypeOf, argument, attributes, qualifier, typeArguments) : node;
 }
 
@@ -3707,7 +3707,7 @@ export function updateJSDocLinkCode(node: JSDocLinkCode, name?: EntityName): JSD
     return node.name !== name ? createJSDocLinkCode(name, node.text) : node;
 }
 
-export function updateTypeParameterDeclaration(node: TypeParameterDeclaration, modifiers: readonly ModifierLike[] | undefined, name: Identifier, constraint?: TypeNode, expression?: Expression, defaultType?: TypeNode): TypeParameterDeclaration {
+export function updateTypeParameterDeclaration(node: TypeParameterDeclaration, modifiers: readonly ModifierLike[] | NodeArray<ModifierLike> | undefined, name: Identifier, constraint?: TypeNode, expression?: Expression, defaultType?: TypeNode): TypeParameterDeclaration {
     return node.modifiers !== modifiers || node.name !== name || node.constraint !== constraint || node.expression !== expression || node.defaultType !== defaultType ? createTypeParameterDeclaration(modifiers, name, constraint, expression, defaultType) : node;
 }
 
@@ -3715,7 +3715,7 @@ export function updateSyntheticReferenceExpression(node: SyntheticReferenceExpre
     return node.expression !== expression || node.thisArg !== thisArg ? createSyntheticReferenceExpression(expression, thisArg) : node;
 }
 
-export function updateJSDocTypeLiteral(node: JSDocTypeLiteral, jsdocPropertyTags?: readonly JSDocTag[]): JSDocTypeLiteral {
+export function updateJSDocTypeLiteral(node: JSDocTypeLiteral, jsdocPropertyTags?: readonly JSDocTag[] | NodeArray<JSDocTag>): JSDocTypeLiteral {
     return node.jsdocPropertyTags !== jsdocPropertyTags ? createJSDocTypeLiteral(jsdocPropertyTags, node.isArrayType) : node;
 }
 
@@ -3727,31 +3727,31 @@ export function updateForOfStatement(node: ForOfStatement, awaitModifier: AwaitK
     return node.awaitModifier !== awaitModifier || node.initializer !== initializer || node.expression !== expression || node.statement !== statement ? createForOfStatement(awaitModifier, initializer, expression, statement) : node;
 }
 
-export function updateCaseClause(node: CaseClause, expression: Expression, statements: readonly Statement[]): CaseClause {
+export function updateCaseClause(node: CaseClause, expression: Expression, statements: readonly Statement[] | NodeArray<Statement>): CaseClause {
     return node.expression !== expression || node.statements !== statements ? createCaseClause(expression, statements) : node;
 }
 
-export function updateDefaultClause(node: DefaultClause, expression: Expression, statements: readonly Statement[]): DefaultClause {
+export function updateDefaultClause(node: DefaultClause, expression: Expression, statements: readonly Statement[] | NodeArray<Statement>): DefaultClause {
     return node.expression !== expression || node.statements !== statements ? createDefaultClause(expression, statements) : node;
 }
 
-export function updateObjectBindingPattern(node: ObjectBindingPattern, elements: readonly BindingElement[]): ObjectBindingPattern {
+export function updateObjectBindingPattern(node: ObjectBindingPattern, elements: readonly BindingElement[] | NodeArray<BindingElement>): ObjectBindingPattern {
     return node.elements !== elements ? createObjectBindingPattern(elements) : node;
 }
 
-export function updateArrayBindingPattern(node: ArrayBindingPattern, elements: readonly BindingElement[]): ArrayBindingPattern {
+export function updateArrayBindingPattern(node: ArrayBindingPattern, elements: readonly BindingElement[] | NodeArray<BindingElement>): ArrayBindingPattern {
     return node.elements !== elements ? createArrayBindingPattern(elements) : node;
 }
 
-export function updateJSDocParameterTag(node: JSDocParameterTag, tagName: Identifier, name: EntityName, typeExpression: TypeNode | undefined, comment: readonly JSDocComment[] | undefined): JSDocParameterTag {
+export function updateJSDocParameterTag(node: JSDocParameterTag, tagName: Identifier, name: EntityName, typeExpression: TypeNode | undefined, comment: readonly JSDocComment[] | NodeArray<JSDocComment> | undefined): JSDocParameterTag {
     return node.tagName !== tagName || node.name !== name || node.typeExpression !== typeExpression || node.comment !== comment ? createJSDocParameterTag(tagName, name, node.isBracketed, typeExpression, node.isNameFirst, comment) : node;
 }
 
-export function updateJSDocPropertyTag(node: JSDocPropertyTag, tagName: Identifier, name: EntityName, typeExpression: TypeNode | undefined, comment: readonly JSDocComment[] | undefined): JSDocPropertyTag {
+export function updateJSDocPropertyTag(node: JSDocPropertyTag, tagName: Identifier, name: EntityName, typeExpression: TypeNode | undefined, comment: readonly JSDocComment[] | NodeArray<JSDocComment> | undefined): JSDocPropertyTag {
     return node.tagName !== tagName || node.name !== name || node.typeExpression !== typeExpression || node.comment !== comment ? createJSDocPropertyTag(tagName, name, node.isBracketed, typeExpression, node.isNameFirst, comment) : node;
 }
 
-export function createSourceFile(statements: readonly Statement[], endOfFileToken: EndOfFile, text: string, fileName: string, path: Path): SourceFile {
+export function createSourceFile(statements: NodeArray<Statement>, endOfFileToken: EndOfFile, text: string, fileName: string, path: Path): SourceFile {
     return new NodeObject(SyntaxKind.SourceFile, {
         statements: createNodeArray(statements),
         endOfFileToken,
@@ -3761,7 +3761,7 @@ export function createSourceFile(statements: readonly Statement[], endOfFileToke
     }) as unknown as SourceFile;
 }
 
-export function updateSourceFile(node: SourceFile, statements: readonly Statement[], endOfFileToken: EndOfFile): SourceFile {
+export function updateSourceFile(node: SourceFile, statements: NodeArray<Statement>, endOfFileToken: EndOfFile): SourceFile {
     return node.statements !== statements || node.endOfFileToken !== endOfFileToken
         ? createSourceFile(statements, endOfFileToken, node.text, node.fileName, node.path)
         : node;

--- a/_packages/native-preview/src/ast/factory.generated.ts
+++ b/_packages/native-preview/src/ast/factory.generated.ts
@@ -3751,7 +3751,7 @@ export function updateJSDocPropertyTag(node: JSDocPropertyTag, tagName: Identifi
     return node.tagName !== tagName || node.name !== name || node.typeExpression !== typeExpression || node.comment !== comment ? createJSDocPropertyTag(tagName, name, node.isBracketed, typeExpression, node.isNameFirst, comment) : node;
 }
 
-export function createSourceFile(statements: NodeArray<Statement>, endOfFileToken: EndOfFile, text: string, fileName: string, path: Path): SourceFile {
+export function createSourceFile(statements: readonly Statement[] | NodeArray<Statement>, endOfFileToken: EndOfFile, text: string, fileName: string, path: Path): SourceFile {
     return new NodeObject(SyntaxKind.SourceFile, {
         statements: createNodeArray(statements),
         endOfFileToken,
@@ -3761,7 +3761,7 @@ export function createSourceFile(statements: NodeArray<Statement>, endOfFileToke
     }) as unknown as SourceFile;
 }
 
-export function updateSourceFile(node: SourceFile, statements: NodeArray<Statement>, endOfFileToken: EndOfFile): SourceFile {
+export function updateSourceFile(node: SourceFile, statements: readonly Statement[] | NodeArray<Statement>, endOfFileToken: EndOfFile): SourceFile {
     return node.statements !== statements || node.endOfFileToken !== endOfFileToken
         ? createSourceFile(statements, endOfFileToken, node.text, node.fileName, node.path)
         : node;

--- a/_packages/native-preview/src/ast/visitor.generated.ts
+++ b/_packages/native-preview/src/ast/visitor.generated.ts
@@ -467,31 +467,23 @@ export function visitNodes<T extends Node>(nodes: NodeArray<T>, visitor: Visitor
 export function visitNodes<T extends Node>(nodes: NodeArray<T> | undefined, visitor: Visitor): NodeArray<T> | undefined;
 export function visitNodes(nodes: NodeArray<Node> | undefined, visitor: Visitor): NodeArray<Node> | undefined {
     if (nodes === undefined) return undefined;
-    const updated = visitNodesArray(nodes, visitor);
-    if (updated === nodes) {
-        return nodes;
-    }
-    return createNodeArray(updated, nodes.pos, nodes.end);
-}
-
-export function visitNodesArray<T extends Node>(nodes: readonly T[], visitor: Visitor): readonly T[];
-export function visitNodesArray<T extends Node>(nodes: readonly T[] | undefined, visitor: Visitor): readonly T[] | undefined;
-export function visitNodesArray(nodes: readonly Node[] | undefined, visitor: Visitor): readonly Node[] | undefined {
-    if (nodes === undefined) return undefined;
     let updated: Node[] | undefined;
     for (let i = 0; i < nodes.length; i++) {
-        const node = nodes[i];
+        const node = nodes.at(i);
         const visited = visitor(node);
         if (updated) {
             if (visited) updated.push(visited);
         }
         else if (visited !== node) {
             updated = [];
-            for (let j = 0; j < i; j++) updated.push(nodes[j]);
+            for (let j = 0; j < i; j++) updated.push(nodes.at(j));
             if (visited) updated.push(visited);
         }
     }
-    return updated ?? nodes;
+    if (updated === undefined) {
+        return nodes;
+    }
+    return createNodeArray(updated, nodes.pos, nodes.end);
 }
 
 /**
@@ -1177,7 +1169,7 @@ const visitEachChildTable: Record<number, VisitEachChildFunction> = {
         return updateJsxExpression(node, _dotDotDotToken, _expression);
     },
     [SyntaxKind.SyntaxList]: (node: SyntaxList, visitor: Visitor): SyntaxList => {
-        const _children = visitNodesArray(node.children, visitor);
+        const _children = visitNodes(node.children, visitor);
         return updateSyntaxList(node, _children);
     },
     [SyntaxKind.JSDoc]: (node: JSDoc, visitor: Visitor): JSDoc => {
@@ -1400,7 +1392,7 @@ const visitEachChildTable: Record<number, VisitEachChildFunction> = {
         return updateSyntheticReferenceExpression(node, _expression, _thisArg);
     },
     [SyntaxKind.JSDocTypeLiteral]: (node: JSDocTypeLiteral, visitor: Visitor): JSDocTypeLiteral => {
-        const _jsdocPropertyTags = visitNodesArray(node.jsdocPropertyTags, visitor);
+        const _jsdocPropertyTags = visitNodes(node.jsdocPropertyTags, visitor);
         return updateJSDocTypeLiteral(node, _jsdocPropertyTags);
     },
     [SyntaxKind.ForInStatement]: (node: ForInStatement, visitor: Visitor): ForInStatement => {

--- a/_packages/native-preview/src/ast/visitor.ts
+++ b/_packages/native-preview/src/ast/visitor.ts
@@ -29,7 +29,7 @@ import {
 } from "./visitor.generated.ts";
 
 export type { Visitor };
-export { visitEachChild, visitNode, visitNodes, visitNodesArray } from "./visitor.generated.ts";
+export { visitEachChild, visitNode, visitNodes } from "./visitor.generated.ts";
 
 // ── forEachChild helpers (same signature as forEachChildTable entries) ──
 

--- a/_packages/native-preview/test/async/api.test.ts
+++ b/_packages/native-preview/test/async/api.test.ts
@@ -117,9 +117,9 @@ describe("Snapshot", () => {
             const sourceFile = await project.program.getSourceFile("/src/index.ts");
             assert.ok(sourceFile);
             const node = cast(
-                cast(sourceFile.statements[0], isImportDeclaration).importClause?.namedBindings,
+                cast(sourceFile.statements.at(0), isImportDeclaration).importClause?.namedBindings,
                 isNamedImports,
-            ).elements[0].name;
+            ).elements.at(0).name;
             assert.ok(node);
             const symbol = await project.checker.getSymbolAtLocation(node);
             assert.ok(symbol);
@@ -694,7 +694,7 @@ export class MyClass {
             const project = snapshot.getProject("/tsconfig.json")!;
             const sourceFile = await project.program.getSourceFile("/src/main.ts");
             assert.ok(sourceFile);
-            const firstVarDecl = sourceFile.statements[2]; // "export const x"
+            const firstVarDecl = sourceFile.statements.at(2); // "export const x"
             assert.ok(firstVarDecl);
             const type = await project.checker.getTypeAtLocation(firstVarDecl);
             assert.ok(type);
@@ -1293,13 +1293,13 @@ foo(42);
 
             // Find the argument "42" in foo(42)
             // statement[1] = foo(42); which is an ExpressionStatement -> CallExpression
-            const callStmt = sourceFile.statements[1];
+            const callStmt = sourceFile.statements.at(1);
             assert.ok(callStmt);
             let numLiteral: import("@typescript/native-preview/ast").Expression | undefined;
             callStmt.forEachChild(function visit(node) {
                 if (isCallExpression(node)) {
                     // First argument
-                    numLiteral = node.arguments[0];
+                    numLiteral = node.arguments.at(0);
                 }
                 node.forEachChild(visit);
             });
@@ -1348,7 +1348,7 @@ export function check(x: string | number) {
             assert.ok(sourceFile);
 
             // statement[0] is the function declaration
-            const funcDecl = sourceFile.statements[0];
+            const funcDecl = sourceFile.statements.at(0);
             assert.ok(funcDecl);
             // Walk to find the first "return x" — inside the if, x should be narrowed to string
             let firstReturnX: import("@typescript/native-preview/ast").Node | undefined;
@@ -2263,7 +2263,7 @@ test("TypeOperator operator kind", async () => {
         const project = snapshot.getProject("/tsconfig.json")!;
         const sourceFile = await project.program.getSourceFile("/src/index.ts");
         assert(sourceFile);
-        const param = (sourceFile.statements[0] as import("@typescript/native-preview/ast").FunctionDeclaration).parameters[0];
+        const param = (sourceFile.statements.at(0) as import("@typescript/native-preview/ast").FunctionDeclaration).parameters.at(0);
         assert(param);
         const type = param.type as import("@typescript/native-preview/ast").TypeOperatorNode;
         assert(type);
@@ -2287,9 +2287,9 @@ test("SpreadAssignment roundtrip", async () => {
         const project = snapshot.getProject("/tsconfig.json")!;
         const sourceFile = await project.program.getSourceFile("/src/index.ts");
         assert(sourceFile);
-        const stmt = sourceFile.statements[0] as import("@typescript/native-preview/ast").VariableStatement;
-        const object = stmt.declarationList.declarations[0].initializer as import("@typescript/native-preview/ast").ObjectLiteralExpression;
-        const assignment = object.properties[0] as import("@typescript/native-preview/ast").SpreadAssignment;
+        const stmt = sourceFile.statements.at(0) as import("@typescript/native-preview/ast").VariableStatement;
+        const object = stmt.declarationList.declarations.at(0).initializer as import("@typescript/native-preview/ast").ObjectLiteralExpression;
+        const assignment = object.properties.at(0) as import("@typescript/native-preview/ast").SpreadAssignment;
         assert(assignment);
         assert.equal(assignment.kind, SyntaxKind.SpreadAssignment);
         const expr = assignment.expression;
@@ -2314,13 +2314,13 @@ test("VariableDeclarationList const flag clone", async () => {
         const sourceFile = await project.program.getSourceFile("/src/index.ts");
         assert(sourceFile);
         {
-            const stmt = sourceFile.statements[0] as import("@typescript/native-preview/ast").VariableStatement;
+            const stmt = sourceFile.statements.at(0) as import("@typescript/native-preview/ast").VariableStatement;
             const list = stmt.declarationList;
             assert(list.flags & NodeFlags.Const);
         }
         const cloned = getSynthesizedDeepClone(sourceFile);
         {
-            const stmt = cloned.statements[0] as import("@typescript/native-preview/ast").VariableStatement;
+            const stmt = cloned.statements.at(0) as import("@typescript/native-preview/ast").VariableStatement;
             const list = stmt.declarationList;
             assert(list.flags & NodeFlags.Const);
         }

--- a/_packages/native-preview/test/sync/api.test.ts
+++ b/_packages/native-preview/test/sync/api.test.ts
@@ -125,9 +125,9 @@ describe("Snapshot", () => {
             const sourceFile = project.program.getSourceFile("/src/index.ts");
             assert.ok(sourceFile);
             const node = cast(
-                cast(sourceFile.statements[0], isImportDeclaration).importClause?.namedBindings,
+                cast(sourceFile.statements.at(0), isImportDeclaration).importClause?.namedBindings,
                 isNamedImports,
-            ).elements[0].name;
+            ).elements.at(0).name;
             assert.ok(node);
             const symbol = project.checker.getSymbolAtLocation(node);
             assert.ok(symbol);
@@ -702,7 +702,7 @@ export class MyClass {
             const project = snapshot.getProject("/tsconfig.json")!;
             const sourceFile = project.program.getSourceFile("/src/main.ts");
             assert.ok(sourceFile);
-            const firstVarDecl = sourceFile.statements[2]; // "export const x"
+            const firstVarDecl = sourceFile.statements.at(2); // "export const x"
             assert.ok(firstVarDecl);
             const type = project.checker.getTypeAtLocation(firstVarDecl);
             assert.ok(type);
@@ -1301,13 +1301,13 @@ foo(42);
 
             // Find the argument "42" in foo(42)
             // statement[1] = foo(42); which is an ExpressionStatement -> CallExpression
-            const callStmt = sourceFile.statements[1];
+            const callStmt = sourceFile.statements.at(1);
             assert.ok(callStmt);
             let numLiteral: import("@typescript/native-preview/ast").Expression | undefined;
             callStmt.forEachChild(function visit(node) {
                 if (isCallExpression(node)) {
                     // First argument
-                    numLiteral = node.arguments[0];
+                    numLiteral = node.arguments.at(0);
                 }
                 node.forEachChild(visit);
             });
@@ -1356,7 +1356,7 @@ export function check(x: string | number) {
             assert.ok(sourceFile);
 
             // statement[0] is the function declaration
-            const funcDecl = sourceFile.statements[0];
+            const funcDecl = sourceFile.statements.at(0);
             assert.ok(funcDecl);
             // Walk to find the first "return x" — inside the if, x should be narrowed to string
             let firstReturnX: import("@typescript/native-preview/ast").Node | undefined;
@@ -2271,7 +2271,7 @@ test("TypeOperator operator kind", () => {
         const project = snapshot.getProject("/tsconfig.json")!;
         const sourceFile = project.program.getSourceFile("/src/index.ts");
         assert(sourceFile);
-        const param = (sourceFile.statements[0] as import("@typescript/native-preview/ast").FunctionDeclaration).parameters[0];
+        const param = (sourceFile.statements.at(0) as import("@typescript/native-preview/ast").FunctionDeclaration).parameters.at(0);
         assert(param);
         const type = param.type as import("@typescript/native-preview/ast").TypeOperatorNode;
         assert(type);
@@ -2295,9 +2295,9 @@ test("SpreadAssignment roundtrip", () => {
         const project = snapshot.getProject("/tsconfig.json")!;
         const sourceFile = project.program.getSourceFile("/src/index.ts");
         assert(sourceFile);
-        const stmt = sourceFile.statements[0] as import("@typescript/native-preview/ast").VariableStatement;
-        const object = stmt.declarationList.declarations[0].initializer as import("@typescript/native-preview/ast").ObjectLiteralExpression;
-        const assignment = object.properties[0] as import("@typescript/native-preview/ast").SpreadAssignment;
+        const stmt = sourceFile.statements.at(0) as import("@typescript/native-preview/ast").VariableStatement;
+        const object = stmt.declarationList.declarations.at(0).initializer as import("@typescript/native-preview/ast").ObjectLiteralExpression;
+        const assignment = object.properties.at(0) as import("@typescript/native-preview/ast").SpreadAssignment;
         assert(assignment);
         assert.equal(assignment.kind, SyntaxKind.SpreadAssignment);
         const expr = assignment.expression;
@@ -2322,13 +2322,13 @@ test("VariableDeclarationList const flag clone", () => {
         const sourceFile = project.program.getSourceFile("/src/index.ts");
         assert(sourceFile);
         {
-            const stmt = sourceFile.statements[0] as import("@typescript/native-preview/ast").VariableStatement;
+            const stmt = sourceFile.statements.at(0) as import("@typescript/native-preview/ast").VariableStatement;
             const list = stmt.declarationList;
             assert(list.flags & NodeFlags.Const);
         }
         const cloned = getSynthesizedDeepClone(sourceFile);
         {
-            const stmt = cloned.statements[0] as import("@typescript/native-preview/ast").VariableStatement;
+            const stmt = cloned.statements.at(0) as import("@typescript/native-preview/ast").VariableStatement;
             const list = stmt.declarationList;
             assert(list.flags & NodeFlags.Const);
         }

--- a/_packages/native-preview/test/sync/ast.test.ts
+++ b/_packages/native-preview/test/sync/ast.test.ts
@@ -542,7 +542,7 @@ describe("RemoteNode + cloneNode", () => {
         const api = spawnAPI();
         try {
             const sf = getRemoteSourceFile(api, "/tsconfig.json", "/src/index.ts");
-            const importDecl = sf.statements[0];
+            const importDecl = sf.statements.at(0);
             assert.ok(isImportDeclaration(importDecl));
 
             const clone = cloneNode(importDecl);
@@ -560,11 +560,11 @@ describe("RemoteNode + cloneNode", () => {
         const api = spawnAPI();
         try {
             const sf = getRemoteSourceFile(api, "/tsconfig.json", "/src/index.ts");
-            const importDecl = sf.statements[0];
+            const importDecl = sf.statements.at(0);
             assert.ok(isImportDeclaration(importDecl));
             const named = importDecl.importClause?.namedBindings;
             assert.ok(named && isNamedImports(named));
-            const fooName = named.elements[0].name;
+            const fooName = named.elements.at(0).name;
 
             const clone = cloneNode(fooName);
             assert.strictEqual(clone.kind, SyntaxKind.Identifier);
@@ -581,7 +581,7 @@ describe("RemoteNode + visitEachChild", () => {
         const api = spawnAPI();
         try {
             const sf = getRemoteSourceFile(api, "/tsconfig.json", "/src/foo.ts");
-            const firstStmt = sf.statements[0];
+            const firstStmt = sf.statements.at(0);
             assert.ok(firstStmt);
 
             // visitEachChild with identity should return the same node
@@ -597,7 +597,7 @@ describe("RemoteNode + visitEachChild", () => {
         const api = spawnAPI();
         try {
             const sf = getRemoteSourceFile(api, "/tsconfig.json", "/src/index.ts");
-            const importDecl = sf.statements[0];
+            const importDecl = sf.statements.at(0);
             assert.ok(isImportDeclaration(importDecl));
 
             // Replace the module specifier with a new string literal
@@ -623,7 +623,7 @@ describe("RemoteNode + getSynthesizedDeepClone", () => {
         const api = spawnAPI();
         try {
             const sf = getRemoteSourceFile(api, "/tsconfig.json", "/src/index.ts");
-            const importDecl = sf.statements[0];
+            const importDecl = sf.statements.at(0);
             assert.ok(isImportDeclaration(importDecl));
 
             const clone = getSynthesizedDeepClone(importDecl);
@@ -643,7 +643,7 @@ describe("RemoteNode + getSynthesizedDeepClone", () => {
         const api = spawnAPI();
         try {
             const sf = getRemoteSourceFile(api, "/tsconfig.json", "/src/foo.ts");
-            const firstStmt = sf.statements[0];
+            const firstStmt = sf.statements.at(0);
             assert.ok(firstStmt);
 
             const clone = getSynthesizedDeepClone(firstStmt);

--- a/_scripts/generate-encoder.ts
+++ b/_scripts/generate-encoder.ts
@@ -1509,8 +1509,9 @@ function emitNodeGeneratedImports(w: CodeWriter) {
 }
 
 function emitRemoteNodeList(w: CodeWriter) {
-    w.write(`export class RemoteNodeList extends Array<RemoteNode> implements NodeArray<RemoteNode> {`);
+    w.write(`export class RemoteNodeList implements NodeArray<RemoteNode> {`);
     w.write(`    parent: RemoteNode;`);
+    w.write(`    length: number;`);
     w.write(`    hasTrailingComma?: boolean;`);
     w.write(`    transformFlags: number = 0;`);
     w.write(`    protected view: DataView;`);
@@ -1536,7 +1537,6 @@ function emitRemoteNodeList(w: CodeWriter) {
     w.write(`    private sourceFile: SourceFileInfo;`);
     w.write(``);
     w.write(`    constructor(view: DataView, index: number, parent: RemoteNode, sourceFile: SourceFileInfo, offsetNodes: number) {`);
-    w.write(`        super();`);
     w.write(`        this.view = view;`);
     w.write(`        this.index = index;`);
     w.write(`        this.parent = parent;`);
@@ -1544,22 +1544,7 @@ function emitRemoteNodeList(w: CodeWriter) {
     w.write(`        this._byteIndex = offsetNodes + index * NODE_LEN;`);
     w.write(`        this.length = this.data;`);
     w.write(``);
-    w.write(`        const length = this.length;`);
-    w.write(`        for (let i = 16; i < length; i++) {`);
-    w.write(`            Object.defineProperty(this, i, {`);
-    w.write(`                get() {`);
-    w.write(`                    return this.at(i);`);
-    w.write(`                },`);
-    w.write(`            });`);
-    w.write(`        }`);
     w.write(`    }`);
-
-    // Emit indexed getters 0..15
-    for (let i = 0; i < 16; i++) {
-        w.write(`    get ${i}(): RemoteNode {`);
-        w.write(`        return this.at(${i});`);
-        w.write(`    }`);
-    }
 
     w.write(``);
     w.write(`    *[Symbol.iterator](): ArrayIterator<RemoteNode> {`);

--- a/_scripts/generate-ts-ast.ts
+++ b/_scripts/generate-ts-ast.ts
@@ -980,7 +980,7 @@ function generateFactory(): string {
     }
 
     // ── createSourceFile (hand-written — SourceFile is handWritten in schema) ──
-    out.push(`export function createSourceFile(statements: NodeArray<Statement>, endOfFileToken: EndOfFile, text: string, fileName: string, path: Path): SourceFile {`);
+    out.push(`export function createSourceFile(statements: readonly Statement[] | NodeArray<Statement>, endOfFileToken: EndOfFile, text: string, fileName: string, path: Path): SourceFile {`);
     out.push(`    return new NodeObject(SyntaxKind.SourceFile, {`);
     out.push(`        statements: createNodeArray(statements),`);
     out.push(`        endOfFileToken,`);
@@ -992,7 +992,7 @@ function generateFactory(): string {
     out.push(``);
 
     // ── updateSourceFile (hand-written in schema) ──
-    out.push(`export function updateSourceFile(node: SourceFile, statements: NodeArray<Statement>, endOfFileToken: EndOfFile): SourceFile {`);
+    out.push(`export function updateSourceFile(node: SourceFile, statements: readonly Statement[] | NodeArray<Statement>, endOfFileToken: EndOfFile): SourceFile {`);
     out.push(`    return node.statements !== statements || node.endOfFileToken !== endOfFileToken`);
     out.push(`        ? createSourceFile(statements, endOfFileToken, node.text, node.fileName, node.path)`);
     out.push(`        : node;`);

--- a/_scripts/generate-ts-ast.ts
+++ b/_scripts/generate-ts-ast.ts
@@ -234,9 +234,6 @@ function visitorGuardName(member: MemberInfo): string | undefined {
 
 function visitorVisitExpression(member: MemberInfo): { expression: string; guardName?: string; } {
     const propName = api.uncapitalize(member.name);
-    if (member.listKind === "raw") {
-        return { expression: `visitNodesArray(node.${propName}, visitor)` };
-    }
     if (member.type.kind === "list") {
         return { expression: `visitNodes(node.${propName}, visitor)` };
     }
@@ -341,7 +338,7 @@ import type { Node, NodeArray } from "./ast.ts";`);
         for (const m of tsInterfaceMembers(node)) {
             if (m.rawType === "SyntaxKind" && m.name === "SyntaxKind") continue;
             const propName = api.uncapitalize(m.name);
-            const propType = m.type.formatTypeScript();
+            const propType = m.type.kind === "list" ? m.type.nodeList().formatTypeScript() : m.type.formatTypeScript();
             const opt = m.optional ? "?" : "";
             memberLines += `\n    readonly ${propName}${opt}: ${propType};`;
         }
@@ -485,7 +482,6 @@ function generateFactory(): string {
         const kindTypeParam = kindTypeParameter(node);
         if (kindTypeParam) addType(kindTypeParam.constraint);
         for (const m of tsMembers(node)) {
-            addType(tsParamTypeFrom(m.type));
             addType(m.type.formatTypeScript());
         }
     }
@@ -577,11 +573,11 @@ function generateFactory(): string {
     out.push(``);
 
     // ── Utility functions ──
-    out.push(`function isNodeArray<T extends Node>(array: readonly T[]): array is NodeArray<T> {`);
+    out.push(`function isNodeArray<T extends Node>(array: readonly T[] | NodeArray<T>): array is NodeArray<T> {`);
     out.push(`    return "pos" in array && "end" in array;`);
     out.push(`}`);
     out.push(``);
-    out.push(`export function createNodeArray<T extends Node>(elements: readonly T[], pos: number = -1, end: number = -1): NodeArray<T> {`);
+    out.push(`export function createNodeArray<T extends Node>(elements: readonly T[] | NodeArray<T>, pos: number = -1, end: number = -1): NodeArray<T> {`);
     out.push(`    if (isNodeArray(elements)) return elements;`);
     out.push(`    const arr = elements.slice() as unknown as NodeArray<T> & { pos: number; end: number; };`);
     out.push(`    arr.pos = pos;`);
@@ -984,7 +980,7 @@ function generateFactory(): string {
     }
 
     // ── createSourceFile (hand-written — SourceFile is handWritten in schema) ──
-    out.push(`export function createSourceFile(statements: readonly Statement[], endOfFileToken: EndOfFile, text: string, fileName: string, path: Path): SourceFile {`);
+    out.push(`export function createSourceFile(statements: NodeArray<Statement>, endOfFileToken: EndOfFile, text: string, fileName: string, path: Path): SourceFile {`);
     out.push(`    return new NodeObject(SyntaxKind.SourceFile, {`);
     out.push(`        statements: createNodeArray(statements),`);
     out.push(`        endOfFileToken,`);
@@ -996,7 +992,7 @@ function generateFactory(): string {
     out.push(``);
 
     // ── updateSourceFile (hand-written in schema) ──
-    out.push(`export function updateSourceFile(node: SourceFile, statements: readonly Statement[], endOfFileToken: EndOfFile): SourceFile {`);
+    out.push(`export function updateSourceFile(node: SourceFile, statements: NodeArray<Statement>, endOfFileToken: EndOfFile): SourceFile {`);
     out.push(`    return node.statements !== statements || node.endOfFileToken !== endOfFileToken`);
     out.push(`        ? createSourceFile(statements, endOfFileToken, node.text, node.fileName, node.path)`);
     out.push(`        : node;`);
@@ -1413,31 +1409,23 @@ function generateVisitor(): string {
     out.push(`export function visitNodes<T extends Node>(nodes: NodeArray<T> | undefined, visitor: Visitor): NodeArray<T> | undefined;`);
     out.push(`export function visitNodes(nodes: NodeArray<Node> | undefined, visitor: Visitor): NodeArray<Node> | undefined {`);
     out.push(`    if (nodes === undefined) return undefined;`);
-    out.push(`    const updated = visitNodesArray(nodes, visitor);`);
-    out.push(`    if (updated === nodes) {`);
-    out.push(`        return nodes;`);
-    out.push(`    }`);
-    out.push(`    return createNodeArray(updated, nodes.pos, nodes.end);`);
-    out.push(`}`);
-    out.push("");
-    out.push(`export function visitNodesArray<T extends Node>(nodes: readonly T[], visitor: Visitor): readonly T[];`);
-    out.push(`export function visitNodesArray<T extends Node>(nodes: readonly T[] | undefined, visitor: Visitor): readonly T[] | undefined;`);
-    out.push(`export function visitNodesArray(nodes: readonly Node[] | undefined, visitor: Visitor): readonly Node[] | undefined {`);
-    out.push(`    if (nodes === undefined) return undefined;`);
     out.push(`    let updated: Node[] | undefined;`);
     out.push(`    for (let i = 0; i < nodes.length; i++) {`);
-    out.push(`        const node = nodes[i];`);
+    out.push(`        const node = nodes.at(i);`);
     out.push(`        const visited = visitor(node);`);
     out.push(`        if (updated) {`);
     out.push(`            if (visited) updated.push(visited);`);
     out.push(`        }`);
     out.push(`        else if (visited !== node) {`);
     out.push(`            updated = [];`);
-    out.push(`            for (let j = 0; j < i; j++) updated.push(nodes[j]);`);
+    out.push(`            for (let j = 0; j < i; j++) updated.push(nodes.at(j));`);
     out.push(`            if (visited) updated.push(visited);`);
     out.push(`        }`);
     out.push(`    }`);
-    out.push(`    return updated ?? nodes;`);
+    out.push(`    if (updated === undefined) {`);
+    out.push(`        return nodes;`);
+    out.push(`    }`);
+    out.push(`    return createNodeArray(updated, nodes.pos, nodes.end);`);
     out.push(`}`);
     out.push("");
     out.push(`/**`);

--- a/_scripts/schema.ts
+++ b/_scripts/schema.ts
@@ -546,8 +546,11 @@ export class ListType extends TypeBase {
 
     formatTypeScript(): string {
         const elementType = this.elementType.formatTypeScript();
-        if (this.listKind === "raw") {
+        if (this.elementType.baseKind() === "primitive") {
             return `readonly ${elementType}[]`;
+        }
+        if (this.listKind === "raw") {
+            return `readonly ${elementType}[] | NodeArray<${elementType}>`;
         }
         return `NodeArray<${elementType}>`;
     }
@@ -561,6 +564,13 @@ export class ListType extends TypeBase {
             return this;
         }
         return this.api.listType(this.elementType, "raw");
+    }
+
+    nodeList(): ListType {
+        if (this.listKind === "NodeList") {
+            return this;
+        }
+        return this.api.listType(this.elementType, "NodeList");
     }
 }
 


### PR DESCRIPTION
This PR makes `NodeArray` no longer inherit from `Array`, which will prevent users from directly using the methods on the `Array` prototype and will only be able to access elements using `.at()`.
This is a breaking change, but it brings significant performance improvements.
before
```
┌─────────┬─────────────────────────────────────────────────────┬─────────────────────┬────────────────────────┬────────────────────────┬────────────────────────┬─────────┐
│ (index) │ Task name                                           │ Latency avg (ns)    │ Latency med (ns)       │ Throughput avg (ops/s) │ Throughput med (ops/s) │ Samples │
├─────────┼─────────────────────────────────────────────────────┼─────────────────────┼────────────────────────┼────────────────────────┼────────────────────────┼─────────┤
│ 6       │ 'materialize program.ts'                            │ '1665333 ± 1.95%'   │ '1566400 ± 53800'      │ '619 ± 1.00%'          │ '638 ± 23'             │ 601     │
│ 7       │ 'materialize checker.ts'                            │ '24862780 ± 7.13%'  │ '26885600 ± 1569500'   │ '42 ± 7.52%'           │ '37 ± 2'               │ 41      │
└─────────┴─────────────────────────────────────────────────────┴─────────────────────┴────────────────────────┴────────────────────────┴────────────────────────┴─────────┘
```

after
```
┌─────────┬─────────────────────────────────────────────────────┬──────────────────────┬────────────────────────┬────────────────────────┬────────────────────────┬─────────┐
│ (index) │ Task name                                           │ Latency avg (ns)     │ Latency med (ns)       │ Throughput avg (ops/s) │ Throughput med (ops/s) │ Samples │
├─────────┼─────────────────────────────────────────────────────┼──────────────────────┼────────────────────────┼────────────────────────┼────────────────────────┼─────────┤
│ 6       │ 'materialize program.ts'                            │ '957022 ± 1.91%'     │ '875700 ± 27700'       │ '1089 ± 0.84%'         │ '1142 ± 36'            │ 1045    │
│ 7       │ 'materialize checker.ts'                            │ '15419973 ± 8.99%'   │ '11502350 ± 1520200'   │ '73 ± 7.79%'           │ '87 ± 13'              │ 66      │
└─────────┴─────────────────────────────────────────────────────┴──────────────────────┴────────────────────────┴────────────────────────┴────────────────────────┴─────────┘
```
