### PR TITLE
Provide implicit index signatures for JS expando object literals

### DIFF
--- a/internal/checker/relater.go
+++ b/internal/checker/relater.go
@@ -4590,10 +4590,9 @@ func (c *Checker) isObjectTypeWithInferableIndex(t *Type) bool {
 		return core.Every(t.Types(), c.isObjectTypeWithInferableIndex)
 	}
 	return t.symbol != nil &&
-		(t.symbol.Flags&(ast.SymbolFlagsObjectLiteral|ast.SymbolFlagsTypeLiteral) != 0 && len(t.symbol.Exports) == 0 ||
-			t.symbol.Flags&(ast.SymbolFlagsEnum|ast.SymbolFlagsValueModule) != 0 && t.symbol.Flags&ast.SymbolFlagsClass == 0) &&
-		!c.typeHasCallOrConstructSignatures(t) ||
-		t.objectFlags&ObjectFlagsObjectRestType != 0 ||
+		t.symbol.Flags&(ast.SymbolFlagsObjectLiteral|ast.SymbolFlagsTypeLiteral|ast.SymbolFlagsEnum|ast.SymbolFlagsValueModule) != 0 &&
+		t.symbol.Flags&ast.SymbolFlagsClass == 0 && !c.typeHasCallOrConstructSignatures(t) ||
+		t.objectFlags&(ObjectFlagsJSLiteral|ObjectFlagsObjectRestType) != 0 ||
 		t.objectFlags&ObjectFlagsReverseMapped != 0 && c.isObjectTypeWithInferableIndex(t.AsReverseMappedType().source)
 }
 

--- a/internal/checker/relater.go
+++ b/internal/checker/relater.go
@@ -4583,8 +4583,10 @@ func (r *Relater) typeRelatedToIndexInfo(source *Type, targetInfo *IndexInfo, re
 	return TernaryFalse
 }
 
