### PR TITLE
fix(project): release stale retainingProjects entries when program drops a reference

### DIFF
--- a/internal/project/projectcollectionbuilder.go
+++ b/internal/project/projectcollectionbuilder.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/microsoft/typescript-go/internal/collections"
+	"github.com/microsoft/typescript-go/internal/compiler"
 	"github.com/microsoft/typescript-go/internal/core"
 	"github.com/microsoft/typescript-go/internal/diagnostics"
 	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
@@ -1056,12 +1057,16 @@ func (b *ProjectCollectionBuilder) updateProgram(entry dirty.Value[*Project], lo
 		b.deleteConfiguredProject(entry, logger)
 	}
 	if updateProgram {
+		projectPath := entry.Value().configFilePath
+		oldProgram := entry.Value().Program
+		var newProgram *compiler.Program
 		entry.Locked(func(entry dirty.Value[*Project]) {
 			entry.Change(func(project *Project) {
 				oldHost := project.host
 				project.host = newCompilerHost(project.currentDirectory, project, b, logger.Fork("CompilerHost"))
 				result := project.CreateProgram()
 				project.Program = result.Program
+				newProgram = result.Program
 				project.checkerPool = result.CheckerPool
 				project.ProgramUpdateKind = result.UpdateKind
 				project.ProgramLastUpdate = b.newSnapshotID
@@ -1076,6 +1081,27 @@ func (b *ProjectCollectionBuilder) updateProgram(entry dirty.Value[*Project], lo
 				project.dirtyFilePath = ""
 			})
 		})
+		// Release project references that were dropped during the rebuild.
+		// We diff old vs new rather than releasing all old refs eagerly, because
+		// incremental updates (single dirty file, same command line) reuse the
+		// existing reference graph without calling GetResolvedProjectReference,
+		// so an eager release would remove the project from retainingProjects of
+		// refs it still holds.
+		if oldProgram != nil {
+			newRefs := make(map[tspath.Path]struct{})
+			if newProgram != nil {
+				newProgram.RangeResolvedProjectReference(func(referencePath tspath.Path, _ *tsoptions.ParsedCommandLine, _ *tsoptions.ParsedCommandLine, _ int) bool {
+					newRefs[referencePath] = struct{}{}
+					return true
+				})
+			}
+			oldProgram.RangeResolvedProjectReference(func(referencePath tspath.Path, _ *tsoptions.ParsedCommandLine, _ *tsoptions.ParsedCommandLine, _ int) bool {
+				if _, kept := newRefs[referencePath]; !kept {
+					b.configFileRegistryBuilder.releaseConfigForProject(referencePath, projectPath)
+				}
+				return true
+			})
+		}
 	}
 	if notifiedLoading && b.client != nil {
 		b.client.ProgressFinish(diagnostics.Project_0, displayName)
@@ -1141,17 +1167,22 @@ func (b *ProjectCollectionBuilder) markFilesChanged(entry dirty.Value[*Project],
 	)
 }
 
+func (b *ProjectCollectionBuilder) releaseProjectReferences(program *compiler.Program, projectPath tspath.Path) {
+	if program == nil {
+		return
+	}
+	program.RangeResolvedProjectReference(func(referencePath tspath.Path, _ *tsoptions.ParsedCommandLine, _ *tsoptions.ParsedCommandLine, _ int) bool {
+		b.configFileRegistryBuilder.releaseConfigForProject(referencePath, projectPath)
+		return true
+	})
+}
+
 func (b *ProjectCollectionBuilder) deleteConfiguredProject(project dirty.Value[*Project], logger *logging.LogTree) {
 	projectPath := project.Value().configFilePath
 	if logger != nil {
 		logger.Log("Deleting configured project: " + project.Value().configFileName)
 	}
-	if program := project.Value().Program; program != nil {
-		program.RangeResolvedProjectReference(func(referencePath tspath.Path, config *tsoptions.ParsedCommandLine, _ *tsoptions.ParsedCommandLine, _ int) bool {
-			b.configFileRegistryBuilder.releaseConfigForProject(referencePath, projectPath)
-			return true
-		})
-	}
+	b.releaseProjectReferences(project.Value().Program, projectPath)
 	b.configFileRegistryBuilder.releaseConfigForProject(projectPath, projectPath)
 	project.Delete()
 }

--- a/internal/project/projectreferencesprogram_test.go
+++ b/internal/project/projectreferencesprogram_test.go
@@ -275,6 +275,58 @@ func TestProjectReferencesProgram(t *testing.T) {
 		assert.Equal(t, len(snapshot.ProjectCollection.Projects()), 1)
 		assert.Check(t, snapshot.ProjectCollection.Projects()[0].Program != programBefore)
 	})
