### PR TITLE
Quote invalid property names in declaration emit

### DIFF
--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -1237,7 +1237,12 @@ func (p *Printer) emitPropertyName(node *ast.PropertyName) {
 
 	switch node.Kind {
 	case ast.KindIdentifier:
-		p.emitIdentifierName(node.AsIdentifier())
+		text := p.getTextOfNode(node, false /*includeTrivia*/)
+		if scanner.IsIdentifierText(text, core.LanguageVariantStandard) {
+			p.emitIdentifierName(node.AsIdentifier())
+		} else {
+			p.writer.WriteStringLiteral("\"" + escapeNonAsciiString(text, QuoteCharDoubleQuote) + "\"")
+		}
 	case ast.KindPrivateIdentifier:
 		p.emitPrivateIdentifier(node.AsPrivateIdentifier())
 	case ast.KindStringLiteral:

--- a/testdata/baselines/reference/compiler/jsDocTypedefPropertyNameDeclarationEmit.js
+++ b/testdata/baselines/reference/compiler/jsDocTypedefPropertyNameDeclarationEmit.js
@@ -1,0 +1,38 @@
+//// [tests/cases/compiler/jsDocTypedefPropertyNameDeclarationEmit.ts] ////
+
+//// [button.js]
+/**
+ * @typedef {Object} ButtonProps
+ * @property {string} label The button label
+ * @property {string | null | undefined} [data-test-name] Test automation attribute
+ * @property {string | null | undefined} [aria-label] Accessibility label
+ */
+
+/**
+ * @param {ButtonProps} props
+ * @returns {ButtonProps}
+ */
+export function Button(props) {
+    return props;
+}
+
+
+
+
+//// [button.d.ts]
+/**
+ * @typedef {Object} ButtonProps
+ * @property {string} label The button label
+ * @property {string | null | undefined} [data-test-name] Test automation attribute
+ * @property {string | null | undefined} [aria-label] Accessibility label
+ */
+export type ButtonProps = {
+    label: string;
+    "data-test-name"?: string | null | undefined;
+    "aria-label"?: string | null | undefined;
+};
+/**
+ * @param {ButtonProps} props
+ * @returns {ButtonProps}
+ */
+export declare function Button(props: ButtonProps): ButtonProps;

--- a/testdata/baselines/reference/compiler/jsDocTypedefPropertyNameDeclarationEmit.symbols
+++ b/testdata/baselines/reference/compiler/jsDocTypedefPropertyNameDeclarationEmit.symbols
@@ -1,0 +1,22 @@
+//// [tests/cases/compiler/jsDocTypedefPropertyNameDeclarationEmit.ts] ////
+
+=== button.js ===
+/**
+ * @typedef {Object} ButtonProps
+ * @property {string} label The button label
+ * @property {string | null | undefined} [data-test-name] Test automation attribute
+ * @property {string | null | undefined} [aria-label] Accessibility label
+ */
+
+/**
+ * @param {ButtonProps} props
+ * @returns {ButtonProps}
+ */
+export function Button(props) {
+>Button : Symbol(Button, Decl(button.js, 0, 0))
+>props : Symbol(props, Decl(button.js, 11, 23))
+
+    return props;
+>props : Symbol(props, Decl(button.js, 11, 23))
+}
+

--- a/testdata/baselines/reference/compiler/jsDocTypedefPropertyNameDeclarationEmit.types
+++ b/testdata/baselines/reference/compiler/jsDocTypedefPropertyNameDeclarationEmit.types
@@ -1,0 +1,22 @@
+//// [tests/cases/compiler/jsDocTypedefPropertyNameDeclarationEmit.ts] ////
+
+=== button.js ===
+/**
+ * @typedef {Object} ButtonProps
+ * @property {string} label The button label
+ * @property {string | null | undefined} [data-test-name] Test automation attribute
+ * @property {string | null | undefined} [aria-label] Accessibility label
+ */
+
+/**
+ * @param {ButtonProps} props
+ * @returns {ButtonProps}
+ */
+export function Button(props) {
+>Button : (props: ButtonProps) => ButtonProps
+>props : ButtonProps
+
+    return props;
+>props : ButtonProps
+}
+

--- a/testdata/tests/cases/compiler/jsDocTypedefPropertyNameDeclarationEmit.ts
+++ b/testdata/tests/cases/compiler/jsDocTypedefPropertyNameDeclarationEmit.ts
@@ -1,0 +1,20 @@
+// @allowJs: true
+// @checkJs: true
+// @declaration: true
+// @emitDeclarationOnly: true
+
+// @filename: button.js
+/**
+ * @typedef {Object} ButtonProps
+ * @property {string} label The button label
+ * @property {string | null | undefined} [data-test-name] Test automation attribute
+ * @property {string | null | undefined} [aria-label] Accessibility label
+ */
+
+/**
+ * @param {ButtonProps} props
+ * @returns {ButtonProps}
+ */
+export function Button(props) {
+    return props;
+}


### PR DESCRIPTION
## Summary
- quote identifier-shaped property names when their printed text is not valid identifier syntax
- add a declaration emit regression test for JSDoc typedef properties such as `data-test-name` and `aria-label`

Fixes #4011.

## Testing
- `go test ./internal/testrunner -run '^TestLocal/jsDocTypedefPropertyNameDeclarationEmit.ts$' -v`