### PR TITLE
Align and simplify `getFunctionLikeHost` and `GetNextJSDocCommentLocation`

### DIFF
--- a/internal/ast/utilities.go
+++ b/internal/ast/utilities.go
@@ -4021,24 +4021,16 @@ func GetHostSignatureFromJSDoc(node *Node) *Node {
 // Finds the declaration that owns the JSDoc for a function-like node.
 // Keep these hosts aligned with JSDoc parameter reparsing so unmatched @param diagnostics use the same attachment rules.
 func GetNextJSDocCommentLocation(node *Node) *Node {
-	parent := node.Parent
-	if parent == nil {
-		return nil
-	}
-	switch parent.Kind {
-	case KindPropertyAssignment, KindExportAssignment, KindPropertyDeclaration, KindReturnStatement:
-		return parent
-	case KindExpressionStatement:
-		if node.Kind == KindPropertyAccessExpression {
+	if parent := node.Parent; parent != nil {
+		switch parent.Kind {
+		case KindPropertyAssignment, KindExportAssignment, KindPropertyDeclaration, KindVariableDeclaration,
+			KindSatisfiesExpression, KindReturnStatement, KindVariableStatement, KindExpressionStatement:
 			return parent
+		case KindVariableDeclarationList:
+			if parent.AsVariableDeclarationList().Declarations.Nodes[0] == node {
+				return parent
+			}
 		}
-	case KindVariableStatement:
-		if HasSyntacticModifier(parent, ModifierFlagsExport) {
-			return parent
-		}
-	}
-	if IsVariableLike(parent) && parent.Initializer() == node {
-		return parent
 	}
 	return nil
 }

--- a/internal/checker/jsdoc.go
+++ b/internal/checker/jsdoc.go
@@ -82,14 +82,16 @@ func (c *Checker) checkUnmatchedJSDocParameters(node *ast.Node) {
 }
 
 func getAllJSDocTags(node *ast.Node) []*ast.Node {
-	for current := node; current != nil; current = ast.GetNextJSDocCommentLocation(current) {
-		jsdocs := current.JSDoc(nil)
-		if len(jsdocs) == 0 {
-			continue
-		}
-		lastJSDoc := jsdocs[len(jsdocs)-1].AsJSDoc()
-		if lastJSDoc.Tags != nil {
-			return lastJSDoc.Tags.Nodes
+	if node.Flags&ast.NodeFlagsJSDoc == 0 {
+		for current := node; current != nil; current = ast.GetNextJSDocCommentLocation(current) {
+			jsdocs := current.JSDoc(nil)
+			if len(jsdocs) == 0 {
+				continue
+			}
+			lastJSDoc := jsdocs[len(jsdocs)-1].AsJSDoc()
+			if lastJSDoc.Tags != nil {
+				return lastJSDoc.Tags.Nodes
+			}
 		}
 	}
 	return nil

--- a/internal/parser/reparser.go
+++ b/internal/parser/reparser.go
@@ -573,25 +573,19 @@ func skipSatisfiesExpressions(node *ast.Node) *ast.Node {
 
 func getFunctionLikeHost(host *ast.Node) *ast.Node {
 	fun := host
-	if host.Kind == ast.KindVariableStatement && host.AsVariableStatement().DeclarationList != nil {
-		for _, declaration := range host.AsVariableStatement().DeclarationList.AsVariableDeclarationList().Declarations.Nodes {
-			initializer := skipSatisfiesExpressions(declaration.Initializer())
-			if ast.IsFunctionLike(initializer) {
-				fun = initializer
-				break
-			}
+	switch host.Kind {
+	case ast.KindVariableStatement:
+		if nodes := host.AsVariableStatement().DeclarationList.AsVariableDeclarationList().Declarations.Nodes; len(nodes) != 0 {
+			fun = nodes[0].Initializer()
 		}
-	} else if host.Kind == ast.KindPropertyAssignment {
-		fun = skipSatisfiesExpressions(host.Initializer())
-	} else if host.Kind == ast.KindPropertyDeclaration {
-		fun = skipSatisfiesExpressions(host.Initializer())
-	} else if host.Kind == ast.KindExportAssignment {
+	case ast.KindPropertyAssignment, ast.KindPropertyDeclaration:
+		fun = host.Initializer()
+	case ast.KindExportAssignment, ast.KindReturnStatement:
 		fun = host.Expression()
-	} else if host.Kind == ast.KindReturnStatement {
-		fun = host.Expression()
-	} else if host.Kind == ast.KindExpressionStatement {
+	case ast.KindExpressionStatement:
 		fun = ast.GetRightMostAssignedExpression(host.Expression())
 	}
+	fun = skipSatisfiesExpressions(fun)
 	if ast.IsFunctionLike(fun) {
 		return fun
 	}

--- a/testdata/baselines/reference/compiler/shorthandPropertyAssignmentNoCrash.symbols
+++ b/testdata/baselines/reference/compiler/shorthandPropertyAssignmentNoCrash.symbols
@@ -1,0 +1,21 @@
+//// [tests/cases/compiler/shorthandPropertyAssignmentNoCrash.ts] ////
+
+=== shorthandPropertyAssignmentNoCrash.ts ===
+// https://github.com/microsoft/typescript-go/issues/3789
+
+function ff(f: any) {
+>ff : Symbol(ff, Decl(shorthandPropertyAssignmentNoCrash.ts, 0, 0))
+>f : Symbol(f, Decl(shorthandPropertyAssignmentNoCrash.ts, 2, 12))
+
+    let g;
+>g : Symbol(g, Decl(shorthandPropertyAssignmentNoCrash.ts, 3, 7))
+
+    ({ g = (x: any, y: any) => x + y } = f);
+>g : Symbol(g, Decl(shorthandPropertyAssignmentNoCrash.ts, 4, 6))
+>x : Symbol(x, Decl(shorthandPropertyAssignmentNoCrash.ts, 4, 12))
+>y : Symbol(y, Decl(shorthandPropertyAssignmentNoCrash.ts, 4, 19))
+>x : Symbol(x, Decl(shorthandPropertyAssignmentNoCrash.ts, 4, 12))
+>y : Symbol(y, Decl(shorthandPropertyAssignmentNoCrash.ts, 4, 19))
+>f : Symbol(f, Decl(shorthandPropertyAssignmentNoCrash.ts, 2, 12))
+}
+

--- a/testdata/baselines/reference/compiler/shorthandPropertyAssignmentNoCrash.types
+++ b/testdata/baselines/reference/compiler/shorthandPropertyAssignmentNoCrash.types
@@ -1,0 +1,26 @@
+//// [tests/cases/compiler/shorthandPropertyAssignmentNoCrash.ts] ////
+
+=== shorthandPropertyAssignmentNoCrash.ts ===
+// https://github.com/microsoft/typescript-go/issues/3789
+
+function ff(f: any) {
+>ff : (f: any) => void
+>f : any
+
+    let g;
+>g : any
+
+    ({ g = (x: any, y: any) => x + y } = f);
+>({ g = (x: any, y: any) => x + y } = f) : any
+>{ g = (x: any, y: any) => x + y } = f : any
+>{ g = (x: any, y: any) => x + y } : { g?: any; }
+>g : any
+>(x: any, y: any) => x + y : (x: any, y: any) => any
+>x : any
+>y : any
+>x + y : any
+>x : any
+>y : any
+>f : any
+}
+

--- a/testdata/tests/cases/compiler/shorthandPropertyAssignmentNoCrash.ts
+++ b/testdata/tests/cases/compiler/shorthandPropertyAssignmentNoCrash.ts
@@ -1,0 +1,8 @@
+// @noEmit: true
+
+// https://github.com/microsoft/typescript-go/issues/3789
+
+function ff(f: any) {
+    let g;
+    ({ g = (x: any, y: any) => x + y } = f);
+}


### PR DESCRIPTION
Fixes #3789.