### PR TITLE
Don't hold snapshotUpdateMu while running GC()

### DIFF
--- a/internal/project/session.go
+++ b/internal/project/session.go
@@ -453,6 +453,8 @@ func (s *Session) scheduleIdleCacheClean() {
 		s.idleCacheCleanMu.Unlock()
 
 		s.snapshotUpdateMu.Lock()
+		defer s.snapshotUpdateMu.Unlock()
+
 		ctx := s.backgroundCtx
 		fileChanges, overlays, ataChanges, newConfig := s.flushChanges(ctx)
 		s.UpdateSnapshot(ctx, overlays, SnapshotChange{
@@ -462,9 +464,8 @@ func (s *Session) scheduleIdleCacheClean() {
 			newConfig:      newConfig,
 			cleanDiskCache: true,
 		})
-		s.snapshotUpdateMu.Unlock()
 
-		runtime.GC()
+		go func() { runtime.GC() }()
 	})
 }
 

--- a/internal/project/session.go
+++ b/internal/project/session.go
@@ -453,8 +453,6 @@ func (s *Session) scheduleIdleCacheClean() {
 		s.idleCacheCleanMu.Unlock()
 
 		s.snapshotUpdateMu.Lock()
-		defer s.snapshotUpdateMu.Unlock()
-
 		ctx := s.backgroundCtx
 		fileChanges, overlays, ataChanges, newConfig := s.flushChanges(ctx)
 		s.UpdateSnapshot(ctx, overlays, SnapshotChange{
@@ -464,6 +462,7 @@ func (s *Session) scheduleIdleCacheClean() {
 			newConfig:      newConfig,
 			cleanDiskCache: true,
 		})
+		s.snapshotUpdateMu.Unlock()
 
 		runtime.GC()
 	})


### PR DESCRIPTION
Noticed this while trying to figure out a possible cause for #2857, but I think this is unlikely to make anything look “stuck”; more just a little slow.