### PR TITLE
Fix crash for destructuring under `noUncheckedIndexedAccess` + `noLib`.

### DIFF
--- a/internal/checker/flow.go
+++ b/internal/checker/flow.go
@@ -2314,6 +2314,9 @@ func (c *Checker) getTypeOfDestructuredArrayElement(t *Type, index int) *Type {
 }
 
 func (c *Checker) includeUndefinedInIndexSignature(t *Type) *Type {
+	if t == nil {
+		return nil
+	}
 	if c.compilerOptions.NoUncheckedIndexedAccess == core.TSTrue {
 		return c.getUnionType([]*Type{t, c.missingType})
 	}

--- a/testdata/baselines/reference/compiler/noLibAndNoUncheckedIndexedAccessDestructuringArray.errors.txt
+++ b/testdata/baselines/reference/compiler/noLibAndNoUncheckedIndexedAccessDestructuringArray.errors.txt
@@ -1,0 +1,29 @@
+error TS2318: Cannot find global type 'Array'.
+error TS2318: Cannot find global type 'Boolean'.
+error TS2318: Cannot find global type 'CallableFunction'.
+error TS2318: Cannot find global type 'Function'.
+error TS2318: Cannot find global type 'IArguments'.
+error TS2318: Cannot find global type 'NewableFunction'.
+error TS2318: Cannot find global type 'Number'.
+error TS2318: Cannot find global type 'Object'.
+error TS2318: Cannot find global type 'RegExp'.
+error TS2318: Cannot find global type 'String'.
+noLibAndNoUncheckedIndexedAccessDestructuringArray.ts(2,6): error TS2339: Property '0' does not exist on type '{}'.
+
+
+!!! error TS2318: Cannot find global type 'Array'.
+!!! error TS2318: Cannot find global type 'Boolean'.
+!!! error TS2318: Cannot find global type 'CallableFunction'.
+!!! error TS2318: Cannot find global type 'Function'.
+!!! error TS2318: Cannot find global type 'IArguments'.
+!!! error TS2318: Cannot find global type 'NewableFunction'.
+!!! error TS2318: Cannot find global type 'Number'.
+!!! error TS2318: Cannot find global type 'Object'.
+!!! error TS2318: Cannot find global type 'RegExp'.
+!!! error TS2318: Cannot find global type 'String'.
+==== noLibAndNoUncheckedIndexedAccessDestructuringArray.ts (1 errors) ====
+    declare var x: string[];
+    var [a] = x;
+         ~
+!!! error TS2339: Property '0' does not exist on type '{}'.
+    

--- a/testdata/baselines/reference/compiler/noLibAndNoUncheckedIndexedAccessDestructuringArray.errors.txt
+++ b/testdata/baselines/reference/compiler/noLibAndNoUncheckedIndexedAccessDestructuringArray.errors.txt
@@ -1,29 +1,21 @@
-error TS2318: Cannot find global type 'Array'.
-error TS2318: Cannot find global type 'Boolean'.
-error TS2318: Cannot find global type 'CallableFunction'.
-error TS2318: Cannot find global type 'Function'.
-error TS2318: Cannot find global type 'IArguments'.
-error TS2318: Cannot find global type 'NewableFunction'.
-error TS2318: Cannot find global type 'Number'.
-error TS2318: Cannot find global type 'Object'.
-error TS2318: Cannot find global type 'RegExp'.
-error TS2318: Cannot find global type 'String'.
-noLibAndNoUncheckedIndexedAccessDestructuringArray.ts(2,6): error TS2339: Property '0' does not exist on type '{}'.
+input.ts(2,6): error TS2339: Property '0' does not exist on type 'string[]'.
 
 
-!!! error TS2318: Cannot find global type 'Array'.
-!!! error TS2318: Cannot find global type 'Boolean'.
-!!! error TS2318: Cannot find global type 'CallableFunction'.
-!!! error TS2318: Cannot find global type 'Function'.
-!!! error TS2318: Cannot find global type 'IArguments'.
-!!! error TS2318: Cannot find global type 'NewableFunction'.
-!!! error TS2318: Cannot find global type 'Number'.
-!!! error TS2318: Cannot find global type 'Object'.
-!!! error TS2318: Cannot find global type 'RegExp'.
-!!! error TS2318: Cannot find global type 'String'.
-==== noLibAndNoUncheckedIndexedAccessDestructuringArray.ts (1 errors) ====
+==== globals.ts (0 errors) ====
+    interface Array<T> {}
+    interface Boolean {}
+    interface Function {}
+    interface CallableFunction {}
+    interface NewableFunction {}
+    interface IArguments {}
+    interface Number {}
+    interface Object {}
+    interface RegExp {}
+    interface String {}
+    
+==== input.ts (1 errors) ====
     declare var x: string[];
     var [a] = x;
          ~
-!!! error TS2339: Property '0' does not exist on type '{}'.
+!!! error TS2339: Property '0' does not exist on type 'string[]'.
     

--- a/testdata/baselines/reference/compiler/noLibAndNoUncheckedIndexedAccessDestructuringArray.js
+++ b/testdata/baselines/reference/compiler/noLibAndNoUncheckedIndexedAccessDestructuringArray.js
@@ -1,10 +1,24 @@
 //// [tests/cases/compiler/noLibAndNoUncheckedIndexedAccessDestructuringArray.ts] ////
 
-//// [noLibAndNoUncheckedIndexedAccessDestructuringArray.ts]
+//// [globals.ts]
+interface Array<T> {}
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number {}
+interface Object {}
+interface RegExp {}
+interface String {}
+
+//// [input.ts]
 declare var x: string[];
 var [a] = x;
 
 
-//// [noLibAndNoUncheckedIndexedAccessDestructuringArray.js]
+//// [globals.js]
+"use strict";
+//// [input.js]
 "use strict";
 var [a] = x;

--- a/testdata/baselines/reference/compiler/noLibAndNoUncheckedIndexedAccessDestructuringArray.js
+++ b/testdata/baselines/reference/compiler/noLibAndNoUncheckedIndexedAccessDestructuringArray.js
@@ -1,0 +1,10 @@
+//// [tests/cases/compiler/noLibAndNoUncheckedIndexedAccessDestructuringArray.ts] ////
+
+//// [noLibAndNoUncheckedIndexedAccessDestructuringArray.ts]
+declare var x: string[];
+var [a] = x;
+
+
+//// [noLibAndNoUncheckedIndexedAccessDestructuringArray.js]
+"use strict";
+var [a] = x;

--- a/testdata/baselines/reference/compiler/noLibAndNoUncheckedIndexedAccessDestructuringArray.symbols
+++ b/testdata/baselines/reference/compiler/noLibAndNoUncheckedIndexedAccessDestructuringArray.symbols
@@ -1,0 +1,10 @@
+//// [tests/cases/compiler/noLibAndNoUncheckedIndexedAccessDestructuringArray.ts] ////
+
+=== noLibAndNoUncheckedIndexedAccessDestructuringArray.ts ===
+declare var x: string[];
+>x : Symbol(x, Decl(noLibAndNoUncheckedIndexedAccessDestructuringArray.ts, 0, 11))
+
+var [a] = x;
+>a : Symbol(a, Decl(noLibAndNoUncheckedIndexedAccessDestructuringArray.ts, 1, 5))
+>x : Symbol(x, Decl(noLibAndNoUncheckedIndexedAccessDestructuringArray.ts, 0, 11))
+

--- a/testdata/baselines/reference/compiler/noLibAndNoUncheckedIndexedAccessDestructuringArray.symbols
+++ b/testdata/baselines/reference/compiler/noLibAndNoUncheckedIndexedAccessDestructuringArray.symbols
@@ -1,10 +1,42 @@
 //// [tests/cases/compiler/noLibAndNoUncheckedIndexedAccessDestructuringArray.ts] ////
 
-=== noLibAndNoUncheckedIndexedAccessDestructuringArray.ts ===
+=== globals.ts ===
+interface Array<T> {}
+>Array : Symbol(Array, Decl(globals.ts, 0, 0))
+>T : Symbol(T, Decl(globals.ts, 0, 16))
+
+interface Boolean {}
+>Boolean : Symbol(Boolean, Decl(globals.ts, 0, 21))
+
+interface Function {}
+>Function : Symbol(Function, Decl(globals.ts, 1, 20))
+
+interface CallableFunction {}
+>CallableFunction : Symbol(CallableFunction, Decl(globals.ts, 2, 21))
+
+interface NewableFunction {}
+>NewableFunction : Symbol(NewableFunction, Decl(globals.ts, 3, 29))
+
+interface IArguments {}
+>IArguments : Symbol(IArguments, Decl(globals.ts, 4, 28))
+
+interface Number {}
+>Number : Symbol(Number, Decl(globals.ts, 5, 23))
+
+interface Object {}
+>Object : Symbol(Object, Decl(globals.ts, 6, 19))
+
+interface RegExp {}
+>RegExp : Symbol(RegExp, Decl(globals.ts, 7, 19))
+
+interface String {}
+>String : Symbol(String, Decl(globals.ts, 8, 19))
+
+=== input.ts ===
 declare var x: string[];
->x : Symbol(x, Decl(noLibAndNoUncheckedIndexedAccessDestructuringArray.ts, 0, 11))
+>x : Symbol(x, Decl(input.ts, 0, 11))
 
 var [a] = x;
->a : Symbol(a, Decl(noLibAndNoUncheckedIndexedAccessDestructuringArray.ts, 1, 5))
->x : Symbol(x, Decl(noLibAndNoUncheckedIndexedAccessDestructuringArray.ts, 0, 11))
+>a : Symbol(a, Decl(input.ts, 1, 5))
+>x : Symbol(x, Decl(input.ts, 0, 11))
 

--- a/testdata/baselines/reference/compiler/noLibAndNoUncheckedIndexedAccessDestructuringArray.types
+++ b/testdata/baselines/reference/compiler/noLibAndNoUncheckedIndexedAccessDestructuringArray.types
@@ -1,0 +1,10 @@
+//// [tests/cases/compiler/noLibAndNoUncheckedIndexedAccessDestructuringArray.ts] ////
+
+=== noLibAndNoUncheckedIndexedAccessDestructuringArray.ts ===
+declare var x: string[];
+>x : {}
+
+var [a] = x;
+>a : any
+>x : {}
+

--- a/testdata/baselines/reference/compiler/noLibAndNoUncheckedIndexedAccessDestructuringArray.types
+++ b/testdata/baselines/reference/compiler/noLibAndNoUncheckedIndexedAccessDestructuringArray.types
@@ -1,10 +1,23 @@
 //// [tests/cases/compiler/noLibAndNoUncheckedIndexedAccessDestructuringArray.ts] ////
 
-=== noLibAndNoUncheckedIndexedAccessDestructuringArray.ts ===
+=== globals.ts ===
+
+interface Array<T> {}
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number {}
+interface Object {}
+interface RegExp {}
+interface String {}
+
+=== input.ts ===
 declare var x: string[];
->x : {}
+>x : string[]
 
 var [a] = x;
 >a : any
->x : {}
+>x : string[]
 

--- a/testdata/tests/cases/compiler/noLibAndNoUncheckedIndexedAccessDestructuringArray.ts
+++ b/testdata/tests/cases/compiler/noLibAndNoUncheckedIndexedAccessDestructuringArray.ts
@@ -1,0 +1,5 @@
+// @noUncheckedIndexedAccess: true
+// @noLib: true
+
+declare var x: string[];
+var [a] = x;

--- a/testdata/tests/cases/compiler/noLibAndNoUncheckedIndexedAccessDestructuringArray.ts
+++ b/testdata/tests/cases/compiler/noLibAndNoUncheckedIndexedAccessDestructuringArray.ts
@@ -1,5 +1,18 @@
 // @noUncheckedIndexedAccess: true
 // @noLib: true
 
+// @filename: globals.ts
+interface Array<T> {}
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number {}
+interface Object {}
+interface RegExp {}
+interface String {}
+
+// @filename: input.ts
 declare var x: string[];
 var [a] = x;


### PR DESCRIPTION
Ports over a missing `nil` check.

Fixes #3759.