### PR TITLE
fix(4019): skip unloaded projects during file rename

### DIFF
--- a/internal/lsp/server_file_rename_test.go
+++ b/internal/lsp/server_file_rename_test.go
@@ -1,0 +1,81 @@
+package lsp_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/bundled"
+	"github.com/microsoft/typescript-go/internal/ls/lsconv"
+	"github.com/microsoft/typescript-go/internal/ls/lsutil"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
+	"github.com/microsoft/typescript-go/internal/testutil/lsptestutil"
+	"gotest.tools/v3/assert"
+)
+
+func TestWillRenameFilesAfterWatchedFileRenameInCompositeProject(t *testing.T) {
+	t.Parallel()
+
+	if !bundled.Embedded {
+		t.Skip("bundled files are not embedded")
+	}
+
+	client, fs := initMutableLSPClient(t, map[string]string{
+		"/root/package.json": `{
+			"name": "tsgo-test",
+			"version": "0.1.0",
+			"type": "module"
+		}`,
+		"/root/tsconfig.base.json": `{
+			"compilerOptions": {
+				"composite": true,
+				"module": "nodenext",
+				"target": "esnext",
+				"types": [],
+				"sourceMap": true,
+				"declaration": true,
+				"declarationMap": true,
+				"strict": true,
+				"jsx": "react-jsx",
+				"verbatimModuleSyntax": true,
+				"isolatedModules": true,
+				"noUncheckedSideEffectImports": true,
+				"moduleDetection": "force",
+				"skipLibCheck": true
+			}
+		}`,
+		"/root/tsconfig.json": `{
+			"files": [],
+			"references": [
+				{ "path": "./projects/a/" }
+			]
+		}`,
+		"/root/projects/a/tsconfig.json": `{
+			"extends": "../../tsconfig.base.json"
+		}`,
+		"/root/projects/a/b.ts": "export const x = 0\n",
+	}, &lsutil.UserPreferences{})
+
+	oldURI := lsconv.FileNameToDocumentURI("/root/projects/a/b.ts")
+	newURI := lsconv.FileNameToDocumentURI("/root/projects/a/b1.ts")
+
+	lsptestutil.SendNotification(t, client, lsproto.TextDocumentDidOpenInfo, &lsproto.DidOpenTextDocumentParams{
+		TextDocument: &lsproto.TextDocumentItem{Uri: oldURI, LanguageId: "typescript", Text: "export const x = 0\n"},
+	})
+
+	assert.NilError(t, fs.Remove("root/projects/a/b.ts"))
+	assert.NilError(t, fs.WriteFile("root/projects/a/b1.ts", "export const x = 0\n", 0o666))
+	lsptestutil.SendNotification(t, client, lsproto.WorkspaceDidChangeWatchedFilesInfo, &lsproto.DidChangeWatchedFilesParams{
+		Changes: []*lsproto.FileEvent{
+			{Uri: oldURI, Type: lsproto.FileChangeTypeDeleted},
+			{Uri: newURI, Type: lsproto.FileChangeTypeCreated},
+		},
+	})
+
+	msg, _, ok := lsptestutil.SendRequest(t, client, lsproto.WorkspaceWillRenameFilesInfo, &lsproto.RenameFilesParams{
+		Files: []*lsproto.FileRename{{
+			OldUri: string(oldURI),
+			NewUri: string(newURI),
+		}},
+	})
+	assert.Assert(t, ok, "expected response")
+	assert.Assert(t, msg.AsResponse().Error == nil)
+}

--- a/internal/project/session.go
+++ b/internal/project/session.go
@@ -1025,7 +1025,9 @@ func (s *Session) GetLanguageServicesForDocuments(ctx context.Context, uris []ls
 	projects := snapshot.ProjectCollection.Projects()
 	services := make([]*ls.LanguageService, 0, len(projects))
 	for _, project := range projects {
-		services = append(services, ls.NewLanguageService(project.configFilePath, project.GetProgram(), snapshot, activeFile))
+		if program := project.GetProgram(); program != nil {
+			services = append(services, ls.NewLanguageService(project.configFilePath, program, snapshot, activeFile))
+		}
 	}
 	return services
 }


### PR DESCRIPTION
Fixes #4019

Skip projects without loaded programs when collecting language services for `workspace/willRenameFiles`. After a watched file rename in a composite project, the session can include a solution/config project whose program is not loaded; constructing a file-rename language service for that project caused a nil pointer panic at `program.Options()`.

This keeps file rename edits scoped to projects that actually have loaded programs, matching the expectations of `LanguageService`.

Adds an LSP regression test covering the composite-project rename + `workspace/didChangeWatchedFiles` scenario from the issue.

## Testing

- `npx hereby all-checks`

## AI Assistance

This PR was authored with AI assistance. I reviewed and understand the changes and will respond to review feedback.
