### PR TITLE
Fix keyof deferred for non-generic substitution types (#2186)

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -26237,9 +26237,16 @@ func (c *Checker) getIndexType(t *Type) *Type {
 
 func (c *Checker) getIndexTypeEx(t *Type, indexFlags IndexFlags) *Type {
 	t = c.getReducedType(t)
-	switch {
-	case c.isNoInferType(t):
+	if c.isNoInferType(t) {
 		return c.getNoInferType(c.getIndexTypeEx(t.AsSubstitutionType().baseType, indexFlags))
+	}
+	if t.flags&TypeFlagsSubstitution != 0 {
+		st := t.AsSubstitutionType()
+		if !c.isGenericType(st.baseType) && !c.isGenericType(st.constraint) {
+			return c.getUnionType([]*Type{c.getIndexTypeEx(st.baseType, indexFlags), c.getIndexTypeEx(st.constraint, indexFlags)})
+		}
+	}
+	switch {
 	case c.shouldDeferIndexType(t, indexFlags):
 		return c.getIndexTypeForGenericType(t, indexFlags)
 	case t.flags&TypeFlagsUnion != 0:

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -26240,11 +26240,9 @@ func (c *Checker) getIndexTypeEx(t *Type, indexFlags IndexFlags) *Type {
 	if c.isNoInferType(t) {
 		return c.getNoInferType(c.getIndexTypeEx(t.AsSubstitutionType().baseType, indexFlags))
 	}
-	if t.flags&TypeFlagsSubstitution != 0 {
+	if t.flags&TypeFlagsSubstitution != 0 && !c.isGenericType(t) {
 		st := t.AsSubstitutionType()
-		if !c.isGenericType(st.baseType) && !c.isGenericType(st.constraint) {
-			return c.getUnionType([]*Type{c.getIndexTypeEx(st.baseType, indexFlags), c.getIndexTypeEx(st.constraint, indexFlags)})
-		}
+		return c.getUnionType([]*Type{c.getIndexTypeEx(st.baseType, indexFlags), c.getIndexTypeEx(st.constraint, indexFlags)})
 	}
 	switch {
 	case c.shouldDeferIndexType(t, indexFlags):

--- a/testdata/baselines/reference/compiler/substitutionTypeNonGenericIndexType1.symbols
+++ b/testdata/baselines/reference/compiler/substitutionTypeNonGenericIndexType1.symbols
@@ -1,0 +1,35 @@
+//// [tests/cases/compiler/substitutionTypeNonGenericIndexType1.ts] ////
+
+=== substitutionTypeNonGenericIndexType1.ts ===
+// https://github.com/microsoft/TypeScript/issues/61728
+
+type BasicConditional<T> = keyof T extends any
+>BasicConditional : Symbol(BasicConditional, Decl(substitutionTypeNonGenericIndexType1.ts, 0, 0))
+>T : Symbol(T, Decl(substitutionTypeNonGenericIndexType1.ts, 2, 22))
+>T : Symbol(T, Decl(substitutionTypeNonGenericIndexType1.ts, 2, 22))
+
+  ? true
+  : false;
+
+type Config = { rejectClose: true };
+>Config : Symbol(Config, Decl(substitutionTypeNonGenericIndexType1.ts, 4, 10))
+>rejectClose : Symbol(rejectClose, Decl(substitutionTypeNonGenericIndexType1.ts, 6, 15))
+
+type Test =
+>Test : Symbol(Test, Decl(substitutionTypeNonGenericIndexType1.ts, 6, 36))
+
+  Config extends {}
+>Config : Symbol(Config, Decl(substitutionTypeNonGenericIndexType1.ts, 4, 10))
+
+    ? {
+        rejectClose: BasicConditional<Config>;
+>rejectClose : Symbol(rejectClose, Decl(substitutionTypeNonGenericIndexType1.ts, 9, 7))
+>BasicConditional : Symbol(BasicConditional, Decl(substitutionTypeNonGenericIndexType1.ts, 0, 0))
+>Config : Symbol(Config, Decl(substitutionTypeNonGenericIndexType1.ts, 4, 10))
+      }
+    : never;
+
+type RejectClose = Test["rejectClose"];
+>RejectClose : Symbol(RejectClose, Decl(substitutionTypeNonGenericIndexType1.ts, 12, 12))
+>Test : Symbol(Test, Decl(substitutionTypeNonGenericIndexType1.ts, 6, 36))
+

--- a/testdata/baselines/reference/compiler/substitutionTypeNonGenericIndexType1.types
+++ b/testdata/baselines/reference/compiler/substitutionTypeNonGenericIndexType1.types
@@ -1,0 +1,32 @@
+//// [tests/cases/compiler/substitutionTypeNonGenericIndexType1.ts] ////
+
+=== substitutionTypeNonGenericIndexType1.ts ===
+// https://github.com/microsoft/TypeScript/issues/61728
+
+type BasicConditional<T> = keyof T extends any
+>BasicConditional : BasicConditional<T>
+
+  ? true
+>true : true
+
+  : false;
+>false : false
+
+type Config = { rejectClose: true };
+>Config : Config
+>rejectClose : true
+>true : true
+
+type Test =
+>Test : { rejectClose: BasicConditional<Config>; }
+
+  Config extends {}
+    ? {
+        rejectClose: BasicConditional<Config>;
+>rejectClose : true
+      }
+    : never;
+
+type RejectClose = Test["rejectClose"];
+>RejectClose : true
+

--- a/testdata/baselines/reference/compiler/substitutionTypeNonGenericIndexType2.symbols
+++ b/testdata/baselines/reference/compiler/substitutionTypeNonGenericIndexType2.symbols
@@ -1,0 +1,30 @@
+//// [tests/cases/compiler/substitutionTypeNonGenericIndexType2.ts] ////
+
+=== substitutionTypeNonGenericIndexType2.ts ===
+type BasicConditional<T> = keyof T extends infer R ? R : never;
+>BasicConditional : Symbol(BasicConditional, Decl(substitutionTypeNonGenericIndexType2.ts, 0, 0))
+>T : Symbol(T, Decl(substitutionTypeNonGenericIndexType2.ts, 0, 22))
+>T : Symbol(T, Decl(substitutionTypeNonGenericIndexType2.ts, 0, 22))
+>R : Symbol(R, Decl(substitutionTypeNonGenericIndexType2.ts, 0, 48))
+>R : Symbol(R, Decl(substitutionTypeNonGenericIndexType2.ts, 0, 48))
+
+type Config = { rejectClose: true };
+>Config : Symbol(Config, Decl(substitutionTypeNonGenericIndexType2.ts, 0, 63))
+>rejectClose : Symbol(rejectClose, Decl(substitutionTypeNonGenericIndexType2.ts, 2, 15))
+
+type Test = Config extends {}
+>Test : Symbol(Test, Decl(substitutionTypeNonGenericIndexType2.ts, 2, 36))
+>Config : Symbol(Config, Decl(substitutionTypeNonGenericIndexType2.ts, 0, 63))
+
+  ? {
+      rejectClose: BasicConditional<Config>;
+>rejectClose : Symbol(rejectClose, Decl(substitutionTypeNonGenericIndexType2.ts, 5, 5))
+>BasicConditional : Symbol(BasicConditional, Decl(substitutionTypeNonGenericIndexType2.ts, 0, 0))
+>Config : Symbol(Config, Decl(substitutionTypeNonGenericIndexType2.ts, 0, 63))
+    }
+  : never;
+
+const test: Test["rejectClose"] = "rejectClose";
+>test : Symbol(test, Decl(substitutionTypeNonGenericIndexType2.ts, 10, 5))
+>Test : Symbol(Test, Decl(substitutionTypeNonGenericIndexType2.ts, 2, 36))
+

--- a/testdata/baselines/reference/compiler/substitutionTypeNonGenericIndexType2.types
+++ b/testdata/baselines/reference/compiler/substitutionTypeNonGenericIndexType2.types
@@ -1,0 +1,24 @@
+//// [tests/cases/compiler/substitutionTypeNonGenericIndexType2.ts] ////
+
+=== substitutionTypeNonGenericIndexType2.ts ===
+type BasicConditional<T> = keyof T extends infer R ? R : never;
+>BasicConditional : BasicConditional<T>
+
+type Config = { rejectClose: true };
+>Config : Config
+>rejectClose : true
+>true : true
+
+type Test = Config extends {}
+>Test : { rejectClose: BasicConditional<Config>; }
+
+  ? {
+      rejectClose: BasicConditional<Config>;
+>rejectClose : "rejectClose"
+    }
+  : never;
+
+const test: Test["rejectClose"] = "rejectClose";
+>test : "rejectClose"
+>"rejectClose" : "rejectClose"
+

--- a/testdata/tests/cases/compiler/substitutionTypeNonGenericIndexType1.ts
+++ b/testdata/tests/cases/compiler/substitutionTypeNonGenericIndexType1.ts
@@ -1,0 +1,18 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/61728
+
+type BasicConditional<T> = keyof T extends any
+  ? true
+  : false;
+
+type Config = { rejectClose: true };
+type Test =
+  Config extends {}
+    ? {
+        rejectClose: BasicConditional<Config>;
+      }
+    : never;
+
+type RejectClose = Test["rejectClose"];

--- a/testdata/tests/cases/compiler/substitutionTypeNonGenericIndexType2.ts
+++ b/testdata/tests/cases/compiler/substitutionTypeNonGenericIndexType2.ts
@@ -1,0 +1,14 @@
+// @strict: true
+// @noEmit: true
+
+type BasicConditional<T> = keyof T extends infer R ? R : never;
+
+type Config = { rejectClose: true };
+
+type Test = Config extends {}
+  ? {
+      rejectClose: BasicConditional<Config>;
+    }
+  : never;
+
+const test: Test["rejectClose"] = "rejectClose";


### PR DESCRIPTION
## Summary
`getIndexTypeEx` was deferring `keyof` for substitution types when `shouldDeferIndexType` applied. For substitution types whose `baseType` and `constraint` are both non-generic, that deferral is incorrect, it breaks assignability for indexed access types like `Test["rejectClose"]` and leaves quick info unsimplified.

This change resolves `keyof` immediately for non-generic substitution types by returning the union of `getIndexTypeEx` on the substitution's `baseType` and `constraint`.

This matches the behavior from microsoft/TypeScript#61999 for microsoft/TypeScript#61728. `NoInfer` substitution types are still handled first, unchanged.

## Tests
- Added local compiler cases `substitutionTypeNonGenericIndexType1.ts` and `substitutionTypeNonGenericIndexType2.ts` under `testdata/tests/cases/compiler/` with committed `.symbols` and `.types` baselines.
- Ran: `go test ./internal/testrunner/ -run "TestLocal/substitutionTypeNonGenericIndexType" -count=1`
 
## Notes
I noticed #2186 is currently in the Post-7.0 milestone. I am submitting this as a checker bug fix / parity change with upstream TypeScript behavior rather than a new feature, but I am happy to defer or retarget if you prefer to keep this for after 7.0.