### PR TITLE
Narrow String#toLowerCase/toUpperCase return types via Lowercase/Uppercase

### DIFF
--- a/internal/bundled/libs/lib.es5.d.ts
+++ b/internal/bundled/libs/lib.es5.d.ts
@@ -497,13 +497,13 @@ interface String {
     substring(start: number, end?: number): string;
 
     /** Converts all the alphabetic characters in a string to lowercase. */
-    toLowerCase(): string;
+    toLowerCase<T extends string>(this: T): string extends T ? string : Lowercase<T>;
 
     /** Converts all alphabetic characters to lowercase, taking into account the host environment's current locale. */
     toLocaleLowerCase(locales?: string | string[]): string;
 
     /** Converts all the alphabetic characters in a string to uppercase. */
-    toUpperCase(): string;
+    toUpperCase<T extends string>(this: T): string extends T ? string : Uppercase<T>;
 
     /** Returns a string where all alphabetic characters have been converted to uppercase, taking into account the host environment's current locale. */
     toLocaleUpperCase(locales?: string | string[]): string;

--- a/testdata/baselines/reference/submodule/compiler/abstractPropertyInConstructor.types
+++ b/testdata/baselines/reference/submodule/compiler/abstractPropertyInConstructor.types
@@ -20,11 +20,11 @@ abstract class AbstractClass {
         let val = this.prop.toLowerCase();
 >val : string
 >this.prop.toLowerCase() : string
->this.prop.toLowerCase : () => string
+>this.prop.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >this.prop : string
 >this : this
 >prop : string
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 
         if (!str) {
 >!str : boolean
@@ -133,11 +133,11 @@ abstract class DerivedAbstractClass extends AbstractClass {
 >this : this
 >cb : (s: string) => void
 >this.prop.toLowerCase() : string
->this.prop.toLowerCase : () => string
+>this.prop.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >this.prop : string
 >this : this
 >prop : string
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 
         this.method(1);
 >this.method(1) : void

--- a/testdata/baselines/reference/submodule/compiler/abstractPropertyInConstructor.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/abstractPropertyInConstructor.types.diff
@@ -1,0 +1,30 @@
+--- old.abstractPropertyInConstructor.types
++++ new.abstractPropertyInConstructor.types
+@@= skipped -19, +19 lines =@@
+         let val = this.prop.toLowerCase();
+ >val : string
+ >this.prop.toLowerCase() : string
+->this.prop.toLowerCase : () => string
++>this.prop.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >this.prop : string
+ >this : this
+ >prop : string
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+
+         if (!str) {
+ >!str : boolean
+@@= skipped -113, +113 lines =@@
+ >this : this
+ >cb : (s: string) => void
+ >this.prop.toLowerCase() : string
+->this.prop.toLowerCase : () => string
++>this.prop.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >this.prop : string
+ >this : this
+ >prop : string
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+
+         this.method(1);
+ >this.method(1) : void

--- a/testdata/baselines/reference/submodule/compiler/arrayconcat.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/arrayconcat.errors.txt
@@ -1,9 +1,13 @@
 arrayconcat.ts(12,9): error TS2564: Property 'options' has no initializer and is not definitely assigned in the constructor.
+arrayconcat.ts(16,25): error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
+  Type 'undefined' is not assignable to type 'string'.
 arrayconcat.ts(16,25): error TS18048: 'a.name' is possibly 'undefined'.
+arrayconcat.ts(17,25): error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
+  Type 'undefined' is not assignable to type 'string'.
 arrayconcat.ts(17,25): error TS18048: 'b.name' is possibly 'undefined'.
 
 
-==== arrayconcat.ts (3 errors) ====
+==== arrayconcat.ts (5 errors) ====
     interface IOptions {
         name?: string;
         flag?: boolean;
@@ -23,8 +27,14 @@ arrayconcat.ts(17,25): error TS18048: 'b.name' is possibly 'undefined'.
     		this.options = this.options.sort(function(a, b) {
                 var aName = a.name.toLowerCase();
                             ~~~~~~
+!!! error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
+!!! error TS2684:   Type 'undefined' is not assignable to type 'string'.
+                            ~~~~~~
 !!! error TS18048: 'a.name' is possibly 'undefined'.
                 var bName = b.name.toLowerCase();
+                            ~~~~~~
+!!! error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
+!!! error TS2684:   Type 'undefined' is not assignable to type 'string'.
                             ~~~~~~
 !!! error TS18048: 'b.name' is possibly 'undefined'.
     

--- a/testdata/baselines/reference/submodule/compiler/arrayconcat.errors.txt.diff
+++ b/testdata/baselines/reference/submodule/compiler/arrayconcat.errors.txt.diff
@@ -1,0 +1,32 @@
+--- old.arrayconcat.errors.txt
++++ new.arrayconcat.errors.txt
+@@= skipped -0, +0 lines =@@
+ arrayconcat.ts(12,9): error TS2564: Property 'options' has no initializer and is not definitely assigned in the constructor.
++arrayconcat.ts(16,25): error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
++  Type 'undefined' is not assignable to type 'string'.
+ arrayconcat.ts(16,25): error TS18048: 'a.name' is possibly 'undefined'.
++arrayconcat.ts(17,25): error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
++  Type 'undefined' is not assignable to type 'string'.
+ arrayconcat.ts(17,25): error TS18048: 'b.name' is possibly 'undefined'.
+
+
+-==== arrayconcat.ts (3 errors) ====
++==== arrayconcat.ts (5 errors) ====
+     interface IOptions {
+         name?: string;
+         flag?: boolean;
+@@= skipped -22, +26 lines =@@
+     		this.options = this.options.sort(function(a, b) {
+                 var aName = a.name.toLowerCase();
+                             ~~~~~~
++!!! error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
++!!! error TS2684:   Type 'undefined' is not assignable to type 'string'.
++                            ~~~~~~
+ !!! error TS18048: 'a.name' is possibly 'undefined'.
+                 var bName = b.name.toLowerCase();
++                            ~~~~~~
++!!! error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
++!!! error TS2684:   Type 'undefined' is not assignable to type 'string'.
+                             ~~~~~~
+ !!! error TS18048: 'b.name' is possibly 'undefined'.
+     

--- a/testdata/baselines/reference/submodule/compiler/arrayconcat.types
+++ b/testdata/baselines/reference/submodule/compiler/arrayconcat.types
@@ -52,20 +52,20 @@ class parser {
             var aName = a.name.toLowerCase();
 >aName : string
 >a.name.toLowerCase() : string
->a.name.toLowerCase : () => string
+>a.name.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >a.name : string | undefined
 >a : IOptions
 >name : string | undefined
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 
             var bName = b.name.toLowerCase();
 >bName : string
 >b.name.toLowerCase() : string
->b.name.toLowerCase : () => string
+>b.name.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >b.name : string | undefined
 >b : IOptions
 >name : string | undefined
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 
             if (aName > bName) {
 >aName > bName : boolean

--- a/testdata/baselines/reference/submodule/compiler/arrayconcat.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/arrayconcat.types.diff
@@ -1,0 +1,27 @@
+--- old.arrayconcat.types
++++ new.arrayconcat.types
+@@= skipped -51, +51 lines =@@
+             var aName = a.name.toLowerCase();
+ >aName : string
+ >a.name.toLowerCase() : string
+->a.name.toLowerCase : () => string
++>a.name.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >a.name : string | undefined
+ >a : IOptions
+ >name : string | undefined
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+
+             var bName = b.name.toLowerCase();
+ >bName : string
+ >b.name.toLowerCase() : string
+->b.name.toLowerCase : () => string
++>b.name.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >b.name : string | undefined
+ >b : IOptions
+ >name : string | undefined
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+
+             if (aName > bName) {
+ >aName > bName : boolean

--- a/testdata/baselines/reference/submodule/compiler/bestChoiceType.types
+++ b/testdata/baselines/reference/submodule/compiler/bestChoiceType.types
@@ -18,9 +18,9 @@
 >s => s.toLowerCase() : (s: string) => string
 >s : string
 >s.toLowerCase() : string
->s.toLowerCase : () => string
+>s.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >s : string
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 
 // Similar cases
 
@@ -50,9 +50,9 @@ function f1() {
 >s => s.toLowerCase() : (s: string) => string
 >s : string
 >s.toLowerCase() : string
->s.toLowerCase : () => string
+>s.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >s : string
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 }
 
 function f2() {
@@ -82,8 +82,8 @@ function f2() {
 >s => s.toLowerCase() : (s: string) => string
 >s : string
 >s.toLowerCase() : string
->s.toLowerCase : () => string
+>s.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >s : string
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 }
 

--- a/testdata/baselines/reference/submodule/compiler/bestChoiceType.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/bestChoiceType.types.diff
@@ -1,0 +1,36 @@
+--- old.bestChoiceType.types
++++ new.bestChoiceType.types
+@@= skipped -17, +17 lines =@@
+ >s => s.toLowerCase() : (s: string) => string
+ >s : string
+ >s.toLowerCase() : string
+->s.toLowerCase : () => string
++>s.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >s : string
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+
+ // Similar cases
+
+@@= skipped -32, +32 lines =@@
+ >s => s.toLowerCase() : (s: string) => string
+ >s : string
+ >s.toLowerCase() : string
+->s.toLowerCase : () => string
++>s.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >s : string
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ }
+
+ function f2() {
+@@= skipped -32, +32 lines =@@
+ >s => s.toLowerCase() : (s: string) => string
+ >s : string
+ >s.toLowerCase() : string
+->s.toLowerCase : () => string
++>s.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >s : string
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ }

--- a/testdata/baselines/reference/submodule/compiler/configFileExtendsAsList.types
+++ b/testdata/baselines/reference/submodule/compiler/configFileExtendsAsList.types
@@ -10,7 +10,7 @@ let y: string;
 
 y.toLowerCase(); // strictNullChecks error
 >y.toLowerCase() : string
->y.toLowerCase : () => string
+>y.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >y : string
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 

--- a/testdata/baselines/reference/submodule/compiler/configFileExtendsAsList.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/configFileExtendsAsList.types.diff
@@ -1,0 +1,11 @@
+--- old.configFileExtendsAsList.types
++++ new.configFileExtendsAsList.types
+@@= skipped -9, +9 lines =@@
+
+ y.toLowerCase(); // strictNullChecks error
+ >y.toLowerCase() : string
+->y.toLowerCase : () => string
++>y.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >y : string
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>

--- a/testdata/baselines/reference/submodule/compiler/controlFlowPropertyDeclarations.types
+++ b/testdata/baselines/reference/submodule/compiler/controlFlowPropertyDeclarations.types
@@ -42,9 +42,9 @@ for (var propname in HTMLDOMPropertyConfig.Properties) {
 >DOMAttributeNames : any
 >propname : string
 >propname.toLowerCase() : string
->propname.toLowerCase : () => string
+>propname.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >propname : string
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 }
 
 /**

--- a/testdata/baselines/reference/submodule/compiler/controlFlowPropertyDeclarations.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/controlFlowPropertyDeclarations.types.diff
@@ -1,0 +1,14 @@
+--- old.controlFlowPropertyDeclarations.types
++++ new.controlFlowPropertyDeclarations.types
+@@= skipped -41, +41 lines =@@
+ >DOMAttributeNames : any
+ >propname : string
+ >propname.toLowerCase() : string
+->propname.toLowerCase : () => string
++>propname.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >propname : string
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ }
+
+ /**

--- a/testdata/baselines/reference/submodule/compiler/destructureTupleWithVariableElement.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/destructureTupleWithVariableElement.errors.txt
@@ -1,9 +1,15 @@
+destructureTupleWithVariableElement.ts(9,1): error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
+  Type 'undefined' is not assignable to type 'string'.
 destructureTupleWithVariableElement.ts(9,1): error TS18048: 's1' is possibly 'undefined'.
+destructureTupleWithVariableElement.ts(10,1): error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
+  Type 'undefined' is not assignable to type 'string'.
 destructureTupleWithVariableElement.ts(10,1): error TS18048: 's2' is possibly 'undefined'.
+destructureTupleWithVariableElement.ts(18,1): error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
+  Type 'undefined' is not assignable to type 'string'.
 destructureTupleWithVariableElement.ts(18,1): error TS18048: 's5' is possibly 'undefined'.
 
 
-==== destructureTupleWithVariableElement.ts (3 errors) ====
+==== destructureTupleWithVariableElement.ts (6 errors) ====
     // repro from #52302
     
     type NonEmptyStringArray = [string, ...Array<string>]
@@ -14,8 +20,14 @@ destructureTupleWithVariableElement.ts(18,1): error TS18048: 's5' is possibly 'u
     s0.toUpperCase()
     s1.toUpperCase() 
     ~~
+!!! error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
+!!! error TS2684:   Type 'undefined' is not assignable to type 'string'.
+    ~~
 !!! error TS18048: 's1' is possibly 'undefined'.
     s2.toUpperCase()
+    ~~
+!!! error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
+!!! error TS2684:   Type 'undefined' is not assignable to type 'string'.
     ~~
 !!! error TS18048: 's2' is possibly 'undefined'.
     
@@ -26,6 +38,9 @@ destructureTupleWithVariableElement.ts(18,1): error TS18048: 's5' is possibly 'u
     s3.toUpperCase()
     s4.toUpperCase() 
     s5.toUpperCase()
+    ~~
+!!! error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
+!!! error TS2684:   Type 'undefined' is not assignable to type 'string'.
     ~~
 !!! error TS18048: 's5' is possibly 'undefined'.
     

--- a/testdata/baselines/reference/submodule/compiler/destructureTupleWithVariableElement.errors.txt.diff
+++ b/testdata/baselines/reference/submodule/compiler/destructureTupleWithVariableElement.errors.txt.diff
@@ -1,0 +1,45 @@
+--- old.destructureTupleWithVariableElement.errors.txt
++++ new.destructureTupleWithVariableElement.errors.txt
+@@= skipped -0, +0 lines =@@
++destructureTupleWithVariableElement.ts(9,1): error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
++  Type 'undefined' is not assignable to type 'string'.
+ destructureTupleWithVariableElement.ts(9,1): error TS18048: 's1' is possibly 'undefined'.
++destructureTupleWithVariableElement.ts(10,1): error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
++  Type 'undefined' is not assignable to type 'string'.
+ destructureTupleWithVariableElement.ts(10,1): error TS18048: 's2' is possibly 'undefined'.
++destructureTupleWithVariableElement.ts(18,1): error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
++  Type 'undefined' is not assignable to type 'string'.
+ destructureTupleWithVariableElement.ts(18,1): error TS18048: 's5' is possibly 'undefined'.
+
+
+-==== destructureTupleWithVariableElement.ts (3 errors) ====
++==== destructureTupleWithVariableElement.ts (6 errors) ====
+     // repro from #52302
+     
+     type NonEmptyStringArray = [string, ...Array<string>]
+@@= skipped -13, +19 lines =@@
+     s0.toUpperCase()
+     s1.toUpperCase() 
+     ~~
++!!! error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
++!!! error TS2684:   Type 'undefined' is not assignable to type 'string'.
++    ~~
+ !!! error TS18048: 's1' is possibly 'undefined'.
+     s2.toUpperCase()
+     ~~
++!!! error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
++!!! error TS2684:   Type 'undefined' is not assignable to type 'string'.
++    ~~
+ !!! error TS18048: 's2' is possibly 'undefined'.
+     
+     declare const strings2: [string, ...Array<string>, string]
+@@= skipped -12, +18 lines =@@
+     s3.toUpperCase()
+     s4.toUpperCase() 
+     s5.toUpperCase()
++    ~~
++!!! error TS2684: The 'this' context of type 'string | undefined' is not assignable to method's 'this' of type 'string'.
++!!! error TS2684:   Type 'undefined' is not assignable to type 'string'.
+     ~~
+ !!! error TS18048: 's5' is possibly 'undefined'.
+     

--- a/testdata/baselines/reference/submodule/compiler/destructureTupleWithVariableElement.types
+++ b/testdata/baselines/reference/submodule/compiler/destructureTupleWithVariableElement.types
@@ -20,21 +20,21 @@ const [s0, s1, s2] = strings;
 
 s0.toUpperCase()
 >s0.toUpperCase() : string
->s0.toUpperCase : () => string
+>s0.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >s0 : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 
 s1.toUpperCase() 
 >s1.toUpperCase() : string
->s1.toUpperCase : () => string
+>s1.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >s1 : string | undefined
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 
 s2.toUpperCase()
 >s2.toUpperCase() : string
->s2.toUpperCase : () => string
+>s2.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >s2 : string | undefined
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 
 declare const strings2: [string, ...Array<string>, string]
 >strings2 : [string, ...string[], string]
@@ -47,19 +47,19 @@ const [s3, s4, s5] = strings2;
 
 s3.toUpperCase()
 >s3.toUpperCase() : string
->s3.toUpperCase : () => string
+>s3.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >s3 : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 
 s4.toUpperCase() 
 >s4.toUpperCase() : string
->s4.toUpperCase : () => string
+>s4.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >s4 : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 
 s5.toUpperCase()
 >s5.toUpperCase() : string
->s5.toUpperCase : () => string
+>s5.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >s5 : string | undefined
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 

--- a/testdata/baselines/reference/submodule/compiler/destructureTupleWithVariableElement.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/destructureTupleWithVariableElement.types.diff
@@ -1,0 +1,55 @@
+--- old.destructureTupleWithVariableElement.types
++++ new.destructureTupleWithVariableElement.types
+@@= skipped -19, +19 lines =@@
+
+ s0.toUpperCase()
+ >s0.toUpperCase() : string
+->s0.toUpperCase : () => string
++>s0.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >s0 : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+
+ s1.toUpperCase() 
+ >s1.toUpperCase() : string
+->s1.toUpperCase : () => string
++>s1.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >s1 : string | undefined
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+
+ s2.toUpperCase()
+ >s2.toUpperCase() : string
+->s2.toUpperCase : () => string
++>s2.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >s2 : string | undefined
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+
+ declare const strings2: [string, ...Array<string>, string]
+ >strings2 : [string, ...string[], string]
+@@= skipped -27, +27 lines =@@
+
+ s3.toUpperCase()
+ >s3.toUpperCase() : string
+->s3.toUpperCase : () => string
++>s3.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >s3 : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+
+ s4.toUpperCase() 
+ >s4.toUpperCase() : string
+->s4.toUpperCase : () => string
++>s4.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >s4 : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+
+ s5.toUpperCase()
+ >s5.toUpperCase() : string
+->s5.toUpperCase : () => string
++>s5.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >s5 : string | undefined
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>

--- a/testdata/baselines/reference/submodule/compiler/fixingTypeParametersRepeatedly1.types
+++ b/testdata/baselines/reference/submodule/compiler/fixingTypeParametersRepeatedly1.types
@@ -18,9 +18,9 @@ f("", x => null, x => x.toLowerCase());
 >x => x.toLowerCase() : (x: string) => string
 >x : string
 >x.toLowerCase() : string
->x.toLowerCase : () => string
+>x.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >x : string
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 
 // First overload of g should type check just like f
 declare function g<T>(x: T, y: (p: T) => T, z: (p: T) => T): T;
@@ -43,7 +43,7 @@ g("", x => null, x => x.toLowerCase());
 >x => x.toLowerCase() : (x: string) => string
 >x : string
 >x.toLowerCase() : string
->x.toLowerCase : () => string
+>x.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >x : string
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 

--- a/testdata/baselines/reference/submodule/compiler/fixingTypeParametersRepeatedly1.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/fixingTypeParametersRepeatedly1.types.diff
@@ -1,0 +1,23 @@
+--- old.fixingTypeParametersRepeatedly1.types
++++ new.fixingTypeParametersRepeatedly1.types
+@@= skipped -17, +17 lines =@@
+ >x => x.toLowerCase() : (x: string) => string
+ >x : string
+ >x.toLowerCase() : string
+->x.toLowerCase : () => string
++>x.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >x : string
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+
+ // First overload of g should type check just like f
+ declare function g<T>(x: T, y: (p: T) => T, z: (p: T) => T): T;
+@@= skipped -25, +25 lines =@@
+ >x => x.toLowerCase() : (x: string) => string
+ >x : string
+ >x.toLowerCase() : string
+->x.toLowerCase : () => string
++>x.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >x : string
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>

--- a/testdata/baselines/reference/submodule/compiler/functionTypeArgumentAssignmentCompat.types
+++ b/testdata/baselines/reference/submodule/compiler/functionTypeArgumentAssignmentCompat.types
@@ -22,18 +22,18 @@ f = g;
 >g : <S>() => S[]
 
 var s = f("str").toUpperCase();
->s : string
->f("str").toUpperCase() : string
->f("str").toUpperCase : () => string
+>s : "STR"
+>f("str").toUpperCase() : "STR"
+>f("str").toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >f("str") : "str"
 >f : <T>(x: T) => T
 >"str" : "str"
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 
 console.log(s);
 >console.log(s) : void
 >console.log : (...data: any[]) => void
 >console : Console
 >log : (...data: any[]) => void
->s : string
+>s : "STR"
 

--- a/testdata/baselines/reference/submodule/compiler/functionTypeArgumentAssignmentCompat.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/functionTypeArgumentAssignmentCompat.types.diff
@@ -1,0 +1,25 @@
+--- old.functionTypeArgumentAssignmentCompat.types
++++ new.functionTypeArgumentAssignmentCompat.types
+@@= skipped -21, +21 lines =@@
+ >g : <S>() => S[]
+
+ var s = f("str").toUpperCase();
+->s : string
+->f("str").toUpperCase() : string
+->f("str").toUpperCase : () => string
++>s : "STR"
++>f("str").toUpperCase() : "STR"
++>f("str").toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >f("str") : "str"
+ >f : <T>(x: T) => T
+ >"str" : "str"
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+
+ console.log(s);
+ >console.log(s) : void
+ >console.log : (...data: any[]) => void
+ >console : Console
+ >log : (...data: any[]) => void
+->s : string
++>s : "STR"

--- a/testdata/baselines/reference/submodule/compiler/genericFunctionCallSignatureReturnTypeMismatch.types
+++ b/testdata/baselines/reference/submodule/compiler/genericFunctionCallSignatureReturnTypeMismatch.types
@@ -16,18 +16,18 @@ f = g;
 >g : <S>() => S[]
 
 var s = f("str").toUpperCase();
->s : string
->f("str").toUpperCase() : string
->f("str").toUpperCase : () => string
+>s : "STR"
+>f("str").toUpperCase() : "STR"
+>f("str").toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >f("str") : "str"
 >f : <T>(x: T) => T
 >"str" : "str"
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 
 console.log(s);
 >console.log(s) : void
 >console.log : (...data: any[]) => void
 >console : Console
 >log : (...data: any[]) => void
->s : string
+>s : "STR"
 

--- a/testdata/baselines/reference/submodule/compiler/genericFunctionCallSignatureReturnTypeMismatch.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/genericFunctionCallSignatureReturnTypeMismatch.types.diff
@@ -1,0 +1,25 @@
+--- old.genericFunctionCallSignatureReturnTypeMismatch.types
++++ new.genericFunctionCallSignatureReturnTypeMismatch.types
+@@= skipped -15, +15 lines =@@
+ >g : <S>() => S[]
+
+ var s = f("str").toUpperCase();
+->s : string
+->f("str").toUpperCase() : string
+->f("str").toUpperCase : () => string
++>s : "STR"
++>f("str").toUpperCase() : "STR"
++>f("str").toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >f("str") : "str"
+ >f : <T>(x: T) => T
+ >"str" : "str"
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+
+ console.log(s);
+ >console.log(s) : void
+ >console.log : (...data: any[]) => void
+ >console : Console
+ >log : (...data: any[]) => void
+->s : string
++>s : "STR"

--- a/testdata/baselines/reference/submodule/compiler/gettersAndSetters.types
+++ b/testdata/baselines/reference/submodule/compiler/gettersAndSetters.types
@@ -163,23 +163,23 @@ if (typeof x === "string") {
 >prop : any
 >_ : any
 >x.toUpperCase() : string
->x.toUpperCase : () => string
+>x.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >x : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 
     get prop() { return x.toUpperCase() },
 >prop : any
 >x.toUpperCase() : string
->x.toUpperCase : () => string
+>x.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >x : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 
     method() { return x.toUpperCase() }
 >method : () => string
 >x.toUpperCase() : string
->x.toUpperCase : () => string
+>x.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >x : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
   }
 }
 

--- a/testdata/baselines/reference/submodule/compiler/gettersAndSetters.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/gettersAndSetters.types.diff
@@ -1,0 +1,31 @@
+--- old.gettersAndSetters.types
++++ new.gettersAndSetters.types
+@@= skipped -162, +162 lines =@@
+ >prop : any
+ >_ : any
+ >x.toUpperCase() : string
+->x.toUpperCase : () => string
++>x.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >x : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+
+     get prop() { return x.toUpperCase() },
+ >prop : any
+ >x.toUpperCase() : string
+->x.toUpperCase : () => string
++>x.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >x : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+
+     method() { return x.toUpperCase() }
+ >method : () => string
+ >x.toUpperCase() : string
+->x.toUpperCase : () => string
++>x.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >x : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+   }
+ }

--- a/testdata/baselines/reference/submodule/compiler/inferFromGenericFunctionReturnTypes1.types
+++ b/testdata/baselines/reference/submodule/compiler/inferFromGenericFunctionReturnTypes1.types
@@ -248,9 +248,9 @@ testSet.transform(
 >x => x.toUpperCase() : (x: string) => string
 >x : string
 >x.toUpperCase() : string
->x.toUpperCase : () => string
+>x.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >x : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 
   )
 )

--- a/testdata/baselines/reference/submodule/compiler/inferFromGenericFunctionReturnTypes1.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/inferFromGenericFunctionReturnTypes1.types.diff
@@ -1,0 +1,14 @@
+--- old.inferFromGenericFunctionReturnTypes1.types
++++ new.inferFromGenericFunctionReturnTypes1.types
+@@= skipped -247, +247 lines =@@
+ >x => x.toUpperCase() : (x: string) => string
+ >x : string
+ >x.toUpperCase() : string
+->x.toUpperCase : () => string
++>x.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >x : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+
+   )
+ )

--- a/testdata/baselines/reference/submodule/compiler/inferFromGenericFunctionReturnTypes2.types
+++ b/testdata/baselines/reference/submodule/compiler/inferFromGenericFunctionReturnTypes2.types
@@ -442,9 +442,9 @@ const t1 = testSet.transform(
 >x => x.toUpperCase() : (x: string) => string
 >x : string
 >x.toUpperCase() : string
->x.toUpperCase : () => string
+>x.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >x : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 
   )
 )
@@ -493,9 +493,9 @@ const t2 = testSet.transform(
 >x => x.toUpperCase() : (x: string) => string
 >x : string
 >x.toUpperCase() : string
->x.toUpperCase : () => string
+>x.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >x : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 
   )
 )

--- a/testdata/baselines/reference/submodule/compiler/inferFromGenericFunctionReturnTypes2.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/inferFromGenericFunctionReturnTypes2.types.diff
@@ -1,0 +1,26 @@
+--- old.inferFromGenericFunctionReturnTypes2.types
++++ new.inferFromGenericFunctionReturnTypes2.types
+@@= skipped -441, +441 lines =@@
+ >x => x.toUpperCase() : (x: string) => string
+ >x : string
+ >x.toUpperCase() : string
+->x.toUpperCase : () => string
++>x.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >x : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+
+   )
+ )
+@@= skipped -51, +51 lines =@@
+ >x => x.toUpperCase() : (x: string) => string
+ >x : string
+ >x.toUpperCase() : string
+->x.toUpperCase : () => string
++>x.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >x : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+
+   )
+ )

--- a/testdata/baselines/reference/submodule/compiler/intersectionsOfLargeUnions.types
+++ b/testdata/baselines/reference/submodule/compiler/intersectionsOfLargeUnions.types
@@ -38,11 +38,11 @@ export function assertNodeTagName<
         const nodeTagName = node.tagName.toLowerCase();
 >nodeTagName : string
 >node.tagName.toLowerCase() : string
->node.tagName.toLowerCase : () => string
+>node.tagName.toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
 >node.tagName : string
 >node : Element
 >tagName : string
->toLowerCase : () => string
+>toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
 
          return nodeTagName === tagName;
 >nodeTagName === tagName : boolean

--- a/testdata/baselines/reference/submodule/compiler/intersectionsOfLargeUnions.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/intersectionsOfLargeUnions.types.diff
@@ -1,0 +1,16 @@
+--- old.intersectionsOfLargeUnions.types
++++ new.intersectionsOfLargeUnions.types
+@@= skipped -37, +37 lines =@@
+         const nodeTagName = node.tagName.toLowerCase();
+ >nodeTagName : string
+ >node.tagName.toLowerCase() : string
+->node.tagName.toLowerCase : () => string
++>node.tagName.toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
+ >node.tagName : string
+ >node : Element
+ >tagName : string
+->toLowerCase : () => string
++>toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
+
+          return nodeTagName === tagName;
+ >nodeTagName === tagName : boolean

--- a/testdata/baselines/reference/submodule/compiler/intersectionsOfLargeUnions2.types
+++ b/testdata/baselines/reference/submodule/compiler/intersectionsOfLargeUnions2.types
@@ -52,11 +52,11 @@ export function assertNodeTagName<
         const nodeTagName = node.tagName.toLowerCase();
 >nodeTagName : string
 >node.tagName.toLowerCase() : string
->node.tagName.toLowerCase : () => string
+>node.tagName.toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
 >node.tagName : string
 >node : Element
 >tagName : string
->toLowerCase : () => string
+>toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
 
          return nodeTagName === tagName;
 >nodeTagName === tagName : boolean

--- a/testdata/baselines/reference/submodule/compiler/intersectionsOfLargeUnions2.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/intersectionsOfLargeUnions2.types.diff
@@ -1,0 +1,16 @@
+--- old.intersectionsOfLargeUnions2.types
++++ new.intersectionsOfLargeUnions2.types
+@@= skipped -51, +51 lines =@@
+         const nodeTagName = node.tagName.toLowerCase();
+ >nodeTagName : string
+ >node.tagName.toLowerCase() : string
+->node.tagName.toLowerCase : () => string
++>node.tagName.toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
+ >node.tagName : string
+ >node : Element
+ >tagName : string
+->toLowerCase : () => string
++>toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
+
+          return nodeTagName === tagName;
+ >nodeTagName === tagName : boolean

--- a/testdata/baselines/reference/submodule/compiler/jsdocParamTagOnPropertyInitializer.types
+++ b/testdata/baselines/reference/submodule/compiler/jsdocParamTagOnPropertyInitializer.types
@@ -10,8 +10,8 @@ class Foo {
 >x => x.toLowerCase() : (x: string) => string
 >x : string
 >x.toLowerCase() : string
->x.toLowerCase : () => string
+>x.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >x : string
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 }
 

--- a/testdata/baselines/reference/submodule/compiler/jsdocParamTagOnPropertyInitializer.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/jsdocParamTagOnPropertyInitializer.types.diff
@@ -1,0 +1,12 @@
+--- old.jsdocParamTagOnPropertyInitializer.types
++++ new.jsdocParamTagOnPropertyInitializer.types
+@@= skipped -9, +9 lines =@@
+ >x => x.toLowerCase() : (x: string) => string
+ >x : string
+ >x.toLowerCase() : string
+->x.toLowerCase : () => string
++>x.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >x : string
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ }

--- a/testdata/baselines/reference/submodule/compiler/jsxEmitWithAttributes.types
+++ b/testdata/baselines/reference/submodule/compiler/jsxEmitWithAttributes.types
@@ -70,11 +70,11 @@ function toCamelCase(text: string): string {
     return text[0].toLowerCase() + text.substring(1);
 >text[0].toLowerCase() + text.substring(1) : string
 >text[0].toLowerCase() : string
->text[0].toLowerCase : () => string
+>text[0].toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >text[0] : string
 >text : string
 >0 : 0
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >text.substring(1) : string
 >text.substring : (start: number, end?: number) => string
 >text : string

--- a/testdata/baselines/reference/submodule/compiler/jsxEmitWithAttributes.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/jsxEmitWithAttributes.types.diff
@@ -1,0 +1,16 @@
+--- old.jsxEmitWithAttributes.types
++++ new.jsxEmitWithAttributes.types
+@@= skipped -69, +69 lines =@@
+     return text[0].toLowerCase() + text.substring(1);
+ >text[0].toLowerCase() + text.substring(1) : string
+ >text[0].toLowerCase() : string
+->text[0].toLowerCase : () => string
++>text[0].toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >text[0] : string
+ >text : string
+ >0 : 0
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >text.substring(1) : string
+ >text.substring : (start: number, end?: number) => string
+ >text : string

--- a/testdata/baselines/reference/submodule/compiler/jsxFactoryAndReactNamespace.types
+++ b/testdata/baselines/reference/submodule/compiler/jsxFactoryAndReactNamespace.types
@@ -70,11 +70,11 @@ function toCamelCase(text: string): string {
     return text[0].toLowerCase() + text.substring(1);
 >text[0].toLowerCase() + text.substring(1) : string
 >text[0].toLowerCase() : string
->text[0].toLowerCase : () => string
+>text[0].toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >text[0] : string
 >text : string
 >0 : 0
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >text.substring(1) : string
 >text.substring : (start: number, end?: number) => string
 >text : string

--- a/testdata/baselines/reference/submodule/compiler/jsxFactoryAndReactNamespace.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/jsxFactoryAndReactNamespace.types.diff
@@ -1,0 +1,16 @@
+--- old.jsxFactoryAndReactNamespace.types
++++ new.jsxFactoryAndReactNamespace.types
+@@= skipped -69, +69 lines =@@
+     return text[0].toLowerCase() + text.substring(1);
+ >text[0].toLowerCase() + text.substring(1) : string
+ >text[0].toLowerCase() : string
+->text[0].toLowerCase : () => string
++>text[0].toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >text[0] : string
+ >text : string
+ >0 : 0
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >text.substring(1) : string
+ >text.substring : (start: number, end?: number) => string
+ >text : string

--- a/testdata/baselines/reference/submodule/compiler/jsxFactoryIdentifier.types
+++ b/testdata/baselines/reference/submodule/compiler/jsxFactoryIdentifier.types
@@ -70,11 +70,11 @@ function toCamelCase(text: string): string {
     return text[0].toLowerCase() + text.substring(1);
 >text[0].toLowerCase() + text.substring(1) : string
 >text[0].toLowerCase() : string
->text[0].toLowerCase : () => string
+>text[0].toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >text[0] : string
 >text : string
 >0 : 0
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >text.substring(1) : string
 >text.substring : (start: number, end?: number) => string
 >text : string

--- a/testdata/baselines/reference/submodule/compiler/jsxFactoryIdentifier.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/jsxFactoryIdentifier.types.diff
@@ -1,0 +1,16 @@
+--- old.jsxFactoryIdentifier.types
++++ new.jsxFactoryIdentifier.types
+@@= skipped -69, +69 lines =@@
+     return text[0].toLowerCase() + text.substring(1);
+ >text[0].toLowerCase() + text.substring(1) : string
+ >text[0].toLowerCase() : string
+->text[0].toLowerCase : () => string
++>text[0].toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >text[0] : string
+ >text : string
+ >0 : 0
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >text.substring(1) : string
+ >text.substring : (start: number, end?: number) => string
+ >text : string

--- a/testdata/baselines/reference/submodule/compiler/jsxFactoryNotIdentifierOrQualifiedName.types
+++ b/testdata/baselines/reference/submodule/compiler/jsxFactoryNotIdentifierOrQualifiedName.types
@@ -70,11 +70,11 @@ function toCamelCase(text: string): string {
     return text[0].toLowerCase() + text.substring(1);
 >text[0].toLowerCase() + text.substring(1) : string
 >text[0].toLowerCase() : string
->text[0].toLowerCase : () => string
+>text[0].toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >text[0] : string
 >text : string
 >0 : 0
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >text.substring(1) : string
 >text.substring : (start: number, end?: number) => string
 >text : string

--- a/testdata/baselines/reference/submodule/compiler/jsxFactoryNotIdentifierOrQualifiedName.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/jsxFactoryNotIdentifierOrQualifiedName.types.diff
@@ -1,0 +1,16 @@
+--- old.jsxFactoryNotIdentifierOrQualifiedName.types
++++ new.jsxFactoryNotIdentifierOrQualifiedName.types
+@@= skipped -69, +69 lines =@@
+     return text[0].toLowerCase() + text.substring(1);
+ >text[0].toLowerCase() + text.substring(1) : string
+ >text[0].toLowerCase() : string
+->text[0].toLowerCase : () => string
++>text[0].toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >text[0] : string
+ >text : string
+ >0 : 0
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >text.substring(1) : string
+ >text.substring : (start: number, end?: number) => string
+ >text : string

--- a/testdata/baselines/reference/submodule/compiler/jsxFactoryNotIdentifierOrQualifiedName2.types
+++ b/testdata/baselines/reference/submodule/compiler/jsxFactoryNotIdentifierOrQualifiedName2.types
@@ -70,11 +70,11 @@ function toCamelCase(text: string): string {
     return text[0].toLowerCase() + text.substring(1);
 >text[0].toLowerCase() + text.substring(1) : string
 >text[0].toLowerCase() : string
->text[0].toLowerCase : () => string
+>text[0].toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >text[0] : string
 >text : string
 >0 : 0
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >text.substring(1) : string
 >text.substring : (start: number, end?: number) => string
 >text : string

--- a/testdata/baselines/reference/submodule/compiler/jsxFactoryNotIdentifierOrQualifiedName2.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/jsxFactoryNotIdentifierOrQualifiedName2.types.diff
@@ -1,0 +1,16 @@
+--- old.jsxFactoryNotIdentifierOrQualifiedName2.types
++++ new.jsxFactoryNotIdentifierOrQualifiedName2.types
+@@= skipped -69, +69 lines =@@
+     return text[0].toLowerCase() + text.substring(1);
+ >text[0].toLowerCase() + text.substring(1) : string
+ >text[0].toLowerCase() : string
+->text[0].toLowerCase : () => string
++>text[0].toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >text[0] : string
+ >text : string
+ >0 : 0
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >text.substring(1) : string
+ >text.substring : (start: number, end?: number) => string
+ >text : string

--- a/testdata/baselines/reference/submodule/compiler/jsxFactoryQualifiedName.types
+++ b/testdata/baselines/reference/submodule/compiler/jsxFactoryQualifiedName.types
@@ -70,11 +70,11 @@ function toCamelCase(text: string): string {
     return text[0].toLowerCase() + text.substring(1);
 >text[0].toLowerCase() + text.substring(1) : string
 >text[0].toLowerCase() : string
->text[0].toLowerCase : () => string
+>text[0].toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >text[0] : string
 >text : string
 >0 : 0
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >text.substring(1) : string
 >text.substring : (start: number, end?: number) => string
 >text : string

--- a/testdata/baselines/reference/submodule/compiler/jsxFactoryQualifiedName.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/jsxFactoryQualifiedName.types.diff
@@ -1,0 +1,16 @@
+--- old.jsxFactoryQualifiedName.types
++++ new.jsxFactoryQualifiedName.types
+@@= skipped -69, +69 lines =@@
+     return text[0].toLowerCase() + text.substring(1);
+ >text[0].toLowerCase() + text.substring(1) : string
+ >text[0].toLowerCase() : string
+->text[0].toLowerCase : () => string
++>text[0].toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >text[0] : string
+ >text : string
+ >0 : 0
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >text.substring(1) : string
+ >text.substring : (start: number, end?: number) => string
+ >text : string

--- a/testdata/baselines/reference/submodule/compiler/moduleAugmentationDeclarationEmit2.types
+++ b/testdata/baselines/reference/submodule/compiler/moduleAugmentationDeclarationEmit2.types
@@ -83,9 +83,9 @@ let z1 = Observable.someValue.toFixed();
 let z2 = Observable.someAnotherValue.toLowerCase();
 >z2 : string
 >Observable.someAnotherValue.toLowerCase() : string
->Observable.someAnotherValue.toLowerCase : () => string
+>Observable.someAnotherValue.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >Observable.someAnotherValue : string
 >Observable : typeof Observable
 >someAnotherValue : string
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 

--- a/testdata/baselines/reference/submodule/compiler/moduleAugmentationDeclarationEmit2.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/moduleAugmentationDeclarationEmit2.types.diff
@@ -1,0 +1,13 @@
+--- old.moduleAugmentationDeclarationEmit2.types
++++ new.moduleAugmentationDeclarationEmit2.types
+@@= skipped -82, +82 lines =@@
+ let z2 = Observable.someAnotherValue.toLowerCase();
+ >z2 : string
+ >Observable.someAnotherValue.toLowerCase() : string
+->Observable.someAnotherValue.toLowerCase : () => string
++>Observable.someAnotherValue.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >Observable.someAnotherValue : string
+ >Observable : typeof Observable
+ >someAnotherValue : string
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>

--- a/testdata/baselines/reference/submodule/compiler/moduleAugmentationExtendAmbientModule2.types
+++ b/testdata/baselines/reference/submodule/compiler/moduleAugmentationExtendAmbientModule2.types
@@ -34,11 +34,11 @@ let z1 = Observable.someValue.toFixed();
 let z2 = Observable.someAnotherValue.toLowerCase();
 >z2 : string
 >Observable.someAnotherValue.toLowerCase() : string
->Observable.someAnotherValue.toLowerCase : () => string
+>Observable.someAnotherValue.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >Observable.someAnotherValue : string
 >Observable : typeof Observable
 >someAnotherValue : string
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 
 === map.ts ===
 import { Observable } from "observable"

--- a/testdata/baselines/reference/submodule/compiler/moduleAugmentationExtendAmbientModule2.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/moduleAugmentationExtendAmbientModule2.types.diff
@@ -1,0 +1,16 @@
+--- old.moduleAugmentationExtendAmbientModule2.types
++++ new.moduleAugmentationExtendAmbientModule2.types
+@@= skipped -33, +33 lines =@@
+ let z2 = Observable.someAnotherValue.toLowerCase();
+ >z2 : string
+ >Observable.someAnotherValue.toLowerCase() : string
+->Observable.someAnotherValue.toLowerCase : () => string
++>Observable.someAnotherValue.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >Observable.someAnotherValue : string
+ >Observable : typeof Observable
+ >someAnotherValue : string
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+
+ === map.ts ===
+ import { Observable } from "observable"

--- a/testdata/baselines/reference/submodule/compiler/moduleAugmentationExtendFileModule2.types
+++ b/testdata/baselines/reference/submodule/compiler/moduleAugmentationExtendFileModule2.types
@@ -83,9 +83,9 @@ let z1 = Observable.someValue.toFixed();
 let z2 = Observable.someAnotherValue.toLowerCase();
 >z2 : string
 >Observable.someAnotherValue.toLowerCase() : string
->Observable.someAnotherValue.toLowerCase : () => string
+>Observable.someAnotherValue.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >Observable.someAnotherValue : string
 >Observable : typeof Observable
 >someAnotherValue : string
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 

--- a/testdata/baselines/reference/submodule/compiler/moduleAugmentationExtendFileModule2.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/moduleAugmentationExtendFileModule2.types.diff
@@ -1,0 +1,13 @@
+--- old.moduleAugmentationExtendFileModule2.types
++++ new.moduleAugmentationExtendFileModule2.types
+@@= skipped -82, +82 lines =@@
+ let z2 = Observable.someAnotherValue.toLowerCase();
+ >z2 : string
+ >Observable.someAnotherValue.toLowerCase() : string
+->Observable.someAnotherValue.toLowerCase : () => string
++>Observable.someAnotherValue.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >Observable.someAnotherValue : string
+ >Observable : typeof Observable
+ >someAnotherValue : string
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>

--- a/testdata/baselines/reference/submodule/compiler/moduleAugmentationGlobal2.types
+++ b/testdata/baselines/reference/submodule/compiler/moduleAugmentationGlobal2.types
@@ -26,10 +26,10 @@ let x = [1];
 let y = x.getCountAsString().toLowerCase();
 >y : string
 >x.getCountAsString().toLowerCase() : string
->x.getCountAsString().toLowerCase : () => string
+>x.getCountAsString().toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >x.getCountAsString() : string
 >x.getCountAsString : () => string
 >x : number[]
 >getCountAsString : () => string
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 

--- a/testdata/baselines/reference/submodule/compiler/moduleAugmentationGlobal2.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/moduleAugmentationGlobal2.types.diff
@@ -1,0 +1,14 @@
+--- old.moduleAugmentationGlobal2.types
++++ new.moduleAugmentationGlobal2.types
+@@= skipped -25, +25 lines =@@
+ let y = x.getCountAsString().toLowerCase();
+ >y : string
+ >x.getCountAsString().toLowerCase() : string
+->x.getCountAsString().toLowerCase : () => string
++>x.getCountAsString().toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >x.getCountAsString() : string
+ >x.getCountAsString : () => string
+ >x : number[]
+ >getCountAsString : () => string
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>

--- a/testdata/baselines/reference/submodule/compiler/moduleAugmentationGlobal3.types
+++ b/testdata/baselines/reference/submodule/compiler/moduleAugmentationGlobal3.types
@@ -29,10 +29,10 @@ let x = [1];
 let y = x.getCountAsString().toLowerCase();
 >y : string
 >x.getCountAsString().toLowerCase() : string
->x.getCountAsString().toLowerCase : () => string
+>x.getCountAsString().toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >x.getCountAsString() : string
 >x.getCountAsString : () => string
 >x : number[]
 >getCountAsString : () => string
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 

--- a/testdata/baselines/reference/submodule/compiler/moduleAugmentationGlobal3.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/moduleAugmentationGlobal3.types.diff
@@ -1,0 +1,14 @@
+--- old.moduleAugmentationGlobal3.types
++++ new.moduleAugmentationGlobal3.types
+@@= skipped -28, +28 lines =@@
+ let y = x.getCountAsString().toLowerCase();
+ >y : string
+ >x.getCountAsString().toLowerCase() : string
+->x.getCountAsString().toLowerCase : () => string
++>x.getCountAsString().toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >x.getCountAsString() : string
+ >x.getCountAsString : () => string
+ >x : number[]
+ >getCountAsString : () => string
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>

--- a/testdata/baselines/reference/submodule/compiler/narrowingInCaseClauseAfterCaseClauseWithReturn.types
+++ b/testdata/baselines/reference/submodule/compiler/narrowingInCaseClauseAfterCaseClauseWithReturn.types
@@ -19,9 +19,9 @@ function test1(arg: string | undefined) {
     case arg.toUpperCase() === "A":
 >arg.toUpperCase() === "A" : boolean
 >arg.toUpperCase() : string
->arg.toUpperCase : () => string
+>arg.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >arg : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >"A" : "A"
 
       return "A";
@@ -30,25 +30,25 @@ function test1(arg: string | undefined) {
     case arg.toUpperCase() === "B":
 >arg.toUpperCase() === "B" : boolean
 >arg.toUpperCase() : string
->arg.toUpperCase : () => string
+>arg.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >arg : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >"B" : "B"
 
     case arg.toUpperCase() === "C":
 >arg.toUpperCase() === "C" : boolean
 >arg.toUpperCase() : string
->arg.toUpperCase : () => string
+>arg.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >arg : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >"C" : "C"
 
     case arg.toUpperCase() === "D":
 >arg.toUpperCase() === "D" : boolean
 >arg.toUpperCase() : string
->arg.toUpperCase : () => string
+>arg.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >arg : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >"D" : "D"
 
       return "B, C or D";
@@ -75,25 +75,25 @@ function test2(arg: string | undefined) {
     case arg.toUpperCase() === "A":
 >arg.toUpperCase() === "A" : boolean
 >arg.toUpperCase() : string
->arg.toUpperCase : () => string
+>arg.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >arg : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >"A" : "A"
 
     case arg.toUpperCase() === "B":
 >arg.toUpperCase() === "B" : boolean
 >arg.toUpperCase() : string
->arg.toUpperCase : () => string
+>arg.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >arg : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >"B" : "B"
 
     case arg.toUpperCase() === "C":
 >arg.toUpperCase() === "C" : boolean
 >arg.toUpperCase() : string
->arg.toUpperCase : () => string
+>arg.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >arg : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >"C" : "C"
 
       return "A, B or C";
@@ -102,9 +102,9 @@ function test2(arg: string | undefined) {
     case arg.toUpperCase() === "D":
 >arg.toUpperCase() === "D" : boolean
 >arg.toUpperCase() : string
->arg.toUpperCase : () => string
+>arg.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >arg : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >"D" : "D"
 
       return "D";

--- a/testdata/baselines/reference/submodule/compiler/narrowingInCaseClauseAfterCaseClauseWithReturn.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/narrowingInCaseClauseAfterCaseClauseWithReturn.types.diff
@@ -1,0 +1,90 @@
+--- old.narrowingInCaseClauseAfterCaseClauseWithReturn.types
++++ new.narrowingInCaseClauseAfterCaseClauseWithReturn.types
+@@= skipped -18, +18 lines =@@
+     case arg.toUpperCase() === "A":
+ >arg.toUpperCase() === "A" : boolean
+ >arg.toUpperCase() : string
+->arg.toUpperCase : () => string
++>arg.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >arg : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >"A" : "A"
+
+       return "A";
+@@= skipped -11, +11 lines =@@
+     case arg.toUpperCase() === "B":
+ >arg.toUpperCase() === "B" : boolean
+ >arg.toUpperCase() : string
+->arg.toUpperCase : () => string
++>arg.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >arg : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >"B" : "B"
+
+     case arg.toUpperCase() === "C":
+ >arg.toUpperCase() === "C" : boolean
+ >arg.toUpperCase() : string
+->arg.toUpperCase : () => string
++>arg.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >arg : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >"C" : "C"
+
+     case arg.toUpperCase() === "D":
+ >arg.toUpperCase() === "D" : boolean
+ >arg.toUpperCase() : string
+->arg.toUpperCase : () => string
++>arg.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >arg : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >"D" : "D"
+
+       return "B, C or D";
+@@= skipped -45, +45 lines =@@
+     case arg.toUpperCase() === "A":
+ >arg.toUpperCase() === "A" : boolean
+ >arg.toUpperCase() : string
+->arg.toUpperCase : () => string
++>arg.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >arg : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >"A" : "A"
+
+     case arg.toUpperCase() === "B":
+ >arg.toUpperCase() === "B" : boolean
+ >arg.toUpperCase() : string
+->arg.toUpperCase : () => string
++>arg.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >arg : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >"B" : "B"
+
+     case arg.toUpperCase() === "C":
+ >arg.toUpperCase() === "C" : boolean
+ >arg.toUpperCase() : string
+->arg.toUpperCase : () => string
++>arg.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >arg : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >"C" : "C"
+
+       return "A, B or C";
+@@= skipped -27, +27 lines =@@
+     case arg.toUpperCase() === "D":
+ >arg.toUpperCase() === "D" : boolean
+ >arg.toUpperCase() : string
+->arg.toUpperCase : () => string
++>arg.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >arg : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >"D" : "D"
+
+       return "D";

--- a/testdata/baselines/reference/submodule/compiler/propertyAccess7.types
+++ b/testdata/baselines/reference/submodule/compiler/propertyAccess7.types
@@ -6,7 +6,7 @@ var foo: string;
 
 foo.toUpperCase();
 >foo.toUpperCase() : string
->foo.toUpperCase : () => string
+>foo.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >foo : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 

--- a/testdata/baselines/reference/submodule/compiler/propertyAccess7.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/propertyAccess7.types.diff
@@ -1,0 +1,11 @@
+--- old.propertyAccess7.types
++++ new.propertyAccess7.types
+@@= skipped -5, +5 lines =@@
+
+ foo.toUpperCase();
+ >foo.toUpperCase() : string
+->foo.toUpperCase : () => string
++>foo.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >foo : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>

--- a/testdata/baselines/reference/submodule/compiler/protectedMembersThisParameter.types
+++ b/testdata/baselines/reference/submodule/compiler/protectedMembersThisParameter.types
@@ -175,10 +175,10 @@ function bString<T extends string>(this: T, arg: B) {
 >arg : B
 
   this.toLowerCase();
->this.toLowerCase() : string
->this.toLowerCase : () => string
+>this.toLowerCase() : string extends T ? T : Lowercase<T>
+>this.toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
 >this : T
->toLowerCase : () => string
+>toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
 
   arg.a(); // should error
 >arg.a() : void

--- a/testdata/baselines/reference/submodule/compiler/protectedMembersThisParameter.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/protectedMembersThisParameter.types.diff
@@ -1,0 +1,16 @@
+--- old.protectedMembersThisParameter.types
++++ new.protectedMembersThisParameter.types
+@@= skipped -174, +174 lines =@@
+ >arg : B
+
+   this.toLowerCase();
+->this.toLowerCase() : string
+->this.toLowerCase : () => string
++>this.toLowerCase() : string extends T ? T : Lowercase<T>
++>this.toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
+ >this : T
+->toLowerCase : () => string
++>toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
+
+   arg.a(); // should error
+ >arg.a() : void

--- a/testdata/baselines/reference/submodule/compiler/strictTypeofUnionNarrowing.types
+++ b/testdata/baselines/reference/submodule/compiler/strictTypeofUnionNarrowing.types
@@ -13,9 +13,9 @@ function stringify1(anything: { toString(): string } | undefined): string {
 >anything : { toString(): string; } | undefined
 >"string" : "string"
 >anything.toUpperCase() : string
->anything.toUpperCase : () => string
+>anything.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >anything : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >"" : ""
 }
 
@@ -30,9 +30,9 @@ function stringify2(anything: {} | undefined): string {
 >anything : {} | undefined
 >"string" : "string"
 >anything.toUpperCase() : string
->anything.toUpperCase : () => string
+>anything.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >anything : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >"" : ""
 }
 
@@ -47,9 +47,9 @@ function stringify3(anything: unknown | undefined): string { // should simplify 
 >anything : unknown
 >"string" : "string"
 >anything.toUpperCase() : string
->anything.toUpperCase : () => string
+>anything.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >anything : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >"" : ""
 }
 
@@ -65,9 +65,9 @@ function stringify4(anything: { toString?(): string } | undefined): string {
 >anything : { toString?(): string; } | undefined
 >"string" : "string"
 >anything.toUpperCase() : string
->anything.toUpperCase : () => string
+>anything.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >anything : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >"" : ""
 }
 

--- a/testdata/baselines/reference/submodule/compiler/strictTypeofUnionNarrowing.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/strictTypeofUnionNarrowing.types.diff
@@ -1,0 +1,49 @@
+--- old.strictTypeofUnionNarrowing.types
++++ new.strictTypeofUnionNarrowing.types
+@@= skipped -12, +12 lines =@@
+ >anything : { toString(): string; } | undefined
+ >"string" : "string"
+ >anything.toUpperCase() : string
+->anything.toUpperCase : () => string
++>anything.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >anything : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >"" : ""
+ }
+
+@@= skipped -17, +17 lines =@@
+ >anything : {} | undefined
+ >"string" : "string"
+ >anything.toUpperCase() : string
+->anything.toUpperCase : () => string
++>anything.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >anything : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >"" : ""
+ }
+
+@@= skipped -17, +17 lines =@@
+ >anything : unknown
+ >"string" : "string"
+ >anything.toUpperCase() : string
+->anything.toUpperCase : () => string
++>anything.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >anything : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >"" : ""
+ }
+
+@@= skipped -18, +18 lines =@@
+ >anything : { toString?(): string; } | undefined
+ >"string" : "string"
+ >anything.toUpperCase() : string
+->anything.toUpperCase : () => string
++>anything.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >anything : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >"" : ""
+ }

--- a/testdata/baselines/reference/submodule/compiler/targetTypingOnFunctions.types
+++ b/testdata/baselines/reference/submodule/compiler/targetTypingOnFunctions.types
@@ -7,9 +7,9 @@ var fu: (s: string) => string = function (s) { return s.toLowerCase() };
 >function (s) { return s.toLowerCase() } : (s: string) => string
 >s : string
 >s.toLowerCase() : string
->s.toLowerCase : () => string
+>s.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >s : string
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 
 var zu = fu = function (s) { return s.toLowerCase() };
 >zu : (s: string) => string
@@ -18,7 +18,7 @@ var zu = fu = function (s) { return s.toLowerCase() };
 >function (s) { return s.toLowerCase() } : (s: string) => string
 >s : string
 >s.toLowerCase() : string
->s.toLowerCase : () => string
+>s.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >s : string
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 

--- a/testdata/baselines/reference/submodule/compiler/targetTypingOnFunctions.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/targetTypingOnFunctions.types.diff
@@ -1,0 +1,23 @@
+--- old.targetTypingOnFunctions.types
++++ new.targetTypingOnFunctions.types
+@@= skipped -6, +6 lines =@@
+ >function (s) { return s.toLowerCase() } : (s: string) => string
+ >s : string
+ >s.toLowerCase() : string
+->s.toLowerCase : () => string
++>s.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >s : string
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+
+ var zu = fu = function (s) { return s.toLowerCase() };
+ >zu : (s: string) => string
+@@= skipped -11, +11 lines =@@
+ >function (s) { return s.toLowerCase() } : (s: string) => string
+ >s : string
+ >s.toLowerCase() : string
+->s.toLowerCase : () => string
++>s.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >s : string
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>

--- a/testdata/baselines/reference/submodule/compiler/unionReductionWithStringMappingAndIdenticalBaseTypeExistsNoCrash.types
+++ b/testdata/baselines/reference/submodule/compiler/unionReductionWithStringMappingAndIdenticalBaseTypeExistsNoCrash.types
@@ -147,9 +147,9 @@ const displayEnum = (value: string) => upperFirst(value.toLowerCase())
 >upperFirst(value.toLowerCase()) : Capitalize<string>
 >upperFirst : <T extends string>(str: T) => Capitalize<T>
 >value.toLowerCase() : string
->value.toLowerCase : () => string
+>value.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >value : string
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 
 function Comp() {
 >Comp : () => React.JSX.Element

--- a/testdata/baselines/reference/submodule/compiler/unionReductionWithStringMappingAndIdenticalBaseTypeExistsNoCrash.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/unionReductionWithStringMappingAndIdenticalBaseTypeExistsNoCrash.types.diff
@@ -1,0 +1,14 @@
+--- old.unionReductionWithStringMappingAndIdenticalBaseTypeExistsNoCrash.types
++++ new.unionReductionWithStringMappingAndIdenticalBaseTypeExistsNoCrash.types
+@@= skipped -146, +146 lines =@@
+ >upperFirst(value.toLowerCase()) : Capitalize<string>
+ >upperFirst : <T extends string>(str: T) => Capitalize<T>
+ >value.toLowerCase() : string
+->value.toLowerCase : () => string
++>value.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >value : string
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+
+ function Comp() {
+ >Comp : () => React.JSX.Element

--- a/testdata/baselines/reference/submodule/compiler/useUnknownInCatchVariables01.types
+++ b/testdata/baselines/reference/submodule/compiler/useUnknownInCatchVariables01.types
@@ -39,9 +39,9 @@ catch (e) {
 >console : Console
 >log : (...data: any[]) => void
 >e.toUpperCase() : string
->e.toUpperCase : () => string
+>e.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >e : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
     }
     if (e instanceof Error) {
 >e instanceof Error : boolean
@@ -50,11 +50,11 @@ catch (e) {
 
         e.stack?.toUpperCase();
 >e.stack?.toUpperCase() : string | undefined
->e.stack?.toUpperCase : (() => string) | undefined
+>e.stack?.toUpperCase : (<T extends string>(this: T) => string extends T ? string : Uppercase<T>) | undefined
 >e.stack : string | undefined
 >e : Error
 >stack : string | undefined
->toUpperCase : (() => string) | undefined
+>toUpperCase : (<T extends string>(this: T) => string extends T ? string : Uppercase<T>) | undefined
     }
     if (typeof e === "number") {
 >typeof e === "number" : boolean

--- a/testdata/baselines/reference/submodule/compiler/useUnknownInCatchVariables01.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/useUnknownInCatchVariables01.types.diff
@@ -1,0 +1,28 @@
+--- old.useUnknownInCatchVariables01.types
++++ new.useUnknownInCatchVariables01.types
+@@= skipped -38, +38 lines =@@
+ >console : Console
+ >log : (...data: any[]) => void
+ >e.toUpperCase() : string
+->e.toUpperCase : () => string
++>e.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >e : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+     }
+     if (e instanceof Error) {
+ >e instanceof Error : boolean
+@@= skipped -11, +11 lines =@@
+
+         e.stack?.toUpperCase();
+ >e.stack?.toUpperCase() : string | undefined
+->e.stack?.toUpperCase : (() => string) | undefined
++>e.stack?.toUpperCase : (<T extends string>(this: T) => string extends T ? string : Uppercase<T>) | undefined
+ >e.stack : string | undefined
+ >e : Error
+ >stack : string | undefined
+->toUpperCase : (() => string) | undefined
++>toUpperCase : (<T extends string>(this: T) => string extends T ? string : Uppercase<T>) | undefined
+     }
+     if (typeof e === "number") {
+ >typeof e === "number" : boolean

--- a/testdata/baselines/reference/submodule/compiler/voidUndefinedReduction.types
+++ b/testdata/baselines/reference/submodule/compiler/voidUndefinedReduction.types
@@ -30,8 +30,8 @@ if (isDefined(foo)) {
 >console : Console
 >log : (...data: any[]) => void
 >foo.toUpperCase() : string
->foo.toUpperCase : () => string
+>foo.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >foo : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 }
 

--- a/testdata/baselines/reference/submodule/compiler/voidUndefinedReduction.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/voidUndefinedReduction.types.diff
@@ -1,0 +1,12 @@
+--- old.voidUndefinedReduction.types
++++ new.voidUndefinedReduction.types
+@@= skipped -29, +29 lines =@@
+ >console : Console
+ >log : (...data: any[]) => void
+ >foo.toUpperCase() : string
+->foo.toUpperCase : () => string
++>foo.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >foo : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ }

--- a/testdata/baselines/reference/submodule/conformance/checkJsdocSatisfiesTag13.types
+++ b/testdata/baselines/reference/submodule/conformance/checkJsdocSatisfiesTag13.types
@@ -9,9 +9,9 @@ const t1 = { f: s => s.toLowerCase() }; // should work
 >s => s.toLowerCase() : (s: string) => string
 >s : string
 >s.toLowerCase() : string
->s.toLowerCase : () => string
+>s.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >s : string
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 
 /** @satisfies {{ f: (x: string) => string }} */
 const t2 = { g: "oops" }; // should error

--- a/testdata/baselines/reference/submodule/conformance/checkJsdocSatisfiesTag13.types.diff
+++ b/testdata/baselines/reference/submodule/conformance/checkJsdocSatisfiesTag13.types.diff
@@ -1,0 +1,14 @@
+--- old.checkJsdocSatisfiesTag13.types
++++ new.checkJsdocSatisfiesTag13.types
+@@= skipped -8, +8 lines =@@
+ >s => s.toLowerCase() : (s: string) => string
+ >s : string
+ >s.toLowerCase() : string
+->s.toLowerCase : () => string
++>s.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >s : string
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+
+ /** @satisfies {{ f: (x: string) => string }} */
+ const t2 = { g: "oops" }; // should error

--- a/testdata/baselines/reference/submodule/conformance/commaOperatorWithSecondOperandObjectType.types
+++ b/testdata/baselines/reference/submodule/conformance/commaOperatorWithSecondOperandObjectType.types
@@ -116,9 +116,9 @@ true, {}
 STRING.toLowerCase(), new CLASS()
 >STRING.toLowerCase(), new CLASS() : CLASS
 >STRING.toLowerCase() : string
->STRING.toLowerCase : () => string
+>STRING.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >STRING : string
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >new CLASS() : CLASS
 >CLASS : typeof CLASS
 
@@ -168,9 +168,9 @@ var resultIsObject11 = (STRING.toLowerCase(), new CLASS());
 >(STRING.toLowerCase(), new CLASS()) : CLASS
 >STRING.toLowerCase(), new CLASS() : CLASS
 >STRING.toLowerCase() : string
->STRING.toLowerCase : () => string
+>STRING.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >STRING : string
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >new CLASS() : CLASS
 >CLASS : typeof CLASS
 

--- a/testdata/baselines/reference/submodule/conformance/commaOperatorWithSecondOperandObjectType.types.diff
+++ b/testdata/baselines/reference/submodule/conformance/commaOperatorWithSecondOperandObjectType.types.diff
@@ -1,0 +1,25 @@
+--- old.commaOperatorWithSecondOperandObjectType.types
++++ new.commaOperatorWithSecondOperandObjectType.types
+@@= skipped -115, +115 lines =@@
+ STRING.toLowerCase(), new CLASS()
+ >STRING.toLowerCase(), new CLASS() : CLASS
+ >STRING.toLowerCase() : string
+->STRING.toLowerCase : () => string
++>STRING.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >STRING : string
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >new CLASS() : CLASS
+ >CLASS : typeof CLASS
+
+@@= skipped -52, +52 lines =@@
+ >(STRING.toLowerCase(), new CLASS()) : CLASS
+ >STRING.toLowerCase(), new CLASS() : CLASS
+ >STRING.toLowerCase() : string
+->STRING.toLowerCase : () => string
++>STRING.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >STRING : string
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >new CLASS() : CLASS
+ >CLASS : typeof CLASS

--- a/testdata/baselines/reference/submodule/conformance/conditionalOperatorConditoinIsStringType.types
+++ b/testdata/baselines/reference/submodule/conformance/conditionalOperatorConditoinIsStringType.types
@@ -130,9 +130,9 @@ typeof condString ? exprAny1 : exprAny2;
 
 condString.toUpperCase ? exprBoolean1 : exprBoolean2;
 >condString.toUpperCase ? exprBoolean1 : exprBoolean2 : boolean
->condString.toUpperCase : () => string
+>condString.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >condString : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >exprBoolean1 : boolean
 >exprBoolean2 : boolean
 
@@ -262,9 +262,9 @@ var resultIsAny3 = typeof condString ? exprAny1 : exprAny2;
 var resultIsBoolean3 = condString.toUpperCase ? exprBoolean1 : exprBoolean2;
 >resultIsBoolean3 : boolean
 >condString.toUpperCase ? exprBoolean1 : exprBoolean2 : boolean
->condString.toUpperCase : () => string
+>condString.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >condString : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >exprBoolean1 : boolean
 >exprBoolean2 : boolean
 
@@ -305,9 +305,9 @@ var resultIsStringOrBoolean3 = typeof condString ? exprString1 : exprBoolean1; /
 var resultIsStringOrBoolean4 = condString.toUpperCase ? exprString1 : exprBoolean1; // union
 >resultIsStringOrBoolean4 : string | boolean
 >condString.toUpperCase ? exprString1 : exprBoolean1 : string | boolean
->condString.toUpperCase : () => string
+>condString.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >condString : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >exprString1 : string
 >exprBoolean1 : boolean
 

--- a/testdata/baselines/reference/submodule/conformance/conditionalOperatorConditoinIsStringType.types.diff
+++ b/testdata/baselines/reference/submodule/conformance/conditionalOperatorConditoinIsStringType.types.diff
@@ -1,0 +1,37 @@
+--- old.conditionalOperatorConditoinIsStringType.types
++++ new.conditionalOperatorConditoinIsStringType.types
+@@= skipped -129, +129 lines =@@
+
+ condString.toUpperCase ? exprBoolean1 : exprBoolean2;
+ >condString.toUpperCase ? exprBoolean1 : exprBoolean2 : boolean
+->condString.toUpperCase : () => string
++>condString.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >condString : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >exprBoolean1 : boolean
+ >exprBoolean2 : boolean
+
+@@= skipped -132, +132 lines =@@
+ var resultIsBoolean3 = condString.toUpperCase ? exprBoolean1 : exprBoolean2;
+ >resultIsBoolean3 : boolean
+ >condString.toUpperCase ? exprBoolean1 : exprBoolean2 : boolean
+->condString.toUpperCase : () => string
++>condString.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >condString : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >exprBoolean1 : boolean
+ >exprBoolean2 : boolean
+
+@@= skipped -43, +43 lines =@@
+ var resultIsStringOrBoolean4 = condString.toUpperCase ? exprString1 : exprBoolean1; // union
+ >resultIsStringOrBoolean4 : string | boolean
+ >condString.toUpperCase ? exprString1 : exprBoolean1 : string | boolean
+->condString.toUpperCase : () => string
++>condString.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >condString : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >exprString1 : string
+ >exprBoolean1 : boolean

--- a/testdata/baselines/reference/submodule/conformance/controlFlowAliasingCatchVariables(useunknownincatchvariables=false).types
+++ b/testdata/baselines/reference/submodule/conformance/controlFlowAliasingCatchVariables(useunknownincatchvariables=false).types
@@ -17,9 +17,9 @@ catch (e) {
 
         e.toUpperCase(); // e string
 >e.toUpperCase() : string
->e.toUpperCase : () => string
+>e.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >e : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
     }
 
     if (typeof e === 'string') {
@@ -30,9 +30,9 @@ catch (e) {
 
         e.toUpperCase(); // e string
 >e.toUpperCase() : string
->e.toUpperCase : () => string
+>e.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >e : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
     }
 }
 
@@ -70,9 +70,9 @@ catch (e) {
 
         e.toUpperCase(); // e string
 >e.toUpperCase() : string
->e.toUpperCase : () => string
+>e.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >e : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
     }
 }
 

--- a/testdata/baselines/reference/submodule/conformance/controlFlowAliasingCatchVariables(useunknownincatchvariables=false).types.diff
+++ b/testdata/baselines/reference/submodule/conformance/controlFlowAliasingCatchVariables(useunknownincatchvariables=false).types.diff
@@ -1,0 +1,37 @@
+--- old.controlFlowAliasingCatchVariables(useunknownincatchvariables=false).types
++++ new.controlFlowAliasingCatchVariables(useunknownincatchvariables=false).types
+@@= skipped -16, +16 lines =@@
+
+         e.toUpperCase(); // e string
+ >e.toUpperCase() : string
+->e.toUpperCase : () => string
++>e.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >e : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+     }
+
+     if (typeof e === 'string') {
+@@= skipped -13, +13 lines =@@
+
+         e.toUpperCase(); // e string
+ >e.toUpperCase() : string
+->e.toUpperCase : () => string
++>e.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >e : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+     }
+ }
+
+@@= skipped -40, +40 lines =@@
+
+         e.toUpperCase(); // e string
+ >e.toUpperCase() : string
+->e.toUpperCase : () => string
++>e.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >e : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+     }
+ }

--- a/testdata/baselines/reference/submodule/conformance/controlFlowAliasingCatchVariables(useunknownincatchvariables=true).types
+++ b/testdata/baselines/reference/submodule/conformance/controlFlowAliasingCatchVariables(useunknownincatchvariables=true).types
@@ -17,9 +17,9 @@ catch (e) {
 
         e.toUpperCase(); // e string
 >e.toUpperCase() : string
->e.toUpperCase : () => string
+>e.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >e : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
     }
 
     if (typeof e === 'string') {
@@ -30,9 +30,9 @@ catch (e) {
 
         e.toUpperCase(); // e string
 >e.toUpperCase() : string
->e.toUpperCase : () => string
+>e.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >e : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
     }
 }
 
@@ -70,9 +70,9 @@ catch (e) {
 
         e.toUpperCase(); // e string
 >e.toUpperCase() : string
->e.toUpperCase : () => string
+>e.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >e : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
     }
 }
 

--- a/testdata/baselines/reference/submodule/conformance/controlFlowAliasingCatchVariables(useunknownincatchvariables=true).types.diff
+++ b/testdata/baselines/reference/submodule/conformance/controlFlowAliasingCatchVariables(useunknownincatchvariables=true).types.diff
@@ -1,0 +1,37 @@
+--- old.controlFlowAliasingCatchVariables(useunknownincatchvariables=true).types
++++ new.controlFlowAliasingCatchVariables(useunknownincatchvariables=true).types
+@@= skipped -16, +16 lines =@@
+
+         e.toUpperCase(); // e string
+ >e.toUpperCase() : string
+->e.toUpperCase : () => string
++>e.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >e : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+     }
+
+     if (typeof e === 'string') {
+@@= skipped -13, +13 lines =@@
+
+         e.toUpperCase(); // e string
+ >e.toUpperCase() : string
+->e.toUpperCase : () => string
++>e.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >e : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+     }
+ }
+
+@@= skipped -40, +40 lines =@@
+
+         e.toUpperCase(); // e string
+ >e.toUpperCase() : string
+->e.toUpperCase : () => string
++>e.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >e : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+     }
+ }

--- a/testdata/baselines/reference/submodule/conformance/controlFlowComputedPropertyNames.types
+++ b/testdata/baselines/reference/submodule/conformance/controlFlowComputedPropertyNames.types
@@ -16,11 +16,11 @@ function f1(obj: Record<string, unknown>, key: string) {
 
         obj[key].toUpperCase();
 >obj[key].toUpperCase() : string
->obj[key].toUpperCase : () => string
+>obj[key].toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >obj[key] : string
 >obj : Record<string, unknown>
 >key : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
     }
 }
 
@@ -38,11 +38,11 @@ function f2(obj: Record<string, string | undefined>, key: string) {
 
         obj[key].toUpperCase();
 >obj[key].toUpperCase() : string
->obj[key].toUpperCase : () => string
+>obj[key].toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >obj[key] : string
 >obj : Record<string, string | undefined>
 >key : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
     }
     let key2 = key + key;
 >key2 : string
@@ -59,11 +59,11 @@ function f2(obj: Record<string, string | undefined>, key: string) {
 
         obj[key2].toUpperCase();
 >obj[key2].toUpperCase() : string
->obj[key2].toUpperCase : () => string
+>obj[key2].toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >obj[key2] : string
 >obj : Record<string, string | undefined>
 >key2 : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
     }
     const key3 = key + key;
 >key3 : string
@@ -80,11 +80,11 @@ function f2(obj: Record<string, string | undefined>, key: string) {
 
         obj[key3].toUpperCase();
 >obj[key3].toUpperCase() : string
->obj[key3].toUpperCase : () => string
+>obj[key3].toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >obj[key3] : string
 >obj : Record<string, string | undefined>
 >key3 : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
     }
 }
 
@@ -116,11 +116,11 @@ function f3(obj: Thing, key: keyof Thing) {
 
             obj[key].toUpperCase();
 >obj[key].toUpperCase() : string
->obj[key].toUpperCase : () => string
+>obj[key].toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >obj[key] : string
 >obj : Thing
 >key : keyof Thing
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
         }
         if (typeof obj[key] === "number") {
 >typeof obj[key] === "number" : boolean
@@ -153,11 +153,11 @@ function f4<K extends string>(obj: Record<K, string | undefined>, key: K) {
 
         obj[key].toUpperCase();
 >obj[key].toUpperCase() : string
->obj[key].toUpperCase : () => string
+>obj[key].toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >obj[key] : string
 >obj : Record<K, string | undefined>
 >key : K
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
     }
 }
 

--- a/testdata/baselines/reference/submodule/conformance/controlFlowComputedPropertyNames.types.diff
+++ b/testdata/baselines/reference/submodule/conformance/controlFlowComputedPropertyNames.types.diff
@@ -1,0 +1,85 @@
+--- old.controlFlowComputedPropertyNames.types
++++ new.controlFlowComputedPropertyNames.types
+@@= skipped -15, +15 lines =@@
+
+         obj[key].toUpperCase();
+ >obj[key].toUpperCase() : string
+->obj[key].toUpperCase : () => string
++>obj[key].toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >obj[key] : string
+ >obj : Record<string, unknown>
+ >key : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+     }
+ }
+
+@@= skipped -22, +22 lines =@@
+
+         obj[key].toUpperCase();
+ >obj[key].toUpperCase() : string
+->obj[key].toUpperCase : () => string
++>obj[key].toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >obj[key] : string
+ >obj : Record<string, string | undefined>
+ >key : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+     }
+     let key2 = key + key;
+ >key2 : string
+@@= skipped -21, +21 lines =@@
+
+         obj[key2].toUpperCase();
+ >obj[key2].toUpperCase() : string
+->obj[key2].toUpperCase : () => string
++>obj[key2].toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >obj[key2] : string
+ >obj : Record<string, string | undefined>
+ >key2 : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+     }
+     const key3 = key + key;
+ >key3 : string
+@@= skipped -21, +21 lines =@@
+
+         obj[key3].toUpperCase();
+ >obj[key3].toUpperCase() : string
+->obj[key3].toUpperCase : () => string
++>obj[key3].toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >obj[key3] : string
+ >obj : Record<string, string | undefined>
+ >key3 : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+     }
+ }
+
+@@= skipped -36, +36 lines =@@
+
+             obj[key].toUpperCase();
+ >obj[key].toUpperCase() : string
+->obj[key].toUpperCase : () => string
++>obj[key].toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >obj[key] : string
+ >obj : Thing
+ >key : keyof Thing
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+         }
+         if (typeof obj[key] === "number") {
+ >typeof obj[key] === "number" : boolean
+@@= skipped -37, +37 lines =@@
+
+         obj[key].toUpperCase();
+ >obj[key].toUpperCase() : string
+->obj[key].toUpperCase : () => string
++>obj[key].toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >obj[key] : string
+ >obj : Record<K, string | undefined>
+ >key : K
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+     }
+ }

