### PR TITLE
Fix crash inferring constrained variadic tuples with optional elements

### DIFF
--- a/internal/checker/inference.go
+++ b/internal/checker/inference.go
@@ -712,9 +712,12 @@ func (c *Checker) inferFromObjectTypes(n *InferenceState, source *Type, target *
 							constraint := c.getBaseConstraintOfType(info.typeParameter)
 							if constraint != nil && isTupleType(constraint) && constraint.TargetTupleType().combinedFlags&ElementFlagsVariable == 0 {
 								impliedArity := constraint.TargetTupleType().fixedLength
-								c.inferFromTypes(n, c.sliceTupleType(source, startLength, sourceArity-(startLength+impliedArity)), elementTypes[startLength])
-								if restType := c.getElementTypeOfSliceOfTupleType(source, startLength+impliedArity, endLength, false, false); restType != nil {
-									c.inferFromTypes(n, restType, elementTypes[startLength+1])
+								if startLength+impliedArity <= source.TargetTupleType().fixedLength {
+									c.inferFromTypes(n, c.sliceTupleType(source, startLength, sourceArity-(startLength+impliedArity)), elementTypes[startLength])
+									restType := c.getElementTypeOfSliceOfTupleType(source, startLength+impliedArity, endLength, false, false)
+									if restType != nil {
+										c.inferFromTypes(n, restType, elementTypes[startLength+1])
+									}
 								}
 							}
 						}
@@ -725,13 +728,16 @@ func (c *Checker) inferFromObjectTypes(n *InferenceState, source *Type, target *
 							constraint := c.getBaseConstraintOfType(info.typeParameter)
 							if constraint != nil && isTupleType(constraint) && constraint.TargetTupleType().combinedFlags&ElementFlagsVariable == 0 {
 								impliedArity := constraint.TargetTupleType().fixedLength
-								endIndex := sourceArity - getEndElementCount(target.TargetTupleType(), ElementFlagsFixed)
-								startIndex := endIndex - impliedArity
-								trailingSlice := c.createTupleTypeEx(c.getTypeArguments(source)[startIndex:endIndex], source.TargetTupleType().elementInfos[startIndex:endIndex], false /*readonly*/)
-								if restType := c.getElementTypeOfSliceOfTupleType(source, startLength, endLength+impliedArity, false, false); restType != nil {
-									c.inferFromTypes(n, restType, elementTypes[startLength])
+								if endLength+impliedArity <= getEndElementCount(source.TargetTupleType(), ElementFlagsFixed) {
+									endIndex := sourceArity - getEndElementCount(target.TargetTupleType(), ElementFlagsFixed)
+									startIndex := endIndex - impliedArity
+									trailingSlice := c.createTupleTypeEx(c.getTypeArguments(source)[startIndex:endIndex], source.TargetTupleType().elementInfos[startIndex:endIndex], false /*readonly*/)
+									restType := c.getElementTypeOfSliceOfTupleType(source, startLength, endLength+impliedArity, false, false)
+									if restType != nil {
+										c.inferFromTypes(n, restType, elementTypes[startLength])
+									}
+									c.inferFromTypes(n, trailingSlice, elementTypes[startLength+1])
 								}
-								c.inferFromTypes(n, trailingSlice, elementTypes[startLength+1])
 							}
 						}
 					}

--- a/internal/checker/inference.go
+++ b/internal/checker/inference.go
@@ -714,8 +714,7 @@ func (c *Checker) inferFromObjectTypes(n *InferenceState, source *Type, target *
 								impliedArity := constraint.TargetTupleType().fixedLength
 								if startLength+impliedArity <= source.TargetTupleType().fixedLength {
 									c.inferFromTypes(n, c.sliceTupleType(source, startLength, sourceArity-(startLength+impliedArity)), elementTypes[startLength])
-									restType := c.getElementTypeOfSliceOfTupleType(source, startLength+impliedArity, endLength, false, false)
-									if restType != nil {
+									if restType := c.getElementTypeOfSliceOfTupleType(source, startLength+impliedArity, endLength, false, false); restType != nil {
 										c.inferFromTypes(n, restType, elementTypes[startLength+1])
 									}
 								}
@@ -732,8 +731,7 @@ func (c *Checker) inferFromObjectTypes(n *InferenceState, source *Type, target *
 									endIndex := sourceArity - getEndElementCount(target.TargetTupleType(), ElementFlagsFixed)
 									startIndex := endIndex - impliedArity
 									trailingSlice := c.createTupleTypeEx(c.getTypeArguments(source)[startIndex:endIndex], source.TargetTupleType().elementInfos[startIndex:endIndex], false /*readonly*/)
-									restType := c.getElementTypeOfSliceOfTupleType(source, startLength, endLength+impliedArity, false, false)
-									if restType != nil {
+									if restType := c.getElementTypeOfSliceOfTupleType(source, startLength, endLength+impliedArity, false, false); restType != nil {
 										c.inferFromTypes(n, restType, elementTypes[startLength])
 									}
 									c.inferFromTypes(n, trailingSlice, elementTypes[startLength+1])

--- a/testdata/baselines/reference/compiler/inferTypesWithFixedTupleExtendsAtVariadicPosition2.errors.txt
+++ b/testdata/baselines/reference/compiler/inferTypesWithFixedTupleExtendsAtVariadicPosition2.errors.txt
@@ -1,0 +1,200 @@
+inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts(112,27): error TS1257: A required element cannot follow an optional element.
+inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts(168,27): error TS1257: A required element cannot follow an optional element.
+
+
+==== inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts (2 errors) ====
+    // repro #51138
+    
+    type SubTup2FixedLength<T extends unknown[]> = T extends [
+      ...infer B extends [any, any],
+      any
+    ]
+      ? B
+      : never;
+    
+    type SubTup2FixedLengthTest2 = SubTup2FixedLength<[a: 0]>;
+    
+    type SubTup2Variadic<T extends unknown[]> = T extends [
+      ...infer B extends [any, any],
+      ...any
+    ]
+      ? B
+      : never;
+    
+    type SubTup2VariadicTest3 = SubTup2Variadic<[a: 0, ...b: 1[]]>;
+    type SubTup2VariadicTest4 = SubTup2Variadic<[...a: 0[]]>;
+    type SubTup2VariadicTest5 = SubTup2Variadic<[a: 0, b: 1]>;
+    
+    type SubTup2VariadicAndRest<T extends unknown[]> = T extends [
+      ...infer B extends [any, any],
+      ...(infer C)[]
+    ]
+      ? [...B, ...[C]]
+      : never;
+    
+    type SubTup2VariadicAndRestTest2 = SubTup2VariadicAndRest<[a: 0, ...b: 1[]]>;
+    type SubTup2VariadicAndRestTest3 = SubTup2VariadicAndRest<[...a: 0[]]>;
+    type SubTup2VariadicAndRestTest4 = SubTup2VariadicAndRest<[a: 0, b: 1]>;
+    
+    type SubTup2TrailingVariadic<T extends unknown[]> = T extends [
+      ...any,
+      ...infer B extends [any, any],
+    ]
+      ? B
+      : never;
+    
+    type SubTup2TrailingVariadicTest3 = SubTup2TrailingVariadic<[...a: 0[], b: 1]>;
+    type SubTup2TrailingVariadicTest4 = SubTup2TrailingVariadic<[...a: 0[]]>;
+    type SubTup2TrailingVariadicTest5 = SubTup2TrailingVariadic<[b: 1, c: 2]>;
+    
+    type SubTup2RestAndTrailingVariadic2<T extends unknown[]> = T extends [
+      ...(infer C)[],
+      ...infer B extends [any, any],
+    ]
+      ? [C, ...B]
+      : never;
+    
+    type SubTup2RestAndTrailingVariadic2Test2 = SubTup2RestAndTrailingVariadic2<[...a: 0[], b: 1]>;
+    type SubTup2RestAndTrailingVariadic2Test3 = SubTup2RestAndTrailingVariadic2<[...a: 0[]]>;
+    type SubTup2RestAndTrailingVariadic2Test4 = SubTup2RestAndTrailingVariadic2<[b: 1, c: 2]>;
+    
+    type SubTup2VariadicWithLeadingFixedElements<T extends unknown[]> = T extends [
+      any,
+      ...infer B extends [any, any],
+      ...any
+    ]
+      ? B
+      : never;
+    
+    type SubTup2VariadicWithLeadingFixedElementsTest3 = SubTup2VariadicWithLeadingFixedElements<[a: 0, b: 1, ...c: 2[]]>;
+    type SubTup2VariadicWithLeadingFixedElementsTest4 = SubTup2VariadicWithLeadingFixedElements<[a: 0, ...b: 1[]]>;
+    type SubTup2VariadicWithLeadingFixedElementsTest5 = SubTup2VariadicWithLeadingFixedElements<[...a: 0[]]>;
+    
+    type SubTup2VariadicWithLeadingFixedElements2<T extends unknown[]> = T extends [
+      any,
+      any,
+      ...infer B extends [any],
+      ...any
+    ]
+      ? B
+      : never;
+    
+    type SubTup2VariadicWithLeadingFixedElements2Test = SubTup2VariadicWithLeadingFixedElements2<[a: 0, b: 1, c: 2, ...d: 3[]]>;
+    type SubTup2VariadicWithLeadingFixedElements2Test2 = SubTup2VariadicWithLeadingFixedElements2<[a: 0, b: 1, c: 2, d: 3, ...e: 4[]]>;
+    type SubTup2VariadicWithLeadingFixedElements2Test3 = SubTup2VariadicWithLeadingFixedElements2<[a: 0, b: 1, ...c: 2[]]>;
+    type SubTup2VariadicWithLeadingFixedElements2Test4 = SubTup2VariadicWithLeadingFixedElements2<[a: 0, ...b: 1[]]>;
+    type SubTup2VariadicWithLeadingFixedElements2Test5 = SubTup2VariadicWithLeadingFixedElements2<[...a: 0[]]>;
+    
+    type SubTup2VariadicWithLeadingFixedElements3<T extends unknown[]> = T extends [
+      any,
+      ...infer B extends [any, any],
+      ...(infer C)[]
+    ]
+      ? [B, C]
+      : never;
+    
+    type SubTup2VariadicWithLeadingFixedElements3Test = SubTup2VariadicWithLeadingFixedElements3<[a: 0, b: 1, c: 2, d: 3, ...e: 4[]]>;
+    type SubTup2VariadicWithLeadingFixedElements3Test2 = SubTup2VariadicWithLeadingFixedElements3<[a: 0, b: 1, c: 2, ...d: 3[]]>;
+    type SubTup2VariadicWithLeadingFixedElements3Test3 = SubTup2VariadicWithLeadingFixedElements3<[a: 0, b: 1, ...c: 2[]]>;
+    type SubTup2VariadicWithLeadingFixedElements3Test4 = SubTup2VariadicWithLeadingFixedElements3<[a: 0, ...b: 1[]]>;
+    type SubTup2VariadicWithLeadingFixedElements3Test5 = SubTup2VariadicWithLeadingFixedElements3<[...a: 0[]]>;
+    type SubTup2VariadicWithLeadingFixedElements3Test6 = SubTup2VariadicWithLeadingFixedElements3<[a: 0, b: 1, c: 2]>;
+    
+    type SubTup2VariadicWithTrailingOptionalElement<T extends unknown[]> = T extends [
+      ...infer B extends [0, 1?],
+      ...any
+    ]
+      ? B
+      : never;
+    
+    type SubTup2VariadicWithTrailingOptionalElementTest = SubTup2VariadicWithTrailingOptionalElement<[a: 0]>;
+    type SubTup2VariadicWithTrailingOptionalElementTest2 = SubTup2VariadicWithTrailingOptionalElement<[a: 0, b: 1]>;
+    type SubTup2VariadicWithTrailingOptionalElementTest3 = SubTup2VariadicWithTrailingOptionalElement<[a: 0, b: 1, c: 2]>;
+    type SubTup2VariadicWithTrailingOptionalElementTest4 = SubTup2VariadicWithTrailingOptionalElement<[a: 0, ...b: 1[]]>;
+    type SubTup2VariadicWithTrailingOptionalElementTest5 = SubTup2VariadicWithTrailingOptionalElement<[...a: 0[]]>;
+    
+    type SubTup2VariadicWithLeadingOptionalElement<T extends unknown[]> = T extends [
+      ...infer B extends [0?, 1],
+                              ~
+!!! error TS1257: A required element cannot follow an optional element.
+      ...any
+    ]
+      ? B
+      : never;
+    
+    type SubTup2VariadicWithLeadingOptionalElementTest = SubTup2VariadicWithLeadingOptionalElement<[b: 1]>;
+    type SubTup2VariadicWithLeadingOptionalElementTest2 = SubTup2VariadicWithLeadingOptionalElement<[a: 0, b: 1]>;
+    type SubTup2VariadicWithLeadingOptionalElementTest3 = SubTup2VariadicWithLeadingOptionalElement<[a: 0, b: 1, c: 2]>;
+    type SubTup2VariadicWithLeadingOptionalElementTest4 = SubTup2VariadicWithLeadingOptionalElement<[a: 0, ...b: 1[]]>;
+    type SubTup2VariadicWithLeadingOptionalElementTest5 = SubTup2VariadicWithLeadingOptionalElement<[...a: 1[]]>;
+    
+    type SubTup2TrailingVariadicWithTrailingFixedElements<T extends unknown[]> = T extends [
+      ...any,
+      ...infer B extends [any, any],
+      any,
+    ]
+      ? B
+      : never;
+    
+    type SubTup2TrailingVariadicWithTrailingFixedElementsTest3 = SubTup2TrailingVariadicWithTrailingFixedElements<[...a: 0[], b: 1, c: 2]>;
+    type SubTup2TrailingVariadicWithTrailingFixedElementsTest4 = SubTup2TrailingVariadicWithTrailingFixedElements<[...a: 0[], b: 1]>;
+    type SubTup2TrailingVariadicWithTrailingFixedElementsTest5 = SubTup2TrailingVariadicWithTrailingFixedElements<[...a: 0[]]>;
+    
+    type SubTup2TrailingVariadicWithTrailingFixedElements2<T extends unknown[]> = T extends [
+      ...any,
+      ...infer B extends [any],
+      any,
+      any,
+    ]
+      ? B
+      : never;
+    
+    type SubTup2TrailingVariadicWithTrailingFixedElements2Test = SubTup2TrailingVariadicWithTrailingFixedElements2<[...a: 0[], b: 1, c: 2, d: 3]>;
+    type SubTup2TrailingVariadicWithTrailingFixedElements2Test2 = SubTup2TrailingVariadicWithTrailingFixedElements2<[...a: 0[], b: 1, c: 2, d: 3, e: 4]>;
+    type SubTup2TrailingVariadicWithTrailingFixedElements2Test3 = SubTup2TrailingVariadicWithTrailingFixedElements2<[...a: 0[], b: 1, c: 2]>;
+    type SubTup2TrailingVariadicWithTrailingFixedElements2Test4 = SubTup2TrailingVariadicWithTrailingFixedElements2<[...a: 0[], b: 1]>;
+    type SubTup2TrailingVariadicWithTrailingFixedElements2Test5 = SubTup2TrailingVariadicWithTrailingFixedElements2<[...a: 0[]]>;
+    
+    type SubTup2TrailingVariadicWithTrailingFixedElements3<T extends unknown[]> = T extends [
+      ...(infer C)[],
+      ...infer B extends [any, any],
+      any,
+    ]
+      ? [C, B]
+      : never;
+    
+    type SubTup2TrailingVariadicWithTrailingFixedElements3Test = SubTup2TrailingVariadicWithTrailingFixedElements3<[...a: 0[], b: 1, c: 2, d: 3, e: 4]>;
+    type SubTup2TrailingVariadicWithTrailingFixedElements3Test2 = SubTup2TrailingVariadicWithTrailingFixedElements3<[...a: 0[], b: 1, c: 2, d: 3]>;
+    type SubTup2TrailingVariadicWithTrailingFixedElements3Test3 = SubTup2TrailingVariadicWithTrailingFixedElements3<[...a: 0[], b: 1, c: 2]>;
+    type SubTup2TrailingVariadicWithTrailingFixedElements3Test4 = SubTup2TrailingVariadicWithTrailingFixedElements3<[...a: 0[], b: 1]>;
+    type SubTup2TrailingVariadicWithTrailingFixedElements3Test5 = SubTup2TrailingVariadicWithTrailingFixedElements3<[...a: 0[]]>;
+    type SubTup2TrailingVariadicWithTrailingFixedElements3Test6 = SubTup2TrailingVariadicWithTrailingFixedElements3<[b: 1, c: 2, d: 3]>;
+    
+    type SubTup2TrailingVariadicWithLeadingOptionalElement<T extends unknown[]> = T extends [
+      ...any,
+      ...infer B extends [0?, 1],
+                              ~
+!!! error TS1257: A required element cannot follow an optional element.
+    ]
+      ? B
+      : never;
+    
+    type SubTup2TrailingVariadicWithLeadingOptionalElementTest = SubTup2TrailingVariadicWithLeadingOptionalElement<[b: 1]>;
+    type SubTup2TrailingVariadicWithLeadingOptionalElementTest2 = SubTup2TrailingVariadicWithLeadingOptionalElement<[a: 0, b: 1]>;
+    type SubTup2TrailingVariadicWithLeadingOptionalElementTest3 = SubTup2TrailingVariadicWithLeadingOptionalElement<[a: 2, b: 0, c: 1]>;
+    type SubTup2TrailingVariadicWithLeadingOptionalElementTest4 = SubTup2TrailingVariadicWithLeadingOptionalElement<[...a: 0[], b: 1]>;
+    type SubTup2TrailingVariadicWithLeadingOptionalElementTest5 = SubTup2TrailingVariadicWithLeadingOptionalElement<[...a: 1[]]>;
+    
+    type SubTup2TrailingVariadicWithTrailingOptionalElement<T extends unknown[]> = T extends [
+      ...any,
+      ...infer B extends [0, 1?],
+    ]
+      ? B
+      : never;
+    
+    type SubTup2TrailingVariadicWithTrailingOptionalElementTest = SubTup2TrailingVariadicWithTrailingOptionalElement<[a: 0]>;
+    type SubTup2TrailingVariadicWithTrailingOptionalElementTest2 = SubTup2TrailingVariadicWithTrailingOptionalElement<[a: 0, b: 1]>;
+    type SubTup2TrailingVariadicWithTrailingOptionalElementTest3 = SubTup2TrailingVariadicWithTrailingOptionalElement<[a: 2, b: 0, c: 1]>;
+    type SubTup2TrailingVariadicWithTrailingOptionalElementTest4 = SubTup2TrailingVariadicWithTrailingOptionalElement<[...a: 0[]]>;
+    type SubTup2TrailingVariadicWithTrailingOptionalElementTest5 = SubTup2TrailingVariadicWithTrailingOptionalElement<[...a: 0[], b: 1]>;
+    

--- a/testdata/baselines/reference/compiler/inferTypesWithFixedTupleExtendsAtVariadicPosition2.symbols
+++ b/testdata/baselines/reference/compiler/inferTypesWithFixedTupleExtendsAtVariadicPosition2.symbols
@@ -1,0 +1,354 @@
+//// [tests/cases/compiler/inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts] ////
+
+=== inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts ===
+// repro #51138
+
+type SubTup2FixedLength<T extends unknown[]> = T extends [
+>SubTup2FixedLength : Symbol(SubTup2FixedLength, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 0, 0))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 2, 24))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 2, 24))
+
+  ...infer B extends [any, any],
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 3, 10))
+
+  any
+]
+  ? B
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 3, 10))
+
+  : never;
+
+type SubTup2FixedLengthTest2 = SubTup2FixedLength<[a: 0]>;
+>SubTup2FixedLengthTest2 : Symbol(SubTup2FixedLengthTest2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 7, 10))
+>SubTup2FixedLength : Symbol(SubTup2FixedLength, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 0, 0))
+
+type SubTup2Variadic<T extends unknown[]> = T extends [
+>SubTup2Variadic : Symbol(SubTup2Variadic, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 9, 58))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 11, 21))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 11, 21))
+
+  ...infer B extends [any, any],
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 12, 10))
+
+  ...any
+]
+  ? B
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 12, 10))
+
+  : never;
+
+type SubTup2VariadicTest3 = SubTup2Variadic<[a: 0, ...b: 1[]]>;
+>SubTup2VariadicTest3 : Symbol(SubTup2VariadicTest3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 16, 10))
+>SubTup2Variadic : Symbol(SubTup2Variadic, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 9, 58))
+
+type SubTup2VariadicTest4 = SubTup2Variadic<[...a: 0[]]>;
+>SubTup2VariadicTest4 : Symbol(SubTup2VariadicTest4, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 18, 63))
+>SubTup2Variadic : Symbol(SubTup2Variadic, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 9, 58))
+
+type SubTup2VariadicTest5 = SubTup2Variadic<[a: 0, b: 1]>;
+>SubTup2VariadicTest5 : Symbol(SubTup2VariadicTest5, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 19, 57))
+>SubTup2Variadic : Symbol(SubTup2Variadic, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 9, 58))
+
+type SubTup2VariadicAndRest<T extends unknown[]> = T extends [
+>SubTup2VariadicAndRest : Symbol(SubTup2VariadicAndRest, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 20, 58))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 22, 28))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 22, 28))
+
+  ...infer B extends [any, any],
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 23, 10))
+
+  ...(infer C)[]
+>C : Symbol(C, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 24, 11))
+
+]
+  ? [...B, ...[C]]
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 23, 10))
+>C : Symbol(C, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 24, 11))
+
+  : never;
+
+type SubTup2VariadicAndRestTest2 = SubTup2VariadicAndRest<[a: 0, ...b: 1[]]>;
+>SubTup2VariadicAndRestTest2 : Symbol(SubTup2VariadicAndRestTest2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 27, 10))
+>SubTup2VariadicAndRest : Symbol(SubTup2VariadicAndRest, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 20, 58))
+
+type SubTup2VariadicAndRestTest3 = SubTup2VariadicAndRest<[...a: 0[]]>;
+>SubTup2VariadicAndRestTest3 : Symbol(SubTup2VariadicAndRestTest3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 29, 77))
+>SubTup2VariadicAndRest : Symbol(SubTup2VariadicAndRest, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 20, 58))
+
+type SubTup2VariadicAndRestTest4 = SubTup2VariadicAndRest<[a: 0, b: 1]>;
+>SubTup2VariadicAndRestTest4 : Symbol(SubTup2VariadicAndRestTest4, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 30, 71))
+>SubTup2VariadicAndRest : Symbol(SubTup2VariadicAndRest, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 20, 58))
+
+type SubTup2TrailingVariadic<T extends unknown[]> = T extends [
+>SubTup2TrailingVariadic : Symbol(SubTup2TrailingVariadic, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 31, 72))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 33, 29))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 33, 29))
+
+  ...any,
+  ...infer B extends [any, any],
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 35, 10))
+
+]
+  ? B
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 35, 10))
+
+  : never;
+
+type SubTup2TrailingVariadicTest3 = SubTup2TrailingVariadic<[...a: 0[], b: 1]>;
+>SubTup2TrailingVariadicTest3 : Symbol(SubTup2TrailingVariadicTest3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 38, 10))
+>SubTup2TrailingVariadic : Symbol(SubTup2TrailingVariadic, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 31, 72))
+
+type SubTup2TrailingVariadicTest4 = SubTup2TrailingVariadic<[...a: 0[]]>;
+>SubTup2TrailingVariadicTest4 : Symbol(SubTup2TrailingVariadicTest4, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 40, 79))
+>SubTup2TrailingVariadic : Symbol(SubTup2TrailingVariadic, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 31, 72))
+
+type SubTup2TrailingVariadicTest5 = SubTup2TrailingVariadic<[b: 1, c: 2]>;
+>SubTup2TrailingVariadicTest5 : Symbol(SubTup2TrailingVariadicTest5, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 41, 73))
+>SubTup2TrailingVariadic : Symbol(SubTup2TrailingVariadic, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 31, 72))
+
+type SubTup2RestAndTrailingVariadic2<T extends unknown[]> = T extends [
+>SubTup2RestAndTrailingVariadic2 : Symbol(SubTup2RestAndTrailingVariadic2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 42, 74))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 44, 37))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 44, 37))
+
+  ...(infer C)[],
+>C : Symbol(C, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 45, 11))
+
+  ...infer B extends [any, any],
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 46, 10))
+
+]
+  ? [C, ...B]
+>C : Symbol(C, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 45, 11))
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 46, 10))
+
+  : never;
+
+type SubTup2RestAndTrailingVariadic2Test2 = SubTup2RestAndTrailingVariadic2<[...a: 0[], b: 1]>;
+>SubTup2RestAndTrailingVariadic2Test2 : Symbol(SubTup2RestAndTrailingVariadic2Test2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 49, 10))
+>SubTup2RestAndTrailingVariadic2 : Symbol(SubTup2RestAndTrailingVariadic2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 42, 74))
+
+type SubTup2RestAndTrailingVariadic2Test3 = SubTup2RestAndTrailingVariadic2<[...a: 0[]]>;
+>SubTup2RestAndTrailingVariadic2Test3 : Symbol(SubTup2RestAndTrailingVariadic2Test3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 51, 95))
+>SubTup2RestAndTrailingVariadic2 : Symbol(SubTup2RestAndTrailingVariadic2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 42, 74))
+
+type SubTup2RestAndTrailingVariadic2Test4 = SubTup2RestAndTrailingVariadic2<[b: 1, c: 2]>;
+>SubTup2RestAndTrailingVariadic2Test4 : Symbol(SubTup2RestAndTrailingVariadic2Test4, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 52, 89))
+>SubTup2RestAndTrailingVariadic2 : Symbol(SubTup2RestAndTrailingVariadic2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 42, 74))
+
+type SubTup2VariadicWithLeadingFixedElements<T extends unknown[]> = T extends [
+>SubTup2VariadicWithLeadingFixedElements : Symbol(SubTup2VariadicWithLeadingFixedElements, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 53, 90))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 55, 45))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 55, 45))
+
+  any,
+  ...infer B extends [any, any],
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 57, 10))
+
+  ...any
+]
+  ? B
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 57, 10))
+
+  : never;
+
+type SubTup2VariadicWithLeadingFixedElementsTest3 = SubTup2VariadicWithLeadingFixedElements<[a: 0, b: 1, ...c: 2[]]>;
+>SubTup2VariadicWithLeadingFixedElementsTest3 : Symbol(SubTup2VariadicWithLeadingFixedElementsTest3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 61, 10))
+>SubTup2VariadicWithLeadingFixedElements : Symbol(SubTup2VariadicWithLeadingFixedElements, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 53, 90))
+
+type SubTup2VariadicWithLeadingFixedElementsTest4 = SubTup2VariadicWithLeadingFixedElements<[a: 0, ...b: 1[]]>;
+>SubTup2VariadicWithLeadingFixedElementsTest4 : Symbol(SubTup2VariadicWithLeadingFixedElementsTest4, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 63, 117))
+>SubTup2VariadicWithLeadingFixedElements : Symbol(SubTup2VariadicWithLeadingFixedElements, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 53, 90))
+
+type SubTup2VariadicWithLeadingFixedElementsTest5 = SubTup2VariadicWithLeadingFixedElements<[...a: 0[]]>;
+>SubTup2VariadicWithLeadingFixedElementsTest5 : Symbol(SubTup2VariadicWithLeadingFixedElementsTest5, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 64, 111))
+>SubTup2VariadicWithLeadingFixedElements : Symbol(SubTup2VariadicWithLeadingFixedElements, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 53, 90))
+
+type SubTup2VariadicWithLeadingFixedElements2<T extends unknown[]> = T extends [
+>SubTup2VariadicWithLeadingFixedElements2 : Symbol(SubTup2VariadicWithLeadingFixedElements2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 65, 105))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 67, 46))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 67, 46))
+
+  any,
+  any,
+  ...infer B extends [any],
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 70, 10))
+
+  ...any
+]
+  ? B
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 70, 10))
+
+  : never;
+
+type SubTup2VariadicWithLeadingFixedElements2Test = SubTup2VariadicWithLeadingFixedElements2<[a: 0, b: 1, c: 2, ...d: 3[]]>;
+>SubTup2VariadicWithLeadingFixedElements2Test : Symbol(SubTup2VariadicWithLeadingFixedElements2Test, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 74, 10))
+>SubTup2VariadicWithLeadingFixedElements2 : Symbol(SubTup2VariadicWithLeadingFixedElements2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 65, 105))
+
+type SubTup2VariadicWithLeadingFixedElements2Test2 = SubTup2VariadicWithLeadingFixedElements2<[a: 0, b: 1, c: 2, d: 3, ...e: 4[]]>;
+>SubTup2VariadicWithLeadingFixedElements2Test2 : Symbol(SubTup2VariadicWithLeadingFixedElements2Test2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 76, 124))
+>SubTup2VariadicWithLeadingFixedElements2 : Symbol(SubTup2VariadicWithLeadingFixedElements2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 65, 105))
+
+type SubTup2VariadicWithLeadingFixedElements2Test3 = SubTup2VariadicWithLeadingFixedElements2<[a: 0, b: 1, ...c: 2[]]>;
+>SubTup2VariadicWithLeadingFixedElements2Test3 : Symbol(SubTup2VariadicWithLeadingFixedElements2Test3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 77, 131))
+>SubTup2VariadicWithLeadingFixedElements2 : Symbol(SubTup2VariadicWithLeadingFixedElements2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 65, 105))
+
+type SubTup2VariadicWithLeadingFixedElements2Test4 = SubTup2VariadicWithLeadingFixedElements2<[a: 0, ...b: 1[]]>;
+>SubTup2VariadicWithLeadingFixedElements2Test4 : Symbol(SubTup2VariadicWithLeadingFixedElements2Test4, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 78, 119))
+>SubTup2VariadicWithLeadingFixedElements2 : Symbol(SubTup2VariadicWithLeadingFixedElements2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 65, 105))
+
+type SubTup2VariadicWithLeadingFixedElements2Test5 = SubTup2VariadicWithLeadingFixedElements2<[...a: 0[]]>;
+>SubTup2VariadicWithLeadingFixedElements2Test5 : Symbol(SubTup2VariadicWithLeadingFixedElements2Test5, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 79, 113))
+>SubTup2VariadicWithLeadingFixedElements2 : Symbol(SubTup2VariadicWithLeadingFixedElements2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 65, 105))
+
+type SubTup2VariadicWithLeadingFixedElements3<T extends unknown[]> = T extends [
+>SubTup2VariadicWithLeadingFixedElements3 : Symbol(SubTup2VariadicWithLeadingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 80, 107))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 82, 46))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 82, 46))
+
+  any,
+  ...infer B extends [any, any],
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 84, 10))
+
+  ...(infer C)[]
+>C : Symbol(C, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 85, 11))
+
+]
+  ? [B, C]
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 84, 10))
+>C : Symbol(C, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 85, 11))
+
+  : never;
+
+type SubTup2VariadicWithLeadingFixedElements3Test = SubTup2VariadicWithLeadingFixedElements3<[a: 0, b: 1, c: 2, d: 3, ...e: 4[]]>;
+>SubTup2VariadicWithLeadingFixedElements3Test : Symbol(SubTup2VariadicWithLeadingFixedElements3Test, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 88, 10))
+>SubTup2VariadicWithLeadingFixedElements3 : Symbol(SubTup2VariadicWithLeadingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 80, 107))
+
+type SubTup2VariadicWithLeadingFixedElements3Test2 = SubTup2VariadicWithLeadingFixedElements3<[a: 0, b: 1, c: 2, ...d: 3[]]>;
+>SubTup2VariadicWithLeadingFixedElements3Test2 : Symbol(SubTup2VariadicWithLeadingFixedElements3Test2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 90, 130))
+>SubTup2VariadicWithLeadingFixedElements3 : Symbol(SubTup2VariadicWithLeadingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 80, 107))
+
+type SubTup2VariadicWithLeadingFixedElements3Test3 = SubTup2VariadicWithLeadingFixedElements3<[a: 0, b: 1, ...c: 2[]]>;
+>SubTup2VariadicWithLeadingFixedElements3Test3 : Symbol(SubTup2VariadicWithLeadingFixedElements3Test3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 91, 125))
+>SubTup2VariadicWithLeadingFixedElements3 : Symbol(SubTup2VariadicWithLeadingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 80, 107))
+
+type SubTup2VariadicWithLeadingFixedElements3Test4 = SubTup2VariadicWithLeadingFixedElements3<[a: 0, ...b: 1[]]>;
+>SubTup2VariadicWithLeadingFixedElements3Test4 : Symbol(SubTup2VariadicWithLeadingFixedElements3Test4, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 92, 119))
+>SubTup2VariadicWithLeadingFixedElements3 : Symbol(SubTup2VariadicWithLeadingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 80, 107))
+
+type SubTup2VariadicWithLeadingFixedElements3Test5 = SubTup2VariadicWithLeadingFixedElements3<[...a: 0[]]>;
+>SubTup2VariadicWithLeadingFixedElements3Test5 : Symbol(SubTup2VariadicWithLeadingFixedElements3Test5, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 93, 113))
+>SubTup2VariadicWithLeadingFixedElements3 : Symbol(SubTup2VariadicWithLeadingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 80, 107))
+
+type SubTup2VariadicWithLeadingFixedElements3Test6 = SubTup2VariadicWithLeadingFixedElements3<[a: 0, b: 1, c: 2]>;
+>SubTup2VariadicWithLeadingFixedElements3Test6 : Symbol(SubTup2VariadicWithLeadingFixedElements3Test6, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 94, 107))
+>SubTup2VariadicWithLeadingFixedElements3 : Symbol(SubTup2VariadicWithLeadingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 80, 107))
+
+type SubTup2TrailingVariadicWithTrailingFixedElements<T extends unknown[]> = T extends [
+>SubTup2TrailingVariadicWithTrailingFixedElements : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 95, 114))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 97, 54))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 97, 54))
+
+  ...any,
+  ...infer B extends [any, any],
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 99, 10))
+
+  any,
+]
+  ? B
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 99, 10))
+
+  : never;
+
+type SubTup2TrailingVariadicWithTrailingFixedElementsTest3 = SubTup2TrailingVariadicWithTrailingFixedElements<[...a: 0[], b: 1, c: 2]>;
+>SubTup2TrailingVariadicWithTrailingFixedElementsTest3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElementsTest3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 103, 10))
+>SubTup2TrailingVariadicWithTrailingFixedElements : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 95, 114))
+
+type SubTup2TrailingVariadicWithTrailingFixedElementsTest4 = SubTup2TrailingVariadicWithTrailingFixedElements<[...a: 0[], b: 1]>;
+>SubTup2TrailingVariadicWithTrailingFixedElementsTest4 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElementsTest4, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 105, 135))
+>SubTup2TrailingVariadicWithTrailingFixedElements : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 95, 114))
+
+type SubTup2TrailingVariadicWithTrailingFixedElementsTest5 = SubTup2TrailingVariadicWithTrailingFixedElements<[...a: 0[]]>;
+>SubTup2TrailingVariadicWithTrailingFixedElementsTest5 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElementsTest5, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 106, 129))
+>SubTup2TrailingVariadicWithTrailingFixedElements : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 95, 114))
+
+type SubTup2TrailingVariadicWithTrailingFixedElements2<T extends unknown[]> = T extends [
+>SubTup2TrailingVariadicWithTrailingFixedElements2 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 107, 123))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 109, 55))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 109, 55))
+
+  ...any,
+  ...infer B extends [any],
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 111, 10))
+
+  any,
+  any,
+]
+  ? B
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 111, 10))
+
+  : never;
+
+type SubTup2TrailingVariadicWithTrailingFixedElements2Test = SubTup2TrailingVariadicWithTrailingFixedElements2<[...a: 0[], b: 1, c: 2, d: 3]>;
+>SubTup2TrailingVariadicWithTrailingFixedElements2Test : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2Test, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 116, 10))
+>SubTup2TrailingVariadicWithTrailingFixedElements2 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 107, 123))
+
+type SubTup2TrailingVariadicWithTrailingFixedElements2Test2 = SubTup2TrailingVariadicWithTrailingFixedElements2<[...a: 0[], b: 1, c: 2, d: 3, e: 4]>;
+>SubTup2TrailingVariadicWithTrailingFixedElements2Test2 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2Test2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 118, 142))
+>SubTup2TrailingVariadicWithTrailingFixedElements2 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 107, 123))
+
+type SubTup2TrailingVariadicWithTrailingFixedElements2Test3 = SubTup2TrailingVariadicWithTrailingFixedElements2<[...a: 0[], b: 1, c: 2]>;
+>SubTup2TrailingVariadicWithTrailingFixedElements2Test3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2Test3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 119, 149))
+>SubTup2TrailingVariadicWithTrailingFixedElements2 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 107, 123))
+
+type SubTup2TrailingVariadicWithTrailingFixedElements2Test4 = SubTup2TrailingVariadicWithTrailingFixedElements2<[...a: 0[], b: 1]>;
+>SubTup2TrailingVariadicWithTrailingFixedElements2Test4 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2Test4, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 120, 137))
+>SubTup2TrailingVariadicWithTrailingFixedElements2 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 107, 123))
+
+type SubTup2TrailingVariadicWithTrailingFixedElements2Test5 = SubTup2TrailingVariadicWithTrailingFixedElements2<[...a: 0[]]>;
+>SubTup2TrailingVariadicWithTrailingFixedElements2Test5 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2Test5, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 121, 131))
+>SubTup2TrailingVariadicWithTrailingFixedElements2 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 107, 123))
+
+type SubTup2TrailingVariadicWithTrailingFixedElements3<T extends unknown[]> = T extends [
+>SubTup2TrailingVariadicWithTrailingFixedElements3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 122, 125))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 124, 55))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 124, 55))
+
+  ...(infer C)[],
+>C : Symbol(C, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 125, 11))
+
+  ...infer B extends [any, any],
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 126, 10))
+
+  any,
+]
+  ? [C, B]
+>C : Symbol(C, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 125, 11))
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 126, 10))
+
+  : never;
+
+type SubTup2TrailingVariadicWithTrailingFixedElements3Test = SubTup2TrailingVariadicWithTrailingFixedElements3<[...a: 0[], b: 1, c: 2, d: 3, e: 4]>;
+>SubTup2TrailingVariadicWithTrailingFixedElements3Test : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3Test, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 130, 10))
+>SubTup2TrailingVariadicWithTrailingFixedElements3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 122, 125))
+
+type SubTup2TrailingVariadicWithTrailingFixedElements3Test2 = SubTup2TrailingVariadicWithTrailingFixedElements3<[...a: 0[], b: 1, c: 2, d: 3]>;
+>SubTup2TrailingVariadicWithTrailingFixedElements3Test2 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3Test2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 132, 148))
+>SubTup2TrailingVariadicWithTrailingFixedElements3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 122, 125))
+
+type SubTup2TrailingVariadicWithTrailingFixedElements3Test3 = SubTup2TrailingVariadicWithTrailingFixedElements3<[...a: 0[], b: 1, c: 2]>;
+>SubTup2TrailingVariadicWithTrailingFixedElements3Test3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3Test3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 133, 143))
+>SubTup2TrailingVariadicWithTrailingFixedElements3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 122, 125))
+
+type SubTup2TrailingVariadicWithTrailingFixedElements3Test4 = SubTup2TrailingVariadicWithTrailingFixedElements3<[...a: 0[], b: 1]>;
+>SubTup2TrailingVariadicWithTrailingFixedElements3Test4 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3Test4, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 134, 137))
+>SubTup2TrailingVariadicWithTrailingFixedElements3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 122, 125))
+
+type SubTup2TrailingVariadicWithTrailingFixedElements3Test5 = SubTup2TrailingVariadicWithTrailingFixedElements3<[...a: 0[]]>;
+>SubTup2TrailingVariadicWithTrailingFixedElements3Test5 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3Test5, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 135, 131))
+>SubTup2TrailingVariadicWithTrailingFixedElements3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 122, 125))
+
+type SubTup2TrailingVariadicWithTrailingFixedElements3Test6 = SubTup2TrailingVariadicWithTrailingFixedElements3<[b: 1, c: 2, d: 3]>;
+>SubTup2TrailingVariadicWithTrailingFixedElements3Test6 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3Test6, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 136, 125))
+>SubTup2TrailingVariadicWithTrailingFixedElements3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 122, 125))
+

