### PR TITLE
Emit publish-order.json with per-package npm dist-tag

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -1767,7 +1767,7 @@ async function runPackNativePreviewPackages() {
     ].map(p => path.basename(p));
 
     const publishManifest = publishOrder.map(pkg => ({
-        package: pkg,
+        filename: pkg,
         tag: "latest",
     }));
 

--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -1766,8 +1766,13 @@ async function runPackNativePreviewPackages() {
         mainNativePreviewPackage.npmTarball,
     ].map(p => path.basename(p));
 
-    const publishOrderPath = path.join(builtNpm, "publish-order.txt");
-    await fs.promises.writeFile(publishOrderPath, publishOrder.join("\n") + "\n");
+    const publishManifest = publishOrder.map(pkg => ({
+        package: pkg,
+        tag: "latest",
+    }));
+
+    const publishOrderPath = path.join(builtNpm, "publish-order.json");
+    await fs.promises.writeFile(publishOrderPath, JSON.stringify(publishManifest, undefined, 4) + "\n");
 }
 
 export const packNativePreviewExtensions = task({


### PR DESCRIPTION
So we can control what dist-tag the publisher uses.