--- a/testdata/baselines/reference/submodule/conformance/dependentDestructuredVariables.types
+++ b/testdata/baselines/reference/submodule/conformance/dependentDestructuredVariables.types
@@ -35,9 +35,9 @@ function f10({ kind, payload }: Action) {
 
         payload.toUpperCase();
 >payload.toUpperCase() : string
->payload.toUpperCase : () => string
+>payload.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >payload : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
     }
 }
 
@@ -68,9 +68,9 @@ function f11(action: Action) {
 
         payload.toUpperCase();
 >payload.toUpperCase() : string
->payload.toUpperCase : () => string
+>payload.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >payload : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
     }
 }
 
@@ -97,9 +97,9 @@ function f12({ kind, payload }: Action) {
 
             payload.toUpperCase();
 >payload.toUpperCase() : string
->payload.toUpperCase : () => string
+>payload.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >payload : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 
             break;
         default:
@@ -132,9 +132,9 @@ function f13<T extends Action>({ kind, payload }: T) {
 
         payload.toUpperCase();
 >payload.toUpperCase() : string
->payload.toUpperCase : () => string
+>payload.toUpperCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Uppercase<T_1>
 >payload : string
->toUpperCase : () => string
+>toUpperCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Uppercase<T_1>
     }
 }
 
