### PR TITLE
Add minimal tsc output format

### DIFF
--- a/internal/core/compileroptions.go
+++ b/internal/core/compileroptions.go
@@ -145,6 +145,7 @@ type CompilerOptions struct {
 	NoEmitForJsFiles    Tristate `json:"noEmitForJsFiles,omitzero"`
 	PreserveWatchOutput Tristate `json:"preserveWatchOutput,omitzero"`
 	Pretty              Tristate `json:"pretty,omitzero"`
+	OutputFormat        string   `json:"outputFormat,omitzero"`
 	Version             Tristate `json:"version,omitzero"`
 	Watch               Tristate `json:"watch,omitzero"`
 	ShowConfig          Tristate `json:"showConfig,omitzero"`
@@ -168,6 +169,11 @@ type noCopy struct{}
 // Lock is a no-op used by -copylocks checker from `go vet`.
 func (*noCopy) Lock()   {}
 func (*noCopy) Unlock() {}
+
+const (
+	OutputFormatDefault = "default"
+	OutputFormatMinimal = "minimal"
+)
 
 var EmptyCompilerOptions = &CompilerOptions{}
 

--- a/internal/diagnostics/diagnostics_generated.go
+++ b/internal/diagnostics/diagnostics_generated.go
@@ -4308,6 +4308,8 @@ var Remove_Unused_Imports = &Message{code: 100017, category: CategoryMessage, ke
 
 var Sort_Imports = &Message{code: 100018, category: CategoryMessage, key: "Sort_Imports_100018", text: "Sort Imports"}
 
+var Specify_how_TypeScript_reports_diagnostics = &Message{code: 100019, category: CategoryMessage, key: "Specify_how_TypeScript_reports_diagnostics_100019", text: "Specify how TypeScript reports diagnostics."}
+
 func keyToMessage(key Key) *Message {
 	switch key {
 	case "Unterminated_string_literal_1002":
@@ -8616,6 +8618,8 @@ func keyToMessage(key Key) *Message {
 		return Remove_Unused_Imports
 	case "Sort_Imports_100018":
 		return Sort_Imports
+	case "Specify_how_TypeScript_reports_diagnostics_100019":
+		return Specify_how_TypeScript_reports_diagnostics
 	default:
 		return nil
 	}

--- a/internal/diagnostics/extraDiagnosticMessages.json
+++ b/internal/diagnostics/extraDiagnosticMessages.json
@@ -123,6 +123,10 @@
         "category": "Message",
         "code": 100018
     },
+    "Specify how TypeScript reports diagnostics.": {
+        "category": "Message",
+        "code": 100019
+    },
     "File rename is not supported by the editor": {
         "category": "Error",
         "code": 8040

--- a/internal/diagnosticwriter/diagnosticwriter.go
+++ b/internal/diagnosticwriter/diagnosticwriter.go
@@ -476,6 +476,38 @@ func WriteFormatDiagnostic(output io.Writer, diagnostic Diagnostic, formatOpts *
 	fmt.Fprint(output, formatOpts.NewLine)
 }
 
+func WriteMinimalDiagnostic(output io.Writer, diagnostic Diagnostic, formatOpts *FormattingOptions) {
+	if diagnostic.File() != nil {
+		line, character := scanner.GetECMALineAndUTF16CharacterOfPosition(diagnostic.File(), diagnostic.Pos())
+		fileName := diagnostic.File().FileName()
+		relativeFileName := tspath.ConvertToRelativePath(fileName, formatOpts.ComparePathsOptions)
+		fmt.Fprintf(output, "%s:%d:%d: ", relativeFileName, line+1, int(character)+1)
+	}
+
+	fmt.Fprintf(output, "TS%d: ", diagnostic.Code())
+	writeFlattenedDiagnosticMessageSingleLine(output, diagnostic, formatOpts.Locale)
+	fmt.Fprint(output, formatOpts.NewLine)
+}
+
+func writeFlattenedDiagnosticMessageSingleLine(writer io.Writer, diagnostic Diagnostic, locale locale.Locale) {
+	first := true
+	var writeMessage func(Diagnostic)
+	writeMessage = func(diagnostic Diagnostic) {
+		message := strings.Join(strings.Fields(diagnostic.Localize(locale)), " ")
+		if message != "" {
+			if !first {
+				fmt.Fprint(writer, " | ")
+			}
+			fmt.Fprint(writer, message)
+			first = false
+		}
+		for _, chain := range diagnostic.MessageChain() {
+			writeMessage(chain)
+		}
+	}
+	writeMessage(diagnostic)
+}
+
 func FormatDiagnosticsStatusWithColorAndTime(output io.Writer, time string, diag Diagnostic, formatOpts *FormattingOptions) {
 	fmt.Fprint(output, "[")
 	writeWithStyleAndReset(output, time, foregroundColorEscapeGrey)

--- a/internal/execute/tsc/diagnostics.go
+++ b/internal/execute/tsc/diagnostics.go
@@ -28,10 +28,15 @@ type DiagnosticReporter = func(*ast.Diagnostic)
 func QuietDiagnosticReporter(diagnostic *ast.Diagnostic) {}
 
 func CreateDiagnosticReporter(sys System, w io.Writer, locale locale.Locale, options *core.CompilerOptions) DiagnosticReporter {
-	if options.Quiet.IsTrue() {
+	if options != nil && options.Quiet.IsTrue() {
 		return QuietDiagnosticReporter
 	}
 	formatOpts := getFormatOptsOfSys(sys, locale)
+	if shouldUseMinimalOutput(options) {
+		return func(diagnostic *ast.Diagnostic) {
+			diagnosticwriter.WriteMinimalDiagnostic(w, diagnosticwriter.WrapASTDiagnostic(diagnostic), formatOpts)
+		}
+	}
 	if shouldBePretty(sys, options) {
 		return func(diagnostic *ast.Diagnostic) {
 			diagnosticwriter.FormatDiagnosticWithColorAndContext(w, diagnosticwriter.WrapASTDiagnostic(diagnostic), formatOpts)
@@ -53,7 +58,14 @@ func defaultIsPretty(sys System) bool {
 	return sys.WriteOutputIsTTY()
 }
 
+func shouldUseMinimalOutput(options *core.CompilerOptions) bool {
+	return options != nil && options.OutputFormat == core.OutputFormatMinimal
+}
+
 func shouldBePretty(sys System, options *core.CompilerOptions) bool {
+	if shouldUseMinimalOutput(options) {
+		return false
+	}
 	if options == nil || options.Pretty.IsUnknown() {
 		return defaultIsPretty(sys)
 	}

--- a/internal/execute/tsctests/tsc_test.go
+++ b/internal/execute/tsctests/tsc_test.go
@@ -179,6 +179,34 @@ func TestTscCommandline(t *testing.T) {
 			commandLineArgs: []string{"--moduleResolution", "nodenext ", "first.ts", "--module", "nodenext", "--target", "esnext", "--moduleDetection", "auto", "--jsx", "react", "--newLine", "crlf"},
 		},
 		{
+			subScenario: "outputFormat minimal",
+			files: FileMap{
+				"/home/src/workspaces/project/index.tsx": stringtestutil.Dedent(`
+					declare namespace JSX {
+						interface ElementChildrenAttribute { children: {}; }
+						interface IntrinsicElements { div: {} }
+					}
+
+					declare var React: any;
+
+					declare function Component(props: never): any;
+					declare function Component(props: { children?: number }): any;
+					(<Component>
+						<div />
+						<div />
+					</Component>)`),
+			},
+			commandLineArgs: []string{"--outputFormat", "minimal", "--noEmit", "--strict", "--jsx", "react", "index.tsx"},
+		},
+		{
+			subScenario:     "outputFormat minimal without file",
+			commandLineArgs: []string{"--outputFormat", "minimal", "--locale", "whoops", "--version"},
+		},
+		{
+			subScenario:     "outputFormat with invalid value",
+			commandLineArgs: []string{"--outputFormat", "verbose", "--version"},
+		},
+		{
 			subScenario: "Parse watch interval option",
 			files: FileMap{
 				"/home/src/workspaces/project/first.ts": `export const a = 1`,

--- a/internal/tsoptions/commandlineoption.go
+++ b/internal/tsoptions/commandlineoption.go
@@ -184,6 +184,7 @@ var commandLineOptionEnumMap = map[string]*collections.OrderedMap[string, any]{
 	"moduleDetection":  moduleDetectionOptionMap,
 	"jsx":              jsxOptionMap,
 	"newLine":          newLineOptionMap,
+	"outputFormat":     outputFormatOptionMap,
 	"watchFile":        watchFileEnumMap,
 	"watchDirectory":   watchDirectoryEnumMap,
 	"fallbackPolling":  fallbackEnumMap,

--- a/internal/tsoptions/declscompiler.go
+++ b/internal/tsoptions/declscompiler.go
@@ -78,6 +78,14 @@ var commonOptionsWithBuild = []*CommandLineOption{
 		DefaultValueDescription:  true,
 	},
 	{
+		Name:                    "outputFormat",
+		Kind:                    CommandLineOptionTypeEnum,
+		IsCommandLineOnly:       true,
+		Category:                diagnostics.Output_Formatting,
+		Description:             diagnostics.Specify_how_TypeScript_reports_diagnostics,
+		DefaultValueDescription: core.OutputFormatDefault,
+	},
+	{
 		Name:                    "traceResolution",
 		Kind:                    CommandLineOptionTypeBoolean,
 		Category:                diagnostics.Compiler_Diagnostics,

--- a/internal/tsoptions/enummaps.go
+++ b/internal/tsoptions/enummaps.go
@@ -204,6 +204,11 @@ var newLineOptionMap = collections.NewOrderedMapFromList([]collections.MapEntry[
 	{Key: "lf", Value: core.NewLineKindLF},
 })
 
+var outputFormatOptionMap = collections.NewOrderedMapFromList([]collections.MapEntry[string, any]{
+	{Key: core.OutputFormatDefault, Value: core.OutputFormatDefault},
+	{Key: core.OutputFormatMinimal, Value: core.OutputFormatMinimal},
+})
+
 var targetToLibMap = map[core.ScriptTarget]string{
 	core.ScriptTargetESNext: "lib.esnext.full.d.ts",
 	core.ScriptTargetES2025: "lib.es2025.full.d.ts",

--- a/internal/tsoptions/parsinghelpers.go
+++ b/internal/tsoptions/parsinghelpers.go
@@ -351,6 +351,8 @@ func parseCompilerOptions(key string, value any, allOptions *core.CompilerOption
 		allOptions.NoUncheckedSideEffectImports = ParseTristate(value)
 	case "outFile":
 		allOptions.OutFile = ParseString(value)
+	case "outputFormat":
+		allOptions.OutputFormat = ParseString(value)
 	case "noResolve":
 		allOptions.NoResolve = ParseTristate(value)
 	case "paths":

--- a/testdata/baselines/reference/tsbuild/commandLine/help.js
+++ b/testdata/baselines/reference/tsbuild/commandLine/help.js
@@ -46,6 +46,11 @@ Enable color and formatting in TypeScript's output to make compiler errors easie
 type: boolean
 default: true
 
+[94m--outputFormat[39m
+Specify how TypeScript reports diagnostics.
+one of: default, minimal
+default: default
+
 [94m--traceResolution[39m
 Log paths used during the 'moduleResolution' process.
 type: boolean

--- a/testdata/baselines/reference/tsbuild/commandLine/locale.js
+++ b/testdata/baselines/reference/tsbuild/commandLine/locale.js
@@ -46,6 +46,11 @@ Enable color and formatting in TypeScript's output to make compiler errors easie
 type: boolean
 default: true
 
+[94m--outputFormat[39m
+Specify how TypeScript reports diagnostics.
+one of: default, minimal
+default: default
+
 [94m--traceResolution[39m
 Log paths used during the 'moduleResolution' process.
 type: boolean

--- a/testdata/baselines/reference/tsc/commandLine/help-all.js
+++ b/testdata/baselines/reference/tsc/commandLine/help-all.js
@@ -582,6 +582,11 @@ Disable truncating types in error messages.
 type: boolean
 default: false
 
+[94m--outputFormat[39m
+Specify how TypeScript reports diagnostics.
+one of: default, minimal
+default: default
+
 [94m--preserveWatchOutput[39m
 Disable wiping the console in watch mode.
 type: boolean

--- a/testdata/baselines/reference/tsc/commandLine/outputFormat-minimal-without-file.js
+++ b/testdata/baselines/reference/tsc/commandLine/outputFormat-minimal-without-file.js
@@ -1,0 +1,9 @@
+currentDirectory::/home/src/workspaces/project
+useCaseSensitiveFileNames::true
+Input::
+
+tsgo --outputFormat minimal --locale whoops --version
+ExitStatus:: DiagnosticsPresent_OutputsSkipped
+Output::
+TS6048: Locale must be an IETF BCP 47 language tag. Examples: 'en', 'ja-jp'.
+

--- a/testdata/baselines/reference/tsc/commandLine/outputFormat-minimal.js
+++ b/testdata/baselines/reference/tsc/commandLine/outputFormat-minimal.js
@@ -1,0 +1,46 @@
+currentDirectory::/home/src/workspaces/project
+useCaseSensitiveFileNames::true
+Input::
+//// [/home/src/workspaces/project/index.tsx] *new* 
+declare namespace JSX {
+    interface ElementChildrenAttribute { children: {}; }
+    interface IntrinsicElements { div: {} }
+}
+
+declare var React: any;
+
+declare function Component(props: never): any;
+declare function Component(props: { children?: number }): any;
+(<Component>
+    <div />
+    <div />
+</Component>)
+
+tsgo --outputFormat minimal --noEmit --strict --jsx react index.tsx
+ExitStatus:: DiagnosticsPresent_OutputsSkipped
+Output::
+index.tsx:10:3: TS2769: No overload matches this call. | The last overload gave the following error. | Type '{ children: any[]; }' is not assignable to type '{ children?: number | undefined; }'. | Types of property 'children' are incompatible. | Type 'any[]' is not assignable to type 'number'.
+//// [/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts] *Lib*
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+interface SymbolConstructor {
+    (desc?: string | number): symbol;
+    for(name: string): symbol;
+    readonly toStringTag: symbol;
+}
+declare var Symbol: SymbolConstructor;
+interface Symbol {
+    readonly [Symbol.toStringTag]: string;
+}
+declare const console: { log(msg: any): void; };
+

--- a/testdata/baselines/reference/tsc/commandLine/outputFormat-with-invalid-value.js
+++ b/testdata/baselines/reference/tsc/commandLine/outputFormat-with-invalid-value.js
@@ -1,0 +1,9 @@
+currentDirectory::/home/src/workspaces/project
+useCaseSensitiveFileNames::true
+Input::
+
+tsgo --outputFormat verbose --version
+ExitStatus:: DiagnosticsPresent_OutputsSkipped
+Output::
+[91merror[0m[90m TS6046: [0mArgument for '--outputFormat' option must be: 'default', 'minimal'.
+


### PR DESCRIPTION
## Summary

Adds an explicit `--outputFormat minimal` command-line option for `tsgo` diagnostics. The minimal reporter emits one diagnostic per line in the form:

```text
path/to/file.ts:line:character: TS1234: message | chained message
```

This keeps the default output unchanged while giving tooling and agents a compact, stable format that is easier to parse and significantly cheaper to feed back into LLM context windows.

## Motivation

AI coding agents frequently run `tsc`/`tsgo` and then include the compiler output in the next prompt. The existing pretty/default diagnostics are excellent for humans, but they include context, spacing, colors, and multi-line message chains that add a lot of tokens. A compact output format reduces token usage and makes repeated fix/test loops less noisy without taking away the current default human-facing experience.

As a future follow-up, we could also auto-select this format when `tsgo` is run by an agent. A similar principle is being explored in oxc by detecting agent-specific environment variables and switching to an agent-oriented output format: https://github.com/oxc-project/oxc/pull/22068. That PR mirrors the environment detection used by `unjs/std-env` agents detection, which is also used by tools like Vitest.
