### PR TITLE
fix(3954): preserve jsdoc on private async method declarations

### DIFF
--- a/internal/transformers/declarations/transform.go
+++ b/internal/transformers/declarations/transform.go
@@ -988,15 +988,16 @@ func (tx *DeclarationTransformer) transformConstructSignatureDeclaration(input *
 func (tx *DeclarationTransformer) omitPrivateMethodType(input *ast.Node) *ast.Node {
 	if input.Symbol() != nil && len(input.Symbol().Declarations) > 0 && input.Symbol().Declarations[0] != input {
 		return nil
-	} else {
-		return tx.Factory().NewPropertyDeclaration(
-			tx.ensureModifiers(input),
-			input.Name(),
-			nil,
-			nil,
-			nil,
-		)
 	}
+	result := tx.Factory().NewPropertyDeclaration(
+		tx.ensureModifiers(input),
+		input.Name(),
+		nil,
+		nil,
+		nil,
+	)
+	tx.preserveJsDoc(result, input)
+	return result
 }
 
 func (tx *DeclarationTransformer) transformMethodSignatureDeclaration(input *ast.MethodSignatureDeclaration) *ast.Node {

--- a/testdata/baselines/reference/compiler/declarationEmitPrivateAsyncMethod.js
+++ b/testdata/baselines/reference/compiler/declarationEmitPrivateAsyncMethod.js
@@ -1,0 +1,44 @@
+//// [tests/cases/compiler/declarationEmitPrivateAsyncMethod.ts] ////
+
+//// [a.ts]
+export class C {
+    /**
+     * Non Async function
+     */
+    private a(): void {
+    }
+
+    /**
+     * Async function
+     */
+    private async b(): Promise<void> {
+    }
+}
+
+
+//// [a.js]
+export class C {
+    /**
+     * Non Async function
+     */
+    a() {
+    }
+    /**
+     * Async function
+     */
+    async b() {
+    }
+}
+
+
+//// [a.d.ts]
+export declare class C {
+    /**
+     * Non Async function
+     */
+    private a;
+    /**
+     * Async function
+     */
+    private b;
+}

--- a/testdata/baselines/reference/compiler/declarationEmitPrivateAsyncMethod.symbols
+++ b/testdata/baselines/reference/compiler/declarationEmitPrivateAsyncMethod.symbols
@@ -1,0 +1,22 @@
+//// [tests/cases/compiler/declarationEmitPrivateAsyncMethod.ts] ////
+
+=== a.ts ===
+export class C {
+>C : Symbol(C, Decl(a.ts, 0, 0))
+
+    /**
+     * Non Async function
+     */
+    private a(): void {
+>a : Symbol(C.a, Decl(a.ts, 0, 16))
+    }
+
+    /**
+     * Async function
+     */
+    private async b(): Promise<void> {
+>b : Symbol(C.b, Decl(a.ts, 5, 5))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+    }
+}
+

--- a/testdata/baselines/reference/compiler/declarationEmitPrivateAsyncMethod.types
+++ b/testdata/baselines/reference/compiler/declarationEmitPrivateAsyncMethod.types
@@ -1,0 +1,21 @@
+//// [tests/cases/compiler/declarationEmitPrivateAsyncMethod.ts] ////
+
+=== a.ts ===
+export class C {
+>C : C
+
+    /**
+     * Non Async function
+     */
+    private a(): void {
+>a : () => void
+    }
+
+    /**
+     * Async function
+     */
+    private async b(): Promise<void> {
+>b : () => Promise<void>
+    }
+}
+

--- a/testdata/tests/cases/compiler/declarationEmitPrivateAsyncMethod.ts
+++ b/testdata/tests/cases/compiler/declarationEmitPrivateAsyncMethod.ts
@@ -1,0 +1,15 @@
+// @declaration: true
+// @filename: a.ts
+export class C {
+    /**
+     * Non Async function
+     */
+    private a(): void {
+    }
+
+    /**
+     * Async function
+     */
+    private async b(): Promise<void> {
+    }
+}


### PR DESCRIPTION
Fixes #3954