### PR TITLE
fix(checker): suppress false TS7008 for empty array assigned to annotated expando property

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -17980,10 +17980,17 @@ func (c *Checker) getAssignmentDeclarationInitializerType(node *ast.Node) *Type 
 			fallthrough
 		default:
 			t = c.checkExpressionForMutableLocation(node.AsBinaryExpression().Right, CheckModeNormal)
-		}
-		if c.isEmptyArrayLiteralType(t) {
-			c.reportImplicitAny(node, c.anyArrayType, WideningKindNormal)
-			return c.anyArrayType
+			if t != nil && c.isEmptyArrayLiteralType(t) {
+				// If the container has an explicit type annotation that covers this property,
+				// use that type instead of falling back to any[] with an implicit-any diagnostic.
+				// This prevents false TS7008 errors when the declared type provides context
+				// (e.g. example.items = [] where example: { items?: string[] }).
+				if annotatedPropType := c.getPropertyTypeFromContainerAnnotation(node); annotatedPropType != nil {
+					return annotatedPropType
+				}
+				c.reportImplicitAny(node, c.anyArrayType, WideningKindNormal)
+				return c.anyArrayType
+			}
 		}
 		return t
 	}
@@ -17991,6 +17998,66 @@ func (c *Checker) getAssignmentDeclarationInitializerType(node *ast.Node) *Type 
 		return c.getTypeFromPropertyDescriptor(node.Arguments()[2])
 	}
 	return nil
