### PR TITLE
Port JS specific code for `this.xxx` assignment declaration typing

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -17699,10 +17699,11 @@ func (c *Checker) getWidenedTypeForAssignmentDeclaration(symbol *ast.Symbol) *Ty
 				t = c.getTypeFromTypeNode(declaration.Type())
 				break
 			}
-			assignedType := c.getAssignmentDeclarationInitializerType(declaration)
-			// We ignore initial assignments of undefined to CommonJS exports when there are multiple assignment declarations
-			if ast.GetAssignmentDeclarationKind(declaration) != ast.JSDeclarationKindExportsProperty || i != 0 || len(symbol.Declarations) == 1 || assignedType.flags&TypeFlagsUndefined == 0 {
-				types = core.AppendIfUnique(types, assignedType)
+			if assignedType := c.getAssignmentDeclarationInitializerType(declaration); assignedType != nil {
+				// We ignore initial assignments of undefined to CommonJS exports when there are multiple assignment declarations
+				if ast.GetAssignmentDeclarationKind(declaration) != ast.JSDeclarationKindExportsProperty || i != 0 || len(symbol.Declarations) == 1 || assignedType.flags&TypeFlagsUndefined == 0 {
+					types = core.AppendIfUnique(types, assignedType)
+				}
 			}
 		}
 		if kind == thisAssignmentDeclarationMethod && len(types) > 0 {
@@ -17711,7 +17712,10 @@ func (c *Checker) getWidenedTypeForAssignmentDeclaration(symbol *ast.Symbol) *Ty
 			}
 		}
 		if t == nil {
-			t = c.getUnionType(types)
+			t = c.anyType
+			if len(types) != 0 {
+				t = c.getUnionType(types)
+			}
 		}
 	}
 	t = c.getWidenedType(t)
