### PR TITLE
Add TS_GO_DEBUG_STACK_LIMIT to Copilot workflow

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -13,6 +13,10 @@ jobs:
       # If you want to clone the repository as part of your setup steps, for example to install dependencies, you'll need the `contents: read` permission. If you don't clone the repository in your setup steps, Copilot will do this for you automatically after the steps complete.
       contents: read
 
+    env:
+      # Prevent stack overflows from hanging
+      TS_GO_DEBUG_STACK_LIMIT: 5000000
+
     # You can define any steps you want, and they will run before the agent starts.
     # If you do not check out your code, Copilot will do this for you.
     steps:


### PR DESCRIPTION
See #3649, this is high enough to let all testcases pass but low enough that runaway recursion terminates in a reasonable amount of time