@@ -165,9 +165,9 @@ function f14<T extends Action>(t: T) {
 
         payload.toUpperCase();
 >payload.toUpperCase() : string
->payload.toUpperCase : () => string
+>payload.toUpperCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Uppercase<T_1>
 >payload : string
->toUpperCase : () => string
+>toUpperCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Uppercase<T_1>
     }
 }
 
@@ -208,9 +208,9 @@ function f20({ kind, payload }: Action2) {
 
             payload.toUpperCase();
 >payload.toUpperCase() : string
->payload.toUpperCase : () => string
+>payload.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >payload : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
         }
     }
 }
@@ -245,9 +245,9 @@ function f21(action: Action2) {
 
             payload.toUpperCase();
 >payload.toUpperCase() : string
->payload.toUpperCase : () => string
+>payload.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >payload : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
         }
     }
 }
@@ -284,9 +284,9 @@ function f22(action: Action2) {
 
             payload.toUpperCase();
 >payload.toUpperCase() : string
->payload.toUpperCase : () => string
+>payload.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >payload : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
         }
     }
 }
@@ -317,9 +317,9 @@ function f23({ kind, payload }: Action2) {
 
                 payload.toUpperCase();
 >payload.toUpperCase() : string
->payload.toUpperCase : () => string
+>payload.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >payload : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 
                 break;
             default:
@@ -414,9 +414,9 @@ function f40(...[kind, data]: Args) {
 
         data.toUpperCase();
 >data.toUpperCase() : string
->data.toUpperCase : () => string
+>data.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >data : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
     }
 }
 