@@ -17726,16 +17730,42 @@ func (c *Checker) getWidenedTypeForAssignmentDeclaration(symbol *ast.Symbol) *Ty
 
 func (c *Checker) getAssignmentDeclarationInitializerType(node *ast.Node) *Type {
 	if ast.IsBinaryExpression(node) {
+		var t *Type
 		switch ast.GetAssignmentDeclarationKind(node) {
 		case ast.JSDeclarationKindModuleExports, ast.JSDeclarationKindExportsProperty:
-			return c.getRegularTypeOfLiteralType(c.checkExpressionCached(ast.GetRightMostAssignedExpression(node)))
+			t = c.getRegularTypeOfLiteralType(c.checkExpressionCached(ast.GetRightMostAssignedExpression(node)))
+		case ast.JSDeclarationKindThisProperty:
+			if c.containsSameNamedThisProperty(node.AsBinaryExpression().Left, node.AsBinaryExpression().Right) {
+				return nil
+			}
+			fallthrough
+		default:
+			t = c.checkExpressionForMutableLocation(node.AsBinaryExpression().Right, CheckModeNormal)
 		}
-		return c.checkExpressionForMutableLocation(node.AsBinaryExpression().Right, CheckModeNormal)
+		if c.isEmptyArrayLiteralType(t) {
+			c.reportImplicitAny(node, c.anyArrayType, WideningKindNormal)
+			return c.anyArrayType
+		}
+		return t
 	}
 	if ast.IsCallExpression(node) {
 		return c.getTypeFromPropertyDescriptor(node.Arguments()[2])
 	}
-	return c.neverType
+	return nil
+}
+
+func (c *Checker) containsSameNamedThisProperty(thisProperty *ast.Node, expression *ast.Node) bool {
+	var visit func(node *ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if c.isMatchingReference(thisProperty, node) {
+			return true
+		}
+		if ast.IsFunctionLike(node) {
+			return false
+		}
+		return node.ForEachChild(visit)
+	}
+	return visit(expression)
 }
 
 func (c *Checker) getTypeFromPropertyDescriptor(node *ast.Node) *Type {

--- a/testdata/baselines/reference/compiler/thisPropertyAssignmentTyping.errors.txt
+++ b/testdata/baselines/reference/compiler/thisPropertyAssignmentTyping.errors.txt
@@ -1,0 +1,81 @@
+main.js(47,21): error TS2532: Object is possibly 'undefined'.
+main.js(55,9): error TS2322: Type 'string' is not assignable to type 'number'.
+main.js(64,9): error TS7008: Member 'bar' implicitly has an 'any[]' type.
+
+
+==== main.js (3 errors) ====
+    class C1 {
+        constructor() {
+            this.foo = [3];
+            this.foo = [this.foo[0] * 2];
+            this.foo;  // number[]
+        }
+    }
+    
+    class C2 {
+        constructor() {
+            this.foo = [3];
+            this.foo;  // number[]
+        }
+        method1() {
+            this.foo = [this.foo[0] * 2];
+        }
+    }
+    
+    class C4 {
+        constructor() {
+            this.bar = [];
+            this.bar.push("baz");
+            this.bar;  // string[]
+        }
+    }
+    
+    // When this.xxx assignment declarations occur only in methods, the declared type of the
+    // property is a union of the types of all assigned values, excluding values from self-referential
+    // assignments, plus undefined. Local CFA removes the undefined when possible.
+    
+    class C5 {
+        method1() {
+            this.foo;  // number[] | undefined
+            this.foo = [3]
+            this.foo = [this.foo[0] * 2]
+            this.foo;  // number[]
+        }
+    }
+    
+    class C6 {
+        method1() {
+            this.foo = [3];
+            this.foo;  // number[]
+        }
+        method2() {
+            this.foo;  // number[] | undefined
+            this.foo = [this.foo[0] * 2];  // Error: Object is possibly undefined
+                        ~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+            this.foo;  // number[]
+        }
+    }
+    
+    class C7 {
+        method1() {
+            this.foo = 0;
+            this.foo = this.foo + "abc";  // Error, 'string' not assignable to 'number'
+            ~~~~~~~~
+!!! error TS2322: Type 'string' is not assignable to type 'number'.
+        }
+    }
+    
+    // When this.xxx assigmment declarations occur only in methods, an assigned empty array
+    // literal value is given type 'any[]'.
+    
+    class C8 {
+        method1() {
+            this.bar = [];  // Error: Implicit any[]
+            ~~~~~~~~~~~~~
+!!! error TS7008: Member 'bar' implicitly has an 'any[]' type.
+            this.bar.push("baz");
+            this.bar;  // any[]
+        }    
+    }
+    

--- a/testdata/baselines/reference/compiler/thisPropertyAssignmentTyping.symbols
+++ b/testdata/baselines/reference/compiler/thisPropertyAssignmentTyping.symbols
@@ -1,0 +1,200 @@
+//// [tests/cases/compiler/thisPropertyAssignmentTyping.ts] ////
+
+=== main.js ===
+class C1 {
+>C1 : Symbol(C1, Decl(main.js, 0, 0))
+
+    constructor() {
+        this.foo = [3];
+>this.foo : Symbol(C1.foo, Decl(main.js, 1, 19), Decl(main.js, 2, 23))
+>this : Symbol(C1, Decl(main.js, 0, 0))
+>foo : Symbol(C1.foo, Decl(main.js, 1, 19), Decl(main.js, 2, 23))
+
+        this.foo = [this.foo[0] * 2];
+>this.foo : Symbol(C1.foo, Decl(main.js, 1, 19), Decl(main.js, 2, 23))
+>this : Symbol(C1, Decl(main.js, 0, 0))
+>foo : Symbol(C1.foo, Decl(main.js, 1, 19), Decl(main.js, 2, 23))
+>this.foo : Symbol(C1.foo, Decl(main.js, 1, 19), Decl(main.js, 2, 23))
+>this : Symbol(C1, Decl(main.js, 0, 0))
+>foo : Symbol(C1.foo, Decl(main.js, 1, 19), Decl(main.js, 2, 23))
+
+        this.foo;  // number[]
+>this.foo : Symbol(C1.foo, Decl(main.js, 1, 19), Decl(main.js, 2, 23))
+>this : Symbol(C1, Decl(main.js, 0, 0))
+>foo : Symbol(C1.foo, Decl(main.js, 1, 19), Decl(main.js, 2, 23))
+    }
+}
+
+class C2 {
+>C2 : Symbol(C2, Decl(main.js, 6, 1))
+
+    constructor() {
+        this.foo = [3];
+>this.foo : Symbol(C2.foo, Decl(main.js, 9, 19), Decl(main.js, 13, 15))
+>this : Symbol(C2, Decl(main.js, 6, 1))
+>foo : Symbol(C2.foo, Decl(main.js, 9, 19), Decl(main.js, 13, 15))
+
+        this.foo;  // number[]
+>this.foo : Symbol(C2.foo, Decl(main.js, 9, 19), Decl(main.js, 13, 15))
+>this : Symbol(C2, Decl(main.js, 6, 1))
+>foo : Symbol(C2.foo, Decl(main.js, 9, 19), Decl(main.js, 13, 15))
+    }
+    method1() {
+>method1 : Symbol(C2.method1, Decl(main.js, 12, 5))
+
+        this.foo = [this.foo[0] * 2];
+>this.foo : Symbol(C2.foo, Decl(main.js, 9, 19), Decl(main.js, 13, 15))
+>this : Symbol(C2, Decl(main.js, 6, 1))
+>foo : Symbol(C2.foo, Decl(main.js, 9, 19), Decl(main.js, 13, 15))
+>this.foo : Symbol(C2.foo, Decl(main.js, 9, 19), Decl(main.js, 13, 15))
+>this : Symbol(C2, Decl(main.js, 6, 1))
+>foo : Symbol(C2.foo, Decl(main.js, 9, 19), Decl(main.js, 13, 15))
+    }
+}
+
+class C4 {
+>C4 : Symbol(C4, Decl(main.js, 16, 1))
+
+    constructor() {
+        this.bar = [];
+>this.bar : Symbol(C4.bar, Decl(main.js, 19, 19))
+>this : Symbol(C4, Decl(main.js, 16, 1))
+>bar : Symbol(C4.bar, Decl(main.js, 19, 19))
+
+        this.bar.push("baz");
+>this.bar.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>this.bar : Symbol(C4.bar, Decl(main.js, 19, 19))
+>this : Symbol(C4, Decl(main.js, 16, 1))
+>bar : Symbol(C4.bar, Decl(main.js, 19, 19))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+
+        this.bar;  // string[]
+>this.bar : Symbol(C4.bar, Decl(main.js, 19, 19))
+>this : Symbol(C4, Decl(main.js, 16, 1))
+>bar : Symbol(C4.bar, Decl(main.js, 19, 19))
+    }
+}
+
+// When this.xxx assignment declarations occur only in methods, the declared type of the
+// property is a union of the types of all assigned values, excluding values from self-referential
+// assignments, plus undefined. Local CFA removes the undefined when possible.
+
+class C5 {
+>C5 : Symbol(C5, Decl(main.js, 24, 1))
+
+    method1() {
+>method1 : Symbol(C5.method1, Decl(main.js, 30, 10))
+
+        this.foo;  // number[] | undefined
+>this.foo : Symbol(C5.foo, Decl(main.js, 32, 17), Decl(main.js, 33, 22))
+>this : Symbol(C5, Decl(main.js, 24, 1))
+>foo : Symbol(C5.foo, Decl(main.js, 32, 17), Decl(main.js, 33, 22))
+
+        this.foo = [3]
+>this.foo : Symbol(C5.foo, Decl(main.js, 32, 17), Decl(main.js, 33, 22))
+>this : Symbol(C5, Decl(main.js, 24, 1))
+>foo : Symbol(C5.foo, Decl(main.js, 32, 17), Decl(main.js, 33, 22))
+
+        this.foo = [this.foo[0] * 2]
+>this.foo : Symbol(C5.foo, Decl(main.js, 32, 17), Decl(main.js, 33, 22))
+>this : Symbol(C5, Decl(main.js, 24, 1))
+>foo : Symbol(C5.foo, Decl(main.js, 32, 17), Decl(main.js, 33, 22))
+>this.foo : Symbol(C5.foo, Decl(main.js, 32, 17), Decl(main.js, 33, 22))
+>this : Symbol(C5, Decl(main.js, 24, 1))
+>foo : Symbol(C5.foo, Decl(main.js, 32, 17), Decl(main.js, 33, 22))
+
+        this.foo;  // number[]
+>this.foo : Symbol(C5.foo, Decl(main.js, 32, 17), Decl(main.js, 33, 22))
+>this : Symbol(C5, Decl(main.js, 24, 1))
+>foo : Symbol(C5.foo, Decl(main.js, 32, 17), Decl(main.js, 33, 22))
+    }
+}
+
+class C6 {
+>C6 : Symbol(C6, Decl(main.js, 37, 1))
+
+    method1() {
+>method1 : Symbol(C6.method1, Decl(main.js, 39, 10))
+
+        this.foo = [3];
+>this.foo : Symbol(C6.foo, Decl(main.js, 40, 15), Decl(main.js, 45, 17))
+>this : Symbol(C6, Decl(main.js, 37, 1))
+>foo : Symbol(C6.foo, Decl(main.js, 40, 15), Decl(main.js, 45, 17))
+
+        this.foo;  // number[]
+>this.foo : Symbol(C6.foo, Decl(main.js, 40, 15), Decl(main.js, 45, 17))
+>this : Symbol(C6, Decl(main.js, 37, 1))
+>foo : Symbol(C6.foo, Decl(main.js, 40, 15), Decl(main.js, 45, 17))
+    }
+    method2() {
+>method2 : Symbol(C6.method2, Decl(main.js, 43, 5))
+
+        this.foo;  // number[] | undefined
+>this.foo : Symbol(C6.foo, Decl(main.js, 40, 15), Decl(main.js, 45, 17))
+>this : Symbol(C6, Decl(main.js, 37, 1))
+>foo : Symbol(C6.foo, Decl(main.js, 40, 15), Decl(main.js, 45, 17))
+
+        this.foo = [this.foo[0] * 2];  // Error: Object is possibly undefined
+>this.foo : Symbol(C6.foo, Decl(main.js, 40, 15), Decl(main.js, 45, 17))
+>this : Symbol(C6, Decl(main.js, 37, 1))
+>foo : Symbol(C6.foo, Decl(main.js, 40, 15), Decl(main.js, 45, 17))
+>this.foo : Symbol(C6.foo, Decl(main.js, 40, 15), Decl(main.js, 45, 17))
+>this : Symbol(C6, Decl(main.js, 37, 1))
+>foo : Symbol(C6.foo, Decl(main.js, 40, 15), Decl(main.js, 45, 17))
+
+        this.foo;  // number[]
+>this.foo : Symbol(C6.foo, Decl(main.js, 40, 15), Decl(main.js, 45, 17))
+>this : Symbol(C6, Decl(main.js, 37, 1))
+>foo : Symbol(C6.foo, Decl(main.js, 40, 15), Decl(main.js, 45, 17))
+    }
+}
+
+class C7 {
+>C7 : Symbol(C7, Decl(main.js, 49, 1))
+
+    method1() {
+>method1 : Symbol(C7.method1, Decl(main.js, 51, 10))
+
+        this.foo = 0;
+>this.foo : Symbol(C7.foo, Decl(main.js, 52, 15), Decl(main.js, 53, 21))
+>this : Symbol(C7, Decl(main.js, 49, 1))
+>foo : Symbol(C7.foo, Decl(main.js, 52, 15), Decl(main.js, 53, 21))
+
+        this.foo = this.foo + "abc";  // Error, 'string' not assignable to 'number'
+>this.foo : Symbol(C7.foo, Decl(main.js, 52, 15), Decl(main.js, 53, 21))
+>this : Symbol(C7, Decl(main.js, 49, 1))
+>foo : Symbol(C7.foo, Decl(main.js, 52, 15), Decl(main.js, 53, 21))
+>this.foo : Symbol(C7.foo, Decl(main.js, 52, 15), Decl(main.js, 53, 21))
+>this : Symbol(C7, Decl(main.js, 49, 1))
+>foo : Symbol(C7.foo, Decl(main.js, 52, 15), Decl(main.js, 53, 21))
+    }
+}
+
+// When this.xxx assigmment declarations occur only in methods, an assigned empty array
+// literal value is given type 'any[]'.
+
+class C8 {
+>C8 : Symbol(C8, Decl(main.js, 56, 1))
+
+    method1() {
+>method1 : Symbol(C8.method1, Decl(main.js, 61, 10))
+
+        this.bar = [];  // Error: Implicit any[]
+>this.bar : Symbol(C8.bar, Decl(main.js, 62, 15))
+>this : Symbol(C8, Decl(main.js, 56, 1))
+>bar : Symbol(C8.bar, Decl(main.js, 62, 15))
+
+        this.bar.push("baz");
+>this.bar.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>this.bar : Symbol(C8.bar, Decl(main.js, 62, 15))
+>this : Symbol(C8, Decl(main.js, 56, 1))
+>bar : Symbol(C8.bar, Decl(main.js, 62, 15))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+
+        this.bar;  // any[]
+>this.bar : Symbol(C8.bar, Decl(main.js, 62, 15))
+>this : Symbol(C8, Decl(main.js, 56, 1))
+>bar : Symbol(C8.bar, Decl(main.js, 62, 15))
+    }    
+}
+

--- a/testdata/baselines/reference/compiler/thisPropertyAssignmentTyping.types
+++ b/testdata/baselines/reference/compiler/thisPropertyAssignmentTyping.types
@@ -1,0 +1,249 @@
+//// [tests/cases/compiler/thisPropertyAssignmentTyping.ts] ////
+
+=== main.js ===
+class C1 {
+>C1 : C1
+
+    constructor() {
+        this.foo = [3];
+>this.foo = [3] : number[]
+>this.foo : any
+>this : this
+>foo : any
+>[3] : number[]
+>3 : 3
+
+        this.foo = [this.foo[0] * 2];
+>this.foo = [this.foo[0] * 2] : number[]
+>this.foo : any
+>this : this
+>foo : any
+>[this.foo[0] * 2] : number[]
+>this.foo[0] * 2 : number
+>this.foo[0] : number
+>this.foo : number[]
+>this : this
+>foo : number[]
+>0 : 0
+>2 : 2
+
+        this.foo;  // number[]
+>this.foo : number[]
+>this : this
+>foo : number[]
+    }
+}
+
+class C2 {
+>C2 : C2
+
+    constructor() {
+        this.foo = [3];
+>this.foo = [3] : number[]
+>this.foo : any
+>this : this
+>foo : any
+>[3] : number[]
+>3 : 3
+
+        this.foo;  // number[]
+>this.foo : number[]
+>this : this
+>foo : number[]
+    }
+    method1() {
+>method1 : () => void
+
+        this.foo = [this.foo[0] * 2];
+>this.foo = [this.foo[0] * 2] : number[]
+>this.foo : number[]
+>this : this
+>foo : number[]
+>[this.foo[0] * 2] : number[]
+>this.foo[0] * 2 : number
+>this.foo[0] : number
+>this.foo : number[]
+>this : this
+>foo : number[]
+>0 : 0
+>2 : 2
+    }
+}
+
+class C4 {
+>C4 : C4
+
+    constructor() {
+        this.bar = [];
+>this.bar = [] : never[]
+>this.bar : any
+>this : this
+>bar : any
+>[] : never[]
+
+        this.bar.push("baz");
+>this.bar.push("baz") : number
+>this.bar.push : (...items: any[]) => number
+>this.bar : any[]
+>this : this
+>bar : any[]
+>push : (...items: any[]) => number
+>"baz" : "baz"
+
+        this.bar;  // string[]
+>this.bar : string[]
+>this : this
+>bar : string[]
+    }
+}
+
+// When this.xxx assignment declarations occur only in methods, the declared type of the
+// property is a union of the types of all assigned values, excluding values from self-referential
+// assignments, plus undefined. Local CFA removes the undefined when possible.
+
+class C5 {
+>C5 : C5
+
+    method1() {
+>method1 : () => void
+
+        this.foo;  // number[] | undefined
+>this.foo : number[] | undefined
+>this : this
+>foo : number[] | undefined
+
+        this.foo = [3]
+>this.foo = [3] : number[]
+>this.foo : number[] | undefined
+>this : this
+>foo : number[] | undefined
+>[3] : number[]
+>3 : 3
+
+        this.foo = [this.foo[0] * 2]
+>this.foo = [this.foo[0] * 2] : number[]
+>this.foo : number[] | undefined
+>this : this
+>foo : number[] | undefined
+>[this.foo[0] * 2] : number[]
+>this.foo[0] * 2 : number
+>this.foo[0] : number
+>this.foo : number[]
+>this : this
+>foo : number[]
+>0 : 0
+>2 : 2
+
+        this.foo;  // number[]
+>this.foo : number[]
+>this : this
+>foo : number[]
+    }
+}
+
+class C6 {
+>C6 : C6
+
+    method1() {
+>method1 : () => void
+
+        this.foo = [3];
+>this.foo = [3] : number[]
+>this.foo : number[] | undefined
+>this : this
+>foo : number[] | undefined
+>[3] : number[]
+>3 : 3
+
+        this.foo;  // number[]
+>this.foo : number[]
+>this : this
+>foo : number[]
+    }
+    method2() {
+>method2 : () => void
+
+        this.foo;  // number[] | undefined
+>this.foo : number[] | undefined
+>this : this
+>foo : number[] | undefined
+
+        this.foo = [this.foo[0] * 2];  // Error: Object is possibly undefined
+>this.foo = [this.foo[0] * 2] : number[]
+>this.foo : number[] | undefined
+>this : this
+>foo : number[] | undefined
+>[this.foo[0] * 2] : number[]
+>this.foo[0] * 2 : number
+>this.foo[0] : number
+>this.foo : number[] | undefined
+>this : this
+>foo : number[] | undefined
+>0 : 0
+>2 : 2
+
+        this.foo;  // number[]
+>this.foo : number[]
+>this : this
+>foo : number[]
+    }
+}
+
+class C7 {
+>C7 : C7
+
+    method1() {
+>method1 : () => void
+
+        this.foo = 0;
+>this.foo = 0 : 0
+>this.foo : number | undefined
+>this : this
+>foo : number | undefined
+>0 : 0
+
+        this.foo = this.foo + "abc";  // Error, 'string' not assignable to 'number'
+>this.foo = this.foo + "abc" : string
+>this.foo : number | undefined
+>this : this
+>foo : number | undefined
+>this.foo + "abc" : string
+>this.foo : number
+>this : this
+>foo : number
+>"abc" : "abc"
+    }
+}
+
+// When this.xxx assigmment declarations occur only in methods, an assigned empty array
+// literal value is given type 'any[]'.
+
+class C8 {
+>C8 : C8
+
+    method1() {
+>method1 : () => void
+
+        this.bar = [];  // Error: Implicit any[]
+>this.bar = [] : never[]
+>this.bar : any[] | undefined
+>this : this
+>bar : any[] | undefined
+>[] : never[]
+
+        this.bar.push("baz");
+>this.bar.push("baz") : number
+>this.bar.push : (...items: any[]) => number
+>this.bar : any[]
+>this : this
+>bar : any[]
+>push : (...items: any[]) => number
+>"baz" : "baz"
+
+        this.bar;  // any[]
+>this.bar : any[]
+>this : this
+>bar : any[]
+    }    
+}
+

--- a/testdata/tests/cases/compiler/thisPropertyAssignmentTyping.ts
+++ b/testdata/tests/cases/compiler/thisPropertyAssignmentTyping.ts
@@ -1,0 +1,78 @@
+// @checkJs: true
+// @noEmit: true
+
+// https://github.com/microsoft/typescript-go/issues/3667
+
+// When this.xxx assignment declarations are present in constructor, the declared type of the
+// property is determined from CFA to the point of exit of the constructor.
+
+// @filename: main.js
+
+class C1 {
+    constructor() {
+        this.foo = [3];
+        this.foo = [this.foo[0] * 2];
+        this.foo;  // number[]
+    }
+}
+
+class C2 {
+    constructor() {
+        this.foo = [3];
+        this.foo;  // number[]
+    }
+    method1() {
+        this.foo = [this.foo[0] * 2];
+    }
+}
+
+class C4 {
+    constructor() {
+        this.bar = [];
+        this.bar.push("baz");
+        this.bar;  // string[]
+    }
+}
+
+// When this.xxx assignment declarations occur only in methods, the declared type of the
+// property is a union of the types of all assigned values, excluding values from self-referential
+// assignments, plus undefined. Local CFA removes the undefined when possible.
+
+class C5 {
+    method1() {
+        this.foo;  // number[] | undefined
+        this.foo = [3]
+        this.foo = [this.foo[0] * 2]
+        this.foo;  // number[]
+    }
+}
+
+class C6 {
+    method1() {
+        this.foo = [3];
+        this.foo;  // number[]
+    }
+    method2() {
+        this.foo;  // number[] | undefined
+        this.foo = [this.foo[0] * 2];  // Error: Object is possibly undefined
+        this.foo;  // number[]
+    }
+}
+
+class C7 {
+    method1() {
+        this.foo = 0;
+        this.foo = this.foo + "abc";  // Error, 'string' not assignable to 'number'
+    }
+}
+
+// When this.xxx assigmment declarations occur only in methods, an assigned empty array
+// literal value is given type 'any[]'.
+
+class C8 {
+    method1() {
+        this.bar = [];  // Error: Implicit any[]
+        this.bar.push("baz");
+        this.bar;  // any[]
+    }    
+}


### PR DESCRIPTION
This PR ports missing code for typing of `this.xxx` assignment declarations in JavaScript. See [here](https://github.com/microsoft/typescript-go/issues/3667#issuecomment-4359947311) for analysis.

Fixes #3667.
