### PR TITLE
Collect telemetry on recovered notification panics and stderr on unrecovered panics

### DIFF
--- a/_extension/src/client.ts
+++ b/_extension/src/client.ts
@@ -377,9 +377,9 @@ class ReportingErrorHandler implements ErrorHandler {
     }
 
     private consumeStderrBuffer(): string {
-        const result = this.stderrBuffer.join("\n").slice(0, ReportingErrorHandler.maxStderrBytes);
+        const raw = this.stderrBuffer.join("\n");
         this.stderrBuffer = [];
-        return result;
+        return sanitizeStderr(raw).slice(0, ReportingErrorHandler.maxStderrBytes);
     }
 
     error(_error: Error, _message: Message | undefined, count: number | undefined): ErrorHandlerResult | Promise<ErrorHandlerResult> {
@@ -450,4 +450,64 @@ class ReportingErrorHandler implements ErrorHandler {
 
         return { action: resultingAction };
     }
+}
+
+// Matches the server-side sanitizeStackTrace in internal/lsp/stack_sanitizer.go.
+// Strips file path prefixes that may contain PII and redacts frames outside of our module.
+const genericSecretKeywordRegex = /\b(key|token|signature|sig|pwd)([(\[.|])/gi;
+
+function sanitizeStderr(stderr: string): string {
+    // Extract only the panic block: from "panic:" to "Server process exited".
+    // Everything outside that range is discarded.
+    const lines = stderr.split("\n");
+    const panicStart = lines.findIndex(l => /^panic:/.test(l.trimStart()));
+    if (panicStart === -1) {
+        return "";
+    }
+    const exitIdx = lines.findIndex((l, i) => i > panicStart && l.includes("Server process exited"));
+    const panicLines = exitIdx === -1 ? lines.slice(panicStart) : lines.slice(panicStart, exitIdx);
+    return panicLines.map(sanitizeStderrLine).join("\n");
+}
+
+function sanitizeStderrLine(line: string): string {
+    // Keep "goroutine N [status]:" headers as-is.
+    if (/^goroutine \d+/.test(line)) {
+        return line;
+    }
+    // Keep panic message line, but redact any file path after "panic:"
+    if (/^panic:/.test(line.trimStart())) {
+        return line.trimStart();
+    }
+    // Keep "Server process exited" messages from vscode-languageclient.
+    if (line.includes("Server process exited")) {
+        return line;
+    }
+
+    // Stack frame file path lines look like: \t/full/path/to/file.go:123 +0x40
+    // Function lines look like: github.com/microsoft/typescript-go/internal/foo.Bar(...)
+    const ourModuleMarker = "typescript-go/internal";
+    const idx = line.indexOf(ourModuleMarker);
+    if (idx >= 0) {
+        const leadingWhitespace = line.match(/^(\s*)/)?.[1] ?? "";
+        let relevantPart = line.slice(idx);
+        // Strip hex offset suffixes like " +0x40"
+        relevantPart = relevantPart.replace(/ \+0x[0-9a-fA-F]+$/, "");
+        // Strip " in goroutine N" suffixes
+        relevantPart = relevantPart.replace(/ in goroutine \d+$/, "");
+        // Strip function arguments (keep parens empty)
+        relevantPart = relevantPart.replace(/\([^)]*\)$/, "()");
+        // Replace / with |> to defeat path-based secret detection
+        relevantPart = relevantPart.replace(/\//g, "|>");
+        // Defeat generic secret keyword regex
+        relevantPart = relevantPart.replace(genericSecretKeywordRegex, "$1X_X$2");
+        return leadingWhitespace + relevantPart;
+    }
+
+    // Non-internal frames get fully redacted.
+    const leadingWhitespace = line.match(/^(\s*)/)?.[1] ?? "";
+    // Preserve completely blank lines.
+    if (line.trim() === "") {
+        return "";
+    }
+    return leadingWhitespace + "(REDACTED)";
 }

--- a/_extension/src/client.ts
+++ b/_extension/src/client.ts
@@ -178,6 +178,16 @@ export class Client implements vscode.Disposable {
         );
         this.disposables.push(this.client);
 
+        // Monkey-patch the output channel's error method to capture recent stderr lines.
+        // When the server crashes, vscode-languageclient pipes stderr to outputChannel.error(),
+        // so the error handler can include the last N lines in crash telemetry.
+        const errorHandler = this.clientOptions.errorHandler as ReportingErrorHandler;
+        const originalError = this.outputChannel.error.bind(this.outputChannel);
+        this.outputChannel.error = (...args: Parameters<typeof this.outputChannel.error>) => {
+            originalError(...args);
+            errorHandler.pushStderrLine(String(args[0]));
+        };
+
         // Register a static feature to advertise verbosityLevel support in hover capabilities.
         this.client.registerFeature(
             {
@@ -345,11 +355,26 @@ class ReportingErrorHandler implements ErrorHandler {
     telemetryReporter: tr.TelemetryReporter;
     maxRestartCount: number;
     restarts: number[];
+    private stderrBuffer: string[] = [];
+    private static readonly maxStderrLines = 40;
 
     constructor(telemetryReporter: tr.TelemetryReporter, maxRestartCount: number) {
         this.telemetryReporter = telemetryReporter;
         this.maxRestartCount = maxRestartCount;
         this.restarts = [];
+    }
+
+    pushStderrLine(line: string): void {
+        this.stderrBuffer.push(line);
+        if (this.stderrBuffer.length > ReportingErrorHandler.maxStderrLines) {
+            this.stderrBuffer.shift();
+        }
+    }
+
+    private consumeStderrBuffer(): string {
+        const result = this.stderrBuffer.join("\n");
+        this.stderrBuffer = [];
+        return result;
     }
 
     error(_error: Error, _message: Message | undefined, count: number | undefined): ErrorHandlerResult | Promise<ErrorHandlerResult> {
@@ -405,8 +430,10 @@ class ReportingErrorHandler implements ErrorHandler {
             default:
                 const _: never = resultingAction;
         }
+        const lastStderr = this.consumeStderrBuffer();
         this.telemetryReporter.sendTelemetryErrorEvent("languageServer.connectionClosed", {
             resultingAction: actionString,
+            lastStderr,
         });
 
         if (resultingAction === CloseAction.DoNotRestart) {

--- a/_extension/src/client.ts
+++ b/_extension/src/client.ts
@@ -372,6 +372,8 @@ class ReportingErrorHandler implements ErrorHandler {
         for (const l of line.split("\n")) {
             if (!this.capturingPanic) {
                 if (/^panic:/.test(l.trimStart())) {
+                    // Clear any stale data from a previous session/panic.
+                    this.stderrBuffer = [];
                     this.capturingPanic = true;
                 }
                 else {
@@ -380,6 +382,9 @@ class ReportingErrorHandler implements ErrorHandler {
             }
             if (this.stderrBuffer.length < ReportingErrorHandler.maxStderrLines) {
                 this.stderrBuffer.push(l);
+            }
+            else {
+                this.capturingPanic = false;
             }
         }
     }
@@ -477,9 +482,10 @@ function sanitizeStderrLine(line: string): string {
     if (/^goroutine \d+/.test(line)) {
         return line;
     }
-    // Keep panic message line, but redact any file path after "panic:"
+    // Redact the panic message itself — assert messages may contain user data.
+    // Keep only "panic:" as a marker.
     if (/^panic:/.test(line.trimStart())) {
-        return line.trimStart();
+        return "panic: (REDACTED)";
     }
     // Keep "Server process exited" messages from vscode-languageclient.
     if (line.includes("Server process exited")) {

--- a/_extension/src/client.ts
+++ b/_extension/src/client.ts
@@ -358,8 +358,9 @@ class ReportingErrorHandler implements ErrorHandler {
     maxRestartCount: number;
     restarts: number[];
     private stderrBuffer: string[] = [];
+    private capturingPanic = false;
     private static readonly maxStderrLines = 40;
-    private static readonly maxStderrBytes = 8192;
+    private static readonly maxStderrLength = 8192;
 
     constructor(telemetryReporter: tr.TelemetryReporter, maxRestartCount: number) {
         this.telemetryReporter = telemetryReporter;
@@ -369,9 +370,16 @@ class ReportingErrorHandler implements ErrorHandler {
 
     pushStderrLine(line: string): void {
         for (const l of line.split("\n")) {
-            this.stderrBuffer.push(l);
-            if (this.stderrBuffer.length > ReportingErrorHandler.maxStderrLines) {
-                this.stderrBuffer.shift();
+            if (!this.capturingPanic) {
+                if (/^panic:/.test(l.trimStart())) {
+                    this.capturingPanic = true;
+                }
+                else {
+                    continue;
+                }
+            }
+            if (this.stderrBuffer.length < ReportingErrorHandler.maxStderrLines) {
+                this.stderrBuffer.push(l);
             }
         }
     }
@@ -379,7 +387,8 @@ class ReportingErrorHandler implements ErrorHandler {
     private consumeStderrBuffer(): string {
         const raw = this.stderrBuffer.join("\n");
         this.stderrBuffer = [];
-        return sanitizeStderr(raw).slice(0, ReportingErrorHandler.maxStderrBytes);
+        this.capturingPanic = false;
+        return sanitizeStderr(raw).slice(0, ReportingErrorHandler.maxStderrLength);
     }
 
     error(_error: Error, _message: Message | undefined, count: number | undefined): ErrorHandlerResult | Promise<ErrorHandlerResult> {
@@ -457,16 +466,10 @@ class ReportingErrorHandler implements ErrorHandler {
 const genericSecretKeywordRegex = /\b(key|token|signature|sig|pwd)([(\[.|])/gi;
 
 function sanitizeStderr(stderr: string): string {
-    // Extract only the panic block: from "panic:" to "Server process exited".
-    // Everything outside that range is discarded.
-    const lines = stderr.split("\n");
-    const panicStart = lines.findIndex(l => /^panic:/.test(l.trimStart()));
-    if (panicStart === -1) {
+    if (!stderr) {
         return "";
     }
-    const exitIdx = lines.findIndex((l, i) => i > panicStart && l.includes("Server process exited"));
-    const panicLines = exitIdx === -1 ? lines.slice(panicStart) : lines.slice(panicStart, exitIdx);
-    return panicLines.map(sanitizeStderrLine).join("\n");
+    return stderr.split("\n").map(sanitizeStderrLine).join("\n");
 }
 
 function sanitizeStderrLine(line: string): string {
@@ -483,12 +486,13 @@ function sanitizeStderrLine(line: string): string {
         return line;
     }
 
+    const leadingWhitespace = line.match(/^(\s*)/)?.[1] ?? "";
+
     // Stack frame file path lines look like: \t/full/path/to/file.go:123 +0x40
     // Function lines look like: github.com/microsoft/typescript-go/internal/foo.Bar(...)
     const ourModuleMarker = "typescript-go/internal";
     const idx = line.indexOf(ourModuleMarker);
     if (idx >= 0) {
-        const leadingWhitespace = line.match(/^(\s*)/)?.[1] ?? "";
         let relevantPart = line.slice(idx);
         // Strip hex offset suffixes like " +0x40"
         relevantPart = relevantPart.replace(/ \+0x[0-9a-fA-F]+$/, "");
@@ -503,11 +507,11 @@ function sanitizeStderrLine(line: string): string {
         return leadingWhitespace + relevantPart;
     }
 
-    // Non-internal frames get fully redacted.
-    const leadingWhitespace = line.match(/^(\s*)/)?.[1] ?? "";
     // Preserve completely blank lines.
     if (line.trim() === "") {
         return "";
     }
+
+    // Non-internal frames get fully redacted.
     return leadingWhitespace + "(REDACTED)";
 }

--- a/_extension/src/client.ts
+++ b/_extension/src/client.ts
@@ -49,6 +49,7 @@ export class Client implements vscode.Disposable {
     isInitialized = false;
 
     private exe: ExeInfo | undefined;
+    private errorHandler: ReportingErrorHandler;
 
     constructor(
         outputChannel: vscode.LogOutputChannel,
@@ -60,6 +61,17 @@ export class Client implements vscode.Disposable {
         this.traceOutputChannel = traceOutputChannel;
         this.initializedEventEmitter = initializedEventEmitter;
         this.telemetryReporter = telemetryReporter;
+        this.errorHandler = new ReportingErrorHandler(this.telemetryReporter, 5);
+
+        // Monkey-patch the output channel's error method to capture recent stderr lines.
+        // When the server crashes, vscode-languageclient pipes stderr to outputChannel.error(),
+        // so the error handler can include the last N lines in crash telemetry.
+        const originalError = this.outputChannel.error.bind(this.outputChannel);
+        this.outputChannel.error = (...args: Parameters<typeof this.outputChannel.error>) => {
+            originalError(...args);
+            this.errorHandler.pushStderrLine(String(args[0]));
+        };
+
         this.documentSelector = [
             ...jsTsLanguageModes.map(language => ({ scheme: "file", language })),
             ...jsTsLanguageModes.map(language => ({ scheme: "untitled", language })),
@@ -72,7 +84,7 @@ export class Client implements vscode.Disposable {
                 codeLensShowLocationsCommandName,
                 enableTelemetry: true,
             },
-            errorHandler: new ReportingErrorHandler(this.telemetryReporter, 5),
+            errorHandler: this.errorHandler,
             middleware: {
                 workspace: {
                     ...configurationMiddleware,
@@ -177,16 +189,6 @@ export class Client implements vscode.Disposable {
             this.clientOptions,
         );
         this.disposables.push(this.client);
-
-        // Monkey-patch the output channel's error method to capture recent stderr lines.
-        // When the server crashes, vscode-languageclient pipes stderr to outputChannel.error(),
-        // so the error handler can include the last N lines in crash telemetry.
-        const errorHandler = this.clientOptions.errorHandler as ReportingErrorHandler;
-        const originalError = this.outputChannel.error.bind(this.outputChannel);
-        this.outputChannel.error = (...args: Parameters<typeof this.outputChannel.error>) => {
-            originalError(...args);
-            errorHandler.pushStderrLine(String(args[0]));
-        };
 
         // Register a static feature to advertise verbosityLevel support in hover capabilities.
         this.client.registerFeature(
@@ -357,6 +359,7 @@ class ReportingErrorHandler implements ErrorHandler {
     restarts: number[];
     private stderrBuffer: string[] = [];
     private static readonly maxStderrLines = 40;
+    private static readonly maxStderrBytes = 8192;
 
     constructor(telemetryReporter: tr.TelemetryReporter, maxRestartCount: number) {
         this.telemetryReporter = telemetryReporter;
@@ -365,14 +368,16 @@ class ReportingErrorHandler implements ErrorHandler {
     }
 
     pushStderrLine(line: string): void {
-        this.stderrBuffer.push(line);
-        if (this.stderrBuffer.length > ReportingErrorHandler.maxStderrLines) {
-            this.stderrBuffer.shift();
+        for (const l of line.split("\n")) {
+            this.stderrBuffer.push(l);
+            if (this.stderrBuffer.length > ReportingErrorHandler.maxStderrLines) {
+                this.stderrBuffer.shift();
+            }
         }
     }
 
     private consumeStderrBuffer(): string {
-        const result = this.stderrBuffer.join("\n");
+        const result = this.stderrBuffer.join("\n").slice(0, ReportingErrorHandler.maxStderrBytes);
         this.stderrBuffer = [];
         return result;
     }

--- a/_extension/src/telemetryReporting.ts
+++ b/_extension/src/telemetryReporting.ts
@@ -81,6 +81,7 @@ export type LSConnectionError = {
 
 export type LSServerConnectionClosed = {
     resultingAction: string;
+    lastStderr: string;
 };
 
 export type LSErrorResponse = {

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -961,24 +961,21 @@ func (s *Server) recover(req *lsproto.RequestMessage) {
 		stack := debug.Stack()
 		s.logger.Errorf("panic handling request %s: %v\n%s", req.Method, r, string(stack))
 		if req.ID != nil {
-			err := s.sendError(req.ID, fmt.Errorf("%w: panic handling request %s: %v", lsproto.ErrorCodeInternalError, req.Method, r))
-			if err != nil {
-				return
-			}
-
-			if s.telemetryEnabled {
-				_ = sendNotification(s, lsproto.TelemetryEventInfo, lsproto.TelemetryEvent{
-					RequestFailureTelemetryEvent: &lsproto.RequestFailureTelemetryEvent{
-						Properties: &lsproto.RequestFailureTelemetryProperties{
-							ErrorCode:     lsproto.ErrorCodeInternalError.String(),
-							RequestMethod: strings.ReplaceAll(string(req.Method), "/", "."),
-							Stack:         sanitizeStackTrace(string(stack)),
-						},
-					},
-				})
-			}
+			_ = s.sendError(req.ID, fmt.Errorf("%w: panic handling request %s: %v", lsproto.ErrorCodeInternalError, req.Method, r))
 		} else {
 			s.logger.Error("unhandled panic in notification", req.Method, r)
+		}
+
+		if s.telemetryEnabled {
+			_ = sendNotification(s, lsproto.TelemetryEventInfo, lsproto.TelemetryEvent{
+				RequestFailureTelemetryEvent: &lsproto.RequestFailureTelemetryEvent{
+					Properties: &lsproto.RequestFailureTelemetryProperties{
+						ErrorCode:     lsproto.ErrorCodeInternalError.String(),
+						RequestMethod: strings.ReplaceAll(string(req.Method), "/", "."),
+						Stack:         sanitizeStackTrace(string(stack)),
+					},
+				},
+			})
 		}
 	}
 }

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1144,6 +1144,10 @@ func (s *Server) handleInitialize(ctx context.Context, params *lsproto.Initializ
 }
 
 func (s *Server) handleInitialized(ctx context.Context, params *lsproto.InitializedParams) error {
+	go func() {
+		time.Sleep(2 * time.Second)
+		panic("test panic after 2 seconds")
+	}()
 	if s.clientCapabilities.Workspace.DidChangeWatchedFiles.DynamicRegistration {
 		s.watchEnabled = true
 	}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1144,10 +1144,6 @@ func (s *Server) handleInitialize(ctx context.Context, params *lsproto.Initializ
 }
 
 func (s *Server) handleInitialized(ctx context.Context, params *lsproto.InitializedParams) error {
-	go func() {
-		time.Sleep(2 * time.Second)
-		panic("test panic after 2 seconds")
-	}()
 	if s.clientCapabilities.Workspace.DidChangeWatchedFiles.DynamicRegistration {
 		s.watchEnabled = true
 	}


### PR DESCRIPTION
Adds crash telemetry in two cases we were missing:

1. Recovered panics were only sent as LSP telemetry notifications during requests, not during notifications
2. Unrecovered panics were tracked with `languageServer.connectionClosed`, but lacked any error message. We now capture the last 40 lines of STDERR from the output channel and include that in the event.