--- a/testdata/baselines/reference/compiler/inferTypesWithFixedTupleExtendsAtVariadicPosition2.symbols
+++ b/testdata/baselines/reference/compiler/inferTypesWithFixedTupleExtendsAtVariadicPosition2.symbols
@@ -244,111 +244,251 @@ type SubTup2VariadicWithLeadingFixedElements3Test6 = SubTup2VariadicWithLeadingF
 >SubTup2VariadicWithLeadingFixedElements3Test6 : Symbol(SubTup2VariadicWithLeadingFixedElements3Test6, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 94, 107))
 >SubTup2VariadicWithLeadingFixedElements3 : Symbol(SubTup2VariadicWithLeadingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 80, 107))
 
+type SubTup2VariadicWithTrailingOptionalElement<T extends unknown[]> = T extends [
+>SubTup2VariadicWithTrailingOptionalElement : Symbol(SubTup2VariadicWithTrailingOptionalElement, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 95, 114))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 97, 48))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 97, 48))
+
+  ...infer B extends [0, 1?],
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 98, 10))
+
+  ...any
+]
+  ? B
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 98, 10))
+
+  : never;
+
+type SubTup2VariadicWithTrailingOptionalElementTest = SubTup2VariadicWithTrailingOptionalElement<[a: 0]>;
+>SubTup2VariadicWithTrailingOptionalElementTest : Symbol(SubTup2VariadicWithTrailingOptionalElementTest, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 102, 10))
+>SubTup2VariadicWithTrailingOptionalElement : Symbol(SubTup2VariadicWithTrailingOptionalElement, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 95, 114))
+
+type SubTup2VariadicWithTrailingOptionalElementTest2 = SubTup2VariadicWithTrailingOptionalElement<[a: 0, b: 1]>;
+>SubTup2VariadicWithTrailingOptionalElementTest2 : Symbol(SubTup2VariadicWithTrailingOptionalElementTest2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 104, 105))
+>SubTup2VariadicWithTrailingOptionalElement : Symbol(SubTup2VariadicWithTrailingOptionalElement, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 95, 114))
+
+type SubTup2VariadicWithTrailingOptionalElementTest3 = SubTup2VariadicWithTrailingOptionalElement<[a: 0, b: 1, c: 2]>;
+>SubTup2VariadicWithTrailingOptionalElementTest3 : Symbol(SubTup2VariadicWithTrailingOptionalElementTest3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 105, 112))
+>SubTup2VariadicWithTrailingOptionalElement : Symbol(SubTup2VariadicWithTrailingOptionalElement, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 95, 114))
+
+type SubTup2VariadicWithTrailingOptionalElementTest4 = SubTup2VariadicWithTrailingOptionalElement<[a: 0, ...b: 1[]]>;
+>SubTup2VariadicWithTrailingOptionalElementTest4 : Symbol(SubTup2VariadicWithTrailingOptionalElementTest4, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 106, 118))
+>SubTup2VariadicWithTrailingOptionalElement : Symbol(SubTup2VariadicWithTrailingOptionalElement, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 95, 114))
+
+type SubTup2VariadicWithTrailingOptionalElementTest5 = SubTup2VariadicWithTrailingOptionalElement<[...a: 0[]]>;
+>SubTup2VariadicWithTrailingOptionalElementTest5 : Symbol(SubTup2VariadicWithTrailingOptionalElementTest5, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 107, 117))
+>SubTup2VariadicWithTrailingOptionalElement : Symbol(SubTup2VariadicWithTrailingOptionalElement, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 95, 114))
+
+type SubTup2VariadicWithLeadingOptionalElement<T extends unknown[]> = T extends [
+>SubTup2VariadicWithLeadingOptionalElement : Symbol(SubTup2VariadicWithLeadingOptionalElement, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 108, 111))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 110, 47))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 110, 47))
+
+  ...infer B extends [0?, 1],
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 111, 10))
+
+  ...any
+]
+  ? B
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 111, 10))
+
+  : never;
+
+type SubTup2VariadicWithLeadingOptionalElementTest = SubTup2VariadicWithLeadingOptionalElement<[b: 1]>;
+>SubTup2VariadicWithLeadingOptionalElementTest : Symbol(SubTup2VariadicWithLeadingOptionalElementTest, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 115, 10))
+>SubTup2VariadicWithLeadingOptionalElement : Symbol(SubTup2VariadicWithLeadingOptionalElement, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 108, 111))
+
+type SubTup2VariadicWithLeadingOptionalElementTest2 = SubTup2VariadicWithLeadingOptionalElement<[a: 0, b: 1]>;
+>SubTup2VariadicWithLeadingOptionalElementTest2 : Symbol(SubTup2VariadicWithLeadingOptionalElementTest2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 117, 103))
+>SubTup2VariadicWithLeadingOptionalElement : Symbol(SubTup2VariadicWithLeadingOptionalElement, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 108, 111))
+
+type SubTup2VariadicWithLeadingOptionalElementTest3 = SubTup2VariadicWithLeadingOptionalElement<[a: 0, b: 1, c: 2]>;
+>SubTup2VariadicWithLeadingOptionalElementTest3 : Symbol(SubTup2VariadicWithLeadingOptionalElementTest3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 118, 110))
+>SubTup2VariadicWithLeadingOptionalElement : Symbol(SubTup2VariadicWithLeadingOptionalElement, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 108, 111))
+
+type SubTup2VariadicWithLeadingOptionalElementTest4 = SubTup2VariadicWithLeadingOptionalElement<[a: 0, ...b: 1[]]>;
+>SubTup2VariadicWithLeadingOptionalElementTest4 : Symbol(SubTup2VariadicWithLeadingOptionalElementTest4, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 119, 116))
+>SubTup2VariadicWithLeadingOptionalElement : Symbol(SubTup2VariadicWithLeadingOptionalElement, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 108, 111))
+
+type SubTup2VariadicWithLeadingOptionalElementTest5 = SubTup2VariadicWithLeadingOptionalElement<[...a: 1[]]>;
+>SubTup2VariadicWithLeadingOptionalElementTest5 : Symbol(SubTup2VariadicWithLeadingOptionalElementTest5, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 120, 115))
+>SubTup2VariadicWithLeadingOptionalElement : Symbol(SubTup2VariadicWithLeadingOptionalElement, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 108, 111))
+
 type SubTup2TrailingVariadicWithTrailingFixedElements<T extends unknown[]> = T extends [
->SubTup2TrailingVariadicWithTrailingFixedElements : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 95, 114))
->T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 97, 54))
->T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 97, 54))
+>SubTup2TrailingVariadicWithTrailingFixedElements : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 121, 109))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 123, 54))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 123, 54))
 
   ...any,
   ...infer B extends [any, any],
