### PR TITLE
Always widen resulting type in `getWidenedTypeForAssignmentDeclaration`

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -17708,9 +17708,10 @@ func (c *Checker) getWidenedTypeForAssignmentDeclaration(symbol *ast.Symbol) *Ty
 			}
 		}
 		if t == nil {
-			t = c.getWidenedType(c.getUnionType(types))
+			t = c.getUnionType(types)
 		}
 	}
+	t = c.getWidenedType(t)
 	// report an all-nullable or empty union as an implicit any in JS files
 	if symbol.ValueDeclaration != nil && ast.IsInJSFile(symbol.ValueDeclaration) &&
 		c.filterType(t, func(c *Type) bool { return c.Flags() & ^TypeFlagsNullable != 0 }) == c.neverType {

--- a/testdata/baselines/reference/compiler/widenedThisPropertyAssignment.symbols
+++ b/testdata/baselines/reference/compiler/widenedThisPropertyAssignment.symbols
@@ -1,0 +1,30 @@
+//// [tests/cases/compiler/widenedThisPropertyAssignment.ts] ////
+
+=== main.js ===
+export class CC {
+>CC : Symbol(CC, Decl(main.js, 0, 0))
+
+    constructor() {
+        this.stuffs = {}
+>this.stuffs : Symbol(CC.stuffs, Decl(main.js, 1, 19), Decl(main.js, 7, 23))
+>this : Symbol(CC, Decl(main.js, 0, 0))
+>stuffs : Symbol(CC.stuffs, Decl(main.js, 1, 19), Decl(main.js, 7, 23))
+    }
+    /**
+     * @param {Object} stuffs
+     */
+    addStuffs(stuffs) {
+>addStuffs : Symbol(CC.addStuffs, Decl(main.js, 3, 5))
+>stuffs : Symbol(stuffs, Decl(main.js, 7, 14))
+
+        this.stuffs = { ...stuffs, ...this.stuffs }
+>this.stuffs : Symbol(CC.stuffs, Decl(main.js, 1, 19), Decl(main.js, 7, 23))
+>this : Symbol(CC, Decl(main.js, 0, 0))
+>stuffs : Symbol(CC.stuffs, Decl(main.js, 1, 19), Decl(main.js, 7, 23))
+>stuffs : Symbol(stuffs, Decl(main.js, 7, 14))
+>this.stuffs : Symbol(CC.stuffs, Decl(main.js, 1, 19), Decl(main.js, 7, 23))
+>this : Symbol(CC, Decl(main.js, 0, 0))
+>stuffs : Symbol(CC.stuffs, Decl(main.js, 1, 19), Decl(main.js, 7, 23))
+    }
+}
+

--- a/testdata/baselines/reference/compiler/widenedThisPropertyAssignment.types
+++ b/testdata/baselines/reference/compiler/widenedThisPropertyAssignment.types
@@ -1,0 +1,34 @@
+//// [tests/cases/compiler/widenedThisPropertyAssignment.ts] ////
+
+=== main.js ===
+export class CC {
+>CC : CC
+
+    constructor() {
+        this.stuffs = {}
+>this.stuffs = {} : {}
+>this.stuffs : any
+>this : this
+>stuffs : any
+>{} : {}
+    }
+    /**
+     * @param {Object} stuffs
+     */
+    addStuffs(stuffs) {
+>addStuffs : (stuffs: Object) => void
+>stuffs : Object
+
+        this.stuffs = { ...stuffs, ...this.stuffs }
+>this.stuffs = { ...stuffs, ...this.stuffs } : { constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; }
+>this.stuffs : {}
+>this : this
+>stuffs : {}
+>{ ...stuffs, ...this.stuffs } : { constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; }
+>stuffs : Object
+>this.stuffs : {}
+>this : this
+>stuffs : {}
+    }
+}
+

--- a/testdata/tests/cases/compiler/widenedThisPropertyAssignment.ts
+++ b/testdata/tests/cases/compiler/widenedThisPropertyAssignment.ts
@@ -1,0 +1,17 @@
+// @checkJs: true
+// @noEmit: true
+
+// https://github.com/microsoft/typescript-go/issues/3642
+
+// @filename: main.js
+export class CC {
+    constructor() {
+        this.stuffs = {}
+    }
+    /**
+     * @param {Object} stuffs
+     */
+    addStuffs(stuffs) {
+        this.stuffs = { ...stuffs, ...this.stuffs }
+    }
+}


### PR DESCRIPTION
Fixes #3639.
Fixes #3642.