### PR TITLE
Fix JSDoc `@extends` mismatch diagnostics for property access bases

### DIFF
--- a/internal/checker/grammarchecks.go
+++ b/internal/checker/grammarchecks.go
@@ -54,6 +54,17 @@ func (c *Checker) grammarErrorOnNodeSkippedOnNoEmit(node *ast.Node, message *dia
 	return false
 }
 
+func getIdentifierFromEntityNameExpression(node *ast.Node) *ast.Node {
+	switch node.Kind {
+	case ast.KindIdentifier:
+		return node
+	case ast.KindPropertyAccessExpression:
+		return node.AsPropertyAccessExpression().Name()
+	default:
+		return nil
+	}
+}
+
 func (c *Checker) checkGrammarRegularExpressionLiteral(node *ast.RegularExpressionLiteral) bool {
 	sourceFile := ast.GetSourceFileOfNode(node.AsNode())
 	if !c.hasParseDiagnostics(sourceFile) {
@@ -919,10 +930,10 @@ func (c *Checker) checkGrammarClassDeclarationHeritageClauses(node *ast.ClassLik
 						if tag.Kind == ast.KindJSDocAugmentsTag {
 							target := typeNodes[0].AsExpressionWithTypeArguments()
 							source := tag.ClassName().AsExpressionWithTypeArguments()
-							if !ast.HasSamePropertyAccessName(target.Expression, source.Expression) &&
-								target.Expression.Kind == ast.KindIdentifier &&
-								source.Expression.Kind == ast.KindIdentifier {
-								return c.grammarErrorOnNode(tag.ClassName(), diagnostics.JSDoc_0_1_does_not_match_the_extends_2_clause, tag.TagName().Text(), source.Expression.Text(), target.Expression.Text())
+							targetName := getIdentifierFromEntityNameExpression(target.Expression)
+							sourceName := getIdentifierFromEntityNameExpression(source.Expression)
+							if targetName != nil && sourceName != nil && targetName.Text() != sourceName.Text() {
+								return c.grammarErrorOnNode(sourceName, diagnostics.JSDoc_0_1_does_not_match_the_extends_2_clause, tag.TagName().Text(), sourceName.Text(), targetName.Text())
 							}
 						}
 					}

--- a/testdata/baselines/reference/compiler/jsdocExtendsClauseMismatch.errors.txt
+++ b/testdata/baselines/reference/compiler/jsdocExtendsClauseMismatch.errors.txt
@@ -1,0 +1,22 @@
+main.js(2,20): error TS8023: JSDoc '@extends Component' does not match the 'extends PureComponent' clause.
+
+
+==== react.d.ts (0 errors) ====
+    declare namespace React {
+        class Component {}
+        class PureComponent {}
+    }
+    
+==== main.js (1 errors) ====
+    /**
+     * @extends {React.Component}
+                       ~~~~~~~~~
+!!! error TS8023: JSDoc '@extends Component' does not match the 'extends PureComponent' clause.
+     */
+    class C extends React.PureComponent {}
+    
+    /**
+     * @extends {React.Component}
+     */
+    class D extends React.Component {}
+    

--- a/testdata/baselines/reference/compiler/jsdocExtendsClauseMismatch.symbols
+++ b/testdata/baselines/reference/compiler/jsdocExtendsClauseMismatch.symbols
@@ -1,0 +1,32 @@
+//// [tests/cases/compiler/jsdocExtendsClauseMismatch.ts] ////
+
+=== react.d.ts ===
+declare namespace React {
+>React : Symbol(React, Decl(react.d.ts, 0, 0))
+
+    class Component {}
+>Component : Symbol(Component, Decl(react.d.ts, 0, 25))
+
+    class PureComponent {}
+>PureComponent : Symbol(PureComponent, Decl(react.d.ts, 1, 22))
+}
+
+=== main.js ===
+/**
+ * @extends {React.Component}
+ */
+class C extends React.PureComponent {}
+>C : Symbol(C, Decl(main.js, 0, 0))
+>React.PureComponent : Symbol(React.PureComponent, Decl(react.d.ts, 1, 22))
+>React : Symbol(React, Decl(react.d.ts, 0, 0))
+>PureComponent : Symbol(React.PureComponent, Decl(react.d.ts, 1, 22))
+
+/**
+ * @extends {React.Component}
+ */
+class D extends React.Component {}
+>D : Symbol(D, Decl(main.js, 3, 38))
+>React.Component : Symbol(React.Component, Decl(react.d.ts, 0, 25))
+>React : Symbol(React, Decl(react.d.ts, 0, 0))
+>Component : Symbol(React.Component, Decl(react.d.ts, 0, 25))
+

--- a/testdata/baselines/reference/compiler/jsdocExtendsClauseMismatch.types
+++ b/testdata/baselines/reference/compiler/jsdocExtendsClauseMismatch.types
@@ -1,0 +1,32 @@
+//// [tests/cases/compiler/jsdocExtendsClauseMismatch.ts] ////
+
+=== react.d.ts ===
+declare namespace React {
+>React : typeof React
+
+    class Component {}
+>Component : Component
+
+    class PureComponent {}
+>PureComponent : PureComponent
+}
+
+=== main.js ===
+/**
+ * @extends {React.Component}
+ */
+class C extends React.PureComponent {}
+>C : C
+>React.PureComponent : React.PureComponent
+>React : typeof React
+>PureComponent : typeof React.PureComponent
+
+/**
+ * @extends {React.Component}
+ */
+class D extends React.Component {}
+>D : D
+>React.Component : React.Component
+>React : typeof React
+>Component : typeof React.Component
+

--- a/testdata/tests/cases/compiler/jsdocExtendsClauseMismatch.ts
+++ b/testdata/tests/cases/compiler/jsdocExtendsClauseMismatch.ts
@@ -1,0 +1,20 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+
+// @filename: react.d.ts
+declare namespace React {
+    class Component {}
+    class PureComponent {}
+}
+
+// @filename: main.js
+/**
+ * @extends {React.Component}
+ */
+class C extends React.PureComponent {}
+
+/**
+ * @extends {React.Component}
+ */
+class D extends React.Component {}


### PR DESCRIPTION
fixes https://github.com/microsoft/typescript-go/issues/3666