### PR TITLE
Fix configuration lookups and prefer saving as `js/ts`

### DIFF
--- a/_extension/src/commands.ts
+++ b/_extension/src/commands.ts
@@ -7,7 +7,10 @@ import type {
 } from "vscode-languageclient";
 
 import type * as tr from "./telemetryReporting";
-import { getExplicitConfigTarget, restartExtHostOnChangeIfNeeded } from "./util";
+import {
+    getExplicitConfigTarget,
+    restartExtHostOnChangeIfNeeded,
+} from "./util";
 
 export function registerEnablementCommands(context: vscode.ExtensionContext, telemetryReporter: tr.TelemetryReporter): void {
     context.subscriptions.push(vscode.commands.registerCommand("typescript.native-preview.enable", () => {

--- a/_extension/src/commands.ts
+++ b/_extension/src/commands.ts
@@ -7,7 +7,7 @@ import type {
 } from "vscode-languageclient";
 
 import type * as tr from "./telemetryReporting";
-import { restartExtHostOnChangeIfNeeded } from "./util";
+import { getExplicitConfigTarget, restartExtHostOnChangeIfNeeded } from "./util";
 
 export function registerEnablementCommands(context: vscode.ExtensionContext, telemetryReporter: tr.TelemetryReporter): void {
     context.subscriptions.push(vscode.commands.registerCommand("typescript.native-preview.enable", () => {
@@ -34,26 +34,28 @@ export async function updateUseTsgoSetting(enable: boolean): Promise<void> {
     const jsTsTarget = getExplicitConfigTarget(jsTsConfig, "experimental.useTsgo");
     const tsTarget = getExplicitConfigTarget(tsConfig, "experimental.useTsgo");
 
-    if (jsTsTarget !== undefined || tsTarget === undefined) {
-        await jsTsConfig.update("experimental.useTsgo", enable, jsTsTarget ?? vscode.ConfigurationTarget.Global);
-    }
-    else if (tsTarget !== undefined) {
-        await tsConfig.update("experimental.useTsgo", enable, tsTarget);
+    // If any are defined, we'll use the most-specific target,
+    // but we'll only set it through `js/ts`.
+    if (jsTsTarget !== undefined || tsTarget !== undefined) {
+        const updates = [];
+
+        const mostSpecificTarget = Math.max(
+            jsTsTarget ?? vscode.ConfigurationTarget.Global,
+            tsTarget ?? vscode.ConfigurationTarget.Global,
+        );
+        updates.push(jsTsConfig.update("experimental.useTsgo", enable, mostSpecificTarget));
+
+        // If `typescript` had the most-specific target
+        // (or shared the most-specific target), then
+        // we'll erase that since we've just set `js/ts` above.
+        if (tsTarget === mostSpecificTarget) {
+            updates.push(tsConfig.update("experimental.useTsgo", undefined, mostSpecificTarget));
+        }
+
+        await Promise.all(updates);
     }
 
     return restartExtHostOnChangeIfNeeded();
-}
-
-function getExplicitConfigTarget(
-    config: vscode.WorkspaceConfiguration,
-    key: string,
-): vscode.ConfigurationTarget | undefined {
-    const inspection = config.inspect(key);
-    if (!inspection) return undefined;
-    if (inspection.workspaceFolderValue !== undefined) return vscode.ConfigurationTarget.WorkspaceFolder;
-    if (inspection.workspaceValue !== undefined) return vscode.ConfigurationTarget.Workspace;
-    if (inspection.globalValue !== undefined) return vscode.ConfigurationTarget.Global;
-    return undefined;
 }
 
 export const codeLensShowLocationsCommandName = "typescript.native-preview.codeLens.showLocations";

--- a/_extension/src/commands.ts
+++ b/_extension/src/commands.ts
@@ -28,22 +28,20 @@ export function registerEnablementCommands(context: vscode.ExtensionContext, tel
  * Handles both `js/ts.experimental.useTsgo` and `typescript.experimental.useTsgo`.
  */
 export async function updateUseTsgoSetting(enable: boolean): Promise<void> {
-    const tsConfig = vscode.workspace.getConfiguration("typescript");
     const jsTsConfig = vscode.workspace.getConfiguration("js/ts");
+    const tsConfig = vscode.workspace.getConfiguration("typescript");
 
-    const tsTarget = getExplicitConfigTarget(tsConfig, "experimental.useTsgo");
     const jsTsTarget = getExplicitConfigTarget(jsTsConfig, "experimental.useTsgo");
+    const tsTarget = getExplicitConfigTarget(tsConfig, "experimental.useTsgo");
 
-    const updates: Thenable<void>[] = [];
-    if (jsTsTarget !== undefined) {
-        updates.push(jsTsConfig.update("experimental.useTsgo", enable, jsTsTarget));
+    if (jsTsTarget !== undefined || tsTarget === undefined) {
+        await jsTsConfig.update("experimental.useTsgo", enable, jsTsTarget ?? vscode.ConfigurationTarget.Global);
     }
-    if (tsTarget !== undefined || jsTsTarget === undefined) {
-        updates.push(tsConfig.update("experimental.useTsgo", enable, tsTarget ?? vscode.ConfigurationTarget.Global));
+    else if (tsTarget !== undefined) {
+        await tsConfig.update("experimental.useTsgo", enable, tsTarget);
     }
-    await Promise.all(updates);
 
-    await restartExtHostOnChangeIfNeeded();
+    return restartExtHostOnChangeIfNeeded();
 }
 
 function getExplicitConfigTarget(

--- a/_extension/src/extension.ts
+++ b/_extension/src/extension.ts
@@ -98,7 +98,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Extens
             }
         }
         else if (useTsgo === false) {
-            const settingName = getUseTsgoFalseSetting() ?? "typescript.experimental.useTsgo";
+            const settingName = getUseTsgoFalseSetting() ?? "js/ts.experimental.useTsgo";
             vscode.window.showWarningMessage(
                 `TypeScript Native Preview is running in development mode with "${settingName}" set to false.`,
                 "Enable Setting",

--- a/_extension/src/extension.ts
+++ b/_extension/src/extension.ts
@@ -95,6 +95,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Extens
                     "The built-in TypeScript extension is disabled. Sync launch.json with launch.template.json to reenable.",
                     "OK",
                 );
+                return;
             }
         }
         else if (useTsgo === false) {
@@ -108,6 +109,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Extens
                     vscode.commands.executeCommand("typescript.native-preview.enable");
                 }
             });
+            return;
         }
     }
     else if (useTsgo === false) {

--- a/_extension/src/util.ts
+++ b/_extension/src/util.ts
@@ -149,9 +149,10 @@ export async function restartExtHostOnChangeIfNeeded(): Promise<void> {
  *
  * Each setting key is resolved using standard VS Code precedence (workspace
  * folder > workspace > global, with language-specific overrides taking
- * priority within each scope). Returns `true` if either resolved value is
- * `true`, `false` if either is `false` (and neither is `true`), or
- * `undefined` if neither setting has been explicitly configured.
+ * priority within each scope). When both keys are explicitly configured, the
+ * value set at the most specific scope wins, and `js/ts` wins over
+ * `typescript` at the same scope. Returns `undefined` if neither setting has
+ * been explicitly configured.
  */
 export function getUseTsgo(): boolean | undefined {
     const tsValue = getExplicitUseTsgo("typescript");

--- a/_extension/src/util.ts
+++ b/_extension/src/util.ts
@@ -156,8 +156,26 @@ export async function restartExtHostOnChangeIfNeeded(): Promise<void> {
 export function getUseTsgo(): boolean | undefined {
     const tsValue = getExplicitUseTsgo("typescript");
     const jsTsValue = getExplicitUseTsgo("js/ts");
-    if (tsValue === true || jsTsValue === true) return true;
-    if (tsValue === false || jsTsValue === false) return false;
+
+    if (tsValue !== undefined || jsTsValue !== undefined) {
+        const jsTsTarget = getExplicitConfigTarget(vscode.workspace.getConfiguration("js/ts"), "experimental.useTsgo");
+        const tsTarget = getExplicitConfigTarget(vscode.workspace.getConfiguration("typescript"), "experimental.useTsgo");
+        const mostSpecific = Math.max(jsTsTarget ?? vscode.ConfigurationTarget.Global, tsTarget ?? vscode.ConfigurationTarget.Global);
+        return jsTsTarget === mostSpecific ? jsTsValue : tsValue;
+    }
+
+    return undefined;
+}
+
+export function getExplicitConfigTarget(
+    config: vscode.WorkspaceConfiguration,
+    key: string,
+): vscode.ConfigurationTarget | undefined {
+    const inspection = config.inspect(key);
+    if (!inspection) return undefined;
+    if (inspection.workspaceFolderValue !== undefined) return vscode.ConfigurationTarget.WorkspaceFolder;
+    if (inspection.workspaceValue !== undefined) return vscode.ConfigurationTarget.Workspace;
+    if (inspection.globalValue !== undefined) return vscode.ConfigurationTarget.Global;
     return undefined;
 }
 


### PR DESCRIPTION
When modifying the `useTsgo` setting, we would previously modify `typescript.experimental.useTsgo`; however, that setting is deprecated.

Additionally, we would always prefer `js/ts.experimental.useTsgo` over `typescript.experimental.useTsgo`, even if the latter occurred in the workspace, and the former occurred in the global user settings.

And finally, we had a bug in development mode where we would always start the server if `useTsgo` was explicitly `false`.

This PR does a few things:

- Respects specificity of options. `typescript.experimental.useTsgo` can now win out over `js/ts.experimental.useTsgo` if it was specified in the workspace, and `js/ts` was specified in the user settings. If both are specified in the same location, `js/ts` always wins out.
- We always set the `js/ts` configuration when making modifications. If the user toggles the settings via our commands, we will migrate any currently-active `typescript` configurations, or just drop them if they coexist in the same settings location.
- Stops immediately after issuing a warning when `useTsgo === false` in development mode, instead of starting up the language server.

Fixes #3668 when different settings keys are configured.