### PR TITLE
Fix stale pull diagnostics after document edits

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -847,11 +847,12 @@ func registerLanguageServiceDocumentRequestHandler[Req lsproto.HasTextDocumentUR
 
 func registerDocumentDiagnosticHandler(handlers handlerMap) {
 	handlers[lsproto.TextDocumentDiagnosticInfo.Method] = func(s *Server, ctx context.Context, req *lsproto.RequestMessage) (func() error, error) {
-		var params *lsproto.DocumentDiagnosticParams
-		if req.Params != nil {
-			params = req.Params.(*lsproto.DocumentDiagnosticParams)
+		params, ok := req.Params.(*lsproto.DocumentDiagnosticParams)
+		if !ok || params == nil {
+			return nil, lsproto.ErrorCodeInvalidParams
 		}
-		return s.session.WithLanguageServiceAndSnapshot(ctx, params.TextDocumentURI(), func(languageService *ls.LanguageService, snapshot *project.Snapshot) (func() error, error) {
+		documentURI := params.TextDocumentURI()
+		return s.session.WithLanguageServiceAndSnapshot(ctx, documentURI, func(languageService *ls.LanguageService, snapshot *project.Snapshot) (func() error, error) {
 			return func() error {
 				defer s.recover(req)
 				resp, lsErr := s.handleDocumentDiagnostic(ctx, languageService, params)
@@ -864,7 +865,7 @@ func registerDocumentDiagnosticHandler(handlers handlerMap) {
 				if ctx.Err() != nil {
 					return ctx.Err()
 				}
-				if !s.session.IsSnapshotCurrentForDocument(snapshot, params.TextDocument.Uri) {
+				if !s.session.IsSnapshotCurrentForDocument(snapshot, documentURI) {
 					return lsproto.ErrorCodeContentModified
 				}
 				return s.sendResult(req.ID, resp)

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -721,7 +721,7 @@ var handlers = sync.OnceValue(func() handlerMap {
 	registerNotificationHandler(handlers, lsproto.SetTraceInfo, (*Server).handleSetTrace)
 	registerRequestHandler(handlers, lsproto.WorkspaceWillRenameFilesInfo, (*Server).handleWillRenameFiles)
 
-	registerLanguageServiceDocumentRequestHandler(handlers, lsproto.TextDocumentDiagnosticInfo, (*Server).handleDocumentDiagnostic)
+	registerDocumentDiagnosticHandler(handlers)
 	registerLanguageServiceDocumentRequestHandler(handlers, lsproto.TextDocumentHoverInfo, (*Server).handleHover)
 	registerLanguageServiceDocumentRequestHandler(handlers, lsproto.TextDocumentDefinitionInfo, (*Server).handleDefinition)
 	registerLanguageServiceDocumentRequestHandler(handlers, lsproto.CustomTextDocumentSourceDefinitionInfo, (*Server).handleSourceDefinition)
@@ -842,6 +842,34 @@ func registerLanguageServiceDocumentRequestHandler[Req lsproto.HasTextDocumentUR
 			}
 			return s.sendResult(req.ID, resp)
 		}, nil
+	}
+}
+
+func registerDocumentDiagnosticHandler(handlers handlerMap) {
+	handlers[lsproto.TextDocumentDiagnosticInfo.Method] = func(s *Server, ctx context.Context, req *lsproto.RequestMessage) (func() error, error) {
+		var params *lsproto.DocumentDiagnosticParams
+		if req.Params != nil {
+			params = req.Params.(*lsproto.DocumentDiagnosticParams)
+		}
+		return s.session.WithLanguageServiceAndSnapshot(ctx, params.TextDocumentURI(), func(languageService *ls.LanguageService, snapshot *project.Snapshot) (func() error, error) {
+			return func() error {
+				defer s.recover(req)
+				resp, lsErr := s.handleDocumentDiagnostic(ctx, languageService, params)
+				// After any language service request, check if new global diagnostics were
+				// discovered during checking and push updated tsconfig diagnostics if so.
+				s.session.EnqueuePublishGlobalDiagnostics()
+				if lsErr != nil {
+					return lsErr
+				}
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				if !s.session.IsSnapshotCurrentForDocument(snapshot, params.TextDocument.Uri) {
+					return lsproto.ErrorCodeContentModified
+				}
+				return s.sendResult(req.ID, resp)
+			}, nil
+		})
 	}
 }
 

--- a/internal/lsp/server_diagnostics_test.go
+++ b/internal/lsp/server_diagnostics_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/microsoft/typescript-go/internal/bundled"
 	"github.com/microsoft/typescript-go/internal/jsonrpc"
@@ -23,11 +24,95 @@ func TestDocumentDiagnosticCancelsStaleSnapshot(t *testing.T) {
 		t.Skip("bundled files are not embedded")
 	}
 
-	ctx := context.Background()
-	fs := bundled.WrapFS(vfstest.FromMap(map[string]string{
+	server, ctx := newDiagnosticTestServer(t, map[string]string{
 		"/home/projects/tsconfig.json": `{"compilerOptions": {"strict": true}}`,
 		"/home/projects/index.ts":      "let value: string = 1;",
-	}, false))
+	})
+
+	uri := lsconv.FileNameToDocumentURI("/home/projects/index.ts")
+	server.session.DidOpenFile(ctx, uri, 1, "let value: string = 1;", lsproto.LanguageKindTypeScript)
+
+	requestID := jsonrpc.NewIDInt(1)
+	req := lsproto.TextDocumentDiagnosticInfo.NewRequestMessage(requestID, &lsproto.DocumentDiagnosticParams{
+		TextDocument: lsproto.TextDocumentIdentifier{Uri: uri},
+	})
+	doAsyncWork, err := handlers()[lsproto.MethodTextDocumentDiagnostic](server, ctx, req)
+	assert.NilError(t, err)
+	assert.Assert(t, doAsyncWork != nil)
+
+	server.session.DidChangeFile(ctx, uri, 2, []lsproto.TextDocumentContentChangePartialOrWholeDocument{
+		{WholeDocument: &lsproto.TextDocumentContentChangeWholeDocument{Text: `let value: string = "ok";`}},
+	})
+	_, err = server.session.GetLanguageService(ctx, uri)
+	assert.NilError(t, err)
+
+	err = doAsyncWork()
+	assert.Assert(t, errors.Is(err, lsproto.ErrorCodeContentModified), "expected stale diagnostics to be rejected, got %v", err)
+}
+
+func TestDocumentDiagnosticAllowsUnrelatedPendingChange(t *testing.T) {
+	t.Parallel()
+	if !bundled.Embedded {
+		t.Skip("bundled files are not embedded")
+	}
+
+	server, ctx := newDiagnosticTestServer(t, map[string]string{
+		"/home/projects/one/tsconfig.json": `{"compilerOptions": {"strict": true}}`,
+		"/home/projects/one/index.ts":      "let value: string = 1;",
+		"/home/projects/two/tsconfig.json": `{"compilerOptions": {"strict": true}}`,
+		"/home/projects/two/other.ts":      "let other: number = 1;",
+	})
+
+	uri := lsconv.FileNameToDocumentURI("/home/projects/one/index.ts")
+	otherURI := lsconv.FileNameToDocumentURI("/home/projects/two/other.ts")
+	server.session.DidOpenFile(ctx, uri, 1, "let value: string = 1;", lsproto.LanguageKindTypeScript)
+	server.session.DidOpenFile(ctx, otherURI, 1, "let other: number = 1;", lsproto.LanguageKindTypeScript)
+
+	requestID := jsonrpc.NewIDInt(1)
+	req := lsproto.TextDocumentDiagnosticInfo.NewRequestMessage(requestID, &lsproto.DocumentDiagnosticParams{
+		TextDocument: lsproto.TextDocumentIdentifier{Uri: uri},
+	})
+	doAsyncWork, err := handlers()[lsproto.MethodTextDocumentDiagnostic](server, ctx, req)
+	assert.NilError(t, err)
+	assert.Assert(t, doAsyncWork != nil)
+
+	server.session.DidChangeFile(ctx, otherURI, 2, []lsproto.TextDocumentContentChangePartialOrWholeDocument{
+		{WholeDocument: &lsproto.TextDocumentContentChangeWholeDocument{Text: "let other: number = 2;"}},
+	})
+
+	err = doAsyncWork()
+	assert.NilError(t, err)
+	select {
+	case msg := <-server.outgoingQueue:
+		assert.Assert(t, msg.AsResponse().Error == nil)
+	case <-time.After(time.Second):
+		t.Fatal("expected diagnostic response")
+	}
+}
+
+func TestDocumentDiagnosticRejectsMissingParams(t *testing.T) {
+	t.Parallel()
+
+	server := NewServer(&ServerOptions{
+		Err: io.Discard,
+		Cwd: "/home/projects",
+		FS:  bundled.WrapFS(vfstest.FromMap(map[string]string{}, false)),
+	})
+	req := &lsproto.RequestMessage{
+		ID:     jsonrpc.NewIDInt(1),
+		Method: lsproto.MethodTextDocumentDiagnostic,
+	}
+
+	doAsyncWork, err := handlers()[lsproto.MethodTextDocumentDiagnostic](server, context.Background(), req)
+	assert.Assert(t, doAsyncWork == nil)
+	assert.Assert(t, errors.Is(err, lsproto.ErrorCodeInvalidParams), "expected invalid params, got %v", err)
+}
+
+func newDiagnosticTestServer(t *testing.T, files map[string]string) (*Server, context.Context) {
+	t.Helper()
+
+	ctx := context.Background()
+	fs := bundled.WrapFS(vfstest.FromMap(files, false))
 	server := NewServer(&ServerOptions{
 		Err:                io.Discard,
 		Cwd:                "/home/projects",
@@ -52,23 +137,5 @@ func TestDocumentDiagnosticCancelsStaleSnapshot(t *testing.T) {
 	t.Cleanup(server.session.Close)
 	server.session.InitializeWithUserConfig(lsutil.NewDefaultUserPreferences())
 
-	uri := lsconv.FileNameToDocumentURI("/home/projects/index.ts")
-	server.session.DidOpenFile(ctx, uri, 1, "let value: string = 1;", lsproto.LanguageKindTypeScript)
-
-	requestID := jsonrpc.NewIDInt(1)
-	req := lsproto.TextDocumentDiagnosticInfo.NewRequestMessage(requestID, &lsproto.DocumentDiagnosticParams{
-		TextDocument: lsproto.TextDocumentIdentifier{Uri: uri},
-	})
-	doAsyncWork, err := handlers()[lsproto.MethodTextDocumentDiagnostic](server, ctx, req)
-	assert.NilError(t, err)
-	assert.Assert(t, doAsyncWork != nil)
-
-	server.session.DidChangeFile(ctx, uri, 2, []lsproto.TextDocumentContentChangePartialOrWholeDocument{
-		{WholeDocument: &lsproto.TextDocumentContentChangeWholeDocument{Text: `let value: string = "ok";`}},
-	})
-	_, err = server.session.GetLanguageService(ctx, uri)
-	assert.NilError(t, err)
-
-	err = doAsyncWork()
-	assert.Assert(t, errors.Is(err, lsproto.ErrorCodeContentModified), "expected stale diagnostics to be rejected, got %v", err)
+	return server, ctx
 }

--- a/internal/lsp/server_diagnostics_test.go
+++ b/internal/lsp/server_diagnostics_test.go
@@ -1,0 +1,74 @@
+package lsp
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/bundled"
+	"github.com/microsoft/typescript-go/internal/jsonrpc"
+	"github.com/microsoft/typescript-go/internal/ls/lsconv"
+	"github.com/microsoft/typescript-go/internal/ls/lsutil"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
+	"github.com/microsoft/typescript-go/internal/project"
+	"github.com/microsoft/typescript-go/internal/project/logging"
+	"github.com/microsoft/typescript-go/internal/vfs/vfstest"
+	"gotest.tools/v3/assert"
+)
+
+func TestDocumentDiagnosticCancelsStaleSnapshot(t *testing.T) {
+	t.Parallel()
+	if !bundled.Embedded {
+		t.Skip("bundled files are not embedded")
+	}
+
+	ctx := context.Background()
+	fs := bundled.WrapFS(vfstest.FromMap(map[string]string{
+		"/home/projects/tsconfig.json": `{"compilerOptions": {"strict": true}}`,
+		"/home/projects/index.ts":      "let value: string = 1;",
+	}, false))
+	server := NewServer(&ServerOptions{
+		Err:                io.Discard,
+		Cwd:                "/home/projects",
+		FS:                 fs,
+		DefaultLibraryPath: bundled.LibPath(),
+	})
+	server.backgroundCtx = ctx
+	server.positionEncoding = lsproto.PositionEncodingKindUTF16
+	server.clientCapabilities = (&lsproto.ClientCapabilities{}).Resolve()
+	server.session = project.NewSession(&project.SessionInit{
+		BackgroundCtx: lsproto.WithClientCapabilities(ctx, &server.clientCapabilities),
+		Options: &project.SessionOptions{
+			CurrentDirectory:       "/home/projects",
+			DefaultLibraryPath:     bundled.LibPath(),
+			PositionEncoding:       lsproto.PositionEncodingKindUTF16,
+			PushDiagnosticsEnabled: false,
+		},
+		FS:     fs,
+		Logger: logging.NewTestLogger(),
+		Client: server,
+	})
+	t.Cleanup(server.session.Close)
+	server.session.InitializeWithUserConfig(lsutil.NewDefaultUserPreferences())
+
+	uri := lsconv.FileNameToDocumentURI("/home/projects/index.ts")
+	server.session.DidOpenFile(ctx, uri, 1, "let value: string = 1;", lsproto.LanguageKindTypeScript)
+
+	requestID := jsonrpc.NewIDInt(1)
+	req := lsproto.TextDocumentDiagnosticInfo.NewRequestMessage(requestID, &lsproto.DocumentDiagnosticParams{
+		TextDocument: lsproto.TextDocumentIdentifier{Uri: uri},
+	})
+	doAsyncWork, err := handlers()[lsproto.MethodTextDocumentDiagnostic](server, ctx, req)
+	assert.NilError(t, err)
+	assert.Assert(t, doAsyncWork != nil)
+
+	server.session.DidChangeFile(ctx, uri, 2, []lsproto.TextDocumentContentChangePartialOrWholeDocument{
+		{WholeDocument: &lsproto.TextDocumentContentChangeWholeDocument{Text: `let value: string = "ok";`}},
+	})
+	_, err = server.session.GetLanguageService(ctx, uri)
+	assert.NilError(t, err)
+
+	err = doAsyncWork()
+	assert.Assert(t, errors.Is(err, lsproto.ErrorCodeContentModified), "expected stale diagnostics to be rejected, got %v", err)
+}

--- a/internal/project/session.go
+++ b/internal/project/session.go
@@ -1115,10 +1115,7 @@ func (s *Session) WithLanguageServiceAndSnapshot(
 // IsSnapshotCurrentForDocument reports whether a request-time snapshot still
 // matches the session's current view of a document and its default project.
 func (s *Session) IsSnapshotCurrentForDocument(snapshot *Snapshot, uri lsproto.DocumentUri) bool {
-	s.pendingFileChangesMu.Lock()
-	hasPendingChanges := len(s.pendingFileChanges) > 0
-	s.pendingFileChangesMu.Unlock()
-	if hasPendingChanges {
+	if s.hasPendingChangesForDocument(snapshot, uri) {
 		return false
 	}
 
@@ -1140,6 +1137,31 @@ func (s *Session) IsSnapshotCurrentForDocument(snapshot *Snapshot, uri lsproto.D
 		return requestProject == currentProject
 	}
 	return requestProject.GetProgram() == currentProject.GetProgram()
+}
+
+func (s *Session) hasPendingChangesForDocument(snapshot *Snapshot, uri lsproto.DocumentUri) bool {
+	project := snapshot.GetDefaultProject(uri)
+	documentPath := snapshot.toPath(uri.FileName())
+	s.pendingFileChangesMu.Lock()
+	defer s.pendingFileChangesMu.Unlock()
+	for _, change := range s.pendingFileChanges {
+		if pendingChangeAffectsDocument(snapshot, project, documentPath, change) {
+			return true
+		}
+	}
+	return false
+}
+
+func pendingChangeAffectsDocument(snapshot *Snapshot, project *Project, documentPath tspath.Path, change FileChange) bool {
+	changedFileName := change.URI.FileName()
+	changedPath := snapshot.toPath(changedFileName)
+	if changedPath == documentPath {
+		return true
+	}
+	if project == nil {
+		return false
+	}
+	return changedPath == project.configFilePath || project.HasFile(changedFileName)
 }
 
 func sameFileHandle(a FileHandle, b FileHandle) bool {

--- a/internal/project/session.go
+++ b/internal/project/session.go
@@ -1112,6 +1112,43 @@ func (s *Session) WithLanguageServiceAndSnapshot(
 	}, nil
 }
 
+// IsSnapshotCurrentForDocument reports whether a request-time snapshot still
+// matches the session's current view of a document and its default project.
+func (s *Session) IsSnapshotCurrentForDocument(snapshot *Snapshot, uri lsproto.DocumentUri) bool {
+	s.pendingFileChangesMu.Lock()
+	hasPendingChanges := len(s.pendingFileChanges) > 0
+	s.pendingFileChangesMu.Unlock()
+	if hasPendingChanges {
+		return false
+	}
+
+	s.snapshotMu.RLock()
+	defer s.snapshotMu.RUnlock()
+	currentSnapshot := s.snapshot
+	if currentSnapshot == snapshot {
+		return true
+	}
+
+	fileName := uri.FileName()
+	if !sameFileHandle(snapshot.GetFile(fileName), currentSnapshot.GetFile(fileName)) {
+		return false
+	}
+
+	requestProject := snapshot.GetDefaultProject(uri)
+	currentProject := currentSnapshot.GetDefaultProject(uri)
+	if requestProject == nil || currentProject == nil {
+		return requestProject == currentProject
+	}
+	return requestProject.GetProgram() == currentProject.GetProgram()
+}
+
+func sameFileHandle(a FileHandle, b FileHandle) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.IsOverlay() == b.IsOverlay() && a.Version() == b.Version() && a.Hash() == b.Hash()
+}
+
 // GetLanguageServiceWithAutoImports clones the given snapshot with auto-import
 // preparation for the given URI, without flushing pending file changes.
 // The cloned snapshot will be adopted as the session's current snapshot in the background


### PR DESCRIPTION
Addresses microsoft/vscode#317522

## Summary

This prevents stale `textDocument/diagnostic` responses from being applied after a document has changed.

Diagnostic requests now keep the request-time snapshot, compute diagnostics against it, and then verify that the snapshot still matches the session's current document/default-project state before sending the response. If the document or project has moved on, the server returns `ContentModified` so the client can retry with fresh state instead of showing outdated errors.

## Changes

- Added a diagnostic-specific request handler that preserves the request snapshot.
- Added a session freshness check for request-time document snapshots.
- Added regression coverage for a diagnostic request invalidated by a later edit.

## Validation

- `go test ./internal/lsp -run TestDocumentDiagnosticCancelsStaleSnapshot -v -count=1 -timeout=45s`
- `go test ./internal/lsp -count=1 -timeout=5m`
- `go test ./internal/project -run TestSession -count=1 -timeout=2m`
- `npx hereby check:format`
- `npx hereby lint`
- `npx hereby build`
- `npx hereby test`

Note: `hereby test` passed with the repo warning that the TypeScript submodule is not cloned, so submodule-dependent tests may be skipped.

## Disclosure

AI assistance was used to prepare this patch; I reviewed, tested, and take responsibility for the changes.