### PR TITLE
Fix crash on non-textual module specifiers in auto-import promote fixes

### DIFF
--- a/internal/fourslash/tests/codeFixImportNonTextualSpecifierText_test.go
+++ b/internal/fourslash/tests/codeFixImportNonTextualSpecifierText_test.go
@@ -1,0 +1,27 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+// https://github.com/microsoft/typescript-go/issues/3944
+func TestCodeFixImportNonTextualSpecifierText(t *testing.T) {
+	fourslash.SkipIfFailing(t)
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = "// @Filename: /a.ts\n" +
+		"import type { A } from `./${myFolder}/${myFile}`;\n" +
+		"\n" +
+		"new A/**/()"
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.GoToMarker(t, "")
+	f.VerifyImportFixAtPosition(t, []string{
+		"import { A } from `./${myFolder}/${myFile}`;\n" +
+			"\n" +
+			"new A()",
+	}, nil /*preferences*/)
+}

--- a/internal/ls/autoimport/fix.go
+++ b/internal/ls/autoimport/fix.go
@@ -1288,10 +1288,10 @@ func getModuleSpecifierText(promotedDeclaration *ast.Node) string {
 		importEqualsDeclaration := promotedDeclaration.AsImportEqualsDeclaration()
 		if ast.IsExternalModuleReference(importEqualsDeclaration.ModuleReference) {
 			expr := importEqualsDeclaration.ModuleReference.Expression()
-			if expr != nil && ast.IsStringLiteralLike(expr) {
-				return expr.Text()
-			}
 			if expr != nil {
+				if ast.IsStringLiteralLike(expr) {
+					return expr.Text()
+				}
 				return scanner.GetTextOfNode(expr)
 			}
 		}

--- a/internal/ls/autoimport/fix.go
+++ b/internal/ls/autoimport/fix.go
@@ -1288,14 +1288,20 @@ func getModuleSpecifierText(promotedDeclaration *ast.Node) string {
 		importEqualsDeclaration := promotedDeclaration.AsImportEqualsDeclaration()
 		if ast.IsExternalModuleReference(importEqualsDeclaration.ModuleReference) {
 			expr := importEqualsDeclaration.ModuleReference.Expression()
-			if expr != nil && expr.Kind == ast.KindStringLiteral {
+			if expr != nil && ast.IsStringLiteralLike(expr) {
 				return expr.Text()
 			}
-
+			if expr != nil {
+				return scanner.GetTextOfNode(expr)
+			}
 		}
-		return importEqualsDeclaration.ModuleReference.Text()
+		return scanner.GetTextOfNode(importEqualsDeclaration.ModuleReference)
 	}
-	return promotedDeclaration.Parent.ModuleSpecifier().Text()
+	moduleSpecifier := promotedDeclaration.Parent.ModuleSpecifier()
+	if ast.IsStringLiteralLike(moduleSpecifier) {
+		return moduleSpecifier.Text()
+	}
+	return scanner.GetTextOfNode(moduleSpecifier)
 }
 
 // returns `-1` if `a` is better than `b`


### PR DESCRIPTION
fixes https://github.com/microsoft/typescript-go/issues/3944