### PR TITLE
Rewrite invalid identifiers originating in JSDoc

### DIFF
--- a/internal/transformers/declarations/transform.go
+++ b/internal/transformers/declarations/transform.go
@@ -735,17 +735,25 @@ func (tx *DeclarationTransformer) transformExpressionWithTypeArguments(input *as
 }
 
 func (tx *DeclarationTransformer) transformTypeParameterDeclaration(input *ast.TypeParameterDeclaration) *ast.Node {
+	name := tx.sanitizeIdentifier(input.Name())
 	if isPrivateMethodTypeParameter(tx.host, input) && (input.DefaultType != nil || input.Constraint != nil) {
 		return tx.Factory().UpdateTypeParameterDeclaration(
 			input,
 			input.Modifiers(),
-			input.Name(),
+			name,
 			nil,
 			input.Expression,
 			nil,
 		)
 	}
-	return tx.Visitor().VisitEachChild(input.AsNode())
+	return tx.Factory().UpdateTypeParameterDeclaration(
+		input,
+		input.Modifiers(),
+		name,
+		tx.Visitor().Visit(input.Constraint),
+		input.Expression,
+		tx.Visitor().Visit(input.DefaultType),
+	)
 }
 
 func (tx *DeclarationTransformer) transformVariableDeclaration(input *ast.VariableDeclaration) *ast.Node {
@@ -867,7 +875,7 @@ func (tx *DeclarationTransformer) transformPropertySignatureDeclaration(input *a
 	return tx.Factory().UpdatePropertySignatureDeclaration(
 		input,
 		tx.ensureModifiers(input.AsNode()),
-		input.Name(),
+		tx.sanitizePropertyName(input.Name()),
 		input.PostfixToken,
 		tx.ensureType(input.AsNode(), false),
 		tx.ensureNoInitializer(input.AsNode()), // TODO: possible strada bug (fixed here) - const property signatures never initialized
@@ -1382,7 +1390,7 @@ func (tx *DeclarationTransformer) transformTypeAliasDeclaration(input *ast.TypeA
 	return tx.Factory().UpdateTypeAliasDeclaration(
 		input,
 		tx.ensureModifiers(input.AsNode()),
-		input.Name(),
+		tx.sanitizeIdentifier(input.Name()),
 		tx.Visitor().VisitNodes(input.TypeParameters),
 		tx.Visitor().Visit(input.Type),
 	)
@@ -1960,13 +1968,61 @@ func (tx *DeclarationTransformer) ensureParameter(p *ast.ParameterDeclaration) *
 		p,
 		nil,
 		p.DotDotDotToken,
-		tx.bindingNameVisitor.VisitNode(p.Name()),
+		tx.sanitizeBindingName(tx.bindingNameVisitor.VisitNode(p.Name())),
 		questionToken,
 		tx.ensureType(p.AsNode(), true),
 		tx.ensureNoInitializer(p.AsNode()),
 	)
 	tx.state.getSymbolAccessibilityDiagnostic = oldDiag
 	return result
+}
+
+// sanitizePropertyName converts invalid identifier property names to string
+// literals so declaration emit produces valid property signatures.
+func (tx *DeclarationTransformer) sanitizePropertyName(name *ast.Node) *ast.Node {
+	if ast.IsIdentifier(name) && !scanner.IsIdentifierText(name.Text(), core.LanguageVariantStandard) {
+		return tx.Factory().NewStringLiteral(name.Text(), ast.TokenFlagsNone)
+	}
+	return name
+}
+
+func (tx *DeclarationTransformer) sanitizeBindingName(name *ast.Node) *ast.Node {
+	if ast.IsIdentifier(name) {
+		return tx.sanitizeIdentifier(name)
+	}
+	return name
+}
+
+func (tx *DeclarationTransformer) sanitizeIdentifier(name *ast.IdentifierNode) *ast.Node {
+	if name == nil {
+		return name
+	}
+	text := name.Text()
+	if text == "" || scanner.IsIdentifierText(text, core.LanguageVariantStandard) {
+		return name
+	}
+	return tx.Factory().NewIdentifier(sanitizeIdentifierText(text))
+}
+
+func sanitizeIdentifierText(text string) string {
+	var result strings.Builder
+	lastWasUnderscore := false
+	writeUnderscore := func() {
+		if !lastWasUnderscore {
+			result.WriteByte('_')
+			lastWasUnderscore = true
+		}
+	}
+	writeUnderscore()
+	for pos, ch := range text {
+		if scanner.IsIdentifierPartEx(ch, core.LanguageVariantStandard) {
+			result.WriteRune(ch)
+			lastWasUnderscore = false
+		} else if pos != 0 {
+			writeUnderscore()
+		}
+	}
+	return result.String()
 }
 
 func (tx *DeclarationTransformer) ensureNoInitializer(node *ast.Node) *ast.Node {
@@ -2138,7 +2194,7 @@ func (tx *DeclarationTransformer) transformJSDocTypeLiteral(input *ast.JSDocType
 func (tx *DeclarationTransformer) transformJSDocPropertyTag(input *ast.JSDocParameterOrPropertyTag) *ast.Node {
 	replacement := tx.Factory().NewPropertySignatureDeclaration(
 		nil,
-		tx.Visitor().Visit(input.TagName),
+		tx.sanitizePropertyName(tx.Visitor().Visit(input.TagName)),
 		nil,
 		tx.Visitor().Visit(input.TypeExpression),
 		nil,

--- a/testdata/baselines/reference/compiler/jsdocTypedefPropertyNameEscaping.js
+++ b/testdata/baselines/reference/compiler/jsdocTypedefPropertyNameEscaping.js
@@ -1,0 +1,246 @@
+//// [tests/cases/compiler/jsdocTypedefPropertyNameEscaping.ts] ////
+
+//// [index.js]
+/**
+ * @typedef {Object} ButtonProps
+ * @property {string} label The button label
+ * @property {string | null | undefined} [data-test-name] Test automation attribute
+ * @property {string | null | undefined} [aria-label] Accessibility label
+ * @property {string | undefined} [`back-quoted-name`] Backquoted property
+ */
+
+/**
+ * @param {ButtonProps} props
+ * @returns {ButtonProps}
+ */
+export function Button(props) {
+    return props;
+}
+
+/** @typedef {string} typedef-name */
+
+/**
+ * @callback callback-name
+ * @param {string} data-test-name
+ * @param {string} [`back-quoted-param`]
+ * @returns {void}
+ */
+
+/**
+ * @template template-name
+ * @returns {void}
+ */
+export function templated() {}
+
+
+
+
+//// [index.d.ts]
+/**
+ * @typedef {Object} ButtonProps
+ * @property {string} label The button label
+ * @property {string | null | undefined} [data-test-name] Test automation attribute
+ * @property {string | null | undefined} [aria-label] Accessibility label
+ * @property {string | undefined} [`back-quoted-name`] Backquoted property
+ */
+export type ButtonProps = {
+    label: string;
+    data-test-name?: string | null | undefined;
+    aria-label?: string | null | undefined;
+    back-quoted-name?: string | undefined;
+};
+/**
+ * @param {ButtonProps} props
+ * @returns {ButtonProps}
+ */
+export declare function Button(props: ButtonProps): ButtonProps;
+export type typedef-name = string;
+export type callback-name = (data-test-name: string, back-quoted-param?: string) => void;
+/** @typedef {string} typedef-name */
+/**
+ * @callback callback-name
+ * @param {string} data-test-name
+ * @param {string} [`back-quoted-param`]
+ * @returns {void}
+ */
+/**
+ * @template template-name
+ * @returns {void}
+ */
+export declare function templated<template-name>(): void;
+
+
+//// [DtsFileErrors]
+
+
+index.d.ts(10,5): error TS1131: Property or signature expected.
+index.d.ts(10,5): error TS2304: Cannot find name 'data'.
+index.d.ts(10,10): error TS2593: Cannot find name 'test'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.
+index.d.ts(10,15): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
+index.d.ts(10,20): error TS1109: Expression expected.
+index.d.ts(10,22): error TS2693: 'string' only refers to a type, but is being used as a value here.
+index.d.ts(10,31): error TS18050: The value 'null' cannot be used here.
+index.d.ts(10,38): error TS18050: The value 'undefined' cannot be used here.
+index.d.ts(11,5): error TS2304: Cannot find name 'aria'.
+index.d.ts(11,10): error TS2304: Cannot find name 'label'.
+index.d.ts(11,16): error TS1109: Expression expected.
+index.d.ts(11,18): error TS2693: 'string' only refers to a type, but is being used as a value here.
+index.d.ts(11,27): error TS18050: The value 'null' cannot be used here.
+index.d.ts(11,34): error TS18050: The value 'undefined' cannot be used here.
+index.d.ts(12,5): error TS2304: Cannot find name 'back'.
+index.d.ts(12,10): error TS2304: Cannot find name 'quoted'.
+index.d.ts(12,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
+index.d.ts(12,22): error TS1109: Expression expected.
+index.d.ts(12,24): error TS2693: 'string' only refers to a type, but is being used as a value here.
+index.d.ts(12,33): error TS18050: The value 'undefined' cannot be used here.
+index.d.ts(13,1): error TS1128: Declaration or statement expected.
+index.d.ts(19,20): error TS1005: '=' expected.
+index.d.ts(19,26): error TS1005: ';' expected.
+index.d.ts(19,28): error TS2693: 'string' only refers to a type, but is being used as a value here.
+index.d.ts(20,21): error TS1005: '=' expected.
+index.d.ts(20,27): error TS1005: ';' expected.
+index.d.ts(20,30): error TS2304: Cannot find name 'data'.
+index.d.ts(20,35): error TS2593: Cannot find name 'test'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.
+index.d.ts(20,40): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
+index.d.ts(20,44): error TS1005: ')' expected.
+index.d.ts(20,46): error TS2693: 'string' only refers to a type, but is being used as a value here.
+index.d.ts(20,46): error TS2695: Left side of comma operator is unused and has no side effects.
+index.d.ts(20,54): error TS2304: Cannot find name 'back'.
+index.d.ts(20,59): error TS2304: Cannot find name 'quoted'.
+index.d.ts(20,66): error TS2304: Cannot find name 'param'.
+index.d.ts(20,72): error TS1109: Expression expected.
+index.d.ts(20,74): error TS2693: 'string' only refers to a type, but is being used as a value here.
+index.d.ts(20,80): error TS1005: ';' expected.
+index.d.ts(20,82): error TS1128: Declaration or statement expected.
+index.d.ts(20,89): error TS1109: Expression expected.
+index.d.ts(32,25): error TS7010: 'templated', which lacks return-type annotation, implicitly has an 'any' return type.
+index.d.ts(32,43): error TS1005: ',' expected.
+index.d.ts(32,50): error TS1109: Expression expected.
+index.d.ts(32,51): error TS1005: ';' expected.
+index.d.ts(32,57): error TS1109: Expression expected.
+
+
+==== index.d.ts (45 errors) ====
+    /**
+     * @typedef {Object} ButtonProps
+     * @property {string} label The button label
+     * @property {string | null | undefined} [data-test-name] Test automation attribute
+     * @property {string | null | undefined} [aria-label] Accessibility label
+     * @property {string | undefined} [`back-quoted-name`] Backquoted property
+     */
+    export type ButtonProps = {
+        label: string;
+        data-test-name?: string | null | undefined;
+        ~~~~
+!!! error TS1131: Property or signature expected.
+        ~~~~
+!!! error TS2304: Cannot find name 'data'.
+             ~~~~
+!!! error TS2593: Cannot find name 'test'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.
+                  ~~~~
+!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
+                       ~
+!!! error TS1109: Expression expected.
+                         ~~~~~~
+!!! error TS2693: 'string' only refers to a type, but is being used as a value here.
+                                  ~~~~
+!!! error TS18050: The value 'null' cannot be used here.
+                                         ~~~~~~~~~
+!!! error TS18050: The value 'undefined' cannot be used here.
+        aria-label?: string | null | undefined;
+        ~~~~
+!!! error TS2304: Cannot find name 'aria'.
+             ~~~~~
+!!! error TS2304: Cannot find name 'label'.
+                   ~
+!!! error TS1109: Expression expected.
+                     ~~~~~~
+!!! error TS2693: 'string' only refers to a type, but is being used as a value here.
+                              ~~~~
+!!! error TS18050: The value 'null' cannot be used here.
+                                     ~~~~~~~~~
+!!! error TS18050: The value 'undefined' cannot be used here.
+        back-quoted-name?: string | undefined;
+        ~~~~
+!!! error TS2304: Cannot find name 'back'.
+             ~~~~~~
+!!! error TS2304: Cannot find name 'quoted'.
+                    ~~~~
+!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
+                         ~
+!!! error TS1109: Expression expected.
+                           ~~~~~~
+!!! error TS2693: 'string' only refers to a type, but is being used as a value here.
+                                    ~~~~~~~~~
+!!! error TS18050: The value 'undefined' cannot be used here.
+    };
+    ~
+!!! error TS1128: Declaration or statement expected.
+    /**
+     * @param {ButtonProps} props
+     * @returns {ButtonProps}
+     */
+    export declare function Button(props: ButtonProps): ButtonProps;
+    export type typedef-name = string;
+                       ~
+!!! error TS1005: '=' expected.
+                             ~
+!!! error TS1005: ';' expected.
+                               ~~~~~~
+!!! error TS2693: 'string' only refers to a type, but is being used as a value here.
+    export type callback-name = (data-test-name: string, back-quoted-param?: string) => void;
+                        ~
+!!! error TS1005: '=' expected.
+                              ~
+!!! error TS1005: ';' expected.
+                                 ~~~~
+!!! error TS2304: Cannot find name 'data'.
+                                      ~~~~
+!!! error TS2593: Cannot find name 'test'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.
+                                           ~~~~
+!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
+                                               ~
+!!! error TS1005: ')' expected.
+                                                 ~~~~~~
+!!! error TS2693: 'string' only refers to a type, but is being used as a value here.
+                                                 ~~~~~~
+!!! error TS2695: Left side of comma operator is unused and has no side effects.
+                                                         ~~~~
+!!! error TS2304: Cannot find name 'back'.
+                                                              ~~~~~~
+!!! error TS2304: Cannot find name 'quoted'.
+                                                                     ~~~~~
+!!! error TS2304: Cannot find name 'param'.
+                                                                           ~
+!!! error TS1109: Expression expected.
+                                                                             ~~~~~~
+!!! error TS2693: 'string' only refers to a type, but is being used as a value here.
+                                                                                   ~
+!!! error TS1005: ';' expected.
+                                                                                     ~~
+!!! error TS1128: Declaration or statement expected.
+                                                                                            ~
+!!! error TS1109: Expression expected.
+    /** @typedef {string} typedef-name */
+    /**
+     * @callback callback-name
+     * @param {string} data-test-name
+     * @param {string} [`back-quoted-param`]
+     * @returns {void}
+     */
+    /**
+     * @template template-name
+     * @returns {void}
+     */
+    export declare function templated<template-name>(): void;
+                            ~~~~~~~~~
+!!! error TS7010: 'templated', which lacks return-type annotation, implicitly has an 'any' return type.
+                                              ~
+!!! error TS1005: ',' expected.
+                                                     ~
+!!! error TS1109: Expression expected.
+                                                      ~
+!!! error TS1005: ';' expected.
+                                                            ~
+!!! error TS1109: Expression expected.
+    

--- a/testdata/baselines/reference/compiler/jsdocTypedefPropertyNameEscaping.js
+++ b/testdata/baselines/reference/compiler/jsdocTypedefPropertyNameEscaping.js
@@ -45,17 +45,17 @@ export function templated() {}
  */
 export type ButtonProps = {
     label: string;
-    data-test-name?: string | null | undefined;
-    aria-label?: string | null | undefined;
-    back-quoted-name?: string | undefined;
+    "data-test-name"?: string | null | undefined;
+    "aria-label"?: string | null | undefined;
+    "back-quoted-name"?: string | undefined;
 };
 /**
  * @param {ButtonProps} props
  * @returns {ButtonProps}
  */
 export declare function Button(props: ButtonProps): ButtonProps;
-export type typedef-name = string;
-export type callback-name = (data-test-name: string, back-quoted-param?: string) => void;
+export type _typedef_name = string;
+export type _callback_name = (_data_test_name: string, _back_quoted_param?: string) => void;
 /** @typedef {string} typedef-name */
 /**
  * @callback callback-name
@@ -67,180 +67,4 @@ export type callback-name = (data-test-name: string, back-quoted-param?: string)
  * @template template-name
  * @returns {void}
  */
-export declare function templated<template-name>(): void;
-
-
-//// [DtsFileErrors]
-
-
-index.d.ts(10,5): error TS1131: Property or signature expected.
-index.d.ts(10,5): error TS2304: Cannot find name 'data'.
-index.d.ts(10,10): error TS2593: Cannot find name 'test'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.
-index.d.ts(10,15): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
-index.d.ts(10,20): error TS1109: Expression expected.
-index.d.ts(10,22): error TS2693: 'string' only refers to a type, but is being used as a value here.
-index.d.ts(10,31): error TS18050: The value 'null' cannot be used here.
-index.d.ts(10,38): error TS18050: The value 'undefined' cannot be used here.
-index.d.ts(11,5): error TS2304: Cannot find name 'aria'.
-index.d.ts(11,10): error TS2304: Cannot find name 'label'.
-index.d.ts(11,16): error TS1109: Expression expected.
-index.d.ts(11,18): error TS2693: 'string' only refers to a type, but is being used as a value here.
-index.d.ts(11,27): error TS18050: The value 'null' cannot be used here.
-index.d.ts(11,34): error TS18050: The value 'undefined' cannot be used here.
-index.d.ts(12,5): error TS2304: Cannot find name 'back'.
-index.d.ts(12,10): error TS2304: Cannot find name 'quoted'.
-index.d.ts(12,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
-index.d.ts(12,22): error TS1109: Expression expected.
-index.d.ts(12,24): error TS2693: 'string' only refers to a type, but is being used as a value here.
-index.d.ts(12,33): error TS18050: The value 'undefined' cannot be used here.
-index.d.ts(13,1): error TS1128: Declaration or statement expected.
-index.d.ts(19,20): error TS1005: '=' expected.
-index.d.ts(19,26): error TS1005: ';' expected.
-index.d.ts(19,28): error TS2693: 'string' only refers to a type, but is being used as a value here.
-index.d.ts(20,21): error TS1005: '=' expected.
-index.d.ts(20,27): error TS1005: ';' expected.
-index.d.ts(20,30): error TS2304: Cannot find name 'data'.
-index.d.ts(20,35): error TS2593: Cannot find name 'test'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.
-index.d.ts(20,40): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
-index.d.ts(20,44): error TS1005: ')' expected.
-index.d.ts(20,46): error TS2693: 'string' only refers to a type, but is being used as a value here.
-index.d.ts(20,46): error TS2695: Left side of comma operator is unused and has no side effects.
-index.d.ts(20,54): error TS2304: Cannot find name 'back'.
-index.d.ts(20,59): error TS2304: Cannot find name 'quoted'.
-index.d.ts(20,66): error TS2304: Cannot find name 'param'.
-index.d.ts(20,72): error TS1109: Expression expected.
-index.d.ts(20,74): error TS2693: 'string' only refers to a type, but is being used as a value here.
-index.d.ts(20,80): error TS1005: ';' expected.
-index.d.ts(20,82): error TS1128: Declaration or statement expected.
-index.d.ts(20,89): error TS1109: Expression expected.
-index.d.ts(32,25): error TS7010: 'templated', which lacks return-type annotation, implicitly has an 'any' return type.
-index.d.ts(32,43): error TS1005: ',' expected.
-index.d.ts(32,50): error TS1109: Expression expected.
-index.d.ts(32,51): error TS1005: ';' expected.
-index.d.ts(32,57): error TS1109: Expression expected.
-
-
-==== index.d.ts (45 errors) ====
-    /**
-     * @typedef {Object} ButtonProps
-     * @property {string} label The button label
-     * @property {string | null | undefined} [data-test-name] Test automation attribute
-     * @property {string | null | undefined} [aria-label] Accessibility label
-     * @property {string | undefined} [`back-quoted-name`] Backquoted property
-     */
-    export type ButtonProps = {
-        label: string;
-        data-test-name?: string | null | undefined;
-        ~~~~
-!!! error TS1131: Property or signature expected.
-        ~~~~
-!!! error TS2304: Cannot find name 'data'.
-             ~~~~
-!!! error TS2593: Cannot find name 'test'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.
-                  ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
-                       ~
-!!! error TS1109: Expression expected.
-                         ~~~~~~
-!!! error TS2693: 'string' only refers to a type, but is being used as a value here.
-                                  ~~~~
-!!! error TS18050: The value 'null' cannot be used here.
-                                         ~~~~~~~~~
-!!! error TS18050: The value 'undefined' cannot be used here.
-        aria-label?: string | null | undefined;
-        ~~~~
-!!! error TS2304: Cannot find name 'aria'.
-             ~~~~~
-!!! error TS2304: Cannot find name 'label'.
-                   ~
-!!! error TS1109: Expression expected.
-                     ~~~~~~
-!!! error TS2693: 'string' only refers to a type, but is being used as a value here.
-                              ~~~~
-!!! error TS18050: The value 'null' cannot be used here.
-                                     ~~~~~~~~~
-!!! error TS18050: The value 'undefined' cannot be used here.
-        back-quoted-name?: string | undefined;
-        ~~~~
-!!! error TS2304: Cannot find name 'back'.
-             ~~~~~~
-!!! error TS2304: Cannot find name 'quoted'.
-                    ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
-                         ~
-!!! error TS1109: Expression expected.
-                           ~~~~~~
-!!! error TS2693: 'string' only refers to a type, but is being used as a value here.
-                                    ~~~~~~~~~
-!!! error TS18050: The value 'undefined' cannot be used here.
-    };
-    ~
-!!! error TS1128: Declaration or statement expected.
-    /**
-     * @param {ButtonProps} props
-     * @returns {ButtonProps}
-     */
-    export declare function Button(props: ButtonProps): ButtonProps;
-    export type typedef-name = string;
-                       ~
-!!! error TS1005: '=' expected.
-                             ~
-!!! error TS1005: ';' expected.
-                               ~~~~~~
-!!! error TS2693: 'string' only refers to a type, but is being used as a value here.
-    export type callback-name = (data-test-name: string, back-quoted-param?: string) => void;
-                        ~
-!!! error TS1005: '=' expected.
-                              ~
-!!! error TS1005: ';' expected.
-                                 ~~~~
-!!! error TS2304: Cannot find name 'data'.
-                                      ~~~~
-!!! error TS2593: Cannot find name 'test'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.
-                                           ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
-                                               ~
-!!! error TS1005: ')' expected.
-                                                 ~~~~~~
-!!! error TS2693: 'string' only refers to a type, but is being used as a value here.
-                                                 ~~~~~~
-!!! error TS2695: Left side of comma operator is unused and has no side effects.
-                                                         ~~~~
-!!! error TS2304: Cannot find name 'back'.
-                                                              ~~~~~~
-!!! error TS2304: Cannot find name 'quoted'.
-                                                                     ~~~~~
-!!! error TS2304: Cannot find name 'param'.
-                                                                           ~
-!!! error TS1109: Expression expected.
-                                                                             ~~~~~~
-!!! error TS2693: 'string' only refers to a type, but is being used as a value here.
-                                                                                   ~
-!!! error TS1005: ';' expected.
-                                                                                     ~~
-!!! error TS1128: Declaration or statement expected.
-                                                                                            ~
-!!! error TS1109: Expression expected.
-    /** @typedef {string} typedef-name */
-    /**
-     * @callback callback-name
-     * @param {string} data-test-name
-     * @param {string} [`back-quoted-param`]
-     * @returns {void}
-     */
-    /**
-     * @template template-name
-     * @returns {void}
-     */
-    export declare function templated<template-name>(): void;
-                            ~~~~~~~~~
-!!! error TS7010: 'templated', which lacks return-type annotation, implicitly has an 'any' return type.
-                                              ~
-!!! error TS1005: ',' expected.
-                                                     ~
-!!! error TS1109: Expression expected.
-                                                      ~
-!!! error TS1005: ';' expected.
-                                                            ~
-!!! error TS1109: Expression expected.
-    
+export declare function templated<_template_name>(): void;

--- a/testdata/baselines/reference/compiler/jsdocTypedefPropertyNameEscaping.symbols
+++ b/testdata/baselines/reference/compiler/jsdocTypedefPropertyNameEscaping.symbols
@@ -1,0 +1,39 @@
+//// [tests/cases/compiler/jsdocTypedefPropertyNameEscaping.ts] ////
+
+=== index.js ===
+/**
+ * @typedef {Object} ButtonProps
+ * @property {string} label The button label
+ * @property {string | null | undefined} [data-test-name] Test automation attribute
+ * @property {string | null | undefined} [aria-label] Accessibility label
+ * @property {string | undefined} [`back-quoted-name`] Backquoted property
+ */
+
+/**
+ * @param {ButtonProps} props
+ * @returns {ButtonProps}
+ */
+export function Button(props) {
+>Button : Symbol(Button, Decl(index.js, 0, 0))
+>props : Symbol(props, Decl(index.js, 12, 23))
+
+    return props;
+>props : Symbol(props, Decl(index.js, 12, 23))
+}
+
+/** @typedef {string} typedef-name */
+
+/**
+ * @callback callback-name
+ * @param {string} data-test-name
+ * @param {string} [`back-quoted-param`]
+ * @returns {void}
+ */
+
+/**
+ * @template template-name
+ * @returns {void}
+ */
+export function templated() {}
+>templated : Symbol(templated, Decl(index.js, 14, 1))
+

--- a/testdata/baselines/reference/compiler/jsdocTypedefPropertyNameEscaping.types
+++ b/testdata/baselines/reference/compiler/jsdocTypedefPropertyNameEscaping.types
@@ -1,0 +1,39 @@
+//// [tests/cases/compiler/jsdocTypedefPropertyNameEscaping.ts] ////
+
+=== index.js ===
+/**
+ * @typedef {Object} ButtonProps
+ * @property {string} label The button label
+ * @property {string | null | undefined} [data-test-name] Test automation attribute
+ * @property {string | null | undefined} [aria-label] Accessibility label
+ * @property {string | undefined} [`back-quoted-name`] Backquoted property
+ */
+
+/**
+ * @param {ButtonProps} props
+ * @returns {ButtonProps}
+ */
+export function Button(props) {
+>Button : (props: ButtonProps) => ButtonProps
+>props : ButtonProps
+
+    return props;
+>props : ButtonProps
+}
+
+/** @typedef {string} typedef-name */
+
+/**
+ * @callback callback-name
+ * @param {string} data-test-name
+ * @param {string} [`back-quoted-param`]
+ * @returns {void}
+ */
+
+/**
+ * @template template-name
+ * @returns {void}
+ */
+export function templated() {}
+>templated : <template-name>() => void
+

--- a/testdata/tests/cases/compiler/jsdocTypedefPropertyNameEscaping.ts
+++ b/testdata/tests/cases/compiler/jsdocTypedefPropertyNameEscaping.ts
@@ -1,0 +1,36 @@
+// @allowJs: true
+// @checkJs: true
+// @declaration: true
+// @emitDeclarationOnly: true
+
+// @filename: index.js
+/**
+ * @typedef {Object} ButtonProps
+ * @property {string} label The button label
+ * @property {string | null | undefined} [data-test-name] Test automation attribute
+ * @property {string | null | undefined} [aria-label] Accessibility label
+ * @property {string | undefined} [`back-quoted-name`] Backquoted property
+ */
+
+/**
+ * @param {ButtonProps} props
+ * @returns {ButtonProps}
+ */
+export function Button(props) {
+    return props;
+}
+
+/** @typedef {string} typedef-name */
+
+/**
+ * @callback callback-name
+ * @param {string} data-test-name
+ * @param {string} [`back-quoted-param`]
+ * @returns {void}
+ */
+
+/**
+ * @template template-name
+ * @returns {void}
+ */
+export function templated() {}


### PR DESCRIPTION
Fixes #1208

## Analysis

JSDoc \@typedef\ declarations with hyphenated property names (e.g. \data-test-name\) were emitted unquoted in \.d.ts\ output, producing invalid TypeScript syntax like \data-test-name?: string\ instead of \\"data-test-name\"?: string\. This caused downstream DTS errors.

The root cause was that the declaration transformer did not sanitize property names, type alias names, type parameter names, or binding names that contain characters invalid in identifiers.

## Fix

Added \sanitizePropertyName\, \sanitizeIdentifier\, \sanitizeBindingName\, and \sanitizeIdentifierText\ helpers to the declaration transformer. These ensure that:
- Property signatures with non-identifier names get string-literal keys
- Type alias names with invalid characters get sanitized to valid identifiers
- Type parameter names get sanitized similarly
- Parameter binding names get sanitized

## Copilot Checklist

I successfully ran these commands at the end of my session, and they completed without error:
 * [x] npx hereby build
 * [x] npx hereby test
 * [x] npx hereby lint
 * [x] npx hereby format