->B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 99, 10))
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 125, 10))
 
   any,
 ]
   ? B
->B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 99, 10))
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 125, 10))
 
   : never;
 
 type SubTup2TrailingVariadicWithTrailingFixedElementsTest3 = SubTup2TrailingVariadicWithTrailingFixedElements<[...a: 0[], b: 1, c: 2]>;
->SubTup2TrailingVariadicWithTrailingFixedElementsTest3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElementsTest3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 103, 10))
->SubTup2TrailingVariadicWithTrailingFixedElements : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 95, 114))
+>SubTup2TrailingVariadicWithTrailingFixedElementsTest3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElementsTest3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 129, 10))
+>SubTup2TrailingVariadicWithTrailingFixedElements : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 121, 109))
 
 type SubTup2TrailingVariadicWithTrailingFixedElementsTest4 = SubTup2TrailingVariadicWithTrailingFixedElements<[...a: 0[], b: 1]>;
->SubTup2TrailingVariadicWithTrailingFixedElementsTest4 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElementsTest4, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 105, 135))
->SubTup2TrailingVariadicWithTrailingFixedElements : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 95, 114))
+>SubTup2TrailingVariadicWithTrailingFixedElementsTest4 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElementsTest4, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 131, 135))
+>SubTup2TrailingVariadicWithTrailingFixedElements : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 121, 109))
 
 type SubTup2TrailingVariadicWithTrailingFixedElementsTest5 = SubTup2TrailingVariadicWithTrailingFixedElements<[...a: 0[]]>;
