### PR TITLE
Handle empty response file name in command line parser

### DIFF
--- a/internal/tsoptions/commandlineparser.go
+++ b/internal/tsoptions/commandlineparser.go
@@ -163,6 +163,10 @@ func getInputOptionName(input string) string {
 }
 
 func (p *commandLineParser) parseResponseFile(fileName string) {
+	if fileName == "" {
+		p.errors = append(p.errors, ast.NewCompilerDiagnostic(diagnostics.Cannot_read_file_0, fileName))
+		return
+	}
 	fileContents, errors := tryReadFile(fileName, func(fileName string) (string, bool) {
 		if p.fs == nil {
 			return "", false


### PR DESCRIPTION
Fixes #3758.

Running tsgo with a bare `@` argument crashes with a panic in the vfs layer:

```
panic: vfs: path "" is not absolute
```

The crash comes from `parseStrings` taking the suffix after `@` (which is empty) and passing it to `parseResponseFile`, which then asks the vfs to read the empty path. `RootLength` in internal/vfs/internal panics on a non-absolute path, so the process exits before any diagnostic is reported.

This change short-circuits at the top of `parseResponseFile` when the file name is empty and reports the existing `Cannot_read_file_0` diagnostic instead, which is what users would get for any other unreadable response file.

The change is four lines in internal/tsoptions/commandlineparser.go. I do not have a Go toolchain on this machine, so I have not run `go test ./...` or `hereby test` locally. Happy to add a baseline test once a maintainer confirms the approach, or if pointed at the right scenario harness.