### PR TITLE
Bump fast-uri to 3.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2665,9 +2665,9 @@
             }
         },
         "node_modules/fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
             "dev": true,
             "funding": [
                 {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "overrides": {
         "@microsoft/applicationinsights-web-basic": "3.3.11",
         "@microsoft/1ds-core-js": "4.3.11",
-        "@microsoft/1ds-post-js": "4.3.11"
+        "@microsoft/1ds-post-js": "4.3.11",
+        "fast-uri": "3.1.2"
     },
     "packageManager": "npm@11.12.1+sha512.cdca14b85d647b3192028d02aadbe82d75f79a446aceea9874be98e6d768f20ebd3555770a48d0e9906106007877bbc690f715e9372f2e2dc644a3c3157fb14c",
     "volta": {


### PR DESCRIPTION
## Dependency Update

**CVE:** [CVE-2026-6321](https://github.com/advisories/GHSA-Q3J6-QGPJ-74H6), [CVE-2026-6322](https://github.com/advisories/GHSA-v39h-62p7-jpjc)
**Severity:** High
**S360 Due Date:** 2026-08-14

### What changed
- Added npm override for \ast-uri\ to pin version \3.1.2\
- Updated \ast-uri\ from \3.1.0\ to \3.1.2\ (transitive dep via \@vscode/vsce\ → \@secretlint/config-loader\ → \jv\ → \ast-uri\)

### Why
- **CVE-2026-6321**: Path traversal via percent-encoded dot segments in fast-uri (fixed in 3.1.1)
- **CVE-2026-6322**: Host confusion via interpretation conflict in fast-uri (fixed in 3.1.2)

### Testing
- [x] \
pm ls fast-uri\ confirms version 3.1.2
- [ ] CI passes

### References
- S360 Item: https://vnext.s360.msftcloudes.com/blades/security?blade=KPI:SFI-ES5.2~SLA:3~Tab:Details
