### PR TITLE
Don't use cached type node when expanding

### DIFF
--- a/internal/checker/nodebuilderimpl.go
+++ b/internal/checker/nodebuilderimpl.go
@@ -3001,7 +3001,8 @@ func (b *NodeBuilderImpl) visitAndTransformType(t *Type, transform func(b *NodeB
 
 	key := CompositeTypeCacheIdentity{typeId, b.ctx.flags, b.ctx.internalFlags}
 	// Don't rely on type cache if we're expanding a type, because we need to compute `canIncreaseExpansionDepth`.
-	if b.ctx.maxExpansionDepth < 0 && b.ctx.enclosingDeclaration != nil && b.links.Has(b.ctx.enclosingDeclaration) {
+	canUseCache := b.ctx.maxExpansionDepth < 0
+	if canUseCache && b.ctx.enclosingDeclaration != nil && b.links.Has(b.ctx.enclosingDeclaration) {
 		links := b.links.Get(b.ctx.enclosingDeclaration)
 		cachedResult, ok := links.serializedTypes[key]
 		if ok {
@@ -3031,7 +3032,7 @@ func (b *NodeBuilderImpl) visitAndTransformType(t *Type, transform func(b *NodeB
 	startLength := b.ctx.approximateLength
 	result := transform(b, t)
 	addedLength := b.ctx.approximateLength - startLength
-	if !b.ctx.reportedDiagnostic && !b.ctx.encounteredError {
+	if canUseCache && !b.ctx.reportedDiagnostic && !b.ctx.encounteredError {
 		links := b.links.Get(b.ctx.enclosingDeclaration)
 		if links.serializedTypes == nil {
 			links.serializedTypes = make(map[CompositeTypeCacheIdentity]*SerializedTypeEntry)

--- a/internal/checker/nodebuilderimpl.go
+++ b/internal/checker/nodebuilderimpl.go
@@ -3000,7 +3000,8 @@ func (b *NodeBuilderImpl) visitAndTransformType(t *Type, transform func(b *NodeB
 	// of types allows us to catch circular references to instantiations of the same anonymous type
 
 	key := CompositeTypeCacheIdentity{typeId, b.ctx.flags, b.ctx.internalFlags}
-	if b.ctx.maxExpansionDepth <= 0 && b.ctx.enclosingDeclaration != nil && b.links.Has(b.ctx.enclosingDeclaration) {
+	// Don't rely on type cache if we're expanding a type, because we need to compute `canIncreaseExpansionDepth`.
+	if b.ctx.maxExpansionDepth < 0 && b.ctx.enclosingDeclaration != nil && b.links.Has(b.ctx.enclosingDeclaration) {
 		links := b.links.Get(b.ctx.enclosingDeclaration)
 		cachedResult, ok := links.serializedTypes[key]
 		if ok {

--- a/internal/checker/printer.go
+++ b/internal/checker/printer.go
@@ -198,9 +198,11 @@ func (c *Checker) typeToStringEx(t *Type, enclosingDeclaration *ast.Node, flags 
 		combinedFlags = combinedFlags | nodebuilder.FlagsNoTruncation
 	}
 	nodeBuilder := c.getNodeBuilder()
-	if vc != nil {
-		nodeBuilder.verbosity = vc
-	}
+	oldVerbosity := nodeBuilder.verbosity
+	nodeBuilder.verbosity = vc
+	defer func() {
+		nodeBuilder.verbosity = oldVerbosity
+	}()
 	typeNode := nodeBuilder.TypeToTypeNode(t, enclosingDeclaration, combinedFlags, nodebuilder.InternalFlagsNone, nil)
 	if typeNode == nil {
 		panic("should always get typenode")
@@ -320,9 +322,11 @@ func (c *Checker) signatureToStringEx(signature *Signature, enclosingDeclaration
 	}
 
 	nodeBuilder := c.getNodeBuilder()
-	if vc != nil {
-		nodeBuilder.verbosity = vc
-	}
+	oldVerbosity := nodeBuilder.verbosity
+	nodeBuilder.verbosity = vc
+	defer func() {
+		nodeBuilder.verbosity = oldVerbosity
+	}()
 	combinedFlags := toNodeBuilderFlags(flags) | nodebuilder.FlagsIgnoreErrors | nodebuilder.FlagsWriteTypeParametersInQualifiedName
 	sig := nodeBuilder.SignatureToSignatureDeclaration(signature, sigOutput, enclosingDeclaration, combinedFlags, nodebuilder.InternalFlagsNone, nil)
 	p := createPrinterWithRemoveCommentsOmitTrailingSemicolonNeverAsciiEscape(nodeBuilder.EmitContext())
@@ -412,7 +416,11 @@ func (c *Checker) SignatureToSignatureDeclaration(signature *Signature, kind ast
 // ExpandSymbolForHover produces declaration strings for a symbol with verbosity support for expandable hover.
 func (c *Checker) ExpandSymbolForHover(symbol *ast.Symbol, meaning ast.SymbolFlags, vc *VerbosityContext) string {
 	nodeBuilder := c.getNodeBuilder()
+	oldVerbosity := nodeBuilder.verbosity
 	nodeBuilder.verbosity = vc
+	defer func() {
+		nodeBuilder.verbosity = oldVerbosity
+	}()
 	nodes := nodeBuilder.ExpandSymbolForHover(symbol, meaning)
 	if len(nodes) == 0 {
 		return ""
@@ -435,7 +443,11 @@ func (c *Checker) ExpandSymbolForHover(symbol *ast.Symbol, meaning ast.SymbolFla
 // TypeParameterToStringEx renders a type parameter declaration (e.g. "T extends Foo") with optional verbosity support.
 func (c *Checker) TypeParameterToStringEx(t *Type, enclosingDeclaration *ast.Node, vc *VerbosityContext) string {
 	nodeBuilder := c.getNodeBuilder()
+	oldVerbosity := nodeBuilder.verbosity
 	nodeBuilder.verbosity = vc
+	defer func() {
+		nodeBuilder.verbosity = oldVerbosity
+	}()
 	typeParamNode := nodeBuilder.TypeParameterToDeclaration(t, enclosingDeclaration, nodebuilder.FlagsIgnoreErrors, nodebuilder.InternalFlagsNone, nil)
 	if typeParamNode == nil {
 		return c.TypeToString(t)

--- a/internal/fourslash/tests/quickinfoVerbosityIncreaseDecrease_test.go
+++ b/internal/fourslash/tests/quickinfoVerbosityIncreaseDecrease_test.go
@@ -1,0 +1,64 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestQuickinfoVerbosityIncreaseDecrease(t *testing.T) {
+	fourslash.SkipIfFailing(t)
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `export const JOB_STATES = ["created", "active", "completed", "failed", "retry", "cancelled", "archive"] as const
+export type JobState = (typeof JOB_STATES)[number]
+type Color = "default" | "primary" | "secondary" | "success" | "warning" | "danger"
+const JobsStateToColor/*a*/: Record<
+  JobState,
+  {
+    color: Color
+    label: string
+    labelPlural: string
+  }
+> = {
+  created: {
+    color: "success",
+    label: "Направљен",
+    labelPlural: "Направљени",
+  },
+  active: {
+    color: "success",
+    label: "Активан",
+    labelPlural: "Активни",
+  },
+  completed: {
+    color: "success",
+    label: "Успешан",
+    labelPlural: "Успешни",
+  },
+  cancelled: {
+    color: "default",
+    label: "Отаказан",
+    labelPlural: "Отаказни",
+  },
+  failed: {
+    color: "danger",
+    label: "Пао",
+    labelPlural: "Пали",
+  },
+  archive: {
+    color: "default",
+    label: "Архивиран",
+    labelPlural: "Архивирани",
+  },
+  retry: {
+    color: "warning",
+    label: "Понавља се",
+    labelPlural: "Понављају се",
+  },
+}`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineHoverWithVerbosity(t, map[string][]int{"a": {0, 1, 0}})
+}

--- a/testdata/baselines/reference/fourslash/quickInfo/quickinfoVerbosityIncreaseDecrease.baseline
+++ b/testdata/baselines/reference/fourslash/quickInfo/quickinfoVerbosityIncreaseDecrease.baseline
@@ -1,0 +1,179 @@
+// === QuickInfo ===
+=== /quickinfoVerbosityIncreaseDecrease.ts ===
+// export const JOB_STATES = ["created", "active", "completed", "failed", "retry", "cancelled", "archive"] as const
+// export type JobState = (typeof JOB_STATES)[number]
+// type Color = "default" | "primary" | "secondary" | "success" | "warning" | "danger"
+// const JobsStateToColor: Record<
+//       ^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | const JobsStateToColor: Record<"active" | "archive" | "cancelled" | "completed" | "created" | "failed" | "retry", {
+// |     color: Color;
+// |     label: string;
+// |     labelPlural: string;
+// | }>
+// | ```
+// | 
+// | (verbosity level: 0)
+// | ----------------------------------------------------------------------
+//       ^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | const JobsStateToColor: Record<"active" | "archive" | "cancelled" | "completed" | "created" | "failed" | "retry", {
+// |     color: "danger" | "default" | "primary" | "secondary" | "success" | "warning";
+// |     label: string;
+// |     labelPlural: string;
+// | }>
+// | ```
+// | 
+// | (verbosity level: 1)
+// | ----------------------------------------------------------------------
+//       ^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | const JobsStateToColor: Record<"active" | "archive" | "cancelled" | "completed" | "created" | "failed" | "retry", {
+// |     color: Color;
+// |     label: string;
+// |     labelPlural: string;
+// | }>
+// | ```
+// | 
+// | (verbosity level: 0)
+// | ----------------------------------------------------------------------
+//   JobState,
+//   {
+//     color: Color
+//     label: string
+//     labelPlural: string
+//   }
+// > = {
+//   created: {
+//     color: "success",
+//     label: "Направљен",
+//     labelPlural: "Направљени",
+//   },
+//   active: {
+//     color: "success",
+//     label: "Активан",
+//     labelPlural: "Активни",
+//   },
+//   completed: {
+//     color: "success",
+//     label: "Успешан",
+//     labelPlural: "Успешни",
+//   },
+//   cancelled: {
+//     color: "default",
+//     label: "Отаказан",
+//     labelPlural: "Отаказни",
+//   },
+//   failed: {
+//     color: "danger",
+//     label: "Пао",
+//     labelPlural: "Пали",
+//   },
+//   archive: {
+//     color: "default",
+//     label: "Архивиран",
+//     labelPlural: "Архивирани",
+//   },
+//   retry: {
+//     color: "warning",
+//     label: "Понавља се",
+//     labelPlural: "Понављају се",
+//   },
+// }
+[
+  {
+    "marker": {
+      "Position": 270,
+      "LSPosition": {
+        "line": 3,
+        "character": 22
+      },
+      "Name": "a",
+      "Data": {}
+    },
+    "item": {
+      "hover": {
+        "contents": {
+          "kind": "markdown",
+          "value": "```typescript\nconst JobsStateToColor: Record<\"active\" | \"archive\" | \"cancelled\" | \"completed\" | \"created\" | \"failed\" | \"retry\", {\n    color: Color;\n    label: string;\n    labelPlural: string;\n}>\n```\n"
+        },
+        "range": {
+          "start": {
+            "line": 3,
+            "character": 6
+          },
+          "end": {
+            "line": 3,
+            "character": 22
+          }
+        },
+        "canIncreaseVerbosity": true
+      },
+      "verbosityLevel": 0
+    }
+  },
+  {
+    "marker": {
+      "Position": 270,
+      "LSPosition": {
+        "line": 3,
+        "character": 22
+      },
+      "Name": "a",
+      "Data": {}
+    },
+    "item": {
+      "hover": {
+        "contents": {
+          "kind": "markdown",
+          "value": "```typescript\nconst JobsStateToColor: Record<\"active\" | \"archive\" | \"cancelled\" | \"completed\" | \"created\" | \"failed\" | \"retry\", {\n    color: \"danger\" | \"default\" | \"primary\" | \"secondary\" | \"success\" | \"warning\";\n    label: string;\n    labelPlural: string;\n}>\n```\n"
+        },
+        "range": {
+          "start": {
+            "line": 3,
+            "character": 6
+          },
+          "end": {
+            "line": 3,
+            "character": 22
+          }
+        }
+      },
+      "verbosityLevel": 1
+    }
+  },
+  {
+    "marker": {
+      "Position": 270,
+      "LSPosition": {
+        "line": 3,
+        "character": 22
+      },
+      "Name": "a",
+      "Data": {}
+    },
+    "item": {
+      "hover": {
+        "contents": {
+          "kind": "markdown",
+          "value": "```typescript\nconst JobsStateToColor: Record<\"active\" | \"archive\" | \"cancelled\" | \"completed\" | \"created\" | \"failed\" | \"retry\", {\n    color: Color;\n    label: string;\n    labelPlural: string;\n}>\n```\n"
+        },
+        "range": {
+          "start": {
+            "line": 3,
+            "character": 6
+          },
+          "end": {
+            "line": 3,
+            "character": 22
+          }
+        },
+        "canIncreaseVerbosity": true
+      },
+      "verbosityLevel": 0
+    }
+  }
+]


### PR DESCRIPTION
Also properly set verbosity on reusable node builder.
Fixes #4010.