### PR TITLE
Fix and simplify JSDoc handling for binding elements

### DIFF
--- a/internal/fourslash/tests/destructuredIntersectionJSDoc_test.go
+++ b/internal/fourslash/tests/destructuredIntersectionJSDoc_test.go
@@ -1,0 +1,45 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestDestructuredIntersectionJSDoc(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `
+type X = {
+    /** Description of a. */
+    a: {}
+}
+
+type Y = X & { a: {} }
+
+declare function f({ /*1*/a }: Y): void
+`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineHover(t)
+}
+
+func TestDestructuredIntersectionJSDocVariable(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `
+type X = {
+    /** Description of a. */
+    a: {}
+}
+
+type Y = X & { a: {} }
+
+declare const y: Y;
+const { /*1*/a } = y;
+`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineHover(t)
+}

--- a/internal/ls/hover.go
+++ b/internal/ls/hover.go
@@ -152,37 +152,9 @@ func (l *LanguageService) getDocumentationFromDeclaration(c *checker.Checker, sy
 	if declaration == nil {
 		return ""
 	}
-
 	isMarkdown := contentFormat == lsproto.MarkupKindMarkdown
 	var b strings.Builder
-	jsdoc := getJSDocOrTag(c, declaration)
-
-	// Handle binding elements specially (variables created from destructuring) - we need to get the documentation from the property type
-	// If the binding element doesn't have its own JSDoc, fall back to the property's JSDoc
-	if jsdoc == nil && symbol != nil && symbol.ValueDeclaration != nil && ast.IsBindingElement(symbol.ValueDeclaration) && ast.IsIdentifier(location) {
-		bindingElement := symbol.ValueDeclaration
-		parent := bindingElement.Parent
-		name := bindingElement.PropertyName()
-		if name == nil {
-			name = bindingElement.Name()
-		}
-		if ast.IsIdentifier(name) && ast.IsObjectBindingPattern(parent) {
-			propertyName := name.Text()
-			objectType := c.GetTypeAtLocation(parent)
-			if objectType != nil {
-				propertySymbol := findPropertyInType(c, objectType, propertyName)
-				if propertySymbol != nil && propertySymbol.ValueDeclaration != nil {
-					jsdoc = getJSDocOrTag(c, propertySymbol.ValueDeclaration)
-					if jsdoc != nil {
-						// Use property declaration for typedef check
-						declaration = propertySymbol.ValueDeclaration
-					}
-				}
-			}
-		}
-	}
-
-	if jsdoc != nil && !(declaration.Flags&ast.NodeFlagsReparsed == 0 && containsTypedefTag(jsdoc)) {
+	if jsdoc := getJSDocOrTag(c, declaration); jsdoc != nil && !(declaration.Flags&ast.NodeFlagsReparsed == 0 && containsTypedefTag(jsdoc)) {
 		l.writeComments(&b, c, jsdoc.Comments(), isMarkdown)
 		if jsdoc.Kind == ast.KindJSDoc && !commentOnly {
 			if tags := jsdoc.AsJSDoc().Tags; tags != nil {
@@ -800,6 +772,18 @@ func getJSDocOrTag(c *checker.Checker, node *ast.Node) *ast.Node {
 	case (ast.IsFunctionExpressionOrArrowFunction(node) || ast.IsClassExpression(node)) &&
 		(ast.IsVariableDeclaration(node.Parent) || ast.IsPropertyDeclaration(node.Parent) || ast.IsPropertyAssignment(node.Parent)) && node.Parent.Initializer() == node:
 		return getJSDocOrTag(c, node.Parent)
+	case ast.IsBindingElement(node) && ast.IsObjectBindingPattern(node.Parent):
+		if name := node.PropertyNameOrName(); ast.IsIdentifier(name) {
+			if objectType := c.GetTypeAtLocation(node.Parent); objectType != nil {
+				if prop := c.GetPropertyOfType(objectType, name.Text()); prop != nil {
+					for _, d := range prop.Declarations {
+						if jsdoc := getJSDoc(d); jsdoc != nil {
+							return jsdoc
+						}
+					}
+				}
+			}
+		}
 	}
 	if symbol := node.Symbol(); symbol != nil && node.Parent != nil {
 		if ast.IsFunctionDeclaration(node) || ast.IsMethodDeclaration(node) || ast.IsMethodSignatureDeclaration(node) || ast.IsConstructorDeclaration(node) || ast.IsConstructSignatureDeclaration(node) {
@@ -1024,20 +1008,6 @@ func writeQuotedString(b *strings.Builder, str string, quote bool) {
 	} else {
 		b.WriteString(str)
 	}
-}
-
-// findPropertyInType finds a property in a type, handling union types by searching constituent types
-func findPropertyInType(c *checker.Checker, objectType *checker.Type, propertyName string) *ast.Symbol {
-	// For union types, try to find the property in any of the constituent types
-	if objectType.IsUnion() {
-		for _, t := range objectType.Types() {
-			if prop := c.GetPropertyOfType(t, propertyName); prop != nil {
-				return prop
-			}
-		}
-		return nil
-	}
-	return c.GetPropertyOfType(objectType, propertyName)
 }
 
 func getEntityNameString(name *ast.Node) string {

--- a/testdata/baselines/reference/fourslash/quickInfo/destructuredIntersectionJSDoc.baseline
+++ b/testdata/baselines/reference/fourslash/quickInfo/destructuredIntersectionJSDoc.baseline
@@ -1,0 +1,48 @@
+// === QuickInfo ===
+=== /destructuredIntersectionJSDoc.ts ===
+// 
+// type X = {
+//     /** Description of a. */
+//     a: {}
+// }
+// 
+// type Y = X & { a: {} }
+// 
+// declare function f({ a }: Y): void
+//                      ^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (parameter) a: {}
+// | ```
+// | Description of a.
+// | ----------------------------------------------------------------------
+// 
+[
+  {
+    "marker": {
+      "Position": 99,
+      "LSPosition": {
+        "line": 8,
+        "character": 21
+      },
+      "Name": "1",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(parameter) a: {}\n```\nDescription of a."
+      },
+      "range": {
+        "start": {
+          "line": 8,
+          "character": 21
+        },
+        "end": {
+          "line": 8,
+          "character": 22
+        }
+      }
+    }
+  }
+]

--- a/testdata/baselines/reference/fourslash/quickInfo/destructuredIntersectionJSDocVariable.baseline
+++ b/testdata/baselines/reference/fourslash/quickInfo/destructuredIntersectionJSDocVariable.baseline
@@ -1,0 +1,49 @@
+// === QuickInfo ===
+=== /destructuredIntersectionJSDocVariable.ts ===
+// 
+// type X = {
+//     /** Description of a. */
+//     a: {}
+// }
+// 
+// type Y = X & { a: {} }
+// 
+// declare const y: Y;
+// const { a } = y;
+//         ^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | const a: {}
+// | ```
+// | Description of a.
+// | ----------------------------------------------------------------------
+// 
+[
+  {
+    "marker": {
+      "Position": 106,
+      "LSPosition": {
+        "line": 9,
+        "character": 8
+      },
+      "Name": "1",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nconst a: {}\n```\nDescription of a."
+      },
+      "range": {
+        "start": {
+          "line": 9,
+          "character": 8
+        },
+        "end": {
+          "line": 9,
+          "character": 9
+        }
+      }
+    }
+  }
+]


### PR DESCRIPTION
This PR fixes our quick info JSDoc handling for destructuring of intersections and also simplifies our implementation of quick info JSDoc for binding elements.

Note that Corsa only displays JSDoc from one source property whereas Strada displays JSDoc from all source properties. It is generally true that Corsa only displays JSDoc from one source, which often is preferable to avoid duplication. We could consider displaying JSDoc from multiple sources, though that would be a separate PR.

Fixes #3405.