@@ -568,9 +568,9 @@ f50((kind, data) => {
 
         data.toUpperCase();
 >data.toUpperCase() : string
->data.toUpperCase : () => string
+>data.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >data : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
     }
 });
 
@@ -599,9 +599,9 @@ const f51: (...args: ['A', number] | ['B', string]) => void = (kind, payload) =>
 
         payload.toUpperCase();
 >payload.toUpperCase() : string
->payload.toUpperCase : () => string
+>payload.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >payload : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
     }
 };
 
@@ -948,9 +948,9 @@ const f60: Func = (kind, payload) => {
 
         payload.toUpperCase();  // error
 >payload.toUpperCase() : string
->payload.toUpperCase : () => string
+>payload.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >payload : string
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
     }
 };
 

--- a/testdata/baselines/reference/submodule/conformance/jsDeclarationsPrivateFields01.types
+++ b/testdata/baselines/reference/submodule/conformance/jsDeclarationsPrivateFields01.types
@@ -25,10 +25,10 @@ export class C {
 
         return this.#hello.toUpperCase();
 >this.#hello.toUpperCase() : string
->this.#hello.toUpperCase : () => string
+>this.#hello.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >this.#hello : string
 >this : this
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
     }
     /** @param value {string} */
     set #screamingHello(value) {

