### PR TITLE
Avoid repeated realpath in vfsmatch

### DIFF
--- a/internal/vfs/internal/internal.go
+++ b/internal/vfs/internal/internal.go
@@ -66,6 +66,8 @@ func (vfs *Common) DirectoryExists(path string) bool {
 }
 
 func (vfs *Common) GetAccessibleEntries(path string) (result vfs.Entries) {
+	result.Symlinks = map[string]struct{}{}
+
 	addToResult := func(name string, mode fs.FileMode, isLink bool) (added bool) {
 		if mode.IsDir() {
 			result.Directories = append(result.Directories, name)
@@ -76,9 +78,6 @@ func (vfs *Common) GetAccessibleEntries(path string) (result vfs.Entries) {
 		}
 
 		if isLink {
-			if result.Symlinks == nil {
-				result.Symlinks = map[string]struct{}{}
-			}
 			result.Symlinks[name] = struct{}{}
 		}
 		return true

--- a/internal/vfs/internal/internal.go
+++ b/internal/vfs/internal/internal.go
@@ -66,31 +66,35 @@ func (vfs *Common) DirectoryExists(path string) bool {
 }
 
 func (vfs *Common) GetAccessibleEntries(path string) (result vfs.Entries) {
-	addToResult := func(name string, mode fs.FileMode) (added bool) {
+	addToResult := func(name string, mode fs.FileMode, isLink bool) (added bool) {
 		if mode.IsDir() {
 			result.Directories = append(result.Directories, name)
-			return true
-		}
-
-		if mode.IsRegular() {
+		} else if mode.IsRegular() {
 			result.Files = append(result.Files, name)
-			return true
+		} else {
+			return false
 		}
 
-		return false
+		if isLink {
+			if result.Symlinks == nil {
+				result.Symlinks = map[string]struct{}{}
+			}
+			result.Symlinks[name] = struct{}{}
+		}
+		return true
 	}
 
 	for _, entry := range vfs.getEntries(path) {
 		entryType := entry.Type()
 
-		if addToResult(entry.Name(), entryType) {
+		if addToResult(entry.Name(), entryType, false) {
 			continue
 		}
 
 		if entryType&fs.ModeSymlink != 0 {
 			// Easy case; UNIX-like system will clearly mark symlinks.
 			if stat := vfs.Stat(path + "/" + entry.Name()); stat != nil {
-				addToResult(entry.Name(), stat.Mode())
+				addToResult(entry.Name(), stat.Mode(), true)
 			}
 			continue
 		}
@@ -101,7 +105,7 @@ func (vfs *Common) GetAccessibleEntries(path string) (result vfs.Entries) {
 			fullPath := path + "/" + entry.Name()
 			if vfs.IsReparsePoint(fullPath) {
 				if stat := vfs.Stat(fullPath); stat != nil {
-					addToResult(entry.Name(), stat.Mode())
+					addToResult(entry.Name(), stat.Mode(), true)
 				}
 			}
 			continue

--- a/internal/vfs/osvfs/realpath_test.go
+++ b/internal/vfs/osvfs/realpath_test.go
@@ -109,4 +109,16 @@ func TestGetAccessibleEntries(t *testing.T) {
 
 	assert.DeepEqual(t, entries.Directories, []string{"dir1", "dir2"})
 	assert.DeepEqual(t, entries.Files, []string{"file1", "file2"})
+	assert.Check(t, entries.Symlinks != nil, "expected Symlinks to be set for directory with symlinks")
+	assert.Check(t, cmp.Len(entries.Symlinks, 4))
+	for _, name := range []string{"file1", "file2", "dir1", "dir2"} {
+		_, ok := entries.Symlinks[name]
+		assert.Check(t, ok, "expected %q to be in Symlinks", name)
+	}
+
+	// Non-symlink directory should have nil Symlinks.
+	entries = fs.GetAccessibleEntries(tspath.NormalizePath(target))
+	assert.DeepEqual(t, entries.Directories, []string{"dir1", "dir2"})
+	assert.DeepEqual(t, entries.Files, []string{"file1", "file2"})
+	assert.Check(t, entries.Symlinks == nil, "expected Symlinks to be nil for directory without symlinks")
 }

--- a/internal/vfs/osvfs/realpath_test.go
+++ b/internal/vfs/osvfs/realpath_test.go
@@ -116,9 +116,9 @@ func TestGetAccessibleEntries(t *testing.T) {
 		assert.Check(t, ok, "expected %q to be in Symlinks", name)
 	}
 
-	// Non-symlink directory should have nil Symlinks.
+	// Non-symlink directory should have empty Symlinks.
 	entries = fs.GetAccessibleEntries(tspath.NormalizePath(target))
 	assert.DeepEqual(t, entries.Directories, []string{"dir1", "dir2"})
 	assert.DeepEqual(t, entries.Files, []string{"file1", "file2"})
-	assert.Check(t, entries.Symlinks == nil, "expected Symlinks to be nil for directory without symlinks")
+	assert.Check(t, cmp.Len(entries.Symlinks, 0), "expected Symlinks to be empty for directory without symlinks")
 }

--- a/internal/vfs/osvfs/realpath_test.go
+++ b/internal/vfs/osvfs/realpath_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/microsoft/typescript-go/internal/tspath"
 	"gotest.tools/v3/assert"
-	"gotest.tools/v3/assert/cmp"
 )
 
 func TestSymlinkRealpath(t *testing.T) {
@@ -25,7 +24,8 @@ func TestSymlinkRealpath(t *testing.T) {
 	targetRealpath := fs.Realpath(tspath.NormalizePath(targetFile))
 	linkRealpath := fs.Realpath(tspath.NormalizePath(linkFile))
 
-	if !assert.Check(t, cmp.Equal(targetRealpath, linkRealpath)) {
+	if targetRealpath != linkRealpath {
+		t.Errorf("expected realpath of target and link to be equal, got %q and %q", targetRealpath, linkRealpath)
 		cmd := exec.Command("node", "-e", `console.log({ native: fs.realpathSync.native(process.argv[1]), node: fs.realpathSync(process.argv[1]) })`, linkFile)
 		out, err := cmd.CombinedOutput()
 		assert.NilError(t, err)
@@ -110,7 +110,7 @@ func TestGetAccessibleEntries(t *testing.T) {
 	assert.DeepEqual(t, entries.Directories, []string{"dir1", "dir2"})
 	assert.DeepEqual(t, entries.Files, []string{"file1", "file2"})
 	assert.Check(t, entries.Symlinks != nil, "expected Symlinks to be set for directory with symlinks")
-	assert.Check(t, cmp.Len(entries.Symlinks, 4))
+	assert.Equal(t, len(entries.Symlinks), 4)
 	for _, name := range []string{"file1", "file2", "dir1", "dir2"} {
 		_, ok := entries.Symlinks[name]
 		assert.Check(t, ok, "expected %q to be in Symlinks", name)
@@ -120,5 +120,6 @@ func TestGetAccessibleEntries(t *testing.T) {
 	entries = fs.GetAccessibleEntries(tspath.NormalizePath(target))
 	assert.DeepEqual(t, entries.Directories, []string{"dir1", "dir2"})
 	assert.DeepEqual(t, entries.Files, []string{"file1", "file2"})
-	assert.Check(t, cmp.Len(entries.Symlinks, 0), "expected Symlinks to be empty for directory without symlinks")
+	assert.Check(t, entries.Symlinks != nil, "expected Symlinks to be non-nil for directory without symlinks")
+	assert.Equal(t, len(entries.Symlinks), 0)
 }

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -52,7 +52,12 @@ type FS interface {
 type Entries struct {
 	Files       []string
 	Directories []string
-	Symlinks    map[string]struct{}
+	// Symlinks contains the names of entries in Files or Directories that were
+	// originally symbolic links (or reparse points) on disk. The names are the
+	// same as those in Files/Directories (i.e., the link name, not the target).
+	// nil means symlink information is not available and the entries may need
+	// to be re-checked for symlinks.
+	Symlinks map[string]struct{}
 }
 
 type (

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -52,6 +52,7 @@ type FS interface {
 type Entries struct {
 	Files       []string
 	Directories []string
+	Symlinks    map[string]struct{}
 }
 
 type (

--- a/internal/vfs/vfsmatch/vfsmatch.go
+++ b/internal/vfs/vfsmatch/vfsmatch.go
@@ -632,11 +632,15 @@ func (v *globVisitor) visit(path, absolutePath string, depth int, resolvedRealPa
 		}
 		absDir := absPrefix + dir
 		var childRealPath string
-		if _, isSymlink := entries.Symlinks[dir]; !isSymlink {
-			// Non-symlink directory: compute realpath incrementally.
-			childRealPath = realPath + "/" + dir
+		if entries.Symlinks != nil {
+			if _, isSymlink := entries.Symlinks[dir]; !isSymlink {
+				// Non-symlink directory: compute realpath incrementally.
+				childRealPath = tspath.CombinePaths(realPath, dir)
+			}
+			// else: symlink directory; leave childRealPath empty to force Realpath call.
 		}
-		// else: symlink directory; leave childRealPath empty to force Realpath call.
+		// If Symlinks is nil, the FS doesn't track symlinks;
+		// leave childRealPath empty to call Realpath (preserving old behavior).
 		v.visit(pathPrefix+dir, absDir, depth, childRealPath)
 	}
 }

--- a/internal/vfs/vfsmatch/vfsmatch.go
+++ b/internal/vfs/vfsmatch/vfsmatch.go
@@ -587,9 +587,18 @@ type globVisitor struct {
 	results                   [][]string
 }
 
-func (v *globVisitor) visit(path, absolutePath string, depth int) {
+// visit walks a directory tree, collecting files that match the glob patterns.
+// resolvedRealPath, when non-empty, is the already-resolved real path for this
+// directory (computed incrementally from the parent). When empty, Realpath is
+// called to resolve symlinks.
+func (v *globVisitor) visit(path, absolutePath string, depth int, resolvedRealPath string) {
 	// Detect symlink cycles
-	realPath := v.host.Realpath(absolutePath)
+	var realPath string
+	if resolvedRealPath != "" {
+		realPath = resolvedRealPath
+	} else {
+		realPath = v.host.Realpath(absolutePath)
+	}
 	canonicalPath := tspath.GetCanonicalFileName(realPath, v.useCaseSensitiveFileNames)
 	if v.visited.Has(canonicalPath) {
 		return
@@ -622,7 +631,13 @@ func (v *globVisitor) visit(path, absolutePath string, depth int) {
 			continue
 		}
 		absDir := absPrefix + dir
-		v.visit(pathPrefix+dir, absDir, depth)
+		var childRealPath string
+		if _, isSymlink := entries.Symlinks[dir]; !isSymlink {
+			// Non-symlink directory: compute realpath incrementally.
+			childRealPath = realPath + "/" + dir
+		}
+		// else: symlink directory; leave childRealPath empty to force Realpath call.
+		v.visit(pathPrefix+dir, absDir, depth, childRealPath)
 	}
 }
 
@@ -644,7 +659,7 @@ func matchFiles(path string, extensions, excludes, includes []string, useCaseSen
 	}
 
 	for _, basePath := range getBasePaths(path, includes, useCaseSensitiveFileNames) {
-		v.visit(basePath, tspath.CombinePaths(currentDirectory, basePath), depth)
+		v.visit(basePath, tspath.CombinePaths(currentDirectory, basePath), depth, "")
 	}
 
 	// Fast path: a single include bucket (or no includes) doesn't need flattening.


### PR DESCRIPTION
In the PR that rewrote vfsmatch, I fixed a bug where we were not checking for symlink cycles by porting the same code over from Strada.

However, Go's EvalSymlink appears to do more work than what we did in Strada, so was very slow.

The fix is this; if we have a realpath of a dir, and then we readdir for its entries, and an entry is not a symlink, then we know its realpath is just the parent dir's realpath joined with the entryname, without asking the OS.

Since most scanned dirs do not contain symlinks, this should actually be a major speedup, since we can just realpath the root of the search and then only join paths from then onward.