### PR TITLE
fix(declarations): strip synthesized namespace for @internal expando functions

### DIFF
--- a/internal/transformers/declarations/transform.go
+++ b/internal/transformers/declarations/transform.go
@@ -2228,6 +2228,10 @@ func (tx *DeclarationTransformer) transformExpandoAssignment(node *ast.BinaryExp
 		return nil
 	}
 
+	if tx.shouldStripInternal(declaration) {
+		return nil
+	}
+
 	if ast.IsVariableDeclaration(declaration) && declaration.Type() != nil {
 		return nil
 	}

--- a/testdata/baselines/reference/compiler/declarationEmitStripInternalExpandoFunction.js
+++ b/testdata/baselines/reference/compiler/declarationEmitStripInternalExpandoFunction.js
@@ -1,0 +1,28 @@
+//// [tests/cases/compiler/declarationEmitStripInternalExpandoFunction.ts] ////
+
+//// [declarationEmitStripInternalExpandoFunction.ts]
+/** @internal */
+export function internalFn(): string {
+    return "hello";
+}
+internalFn.debugFlag = true;
+
+export function publicFn(): void {}
+publicFn.metadata = "public";
+
+
+//// [declarationEmitStripInternalExpandoFunction.js]
+/** @internal */
+export function internalFn() {
+    return "hello";
+}
+internalFn.debugFlag = true;
+export function publicFn() { }
+publicFn.metadata = "public";
+
+
+//// [declarationEmitStripInternalExpandoFunction.d.ts]
+export declare function publicFn(): void;
+export declare namespace publicFn {
+    var metadata: string;
+}

--- a/testdata/baselines/reference/compiler/declarationEmitStripInternalExpandoFunction.symbols
+++ b/testdata/baselines/reference/compiler/declarationEmitStripInternalExpandoFunction.symbols
@@ -1,0 +1,22 @@
+//// [tests/cases/compiler/declarationEmitStripInternalExpandoFunction.ts] ////
+
+=== declarationEmitStripInternalExpandoFunction.ts ===
+/** @internal */
+export function internalFn(): string {
+>internalFn : Symbol(internalFn, Decl(declarationEmitStripInternalExpandoFunction.ts, 0, 0))
+
+    return "hello";
+}
+internalFn.debugFlag = true;
+>internalFn.debugFlag : Symbol(internalFn.debugFlag, Decl(declarationEmitStripInternalExpandoFunction.ts, 3, 1))
+>internalFn : Symbol(internalFn, Decl(declarationEmitStripInternalExpandoFunction.ts, 0, 0))
+>debugFlag : Symbol(internalFn.debugFlag, Decl(declarationEmitStripInternalExpandoFunction.ts, 3, 1))
+
+export function publicFn(): void {}
+>publicFn : Symbol(publicFn, Decl(declarationEmitStripInternalExpandoFunction.ts, 4, 28))
+
+publicFn.metadata = "public";
+>publicFn.metadata : Symbol(publicFn.metadata, Decl(declarationEmitStripInternalExpandoFunction.ts, 6, 35))
+>publicFn : Symbol(publicFn, Decl(declarationEmitStripInternalExpandoFunction.ts, 4, 28))
+>metadata : Symbol(publicFn.metadata, Decl(declarationEmitStripInternalExpandoFunction.ts, 6, 35))
+

--- a/testdata/baselines/reference/compiler/declarationEmitStripInternalExpandoFunction.types
+++ b/testdata/baselines/reference/compiler/declarationEmitStripInternalExpandoFunction.types
@@ -1,0 +1,27 @@
+//// [tests/cases/compiler/declarationEmitStripInternalExpandoFunction.ts] ////
+
+=== declarationEmitStripInternalExpandoFunction.ts ===
+/** @internal */
+export function internalFn(): string {
+>internalFn : { (): string; debugFlag: boolean; }
+
+    return "hello";
+>"hello" : "hello"
+}
+internalFn.debugFlag = true;
+>internalFn.debugFlag = true : true
+>internalFn.debugFlag : boolean
+>internalFn : { (): string; debugFlag: boolean; }
+>debugFlag : boolean
+>true : true
+
+export function publicFn(): void {}
+>publicFn : { (): void; metadata: string; }
+
+publicFn.metadata = "public";
+>publicFn.metadata = "public" : "public"
+>publicFn.metadata : string
+>publicFn : { (): void; metadata: string; }
+>metadata : string
+>"public" : "public"
+

--- a/testdata/tests/cases/compiler/declarationEmitStripInternalExpandoFunction.ts
+++ b/testdata/tests/cases/compiler/declarationEmitStripInternalExpandoFunction.ts
@@ -1,0 +1,11 @@
+// @declaration: true
+// @stripInternal: true
+
+/** @internal */
+export function internalFn(): string {
+    return "hello";
+}
+internalFn.debugFlag = true;
+
+export function publicFn(): void {}
+publicFn.metadata = "public";


### PR DESCRIPTION
Fixes #3983

## Analysis

With `stripInternal: true`, expando functions marked `@internal` should disappear from `.d.ts` output entirely: declaration and synthesized namespace both. The declaration was getting stripped; the namespace was not.

```ts
/** @internal */
export function internalFn(): string { return "hello"; }
internalFn.debugFlag = true;
```

`tsgo` was emitting:

```ts
export declare namespace internalFn {
    var debugFlag: boolean;
}
```

`tsc` 6.0.3 emits nothing for `internalFn`. Parity gap.

`transformExpandoAssignment` guards the synthesis path with `isDeclarationAndNotVisible`, but has no `shouldStripInternal` check. They cover different exit conditions; both need to be there. The function declaration is stripped upstream. By the time `transformExpandoAssignment` processes the assignment, only the namespace synthesis path is left.

If the checklist note on the pre-existing failure reads awkwardly, I can rephrase it — figured transparency beats a silent unchecked box.

## Fix

One guard added after the nil-declaration check in `transformExpandoAssignment`:

```go
if tx.shouldStripInternal(declaration) {
    return nil
}
```

Mirrors the `isDeclarationAndNotVisible` check four lines below. New regression test `declarationEmitStripInternalExpandoFunction.ts`; baseline confirms only `publicFn` and its namespace appear in the output.

## Copilot Checklist

I successfully ran these commands at the end of my session, and they completed without error:
 * [x] npx hereby build
 * [x] npx hereby test (one pre-existing failure in `TestIsReparsePointRelativePath`/`internal/vfs/osvfs`: Windows symlink privilege, unrelated to declaration emit; CI `test (windows-latest)` passes cleanly on main)
 * [x] npx hereby lint
 * [x] npx hereby format