### PR TITLE
Don't send bundled file watchers to client

### DIFF
--- a/internal/project/session.go
+++ b/internal/project/session.go
@@ -14,6 +14,7 @@ import (
 
 	osmemory "github.com/mackerelio/go-osstat/memory"
 	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/bundled"
 	"github.com/microsoft/typescript-go/internal/collections"
 	"github.com/microsoft/typescript-go/internal/core"
 	"github.com/microsoft/typescript-go/internal/diagnostics"
@@ -1155,6 +1156,10 @@ func updateWatch[T any](ctx context.Context, session *Session, logger logging.Lo
 		if len(watchers) > 0 {
 			var newWatchers collections.OrderedMap[WatcherID, *lsproto.FileSystemWatcher]
 			for i, watcher := range watchers {
+				// Skip bundled paths - they are embedded so the client cannot watch them.
+				if bundled.IsBundled(fileSystemWatcherGlobString(watcher)) {
+					continue
+				}
 				globId := WatcherID(fmt.Sprintf("%s.%d", w.WatcherID, i))
 				if session.watches.Acquire(watcher, globId) {
 					newWatchers.Set(globId, watcher)


### PR DESCRIPTION
The LSP server was requesting clients to watch embedded TypeScript library files using the pattern 'bundled:///libs/**/*'.

This PR filter out bundled watchers before sending them to the client in the updateWatch function to prevent this invalid request.