--- a/testdata/baselines/reference/submodule/conformance/jsDeclarationsPrivateFields01.types.diff
+++ b/testdata/baselines/reference/submodule/conformance/jsDeclarationsPrivateFields01.types.diff
@@ -1,0 +1,15 @@
+--- old.jsDeclarationsPrivateFields01.types
++++ new.jsDeclarationsPrivateFields01.types
+@@= skipped -24, +24 lines =@@
+
+         return this.#hello.toUpperCase();
+ >this.#hello.toUpperCase() : string
+->this.#hello.toUpperCase : () => string
++>this.#hello.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >this.#hello : string
+ >this : this
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+     }
+     /** @param value {string} */
+     set #screamingHello(value) {

--- a/testdata/baselines/reference/submodule/conformance/logicalOrExpressionIsNotContextuallyTyped.types
+++ b/testdata/baselines/reference/submodule/conformance/logicalOrExpressionIsNotContextuallyTyped.types
@@ -20,7 +20,7 @@ var r = a || ((a) => a.toLowerCase());
 >(a) => a.toLowerCase() : (a: string) => string
 >a : string
 >a.toLowerCase() : string
->a.toLowerCase : () => string
+>a.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >a : string
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 

--- a/testdata/baselines/reference/submodule/conformance/logicalOrExpressionIsNotContextuallyTyped.types.diff
+++ b/testdata/baselines/reference/submodule/conformance/logicalOrExpressionIsNotContextuallyTyped.types.diff
@@ -1,0 +1,11 @@
+--- old.logicalOrExpressionIsNotContextuallyTyped.types
++++ new.logicalOrExpressionIsNotContextuallyTyped.types
+@@= skipped -19, +19 lines =@@
+ >(a) => a.toLowerCase() : (a: string) => string
+ >a : string
+ >a.toLowerCase() : string
+->a.toLowerCase : () => string
++>a.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >a : string
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>

