### PR TITLE
Fix repeated path component in exports completions after directory separator

### DIFF
--- a/internal/fourslash/tests/manual/pathCompletionsPackageJsonExportsExactSubpathPrefix_test.go
+++ b/internal/fourslash/tests/manual/pathCompletionsPackageJsonExportsExactSubpathPrefix_test.go
@@ -1,0 +1,61 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	. "github.com/microsoft/typescript-go/internal/fourslash/tests/util"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+// Regression test for https://github.com/microsoft/typescript-go/issues/3981
+//
+// When a package has only exact (non-wildcard) exports under a shared prefix
+// (e.g. "./unstable/sync", "./unstable/ast") and the user types the prefix
+// followed by "/", completions must name only the suffix component ("sync",
+// "ast"), not repeat the whole subpath ("unstable/sync", "unstable/ast").
+// Accepting a completion should yield e.g. "pkg/unstable/sync", not
+// "pkg/unstable/unstable/sync".
+func TestPathCompletionsPackageJsonExportsExactSubpathPrefix(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `// @module: node18
+// @Filename: /node_modules/pkg/package.json
+{
+  "name": "pkg",
+  "exports": {
+    "./unstable/sync":  { "default": "./dist/sync.js" },
+    "./unstable/async": { "default": "./dist/async.js" },
+    "./unstable/ast":   { "default": "./dist/ast.js" }
+  }
+}
+// @Filename: /node_modules/pkg/dist/sync.d.ts
+export const sync = 0;
+// @Filename: /node_modules/pkg/dist/async.d.ts
+export const async = 0;
+// @Filename: /node_modules/pkg/dist/ast.d.ts
+export const ast = 0;
+// @Filename: /index.mts
+import { } from "pkg/unstable//**/";`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyCompletions(t, "", &fourslash.CompletionsExpectedList{
+		IsIncomplete: false,
+		ItemDefaults: &fourslash.CompletionsExpectedItemDefaults{
+			CommitCharacters: &[]string{},
+			EditRange:        Ignored,
+		},
+		Items: &fourslash.CompletionsExpectedItems{
+			// Completions must name only the suffix after "unstable/" — not repeat the full
+			// subpath — so that accepting "sync" yields "pkg/unstable/sync", not
+			// "pkg/unstable/unstable/sync".
+			Includes: []fourslash.CompletionsExpectedItem{
+				"sync",
+				"async",
+				"ast",
+			},
+			// These duplicated-prefix names must not appear.
+			Excludes: []string{"unstable/sync", "unstable/async", "unstable/ast"},
+		},
+	})
+}

--- a/internal/ls/string_completions.go
+++ b/internal/ls/string_completions.go
@@ -1468,8 +1468,20 @@ func (l *LanguageService) getCompletionsForPathMapping(
 ) []moduleCompletionNameAndKind {
 	justPathMappingName := func(name string, kind moduleCompletionKind, extension string) []moduleCompletionNameAndKind {
 		if strings.HasPrefix(name, fragment) {
+			completionName := name
+			// When fragment ends with '/', the cursor is right after a directory separator
+			// and no replacement span will be set (textRange = nil), so the name is inserted
+			// verbatim at the cursor. Strip the already-traversed prefix so the completion
+			// doesn't duplicate path components already present in the import string.
+			// e.g. fragment="unstable/" + name="unstable/sync" -> insert "sync", not "unstable/sync"
+			if tspath.HasTrailingDirectorySeparator(fragment) {
+				completionName = name[len(fragment):]
+				if completionName == "" {
+					return nil
+				}
+			}
 			return []moduleCompletionNameAndKind{{
-				name:      tspath.RemoveTrailingDirectorySeparator(name),
+				name:      tspath.RemoveTrailingDirectorySeparator(completionName),
 				kind:      kind,
 				extension: extension,
 			}}


### PR DESCRIPTION
Fixes #3981

## Analysis

When the cursor sits right after a directory separator (e.g. `"pkg/unstable/"`), `getDirectoryFragmentRange` returns `nil`: there is no replacement span. The completion label is inserted verbatim at the cursor rather than replacing any existing text.

`justPathMappingName` was returning the full normalized export key regardless of how much of the path the user had already typed. For a package with exact exports like `"./unstable/sync"` and `"./unstable/ast"`, accepting `"unstable/sync"` at cursor position `"pkg/unstable/"` inserts the full string verbatim and produces `"pkg/unstable/unstable/sync"`. The directory component doubled.

When `fragment` ends with `/`, the correct completion label is the portion of the export key after the already-traversed prefix, not the full key.

## Fix

In `justPathMappingName`, when `fragment` has a trailing directory separator, strip `fragment` from the completion name before returning it. Cursors mid-component (no trailing `/`) are unaffected: those have a replacement span covering the partial component, so the full name is correct in that path.

Edge case: if `name == fragment` exactly (a deprecated trailing-slash export key whose path equals the typed fragment), stripping produces an empty string. The fix returns `nil` rather than emitting an empty completion item.

## Copilot Checklist

<!-- don't lie! -->
I successfully ran these commands at the end of my session, and they completed without error:
 * [x] npx hereby build
 * [x] npx hereby test
 * [x] npx hereby lint
 * [x] npx hereby format