### PR TITLE
Defer global ambient module merging in `initializeChecker`

### DIFF
--- a/internal/ast/utilities.go
+++ b/internal/ast/utilities.go
@@ -1619,6 +1619,10 @@ func IsAmbientModule(node *Node) bool {
 	return IsModuleDeclaration(node) && (node.AsModuleDeclaration().Name().Kind == KindStringLiteral || IsGlobalScopeAugmentation(node))
 }
 
+func IsAmbientModuleSymbolName(s string) bool {
+	return strings.HasPrefix(s, "\"") && strings.HasSuffix(s, "\"")
+}
+
 func IsExternalModule(file *SourceFile) bool {
 	return file.ExternalModuleIndicator != nil
 }

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -1284,6 +1284,7 @@ func (c *Checker) initializeIterationResolvers() {
 
 func (c *Checker) initializeChecker() {
 	// Initialize global symbol table
+	var ambientModuleSymbols []*ast.Symbol
 	augmentations := make([][]*ast.Node, 0, len(c.files))
 	for _, file := range c.files {
 		if !ast.IsExternalOrCommonJSModule(file) {
@@ -1293,7 +1294,15 @@ func (c *Checker) initializeChecker() {
 					c.diagnostics.Add(NewDiagnosticForNode(d, diagnostics.Declaration_name_conflicts_with_built_in_global_identifier_0, "globalThis"))
 				}
 			}
-			c.mergeSymbolTable(c.globals, file.Locals, false, nil)
+			for _, symbol := range file.Locals {
+				// We defer merging of global ambient module declarations since they may require other global symbols
+				// and types to be resolved. See https://github.com/microsoft/typescript-go/issues/2953.
+				if symbol.Flags&ast.SymbolFlagsModule != 0 && strings.HasPrefix(symbol.Name, "\"") && strings.HasSuffix(symbol.Name, "\"") {
+					ambientModuleSymbols = append(ambientModuleSymbols, symbol)
+				} else {
+					c.mergeGlobalSymbol(symbol)
+				}
+			}
 		}
 		c.patternAmbientModules = append(c.patternAmbientModules, file.PatternAmbientModules...)
 		augmentations = append(augmentations, file.ModuleAugmentations)
@@ -1348,6 +1357,10 @@ func (c *Checker) initializeChecker() {
 	}
 	c.anyReadonlyArrayType = c.createTypeFromGenericGlobalType(c.globalReadonlyArrayType, []*Type{c.anyType})
 	c.globalThisType = c.getGlobalType("ThisType", 1 /*arity*/, false /*reportErrors*/)
+	// Now merge global ambient module declarations
+	for _, symbol := range ambientModuleSymbols {
+		c.mergeGlobalSymbol(symbol)
+	}
 	// merge _nonglobal_ module augmentations.
 	// this needs to be done after global symbol table is initialized to make sure that all ambient modules are indexed
 	for _, list := range augmentations {
@@ -1357,6 +1370,17 @@ func (c *Checker) initializeChecker() {
 			}
 		}
 	}
+}
+
+func (c *Checker) mergeGlobalSymbol(symbol *ast.Symbol) {
+	globalSymbol := c.globals[symbol.Name]
+	var merged *ast.Symbol
+	if globalSymbol != nil {
+		merged = c.mergeSymbol(globalSymbol, symbol, false /*unidirectional*/)
+	} else {
+		merged = c.getMergedSymbol(symbol)
+	}
+	c.globals[symbol.Name] = merged
 }
 
 func (c *Checker) mergeModuleAugmentation(moduleName *ast.Node) {

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -1297,7 +1297,7 @@ func (c *Checker) initializeChecker() {
 			for _, symbol := range file.Locals {
 				// We defer merging of global ambient module declarations since they may require other global symbols
 				// and types to be resolved. See https://github.com/microsoft/typescript-go/issues/2953.
-				if symbol.Flags&ast.SymbolFlagsModule != 0 && strings.HasPrefix(symbol.Name, "\"") && strings.HasSuffix(symbol.Name, "\"") {
+				if symbol.Flags&ast.SymbolFlagsModule != 0 && ast.IsAmbientModuleSymbolName(symbol.Name) {
 					ambientModuleSymbols = append(ambientModuleSymbols, symbol)
 				} else {
 					c.mergeGlobalSymbol(symbol)

--- a/internal/checker/nodebuilderimpl.go
+++ b/internal/checker/nodebuilderimpl.go
@@ -1176,10 +1176,6 @@ func (b_ *NodeBuilderImpl) sortByBestName(a sortedSymbolNamePair, b sortedSymbol
 	return b_.ch.compareSymbols(a.sym, b.sym) // must sort symbols for stable ordering
 }
 
-func isAmbientModuleSymbolName(s string) bool {
-	return strings.HasPrefix(s, "\"") && strings.HasSuffix(s, "\"")
-}
-
 func canHaveModuleSpecifier(node *ast.Node) bool {
 	if node == nil {
 		return false
@@ -1269,12 +1265,12 @@ func (b *NodeBuilderImpl) getSpecifierForModuleSymbol(symbol *ast.Symbol, overri
 	}
 
 	if file == nil {
-		if isAmbientModuleSymbolName(symbol.Name) {
+		if ast.IsAmbientModuleSymbolName(symbol.Name) {
 			return stringutil.StripQuotes(symbol.Name)
 		}
 	}
 	if b.ctx.enclosingFile == nil {
-		if isAmbientModuleSymbolName(symbol.Name) {
+		if ast.IsAmbientModuleSymbolName(symbol.Name) {
 			return stringutil.StripQuotes(symbol.Name)
 		}
 		return ast.GetSourceFileOfModule(symbol).FileName()

--- a/testdata/baselines/reference/compiler/globalArrayAugmentationWithAmbientModuleReexportMerge1.errors.txt
+++ b/testdata/baselines/reference/compiler/globalArrayAugmentationWithAmbientModuleReexportMerge1.errors.txt
@@ -1,0 +1,37 @@
+/a.d.ts(1,63): error TS2451: Cannot redeclare block-scoped variable 'foo'.
+/b.d.ts(1,39): error TS2451: Cannot redeclare block-scoped variable 'foo'.
+
+
+==== /node_modules/foo/index.d.ts (0 errors) ====
+    declare function foo(): void;
+    declare namespace foo { export const items: string[]; }
+    export = foo;
+    
+==== /a.d.ts (1 errors) ====
+    declare module 'mymod' { import * as foo from 'foo'; export { foo }; }
+                                                                  ~~~
+!!! error TS2451: Cannot redeclare block-scoped variable 'foo'.
+!!! related TS6203 /b.d.ts:1:39: 'foo' was also declared here.
+    
+==== /b.d.ts (1 errors) ====
+    declare module 'mymod' { export const foo: number; }
+                                          ~~~
+!!! error TS2451: Cannot redeclare block-scoped variable 'foo'.
+!!! related TS6203 /a.d.ts:1:63: 'foo' was also declared here.
+    
+==== /augment.ts (0 errors) ====
+    declare global {
+        interface Array<T> {
+            customMethod(): T;
+        }
+    }
+    export {};
+    
+==== /index.ts (0 errors) ====
+    import * as foo from 'foo';
+    const items = foo.items;
+    const result: string = items.customMethod();
+    
+    const fresh: string[] = [];
+    const result2: string = fresh.customMethod();
+    

--- a/testdata/baselines/reference/compiler/globalArrayAugmentationWithAmbientModuleReexportMerge1.symbols
+++ b/testdata/baselines/reference/compiler/globalArrayAugmentationWithAmbientModuleReexportMerge1.symbols
@@ -1,0 +1,64 @@
+//// [tests/cases/compiler/globalArrayAugmentationWithAmbientModuleReexportMerge1.ts] ////
+
+=== /node_modules/foo/index.d.ts ===
+declare function foo(): void;
+>foo : Symbol(foo, Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 29))
+
+declare namespace foo { export const items: string[]; }
+>foo : Symbol(foo, Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 29))
+>items : Symbol(items, Decl(index.d.ts, 1, 36))
+
+export = foo;
+>foo : Symbol(foo, Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 29))
+
+=== /a.d.ts ===
+declare module 'mymod' { import * as foo from 'foo'; export { foo }; }
+>'mymod' : Symbol("mymod", Decl(a.d.ts, 0, 0), Decl(b.d.ts, 0, 0))
+>foo : Symbol(foo, Decl(a.d.ts, 0, 31))
+>foo : Symbol(foo, Decl(a.d.ts, 0, 61))
+
+=== /b.d.ts ===
+declare module 'mymod' { export const foo: number; }
+>'mymod' : Symbol("mymod", Decl(a.d.ts, 0, 0), Decl(b.d.ts, 0, 0))
+>foo : Symbol(foo, Decl(b.d.ts, 0, 37))
+
+=== /augment.ts ===
+declare global {
+>global : Symbol(global, Decl(augment.ts, 0, 0))
+
+    interface Array<T> {
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(augment.ts, 0, 16))
+>T : Symbol(T, Decl(lib.es5.d.ts, --, --), Decl(augment.ts, 1, 20))
+
+        customMethod(): T;
+>customMethod : Symbol(Array.customMethod, Decl(augment.ts, 1, 24))
+>T : Symbol(T, Decl(lib.es5.d.ts, --, --), Decl(augment.ts, 1, 20))
+    }
+}
+export {};
+
+=== /index.ts ===
+import * as foo from 'foo';
+>foo : Symbol(foo, Decl(index.ts, 0, 6))
+
+const items = foo.items;
+>items : Symbol(items, Decl(index.ts, 1, 5))
+>foo.items : Symbol(items, Decl(index.d.ts, 1, 36))
+>foo : Symbol(foo, Decl(index.ts, 0, 6))
+>items : Symbol(items, Decl(index.d.ts, 1, 36))
+
+const result: string = items.customMethod();
+>result : Symbol(result, Decl(index.ts, 2, 5))
+>items.customMethod : Symbol(Array.customMethod, Decl(augment.ts, 1, 24))
+>items : Symbol(items, Decl(index.ts, 1, 5))
+>customMethod : Symbol(Array.customMethod, Decl(augment.ts, 1, 24))
+
+const fresh: string[] = [];
+>fresh : Symbol(fresh, Decl(index.ts, 4, 5))
+
+const result2: string = fresh.customMethod();
+>result2 : Symbol(result2, Decl(index.ts, 5, 5))
+>fresh.customMethod : Symbol(Array.customMethod, Decl(augment.ts, 1, 24))
+>fresh : Symbol(fresh, Decl(index.ts, 4, 5))
+>customMethod : Symbol(Array.customMethod, Decl(augment.ts, 1, 24))
+

--- a/testdata/baselines/reference/compiler/globalArrayAugmentationWithAmbientModuleReexportMerge1.types
+++ b/testdata/baselines/reference/compiler/globalArrayAugmentationWithAmbientModuleReexportMerge1.types
@@ -1,0 +1,63 @@
+//// [tests/cases/compiler/globalArrayAugmentationWithAmbientModuleReexportMerge1.ts] ////
+
+=== /node_modules/foo/index.d.ts ===
+declare function foo(): void;
+>foo : typeof foo
+
+declare namespace foo { export const items: string[]; }
+>foo : typeof foo
+>items : string[]
+
+export = foo;
+>foo : typeof foo
+
+=== /a.d.ts ===
+declare module 'mymod' { import * as foo from 'foo'; export { foo }; }
+>'mymod' : typeof import("mymod")
+>foo : typeof foo
+>foo : typeof foo
+
+=== /b.d.ts ===
+declare module 'mymod' { export const foo: number; }
+>'mymod' : typeof import("mymod")
+>foo : number
+
+=== /augment.ts ===
+declare global {
+>global : any
+
+    interface Array<T> {
+        customMethod(): T;
+>customMethod : () => T
+    }
+}
+export {};
+
+=== /index.ts ===
+import * as foo from 'foo';
+>foo : typeof foo
+
+const items = foo.items;
+>items : string[]
+>foo.items : string[]
+>foo : typeof foo
+>items : string[]
+
+const result: string = items.customMethod();
+>result : string
+>items.customMethod() : string
+>items.customMethod : () => string
+>items : string[]
+>customMethod : () => string
+
+const fresh: string[] = [];
+>fresh : string[]
+>[] : never[]
+
+const result2: string = fresh.customMethod();
+>result2 : string
+>fresh.customMethod() : string
+>fresh.customMethod : () => string
+>fresh : string[]
+>customMethod : () => string
+

--- a/testdata/tests/cases/compiler/globalArrayAugmentationWithAmbientModuleReexportMerge1.ts
+++ b/testdata/tests/cases/compiler/globalArrayAugmentationWithAmbientModuleReexportMerge1.ts
@@ -1,0 +1,30 @@
+// @target: es2015
+// @lib: es5
+// @noEmit: true
+
+// @Filename: /node_modules/foo/index.d.ts
+declare function foo(): void;
+declare namespace foo { export const items: string[]; }
+export = foo;
+
+// @Filename: /a.d.ts
+declare module 'mymod' { import * as foo from 'foo'; export { foo }; }
+
+// @Filename: /b.d.ts
+declare module 'mymod' { export const foo: number; }
+
+// @Filename: /augment.ts
+declare global {
+    interface Array<T> {
+        customMethod(): T;
+    }
+}
+export {};
+
+// @Filename: /index.ts
+import * as foo from 'foo';
+const items = foo.items;
+const result: string = items.customMethod();
+
+const fresh: string[] = [];
+const result2: string = fresh.customMethod();


### PR DESCRIPTION
This PR defers merging of global ambient module declarations beyond resolution of global symbols and types. I think this is a less impactful and more predictable fix than #2970, but I'm keeping the test from that PR and appreciate the detective work! (Thanks, @Andarist.)

Fixes #2953.