### PR TITLE
No widening to `any[]` when parent of expando has type annotation

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -17984,7 +17984,7 @@ func (c *Checker) getAssignmentDeclarationInitializerType(node *ast.Node) *Type 
 		default:
 			t = c.checkExpressionForMutableLocation(node.AsBinaryExpression().Right, CheckModeNormal)
 		}
-		if c.isEmptyArrayLiteralType(t) {
+		if c.isEmptyArrayLiteralType(t) && !c.hasParentWithTypeAnnotation(node.Symbol()) {
 			c.reportImplicitAny(node, c.anyArrayType, WideningKindNormal)
 			return c.anyArrayType
 		}
@@ -17994,6 +17994,20 @@ func (c *Checker) getAssignmentDeclarationInitializerType(node *ast.Node) *Type 
 		return c.getTypeFromPropertyDescriptor(node.Arguments()[2])
 	}
 	return nil
+}
+
+// Return true if the parent symbol of the given assignment declaration symbol has declaration with a type
+// annotation. For example, returns true for the symbol associated with `f.a` below:
+//
+//	const f: { (): void, a: string[] } = () => {};
+//	f.a = [];
+func (c *Checker) hasParentWithTypeAnnotation(symbol *ast.Symbol) bool {
+	if symbol.Parent != nil && symbol.Parent.ValueDeclaration != nil && ast.IsFunctionExpressionOrArrowFunction(symbol.Parent.ValueDeclaration) {
+		if possiblyAnnotatedSymbol := c.getSymbolOfNode(symbol.Parent.ValueDeclaration.Parent); possiblyAnnotatedSymbol != nil && possiblyAnnotatedSymbol.ValueDeclaration != nil {
+			return possiblyAnnotatedSymbol.ValueDeclaration.Type() != nil
+		}
+	}
+	return false
 }
 
 func (c *Checker) containsSameNamedThisProperty(thisProperty *ast.Node, expression *ast.Node) bool {

--- a/testdata/baselines/reference/compiler/expandoPropertyEmptyArrayWidening.errors.txt
+++ b/testdata/baselines/reference/compiler/expandoPropertyEmptyArrayWidening.errors.txt
@@ -1,0 +1,35 @@
+expandoPropertyEmptyArrayWidening.ts(10,1): error TS7008: Member 'a' implicitly has an 'any[]' type.
+expandoPropertyEmptyArrayWidening.ts(13,1): error TS7008: Member 'a' implicitly has an 'any[]' type.
+expandoPropertyEmptyArrayWidening.ts(16,1): error TS7008: Member 'a' implicitly has an 'any[]' type.
+
+
+==== expandoPropertyEmptyArrayWidening.ts (3 errors) ====
+    // https://github.com/microsoft/typescript-go/issues/3976
+    
+    const example: {
+      (): void;
+      items?: string[];
+    } = () => undefined;
+    example.items = [];
+    
+    function f1() {}
+    f1.a = [];  // Implicit any error
+    ~~~~~~~~~
+!!! error TS7008: Member 'a' implicitly has an 'any[]' type.
+    
+    const f2 = function() {};
+    f2.a = [];  // Implicit any error
+    ~~~~~~~~~
+!!! error TS7008: Member 'a' implicitly has an 'any[]' type.
+    
+    const f3 = () => {};
+    f3.a = [];  // Implicit any error
+    ~~~~~~~~~
+!!! error TS7008: Member 'a' implicitly has an 'any[]' type.
+    
+    const f4: { (): void, a: string[] } = () => {};
+    f4.a = [];
+    
+    const f5: { (): void, a: string[] } = function() {};
+    f5.a = [];
+    

--- a/testdata/baselines/reference/compiler/expandoPropertyEmptyArrayWidening.symbols
+++ b/testdata/baselines/reference/compiler/expandoPropertyEmptyArrayWidening.symbols
@@ -1,0 +1,62 @@
+//// [tests/cases/compiler/expandoPropertyEmptyArrayWidening.ts] ////
+
+=== expandoPropertyEmptyArrayWidening.ts ===
+// https://github.com/microsoft/typescript-go/issues/3976
+
+const example: {
+>example : Symbol(example, Decl(expandoPropertyEmptyArrayWidening.ts, 2, 5))
+
+  (): void;
+  items?: string[];
+>items : Symbol(items, Decl(expandoPropertyEmptyArrayWidening.ts, 3, 11))
+
+} = () => undefined;
+>undefined : Symbol(undefined)
+
+example.items = [];
+>example.items : Symbol(items, Decl(expandoPropertyEmptyArrayWidening.ts, 3, 11))
+>example : Symbol(example, Decl(expandoPropertyEmptyArrayWidening.ts, 2, 5))
+>items : Symbol(items, Decl(expandoPropertyEmptyArrayWidening.ts, 3, 11))
+
+function f1() {}
+>f1 : Symbol(f1, Decl(expandoPropertyEmptyArrayWidening.ts, 6, 19))
+
+f1.a = [];  // Implicit any error
+>f1.a : Symbol(f1.a, Decl(expandoPropertyEmptyArrayWidening.ts, 8, 16))
+>f1 : Symbol(f1, Decl(expandoPropertyEmptyArrayWidening.ts, 6, 19))
+>a : Symbol(f1.a, Decl(expandoPropertyEmptyArrayWidening.ts, 8, 16))
+
+const f2 = function() {};
+>f2 : Symbol(f2, Decl(expandoPropertyEmptyArrayWidening.ts, 11, 5))
+
+f2.a = [];  // Implicit any error
+>f2.a : Symbol(f2.a, Decl(expandoPropertyEmptyArrayWidening.ts, 11, 25))
+>f2 : Symbol(f2, Decl(expandoPropertyEmptyArrayWidening.ts, 11, 5))
+>a : Symbol(f2.a, Decl(expandoPropertyEmptyArrayWidening.ts, 11, 25))
+
+const f3 = () => {};
+>f3 : Symbol(f3, Decl(expandoPropertyEmptyArrayWidening.ts, 14, 5))
+
+f3.a = [];  // Implicit any error
+>f3.a : Symbol(f3.a, Decl(expandoPropertyEmptyArrayWidening.ts, 14, 20))
+>f3 : Symbol(f3, Decl(expandoPropertyEmptyArrayWidening.ts, 14, 5))
+>a : Symbol(f3.a, Decl(expandoPropertyEmptyArrayWidening.ts, 14, 20))
+
+const f4: { (): void, a: string[] } = () => {};
+>f4 : Symbol(f4, Decl(expandoPropertyEmptyArrayWidening.ts, 17, 5))
+>a : Symbol(a, Decl(expandoPropertyEmptyArrayWidening.ts, 17, 21))
+
+f4.a = [];
+>f4.a : Symbol(a, Decl(expandoPropertyEmptyArrayWidening.ts, 17, 21))
+>f4 : Symbol(f4, Decl(expandoPropertyEmptyArrayWidening.ts, 17, 5))
+>a : Symbol(a, Decl(expandoPropertyEmptyArrayWidening.ts, 17, 21))
+
+const f5: { (): void, a: string[] } = function() {};
+>f5 : Symbol(f5, Decl(expandoPropertyEmptyArrayWidening.ts, 20, 5))
+>a : Symbol(a, Decl(expandoPropertyEmptyArrayWidening.ts, 20, 21))
+
+f5.a = [];
+>f5.a : Symbol(a, Decl(expandoPropertyEmptyArrayWidening.ts, 20, 21))
+>f5 : Symbol(f5, Decl(expandoPropertyEmptyArrayWidening.ts, 20, 5))
+>a : Symbol(a, Decl(expandoPropertyEmptyArrayWidening.ts, 20, 21))
+

--- a/testdata/baselines/reference/compiler/expandoPropertyEmptyArrayWidening.types
+++ b/testdata/baselines/reference/compiler/expandoPropertyEmptyArrayWidening.types
@@ -1,0 +1,79 @@
+//// [tests/cases/compiler/expandoPropertyEmptyArrayWidening.ts] ////
+
+=== expandoPropertyEmptyArrayWidening.ts ===
+// https://github.com/microsoft/typescript-go/issues/3976
+
+const example: {
+>example : { (): void; items?: string[]; }
+
+  (): void;
+  items?: string[];
+>items : string[] | undefined
+
+} = () => undefined;
+>() => undefined : { (): undefined; items: never[]; }
+>undefined : undefined
+
+example.items = [];
+>example.items = [] : never[]
+>example.items : string[] | undefined
+>example : { (): void; items?: string[]; }
+>items : string[] | undefined
+>[] : never[]
+
+function f1() {}
+>f1 : { (): void; a: any[]; }
+
+f1.a = [];  // Implicit any error
+>f1.a = [] : never[]
+>f1.a : any[]
+>f1 : { (): void; a: any[]; }
+>a : any[]
+>[] : never[]
+
+const f2 = function() {};
+>f2 : { (): void; a: any[]; }
+>function() {} : { (): void; a: any[]; }
+
+f2.a = [];  // Implicit any error
+>f2.a = [] : never[]
+>f2.a : any[]
+>f2 : { (): void; a: any[]; }
+>a : any[]
+>[] : never[]
+
+const f3 = () => {};
+>f3 : { (): void; a: any[]; }
+>() => {} : { (): void; a: any[]; }
+
+f3.a = [];  // Implicit any error
+>f3.a = [] : never[]
+>f3.a : any[]
+>f3 : { (): void; a: any[]; }
+>a : any[]
+>[] : never[]
+
+const f4: { (): void, a: string[] } = () => {};
+>f4 : { (): void; a: string[]; }
+>a : string[]
+>() => {} : { (): void; a: never[]; }
+
+f4.a = [];
+>f4.a = [] : never[]
+>f4.a : string[]
+>f4 : { (): void; a: string[]; }
+>a : string[]
+>[] : never[]
+
+const f5: { (): void, a: string[] } = function() {};
+>f5 : { (): void; a: string[]; }
+>a : string[]
+>function() {} : { (): void; a: never[]; }
+
+f5.a = [];
+>f5.a = [] : never[]
+>f5.a : string[]
+>f5 : { (): void; a: string[]; }
+>a : string[]
+>[] : never[]
+

--- a/testdata/tests/cases/compiler/expandoPropertyEmptyArrayWidening.ts
+++ b/testdata/tests/cases/compiler/expandoPropertyEmptyArrayWidening.ts
@@ -1,0 +1,24 @@
+// @noEmit: true
+
+// https://github.com/microsoft/typescript-go/issues/3976
+
+const example: {
+  (): void;
+  items?: string[];
+} = () => undefined;
+example.items = [];
+
+function f1() {}
+f1.a = [];  // Implicit any error
+
+const f2 = function() {};
+f2.a = [];  // Implicit any error
+
+const f3 = () => {};
+f3.a = [];  // Implicit any error
+
+const f4: { (): void, a: string[] } = () => {};
+f4.a = [];
+
+const f5: { (): void, a: string[] } = function() {};
+f5.a = [];


### PR DESCRIPTION
With this PR we don't widen empty array literals to `any[]` in expando property assignments when the expando object has a type annotation. This mirrors the behavior in Strada. Part of me wants to just treat such expando property assignments the same as property assignments in object literals, meaning that we'd type the literals as `never[]` when `noImplicitAny: true`, but that would be a breaking change.

```ts
function f1() {}
f1.a = [];  // Implicit any error

const f2 = function() {};
f2.a = [];  // Implicit any error

const f3 = () => {};
f3.a = [];  // Implicit any error

const f4: { (): void, a: string[] } = () => {};
f4.a = [];

const f5: { (): void, a: string[] } = function() {};
f5.a = [];
```

Fixes #3976.