### PR TITLE
Fix crashes related to call hierarchy container names for computed properties

### DIFF
--- a/internal/fourslash/tests/callHierarchyIncomingCallsObjectLiteralMethodInExpressionComputedProperty_test.go
+++ b/internal/fourslash/tests/callHierarchyIncomingCallsObjectLiteralMethodInExpressionComputedProperty_test.go
@@ -1,0 +1,25 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestCallHierarchyIncomingCallsObjectLiteralMethodInExpressionComputedProperty(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `const obj = {
+  [1 + 2]: {
+    method() {
+      return ""./*split*/split(",");
+    }
+  }
+};
+`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.GoToMarker(t, "split")
+	f.VerifyBaselineCallHierarchy(t)
+}

--- a/internal/fourslash/tests/callHierarchyIncomingCallsObjectLiteralMethodInIdentifierComputedProperty_test.go
+++ b/internal/fourslash/tests/callHierarchyIncomingCallsObjectLiteralMethodInIdentifierComputedProperty_test.go
@@ -1,0 +1,26 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestCallHierarchyIncomingCallsObjectLiteralMethodInIdentifierComputedProperty(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `const key = "x";
+const obj = {
+  [key]: {
+    method() {
+      return ""./*split*/split(",");
+    }
+  }
+};
+`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.GoToMarker(t, "split")
+	f.VerifyBaselineCallHierarchy(t)
+}

--- a/internal/fourslash/tests/callHierarchyIncomingCallsObjectLiteralMethodInStringLiteralComputedProperty_test.go
+++ b/internal/fourslash/tests/callHierarchyIncomingCallsObjectLiteralMethodInStringLiteralComputedProperty_test.go
@@ -1,0 +1,25 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestCallHierarchyIncomingCallsObjectLiteralMethodInStringLiteralComputedProperty(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `const obj = {
+  ["x"]: {
+    method() {
+      return ""./*split*/split(",");
+    }
+  }
+};
+`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.GoToMarker(t, "split")
+	f.VerifyBaselineCallHierarchy(t)
+}

--- a/internal/ls/callhierarchy.go
+++ b/internal/ls/callhierarchy.go
@@ -208,35 +208,7 @@ func getCallHierarchyItemName(program *compiler.Program, node *ast.Node) (text s
 		debug.Assert(declName != nil, "Expected call hierarchy item to have a name")
 	}
 
-	if ast.IsIdentifier(declName) {
-		text = declName.Text()
-	} else if ast.IsStringOrNumericLiteralLike(declName) {
-		text = declName.Text()
-	} else if ast.IsComputedPropertyName(declName) {
-		expr := declName.Expression()
-		if ast.IsStringOrNumericLiteralLike(expr) {
-			text = expr.Text()
-		}
-	}
-
-	if text == "" {
-		c, done := program.GetTypeCheckerForFile(context.Background(), ast.GetSourceFileOfNode(node))
-		defer done()
-		symbol := c.GetSymbolAtLocation(declName)
-		if symbol != nil {
-			text = c.SymbolToString(symbol)
-		}
-	}
-
-	// get the text from printing the node on a single line without comments...
-	if text == "" {
-		sourceFile := ast.GetSourceFileOfNode(node)
-		writer, putWriter := printer.GetSingleLineStringWriter()
-		defer putWriter()
-		p := printer.NewPrinter(printer.PrinterOptions{RemoveComments: true}, printer.PrintHandlers{}, nil)
-		p.Write(node, sourceFile, writer, nil)
-		text = writer.String()
-	}
+	text = getTextOfCallHierarchyName(program, node, declName, node)
 
 	sourceFile := ast.GetSourceFileOfNode(node)
 	namePos := scanner.SkipTrivia(sourceFile.Text(), declName.Pos())
@@ -244,17 +216,46 @@ func getCallHierarchyItemName(program *compiler.Program, node *ast.Node) (text s
 	return text, namePos, declName.End()
 }
 
