### PR TITLE
fix: handle symlink workspace roots in project reference redirects

### DIFF
--- a/internal/compiler/projectreferenceparser.go
+++ b/internal/compiler/projectreferenceparser.go
@@ -1,7 +1,7 @@
 package compiler
 
 import (
-	"maps"
+	"strings"
 
 	"github.com/microsoft/typescript-go/internal/collections"
 	"github.com/microsoft/typescript-go/internal/core"
@@ -96,8 +96,20 @@ func (p *projectReferenceParser) initMapperWorker(tasks []*projectReferenceParse
 			// Map current task's files first, before recursing into subtasks.
 			// This matches TypeScript's behavior where child project references
 			// overwrite parent entries when a file belongs to multiple projects.
-			maps.Copy(p.loader.projectReferenceFileMapper.sourceToProjectReference, task.resolved.SourceToProjectReference())
-			maps.Copy(p.loader.projectReferenceFileMapper.outputDtsToProjectReference, task.resolved.OutputDtsToProjectReference())
+			p.addRealpathAliases(
+				p.loader.projectReferenceFileMapper.sourceToProjectReference,
+				task.resolved.SourceToProjectReference(),
+				func(projectReference *tsoptions.SourceOutputAndProjectReference) string {
+					return projectReference.Source
+				},
+			)
+			p.addRealpathAliases(
+				p.loader.projectReferenceFileMapper.outputDtsToProjectReference,
+				task.resolved.OutputDtsToProjectReference(),
+				func(projectReference *tsoptions.SourceOutputAndProjectReference) string {
+					return projectReference.OutputDts
+				},
+			)
 			if p.loader.projectReferenceFileMapper.opts.canUseProjectReferenceSource() {
 				declDir := task.resolved.CompilerOptions().DeclarationDir
 				if declDir == "" {
@@ -112,4 +124,43 @@ func (p *projectReferenceParser) initMapperWorker(tasks []*projectReferenceParse
 		p.loader.projectReferenceFileMapper.referencesInConfigFile[path] = referencesInConfig
 	}
 	return results
+}
+
+func (p *projectReferenceParser) addRealpathAliases(
+	target map[tspath.Path]*tsoptions.SourceOutputAndProjectReference,
+	entries map[tspath.Path]*tsoptions.SourceOutputAndProjectReference,
+	getFileName func(*tsoptions.SourceOutputAndProjectReference) string,
+) {
+	for path, projectReference := range entries {
+		target[path] = projectReference
+		fileName := getFileName(projectReference)
+		if fileName == "" {
+			continue
+		}
+		realpath := p.getRealpathForPossiblyMissingPath(fileName)
+		if realpath == "" || realpath == fileName {
+			continue
+		}
+		target[p.loader.toPath(realpath)] = projectReference
+	}
+}
+
+func (p *projectReferenceParser) getRealpathForPossiblyMissingPath(fileName string) string {
+	fs := p.loader.opts.Host.FS()
+	if realpath := fs.Realpath(fileName); realpath != "" && realpath != fileName {
+		return realpath
+	}
+	for probe := fileName; ; {
+		parent := tspath.GetDirectoryPath(probe)
+		if parent == "" || parent == probe {
+			return fileName
+		}
+		if fs.DirectoryExists(parent) {
+			realParent := fs.Realpath(parent)
+			if realParent != "" && realParent != parent {
+				return tspath.NormalizePath(realParent + strings.TrimPrefix(fileName, parent))
+			}
+		}
+		probe = parent
+	}
 }

--- a/internal/project/symlink_workspace_repro_test.go
+++ b/internal/project/symlink_workspace_repro_test.go
@@ -1,0 +1,135 @@
+package project_test
+
+import (
+	"context"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/microsoft/typescript-go/internal/bundled"
+	"github.com/microsoft/typescript-go/internal/core"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
+	"github.com/microsoft/typescript-go/internal/project"
+	"github.com/microsoft/typescript-go/internal/testutil/projecttestutil"
+	"github.com/microsoft/typescript-go/internal/vfs/vfstest"
+)
+
+func TestWorkspaceRootSymlinkProjectReferenceRepro(t *testing.T) {
+	t.Parallel()
+
+	if !bundled.Embedded {
+		t.Skip("bundled files are not embedded")
+	}
+
+	files := map[string]any{
+		"/home": vfstest.Symlink("/real/home"),
+
+		"/real/home/workspace/tsconfig.json": `{
+			"files": [],
+			"references": [
+				{ "path": "./app" },
+				{ "path": "./pkg" }
+			]
+		}`,
+		"/real/home/workspace/app/tsconfig.json": `{
+			"compilerOptions": {
+				"composite": true,
+				"module": "nodenext",
+				"moduleResolution": "nodenext",
+				"rootDir": "./src",
+				"outDir": "./dist"
+			},
+			"files": ["src/index.ts"],
+			"references": [
+				{ "path": "../pkg" }
+			]
+		}`,
+		"/real/home/workspace/app/src/index.ts": `import { value } from "mylib";
+export const answer = value;`,
+		"/real/home/workspace/app/node_modules/mylib": vfstest.Symlink("/real/home/workspace/pkg"),
+
+		"/real/home/workspace/pkg/tsconfig.json": `{
+			"compilerOptions": {
+				"composite": true,
+				"module": "nodenext",
+				"moduleResolution": "nodenext",
+				"rootDir": "./src",
+				"outDir": "./dist",
+				"declaration": true
+			},
+			"files": ["src/index.ts"]
+		}`,
+		"/real/home/workspace/pkg/package.json": `{
+			"name": "mylib",
+			"main": "./dist/index.js",
+			"types": "./dist/index.d.ts"
+		}`,
+		"/real/home/workspace/pkg/src/index.ts": `export const value = 42;`,
+	}
+
+	t.Run("realpath open works", func(t *testing.T) {
+		t.Parallel()
+
+		session, _ := projecttestutil.SetupWithOptions(files, &project.SessionOptions{
+			CurrentDirectory:   "/real/home/workspace/app",
+			DefaultLibraryPath: bundled.LibPath(),
+			TypingsLocation:    projecttestutil.TestTypingsLocation,
+			PositionEncoding:   lsproto.PositionEncodingKindUTF8,
+			WatchEnabled:       true,
+			LoggingEnabled:     true,
+		})
+
+		uri := lsproto.DocumentUri("file:///real/home/workspace/app/src/index.ts")
+		session.DidOpenFile(context.Background(), uri, 1, files["/real/home/workspace/app/src/index.ts"].(string), lsproto.LanguageKindTypeScript)
+
+		defaultProject, _, allProjects, err := session.GetLanguageServiceAndProjectsForFile(context.Background(), uri)
+		assert.NilError(t, err)
+		assert.Equal(t, defaultProject.Name(), "/real/home/workspace/app/tsconfig.json")
+		assert.Equal(t, len(allProjects), 1)
+
+		ls, err := session.GetLanguageService(context.Background(), uri)
+		assert.NilError(t, err)
+		program := ls.GetProgram()
+		sourceFile := program.GetSourceFile("/real/home/workspace/app/src/index.ts")
+		assert.Assert(t, sourceFile != nil)
+		resolved := program.ResolveModuleName("mylib", sourceFile.FileName(), core.ResolutionModeCommonJS)
+		assert.Assert(t, resolved != nil)
+		assert.Equal(t, resolved.OriginalPath, "/real/home/workspace/app/node_modules/mylib/dist/index.d.ts")
+		assert.Equal(t, resolved.ResolvedFileName, "/real/home/workspace/pkg/dist/index.d.ts")
+		diags := program.GetSemanticDiagnostics(projecttestutil.WithRequestID(t.Context()), sourceFile)
+		assert.Equal(t, len(diags), 0)
+	})
+
+	t.Run("symlink open works", func(t *testing.T) {
+		t.Parallel()
+
+		session, _ := projecttestutil.SetupWithOptions(files, &project.SessionOptions{
+			CurrentDirectory:   "/home/workspace/app",
+			DefaultLibraryPath: bundled.LibPath(),
+			TypingsLocation:    projecttestutil.TestTypingsLocation,
+			PositionEncoding:   lsproto.PositionEncodingKindUTF8,
+			WatchEnabled:       true,
+			LoggingEnabled:     true,
+		})
+
+		uri := lsproto.DocumentUri("file:///home/workspace/app/src/index.ts")
+		session.DidOpenFile(context.Background(), uri, 1, files["/real/home/workspace/app/src/index.ts"].(string), lsproto.LanguageKindTypeScript)
+
+		defaultProject, _, allProjects, err := session.GetLanguageServiceAndProjectsForFile(context.Background(), uri)
+		assert.NilError(t, err)
+		assert.Equal(t, defaultProject.Name(), "/home/workspace/app/tsconfig.json")
+		assert.Equal(t, len(allProjects), 1)
+
+		ls, err := session.GetLanguageService(context.Background(), uri)
+		assert.NilError(t, err)
+		program := ls.GetProgram()
+		sourceFile := program.GetSourceFile("/home/workspace/app/src/index.ts")
+		assert.Assert(t, sourceFile != nil)
+		resolved := program.ResolveModuleName("mylib", sourceFile.FileName(), core.ResolutionModeCommonJS)
+		assert.Assert(t, resolved != nil)
+		assert.Equal(t, resolved.OriginalPath, "/home/workspace/app/node_modules/mylib/dist/index.d.ts")
+		assert.Equal(t, resolved.ResolvedFileName, "/real/home/workspace/pkg/dist/index.d.ts")
+		diags := program.GetSemanticDiagnostics(projecttestutil.WithRequestID(t.Context()), sourceFile)
+		assert.Equal(t, len(diags), 0)
+	})
+}


### PR DESCRIPTION
fix #3689