-// Return true if type was inferred from a non-expando object literal, written as an object type literal, or is the shape of a module
-// with no call or construct signatures.
+// Return true if the type was inferred from
+//   - an oject literal, object type literal, enum type, or a value module and has no call or construct signatures, or
+//   - a JS expando object literal or a rest type, or
+//   - a reverse mapped type with a source for which one of the above is true.
 func (c *Checker) isObjectTypeWithInferableIndex(t *Type) bool {
 	if t.flags&TypeFlagsIntersection != 0 {
 		return core.Every(t.Types(), c.isObjectTypeWithInferableIndex)

--- a/internal/checker/relater.go
+++ b/internal/checker/relater.go
@@ -4584,7 +4584,7 @@ func (r *Relater) typeRelatedToIndexInfo(source *Type, targetInfo *IndexInfo, re
 }
 
 // Return true if the type was inferred from
-//   - an oject literal, object type literal, enum type, or a value module and has no call or construct signatures, or
+//   - an object literal, object type literal, enum type, or a value module and has no call or construct signatures, or
 //   - a JS expando object literal or a rest type, or
 //   - a reverse mapped type with a source for which one of the above is true.
 func (c *Checker) isObjectTypeWithInferableIndex(t *Type) bool {
@@ -4592,8 +4592,7 @@ func (c *Checker) isObjectTypeWithInferableIndex(t *Type) bool {
 		return core.Every(t.Types(), c.isObjectTypeWithInferableIndex)
 	}
 	return t.symbol != nil &&
-		t.symbol.Flags&(ast.SymbolFlagsObjectLiteral|ast.SymbolFlagsTypeLiteral|ast.SymbolFlagsEnum|ast.SymbolFlagsValueModule) != 0 &&
-		t.symbol.Flags&ast.SymbolFlagsClass == 0 && !c.typeHasCallOrConstructSignatures(t) ||
+		t.symbol.Flags&(ast.SymbolFlagsObjectLiteral|ast.SymbolFlagsTypeLiteral|ast.SymbolFlagsEnum|ast.SymbolFlagsValueModule) != 0 && t.symbol.Flags&ast.SymbolFlagsClass == 0 && !c.typeHasCallOrConstructSignatures(t) ||
 		t.objectFlags&(ObjectFlagsJSLiteral|ObjectFlagsObjectRestType) != 0 ||
 		t.objectFlags&ObjectFlagsReverseMapped != 0 && c.isObjectTypeWithInferableIndex(t.AsReverseMappedType().source)
 }

--- a/testdata/baselines/reference/compiler/expandoNoInferredIndex.errors.txt
+++ b/testdata/baselines/reference/compiler/expandoNoInferredIndex.errors.txt
@@ -1,0 +1,15 @@
+main.js(6,9): error TS7022: 'buzz' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
+
+
+==== main.js (1 errors) ====
+    export class C {
+        method() {
+            const obj = {};
+            obj.foo = 'foo';
+            obj.bar = 'bar';
+            obj.buzz = Object.values(obj);
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS7022: 'buzz' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
+        }
+    }
+    

--- a/testdata/baselines/reference/compiler/expandoNoInferredIndex.types
+++ b/testdata/baselines/reference/compiler/expandoNoInferredIndex.types
@@ -8,33 +8,33 @@ export class C {
 >method : () => void
 
         const obj = {};
->obj : { foo: string; bar: string; buzz: any[]; }
->{} : { foo: string; bar: string; buzz: any[]; }
+>obj : { foo: string; bar: string; buzz: any; }
+>{} : { foo: string; bar: string; buzz: any; }
 
         obj.foo = 'foo';
 >obj.foo = 'foo' : "foo"
 >obj.foo : string
->obj : { foo: string; bar: string; buzz: any[]; }
+>obj : { foo: string; bar: string; buzz: any; }
 >foo : string
 >'foo' : "foo"
 
         obj.bar = 'bar';
 >obj.bar = 'bar' : "bar"
 >obj.bar : string
->obj : { foo: string; bar: string; buzz: any[]; }
+>obj : { foo: string; bar: string; buzz: any; }
 >bar : string
 >'bar' : "bar"
 
         obj.buzz = Object.values(obj);
 >obj.buzz = Object.values(obj) : any[]
->obj.buzz : any[]
->obj : { foo: string; bar: string; buzz: any[]; }
->buzz : any[]
+>obj.buzz : any
+>obj : { foo: string; bar: string; buzz: any; }
+>buzz : any
 >Object.values(obj) : any[]
 >Object.values : { <T>(o: { [s: string]: T; } | ArrayLike<T>): T[]; (o: {}): any[]; }
 >Object : ObjectConstructor
 >values : { <T>(o: { [s: string]: T; } | ArrayLike<T>): T[]; (o: {}): any[]; }
->obj : { foo: string; bar: string; buzz: any[]; }
+>obj : { foo: string; bar: string; buzz: any; }
     }
 }
 

--- a/testdata/baselines/reference/compiler/expandoObjectIndexSignatures.errors.txt
+++ b/testdata/baselines/reference/compiler/expandoObjectIndexSignatures.errors.txt
@@ -1,0 +1,40 @@
+main.js(24,1): error TS7022: 'y' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
+main.js(29,5): error TS7022: 'y' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
+
+
+==== main.js (2 errors) ====
+    /** @param {Record<string, number>} obj */
+    function fx(obj) {}
+    
+    const obj1 = {};
+    fx(obj1);
+    
+    const obj2 = {};
+    obj2.x = 1
+    fx(obj2);
+    
+    function f1() {
+        const obj1 = {};
+        fx(obj1);
+    }
+    
+    function f2() {
+        const obj2 = {};
+        obj2.x = 1
+        fx(obj2);
+    }
+    
+    const obj3 = {};
+    obj3.x = 1;
+    obj3.y = Object.values(obj3);  // Circularity error
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS7022: 'y' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
+    
+    function f3() {
+        const obj3 = {};
+        obj3.x = 1;
+        obj3.y = Object.values(obj3);  // Circularity error
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS7022: 'y' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
+    }
+    

--- a/testdata/baselines/reference/compiler/expandoObjectIndexSignatures.symbols
+++ b/testdata/baselines/reference/compiler/expandoObjectIndexSignatures.symbols
@@ -1,0 +1,92 @@
+//// [tests/cases/compiler/expandoObjectIndexSignatures.ts] ////
+
+=== main.js ===
+/** @param {Record<string, number>} obj */
+function fx(obj) {}
+>fx : Symbol(fx, Decl(main.js, 0, 0))
+>obj : Symbol(obj, Decl(main.js, 1, 12))
+
+const obj1 = {};
+>obj1 : Symbol(obj1, Decl(main.js, 3, 5))
+
+fx(obj1);
+>fx : Symbol(fx, Decl(main.js, 0, 0))
+>obj1 : Symbol(obj1, Decl(main.js, 3, 5))
+
+const obj2 = {};
+>obj2 : Symbol(obj2, Decl(main.js, 6, 5))
+
+obj2.x = 1
+>obj2.x : Symbol(x, Decl(main.js, 6, 16))
+>obj2 : Symbol(obj2, Decl(main.js, 6, 5))
+>x : Symbol(x, Decl(main.js, 6, 16))
+
+fx(obj2);
+>fx : Symbol(fx, Decl(main.js, 0, 0))
+>obj2 : Symbol(obj2, Decl(main.js, 6, 5))
+
+function f1() {
+>f1 : Symbol(f1, Decl(main.js, 8, 9))
+
+    const obj1 = {};
+>obj1 : Symbol(obj1, Decl(main.js, 11, 9))
+
+    fx(obj1);
+>fx : Symbol(fx, Decl(main.js, 0, 0))
+>obj1 : Symbol(obj1, Decl(main.js, 11, 9))
+}
+
+function f2() {
+>f2 : Symbol(f2, Decl(main.js, 13, 1))
+
+    const obj2 = {};
+>obj2 : Symbol(obj2, Decl(main.js, 16, 9))
+
+    obj2.x = 1
+>obj2.x : Symbol(x, Decl(main.js, 16, 20))
+>obj2 : Symbol(obj2, Decl(main.js, 16, 9))
+>x : Symbol(x, Decl(main.js, 16, 20))
+
+    fx(obj2);
+>fx : Symbol(fx, Decl(main.js, 0, 0))
+>obj2 : Symbol(obj2, Decl(main.js, 16, 9))
+}
+
+const obj3 = {};
+>obj3 : Symbol(obj3, Decl(main.js, 21, 5))
+
+obj3.x = 1;
+>obj3.x : Symbol(x, Decl(main.js, 21, 16))
+>obj3 : Symbol(obj3, Decl(main.js, 21, 5))
+>x : Symbol(x, Decl(main.js, 21, 16))
+
+obj3.y = Object.values(obj3);  // Circularity error
+>obj3.y : Symbol(y, Decl(main.js, 22, 11))
+>obj3 : Symbol(obj3, Decl(main.js, 21, 5))
+>y : Symbol(y, Decl(main.js, 22, 11))
+>Object.values : Symbol(ObjectConstructor.values, Decl(lib.es2017.object.d.ts, --, --), Decl(lib.es2017.object.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>values : Symbol(ObjectConstructor.values, Decl(lib.es2017.object.d.ts, --, --), Decl(lib.es2017.object.d.ts, --, --))
+>obj3 : Symbol(obj3, Decl(main.js, 21, 5))
+
+function f3() {
+>f3 : Symbol(f3, Decl(main.js, 23, 29))
+
+    const obj3 = {};
+>obj3 : Symbol(obj3, Decl(main.js, 26, 9))
+
+    obj3.x = 1;
+>obj3.x : Symbol(x, Decl(main.js, 26, 20))
+>obj3 : Symbol(obj3, Decl(main.js, 26, 9))
+>x : Symbol(x, Decl(main.js, 26, 20))
+
+    obj3.y = Object.values(obj3);  // Circularity error
+>obj3.y : Symbol(y, Decl(main.js, 27, 15))
+>obj3 : Symbol(obj3, Decl(main.js, 26, 9))
+>y : Symbol(y, Decl(main.js, 27, 15))
+>Object.values : Symbol(ObjectConstructor.values, Decl(lib.es2017.object.d.ts, --, --), Decl(lib.es2017.object.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>values : Symbol(ObjectConstructor.values, Decl(lib.es2017.object.d.ts, --, --), Decl(lib.es2017.object.d.ts, --, --))
+>obj3 : Symbol(obj3, Decl(main.js, 26, 9))
+}
+

--- a/testdata/baselines/reference/compiler/expandoObjectIndexSignatures.types
+++ b/testdata/baselines/reference/compiler/expandoObjectIndexSignatures.types
@@ -1,0 +1,114 @@
+//// [tests/cases/compiler/expandoObjectIndexSignatures.ts] ////
+
+=== main.js ===
+/** @param {Record<string, number>} obj */
+function fx(obj) {}
+>fx : (obj: Record<string, number>) => void
+>obj : Record<string, number>
+
+const obj1 = {};
+>obj1 : {}
+>{} : {}
+
+fx(obj1);
+>fx(obj1) : void
+>fx : (obj: Record<string, number>) => void
+>obj1 : {}
+
+const obj2 = {};
+>obj2 : { x: number; }
+>{} : { x: number; }
+
+obj2.x = 1
+>obj2.x = 1 : 1
+>obj2.x : number
+>obj2 : { x: number; }
+>x : number
+>1 : 1
+
+fx(obj2);
+>fx(obj2) : void
+>fx : (obj: Record<string, number>) => void
+>obj2 : { x: number; }
+
+function f1() {
+>f1 : () => void
+
+    const obj1 = {};
+>obj1 : {}
+>{} : {}
+
+    fx(obj1);
+>fx(obj1) : void
+>fx : (obj: Record<string, number>) => void
+>obj1 : {}
+}
+
+function f2() {
+>f2 : () => void
+
+    const obj2 = {};
+>obj2 : { x: number; }
+>{} : { x: number; }
+
+    obj2.x = 1
+>obj2.x = 1 : 1
+>obj2.x : number
+>obj2 : { x: number; }
+>x : number
+>1 : 1
+
+    fx(obj2);
+>fx(obj2) : void
+>fx : (obj: Record<string, number>) => void
+>obj2 : { x: number; }
+}
+
+const obj3 = {};
+>obj3 : { x: number; y: any; }
+>{} : { x: number; y: any; }
+
+obj3.x = 1;
+>obj3.x = 1 : 1
+>obj3.x : number
+>obj3 : { x: number; y: any; }
+>x : number
+>1 : 1
+
+obj3.y = Object.values(obj3);  // Circularity error
+>obj3.y = Object.values(obj3) : any[]
+>obj3.y : any
+>obj3 : { x: number; y: any; }
+>y : any
+>Object.values(obj3) : any[]
+>Object.values : { <T>(o: { [s: string]: T; } | ArrayLike<T>): T[]; (o: {}): any[]; }
+>Object : ObjectConstructor
+>values : { <T>(o: { [s: string]: T; } | ArrayLike<T>): T[]; (o: {}): any[]; }
+>obj3 : { x: number; y: any; }
+
+function f3() {
+>f3 : () => void
+
+    const obj3 = {};
+>obj3 : { x: number; y: any; }
+>{} : { x: number; y: any; }
+
+    obj3.x = 1;
+>obj3.x = 1 : 1
+>obj3.x : number
+>obj3 : { x: number; y: any; }
+>x : number
+>1 : 1
+
+    obj3.y = Object.values(obj3);  // Circularity error
+>obj3.y = Object.values(obj3) : any[]
+>obj3.y : any
+>obj3 : { x: number; y: any; }
+>y : any
+>Object.values(obj3) : any[]
+>Object.values : { <T>(o: { [s: string]: T; } | ArrayLike<T>): T[]; (o: {}): any[]; }
+>Object : ObjectConstructor
+>values : { <T>(o: { [s: string]: T; } | ArrayLike<T>): T[]; (o: {}): any[]; }
+>obj3 : { x: number; y: any; }
+}
+

--- a/testdata/tests/cases/compiler/expandoObjectIndexSignatures.ts
+++ b/testdata/tests/cases/compiler/expandoObjectIndexSignatures.ts
@@ -1,0 +1,37 @@
+// @checkJs: true
+// @noEmit: true
+
+// https://github.com/microsoft/typescript-go/issues/3739
+
+// @filename: main.js
+
+/** @param {Record<string, number>} obj */
+function fx(obj) {}
+
+const obj1 = {};
+fx(obj1);
+
+const obj2 = {};
+obj2.x = 1
+fx(obj2);
+
+function f1() {
+    const obj1 = {};
+    fx(obj1);
+}
+
+function f2() {
+    const obj2 = {};
+    obj2.x = 1
+    fx(obj2);
+}
+
+const obj3 = {};
+obj3.x = 1;
+obj3.y = Object.values(obj3);  // Circularity error
+
+function f3() {
+    const obj3 = {};
+    obj3.x = 1;
+    obj3.y = Object.values(obj3);  // Circularity error
+}


### PR DESCRIPTION
With this PR we consistently provide implicit index signatures for JS expando object literals. We're currently in a very confused state in this area as [discussed here](https://github.com/microsoft/typescript-go/issues/3739#issuecomment-4424583608).

Note that this will resurrect the error observed in #3691, but that was fixed in the belief that TS6 was consistent here, which it isn't. In particular, the repro from #3691 errors when contained in a function or method, but succeeds at top-level. With this PR we'll consistently catch the circularity and report it with `noImplicitAny: true`.

Fixes #3739.