-func getCallHierarchyItemContainerName(node *ast.Node) string {
+func getTextOfCallHierarchyName(program *compiler.Program, sourceNode *ast.Node, name *ast.Node, printNode *ast.Node) string {
+	if ast.IsIdentifier(name) || ast.IsStringOrNumericLiteralLike(name) {
+		return name.Text()
+	}
+	if ast.IsComputedPropertyName(name) {
+		expr := name.Expression()
+		if ast.IsStringOrNumericLiteralLike(expr) {
+			return expr.Text()
+		}
+	}
+
+	c, done := program.GetTypeCheckerForFile(context.Background(), ast.GetSourceFileOfNode(sourceNode))
+	defer done()
+	symbol := c.GetSymbolAtLocation(name)
+	if symbol != nil {
+		text := c.SymbolToString(symbol)
+		if text != "" {
+			return text
+		}
+	}
+
+	sourceFile := ast.GetSourceFileOfNode(sourceNode)
+	writer, putWriter := printer.GetSingleLineStringWriter()
+	defer putWriter()
+	p := printer.NewPrinter(printer.PrinterOptions{RemoveComments: true}, printer.PrintHandlers{}, nil)
+	p.Write(printNode, sourceFile, writer, nil)
+	return writer.String()
+}
+
+func getCallHierarchyItemContainerName(program *compiler.Program, node *ast.Node) string {
 	if isAssignedExpression(node) {
 		parent := node.Parent
 		if ast.IsPropertyDeclaration(parent) && ast.IsClassLike(parent.Parent) {
 			if ast.IsClassExpression(parent.Parent) {
 				if assignedName := ast.GetAssignedName(parent.Parent); assignedName != nil {
-					return assignedName.Text()
+					return getTextOfCallHierarchyName(program, node, assignedName, assignedName)
 				}
 			} else {
 				if name := parent.Parent.Name(); name != nil {
-					return name.Text()
+					return getTextOfCallHierarchyName(program, node, name, name)
 				}
 			}
 		}
@@ -273,11 +274,11 @@ func getCallHierarchyItemContainerName(node *ast.Node) string {
 	case ast.KindGetAccessor, ast.KindSetAccessor, ast.KindMethodDeclaration:
 		if node.Parent.Kind == ast.KindObjectLiteralExpression {
 			if assignedName := ast.GetAssignedName(node.Parent); assignedName != nil {
-				return assignedName.Text()
+				return getTextOfCallHierarchyName(program, node, assignedName, assignedName)
 			}
 		}
 		if name := ast.GetNameOfDeclaration(node.Parent); name != nil {
-			return name.Text()
+			return getTextOfCallHierarchyName(program, node, name, name)
 		}
 	case ast.KindFunctionDeclaration, ast.KindClassDeclaration, ast.KindModuleDeclaration:
 		if ast.IsModuleBlock(node.Parent) {
@@ -498,7 +499,7 @@ func resolveCallHierarchyDeclaration(program *compiler.Program, location *ast.No
 func (l *LanguageService) createCallHierarchyItem(program *compiler.Program, node *ast.Node) *lsproto.CallHierarchyItem {
 	sourceFile := ast.GetSourceFileOfNode(node)
 	nameText, namePos, nameEnd := getCallHierarchyItemName(program, node)
-	containerName := getCallHierarchyItemContainerName(node)
+	containerName := getCallHierarchyItemContainerName(program, node)
 
 	kind := getSymbolKindFromNode(node)
 

--- a/testdata/baselines/reference/fourslash/callHierarchy/callHierarchyIncomingCallsObjectLiteralMethodInExpressionComputedProperty.callHierarchy.txt
+++ b/testdata/baselines/reference/fourslash/callHierarchy/callHierarchyIncomingCallsObjectLiteralMethodInExpressionComputedProperty.callHierarchy.txt
@@ -1,0 +1,101 @@
+// === Call Hierarchy ===
+╭ name: split
+├ kind: method
+├ file: bundled:///libs/lib.es2015.symbol.wellknown.d.ts
+├ span:
+│ ╭ bundled:///libs/lib.es2015.symbol.wellknown.d.ts:261:5-266:110
+│ │ 261:     /**
+│ │          ^^^
+│ │ 262:      * Split a string into substrings using the specified separator and return them as an array.
+│ │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ │ 263:      * @param splitter An object that can split a string.
+│ │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ │ 264:      * @param limit A value used to limit the number of elements returned in the array.
+│ │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ │ 265:      */
+│ │      ^^^^^^^
+│ │ 266:     split(splitter: { [Symbol.split](string: string, limit?: number): string[]; }, limit?: number): string[];
+│ │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ ╰
+├ selectionSpan:
+│ ╭ bundled:///libs/lib.es2015.symbol.wellknown.d.ts:266:5-266:10
+│ │ 266:     split(splitter: { [Symbol.split](string: string, limit?: number): string[]; }, limit?: number): string[];
+│ │          ^^^^^
+│ ╰
+├ incoming:
+│ ╭ from:
+│ │ ╭ name: method
+│ │ ├ kind: method
+│ │ ├ containerName: [1 + 2]
+│ │ ├ file: /callHierarchyIncomingCallsObjectLiteralMethodInExpressionComputedProperty.ts
+│ │ ├ span:
+│ │ │ ╭ /callHierarchyIncomingCallsObjectLiteralMethodInExpressionComputedProperty.ts:3:5-5:6
+│ │ │ │ 3:     method() {
+│ │ │ │        ^^^^^^^^^^
+│ │ │ │ 4:       return "".split(",");
+│ │ │ │    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ │ │ │ 5:     }
+│ │ │ │    ^^^^^
+│ │ │ ╰
+│ │ ├ selectionSpan:
+│ │ │ ╭ /callHierarchyIncomingCallsObjectLiteralMethodInExpressionComputedProperty.ts:3:5-3:11
+│ │ │ │ 3:     method() {
+│ │ │ │        ^^^^^^
+│ │ │ ╰
+│ │ ╰ incoming: none
+│ ├ fromSpans:
+│ │ ╭ /callHierarchyIncomingCallsObjectLiteralMethodInExpressionComputedProperty.ts:4:17-4:22
+│ │ │ 4:       return "".split(",");
+│ │ │                    ^^^^^
+│ ╰ ╰
+╰ outgoing: none
+╭ name: split
+├ kind: method
+├ file: bundled:///libs/lib.es5.d.ts
+├ span:
+│ ╭ bundled:///libs/lib.es5.d.ts:484:5-489:65
+│ │ 484:     /**
+│ │          ^^^
+│ │ 485:      * Split a string into substrings using the specified separator and return them as an array.
+│ │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ │ 486:      * @param separator A string that identifies character or characters to use in separating the string. If omitted, a single-element array containing the entire string is returned.
+│ │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ │ 487:      * @param limit A value used to limit the number of elements returned in the array.
+│ │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ │ 488:      */
+│ │      ^^^^^^^
+│ │ 489:     split(separator: string | RegExp, limit?: number): string[];
+│ │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ ╰
+├ selectionSpan:
+│ ╭ bundled:///libs/lib.es5.d.ts:489:5-489:10
+│ │ 489:     split(separator: string | RegExp, limit?: number): string[];
+│ │          ^^^^^
+│ ╰
+├ incoming:
+│ ╭ from:
+│ │ ╭ name: method
+│ │ ├ kind: method
+│ │ ├ containerName: [1 + 2]
+│ │ ├ file: /callHierarchyIncomingCallsObjectLiteralMethodInExpressionComputedProperty.ts
+│ │ ├ span:
+│ │ │ ╭ /callHierarchyIncomingCallsObjectLiteralMethodInExpressionComputedProperty.ts:3:5-5:6
+│ │ │ │ 3:     method() {
+│ │ │ │        ^^^^^^^^^^
+│ │ │ │ 4:       return "".split(",");
+│ │ │ │    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ │ │ │ 5:     }
+│ │ │ │    ^^^^^
+│ │ │ ╰
+│ │ ├ selectionSpan:
+│ │ │ ╭ /callHierarchyIncomingCallsObjectLiteralMethodInExpressionComputedProperty.ts:3:5-3:11
+│ │ │ │ 3:     method() {
+│ │ │ │        ^^^^^^
+│ │ │ ╰
+│ │ ╰ incoming: none
+│ ├ fromSpans:
+│ │ ╭ /callHierarchyIncomingCallsObjectLiteralMethodInExpressionComputedProperty.ts:4:17-4:22
+│ │ │ 4:       return "".split(",");
+│ │ │                    ^^^^^
+│ ╰ ╰
+╰ outgoing: none

--- a/testdata/baselines/reference/fourslash/callHierarchy/callHierarchyIncomingCallsObjectLiteralMethodInIdentifierComputedProperty.callHierarchy.txt
+++ b/testdata/baselines/reference/fourslash/callHierarchy/callHierarchyIncomingCallsObjectLiteralMethodInIdentifierComputedProperty.callHierarchy.txt
@@ -1,0 +1,101 @@
+// === Call Hierarchy ===
+╭ name: split
+├ kind: method
+├ file: bundled:///libs/lib.es2015.symbol.wellknown.d.ts
+├ span:
+│ ╭ bundled:///libs/lib.es2015.symbol.wellknown.d.ts:261:5-266:110
+│ │ 261:     /**
+│ │          ^^^
+│ │ 262:      * Split a string into substrings using the specified separator and return them as an array.
+│ │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ │ 263:      * @param splitter An object that can split a string.
+│ │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ │ 264:      * @param limit A value used to limit the number of elements returned in the array.
+│ │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ │ 265:      */
+│ │      ^^^^^^^
+│ │ 266:     split(splitter: { [Symbol.split](string: string, limit?: number): string[]; }, limit?: number): string[];
+│ │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ ╰
+├ selectionSpan:
+│ ╭ bundled:///libs/lib.es2015.symbol.wellknown.d.ts:266:5-266:10
+│ │ 266:     split(splitter: { [Symbol.split](string: string, limit?: number): string[]; }, limit?: number): string[];
+│ │          ^^^^^
+│ ╰
+├ incoming:
+│ ╭ from:
+│ │ ╭ name: method
+│ │ ├ kind: method
+│ │ ├ containerName: [key]
+│ │ ├ file: /callHierarchyIncomingCallsObjectLiteralMethodInIdentifierComputedProperty.ts
+│ │ ├ span:
+│ │ │ ╭ /callHierarchyIncomingCallsObjectLiteralMethodInIdentifierComputedProperty.ts:4:5-6:6
+│ │ │ │ 4:     method() {
+│ │ │ │        ^^^^^^^^^^
+│ │ │ │ 5:       return "".split(",");
+│ │ │ │    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ │ │ │ 6:     }
+│ │ │ │    ^^^^^
+│ │ │ ╰
+│ │ ├ selectionSpan:
+│ │ │ ╭ /callHierarchyIncomingCallsObjectLiteralMethodInIdentifierComputedProperty.ts:4:5-4:11
+│ │ │ │ 4:     method() {
+│ │ │ │        ^^^^^^
+│ │ │ ╰
+│ │ ╰ incoming: none
+│ ├ fromSpans:
+│ │ ╭ /callHierarchyIncomingCallsObjectLiteralMethodInIdentifierComputedProperty.ts:5:17-5:22
+│ │ │ 5:       return "".split(",");
+│ │ │                    ^^^^^
+│ ╰ ╰
+╰ outgoing: none
+╭ name: split
+├ kind: method
+├ file: bundled:///libs/lib.es5.d.ts
+├ span:
+│ ╭ bundled:///libs/lib.es5.d.ts:484:5-489:65
+│ │ 484:     /**
+│ │          ^^^
+│ │ 485:      * Split a string into substrings using the specified separator and return them as an array.
+│ │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ │ 486:      * @param separator A string that identifies character or characters to use in separating the string. If omitted, a single-element array containing the entire string is returned.
+│ │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ │ 487:      * @param limit A value used to limit the number of elements returned in the array.
+│ │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ │ 488:      */
+│ │      ^^^^^^^
+│ │ 489:     split(separator: string | RegExp, limit?: number): string[];
+│ │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ ╰
+├ selectionSpan:
+│ ╭ bundled:///libs/lib.es5.d.ts:489:5-489:10
+│ │ 489:     split(separator: string | RegExp, limit?: number): string[];
+│ │          ^^^^^
+│ ╰
+├ incoming:
+│ ╭ from:
+│ │ ╭ name: method
+│ │ ├ kind: method
+│ │ ├ containerName: [key]
+│ │ ├ file: /callHierarchyIncomingCallsObjectLiteralMethodInIdentifierComputedProperty.ts
+│ │ ├ span:
+│ │ │ ╭ /callHierarchyIncomingCallsObjectLiteralMethodInIdentifierComputedProperty.ts:4:5-6:6
+│ │ │ │ 4:     method() {
+│ │ │ │        ^^^^^^^^^^
+│ │ │ │ 5:       return "".split(",");
+│ │ │ │    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ │ │ │ 6:     }
+│ │ │ │    ^^^^^
+│ │ │ ╰
+│ │ ├ selectionSpan:
+│ │ │ ╭ /callHierarchyIncomingCallsObjectLiteralMethodInIdentifierComputedProperty.ts:4:5-4:11
+│ │ │ │ 4:     method() {
+│ │ │ │        ^^^^^^
+│ │ │ ╰
+│ │ ╰ incoming: none
+│ ├ fromSpans:
+│ │ ╭ /callHierarchyIncomingCallsObjectLiteralMethodInIdentifierComputedProperty.ts:5:17-5:22
+│ │ │ 5:       return "".split(",");
+│ │ │                    ^^^^^
+│ ╰ ╰
+╰ outgoing: none

--- a/testdata/baselines/reference/fourslash/callHierarchy/callHierarchyIncomingCallsObjectLiteralMethodInStringLiteralComputedProperty.callHierarchy.txt
+++ b/testdata/baselines/reference/fourslash/callHierarchy/callHierarchyIncomingCallsObjectLiteralMethodInStringLiteralComputedProperty.callHierarchy.txt
@@ -1,0 +1,101 @@
+// === Call Hierarchy ===
+╭ name: split
+├ kind: method
+├ file: bundled:///libs/lib.es2015.symbol.wellknown.d.ts
+├ span:
+│ ╭ bundled:///libs/lib.es2015.symbol.wellknown.d.ts:261:5-266:110
+│ │ 261:     /**
+│ │          ^^^
+│ │ 262:      * Split a string into substrings using the specified separator and return them as an array.
+│ │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ │ 263:      * @param splitter An object that can split a string.
+│ │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ │ 264:      * @param limit A value used to limit the number of elements returned in the array.
+│ │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ │ 265:      */
+│ │      ^^^^^^^
+│ │ 266:     split(splitter: { [Symbol.split](string: string, limit?: number): string[]; }, limit?: number): string[];
+│ │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ ╰
+├ selectionSpan:
+│ ╭ bundled:///libs/lib.es2015.symbol.wellknown.d.ts:266:5-266:10
+│ │ 266:     split(splitter: { [Symbol.split](string: string, limit?: number): string[]; }, limit?: number): string[];
+│ │          ^^^^^
+│ ╰
+├ incoming:
+│ ╭ from:
+│ │ ╭ name: method
+│ │ ├ kind: method
+│ │ ├ containerName: x
+│ │ ├ file: /callHierarchyIncomingCallsObjectLiteralMethodInStringLiteralComputedProperty.ts
+│ │ ├ span:
+│ │ │ ╭ /callHierarchyIncomingCallsObjectLiteralMethodInStringLiteralComputedProperty.ts:3:5-5:6
+│ │ │ │ 3:     method() {
+│ │ │ │        ^^^^^^^^^^
+│ │ │ │ 4:       return "".split(",");
+│ │ │ │    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ │ │ │ 5:     }
+│ │ │ │    ^^^^^
+│ │ │ ╰
+│ │ ├ selectionSpan:
+│ │ │ ╭ /callHierarchyIncomingCallsObjectLiteralMethodInStringLiteralComputedProperty.ts:3:5-3:11
+│ │ │ │ 3:     method() {
+│ │ │ │        ^^^^^^
+│ │ │ ╰
+│ │ ╰ incoming: none
+│ ├ fromSpans:
+│ │ ╭ /callHierarchyIncomingCallsObjectLiteralMethodInStringLiteralComputedProperty.ts:4:17-4:22
+│ │ │ 4:       return "".split(",");
+│ │ │                    ^^^^^
+│ ╰ ╰
+╰ outgoing: none
+╭ name: split
+├ kind: method
+├ file: bundled:///libs/lib.es5.d.ts
+├ span:
+│ ╭ bundled:///libs/lib.es5.d.ts:484:5-489:65
+│ │ 484:     /**
+│ │          ^^^
+│ │ 485:      * Split a string into substrings using the specified separator and return them as an array.
+│ │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ │ 486:      * @param separator A string that identifies character or characters to use in separating the string. If omitted, a single-element array containing the entire string is returned.
+│ │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ │ 487:      * @param limit A value used to limit the number of elements returned in the array.
+│ │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ │ 488:      */
+│ │      ^^^^^^^
+│ │ 489:     split(separator: string | RegExp, limit?: number): string[];
+│ │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ ╰
+├ selectionSpan:
+│ ╭ bundled:///libs/lib.es5.d.ts:489:5-489:10
+│ │ 489:     split(separator: string | RegExp, limit?: number): string[];
+│ │          ^^^^^
+│ ╰
+├ incoming:
+│ ╭ from:
+│ │ ╭ name: method
+│ │ ├ kind: method
+│ │ ├ containerName: x
+│ │ ├ file: /callHierarchyIncomingCallsObjectLiteralMethodInStringLiteralComputedProperty.ts
+│ │ ├ span:
+│ │ │ ╭ /callHierarchyIncomingCallsObjectLiteralMethodInStringLiteralComputedProperty.ts:3:5-5:6
+│ │ │ │ 3:     method() {
+│ │ │ │        ^^^^^^^^^^
+│ │ │ │ 4:       return "".split(",");
+│ │ │ │    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ │ │ │ 5:     }
+│ │ │ │    ^^^^^
+│ │ │ ╰
+│ │ ├ selectionSpan:
+│ │ │ ╭ /callHierarchyIncomingCallsObjectLiteralMethodInStringLiteralComputedProperty.ts:3:5-3:11
+│ │ │ │ 3:     method() {
+│ │ │ │        ^^^^^^
+│ │ │ ╰
+│ │ ╰ incoming: none
+│ ├ fromSpans:
+│ │ ╭ /callHierarchyIncomingCallsObjectLiteralMethodInStringLiteralComputedProperty.ts:4:17-4:22
+│ │ │ 4:       return "".split(",");
+│ │ │                    ^^^^^
+│ ╰ ╰
+╰ outgoing: none


### PR DESCRIPTION
fixes the crash reported here https://github.com/microsoft/typescript-go/issues/3782#issuecomment-4410162117