+
+	// Regression test for https://github.com/microsoft/typescript-go/issues/3942.
+	// When a project reference is removed and the program rebuilt, the dropped reference's
+	// retainingProjects entry must be released. Otherwise markProjectsAffectedByConfigChanges
+	// panics when the referenced config changes after the project is deleted.
+	t.Run("no panic when referenced config changes after reference is removed from tsconfig", func(t *testing.T) {
+		t.Parallel()
+		files := map[string]any{
+			"/main/tsconfig.json": `{"compilerOptions":{"noLib":true,"composite":true},"references":[{"path":"../dep"}]}`,
+			"/main/index.ts":      `export const x = 1;`,
+			"/dep/tsconfig.json":  `{"compilerOptions":{"noLib":true,"composite":true}}`,
+			"/dep/index.ts":       `export const y = 2;`,
+		}
+		session, utils := projecttestutil.Setup(files)
+
+		mainURI := lsproto.DocumentUri("file:///main/index.ts")
+		depURI := lsproto.DocumentUri("file:///dep/index.ts")
+
+		// Build main's program with a reference to dep.
+		session.DidOpenFile(context.Background(), mainURI, 1, files["/main/index.ts"].(string), lsproto.LanguageKindTypeScript)
+		_, err := session.GetLanguageService(context.Background(), mainURI)
+		assert.NilError(t, err)
+
+		// Remove the reference to dep and rebuild. Without the fix, dep's
+		// retainingProjects still holds main's path after this rebuild.
+		err = utils.FS().WriteFile("/main/tsconfig.json", `{"compilerOptions":{"noLib":true,"composite":true}}`)
+		assert.NilError(t, err)
+		session.DidChangeWatchedFiles(context.Background(), []*lsproto.FileEvent{
+			{Uri: "file:///main/tsconfig.json", Type: lsproto.FileChangeTypeChanged},
+		})
+		_, err = session.GetLanguageService(context.Background(), mainURI)
+		assert.NilError(t, err)
+
+		// Close main and open dep. The close+open snapshot deletes the main project.
+		// deleteConfiguredProject only releases current-program refs (none after the
+		// rebuild), so without the fix dep.retainingProjects still has main.
+		session.DidCloseFile(context.Background(), mainURI)
+		session.DidOpenFile(context.Background(), depURI, 1, files["/dep/index.ts"].(string), lsproto.LanguageKindTypeScript)
+		_, err = session.GetLanguageService(context.Background(), depURI)
+		assert.NilError(t, err)
+
+		// Change dep's tsconfig. markProjectsAffectedByConfigChanges would panic
+		// here without the fix because it finds main in dep's retainingProjects but
+		// main is no longer in configuredProjects.
+		err = utils.FS().WriteFile("/dep/tsconfig.json", `{"compilerOptions":{"noLib":true,"composite":true,"strict":true}}`)
+		assert.NilError(t, err)
+		session.DidChangeWatchedFiles(context.Background(), []*lsproto.FileEvent{
+			{Uri: "file:///dep/tsconfig.json", Type: lsproto.FileChangeTypeChanged},
+		})
+		_, err = session.GetLanguageService(context.Background(), depURI)
+		assert.NilError(t, err)
+	})
 }
 
 func filesForReferencedProjectProgram(disableSourceOfProjectReferenceRedirect bool) map[string]any {


### PR DESCRIPTION
Fixes #3942

Thanks to @DanielRosenwasser for the stack trace, which made tracing the root cause much more direct.

## Analysis

`updateProgram` calls `acquireConfigForProject` for every project reference it resolves via `GetResolvedProjectReference`, adding the current project's config path to each referenced config's `retainingProjects`. When the program is rebuilt with fewer references (a `references` entry removed from tsconfig), only the new set is acquired. Nothing releases the entries that were in the old program but dropped from the new one.

The dropped config ends up with a stale entry in `retainingProjects`: the project path is present, but the project no longer treats that config as a reference. The stale entry is invisible during the rebuild because the project is still alive.

The invariant breaks when the project is later deleted. `deleteConfiguredProject` calls `program.RangeResolvedProjectReference` to release all references, but that iterates the current program, which does not include the dropped reference. The stale `retainingProjects` entry survives deletion and persists into the finalized snapshot.

In the next snapshot, if that referenced config changes, `configFileRegistryBuilder.DidChangeFiles` copies `retainingProjects` into `affectedProjects` and passes it to `markProjectsAffectedByConfigChanges`. That function loads the project path from `configuredProjects` and panics because the project was already deleted.

The `scheduleIdleCacheClean` timer is a common trigger. It fires after the project is already gone, carrying accumulated file changes that may include a tsconfig modification.

## Fix

After `CreateProgram` completes, diff the old program's project references against the new program's and release any absent from the new one. This is safer than releasing all old refs eagerly before the rebuild: on incremental updates (single dirty file, same command line), `CreateProgram` clones the old program via `UpdateProgram` without calling `GetResolvedProjectReference`, so the new program's reference set is identical to the old one. An eager release in that path would remove the project from every dependency's `retainingProjects`, causing config changes in those dependencies to stop marking this project dirty.

The post-rebuild diff catches dropped references regardless of whether the rebuild was full or incremental. References the new program still holds remain untouched. The diff happens outside `entry.Locked`, matching the existing pattern.

`deleteConfiguredProject` still releases all references unconditionally on project deletion; the release logic lives in a shared `releaseProjectReferences` helper. `updateProgram` uses the post-rebuild diff instead.

The regression test in `TestProjectReferencesProgram` walks the full sequence: open a file that causes a project reference to be acquired, rebuild after removing the reference, delete the project by closing the file, then change the formerly-referenced config. Without the fix this panics. With the fix it completes cleanly.

PR #3987 addresses the same crash by replacing the panic in `markProjectsAffectedByConfigChanges` with a guarded skip. That's a reasonable defensive measure. This PR fixes the root cause instead, so `retainingProjects` stays consistent and the panic legitimately never fires.

## Copilot Checklist

<!-- don't lie! -->
I successfully ran these commands at the end of my session, and they completed without error:
 * [x] npx hereby build
 * [ ] npx hereby test  (`TestFindAllRefsDoesNotTryToSearchProjectAfterItsUpdateDoesNotIncludeTheFile` and `TestDeclarationMapsRename` fail with baseline drift; these also fail on `origin/main` without this change. `go test ./internal/project/...` passes cleanly.)
 * [x] npx hereby lint
 * [x] npx hereby format