+}
+
+// getPropertyTypeFromContainerAnnotation returns the declared property type from the type
+// annotation on the container variable of an assignment declaration. Used to avoid false TS7008
+// diagnostics when the property has a known declared type (e.g. fn.items = [] where fn is
+// typed as { items?: string[] }).
+//
+// For expando assignments on function values (const fn: T = () => {}), the binder stores the
+// property on the function expression's symbol (not the variable's). We navigate from the
+// function expression's ValueDeclaration back up to the enclosing VariableDeclaration to find
+// the type annotation.
+//
+// Returns nil if no explicit annotation is found or if any step in the chain is missing,
+// preserving the existing TS7008 behavior as the safe fallback.
+func (c *Checker) getPropertyTypeFromContainerAnnotation(node *ast.Node) *Type {
+	if !ast.IsBinaryExpression(node) {
+		return nil
+	}
+	lhs := node.AsBinaryExpression().Left
+	if !ast.IsPropertyAccessExpression(lhs) {
+		return nil
+	}
+	// Get the assignment declaration symbol for this binary expression.
+	assignSym := c.getSymbolOfNode(node)
+	if assignSym == nil || assignSym.Parent == nil {
+		return nil
+	}
+	parentSym := assignSym.Parent
+	if parentSym.ValueDeclaration == nil {
+		return nil
+	}
+	// Locate the VariableDeclaration that carries the explicit type annotation.
+	// For `const fn: T = () => undefined`, the binder attaches the expando property to the
+	// arrow-function's symbol. The arrow function's Parent in the AST is the VariableDeclaration.
+	parentDecl := parentSym.ValueDeclaration
+	var varDecl *ast.Node
+	switch {
+	case ast.IsFunctionExpressionOrArrowFunction(parentDecl):
+		// Navigate up: ArrowFunction → VariableDeclaration
+		if p := parentDecl.Parent; p != nil && ast.IsVariableDeclaration(p) {
+			varDecl = p
+		}
+	case ast.IsVariableDeclaration(parentDecl):
+		varDecl = parentDecl
+	}
+	if varDecl == nil {
+		return nil
+	}
+	// Use only the explicit type annotation to avoid triggering inferred-type resolution,
+	// which could cause circular dependencies.
+	containerType := c.tryGetTypeFromTypeNode(varDecl)
+	if containerType == nil || containerType == c.errorType {
+		return nil
+	}
+	propName := lhs.AsPropertyAccessExpression().Name().Text()
+	prop := c.getPropertyOfType(containerType, propName)
+	if prop == nil {
+		return nil
+	}
+	return c.getTypeOfSymbol(prop)
 }
 
 func (c *Checker) containsSameNamedThisProperty(thisProperty *ast.Node, expression *ast.Node) bool {

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -18036,7 +18036,7 @@ func (c *Checker) getPropertyTypeFromContainerAnnotation(node *ast.Node) *Type {
 	if prop == nil {
 		return nil
 	}
-	return c.getTypeOfSymbol(prop)
+	return c.getWriteTypeOfSymbol(prop)
 }
 
 func (c *Checker) containsSameNamedThisProperty(thisProperty *ast.Node, expression *ast.Node) bool {

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -17981,10 +17981,7 @@ func (c *Checker) getAssignmentDeclarationInitializerType(node *ast.Node) *Type 
 		default:
 			t = c.checkExpressionForMutableLocation(node.AsBinaryExpression().Right, CheckModeNormal)
 			if t != nil && c.isEmptyArrayLiteralType(t) {
-				// If the container has an explicit type annotation that covers this property,
-				// use that type instead of falling back to any[] with an implicit-any diagnostic.
-				// This prevents false TS7008 errors when the declared type provides context
-				// (e.g. example.items = [] where example: { items?: string[] }).
+				// Skip TS7008 if the container's explicit annotation names the property type.
 				if annotatedPropType := c.getPropertyTypeFromContainerAnnotation(node); annotatedPropType != nil {
 					return annotatedPropType
 				}
@@ -18000,18 +17997,7 @@ func (c *Checker) getAssignmentDeclarationInitializerType(node *ast.Node) *Type 
 	return nil
 }
 
-// getPropertyTypeFromContainerAnnotation returns the declared property type from the type
-// annotation on the container variable of an assignment declaration. Used to avoid false TS7008
-// diagnostics when the property has a known declared type (e.g. fn.items = [] where fn is
-// typed as { items?: string[] }).
-//
-// For expando assignments on function values (const fn: T = () => {}), the binder stores the
-// property on the function expression's symbol (not the variable's). We navigate from the
-// function expression's ValueDeclaration back up to the enclosing VariableDeclaration to find
-// the type annotation.
-//
-// Returns nil if no explicit annotation is found or if any step in the chain is missing,
-// preserving the existing TS7008 behavior as the safe fallback.
+// getPropertyTypeFromContainerAnnotation reads the property type from the container's explicit annotation, bypassing the circular resolution path that causes false TS7008 on expando assignments.
 func (c *Checker) getPropertyTypeFromContainerAnnotation(node *ast.Node) *Type {
 	if !ast.IsBinaryExpression(node) {
 		return nil
@@ -18020,7 +18006,6 @@ func (c *Checker) getPropertyTypeFromContainerAnnotation(node *ast.Node) *Type {
 	if !ast.IsPropertyAccessExpression(lhs) {
 		return nil
 	}
-	// Get the assignment declaration symbol for this binary expression.
 	assignSym := c.getSymbolOfNode(node)
 	if assignSym == nil || assignSym.Parent == nil {
 		return nil
@@ -18029,14 +18014,10 @@ func (c *Checker) getPropertyTypeFromContainerAnnotation(node *ast.Node) *Type {
 	if parentSym.ValueDeclaration == nil {
 		return nil
 	}
-	// Locate the VariableDeclaration that carries the explicit type annotation.
-	// For `const fn: T = () => undefined`, the binder attaches the expando property to the
-	// arrow-function's symbol. The arrow function's Parent in the AST is the VariableDeclaration.
 	parentDecl := parentSym.ValueDeclaration
 	var varDecl *ast.Node
 	switch {
 	case ast.IsFunctionExpressionOrArrowFunction(parentDecl):
-		// Navigate up: ArrowFunction → VariableDeclaration
 		if p := parentDecl.Parent; p != nil && ast.IsVariableDeclaration(p) {
 			varDecl = p
 		}
@@ -18046,8 +18027,6 @@ func (c *Checker) getPropertyTypeFromContainerAnnotation(node *ast.Node) *Type {
 	if varDecl == nil {
 		return nil
 	}
-	// Use only the explicit type annotation to avoid triggering inferred-type resolution,
-	// which could cause circular dependencies.
 	containerType := c.tryGetTypeFromTypeNode(varDecl)
 	if containerType == nil || containerType == c.errorType {
 		return nil

--- a/testdata/baselines/reference/compiler/callableTypePropertyEmptyArrayAssignment.errors.txt
+++ b/testdata/baselines/reference/compiler/callableTypePropertyEmptyArrayAssignment.errors.txt
@@ -1,0 +1,31 @@
+callableTypePropertyEmptyArrayAssignment.ts(24,1): error TS7008: Member 'labels' implicitly has an 'any[]' type.
+
+
+==== callableTypePropertyEmptyArrayAssignment.ts (1 errors) ====
+    // https://github.com/microsoft/typescript-go/issues/3976
+    
+    // Assigning [] to a property of a callable-type variable with a declared type
+    // annotation should not produce TS7008.
+    
+    const fn1: {
+        (): void;
+        items?: string[];
+    } = () => undefined;
+    fn1.items = [];  // No error: items is declared as string[] | undefined
+    
+    const fn2: {
+        (): void;
+        counts?: number[];
+    } = () => undefined;
+    fn2.counts = [];  // No error: counts is declared as number[] | undefined
+    
+    // A variable with a simple object type annotation also benefits from this.
+    const obj: { tags?: string[] } = {};
+    obj.tags = [];  // No error: tags is declared as string[] | undefined
+    
+    // Without a type annotation, the empty array assignment should still produce TS7008.
+    const fn3 = () => undefined;
+    fn3.labels = [];  // Error: Member 'labels' implicitly has an 'any[]' type.
+    ~~~~~~~~~~~~~~~
+!!! error TS7008: Member 'labels' implicitly has an 'any[]' type.
+    

--- a/testdata/baselines/reference/compiler/callableTypePropertyEmptyArrayAssignment.symbols
+++ b/testdata/baselines/reference/compiler/callableTypePropertyEmptyArrayAssignment.symbols
@@ -1,0 +1,48 @@
+//// [tests/cases/compiler/callableTypePropertyEmptyArrayAssignment.ts] ////
+
+=== callableTypePropertyEmptyArrayAssignment.ts ===
+// https://github.com/microsoft/typescript-go/issues/3976
+
+// Assigning [] to a property of a callable-type variable with a declared type
+// annotation should not produce TS7008.
+
+const fn1: {
+>fn1 : Symbol(fn1, Decl(callableTypePropertyEmptyArrayAssignment.ts, 5, 5))
+
+    (): void;
+    items?: string[];
+>items : Symbol(items, Decl(callableTypePropertyEmptyArrayAssignment.ts, 6, 13))
+
+} = () => undefined;
+>undefined : Symbol(undefined)
+
+fn1.items = [];  // No error: items is declared as string[] | undefined
+>fn1.items : Symbol(items, Decl(callableTypePropertyEmptyArrayAssignment.ts, 6, 13))
+>fn1 : Symbol(fn1, Decl(callableTypePropertyEmptyArrayAssignment.ts, 5, 5))
+>items : Symbol(items, Decl(callableTypePropertyEmptyArrayAssignment.ts, 6, 13))
+
+const fn2: {
+>fn2 : Symbol(fn2, Decl(callableTypePropertyEmptyArrayAssignment.ts, 11, 5))
+
+    (): void;
+    counts?: number[];
+>counts : Symbol(counts, Decl(callableTypePropertyEmptyArrayAssignment.ts, 12, 13))
+
+} = () => undefined;
+>undefined : Symbol(undefined)
+
+fn2.counts = [];  // No error: counts is declared as number[] | undefined
+>fn2.counts : Symbol(counts, Decl(callableTypePropertyEmptyArrayAssignment.ts, 12, 13))
+>fn2 : Symbol(fn2, Decl(callableTypePropertyEmptyArrayAssignment.ts, 11, 5))
+>counts : Symbol(counts, Decl(callableTypePropertyEmptyArrayAssignment.ts, 12, 13))
+
+// A variable with a simple object type annotation also benefits from this.
+const obj: { tags?: string[] } = {};
+>obj : Symbol(obj, Decl(callableTypePropertyEmptyArrayAssignment.ts, 18, 5))
+>tags : Symbol(tags, Decl(callableTypePropertyEmptyArrayAssignment.ts, 18, 12))
+
+obj.tags = [];  // No error: tags is declared as string[] | undefined
+>obj.tags : Symbol(tags, Decl(callableTypePropertyEmptyArrayAssignment.ts, 18, 12))
+>obj : Symbol(obj, Decl(callableTypePropertyEmptyArrayAssignment.ts, 18, 5))
+>tags : Symbol(tags, Decl(callableTypePropertyEmptyArrayAssignment.ts, 18, 12))
+

--- a/testdata/baselines/reference/compiler/callableTypePropertyEmptyArrayAssignment.symbols
+++ b/testdata/baselines/reference/compiler/callableTypePropertyEmptyArrayAssignment.symbols
@@ -46,3 +46,13 @@ obj.tags = [];  // No error: tags is declared as string[] | undefined
 >obj : Symbol(obj, Decl(callableTypePropertyEmptyArrayAssignment.ts, 18, 5))
 >tags : Symbol(tags, Decl(callableTypePropertyEmptyArrayAssignment.ts, 18, 12))
 
+// Without a type annotation, the empty array assignment should still produce TS7008.
+const fn3 = () => undefined;
+>fn3 : Symbol(fn3, Decl(callableTypePropertyEmptyArrayAssignment.ts, 22, 5))
+>undefined : Symbol(undefined)
+
+fn3.labels = [];  // Error: Member 'labels' implicitly has an 'any[]' type.
+>fn3.labels : Symbol(fn3.labels, Decl(callableTypePropertyEmptyArrayAssignment.ts, 22, 28))
+>fn3 : Symbol(fn3, Decl(callableTypePropertyEmptyArrayAssignment.ts, 22, 5))
+>labels : Symbol(fn3.labels, Decl(callableTypePropertyEmptyArrayAssignment.ts, 22, 28))
+

--- a/testdata/baselines/reference/compiler/callableTypePropertyEmptyArrayAssignment.types
+++ b/testdata/baselines/reference/compiler/callableTypePropertyEmptyArrayAssignment.types
@@ -55,3 +55,16 @@ obj.tags = [];  // No error: tags is declared as string[] | undefined
 >tags : string[] | undefined
 >[] : never[]
 
+// Without a type annotation, the empty array assignment should still produce TS7008.
+const fn3 = () => undefined;
+>fn3 : { (): undefined; labels: any[]; }
+>() => undefined : { (): undefined; labels: any[]; }
+>undefined : undefined
+
+fn3.labels = [];  // Error: Member 'labels' implicitly has an 'any[]' type.
+>fn3.labels = [] : never[]
+>fn3.labels : any[]
+>fn3 : { (): undefined; labels: any[]; }
+>labels : any[]
+>[] : never[]
+

--- a/testdata/baselines/reference/compiler/callableTypePropertyEmptyArrayAssignment.types
+++ b/testdata/baselines/reference/compiler/callableTypePropertyEmptyArrayAssignment.types
@@ -1,0 +1,57 @@
+//// [tests/cases/compiler/callableTypePropertyEmptyArrayAssignment.ts] ////
+
+=== callableTypePropertyEmptyArrayAssignment.ts ===
+// https://github.com/microsoft/typescript-go/issues/3976
+
+// Assigning [] to a property of a callable-type variable with a declared type
+// annotation should not produce TS7008.
+
+const fn1: {
+>fn1 : { (): void; items?: string[]; }
+
+    (): void;
+    items?: string[];
+>items : string[] | undefined
+
+} = () => undefined;
+>() => undefined : { (): undefined; items: string[] | undefined; }
+>undefined : undefined
+
+fn1.items = [];  // No error: items is declared as string[] | undefined
+>fn1.items = [] : never[]
+>fn1.items : string[] | undefined
+>fn1 : { (): void; items?: string[]; }
+>items : string[] | undefined
+>[] : never[]
+
+const fn2: {
+>fn2 : { (): void; counts?: number[]; }
+
+    (): void;
+    counts?: number[];
+>counts : number[] | undefined
+
+} = () => undefined;
+>() => undefined : { (): undefined; counts: number[] | undefined; }
+>undefined : undefined
+
+fn2.counts = [];  // No error: counts is declared as number[] | undefined
+>fn2.counts = [] : never[]
+>fn2.counts : number[] | undefined
+>fn2 : { (): void; counts?: number[]; }
+>counts : number[] | undefined
+>[] : never[]
+
+// A variable with a simple object type annotation also benefits from this.
+const obj: { tags?: string[] } = {};
+>obj : { tags?: string[]; }
+>tags : string[] | undefined
+>{} : {}
+
+obj.tags = [];  // No error: tags is declared as string[] | undefined
+>obj.tags = [] : never[]
+>obj.tags : string[] | undefined
+>obj : { tags?: string[]; }
+>tags : string[] | undefined
+>[] : never[]
+

--- a/testdata/baselines/reference/compiler/callableTypePropertyEmptyArrayAssignmentExactOptional.errors.txt
+++ b/testdata/baselines/reference/compiler/callableTypePropertyEmptyArrayAssignmentExactOptional.errors.txt
@@ -1,0 +1,24 @@
+callableTypePropertyEmptyArrayAssignmentExactOptional.ts(17,1): error TS7008: Member 'labels' implicitly has an 'any[]' type.
+
+
+==== callableTypePropertyEmptyArrayAssignmentExactOptional.ts (1 errors) ====
+    // https://github.com/microsoft/typescript-go/issues/3976
+    // Regression: under exactOptionalPropertyTypes the helper must use getWriteTypeOfSymbol
+    // (not getTypeOfSymbol) so the internal `missing` type is stripped before being
+    // returned as the initializer type of the assignment declaration.
+    
+    const fn1: {
+        (): void;
+        items?: string[];
+    } = () => undefined;
+    fn1.items = [];  // No error: items is declared as string[]
+    
+    const obj: { tags?: string[] } = {};
+    obj.tags = [];  // No error: tags is declared as string[]
+    
+    // Without a type annotation TS7008 should still fire.
+    const fn2 = () => undefined;
+    fn2.labels = [];  // Error: Member 'labels' implicitly has an 'any[]' type.
+    ~~~~~~~~~~~~~~~
+!!! error TS7008: Member 'labels' implicitly has an 'any[]' type.
+    

--- a/testdata/baselines/reference/compiler/callableTypePropertyEmptyArrayAssignmentExactOptional.symbols
+++ b/testdata/baselines/reference/compiler/callableTypePropertyEmptyArrayAssignmentExactOptional.symbols
@@ -1,0 +1,42 @@
+//// [tests/cases/compiler/callableTypePropertyEmptyArrayAssignmentExactOptional.ts] ////
+
+=== callableTypePropertyEmptyArrayAssignmentExactOptional.ts ===
+// https://github.com/microsoft/typescript-go/issues/3976
+// Regression: under exactOptionalPropertyTypes the helper must use getWriteTypeOfSymbol
+// (not getTypeOfSymbol) so the internal `missing` type is stripped before being
+// returned as the initializer type of the assignment declaration.
+
+const fn1: {
+>fn1 : Symbol(fn1, Decl(callableTypePropertyEmptyArrayAssignmentExactOptional.ts, 5, 5))
+
+    (): void;
+    items?: string[];
+>items : Symbol(items, Decl(callableTypePropertyEmptyArrayAssignmentExactOptional.ts, 6, 13))
+
+} = () => undefined;
+>undefined : Symbol(undefined)
+
+fn1.items = [];  // No error: items is declared as string[]
+>fn1.items : Symbol(items, Decl(callableTypePropertyEmptyArrayAssignmentExactOptional.ts, 6, 13))
+>fn1 : Symbol(fn1, Decl(callableTypePropertyEmptyArrayAssignmentExactOptional.ts, 5, 5))
+>items : Symbol(items, Decl(callableTypePropertyEmptyArrayAssignmentExactOptional.ts, 6, 13))
+
+const obj: { tags?: string[] } = {};
+>obj : Symbol(obj, Decl(callableTypePropertyEmptyArrayAssignmentExactOptional.ts, 11, 5))
+>tags : Symbol(tags, Decl(callableTypePropertyEmptyArrayAssignmentExactOptional.ts, 11, 12))
+
+obj.tags = [];  // No error: tags is declared as string[]
+>obj.tags : Symbol(tags, Decl(callableTypePropertyEmptyArrayAssignmentExactOptional.ts, 11, 12))
+>obj : Symbol(obj, Decl(callableTypePropertyEmptyArrayAssignmentExactOptional.ts, 11, 5))
+>tags : Symbol(tags, Decl(callableTypePropertyEmptyArrayAssignmentExactOptional.ts, 11, 12))
+
+// Without a type annotation TS7008 should still fire.
+const fn2 = () => undefined;
+>fn2 : Symbol(fn2, Decl(callableTypePropertyEmptyArrayAssignmentExactOptional.ts, 15, 5))
+>undefined : Symbol(undefined)
+
+fn2.labels = [];  // Error: Member 'labels' implicitly has an 'any[]' type.
+>fn2.labels : Symbol(fn2.labels, Decl(callableTypePropertyEmptyArrayAssignmentExactOptional.ts, 15, 28))
+>fn2 : Symbol(fn2, Decl(callableTypePropertyEmptyArrayAssignmentExactOptional.ts, 15, 5))
+>labels : Symbol(fn2.labels, Decl(callableTypePropertyEmptyArrayAssignmentExactOptional.ts, 15, 28))
+

--- a/testdata/baselines/reference/compiler/callableTypePropertyEmptyArrayAssignmentExactOptional.types
+++ b/testdata/baselines/reference/compiler/callableTypePropertyEmptyArrayAssignmentExactOptional.types
@@ -1,0 +1,51 @@
+//// [tests/cases/compiler/callableTypePropertyEmptyArrayAssignmentExactOptional.ts] ////
+
+=== callableTypePropertyEmptyArrayAssignmentExactOptional.ts ===
+// https://github.com/microsoft/typescript-go/issues/3976
+// Regression: under exactOptionalPropertyTypes the helper must use getWriteTypeOfSymbol
+// (not getTypeOfSymbol) so the internal `missing` type is stripped before being
+// returned as the initializer type of the assignment declaration.
+
+const fn1: {
+>fn1 : { (): void; items?: string[]; }
+
+    (): void;
+    items?: string[];
+>items : string[] | undefined
+
+} = () => undefined;
+>() => undefined : { (): undefined; items: string[]; }
+>undefined : undefined
+
+fn1.items = [];  // No error: items is declared as string[]
+>fn1.items = [] : never[]
+>fn1.items : string[]
+>fn1 : { (): void; items?: string[]; }
+>items : string[]
+>[] : never[]
+
+const obj: { tags?: string[] } = {};
+>obj : { tags?: string[]; }
+>tags : string[] | undefined
+>{} : {}
+
+obj.tags = [];  // No error: tags is declared as string[]
+>obj.tags = [] : never[]
+>obj.tags : string[]
+>obj : { tags?: string[]; }
+>tags : string[]
+>[] : never[]
+
+// Without a type annotation TS7008 should still fire.
+const fn2 = () => undefined;
+>fn2 : { (): undefined; labels: any[]; }
+>() => undefined : { (): undefined; labels: any[]; }
+>undefined : undefined
+
+fn2.labels = [];  // Error: Member 'labels' implicitly has an 'any[]' type.
+>fn2.labels = [] : never[]
+>fn2.labels : any[]
+>fn2 : { (): undefined; labels: any[]; }
+>labels : any[]
+>[] : never[]
+

--- a/testdata/tests/cases/compiler/callableTypePropertyEmptyArrayAssignment.ts
+++ b/testdata/tests/cases/compiler/callableTypePropertyEmptyArrayAssignment.ts
@@ -1,0 +1,23 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/typescript-go/issues/3976
+
+// Assigning [] to a property of a callable-type variable with a declared type
+// annotation should not produce TS7008.
+
+const fn1: {
+    (): void;
+    items?: string[];
+} = () => undefined;
+fn1.items = [];  // No error: items is declared as string[] | undefined
+
+const fn2: {
+    (): void;
+    counts?: number[];
+} = () => undefined;
+fn2.counts = [];  // No error: counts is declared as number[] | undefined
+
+// A variable with a simple object type annotation also benefits from this.
+const obj: { tags?: string[] } = {};
+obj.tags = [];  // No error: tags is declared as string[] | undefined

--- a/testdata/tests/cases/compiler/callableTypePropertyEmptyArrayAssignment.ts
+++ b/testdata/tests/cases/compiler/callableTypePropertyEmptyArrayAssignment.ts
@@ -21,3 +21,7 @@ fn2.counts = [];  // No error: counts is declared as number[] | undefined
 // A variable with a simple object type annotation also benefits from this.
 const obj: { tags?: string[] } = {};
 obj.tags = [];  // No error: tags is declared as string[] | undefined
+
+// Without a type annotation, the empty array assignment should still produce TS7008.
+const fn3 = () => undefined;
+fn3.labels = [];  // Error: Member 'labels' implicitly has an 'any[]' type.

--- a/testdata/tests/cases/compiler/callableTypePropertyEmptyArrayAssignmentExactOptional.ts
+++ b/testdata/tests/cases/compiler/callableTypePropertyEmptyArrayAssignmentExactOptional.ts
@@ -1,0 +1,21 @@
+// @strict: true
+// @exactOptionalPropertyTypes: true
+// @noEmit: true
+
+// https://github.com/microsoft/typescript-go/issues/3976
+// Regression: under exactOptionalPropertyTypes the helper must use getWriteTypeOfSymbol
+// (not getTypeOfSymbol) so the internal `missing` type is stripped before being
+// returned as the initializer type of the assignment declaration.
+
+const fn1: {
+    (): void;
+    items?: string[];
+} = () => undefined;
+fn1.items = [];  // No error: items is declared as string[]
+
+const obj: { tags?: string[] } = {};
+obj.tags = [];  // No error: tags is declared as string[]
+
+// Without a type annotation TS7008 should still fire.
+const fn2 = () => undefined;
+fn2.labels = [];  // Error: Member 'labels' implicitly has an 'any[]' type.


### PR DESCRIPTION
Fixes #3976

Credit to @chriskrycho, who traced the regression to `#3680` and the exact nightly in the bug report. That diagnosis was the map.

## Analysis

Callable-type variables with expando property assignments like `fn.items = []` were incorrectly producing TS7008 ("Member 'items' implicitly has an 'any[]' type") even when `fn` carries an explicit type annotation that declares the property.

The root cause is a circular type resolution path. When `getAssignmentDeclarationInitializerType` evaluates `fn.items = []`, it calls `checkExpressionForMutableLocation` on the `[]` RHS. That function tries to establish a contextual type by resolving `fn.items`, which requires computing the type of the assignment declaration — which is the function we're currently in. The circularity causes `[]` to resolve as `never[]` instead of `string[]`. The existing `isEmptyArrayLiteralType` check then sees `never[]` and fires TS7008.

For plain object variables (`const obj: { tags?: string[] } = {}`), this doesn't occur because the binder doesn't create an assignment declaration symbol for that case (plain objects aren't expando initializers in TS mode).

## Fix

Added `getPropertyTypeFromContainerAnnotation`, a helper called before the TS7008 diagnostic fires. It navigates through the AST to the explicit type annotation on the container variable — bypassing the circular resolution path entirely — and looks up the declared property type. If an annotation covers the property, that type is returned directly and TS7008 is skipped.

The navigation path for `const fn: T = () => undefined; fn.items = []`:
1. `getSymbolOfNode(binaryExpr)` → `items` symbol (set by the binder on the assignment declaration)
2. `.Parent` → the arrow function's symbol
3. `.ValueDeclaration` → the arrow function node
4. `.Parent` (AST) → the `VariableDeclaration` carrying the explicit type annotation
5. `tryGetTypeFromTypeNode(varDecl)` → reads the annotation type without triggering inference
6. `getPropertyOfType(containerType, "items")` + `getWriteTypeOfSymbol(prop)` → the write type of the property (for optional properties: `string[]`, not `string[] | missing`; for accessor properties: the setter type)

If any step returns nil (no annotation, wrong declaration shape, etc.), the helper returns nil and TS7008 fires as before. This preserves the diagnostic for genuinely untyped cases like `const fn3 = () => undefined; fn3.labels = []`.

**Second commit:** Under `exactOptionalPropertyTypes`, optional properties carry an internal `missing` type that `getTypeOfSymbol` returns raw. Changed to `getWriteTypeOfSymbol`, which strips it via `removeMissingType`: the right behavior for any assignment-context type lookup. Added a compiler test with `// @exactOptionalPropertyTypes: true` covering both annotated containers (no error) and the unannotated control (TS7008 still fires).

Regression introduced by #3680.

## Copilot Checklist

I successfully ran these commands at the end of my session, and they completed without error:
 * [x] npx hereby build
 * [x] npx hereby test
 * [x] npx hereby lint
 * [x] npx hereby format
