### PR TITLE
Fix external helper crash after module-status updates (TDD rewrite)

### DIFF
--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -343,6 +343,8 @@ func canReplaceFileInProgram(file1 *ast.SourceFile, file2 *ast.SourceFile) bool 
 	return file2 != nil &&
 		file1.ParseOptions() == file2.ParseOptions() &&
 		file1.UsesUriStyleNodeCoreModules == file2.UsesUriStyleNodeCoreModules &&
+		(file1.ExternalModuleIndicator != nil) == (file2.ExternalModuleIndicator != nil) &&
+		(file1.CommonJSModuleIndicator != nil) == (file2.CommonJSModuleIndicator != nil) &&
 		slices.EqualFunc(file1.Imports(), file2.Imports(), equalModuleSpecifiers) &&
 		slices.EqualFunc(file1.ModuleAugmentations, file2.ModuleAugmentations, equalModuleAugmentationNames) &&
 		slices.Equal(file1.AmbientModuleNames, file2.AmbientModuleNames) &&

--- a/internal/fourslash/tests/importHelpersAfterScriptBecomesDecoratedModule_test.go
+++ b/internal/fourslash/tests/importHelpersAfterScriptBecomesDecoratedModule_test.go
@@ -1,0 +1,47 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestImportHelpersAfterScriptBecomesDecoratedModule(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+
+	const content = `// @Filename: /tsconfig.json
+{
+"compilerOptions": {
+"target": "es2015",
+"module": "commonjs",
+"experimentalDecorators": true,
+"importHelpers": true
+},
+"files": ["foo.ts"]
+}
+
+// @Filename: /foo.ts
+declare function dec(value: Function): void;
+/*insert*/class C {}
+
+// @Filename: /node_modules/tslib/package.json
+{ "name": "tslib", "typings": "tslib.d.ts" }
+
+// @Filename: /node_modules/tslib/tslib.d.ts
+export declare function __decorate(...args: any[]): any;
+
+// @Filename: /node_modules/tslib/tslib.js
+exports.__decorate = function () {};
+`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+
+	f.GoToFile(t, "/foo.ts")
+	f.VerifyNumberOfErrorsInCurrentFile(t, 0)
+	f.Replace(t, f.MarkerByName(t, "insert").Position, 0, `@dec
+export `)
+	// The second diagnostics request forces external helper resolution after the edit.
+	f.VerifyNumberOfErrorsInCurrentFile(t, 0)
+}


### PR DESCRIPTION
Fixes #3878
Rewrite of #3994

## Analysis

\\checkExternalEmitHelpers\\ panics with a nil pointer dereference in \\esolveExternalModule\\ (via \\IsStringLiteralLike\\) after an incremental program update when a file transitions from script to module. The root cause is that \\canReplaceFileInProgram\\ allows file reuse even when the module indicator status has changed. When a file becomes a module (e.g. by adding \\xport\\), the reused program state lacks the synthetic \\	slib\\ import specifier needed for helper resolution, causing the nil dereference.

## Fix

Add checks in \\canReplaceFileInProgram\\ to compare \\ExternalModuleIndicator\\ and \\CommonJSModuleIndicator\\ between old and new file versions. When either changes (nil to non-nil or vice versa), the file cannot be reused and module-resolution state is rebuilt with the correct synthetic imports.

## Copilot Checklist

I successfully ran these commands at the end of my session, and they completed without error:
 * [x] npx hereby build
 * [x] npx hereby test
 * [x] npx hereby lint
 * [x] npx hereby format