->SubTup2TrailingVariadicWithTrailingFixedElementsTest5 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElementsTest5, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 106, 129))
->SubTup2TrailingVariadicWithTrailingFixedElements : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 95, 114))
+>SubTup2TrailingVariadicWithTrailingFixedElementsTest5 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElementsTest5, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 132, 129))
+>SubTup2TrailingVariadicWithTrailingFixedElements : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 121, 109))
 
 type SubTup2TrailingVariadicWithTrailingFixedElements2<T extends unknown[]> = T extends [
->SubTup2TrailingVariadicWithTrailingFixedElements2 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 107, 123))
->T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 109, 55))
->T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 109, 55))
+>SubTup2TrailingVariadicWithTrailingFixedElements2 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 133, 123))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 135, 55))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 135, 55))
 
   ...any,
   ...infer B extends [any],
->B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 111, 10))
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 137, 10))
 
   any,
   any,
 ]
   ? B
->B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 111, 10))
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 137, 10))
 
   : never;
 
 type SubTup2TrailingVariadicWithTrailingFixedElements2Test = SubTup2TrailingVariadicWithTrailingFixedElements2<[...a: 0[], b: 1, c: 2, d: 3]>;
->SubTup2TrailingVariadicWithTrailingFixedElements2Test : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2Test, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 116, 10))
->SubTup2TrailingVariadicWithTrailingFixedElements2 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 107, 123))
+>SubTup2TrailingVariadicWithTrailingFixedElements2Test : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2Test, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 142, 10))
+>SubTup2TrailingVariadicWithTrailingFixedElements2 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 133, 123))
 
 type SubTup2TrailingVariadicWithTrailingFixedElements2Test2 = SubTup2TrailingVariadicWithTrailingFixedElements2<[...a: 0[], b: 1, c: 2, d: 3, e: 4]>;
