### PR TITLE
fix(printer): clamp out-of-range pos in getLineAndCharacter for source map emit

### DIFF
--- a/internal/printer/utilities.go
+++ b/internal/printer/utilities.go
@@ -909,6 +909,12 @@ func newLineCharacterCache(source sourcemap.Source) *lineCharacterCache {
 // getLineAndCharacter returns the 0-based line number and UTF-16 code unit
 // offset from the start of that line for the given byte position.
 func (c *lineCharacterCache) getLineAndCharacter(pos int) (line int, character core.UTF16Offset) {
+	// Synthetic tokens (e.g. auto-inserted '}' for an unclosed block) can have
+	// positions beyond the end of the source text. Clamp to match JS semantics
+	// where string.slice(start, end) silently caps end at string.length.
+	if pos > len(c.text) {
+		pos = len(c.text)
+	}
 	line = scanner.ComputeLineOfPosition(c.lineMap, pos)
 	if c.hasCached && line == c.cachedLine && pos >= c.cachedPos {
 		// Incremental: only count UTF-16 code units from the last cached position.

--- a/testdata/baselines/reference/compiler/sourceMapEmitUnclosedBlock.errors.txt
+++ b/testdata/baselines/reference/compiler/sourceMapEmitUnclosedBlock.errors.txt
@@ -1,0 +1,9 @@
+sourceMapEmitUnclosedBlock.ts(2,1): error TS1005: '}' expected.
+
+
+==== sourceMapEmitUnclosedBlock.ts (1 errors) ====
+    {
+    
+    
+!!! error TS1005: '}' expected.
+!!! related TS1007 sourceMapEmitUnclosedBlock.ts:1:1: The parser expected to find a '}' to match the '{' token here.

--- a/testdata/baselines/reference/compiler/sourceMapEmitUnclosedBlock.js
+++ b/testdata/baselines/reference/compiler/sourceMapEmitUnclosedBlock.js
@@ -1,0 +1,11 @@
+//// [tests/cases/compiler/sourceMapEmitUnclosedBlock.ts] ////
+
+//// [sourceMapEmitUnclosedBlock.ts]
+{
+
+
+//// [sourceMapEmitUnclosedBlock.js]
+"use strict";
+{
+}
+//# sourceMappingURL=sourceMapEmitUnclosedBlock.js.map

--- a/testdata/baselines/reference/compiler/sourceMapEmitUnclosedBlock.js.map
+++ b/testdata/baselines/reference/compiler/sourceMapEmitUnclosedBlock.js.map
@@ -1,0 +1,3 @@
+//// [sourceMapEmitUnclosedBlock.js.map]
+{"version":3,"file":"sourceMapEmitUnclosedBlock.js","sourceRoot":"","sources":["sourceMapEmitUnclosedBlock.ts"],"names":[],"mappings":";AAAA,CAAC;AACD,CAAA,AADC"}
+//// https://sokra.github.io/source-map-visualization#base64,InVzZSBzdHJpY3QiOw0Kew0KfQ0KLy8jIHNvdXJjZU1hcHBpbmdVUkw9c291cmNlTWFwRW1pdFVuY2xvc2VkQmxvY2suanMubWFw,eyJ2ZXJzaW9uIjozLCJmaWxlIjoic291cmNlTWFwRW1pdFVuY2xvc2VkQmxvY2suanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJzb3VyY2VNYXBFbWl0VW5jbG9zZWRCbG9jay50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiO0FBQUEsQ0FBQztBQUNELENBQUEsQUFEQyJ9,ewo=

--- a/testdata/baselines/reference/compiler/sourceMapEmitUnclosedBlock.sourcemap.txt
+++ b/testdata/baselines/reference/compiler/sourceMapEmitUnclosedBlock.sourcemap.txt
@@ -1,0 +1,34 @@
+===================================================================
+JsFile: sourceMapEmitUnclosedBlock.js
+mapUrl: sourceMapEmitUnclosedBlock.js.map
+sourceRoot: 
+sources: sourceMapEmitUnclosedBlock.ts
+===================================================================
+-------------------------------------------------------------------
+emittedFile:sourceMapEmitUnclosedBlock.js
+sourceFile:sourceMapEmitUnclosedBlock.ts
+-------------------------------------------------------------------
+>>>"use strict";
+>>>{
+1 >
+2 >^
+3 > ^->
+1 >
+2 >{
+1 >Emitted(2, 1) Source(1, 1) + SourceIndex(0)
+2 >Emitted(2, 2) Source(1, 2) + SourceIndex(0)
+---
+>>>}
+1->
+2 >^
+3 > 
+4 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+1->
+  >
+2 >
+3 > 
+1->Emitted(3, 1) Source(2, 1) + SourceIndex(0)
+2 >Emitted(3, 2) Source(2, 1) + SourceIndex(0)
+3 >Emitted(3, 2) Source(1, 2) + SourceIndex(0)
+---
+>>>//# sourceMappingURL=sourceMapEmitUnclosedBlock.js.map

--- a/testdata/baselines/reference/compiler/sourceMapEmitUnclosedBlock.symbols
+++ b/testdata/baselines/reference/compiler/sourceMapEmitUnclosedBlock.symbols
@@ -1,0 +1,5 @@
+//// [tests/cases/compiler/sourceMapEmitUnclosedBlock.ts] ////
+
+=== sourceMapEmitUnclosedBlock.ts ===
+{
+

--- a/testdata/baselines/reference/compiler/sourceMapEmitUnclosedBlock.types
+++ b/testdata/baselines/reference/compiler/sourceMapEmitUnclosedBlock.types
@@ -1,0 +1,5 @@
+//// [tests/cases/compiler/sourceMapEmitUnclosedBlock.ts] ////
+
+=== sourceMapEmitUnclosedBlock.ts ===
+{
+

--- a/testdata/tests/cases/compiler/sourceMapEmitUnclosedBlock.ts
+++ b/testdata/tests/cases/compiler/sourceMapEmitUnclosedBlock.ts
@@ -1,0 +1,3 @@
+// @sourceMap: true
+
+{


### PR DESCRIPTION
Fixes #3900

## Analysis

`tsgo --sourceMap` on any file that triggers a parse error producing a synthetic closing token will panic:

```sh
echo '{' > bug.ts && tsgo --sourceMap bug.ts
# panic: runtime error: slice bounds out of range [:3] with length 2
```

The crash is in `lineCharacterCache.getLineAndCharacter` (`internal/printer/utilities.go`). It computes source map character offsets by slicing the source text: `c.text[cachedPos:pos]`. When the parser encounters an unclosed `{`, it inserts a synthetic `}` at a position past the end of the file (position 3 for a 2-byte file, `{\n`). Go panics on the out-of-bounds slice.

TypeScript's original implementation doesn't have this problem because `String.prototype.slice` silently clamps its end index to `string.length`. The Go port replicates the algorithm but not that implicit clamp.

## Fix

One guard at the top of `getLineAndCharacter`: if `pos > len(c.text)`, clamp it to `len(c.text)`. Positions within bounds pass through unchanged, so this only affects synthetic tokens at or past end-of-file. The clamped position maps them to EOF in the source map, matching what TypeScript's JS implementation produces.

## Copilot Checklist

I successfully ran these commands at the end of my session, and they completed without error:
 * [x] npx hereby build
 * [x] npx hereby test
 * [x] npx hereby lint
 * [x] npx hereby format