### PR TITLE
Fix crash on completing default import identifiers when `from` is on following line

### DIFF
--- a/internal/fourslash/tests/completionsForMultilineDefaultImportWithFromOnNextLine_test.go
+++ b/internal/fourslash/tests/completionsForMultilineDefaultImportWithFromOnNextLine_test.go
@@ -1,0 +1,43 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	fourslashUtil "github.com/microsoft/typescript-go/internal/fourslash/tests/util"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestCompletionsOnImportIdentifierWithFromOnNextLine(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `import something/*1*/
+from`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyCompletions(t, "1", &fourslash.CompletionsExpectedList{
+		IsIncomplete: false,
+		ItemDefaults: &fourslash.CompletionsExpectedItemDefaults{
+			CommitCharacters: &[]string{},
+			EditRange:        fourslashUtil.Ignored,
+		},
+		Items: &fourslash.CompletionsExpectedItems{},
+	})
+}
+
+func TestCompletionsOnImportTypeWithFromOnNextLine(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `import type/*1*/
+from`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyCompletions(t, "1", &fourslash.CompletionsExpectedList{
+		IsIncomplete: false,
+		ItemDefaults: &fourslash.CompletionsExpectedItemDefaults{
+			CommitCharacters: &[]string{},
+			EditRange:        fourslashUtil.Ignored,
+		},
+		Items: &fourslash.CompletionsExpectedItems{},
+	})
+}

--- a/internal/ls/completions.go
+++ b/internal/ls/completions.go
@@ -5149,9 +5149,7 @@ func (l *LanguageService) getSingleLineReplacementSpanForImportCompletionNode(no
 	if node.Kind == ast.KindImportDeclaration || node.Kind == ast.KindJSDocImportTag {
 		var specifier *ast.Node
 		if importClause := node.ImportClause(); importClause != nil {
-			if namedBindings := importClause.AsImportClause().NamedBindings; namedBindings != nil {
-				specifier = getPotentiallyInvalidImportSpecifier(namedBindings)
-			}
+			specifier = getPotentiallyInvalidImportSpecifier(importClause.AsImportClause().NamedBindings)
 		}
 
 		if specifier != nil {

--- a/internal/ls/completions.go
+++ b/internal/ls/completions.go
@@ -5149,8 +5149,11 @@ func (l *LanguageService) getSingleLineReplacementSpanForImportCompletionNode(no
 	if node.Kind == ast.KindImportDeclaration || node.Kind == ast.KindJSDocImportTag {
 		var specifier *ast.Node
 		if importClause := node.ImportClause(); importClause != nil {
-			specifier = getPotentiallyInvalidImportSpecifier(importClause.AsImportClause().NamedBindings)
+			if namedBindings := importClause.AsImportClause().NamedBindings; namedBindings != nil {
+				specifier = getPotentiallyInvalidImportSpecifier(namedBindings)
+			}
 		}
+
 		if specifier != nil {
 			potentialSplitPoint = specifier
 		} else {
@@ -5209,7 +5212,7 @@ func canCompleteFromNamedBindings(namedBindings *ast.NamedImportBindings) bool {
 // in which `Foo`, `interface`, and `Bar` are all parsed as import specifiers. The caller
 // will also check if this token is on a separate line from the rest of the import.
 func getPotentiallyInvalidImportSpecifier(namedBindings *ast.NamedImportBindings) *ast.Node {
-	if namedBindings.Kind != ast.KindNamedImports {
+	if namedBindings == nil || namedBindings.Kind != ast.KindNamedImports {
 		return nil
 	}
 	return core.Find(namedBindings.Elements(), func(e *ast.Node) bool {


### PR DESCRIPTION
Ports missing `nil` checks to `getSingleLineReplacementSpanForImportCompletionNode` and `getPotentiallyInvalidImportSpecifier` to fix a completions crash.

Fixes #3766