### PR TITLE
Handle type parameter declaration as type node in printer

### DIFF
--- a/internal/ast/precedence.go
+++ b/internal/ast/precedence.go
@@ -709,7 +709,8 @@ func GetTypeNodePrecedence(n *TypeNode) TypePrecedence {
 		KindImportType,
 		// These occur in pseudo-types like `f<T>.C`, where `f` is a generic function and `C` is a local type
 		KindPropertyAccessExpression,
-		KindExpressionWithTypeArguments:
+		KindExpressionWithTypeArguments,
+		KindTypeParameter:
 		return TypePrecedenceNonArray
 	default:
 		panic(fmt.Sprintf("unhandled TypeNode: %v", n.Kind))

--- a/internal/fourslash/tests/hoverVerbosityNestedGenericNamespaceMerge_test.go
+++ b/internal/fourslash/tests/hoverVerbosityNestedGenericNamespaceMerge_test.go
@@ -1,0 +1,43 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestHoverVerbosityNestedGenericNamespaceMerge(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `
+declare namespace NS {
+    export class Box<TElement = HTMLElement> {}
+    export namespace Box {
+        export interface ResultBase<TR, TJ, TN> {
+            next<ARD, AJD, AND>(
+                doneFilter: (
+                    value: TR
+                ) => ResultBase<ARD, AJD, AND> | ARD,
+            ): ResultBase<ARD, AJD, AND>;
+        }
+        export interface Result<TR, TJ = any, TN = any> extends ResultBase<TR, TJ, TN> {}
+    }
+}
+
+interface Operation<T> extends NS.Box.Result<T> {}
+
+declare namespace Work {
+    interface Item {
+        run(force?: boolean): Operation<any>;
+    }
+}
+
+declare const item: Work.Item;
+item./*1*/run();
+`
+
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineHoverWithVerbosity(t, map[string][]int{"1": {0, 1, 2}})
+}

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -2322,13 +2322,6 @@ func (p *Printer) emitTypeNode(node *ast.TypeNode, precedence ast.TypePrecedence
 	case ast.KindImportType:
 		p.emitImportTypeNode(node.AsImportTypeNode())
 
-	case ast.KindPropertyAccessExpression:
-		// Occurs in pseudo-types such as `f<T>.C`, where `f` is a generic function and `C` is a local type
-		p.emitPropertyAccessExpression(node.AsPropertyAccessExpression())
-	case ast.KindExpressionWithTypeArguments:
-		// !!! Should this actually be considered a type?
-		p.emitExpressionWithTypeArguments(node.AsExpressionWithTypeArguments())
-
 	case ast.KindJSDocAllType:
 		p.emitJSDocAllType(node)
 	case ast.KindJSDocNonNullableType:
@@ -2339,6 +2332,14 @@ func (p *Printer) emitTypeNode(node *ast.TypeNode, precedence ast.TypePrecedence
 		p.emitJSDocOptionalType(node.AsJSDocOptionalType())
 	case ast.KindJSDocVariadicType:
 		p.emitJSDocVariadicType(node.AsJSDocVariadicType())
+
+	// Occurs in pseudo-types such as `f<T>.C`, where `f` is a generic function and `C` is a local type
+	case ast.KindPropertyAccessExpression:
+		p.emitPropertyAccessExpression(node.AsPropertyAccessExpression())
+	case ast.KindExpressionWithTypeArguments:
+		p.emitExpressionWithTypeArguments(node.AsExpressionWithTypeArguments())
+	case ast.KindTypeParameter:
+		p.emitTypeParameter(node.AsTypeParameterDeclaration())
 
 	default:
 		panic(fmt.Sprintf("unhandled TypeNode: %v", node.Kind))

--- a/testdata/baselines/reference/fourslash/quickInfo/hoverVerbosityNestedGenericNamespaceMerge.baseline
+++ b/testdata/baselines/reference/fourslash/quickInfo/hoverVerbosityNestedGenericNamespaceMerge.baseline
@@ -1,0 +1,155 @@
+// === QuickInfo ===
+=== /hoverVerbosityNestedGenericNamespaceMerge.ts ===
+// 
+// declare namespace NS {
+//     export class Box<TElement = HTMLElement> {}
+//     export namespace Box {
+//         export interface ResultBase<TR, TJ, TN> {
+//             next<ARD, AJD, AND>(
+//                 doneFilter: (
+//                     value: TR
+//                 ) => ResultBase<ARD, AJD, AND> | ARD,
+//             ): ResultBase<ARD, AJD, AND>;
+//         }
+//         export interface Result<TR, TJ = any, TN = any> extends ResultBase<TR, TJ, TN> {}
+//     }
+// }
+// 
+// interface Operation<T> extends NS.Box.Result<T> {}
+// 
+// declare namespace Work {
+//     interface Item {
+//         run(force?: boolean): Operation<any>;
+//     }
+// }
+// 
+// declare const item: Work.Item;
+// item.run();
+//      ^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (method) Work.Item.run(force?: boolean | undefined): {
+// |     next<ARD, AJD, AND>(doneFilter: (value: any) => ARD | {
+// |         next<ARD, AJD, AND>(doneFilter: (value: ARD) => ARD | NS.Box<TElement = HTMLElement>.ResultBase<ARD, AJD, AND>): NS.Box<TElement = HTMLElement>.ResultBase<ARD, AJD, AND>;
+// |     }): {
+// |         next<ARD, AJD, AND>(doneFilter: (value: ARD) => ARD | NS.Box<TElement = HTMLElement>.ResultBase<ARD, AJD, AND>): NS.Box<TElement = HTMLElement>.ResultBase<ARD, AJD, AND>;
+// |     };
+// | }
+// | ```
+// | 
+// | (verbosity level: 2)
+// | ----------------------------------------------------------------------
+//      ^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (method) Work.Item.run(force?: boolean | undefined): {
+// |     next<ARD, AJD, AND>(doneFilter: (value: any) => ARD | NS.Box<TElement = HTMLElement>.ResultBase<ARD, AJD, AND>): NS.Box<TElement = HTMLElement>.ResultBase<ARD, AJD, AND>;
+// | }
+// | ```
+// | 
+// | (verbosity level: 1)
+// | ----------------------------------------------------------------------
+//      ^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (method) Work.Item.run(force?: boolean): Operation<any>
+// | ```
+// | 
+// | (verbosity level: 0)
+// | ----------------------------------------------------------------------
+// 
+[
+  {
+    "marker": {
+      "Position": 636,
+      "LSPosition": {
+        "line": 24,
+        "character": 5
+      },
+      "Name": "1",
+      "Data": {}
+    },
+    "item": {
+      "hover": {
+        "contents": {
+          "kind": "markdown",
+          "value": "```typescript\n(method) Work.Item.run(force?: boolean): Operation<any>\n```\n"
+        },
+        "range": {
+          "start": {
+            "line": 24,
+            "character": 5
+          },
+          "end": {
+            "line": 24,
+            "character": 8
+          }
+        },
+        "canIncreaseVerbosity": true
+      },
+      "verbosityLevel": 0
+    }
+  },
+  {
+    "marker": {
+      "Position": 636,
+      "LSPosition": {
+        "line": 24,
+        "character": 5
+      },
+      "Name": "1",
+      "Data": {}
+    },
+    "item": {
+      "hover": {
+        "contents": {
+          "kind": "markdown",
+          "value": "```typescript\n(method) Work.Item.run(force?: boolean | undefined): {\n    next<ARD, AJD, AND>(doneFilter: (value: any) => ARD | NS.Box<TElement = HTMLElement>.ResultBase<ARD, AJD, AND>): NS.Box<TElement = HTMLElement>.ResultBase<ARD, AJD, AND>;\n}\n```\n"
+        },
+        "range": {
+          "start": {
+            "line": 24,
+            "character": 5
+          },
+          "end": {
+            "line": 24,
+            "character": 8
+          }
+        },
+        "canIncreaseVerbosity": true
+      },
+      "verbosityLevel": 1
+    }
+  },
+  {
+    "marker": {
+      "Position": 636,
+      "LSPosition": {
+        "line": 24,
+        "character": 5
+      },
+      "Name": "1",
+      "Data": {}
+    },
+    "item": {
+      "hover": {
+        "contents": {
+          "kind": "markdown",
+          "value": "```typescript\n(method) Work.Item.run(force?: boolean | undefined): {\n    next<ARD, AJD, AND>(doneFilter: (value: any) => ARD | {\n        next<ARD, AJD, AND>(doneFilter: (value: ARD) => ARD | NS.Box<TElement = HTMLElement>.ResultBase<ARD, AJD, AND>): NS.Box<TElement = HTMLElement>.ResultBase<ARD, AJD, AND>;\n    }): {\n        next<ARD, AJD, AND>(doneFilter: (value: ARD) => ARD | NS.Box<TElement = HTMLElement>.ResultBase<ARD, AJD, AND>): NS.Box<TElement = HTMLElement>.ResultBase<ARD, AJD, AND>;\n    };\n}\n```\n"
+        },
+        "range": {
+          "start": {
+            "line": 24,
+            "character": 5
+          },
+          "end": {
+            "line": 24,
+            "character": 8
+          }
+        },
+        "canIncreaseVerbosity": true
+      },
+      "verbosityLevel": 2
+    }
+  }
+]


### PR DESCRIPTION
Fixes crash found in https://github.com/microsoft/typescript-go/issues/3512#issuecomment-4299732162.
Supersedes #3524.

Needed because in hover, when emitting type arguments for expressions with type arguments, we use type parameter declarations instead of type references to type parameters so that we can print type arguments as in `Foo<T extends Blah>.bar` instead of `Foo<T>.bar`.