--- a/testdata/baselines/reference/submodule/conformance/mergedWithLocalValue.types
+++ b/testdata/baselines/reference/submodule/conformance/mergedWithLocalValue.types
@@ -13,8 +13,8 @@ const A: A = "a";
 >"a" : "a"
 
 A.toUpperCase();
->A.toUpperCase() : string
->A.toUpperCase : () => string
+>A.toUpperCase() : "A"
+>A.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >A : "a"
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 

--- a/testdata/baselines/reference/submodule/conformance/mergedWithLocalValue.types.diff
+++ b/testdata/baselines/reference/submodule/conformance/mergedWithLocalValue.types.diff
@@ -1,0 +1,13 @@
+--- old.mergedWithLocalValue.types
++++ new.mergedWithLocalValue.types
+@@= skipped -12, +12 lines =@@
+ >"a" : "a"
+
+ A.toUpperCase();
+->A.toUpperCase() : string
+->A.toUpperCase : () => string
++>A.toUpperCase() : "A"
++>A.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >A : "a"
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>

--- a/testdata/baselines/reference/submodule/conformance/moduleExportDuplicateAlias3.types
+++ b/testdata/baselines/reference/submodule/conformance/moduleExportDuplicateAlias3.types
@@ -53,13 +53,13 @@ exports.apply = 'ok'
 >'ok' : "ok"
 
 var OK = exports.apply.toUpperCase()
