### PR TITLE
Speed up realpath on Linux and macOS

### DIFF
--- a/internal/vfs/osvfs/eintr_unix.go
+++ b/internal/vfs/osvfs/eintr_unix.go
@@ -4,16 +4,7 @@ package osvfs
 
 import "syscall"
 
-func ignoringEINTR(fn func() error) error {
-	for {
-		err := fn()
-		if err != syscall.EINTR { //nolint:errorlint // syscall functions return raw syscall.Errno, never wrapped
-			return err
-		}
-	}
-}
-
-func ignoringEINTR2[T any](fn func() (T, error)) (T, error) {
+func ignoringEINTR[T any](fn func() (T, error)) (T, error) {
 	for {
 		v, err := fn()
 		if err != syscall.EINTR { //nolint:errorlint // syscall functions return raw syscall.Errno, never wrapped

--- a/internal/vfs/osvfs/eintr_unix.go
+++ b/internal/vfs/osvfs/eintr_unix.go
@@ -7,7 +7,7 @@ import "syscall"
 func ignoringEINTR(fn func() error) error {
 	for {
 		err := fn()
-		if err != syscall.EINTR {
+		if err != syscall.EINTR { //nolint:errorlint // syscall functions return raw syscall.Errno, never wrapped
 			return err
 		}
 	}
@@ -16,7 +16,7 @@ func ignoringEINTR(fn func() error) error {
 func ignoringEINTR2[T any](fn func() (T, error)) (T, error) {
 	for {
 		v, err := fn()
-		if err != syscall.EINTR {
+		if err != syscall.EINTR { //nolint:errorlint // syscall functions return raw syscall.Errno, never wrapped
 			return v, err
 		}
 	}

--- a/internal/vfs/osvfs/eintr_unix.go
+++ b/internal/vfs/osvfs/eintr_unix.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+package osvfs
+
+import "syscall"
+
+func ignoringEINTR(fn func() error) error {
+	for {
+		err := fn()
+		if err != syscall.EINTR {
+			return err
+		}
+	}
+}
+
+func ignoringEINTR2[T any](fn func() (T, error)) (T, error) {
+	for {
+		v, err := fn()
+		if err != syscall.EINTR {
+			return v, err
+		}
+	}
+}

--- a/internal/vfs/osvfs/eintr_unix.go
+++ b/internal/vfs/osvfs/eintr_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build linux || darwin
 
 package osvfs
 

--- a/internal/vfs/osvfs/realpath_darwin.go
+++ b/internal/vfs/osvfs/realpath_darwin.go
@@ -1,0 +1,62 @@
+package osvfs
+
+import (
+	"path/filepath"
+	"sync"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// On macOS, we use open + fcntl(F_GETPATH) to resolve the canonical path in
+// O(1) syscalls instead of Go's filepath.EvalSymlinks which does an lstat per
+// path component — O(depth).
+//
+// How it works:
+//   - open(path, O_EVTONLY|O_CLOEXEC) follows all symlinks and gives us a
+//     lightweight fd. O_EVTONLY is macOS's event-only descriptor — it doesn't
+//     require read permission (similar to Linux's O_PATH) but still references
+//     the vnode.
+//   - fcntl(fd, F_GETPATH, buf) asks the kernel for the canonical path of the
+//     open file descriptor, written into a MAXPATHLEN buffer.
+//
+// unix.FcntlInt takes an int arg, but on darwin amd64/arm64 Go's int is
+// 64 bits — the same width as a pointer — so the buffer address
+// round-trips through int without loss.
+
+var hasFGetPath = sync.OnceValue(func() bool {
+	// Verify that F_GETPATH is supported by this kernel version.
+	var buf [unix.PathMax]byte
+	fd, err := unix.Open(".", unix.O_EVTONLY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return false
+	}
+	defer unix.Close(fd)
+	_, err = fcntlGetPath(fd, &buf)
+	return err == nil
+})
+
+func fcntlGetPath(fd int, buf *[unix.PathMax]byte) (int, error) {
+	return ignoringEINTR2(func() (int, error) {
+		return unix.FcntlInt(uintptr(fd), unix.F_GETPATH, int(uintptr(unsafe.Pointer(&buf[0]))))
+	})
+}
+
+func realpath(path string) (string, error) {
+	if !hasFGetPath() {
+		return filepath.EvalSymlinks(path)
+	}
+
+	fd, err := unix.Open(path, unix.O_EVTONLY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return "", err
+	}
+	defer unix.Close(fd)
+
+	var buf [unix.PathMax]byte
+	if _, err := fcntlGetPath(fd, &buf); err != nil {
+		return "", err
+	}
+
+	return unix.ByteSliceToString(buf[:]), nil
+}

--- a/internal/vfs/osvfs/realpath_darwin.go
+++ b/internal/vfs/osvfs/realpath_darwin.go
@@ -37,7 +37,7 @@ var hasFGetPath = sync.OnceValue(func() bool {
 })
 
 func fcntlGetPath(fd int, buf *[unix.PathMax]byte) (int, error) {
-	return ignoringEINTR2(func() (int, error) {
+	return ignoringEINTR(func() (int, error) {
 		return unix.FcntlInt(uintptr(fd), unix.F_GETPATH, int(uintptr(unsafe.Pointer(&buf[0]))))
 	})
 }

--- a/internal/vfs/osvfs/realpath_darwin.go
+++ b/internal/vfs/osvfs/realpath_darwin.go
@@ -13,10 +13,10 @@ import (
 // path component — O(depth).
 //
 // How it works:
-//   - open(path, O_EVTONLY|O_CLOEXEC) follows all symlinks and gives us a
-//     lightweight fd. O_EVTONLY is macOS's event-only descriptor — it doesn't
-//     require read permission (similar to Linux's O_PATH) but still references
-//     the vnode.
+//   - open(path, O_EVTONLY|O_NONBLOCK|O_CLOEXEC) follows all symlinks and gives
+//     us a lightweight fd. O_EVTONLY is macOS's event-only descriptor — it
+//     doesn't require read permission (similar to Linux's O_PATH) but still
+//     references the vnode. O_NONBLOCK prevents blocking on FIFOs.
 //   - fcntl(fd, F_GETPATH, buf) asks the kernel for the canonical path of the
 //     open file descriptor, written into a MAXPATHLEN buffer.
 //
@@ -27,7 +27,7 @@ import (
 var hasFGetPath = sync.OnceValue(func() bool {
 	// Verify that F_GETPATH is supported by this kernel version.
 	var buf [unix.PathMax]byte
-	fd, err := unix.Open(".", unix.O_EVTONLY|unix.O_CLOEXEC, 0)
+	fd, err := unix.Open(".", unix.O_EVTONLY|unix.O_NONBLOCK|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return false
 	}
@@ -47,7 +47,7 @@ func realpath(path string) (string, error) {
 		return filepath.EvalSymlinks(path)
 	}
 
-	fd, err := unix.Open(path, unix.O_EVTONLY|unix.O_CLOEXEC, 0)
+	fd, err := unix.Open(path, unix.O_EVTONLY|unix.O_NONBLOCK|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return "", err
 	}

--- a/internal/vfs/osvfs/realpath_linux.go
+++ b/internal/vfs/osvfs/realpath_linux.go
@@ -1,0 +1,66 @@
+package osvfs
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+
+	"golang.org/x/sys/unix"
+)
+
+// On Linux, we use the O_PATH + /proc/self/fd trick to resolve the canonical
+// path in O(1) syscalls (open + readlink + close) instead of Go's
+// filepath.EvalSymlinks which does an lstat per path component — O(depth).
+//
+// This is the approach libuv/Node.js could use, though libuv currently just
+// calls C realpath(3) which itself does a readlink per component. On the Go
+// side, the per-component approach is even more expensive because each
+// os.Lstat call involves goroutine scheduling overhead (entersyscall /
+// exitsyscall).
+//
+// How it works:
+//   - open(path, O_PATH|O_CLOEXEC) gives us a lightweight fd that follows all
+//     symlinks to the final target. O_PATH requires only search permission on
+//     directories (same as lstat), and works for both files and directories.
+//   - readlink("/proc/self/fd/<fd>") returns the fully resolved canonical path
+//     that the kernel computed during the open.
+//
+// Falls back to filepath.EvalSymlinks if /proc is not available (e.g. containers
+// or chroots without procfs mounted).
+
+const _procSelfFD = "/proc/self/fd/"
+
+var hasProcSelfFD = sync.OnceValue(func() bool {
+	var stat unix.Stat_t
+	return unix.Stat(_procSelfFD, &stat) == nil
+})
+
+func realpath(path string) (string, error) {
+	if !hasProcSelfFD() {
+		return filepath.EvalSymlinks(path)
+	}
+
+	fd, err := unix.Open(path, unix.O_CLOEXEC|unix.O_PATH, 0)
+	if err != nil {
+		return "", &os.PathError{Op: "open", Path: path, Err: err}
+	}
+	defer unix.Close(fd)
+
+	var procBuf [len(_procSelfFD) + 20]byte // 20 digits is enough for any int64 fd
+	n := copy(procBuf[:], _procSelfFD)
+	n += copy(procBuf[n:], strconv.Itoa(fd))
+
+	buf := make([]byte, 256)
+	for {
+		nn, err := unix.Readlink(string(procBuf[:n]), buf)
+		if err != nil {
+			return "", &os.PathError{Op: "readlink", Path: path, Err: err}
+		}
+		if nn < len(buf) {
+			return string(buf[:nn]), nil
+		}
+		buf = make([]byte, len(buf)*2)
+	}
+}
+

--- a/internal/vfs/osvfs/realpath_linux.go
+++ b/internal/vfs/osvfs/realpath_linux.go
@@ -41,7 +41,9 @@ func realpath(path string) (string, error) {
 		return filepath.EvalSymlinks(path)
 	}
 
-	fd, err := unix.Open(path, unix.O_CLOEXEC|unix.O_PATH, 0)
+	fd, err := ignoringEINTR2(func() (int, error) {
+		return unix.Open(path, unix.O_CLOEXEC|unix.O_PATH, 0)
+	})
 	if err != nil {
 		return "", &os.PathError{Op: "open", Path: path, Err: err}
 	}
@@ -50,10 +52,13 @@ func realpath(path string) (string, error) {
 	var procBuf [len(_procSelfFD) + 20]byte // 20 digits is enough for any int64 fd
 	n := copy(procBuf[:], _procSelfFD)
 	n += copy(procBuf[n:], strconv.Itoa(fd))
+	procPath := string(procBuf[:n])
 
 	buf := make([]byte, 256)
 	for {
-		nn, err := unix.Readlink(string(procBuf[:n]), buf)
+		nn, err := ignoringEINTR2(func() (int, error) {
+			return unix.Readlink(procPath, buf)
+		})
 		if err != nil {
 			return "", &os.PathError{Op: "readlink", Path: path, Err: err}
 		}

--- a/internal/vfs/osvfs/realpath_linux.go
+++ b/internal/vfs/osvfs/realpath_linux.go
@@ -41,7 +41,7 @@ func realpath(path string) (string, error) {
 		return filepath.EvalSymlinks(path)
 	}
 
-	fd, err := ignoringEINTR2(func() (int, error) {
+	fd, err := ignoringEINTR(func() (int, error) {
 		return unix.Open(path, unix.O_CLOEXEC|unix.O_PATH, 0)
 	})
 	if err != nil {
@@ -56,7 +56,7 @@ func realpath(path string) (string, error) {
 
 	buf := make([]byte, 256)
 	for {
-		nn, err := ignoringEINTR2(func() (int, error) {
+		nn, err := ignoringEINTR(func() (int, error) {
 			return unix.Readlink(procPath, buf)
 		})
 		if err != nil {

--- a/internal/vfs/osvfs/realpath_linux.go
+++ b/internal/vfs/osvfs/realpath_linux.go
@@ -68,4 +68,3 @@ func realpath(path string) (string, error) {
 		buf = make([]byte, len(buf)*2)
 	}
 }
-

--- a/internal/vfs/osvfs/realpath_other.go
+++ b/internal/vfs/osvfs/realpath_other.go
@@ -1,4 +1,4 @@
-//go:build !windows && !linux
+//go:build !windows && !linux && !darwin
 
 package osvfs
 

--- a/internal/vfs/osvfs/realpath_other.go
+++ b/internal/vfs/osvfs/realpath_other.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !linux
 
 package osvfs
 

--- a/internal/vfs/osvfs/realpath_test.go
+++ b/internal/vfs/osvfs/realpath_test.go
@@ -74,6 +74,33 @@ func BenchmarkRealpath(b *testing.B) {
 			fs.Realpath(normalizedLinkFile)
 		}
 	})
+
+	// Simulate a deep node_modules path to show scaling with depth.
+	deepDir := b.TempDir()
+	for _, seg := range []string{"project", "node_modules", "@scope", "package", "node_modules", "dep", "lib", "dist", "esm", "internal", "utils"} {
+		deepDir = filepath.Join(deepDir, seg)
+	}
+	assert.NilError(b, os.MkdirAll(deepDir, 0o777))
+	deepFile := filepath.Join(deepDir, "index.js")
+	assert.NilError(b, os.WriteFile(deepFile, []byte("module.exports = {}"), 0o666))
+	normalizedDeepFile := tspath.NormalizePath(deepFile)
+
+	b.Run("deep", func(b *testing.B) {
+		b.ReportAllocs()
+
+		for b.Loop() {
+			fs.Realpath(normalizedDeepFile)
+		}
+	})
+
+	b.Run("deep_evalSymlinks", func(b *testing.B) {
+		b.ReportAllocs()
+		deepNative := filepath.FromSlash(normalizedDeepFile)
+
+		for b.Loop() {
+			filepath.EvalSymlinks(deepNative) //nolint:errcheck
+		}
+	})
 }
 
 func TestGetAccessibleEntries(t *testing.T) {


### PR DESCRIPTION
On Linux, we can open a file with `O_PATH` to ask it to be opened _only_ for path resolution, then check `/proc/self/fd/<fd>` for the finalized path in one go. This avoids `EvalSymlinks` entirely, greatly speeding up realpath.

```
goos: linux
goarch: amd64
pkg: github.com/microsoft/typescript-go/internal/vfs/osvfs
cpu: Intel(R) Core(TM) i9-10900K CPU @ 3.70GHz
                              │   old.txt    │               new.txt               │
                              │    sec/op    │   sec/op     vs base                │
Realpath/target-20               4.968µ ± 2%   3.413µ ± 1%  -31.29% (p=0.000 n=10)
Realpath/link-20                 9.703µ ± 1%   3.661µ ± 1%  -62.27% (p=0.000 n=10)
Realpath/deep-20                18.681µ ± 0%   4.074µ ± 1%  -78.19% (p=0.000 n=10)
Realpath/deep_evalSymlinks-20    18.32µ ± 1%   18.21µ ± 1%        ~ (p=0.105 n=10)
geomean                          11.33µ        5.518µ       -51.31%
```
```
                              │   old.txt    │                new.txt                 │
                              │     B/op     │     B/op      vs base                  │
Realpath/target-20               1584.0 ± 0%     128.0 ± 0%  -91.92% (p=0.000 n=10)
Realpath/link-20                 3072.0 ± 0%     112.0 ± 0%  -96.35% (p=0.000 n=10)
Realpath/deep-20                 6720.0 ± 0%     272.0 ± 0%  -95.95% (p=0.000 n=10)
Realpath/deep_evalSymlinks-20   6.562Ki ± 0%   6.562Ki ± 0%        ~ (p=1.000 n=10) ¹
geomean                         3.760Ki          402.3       -89.55%
¹ all samples are equal
```
```
                              │   old.txt   │               new.txt                │
                              │  allocs/op  │ allocs/op   vs base                  │
Realpath/target-20              19.000 ± 0%   3.000 ± 0%  -84.21% (p=0.000 n=10)
Realpath/link-20                38.000 ± 0%   3.000 ± 0%  -92.11% (p=0.000 n=10)
Realpath/deep-20                59.000 ± 0%   3.000 ± 0%  -94.92% (p=0.000 n=10)
Realpath/deep_evalSymlinks-20    59.00 ± 0%   59.00 ± 0%        ~ (p=1.000 n=10) ¹
geomean                          39.82        6.318       -84.13%
¹ all samples are equal
```

On `macOS`, we can do a similar thing using `fcntl(F_GETPATH)`. This is not that drastic, but is still faster for unlinked files, the common case.

```
goos: darwin
goarch: arm64
pkg: github.com/microsoft/typescript-go/internal/vfs/osvfs
cpu: Apple M1
                             │   old.txt    │               new.txt               │
                             │    sec/op    │   sec/op     vs base                │
Realpath/target-8              140.3µ ± 28%   115.8µ ± 0%  -17.48% (p=0.000 n=10)
Realpath/link-8                116.8µ ± 56%   116.4µ ± 0%        ~ (p=0.631 n=10)
Realpath/deep-8                120.4µ ±  0%   119.5µ ± 0%   -0.70% (p=0.000 n=10)
Realpath/deep_evalSymlinks-8   26.25µ ±  0%   26.34µ ± 0%   +0.32% (p=0.001 n=10)
geomean                        84.83µ         80.70µ        -4.86%
```
```
                             │   old.txt    │                new.txt                │
                             │     B/op     │     B/op      vs base                 │
Realpath/target-8                208.0 ± 0%     208.0 ± 0%       ~ (p=1.000 n=10) ¹
Realpath/link-8                  208.0 ± 0%     208.0 ± 0%       ~ (p=1.000 n=10) ¹
Realpath/deep-8                  368.0 ± 0%     368.0 ± 0%       ~ (p=1.000 n=10) ¹
Realpath/deep_evalSymlinks-8   10.83Ki ± 0%   10.83Ki ± 0%       ~ (p=1.000 n=10) ¹
geomean                          648.2          648.2       +0.00%
¹ all samples are equal
```
```
                             │  old.txt   │               new.txt               │
                             │ allocs/op  │ allocs/op   vs base                 │
Realpath/target-8              2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=10) ¹
Realpath/link-8                2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=10) ¹
Realpath/deep-8                2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=10) ¹
Realpath/deep_evalSymlinks-8   86.00 ± 0%   86.00 ± 0%       ~ (p=1.000 n=10) ¹
geomean                        5.121        5.121       +0.00%
¹ all samples are equal
```

Other OSs might have something like this, but now we have special cases for Windows, Linux, and macOS, which is most everyone.