### PR TITLE
Fixed user/workspace priority ordering for 'useTsgo' vscode setting

### DIFF
--- a/_extension/src/util.ts
+++ b/_extension/src/util.ts
@@ -147,9 +147,11 @@ export async function restartExtHostOnChangeIfNeeded(): Promise<void> {
  * `typescript.experimental.useTsgo`, using `inspect()` to only consider
  * explicitly set values (ignoring VS Code defaults).
  *
- * Returns `true` if either setting is explicitly `true`, `false` if either
- * is explicitly `false` (and neither is `true`), or `undefined` if neither
- * setting has been explicitly configured.
+ * Each setting key is resolved using standard VS Code precedence (workspace
+ * folder > workspace > global, with language-specific overrides taking
+ * priority within each scope). Returns `true` if either resolved value is
+ * `true`, `false` if either is `false` (and neither is `true`), or
+ * `undefined` if neither setting has been explicitly configured.
  */
 export function getUseTsgo(): boolean | undefined {
     const tsValue = getExplicitUseTsgo("typescript");
@@ -184,8 +186,9 @@ function getExplicitUseTsgo(section: string): boolean | undefined {
         inspected.globalValue,
     ];
 
-    if (explicitValues.some(v => v === true)) return true;
-    if (explicitValues.some(v => v === false)) return false;
+    for (const v of explicitValues) {
+        if (v !== undefined) return v;
+    }
     return undefined;
 }
 


### PR DESCRIPTION
Previously, `getUseTsgo` would return true if this setting was true at any level, but a user level setting of true should be overridden by a workspace setting of false. Implemented priority ordering such that the first non-undefined setting found in priority order will be returned.

Fixes #3668 