->OK : string
->exports.apply.toUpperCase() : string
->exports.apply.toUpperCase : () => string
+>OK : "OK"
+>exports.apply.toUpperCase() : "OK"
+>exports.apply.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >exports.apply : "ok"
 >exports : typeof import("./moduleExportAliasDuplicateAlias")
 >apply : "ok"
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 
 exports.apply = 1
 >exports.apply = 1 : 1

--- a/testdata/baselines/reference/submodule/conformance/moduleExportDuplicateAlias3.types.diff
+++ b/testdata/baselines/reference/submodule/conformance/moduleExportDuplicateAlias3.types.diff
@@ -24,3 +24,21 @@
 
  === moduleExportAliasDuplicateAlias.js ===
  exports.apply = undefined;
+@@= skipped -51, +51 lines =@@
+ >'ok' : "ok"
+
+ var OK = exports.apply.toUpperCase()
+->OK : string
+->exports.apply.toUpperCase() : string
+->exports.apply.toUpperCase : () => string
++>OK : "OK"
++>exports.apply.toUpperCase() : "OK"
++>exports.apply.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >exports.apply : "ok"
+ >exports : typeof import("./moduleExportAliasDuplicateAlias")
+ >apply : "ok"
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+
+ exports.apply = 1
+ >exports.apply = 1 : 1

--- a/testdata/baselines/reference/submodule/conformance/nullishCoalescingOperator9.types
+++ b/testdata/baselines/reference/submodule/conformance/nullishCoalescingOperator9.types
@@ -14,9 +14,9 @@ let g = f || (abc => { void abc.toLowerCase() })
 >abc : string
 >void abc.toLowerCase() : undefined
 >abc.toLowerCase() : string
->abc.toLowerCase : () => string
+>abc.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >abc : string
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 
 let gg = f ?? (abc => { void abc.toLowerCase() })
 >gg : (x: string) => void
@@ -27,7 +27,7 @@ let gg = f ?? (abc => { void abc.toLowerCase() })
 >abc : string
 >void abc.toLowerCase() : undefined
 >abc.toLowerCase() : string
->abc.toLowerCase : () => string
+>abc.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >abc : string
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 

--- a/testdata/baselines/reference/submodule/conformance/nullishCoalescingOperator9.types.diff
+++ b/testdata/baselines/reference/submodule/conformance/nullishCoalescingOperator9.types.diff
@@ -1,0 +1,23 @@
+--- old.nullishCoalescingOperator9.types
++++ new.nullishCoalescingOperator9.types
+@@= skipped -13, +13 lines =@@
+ >abc : string
+ >void abc.toLowerCase() : undefined
+ >abc.toLowerCase() : string
+->abc.toLowerCase : () => string
++>abc.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >abc : string
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+
+ let gg = f ?? (abc => { void abc.toLowerCase() })
+ >gg : (x: string) => void
+@@= skipped -13, +13 lines =@@
+ >abc : string
+ >void abc.toLowerCase() : undefined
+ >abc.toLowerCase() : string
+->abc.toLowerCase : () => string
++>abc.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >abc : string
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>

--- a/testdata/baselines/reference/submodule/conformance/operatorsAndIntersectionTypes.types
+++ b/testdata/baselines/reference/submodule/conformance/operatorsAndIntersectionTypes.types
@@ -68,11 +68,11 @@ const s1 = "{" + guid + "}";
 >"}" : "}"
 
 const s2 = guid.toLowerCase();
->s2 : string
->guid.toLowerCase() : string
->guid.toLowerCase : () => string
+>s2 : Lowercase<`${Guid}`>
+>guid.toLowerCase() : Lowercase<`${Guid}`>
+>guid.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >guid : Guid
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 
 const s3 = guid + guid;
 >s3 : string

--- a/testdata/baselines/reference/submodule/conformance/operatorsAndIntersectionTypes.types.diff
+++ b/testdata/baselines/reference/submodule/conformance/operatorsAndIntersectionTypes.types.diff
@@ -1,0 +1,18 @@
+--- old.operatorsAndIntersectionTypes.types
++++ new.operatorsAndIntersectionTypes.types
+@@= skipped -67, +67 lines =@@
+ >"}" : "}"
+
+ const s2 = guid.toLowerCase();
+->s2 : string
+->guid.toLowerCase() : string
+->guid.toLowerCase : () => string
++>s2 : Lowercase<`${Guid}`>
++>guid.toLowerCase() : Lowercase<`${Guid}`>
++>guid.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >guid : Guid
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+
+ const s3 = guid + guid;
+ >s3 : string

--- a/testdata/baselines/reference/submodule/conformance/stringLiteralTypeIsSubtypeOfString.errors.txt
+++ b/testdata/baselines/reference/submodule/conformance/stringLiteralTypeIsSubtypeOfString.errors.txt
@@ -1,8 +1,12 @@
-stringLiteralTypeIsSubtypeOfString.ts(42,7): error TS2420: Class 'C' incorrectly implements interface 'String'.
-  Type 'C' is missing the following properties from type 'String': codePointAt, includes, endsWith, normalize, and 16 more.
+stringLiteralTypeIsSubtypeOfString.ts(56,5): error TS2416: Property 'toLowerCase' in type 'C' is not assignable to the same property in base type 'String'.
+  Type '() => string' is not assignable to type '<T extends string>(this: T) => string extends T ? string : Lowercase<T>'.
+    Type 'string' is not assignable to type 'string extends T ? string : Lowercase<T>'.
+stringLiteralTypeIsSubtypeOfString.ts(58,5): error TS2416: Property 'toUpperCase' in type 'C' is not assignable to the same property in base type 'String'.
+  Type '() => string' is not assignable to type '<T extends string>(this: T) => string extends T ? string : Uppercase<T>'.
+    Type 'string' is not assignable to type 'string extends T ? string : Uppercase<T>'.
 
 
-==== stringLiteralTypeIsSubtypeOfString.ts (1 errors) ====
+==== stringLiteralTypeIsSubtypeOfString.ts (2 errors) ====
     // string literal types are subtypes of string, any
     
     // ok