->SubTup2TrailingVariadicWithTrailingFixedElements2Test2 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2Test2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 118, 142))
->SubTup2TrailingVariadicWithTrailingFixedElements2 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 107, 123))
+>SubTup2TrailingVariadicWithTrailingFixedElements2Test2 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2Test2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 144, 142))
+>SubTup2TrailingVariadicWithTrailingFixedElements2 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 133, 123))
 
 type SubTup2TrailingVariadicWithTrailingFixedElements2Test3 = SubTup2TrailingVariadicWithTrailingFixedElements2<[...a: 0[], b: 1, c: 2]>;
->SubTup2TrailingVariadicWithTrailingFixedElements2Test3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2Test3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 119, 149))
->SubTup2TrailingVariadicWithTrailingFixedElements2 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 107, 123))
+>SubTup2TrailingVariadicWithTrailingFixedElements2Test3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2Test3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 145, 149))
+>SubTup2TrailingVariadicWithTrailingFixedElements2 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 133, 123))
 
 type SubTup2TrailingVariadicWithTrailingFixedElements2Test4 = SubTup2TrailingVariadicWithTrailingFixedElements2<[...a: 0[], b: 1]>;
->SubTup2TrailingVariadicWithTrailingFixedElements2Test4 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2Test4, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 120, 137))
->SubTup2TrailingVariadicWithTrailingFixedElements2 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 107, 123))
+>SubTup2TrailingVariadicWithTrailingFixedElements2Test4 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2Test4, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 146, 137))
+>SubTup2TrailingVariadicWithTrailingFixedElements2 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 133, 123))
 
 type SubTup2TrailingVariadicWithTrailingFixedElements2Test5 = SubTup2TrailingVariadicWithTrailingFixedElements2<[...a: 0[]]>;
->SubTup2TrailingVariadicWithTrailingFixedElements2Test5 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2Test5, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 121, 131))
->SubTup2TrailingVariadicWithTrailingFixedElements2 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 107, 123))
+>SubTup2TrailingVariadicWithTrailingFixedElements2Test5 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2Test5, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 147, 131))
+>SubTup2TrailingVariadicWithTrailingFixedElements2 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 133, 123))
 
 type SubTup2TrailingVariadicWithTrailingFixedElements3<T extends unknown[]> = T extends [
->SubTup2TrailingVariadicWithTrailingFixedElements3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 122, 125))
->T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 124, 55))
->T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 124, 55))
+>SubTup2TrailingVariadicWithTrailingFixedElements3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 148, 125))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 150, 55))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 150, 55))
 
   ...(infer C)[],
->C : Symbol(C, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 125, 11))
+>C : Symbol(C, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 151, 11))
 
   ...infer B extends [any, any],
->B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 126, 10))
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 152, 10))
 
   any,
 ]
   ? [C, B]
->C : Symbol(C, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 125, 11))
->B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 126, 10))
+>C : Symbol(C, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 151, 11))
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 152, 10))
 
   : never;
 
 type SubTup2TrailingVariadicWithTrailingFixedElements3Test = SubTup2TrailingVariadicWithTrailingFixedElements3<[...a: 0[], b: 1, c: 2, d: 3, e: 4]>;
->SubTup2TrailingVariadicWithTrailingFixedElements3Test : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3Test, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 130, 10))
->SubTup2TrailingVariadicWithTrailingFixedElements3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 122, 125))
+>SubTup2TrailingVariadicWithTrailingFixedElements3Test : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3Test, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 156, 10))
+>SubTup2TrailingVariadicWithTrailingFixedElements3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 148, 125))
 
 type SubTup2TrailingVariadicWithTrailingFixedElements3Test2 = SubTup2TrailingVariadicWithTrailingFixedElements3<[...a: 0[], b: 1, c: 2, d: 3]>;
->SubTup2TrailingVariadicWithTrailingFixedElements3Test2 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3Test2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 132, 148))
->SubTup2TrailingVariadicWithTrailingFixedElements3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 122, 125))
+>SubTup2TrailingVariadicWithTrailingFixedElements3Test2 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3Test2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 158, 148))
+>SubTup2TrailingVariadicWithTrailingFixedElements3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 148, 125))
 
 type SubTup2TrailingVariadicWithTrailingFixedElements3Test3 = SubTup2TrailingVariadicWithTrailingFixedElements3<[...a: 0[], b: 1, c: 2]>;
->SubTup2TrailingVariadicWithTrailingFixedElements3Test3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3Test3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 133, 143))
->SubTup2TrailingVariadicWithTrailingFixedElements3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 122, 125))
+>SubTup2TrailingVariadicWithTrailingFixedElements3Test3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3Test3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 159, 143))
+>SubTup2TrailingVariadicWithTrailingFixedElements3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 148, 125))
 
 type SubTup2TrailingVariadicWithTrailingFixedElements3Test4 = SubTup2TrailingVariadicWithTrailingFixedElements3<[...a: 0[], b: 1]>;
->SubTup2TrailingVariadicWithTrailingFixedElements3Test4 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3Test4, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 134, 137))
->SubTup2TrailingVariadicWithTrailingFixedElements3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 122, 125))
+>SubTup2TrailingVariadicWithTrailingFixedElements3Test4 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3Test4, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 160, 137))
+>SubTup2TrailingVariadicWithTrailingFixedElements3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 148, 125))
 
 type SubTup2TrailingVariadicWithTrailingFixedElements3Test5 = SubTup2TrailingVariadicWithTrailingFixedElements3<[...a: 0[]]>;
->SubTup2TrailingVariadicWithTrailingFixedElements3Test5 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3Test5, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 135, 131))
->SubTup2TrailingVariadicWithTrailingFixedElements3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 122, 125))
+>SubTup2TrailingVariadicWithTrailingFixedElements3Test5 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3Test5, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 161, 131))
+>SubTup2TrailingVariadicWithTrailingFixedElements3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 148, 125))
 
 type SubTup2TrailingVariadicWithTrailingFixedElements3Test6 = SubTup2TrailingVariadicWithTrailingFixedElements3<[b: 1, c: 2, d: 3]>;
->SubTup2TrailingVariadicWithTrailingFixedElements3Test6 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3Test6, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 136, 125))
->SubTup2TrailingVariadicWithTrailingFixedElements3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 122, 125))
+>SubTup2TrailingVariadicWithTrailingFixedElements3Test6 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3Test6, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 162, 125))
+>SubTup2TrailingVariadicWithTrailingFixedElements3 : Symbol(SubTup2TrailingVariadicWithTrailingFixedElements3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 148, 125))
+
+type SubTup2TrailingVariadicWithLeadingOptionalElement<T extends unknown[]> = T extends [
+>SubTup2TrailingVariadicWithLeadingOptionalElement : Symbol(SubTup2TrailingVariadicWithLeadingOptionalElement, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 163, 132))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 165, 55))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 165, 55))
+
+  ...any,
+  ...infer B extends [0?, 1],
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 167, 10))
+
+]
+  ? B
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 167, 10))
+
+  : never;
+
+type SubTup2TrailingVariadicWithLeadingOptionalElementTest = SubTup2TrailingVariadicWithLeadingOptionalElement<[b: 1]>;
+>SubTup2TrailingVariadicWithLeadingOptionalElementTest : Symbol(SubTup2TrailingVariadicWithLeadingOptionalElementTest, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 170, 10))
+>SubTup2TrailingVariadicWithLeadingOptionalElement : Symbol(SubTup2TrailingVariadicWithLeadingOptionalElement, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 163, 132))
+
+type SubTup2TrailingVariadicWithLeadingOptionalElementTest2 = SubTup2TrailingVariadicWithLeadingOptionalElement<[a: 0, b: 1]>;
+>SubTup2TrailingVariadicWithLeadingOptionalElementTest2 : Symbol(SubTup2TrailingVariadicWithLeadingOptionalElementTest2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 172, 119))
+>SubTup2TrailingVariadicWithLeadingOptionalElement : Symbol(SubTup2TrailingVariadicWithLeadingOptionalElement, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 163, 132))
+
+type SubTup2TrailingVariadicWithLeadingOptionalElementTest3 = SubTup2TrailingVariadicWithLeadingOptionalElement<[a: 2, b: 0, c: 1]>;
+>SubTup2TrailingVariadicWithLeadingOptionalElementTest3 : Symbol(SubTup2TrailingVariadicWithLeadingOptionalElementTest3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 173, 126))
+>SubTup2TrailingVariadicWithLeadingOptionalElement : Symbol(SubTup2TrailingVariadicWithLeadingOptionalElement, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 163, 132))
+
+type SubTup2TrailingVariadicWithLeadingOptionalElementTest4 = SubTup2TrailingVariadicWithLeadingOptionalElement<[...a: 0[], b: 1]>;
+>SubTup2TrailingVariadicWithLeadingOptionalElementTest4 : Symbol(SubTup2TrailingVariadicWithLeadingOptionalElementTest4, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 174, 132))
+>SubTup2TrailingVariadicWithLeadingOptionalElement : Symbol(SubTup2TrailingVariadicWithLeadingOptionalElement, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 163, 132))
+
+type SubTup2TrailingVariadicWithLeadingOptionalElementTest5 = SubTup2TrailingVariadicWithLeadingOptionalElement<[...a: 1[]]>;
+>SubTup2TrailingVariadicWithLeadingOptionalElementTest5 : Symbol(SubTup2TrailingVariadicWithLeadingOptionalElementTest5, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 175, 131))
+>SubTup2TrailingVariadicWithLeadingOptionalElement : Symbol(SubTup2TrailingVariadicWithLeadingOptionalElement, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 163, 132))
+
+type SubTup2TrailingVariadicWithTrailingOptionalElement<T extends unknown[]> = T extends [
+>SubTup2TrailingVariadicWithTrailingOptionalElement : Symbol(SubTup2TrailingVariadicWithTrailingOptionalElement, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 176, 125))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 178, 56))
+>T : Symbol(T, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 178, 56))
+
+  ...any,
+  ...infer B extends [0, 1?],
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 180, 10))
+
+]
+  ? B
+>B : Symbol(B, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 180, 10))
+
+  : never;
+
+type SubTup2TrailingVariadicWithTrailingOptionalElementTest = SubTup2TrailingVariadicWithTrailingOptionalElement<[a: 0]>;
+>SubTup2TrailingVariadicWithTrailingOptionalElementTest : Symbol(SubTup2TrailingVariadicWithTrailingOptionalElementTest, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 183, 10))
+>SubTup2TrailingVariadicWithTrailingOptionalElement : Symbol(SubTup2TrailingVariadicWithTrailingOptionalElement, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 176, 125))
+
+type SubTup2TrailingVariadicWithTrailingOptionalElementTest2 = SubTup2TrailingVariadicWithTrailingOptionalElement<[a: 0, b: 1]>;
+>SubTup2TrailingVariadicWithTrailingOptionalElementTest2 : Symbol(SubTup2TrailingVariadicWithTrailingOptionalElementTest2, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 185, 121))
+>SubTup2TrailingVariadicWithTrailingOptionalElement : Symbol(SubTup2TrailingVariadicWithTrailingOptionalElement, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 176, 125))
+
+type SubTup2TrailingVariadicWithTrailingOptionalElementTest3 = SubTup2TrailingVariadicWithTrailingOptionalElement<[a: 2, b: 0, c: 1]>;
+>SubTup2TrailingVariadicWithTrailingOptionalElementTest3 : Symbol(SubTup2TrailingVariadicWithTrailingOptionalElementTest3, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 186, 128))
+>SubTup2TrailingVariadicWithTrailingOptionalElement : Symbol(SubTup2TrailingVariadicWithTrailingOptionalElement, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 176, 125))
+
+type SubTup2TrailingVariadicWithTrailingOptionalElementTest4 = SubTup2TrailingVariadicWithTrailingOptionalElement<[...a: 0[]]>;
+>SubTup2TrailingVariadicWithTrailingOptionalElementTest4 : Symbol(SubTup2TrailingVariadicWithTrailingOptionalElementTest4, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 187, 134))
+>SubTup2TrailingVariadicWithTrailingOptionalElement : Symbol(SubTup2TrailingVariadicWithTrailingOptionalElement, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 176, 125))
+
+type SubTup2TrailingVariadicWithTrailingOptionalElementTest5 = SubTup2TrailingVariadicWithTrailingOptionalElement<[...a: 0[], b: 1]>;
+>SubTup2TrailingVariadicWithTrailingOptionalElementTest5 : Symbol(SubTup2TrailingVariadicWithTrailingOptionalElementTest5, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 188, 127))
+>SubTup2TrailingVariadicWithTrailingOptionalElement : Symbol(SubTup2TrailingVariadicWithTrailingOptionalElement, Decl(inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts, 176, 125))
 

