### PR TITLE
fix(3905): fix out-of-bounds access when flattening destructuring with no bindings

### DIFF
--- a/internal/transformers/destructuring.go
+++ b/internal/transformers/destructuring.go
@@ -257,11 +257,17 @@ func (f *flattener) flattenDestructuringBinding(node *ast.Node, rval *ast.Node, 
 
 	if len(f.expressions) > 0 {
 		temp := f.tx.Factory().NewTempVariable()
-		f.tx.EmitContext().AddVariableDeclaration(temp)
-		last := &f.declarations[len(f.declarations)-1]
-		last.pendingExpressions = append(last.pendingExpressions, f.tx.Factory().NewAssignmentExpression(temp, last.value))
-		last.pendingExpressions = append(last.pendingExpressions, f.expressions...)
-		last.value = temp
+		if f.hoistTempVariables {
+			value := f.tx.Factory().InlineExpressions(f.expressions)
+			f.expressions = nil
+			f.emitBindingOrAssignment(f, temp, value, core.TextRange{}, nil)
+		} else {
+			f.tx.EmitContext().AddVariableDeclaration(temp)
+			last := &f.declarations[len(f.declarations)-1]
+			last.pendingExpressions = append(last.pendingExpressions, f.tx.Factory().NewAssignmentExpression(temp, last.value))
+			last.pendingExpressions = append(last.pendingExpressions, f.expressions...)
+			last.value = temp
+		}
 	}
 
 	decls := make([]*ast.Node, 0, len(f.declarations))

--- a/testdata/baselines/reference/compiler/destructuringEmptyBinding.errors.txt
+++ b/testdata/baselines/reference/compiler/destructuringEmptyBinding.errors.txt
@@ -1,0 +1,11 @@
+a.ts(1,16): error TS1003: Identifier expected.
+a.ts(1,23): error TS2304: Cannot find name 'x'.
+
+
+==== a.ts (2 errors) ====
+    export var {...{ }} = x;
+                   ~
+!!! error TS1003: Identifier expected.
+                          ~
+!!! error TS2304: Cannot find name 'x'.
+    

--- a/testdata/baselines/reference/compiler/destructuringEmptyBinding.js
+++ b/testdata/baselines/reference/compiler/destructuringEmptyBinding.js
@@ -1,0 +1,20 @@
+//// [tests/cases/compiler/destructuringEmptyBinding.ts] ////
+
+//// [a.ts]
+export var {...{ }} = x;
+
+
+//// [a.js]
+var __rest = (this && this.__rest) || function (s, e) {
+    var t = {};
+    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+        t[p] = s[p];
+    if (s != null && typeof Object.getOwnPropertySymbols === "function")
+        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
+            if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i]))
+                t[p[i]] = s[p[i]];
+        }
+    return t;
+};
+var _a;
+export var _b = _a = __rest(x, []);

--- a/testdata/baselines/reference/compiler/destructuringEmptyBinding.symbols
+++ b/testdata/baselines/reference/compiler/destructuringEmptyBinding.symbols
@@ -1,0 +1,6 @@
+//// [tests/cases/compiler/destructuringEmptyBinding.ts] ////
+
+=== a.ts ===
+
+export var {...{ }} = x;
+

--- a/testdata/baselines/reference/compiler/destructuringEmptyBinding.types
+++ b/testdata/baselines/reference/compiler/destructuringEmptyBinding.types
@@ -1,0 +1,7 @@
+//// [tests/cases/compiler/destructuringEmptyBinding.ts] ////
+
+=== a.ts ===
+export var {...{ }} = x;
+> : any
+>x : any
+

--- a/testdata/tests/cases/compiler/destructuringEmptyBinding.ts
+++ b/testdata/tests/cases/compiler/destructuringEmptyBinding.ts
@@ -1,0 +1,3 @@
+// @target: es2017
+// @filename: a.ts
+export var {...{ }} = x;


### PR DESCRIPTION
Fixes #3905

---

https://github.com/microsoft/TypeScript/blob/f350b52331494b68c90ab02e2b6d0828d2a22a74/src/compiler/transformers/destructuring.ts#L285-L289