@@ -45,9 +49,6 @@ stringLiteralTypeIsSubtypeOfString.ts(42,7): error TS2420: Class 'C' incorrectly
     function f9(x: any) { }
     
     class C implements String {
-          ~
-!!! error TS2420: Class 'C' incorrectly implements interface 'String'.
-!!! error TS2420:   Type 'C' is missing the following properties from type 'String': codePointAt, includes, endsWith, normalize, and 16 more.
         toString(): string { return null; }
         charAt(pos: number): string { return null; }
         charCodeAt(index: number): number { return null; }
@@ -62,8 +63,16 @@ stringLiteralTypeIsSubtypeOfString.ts(42,7): error TS2420: Class 'C' incorrectly
         split(separator: any, limit?: number): string[] { return null; }
         substring(start: number, end?: number): string { return null; }
         toLowerCase(): string { return null; }
+        ~~~~~~~~~~~
+!!! error TS2416: Property 'toLowerCase' in type 'C' is not assignable to the same property in base type 'String'.
+!!! error TS2416:   Type '() => string' is not assignable to type '<T extends string>(this: T) => string extends T ? string : Lowercase<T>'.
+!!! error TS2416:     Type 'string' is not assignable to type 'string extends T ? string : Lowercase<T>'.
         toLocaleLowerCase(): string { return null; }
         toUpperCase(): string { return null; }
+        ~~~~~~~~~~~
+!!! error TS2416: Property 'toUpperCase' in type 'C' is not assignable to the same property in base type 'String'.
+!!! error TS2416:   Type '() => string' is not assignable to type '<T extends string>(this: T) => string extends T ? string : Uppercase<T>'.
+!!! error TS2416:     Type 'string' is not assignable to type 'string extends T ? string : Uppercase<T>'.
         toLocaleUpperCase(): string { return null; }
         trim(): string { return null; }
         length: number;

--- a/testdata/baselines/reference/submodule/conformance/stringLiteralTypeIsSubtypeOfString.errors.txt.diff
+++ b/testdata/baselines/reference/submodule/conformance/stringLiteralTypeIsSubtypeOfString.errors.txt.diff
@@ -1,0 +1,47 @@
+--- old.stringLiteralTypeIsSubtypeOfString.errors.txt
++++ new.stringLiteralTypeIsSubtypeOfString.errors.txt
+@@= skipped -0, +0 lines =@@
+-stringLiteralTypeIsSubtypeOfString.ts(42,7): error TS2420: Class 'C' incorrectly implements interface 'String'.
+-  Type 'C' is missing the following properties from type 'String': codePointAt, includes, endsWith, normalize, and 16 more.
+-
+-
+-==== stringLiteralTypeIsSubtypeOfString.ts (1 errors) ====
++stringLiteralTypeIsSubtypeOfString.ts(56,5): error TS2416: Property 'toLowerCase' in type 'C' is not assignable to the same property in base type 'String'.
++  Type '() => string' is not assignable to type '<T extends string>(this: T) => string extends T ? string : Lowercase<T>'.
++    Type 'string' is not assignable to type 'string extends T ? string : Lowercase<T>'.
++stringLiteralTypeIsSubtypeOfString.ts(58,5): error TS2416: Property 'toUpperCase' in type 'C' is not assignable to the same property in base type 'String'.
++  Type '() => string' is not assignable to type '<T extends string>(this: T) => string extends T ? string : Uppercase<T>'.
++    Type 'string' is not assignable to type 'string extends T ? string : Uppercase<T>'.
++
++
++==== stringLiteralTypeIsSubtypeOfString.ts (2 errors) ====
+     // string literal types are subtypes of string, any
+     
+     // ok
+@@= skipped -44, +48 lines =@@
+     function f9(x: any) { }
+     
+     class C implements String {
+-          ~
+-!!! error TS2420: Class 'C' incorrectly implements interface 'String'.
+-!!! error TS2420:   Type 'C' is missing the following properties from type 'String': codePointAt, includes, endsWith, normalize, and 16 more.
+         toString(): string { return null; }
+         charAt(pos: number): string { return null; }
+         charCodeAt(index: number): number { return null; }
+@@= skipped -17, +14 lines =@@
+         split(separator: any, limit?: number): string[] { return null; }
+         substring(start: number, end?: number): string { return null; }
+         toLowerCase(): string { return null; }
++        ~~~~~~~~~~~
++!!! error TS2416: Property 'toLowerCase' in type 'C' is not assignable to the same property in base type 'String'.
++!!! error TS2416:   Type '() => string' is not assignable to type '<T extends string>(this: T) => string extends T ? string : Lowercase<T>'.
++!!! error TS2416:     Type 'string' is not assignable to type 'string extends T ? string : Lowercase<T>'.
+         toLocaleLowerCase(): string { return null; }
+         toUpperCase(): string { return null; }
++        ~~~~~~~~~~~
++!!! error TS2416: Property 'toUpperCase' in type 'C' is not assignable to the same property in base type 'String'.
++!!! error TS2416:   Type '() => string' is not assignable to type '<T extends string>(this: T) => string extends T ? string : Uppercase<T>'.
++!!! error TS2416:     Type 'string' is not assignable to type 'string extends T ? string : Uppercase<T>'.
+         toLocaleUpperCase(): string { return null; }
+         trim(): string { return null; }
+         length: number;

--- a/testdata/baselines/reference/submodule/conformance/switchWithConstrainedTypeVariable.types
+++ b/testdata/baselines/reference/submodule/conformance/switchWithConstrainedTypeVariable.types
@@ -14,18 +14,18 @@ function function1<T extends 'a' | 'b'>(key: T) {
 >'a' : "a"
 
       key.toLowerCase();
->key.toLowerCase() : string
->key.toLowerCase : () => string
+>key.toLowerCase() : "a"
+>key.toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
 >key : "a"
->toLowerCase : () => string
+>toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
 
       break;
     default:
       key.toLowerCase();
->key.toLowerCase() : string
->key.toLowerCase : () => string
+>key.toLowerCase() : "b"
+>key.toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
 >key : "b"
->toLowerCase : () => string
+>toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
 
       break;
   }

--- a/testdata/baselines/reference/submodule/conformance/typeAliases.types
+++ b/testdata/baselines/reference/submodule/conformance/typeAliases.types
@@ -176,13 +176,13 @@ declare function f15(a: Meters): string;
 
 f15(E.x).toLowerCase();
 >f15(E.x).toLowerCase() : string
->f15(E.x).toLowerCase : () => string
+>f15(E.x).toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >f15(E.x) : string
 >f15 : { (a: string): boolean; (a: Meters): string; }
 >E.x : E
 >E : typeof E
 >x : E
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 
 type StringAndBoolean = [string, boolean]
 >StringAndBoolean : StringAndBoolean
@@ -207,9 +207,9 @@ var y: StringAndBoolean = ["1", false];
 
 y[0].toLowerCase();
 >y[0].toLowerCase() : string
->y[0].toLowerCase : () => string
+>y[0].toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >y[0] : string
 >y : StringAndBoolean
 >0 : 0
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 

--- a/testdata/baselines/reference/submodule/conformance/typeAliases.types.diff
+++ b/testdata/baselines/reference/submodule/conformance/typeAliases.types.diff
@@ -1,0 +1,29 @@
+--- old.typeAliases.types
++++ new.typeAliases.types
+@@= skipped -175, +175 lines =@@
+
+ f15(E.x).toLowerCase();
+ >f15(E.x).toLowerCase() : string
+->f15(E.x).toLowerCase : () => string
++>f15(E.x).toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >f15(E.x) : string
+ >f15 : { (a: string): boolean; (a: Meters): string; }
+ >E.x : E
+ >E : typeof E
+ >x : E
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+
+ type StringAndBoolean = [string, boolean]
+ >StringAndBoolean : StringAndBoolean
+@@= skipped -31, +31 lines =@@
+
+ y[0].toLowerCase();
+ >y[0].toLowerCase() : string
+->y[0].toLowerCase : () => string
++>y[0].toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >y[0] : string
+ >y : StringAndBoolean
+ >0 : 0
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>

--- a/testdata/baselines/reference/submodule/conformance/typeGuardsOnClassProperty.types
+++ b/testdata/baselines/reference/submodule/conformance/typeGuardsOnClassProperty.types
@@ -89,11 +89,11 @@ if (typeof o.prop1 === "string" && o.prop1.toLowerCase()) {}
 >prop1 : string | number
 >"string" : "string"
 >o.prop1.toLowerCase() : string
->o.prop1.toLowerCase : () => string
+>o.prop1.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 >o.prop1 : string
 >o : { prop1: number | string; prop2: boolean | string; }
 >prop1 : string
->toLowerCase : () => string
+>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
 
 var prop1 = o.prop1;
 >prop1 : string | number

--- a/testdata/baselines/reference/submodule/conformance/typeGuardsOnClassProperty.types.diff
+++ b/testdata/baselines/reference/submodule/conformance/typeGuardsOnClassProperty.types.diff
@@ -1,0 +1,16 @@
+--- old.typeGuardsOnClassProperty.types
++++ new.typeGuardsOnClassProperty.types
+@@= skipped -88, +88 lines =@@
+ >prop1 : string | number
+ >"string" : "string"
+ >o.prop1.toLowerCase() : string
+->o.prop1.toLowerCase : () => string
++>o.prop1.toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+ >o.prop1 : string
+ >o : { prop1: number | string; prop2: boolean | string; }
+ >prop1 : string
+->toLowerCase : () => string
++>toLowerCase : <T extends string>(this: T) => string extends T ? string : Lowercase<T>
+
+ var prop1 = o.prop1;
+ >prop1 : string | number

--- a/testdata/baselines/reference/submodule/conformance/unionAndIntersectionInference1.types
+++ b/testdata/baselines/reference/submodule/conformance/unionAndIntersectionInference1.types
@@ -136,11 +136,11 @@ let foo: Maybe<string>;
 
 get(foo).toUpperCase(); // Ok
 >get(foo).toUpperCase() : string
->get(foo).toUpperCase : () => string
+>get(foo).toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 >get(foo) : string
 >get : <U>(x: U | void) => U
 >foo : Maybe<string>
->toUpperCase : () => string
+>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
 
 // Repro from #5456
 

--- a/testdata/baselines/reference/submodule/conformance/unionAndIntersectionInference1.types.diff
+++ b/testdata/baselines/reference/submodule/conformance/unionAndIntersectionInference1.types.diff
@@ -1,0 +1,15 @@
+--- old.unionAndIntersectionInference1.types
++++ new.unionAndIntersectionInference1.types
+@@= skipped -135, +135 lines =@@
+
+ get(foo).toUpperCase(); // Ok
+ >get(foo).toUpperCase() : string
+->get(foo).toUpperCase : () => string
++>get(foo).toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >get(foo) : string
+ >get : <U>(x: U | void) => U
+ >foo : Maybe<string>
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+
+ // Repro from #5456

--- a/testdata/baselines/reference/submoduleAccepted/conformance/dependentDestructuredVariables.types.diff
+++ b/testdata/baselines/reference/submoduleAccepted/conformance/dependentDestructuredVariables.types.diff
@@ -1,6 +1,135 @@
 --- old.dependentDestructuredVariables.types
 +++ new.dependentDestructuredVariables.types
-@@= skipped -574, +574 lines =@@
+@@= skipped -34, +34 lines =@@
+
+         payload.toUpperCase();
+ >payload.toUpperCase() : string
+->payload.toUpperCase : () => string
++>payload.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >payload : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+     }
+ }
+
+@@= skipped -33, +33 lines =@@
+
+         payload.toUpperCase();
+ >payload.toUpperCase() : string
+->payload.toUpperCase : () => string
++>payload.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >payload : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+     }
+ }
+
+@@= skipped -29, +29 lines =@@
+
+             payload.toUpperCase();
+ >payload.toUpperCase() : string
+->payload.toUpperCase : () => string
++>payload.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >payload : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+
+             break;
+         default:
+@@= skipped -35, +35 lines =@@
+
+         payload.toUpperCase();
+ >payload.toUpperCase() : string
+->payload.toUpperCase : () => string
++>payload.toUpperCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Uppercase<T_1>
+ >payload : string
+->toUpperCase : () => string
++>toUpperCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Uppercase<T_1>
+     }
+ }
+
+@@= skipped -33, +33 lines =@@
+
+         payload.toUpperCase();
+ >payload.toUpperCase() : string
+->payload.toUpperCase : () => string
++>payload.toUpperCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Uppercase<T_1>
+ >payload : string
+->toUpperCase : () => string
++>toUpperCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Uppercase<T_1>
+     }
+ }
+
+@@= skipped -43, +43 lines =@@
+
+             payload.toUpperCase();
+ >payload.toUpperCase() : string
+->payload.toUpperCase : () => string
++>payload.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >payload : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+         }
+     }
+ }
+@@= skipped -37, +37 lines =@@
+
+             payload.toUpperCase();
+ >payload.toUpperCase() : string
+->payload.toUpperCase : () => string
++>payload.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >payload : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+         }
+     }
+ }
+@@= skipped -39, +39 lines =@@
+
+             payload.toUpperCase();
+ >payload.toUpperCase() : string
+->payload.toUpperCase : () => string
++>payload.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >payload : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+         }
+     }
+ }
+@@= skipped -33, +33 lines =@@
+
+                 payload.toUpperCase();
+ >payload.toUpperCase() : string
+->payload.toUpperCase : () => string
++>payload.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >payload : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+
+                 break;
+             default:
+@@= skipped -97, +97 lines =@@
+
+         data.toUpperCase();
+ >data.toUpperCase() : string
+->data.toUpperCase : () => string
++>data.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >data : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+     }
+ }
+
+@@= skipped -154, +154 lines =@@
+
+         data.toUpperCase();
+ >data.toUpperCase() : string
+->data.toUpperCase : () => string
++>data.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >data : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+     }
  });
 
  const f51: (...args: ['A', number] | ['B', string]) => void = (kind, payload) => {
@@ -10,6 +139,15 @@
  >(kind, payload) => {    if (kind === 'A') {        payload.toFixed();    }    if (kind === 'B') {        payload.toUpperCase();    }} : (kind: "A" | "B", payload: string | number) => void
  >kind : "A" | "B"
 @@= skipped -31, +31 lines =@@
+
+         payload.toUpperCase();
+ >payload.toUpperCase() : string
+->payload.toUpperCase : () => string
++>payload.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >payload : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+     }
  };
 
  const f52: (...args: ['A', number] | ['B']) => void = (kind, payload?) => {
@@ -18,3 +156,14 @@
  >args : ["B"] | ["A", number]
  >(kind, payload?) => {    if (kind === 'A') {        payload.toFixed();    }    else {        payload;  // undefined    }} : (kind: "A" | "B", payload?: number | undefined) => void
  >kind : "A" | "B"
+@@= skipped -349, +349 lines =@@
+
+         payload.toUpperCase();  // error
+ >payload.toUpperCase() : string
+->payload.toUpperCase : () => string
++>payload.toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+ >payload : string
+->toUpperCase : () => string
++>toUpperCase : <T extends string>(this: T) => string extends T ? string : Uppercase<T>
+     }
+ };

--- a/testdata/baselines/reference/submoduleAccepted/conformance/switchWithConstrainedTypeVariable.types.diff
+++ b/testdata/baselines/reference/submoduleAccepted/conformance/switchWithConstrainedTypeVariable.types.diff
@@ -9,3 +9,28 @@
  >key : T
 
    switch (key) {
+@@= skipped -10, +10 lines =@@
+ >'a' : "a"
+
+       key.toLowerCase();
+->key.toLowerCase() : string
+->key.toLowerCase : () => string
++>key.toLowerCase() : "a"
++>key.toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
+ >key : "a"
+->toLowerCase : () => string
++>toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
+
+       break;
+     default:
+       key.toLowerCase();
+->key.toLowerCase() : string
+->key.toLowerCase : () => string
++>key.toLowerCase() : "b"
++>key.toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
+ >key : "b"
+->toLowerCase : () => string
++>toLowerCase : <T_1 extends string>(this: T_1) => string extends T_1 ? string : Lowercase<T_1>
+
+       break;
+   }


### PR DESCRIPTION
Make String.prototype.toLowerCase and toUpperCase preserve string-literal types in their return type, by typing them as `<T extends string>(this: T): Lowercase<T>` and `Uppercase<T>` respectively.

For non-literal `string` receivers, `Lowercase<string>` resolves to `string`, preserving existing behavior. For literal receivers (e.g. `"FOO".toLowerCase()`), the result narrows to the corresponding literal (`"foo"`).