--- a/testdata/baselines/reference/compiler/inferTypesWithFixedTupleExtendsAtVariadicPosition2.types
+++ b/testdata/baselines/reference/compiler/inferTypesWithFixedTupleExtendsAtVariadicPosition2.types
@@ -1,0 +1,235 @@
+//// [tests/cases/compiler/inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts] ////
+
+=== inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts ===
+// repro #51138
+
+type SubTup2FixedLength<T extends unknown[]> = T extends [
+>SubTup2FixedLength : SubTup2FixedLength<T>
+
+  ...infer B extends [any, any],
+  any
+]
+  ? B
+  : never;
+
+type SubTup2FixedLengthTest2 = SubTup2FixedLength<[a: 0]>;
+>SubTup2FixedLengthTest2 : never
+
+type SubTup2Variadic<T extends unknown[]> = T extends [
+>SubTup2Variadic : SubTup2Variadic<T>
+
+  ...infer B extends [any, any],
+  ...any
+]
+  ? B
+  : never;
+
+type SubTup2VariadicTest3 = SubTup2Variadic<[a: 0, ...b: 1[]]>;
+>SubTup2VariadicTest3 : never
+
+type SubTup2VariadicTest4 = SubTup2Variadic<[...a: 0[]]>;
+>SubTup2VariadicTest4 : never
+
+type SubTup2VariadicTest5 = SubTup2Variadic<[a: 0, b: 1]>;
+>SubTup2VariadicTest5 : [a: 0, b: 1]
+
+type SubTup2VariadicAndRest<T extends unknown[]> = T extends [
+>SubTup2VariadicAndRest : SubTup2VariadicAndRest<T>
+
+  ...infer B extends [any, any],
+  ...(infer C)[]
+]
+  ? [...B, ...[C]]
+  : never;
+
+type SubTup2VariadicAndRestTest2 = SubTup2VariadicAndRest<[a: 0, ...b: 1[]]>;
+>SubTup2VariadicAndRestTest2 : never
+
+type SubTup2VariadicAndRestTest3 = SubTup2VariadicAndRest<[...a: 0[]]>;
+>SubTup2VariadicAndRestTest3 : never
+
+type SubTup2VariadicAndRestTest4 = SubTup2VariadicAndRest<[a: 0, b: 1]>;
+>SubTup2VariadicAndRestTest4 : [a: 0, b: 1, unknown]
+
+type SubTup2TrailingVariadic<T extends unknown[]> = T extends [
+>SubTup2TrailingVariadic : SubTup2TrailingVariadic<T>
+
+  ...any,
+  ...infer B extends [any, any],
+]
+  ? B
+  : never;
+
+type SubTup2TrailingVariadicTest3 = SubTup2TrailingVariadic<[...a: 0[], b: 1]>;
+>SubTup2TrailingVariadicTest3 : never
+
+type SubTup2TrailingVariadicTest4 = SubTup2TrailingVariadic<[...a: 0[]]>;
+>SubTup2TrailingVariadicTest4 : never
+
+type SubTup2TrailingVariadicTest5 = SubTup2TrailingVariadic<[b: 1, c: 2]>;
+>SubTup2TrailingVariadicTest5 : [b: 1, c: 2]
+
+type SubTup2RestAndTrailingVariadic2<T extends unknown[]> = T extends [
+>SubTup2RestAndTrailingVariadic2 : SubTup2RestAndTrailingVariadic2<T>
+
+  ...(infer C)[],
+  ...infer B extends [any, any],
+]
+  ? [C, ...B]
+  : never;
+
+type SubTup2RestAndTrailingVariadic2Test2 = SubTup2RestAndTrailingVariadic2<[...a: 0[], b: 1]>;
+>SubTup2RestAndTrailingVariadic2Test2 : never
+
+type SubTup2RestAndTrailingVariadic2Test3 = SubTup2RestAndTrailingVariadic2<[...a: 0[]]>;
+>SubTup2RestAndTrailingVariadic2Test3 : never
+
+type SubTup2RestAndTrailingVariadic2Test4 = SubTup2RestAndTrailingVariadic2<[b: 1, c: 2]>;
+>SubTup2RestAndTrailingVariadic2Test4 : [unknown, b: 1, c: 2]
+
+type SubTup2VariadicWithLeadingFixedElements<T extends unknown[]> = T extends [
+>SubTup2VariadicWithLeadingFixedElements : SubTup2VariadicWithLeadingFixedElements<T>
+
+  any,
+  ...infer B extends [any, any],
+  ...any
+]
+  ? B
+  : never;
+
+type SubTup2VariadicWithLeadingFixedElementsTest3 = SubTup2VariadicWithLeadingFixedElements<[a: 0, b: 1, ...c: 2[]]>;
+>SubTup2VariadicWithLeadingFixedElementsTest3 : never
+
+type SubTup2VariadicWithLeadingFixedElementsTest4 = SubTup2VariadicWithLeadingFixedElements<[a: 0, ...b: 1[]]>;
+>SubTup2VariadicWithLeadingFixedElementsTest4 : never
+
+type SubTup2VariadicWithLeadingFixedElementsTest5 = SubTup2VariadicWithLeadingFixedElements<[...a: 0[]]>;
+>SubTup2VariadicWithLeadingFixedElementsTest5 : never
+
+type SubTup2VariadicWithLeadingFixedElements2<T extends unknown[]> = T extends [
+>SubTup2VariadicWithLeadingFixedElements2 : SubTup2VariadicWithLeadingFixedElements2<T>
+
+  any,
+  any,
+  ...infer B extends [any],
+  ...any
+]
+  ? B
+  : never;
+
+type SubTup2VariadicWithLeadingFixedElements2Test = SubTup2VariadicWithLeadingFixedElements2<[a: 0, b: 1, c: 2, ...d: 3[]]>;
+>SubTup2VariadicWithLeadingFixedElements2Test : [c: 2]
+
+type SubTup2VariadicWithLeadingFixedElements2Test2 = SubTup2VariadicWithLeadingFixedElements2<[a: 0, b: 1, c: 2, d: 3, ...e: 4[]]>;
+>SubTup2VariadicWithLeadingFixedElements2Test2 : [c: 2]
+
+type SubTup2VariadicWithLeadingFixedElements2Test3 = SubTup2VariadicWithLeadingFixedElements2<[a: 0, b: 1, ...c: 2[]]>;
+>SubTup2VariadicWithLeadingFixedElements2Test3 : never
+
+type SubTup2VariadicWithLeadingFixedElements2Test4 = SubTup2VariadicWithLeadingFixedElements2<[a: 0, ...b: 1[]]>;
+>SubTup2VariadicWithLeadingFixedElements2Test4 : never
+
+type SubTup2VariadicWithLeadingFixedElements2Test5 = SubTup2VariadicWithLeadingFixedElements2<[...a: 0[]]>;
+>SubTup2VariadicWithLeadingFixedElements2Test5 : never
+
+type SubTup2VariadicWithLeadingFixedElements3<T extends unknown[]> = T extends [
+>SubTup2VariadicWithLeadingFixedElements3 : SubTup2VariadicWithLeadingFixedElements3<T>
+
+  any,
+  ...infer B extends [any, any],
+  ...(infer C)[]
+]
+  ? [B, C]
+  : never;
+
+type SubTup2VariadicWithLeadingFixedElements3Test = SubTup2VariadicWithLeadingFixedElements3<[a: 0, b: 1, c: 2, d: 3, ...e: 4[]]>;
+>SubTup2VariadicWithLeadingFixedElements3Test : [[b: 1, c: 2], 3 | 4]
+
+type SubTup2VariadicWithLeadingFixedElements3Test2 = SubTup2VariadicWithLeadingFixedElements3<[a: 0, b: 1, c: 2, ...d: 3[]]>;
+>SubTup2VariadicWithLeadingFixedElements3Test2 : [[b: 1, c: 2], 3]
+
+type SubTup2VariadicWithLeadingFixedElements3Test3 = SubTup2VariadicWithLeadingFixedElements3<[a: 0, b: 1, ...c: 2[]]>;
+>SubTup2VariadicWithLeadingFixedElements3Test3 : never
+
+type SubTup2VariadicWithLeadingFixedElements3Test4 = SubTup2VariadicWithLeadingFixedElements3<[a: 0, ...b: 1[]]>;
+>SubTup2VariadicWithLeadingFixedElements3Test4 : never
+
+type SubTup2VariadicWithLeadingFixedElements3Test5 = SubTup2VariadicWithLeadingFixedElements3<[...a: 0[]]>;
+>SubTup2VariadicWithLeadingFixedElements3Test5 : never
+
+type SubTup2VariadicWithLeadingFixedElements3Test6 = SubTup2VariadicWithLeadingFixedElements3<[a: 0, b: 1, c: 2]>;
+>SubTup2VariadicWithLeadingFixedElements3Test6 : [[b: 1, c: 2], unknown]
+
+type SubTup2TrailingVariadicWithTrailingFixedElements<T extends unknown[]> = T extends [
+>SubTup2TrailingVariadicWithTrailingFixedElements : SubTup2TrailingVariadicWithTrailingFixedElements<T>
+
+  ...any,
+  ...infer B extends [any, any],
+  any,
+]
+  ? B
+  : never;
+
+type SubTup2TrailingVariadicWithTrailingFixedElementsTest3 = SubTup2TrailingVariadicWithTrailingFixedElements<[...a: 0[], b: 1, c: 2]>;
+>SubTup2TrailingVariadicWithTrailingFixedElementsTest3 : never
+
+type SubTup2TrailingVariadicWithTrailingFixedElementsTest4 = SubTup2TrailingVariadicWithTrailingFixedElements<[...a: 0[], b: 1]>;
+>SubTup2TrailingVariadicWithTrailingFixedElementsTest4 : never
+
+type SubTup2TrailingVariadicWithTrailingFixedElementsTest5 = SubTup2TrailingVariadicWithTrailingFixedElements<[...a: 0[]]>;
+>SubTup2TrailingVariadicWithTrailingFixedElementsTest5 : never
+
+type SubTup2TrailingVariadicWithTrailingFixedElements2<T extends unknown[]> = T extends [
+>SubTup2TrailingVariadicWithTrailingFixedElements2 : SubTup2TrailingVariadicWithTrailingFixedElements2<T>
+
+  ...any,
+  ...infer B extends [any],
+  any,
+  any,
+]
+  ? B
+  : never;
+
+type SubTup2TrailingVariadicWithTrailingFixedElements2Test = SubTup2TrailingVariadicWithTrailingFixedElements2<[...a: 0[], b: 1, c: 2, d: 3]>;
+>SubTup2TrailingVariadicWithTrailingFixedElements2Test : [b: 1]
+
+type SubTup2TrailingVariadicWithTrailingFixedElements2Test2 = SubTup2TrailingVariadicWithTrailingFixedElements2<[...a: 0[], b: 1, c: 2, d: 3, e: 4]>;
+>SubTup2TrailingVariadicWithTrailingFixedElements2Test2 : [c: 2]
+
+type SubTup2TrailingVariadicWithTrailingFixedElements2Test3 = SubTup2TrailingVariadicWithTrailingFixedElements2<[...a: 0[], b: 1, c: 2]>;
+>SubTup2TrailingVariadicWithTrailingFixedElements2Test3 : never
+
+type SubTup2TrailingVariadicWithTrailingFixedElements2Test4 = SubTup2TrailingVariadicWithTrailingFixedElements2<[...a: 0[], b: 1]>;
+>SubTup2TrailingVariadicWithTrailingFixedElements2Test4 : never
+
+type SubTup2TrailingVariadicWithTrailingFixedElements2Test5 = SubTup2TrailingVariadicWithTrailingFixedElements2<[...a: 0[]]>;
+>SubTup2TrailingVariadicWithTrailingFixedElements2Test5 : never
+
+type SubTup2TrailingVariadicWithTrailingFixedElements3<T extends unknown[]> = T extends [
+>SubTup2TrailingVariadicWithTrailingFixedElements3 : SubTup2TrailingVariadicWithTrailingFixedElements3<T>
+
+  ...(infer C)[],
+  ...infer B extends [any, any],
+  any,
+]
+  ? [C, B]
+  : never;
+
+type SubTup2TrailingVariadicWithTrailingFixedElements3Test = SubTup2TrailingVariadicWithTrailingFixedElements3<[...a: 0[], b: 1, c: 2, d: 3, e: 4]>;
+>SubTup2TrailingVariadicWithTrailingFixedElements3Test : [0 | 1, [c: 2, d: 3]]
+
+type SubTup2TrailingVariadicWithTrailingFixedElements3Test2 = SubTup2TrailingVariadicWithTrailingFixedElements3<[...a: 0[], b: 1, c: 2, d: 3]>;
+>SubTup2TrailingVariadicWithTrailingFixedElements3Test2 : [0, [b: 1, c: 2]]
+
+type SubTup2TrailingVariadicWithTrailingFixedElements3Test3 = SubTup2TrailingVariadicWithTrailingFixedElements3<[...a: 0[], b: 1, c: 2]>;
+>SubTup2TrailingVariadicWithTrailingFixedElements3Test3 : never
+
+type SubTup2TrailingVariadicWithTrailingFixedElements3Test4 = SubTup2TrailingVariadicWithTrailingFixedElements3<[...a: 0[], b: 1]>;
+>SubTup2TrailingVariadicWithTrailingFixedElements3Test4 : never
+
+type SubTup2TrailingVariadicWithTrailingFixedElements3Test5 = SubTup2TrailingVariadicWithTrailingFixedElements3<[...a: 0[]]>;
+>SubTup2TrailingVariadicWithTrailingFixedElements3Test5 : never
+
+type SubTup2TrailingVariadicWithTrailingFixedElements3Test6 = SubTup2TrailingVariadicWithTrailingFixedElements3<[b: 1, c: 2, d: 3]>;
+>SubTup2TrailingVariadicWithTrailingFixedElements3Test6 : [unknown, [b: 1, c: 2]]
+

