### PR TITLE
fix(checker): check type expressions on unmatched JSDoc @param tags

### DIFF
--- a/internal/checker/jsdoc.go
+++ b/internal/checker/jsdoc.go
@@ -77,6 +77,28 @@ func (c *Checker) checkUnmatchedJSDocParameters(node *ast.Node) {
 					)
 				}
 			}
+			// Check the type expression even for unmatched params so diagnostics
+			// like TS2314 (generic type missing type arguments) are still reported.
+			// Restrict to JS files: in TS files the JSDoc type is not the source
+			// of truth and surfacing name-resolution errors there produces false
+			// positives (e.g. a local variable name used in a @param type).
+			// Skip function/constructor/signature types: their parameters are not
+			// symbol-bound inside JSDoc type expressions and checkSignatureDeclaration
+			// would nil-panic on them.
+			if isJs {
+				if typeExpr := tag.AsJSDocParameterOrPropertyTag().TypeExpression; typeExpr != nil {
+					if typeNode := typeExpr.Type(); typeNode != nil {
+						switch typeNode.Kind {
+						case ast.KindFunctionType, ast.KindConstructorType,
+							ast.KindCallSignature, ast.KindConstructSignature,
+							ast.KindIndexSignature:
+							// skip
+						default:
+							c.checkSourceElement(typeNode)
+						}
+					}
+				}
+			}
 		}
 	}
 }

--- a/testdata/baselines/reference/compiler/jsdocUnmatchedParamTypeChecked.errors.txt
+++ b/testdata/baselines/reference/compiler/jsdocUnmatchedParamTypeChecked.errors.txt
@@ -1,0 +1,14 @@
+jsdocUnmatchedParamTypeChecked.js(2,12): error TS2314: Generic type 'Record' requires 2 type argument(s).
+jsdocUnmatchedParamTypeChecked.js(2,20): error TS8024: JSDoc '@param' tag has name 'bar', but there is no parameter with that name.
+
+
+==== jsdocUnmatchedParamTypeChecked.js (2 errors) ====
+    /**
+     * @param {Record} bar
+               ~~~~~~
+!!! error TS2314: Generic type 'Record' requires 2 type argument(s).
+                       ~~~
+!!! error TS8024: JSDoc '@param' tag has name 'bar', but there is no parameter with that name.
+     */
+    function foo() {}
+    

--- a/testdata/baselines/reference/compiler/jsdocUnmatchedParamTypeChecked.symbols
+++ b/testdata/baselines/reference/compiler/jsdocUnmatchedParamTypeChecked.symbols
@@ -1,0 +1,9 @@
+//// [tests/cases/compiler/jsdocUnmatchedParamTypeChecked.ts] ////
+
+=== jsdocUnmatchedParamTypeChecked.js ===
+/**
+ * @param {Record} bar
+ */
+function foo() {}
+>foo : Symbol(foo, Decl(jsdocUnmatchedParamTypeChecked.js, 0, 0))
+

--- a/testdata/baselines/reference/compiler/jsdocUnmatchedParamTypeChecked.types
+++ b/testdata/baselines/reference/compiler/jsdocUnmatchedParamTypeChecked.types
@@ -1,0 +1,9 @@
+//// [tests/cases/compiler/jsdocUnmatchedParamTypeChecked.ts] ////
+
+=== jsdocUnmatchedParamTypeChecked.js ===
+/**
+ * @param {Record} bar
+ */
+function foo() {}
+>foo : () => void
+

--- a/testdata/tests/cases/compiler/jsdocUnmatchedParamTypeChecked.ts
+++ b/testdata/tests/cases/compiler/jsdocUnmatchedParamTypeChecked.ts
@@ -1,0 +1,9 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @filename: jsdocUnmatchedParamTypeChecked.js
+
+/**
+ * @param {Record} bar
+ */
+function foo() {}


### PR DESCRIPTION
Fixes #3742

Hat tip to @hkleungai: the side-by-side tsc/tsgo output in that thread made the gap easy to trace.

`checkUnmatchedJSDocParameters` correctly emits TS8024 when a `@param` name doesn't match any real parameter, but it drops the type expression without checking it. So `@param {Record} bar` on a zero-parameter function gives you TS8024 and silently misses TS2314 ("Generic type 'Record' requires 2 type argument(s)"). tsc reports both.

## Analysis

For **matched** params, the type expression reaches `checkSourceElement` through `checkVariableLikeDeclaration`, which is what triggers `checkTypeReferenceNode` and eventually TS2314 for things like `Record`. For **unmatched** params, the loop calls `errorOrSuggestion` for TS8024 and then moves on. The type expression is never touched.

## Fix

After the TS8024 emission (or the `isNameFirst` skip), check the tag's type expression if present. Two guards are needed:

**JS files only.** In `.ts` files, JSDoc types are documentation, not the type system. Without the `isJs` gate, a local variable name used as a `@param` type (common in tsc's own checker.ts) incorrectly surfaces TS2304 ("Cannot find name 'X'"). Every other JSDoc type check in the checker observes the same boundary.

**Skip signature types.** `KindFunctionType`, `KindConstructorType`, `KindCallSignature`, `KindConstructSignature`, and `KindIndexSignature` all dispatch to `checkSignatureDeclaration`, which calls `checkParameter` on the signature's parameter list. Those parameters are not symbol-bound inside JSDoc type expressions, so `getSymbolOfDeclaration` returns nil, causing a nil-pointer panic. Callback-style `@param {(x: T) => U} fn` types are excluded from checking for now; recovering diagnostics from inside those signatures is a separate, harder problem.

## Test

Added `testdata/tests/cases/compiler/jsdocUnmatchedParamTypeChecked.ts`: a JS file with `@param {Record} bar` on a zero-parameter function. The baseline shows both TS2314 and TS8024, matching tsc output.

## Copilot Checklist

<!-- don't lie! -->
I successfully ran these commands at the end of my session, and they completed without error:
 * [x] npx hereby build
 * [x] npx hereby test
 * [x] npx hereby lint
 * [x] npx hereby format