### PR TITLE
Fix resolveNodeHandle to check not only child nodes but ancestor nodes

### DIFF
--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -1838,7 +1838,7 @@ func (s *Session) resolveNodeHandle(program *compiler.Program, handle Handle[ast
 	}
 
 	// Verify the kind and end match
-	if node.Kind != kind || node.End() != end {
+	if node.Kind != kind || node.Pos() != pos || node.End() != end {
 		// Try to find the exact node by walking ancestors
 		for parent := node.Parent; parent != nil && parent.Kind != ast.KindSourceFile; parent = parent.Parent {
 			if parent.Pos() == pos && parent.End() == end && parent.Kind == kind {

--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -1839,6 +1839,12 @@ func (s *Session) resolveNodeHandle(program *compiler.Program, handle Handle[ast
 
 	// Verify the kind and end match
 	if node.Kind != kind || node.End() != end {
+		// Try to find the exact node by walking ancestors
+		for parent := node.Parent; parent != nil && parent.Kind != ast.KindSourceFile; parent = parent.Parent {
+			if parent.Pos() == pos && parent.End() == end && parent.Kind == kind {
+				return parent, nil
+			}
+		}
 		// Try to find the exact node by walking children
 		var found *ast.Node
 		node.ForEachChild(func(child *ast.Node) bool {


### PR DESCRIPTION
Fixes #3938 

Add ancestor traversals in `resolveNodeHandle` to detect the actual Node.  
Since `ast.GetNodeAtPosition` only uses `pos` (not `pos` and `end`), some nodes may be hidden by their children (with same `pos`), such as `PropertyAccessExpression` (itself and `expression` node may be the same `pos`, and if `expression` is such as `Expression` node, `ast.GetNodeAtPosition` returns `expression`, not the parent `PropertyAccessExpression`).
This PR fixes those patterns.