--- a/testdata/baselines/reference/compiler/inferTypesWithFixedTupleExtendsAtVariadicPosition2.types
+++ b/testdata/baselines/reference/compiler/inferTypesWithFixedTupleExtendsAtVariadicPosition2.types
@@ -160,6 +160,54 @@ type SubTup2VariadicWithLeadingFixedElements3Test5 = SubTup2VariadicWithLeadingF
 type SubTup2VariadicWithLeadingFixedElements3Test6 = SubTup2VariadicWithLeadingFixedElements3<[a: 0, b: 1, c: 2]>;
 >SubTup2VariadicWithLeadingFixedElements3Test6 : [[b: 1, c: 2], unknown]
 
+type SubTup2VariadicWithTrailingOptionalElement<T extends unknown[]> = T extends [
+>SubTup2VariadicWithTrailingOptionalElement : SubTup2VariadicWithTrailingOptionalElement<T>
+
+  ...infer B extends [0, 1?],
+  ...any
+]
+  ? B
+  : never;
+
+type SubTup2VariadicWithTrailingOptionalElementTest = SubTup2VariadicWithTrailingOptionalElement<[a: 0]>;
+>SubTup2VariadicWithTrailingOptionalElementTest : [0, (1 | undefined)?]
+
+type SubTup2VariadicWithTrailingOptionalElementTest2 = SubTup2VariadicWithTrailingOptionalElement<[a: 0, b: 1]>;
+>SubTup2VariadicWithTrailingOptionalElementTest2 : [a: 0, b: 1]
+
+type SubTup2VariadicWithTrailingOptionalElementTest3 = SubTup2VariadicWithTrailingOptionalElement<[a: 0, b: 1, c: 2]>;
+>SubTup2VariadicWithTrailingOptionalElementTest3 : [a: 0, b: 1]
+
+type SubTup2VariadicWithTrailingOptionalElementTest4 = SubTup2VariadicWithTrailingOptionalElement<[a: 0, ...b: 1[]]>;
+>SubTup2VariadicWithTrailingOptionalElementTest4 : [0, (1 | undefined)?]
+
+type SubTup2VariadicWithTrailingOptionalElementTest5 = SubTup2VariadicWithTrailingOptionalElement<[...a: 0[]]>;
+>SubTup2VariadicWithTrailingOptionalElementTest5 : never
+
+type SubTup2VariadicWithLeadingOptionalElement<T extends unknown[]> = T extends [
+>SubTup2VariadicWithLeadingOptionalElement : SubTup2VariadicWithLeadingOptionalElement<T>
+
+  ...infer B extends [0?, 1],
+  ...any
+]
+  ? B
+  : never;
+
+type SubTup2VariadicWithLeadingOptionalElementTest = SubTup2VariadicWithLeadingOptionalElement<[b: 1]>;
+>SubTup2VariadicWithLeadingOptionalElementTest : never
+
+type SubTup2VariadicWithLeadingOptionalElementTest2 = SubTup2VariadicWithLeadingOptionalElement<[a: 0, b: 1]>;
+>SubTup2VariadicWithLeadingOptionalElementTest2 : [a: 0, b: 1]
+
+type SubTup2VariadicWithLeadingOptionalElementTest3 = SubTup2VariadicWithLeadingOptionalElement<[a: 0, b: 1, c: 2]>;
+>SubTup2VariadicWithLeadingOptionalElementTest3 : [a: 0, b: 1]
+
+type SubTup2VariadicWithLeadingOptionalElementTest4 = SubTup2VariadicWithLeadingOptionalElement<[a: 0, ...b: 1[]]>;
+>SubTup2VariadicWithLeadingOptionalElementTest4 : never
+
+type SubTup2VariadicWithLeadingOptionalElementTest5 = SubTup2VariadicWithLeadingOptionalElement<[...a: 1[]]>;
+>SubTup2VariadicWithLeadingOptionalElementTest5 : never
+
 type SubTup2TrailingVariadicWithTrailingFixedElements<T extends unknown[]> = T extends [
 >SubTup2TrailingVariadicWithTrailingFixedElements : SubTup2TrailingVariadicWithTrailingFixedElements<T>
 
@@ -232,4 +280,52 @@ type SubTup2TrailingVariadicWithTrailingFixedElements3Test5 = SubTup2TrailingVar
 
 type SubTup2TrailingVariadicWithTrailingFixedElements3Test6 = SubTup2TrailingVariadicWithTrailingFixedElements3<[b: 1, c: 2, d: 3]>;
 >SubTup2TrailingVariadicWithTrailingFixedElements3Test6 : [unknown, [b: 1, c: 2]]
+
+type SubTup2TrailingVariadicWithLeadingOptionalElement<T extends unknown[]> = T extends [
+>SubTup2TrailingVariadicWithLeadingOptionalElement : SubTup2TrailingVariadicWithLeadingOptionalElement<T>
+
+  ...any,
+  ...infer B extends [0?, 1],
+]
+  ? B
+  : never;
+
+type SubTup2TrailingVariadicWithLeadingOptionalElementTest = SubTup2TrailingVariadicWithLeadingOptionalElement<[b: 1]>;
+>SubTup2TrailingVariadicWithLeadingOptionalElementTest : never
+
+type SubTup2TrailingVariadicWithLeadingOptionalElementTest2 = SubTup2TrailingVariadicWithLeadingOptionalElement<[a: 0, b: 1]>;
+>SubTup2TrailingVariadicWithLeadingOptionalElementTest2 : [a: 0, b: 1]
+
+type SubTup2TrailingVariadicWithLeadingOptionalElementTest3 = SubTup2TrailingVariadicWithLeadingOptionalElement<[a: 2, b: 0, c: 1]>;
+>SubTup2TrailingVariadicWithLeadingOptionalElementTest3 : [b: 0, c: 1]
+
+type SubTup2TrailingVariadicWithLeadingOptionalElementTest4 = SubTup2TrailingVariadicWithLeadingOptionalElement<[...a: 0[], b: 1]>;
+>SubTup2TrailingVariadicWithLeadingOptionalElementTest4 : never
+
+type SubTup2TrailingVariadicWithLeadingOptionalElementTest5 = SubTup2TrailingVariadicWithLeadingOptionalElement<[...a: 1[]]>;
+>SubTup2TrailingVariadicWithLeadingOptionalElementTest5 : never
+
+type SubTup2TrailingVariadicWithTrailingOptionalElement<T extends unknown[]> = T extends [
+>SubTup2TrailingVariadicWithTrailingOptionalElement : SubTup2TrailingVariadicWithTrailingOptionalElement<T>
+
+  ...any,
+  ...infer B extends [0, 1?],
+]
+  ? B
+  : never;
+
+type SubTup2TrailingVariadicWithTrailingOptionalElementTest = SubTup2TrailingVariadicWithTrailingOptionalElement<[a: 0]>;
+>SubTup2TrailingVariadicWithTrailingOptionalElementTest : [0, (1 | undefined)?]
+
+type SubTup2TrailingVariadicWithTrailingOptionalElementTest2 = SubTup2TrailingVariadicWithTrailingOptionalElement<[a: 0, b: 1]>;
+>SubTup2TrailingVariadicWithTrailingOptionalElementTest2 : [a: 0, b: 1]
+
+type SubTup2TrailingVariadicWithTrailingOptionalElementTest3 = SubTup2TrailingVariadicWithTrailingOptionalElement<[a: 2, b: 0, c: 1]>;
+>SubTup2TrailingVariadicWithTrailingOptionalElementTest3 : [b: 0, c: 1]
+
+type SubTup2TrailingVariadicWithTrailingOptionalElementTest4 = SubTup2TrailingVariadicWithTrailingOptionalElement<[...a: 0[]]>;
+>SubTup2TrailingVariadicWithTrailingOptionalElementTest4 : [0, (1 | undefined)?]
+
+type SubTup2TrailingVariadicWithTrailingOptionalElementTest5 = SubTup2TrailingVariadicWithTrailingOptionalElement<[...a: 0[], b: 1]>;
+>SubTup2TrailingVariadicWithTrailingOptionalElementTest5 : [0, (1 | undefined)?]
 

--- a/testdata/tests/cases/compiler/inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts
+++ b/testdata/tests/cases/compiler/inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts
@@ -99,6 +99,32 @@ type SubTup2VariadicWithLeadingFixedElements3Test4 = SubTup2VariadicWithLeadingF
 type SubTup2VariadicWithLeadingFixedElements3Test5 = SubTup2VariadicWithLeadingFixedElements3<[...a: 0[]]>;
 type SubTup2VariadicWithLeadingFixedElements3Test6 = SubTup2VariadicWithLeadingFixedElements3<[a: 0, b: 1, c: 2]>;
 
+type SubTup2VariadicWithTrailingOptionalElement<T extends unknown[]> = T extends [
+  ...infer B extends [0, 1?],
+  ...any
+]
+  ? B
+  : never;
+
+type SubTup2VariadicWithTrailingOptionalElementTest = SubTup2VariadicWithTrailingOptionalElement<[a: 0]>;
+type SubTup2VariadicWithTrailingOptionalElementTest2 = SubTup2VariadicWithTrailingOptionalElement<[a: 0, b: 1]>;
+type SubTup2VariadicWithTrailingOptionalElementTest3 = SubTup2VariadicWithTrailingOptionalElement<[a: 0, b: 1, c: 2]>;
+type SubTup2VariadicWithTrailingOptionalElementTest4 = SubTup2VariadicWithTrailingOptionalElement<[a: 0, ...b: 1[]]>;
+type SubTup2VariadicWithTrailingOptionalElementTest5 = SubTup2VariadicWithTrailingOptionalElement<[...a: 0[]]>;
+
+type SubTup2VariadicWithLeadingOptionalElement<T extends unknown[]> = T extends [
+  ...infer B extends [0?, 1],
+  ...any
+]
+  ? B
+  : never;
+
+type SubTup2VariadicWithLeadingOptionalElementTest = SubTup2VariadicWithLeadingOptionalElement<[b: 1]>;
+type SubTup2VariadicWithLeadingOptionalElementTest2 = SubTup2VariadicWithLeadingOptionalElement<[a: 0, b: 1]>;
+type SubTup2VariadicWithLeadingOptionalElementTest3 = SubTup2VariadicWithLeadingOptionalElement<[a: 0, b: 1, c: 2]>;
+type SubTup2VariadicWithLeadingOptionalElementTest4 = SubTup2VariadicWithLeadingOptionalElement<[a: 0, ...b: 1[]]>;
+type SubTup2VariadicWithLeadingOptionalElementTest5 = SubTup2VariadicWithLeadingOptionalElement<[...a: 1[]]>;
+
 type SubTup2TrailingVariadicWithTrailingFixedElements<T extends unknown[]> = T extends [
   ...any,
   ...infer B extends [any, any],
@@ -140,3 +166,29 @@ type SubTup2TrailingVariadicWithTrailingFixedElements3Test3 = SubTup2TrailingVar
 type SubTup2TrailingVariadicWithTrailingFixedElements3Test4 = SubTup2TrailingVariadicWithTrailingFixedElements3<[...a: 0[], b: 1]>;
 type SubTup2TrailingVariadicWithTrailingFixedElements3Test5 = SubTup2TrailingVariadicWithTrailingFixedElements3<[...a: 0[]]>;
 type SubTup2TrailingVariadicWithTrailingFixedElements3Test6 = SubTup2TrailingVariadicWithTrailingFixedElements3<[b: 1, c: 2, d: 3]>;
+
+type SubTup2TrailingVariadicWithLeadingOptionalElement<T extends unknown[]> = T extends [
+  ...any,
+  ...infer B extends [0?, 1],
+]
+  ? B
+  : never;
+
+type SubTup2TrailingVariadicWithLeadingOptionalElementTest = SubTup2TrailingVariadicWithLeadingOptionalElement<[b: 1]>;
+type SubTup2TrailingVariadicWithLeadingOptionalElementTest2 = SubTup2TrailingVariadicWithLeadingOptionalElement<[a: 0, b: 1]>;
+type SubTup2TrailingVariadicWithLeadingOptionalElementTest3 = SubTup2TrailingVariadicWithLeadingOptionalElement<[a: 2, b: 0, c: 1]>;
+type SubTup2TrailingVariadicWithLeadingOptionalElementTest4 = SubTup2TrailingVariadicWithLeadingOptionalElement<[...a: 0[], b: 1]>;
+type SubTup2TrailingVariadicWithLeadingOptionalElementTest5 = SubTup2TrailingVariadicWithLeadingOptionalElement<[...a: 1[]]>;
+
+type SubTup2TrailingVariadicWithTrailingOptionalElement<T extends unknown[]> = T extends [
+  ...any,
+  ...infer B extends [0, 1?],
+]
+  ? B
+  : never;
+
+type SubTup2TrailingVariadicWithTrailingOptionalElementTest = SubTup2TrailingVariadicWithTrailingOptionalElement<[a: 0]>;
+type SubTup2TrailingVariadicWithTrailingOptionalElementTest2 = SubTup2TrailingVariadicWithTrailingOptionalElement<[a: 0, b: 1]>;
+type SubTup2TrailingVariadicWithTrailingOptionalElementTest3 = SubTup2TrailingVariadicWithTrailingOptionalElement<[a: 2, b: 0, c: 1]>;
+type SubTup2TrailingVariadicWithTrailingOptionalElementTest4 = SubTup2TrailingVariadicWithTrailingOptionalElement<[...a: 0[]]>;
+type SubTup2TrailingVariadicWithTrailingOptionalElementTest5 = SubTup2TrailingVariadicWithTrailingOptionalElement<[...a: 0[], b: 1]>;

--- a/testdata/tests/cases/compiler/inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts
+++ b/testdata/tests/cases/compiler/inferTypesWithFixedTupleExtendsAtVariadicPosition2.ts
@@ -1,0 +1,142 @@
+// @target: es2015
+// @strict: true
+// @noEmit: true
+
+// repro #51138
+
+type SubTup2FixedLength<T extends unknown[]> = T extends [
+  ...infer B extends [any, any],
+  any
+]
+  ? B
+  : never;
+
+type SubTup2FixedLengthTest2 = SubTup2FixedLength<[a: 0]>;
+
+type SubTup2Variadic<T extends unknown[]> = T extends [
+  ...infer B extends [any, any],
+  ...any
+]
+  ? B
+  : never;
+
+type SubTup2VariadicTest3 = SubTup2Variadic<[a: 0, ...b: 1[]]>;
+type SubTup2VariadicTest4 = SubTup2Variadic<[...a: 0[]]>;
+type SubTup2VariadicTest5 = SubTup2Variadic<[a: 0, b: 1]>;
+
+type SubTup2VariadicAndRest<T extends unknown[]> = T extends [
+  ...infer B extends [any, any],
+  ...(infer C)[]
+]
+  ? [...B, ...[C]]
+  : never;
+
+type SubTup2VariadicAndRestTest2 = SubTup2VariadicAndRest<[a: 0, ...b: 1[]]>;
+type SubTup2VariadicAndRestTest3 = SubTup2VariadicAndRest<[...a: 0[]]>;
+type SubTup2VariadicAndRestTest4 = SubTup2VariadicAndRest<[a: 0, b: 1]>;
+
+type SubTup2TrailingVariadic<T extends unknown[]> = T extends [
+  ...any,
+  ...infer B extends [any, any],
+]
+  ? B
+  : never;
+
+type SubTup2TrailingVariadicTest3 = SubTup2TrailingVariadic<[...a: 0[], b: 1]>;
+type SubTup2TrailingVariadicTest4 = SubTup2TrailingVariadic<[...a: 0[]]>;
+type SubTup2TrailingVariadicTest5 = SubTup2TrailingVariadic<[b: 1, c: 2]>;
+
+type SubTup2RestAndTrailingVariadic2<T extends unknown[]> = T extends [
+  ...(infer C)[],
+  ...infer B extends [any, any],
+]
+  ? [C, ...B]
+  : never;
+
+type SubTup2RestAndTrailingVariadic2Test2 = SubTup2RestAndTrailingVariadic2<[...a: 0[], b: 1]>;
+type SubTup2RestAndTrailingVariadic2Test3 = SubTup2RestAndTrailingVariadic2<[...a: 0[]]>;
+type SubTup2RestAndTrailingVariadic2Test4 = SubTup2RestAndTrailingVariadic2<[b: 1, c: 2]>;
+
+type SubTup2VariadicWithLeadingFixedElements<T extends unknown[]> = T extends [
+  any,
+  ...infer B extends [any, any],
+  ...any
+]
+  ? B
+  : never;
+
+type SubTup2VariadicWithLeadingFixedElementsTest3 = SubTup2VariadicWithLeadingFixedElements<[a: 0, b: 1, ...c: 2[]]>;
+type SubTup2VariadicWithLeadingFixedElementsTest4 = SubTup2VariadicWithLeadingFixedElements<[a: 0, ...b: 1[]]>;
+type SubTup2VariadicWithLeadingFixedElementsTest5 = SubTup2VariadicWithLeadingFixedElements<[...a: 0[]]>;
+
+type SubTup2VariadicWithLeadingFixedElements2<T extends unknown[]> = T extends [
+  any,
+  any,
+  ...infer B extends [any],
+  ...any
+]
+  ? B
+  : never;
+
+type SubTup2VariadicWithLeadingFixedElements2Test = SubTup2VariadicWithLeadingFixedElements2<[a: 0, b: 1, c: 2, ...d: 3[]]>;
+type SubTup2VariadicWithLeadingFixedElements2Test2 = SubTup2VariadicWithLeadingFixedElements2<[a: 0, b: 1, c: 2, d: 3, ...e: 4[]]>;
+type SubTup2VariadicWithLeadingFixedElements2Test3 = SubTup2VariadicWithLeadingFixedElements2<[a: 0, b: 1, ...c: 2[]]>;
+type SubTup2VariadicWithLeadingFixedElements2Test4 = SubTup2VariadicWithLeadingFixedElements2<[a: 0, ...b: 1[]]>;
+type SubTup2VariadicWithLeadingFixedElements2Test5 = SubTup2VariadicWithLeadingFixedElements2<[...a: 0[]]>;
+
+type SubTup2VariadicWithLeadingFixedElements3<T extends unknown[]> = T extends [
+  any,
+  ...infer B extends [any, any],
+  ...(infer C)[]
+]
+  ? [B, C]
+  : never;
+
+type SubTup2VariadicWithLeadingFixedElements3Test = SubTup2VariadicWithLeadingFixedElements3<[a: 0, b: 1, c: 2, d: 3, ...e: 4[]]>;
+type SubTup2VariadicWithLeadingFixedElements3Test2 = SubTup2VariadicWithLeadingFixedElements3<[a: 0, b: 1, c: 2, ...d: 3[]]>;
+type SubTup2VariadicWithLeadingFixedElements3Test3 = SubTup2VariadicWithLeadingFixedElements3<[a: 0, b: 1, ...c: 2[]]>;
+type SubTup2VariadicWithLeadingFixedElements3Test4 = SubTup2VariadicWithLeadingFixedElements3<[a: 0, ...b: 1[]]>;
+type SubTup2VariadicWithLeadingFixedElements3Test5 = SubTup2VariadicWithLeadingFixedElements3<[...a: 0[]]>;
+type SubTup2VariadicWithLeadingFixedElements3Test6 = SubTup2VariadicWithLeadingFixedElements3<[a: 0, b: 1, c: 2]>;
+
+type SubTup2TrailingVariadicWithTrailingFixedElements<T extends unknown[]> = T extends [
+  ...any,
+  ...infer B extends [any, any],
+  any,
+]
+  ? B
+  : never;
+
+type SubTup2TrailingVariadicWithTrailingFixedElementsTest3 = SubTup2TrailingVariadicWithTrailingFixedElements<[...a: 0[], b: 1, c: 2]>;
+type SubTup2TrailingVariadicWithTrailingFixedElementsTest4 = SubTup2TrailingVariadicWithTrailingFixedElements<[...a: 0[], b: 1]>;
+type SubTup2TrailingVariadicWithTrailingFixedElementsTest5 = SubTup2TrailingVariadicWithTrailingFixedElements<[...a: 0[]]>;
+
+type SubTup2TrailingVariadicWithTrailingFixedElements2<T extends unknown[]> = T extends [
+  ...any,
+  ...infer B extends [any],
+  any,
+  any,
+]
+  ? B
+  : never;
+
+type SubTup2TrailingVariadicWithTrailingFixedElements2Test = SubTup2TrailingVariadicWithTrailingFixedElements2<[...a: 0[], b: 1, c: 2, d: 3]>;
+type SubTup2TrailingVariadicWithTrailingFixedElements2Test2 = SubTup2TrailingVariadicWithTrailingFixedElements2<[...a: 0[], b: 1, c: 2, d: 3, e: 4]>;
+type SubTup2TrailingVariadicWithTrailingFixedElements2Test3 = SubTup2TrailingVariadicWithTrailingFixedElements2<[...a: 0[], b: 1, c: 2]>;
+type SubTup2TrailingVariadicWithTrailingFixedElements2Test4 = SubTup2TrailingVariadicWithTrailingFixedElements2<[...a: 0[], b: 1]>;
+type SubTup2TrailingVariadicWithTrailingFixedElements2Test5 = SubTup2TrailingVariadicWithTrailingFixedElements2<[...a: 0[]]>;
+
+type SubTup2TrailingVariadicWithTrailingFixedElements3<T extends unknown[]> = T extends [
+  ...(infer C)[],
+  ...infer B extends [any, any],
+  any,
+]
+  ? [C, B]
+  : never;
+
+type SubTup2TrailingVariadicWithTrailingFixedElements3Test = SubTup2TrailingVariadicWithTrailingFixedElements3<[...a: 0[], b: 1, c: 2, d: 3, e: 4]>;
+type SubTup2TrailingVariadicWithTrailingFixedElements3Test2 = SubTup2TrailingVariadicWithTrailingFixedElements3<[...a: 0[], b: 1, c: 2, d: 3]>;
+type SubTup2TrailingVariadicWithTrailingFixedElements3Test3 = SubTup2TrailingVariadicWithTrailingFixedElements3<[...a: 0[], b: 1, c: 2]>;
+type SubTup2TrailingVariadicWithTrailingFixedElements3Test4 = SubTup2TrailingVariadicWithTrailingFixedElements3<[...a: 0[], b: 1]>;
+type SubTup2TrailingVariadicWithTrailingFixedElements3Test5 = SubTup2TrailingVariadicWithTrailingFixedElements3<[...a: 0[]]>;
+type SubTup2TrailingVariadicWithTrailingFixedElements3Test6 = SubTup2TrailingVariadicWithTrailingFixedElements3<[b: 1, c: 2, d: 3]>;


### PR DESCRIPTION
followup to https://github.com/microsoft/typescript-go/pull/2928
ports https://github.com/microsoft/TypeScript/pull/63014