### PR TITLE
fix(checker): align template literal inference with tsc UTF-16 surrog…

### DIFF
--- a/internal/checker/relater.go
+++ b/internal/checker/relater.go
@@ -2435,8 +2435,25 @@ func (c *Checker) inferFromLiteralPartsToTemplateLiteral(sourceTexts []string, s
 			addMatch(s, p)
 			pos += len(delim)
 		} else if sourceText := getSourceText(seg); pos < len(sourceText) {
-			_, size := utf8.DecodeRuneInString(sourceText[pos:])
-			addMatch(seg, pos+size)
+			r, size := utf8.DecodeRuneInString(sourceText[pos:])
+
+			if r > 0xFFFF {
+				// Simulating tsc's UTF-16 code unit behavior by splitting the 4-byte UTF-8
+				// sequence of a supplementary character into two 2-byte chunks.
+				matches = append(matches, c.getStringLiteralType(sourceText[pos:pos+2]))
+				newSourceText := sourceText[:pos] + sourceText[pos+2:]
+
+				if seg < lastSourceIndex {
+					newSourceTexts := make([]string, len(sourceTexts))
+					copy(newSourceTexts, sourceTexts)
+					newSourceTexts[seg] = newSourceText
+					sourceTexts = newSourceTexts
+				} else {
+					remainingEndText = newSourceText
+				}
+			} else {
+				addMatch(seg, pos+size)
+			}
 		} else if seg < lastSourceIndex {
 			addMatch(seg+1, 0)
 		} else {
@@ -2446,7 +2463,6 @@ func (c *Checker) inferFromLiteralPartsToTemplateLiteral(sourceTexts []string, s
 	addMatch(lastSourceIndex, len(getSourceText(lastSourceIndex)))
 	return matches
 }
-
 func (c *Checker) getStringLikeTypeForType(t *Type) *Type {
 	if t.flags&(TypeFlagsAny|TypeFlagsStringLike) != 0 {
 		return t

--- a/internal/checker/relater.go
+++ b/internal/checker/relater.go
@@ -4,6 +4,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"unicode/utf16"
 	"unicode/utf8"
 
 	"github.com/microsoft/typescript-go/internal/ast"
@@ -2438,10 +2439,10 @@ func (c *Checker) inferFromLiteralPartsToTemplateLiteral(sourceTexts []string, s
 			r, size := utf8.DecodeRuneInString(sourceText[pos:])
 
 			if r > 0xFFFF {
-				// Simulating tsc's UTF-16 code unit behavior by splitting the 4-byte UTF-8
-				// sequence of a supplementary character into two 2-byte chunks.
-				matches = append(matches, c.getStringLiteralType(sourceText[pos:pos+2]))
-				newSourceText := sourceText[:pos] + sourceText[pos+2:]
+				// Convert the rune to its UTF-16 surrogate pair per Copilot review
+				high, low := utf16.EncodeRune(r)
+				matches = append(matches, c.getStringLiteralType(string(high)))
+				newSourceText := sourceText[:pos] + string(low) + sourceText[pos+size:]
 
 				if seg < lastSourceIndex {
 					newSourceTexts := make([]string, len(sourceTexts))
@@ -2463,6 +2464,7 @@ func (c *Checker) inferFromLiteralPartsToTemplateLiteral(sourceTexts []string, s
 	addMatch(lastSourceIndex, len(getSourceText(lastSourceIndex)))
 	return matches
 }
+
 func (c *Checker) getStringLikeTypeForType(t *Type) *Type {
 	if t.flags&(TypeFlagsAny|TypeFlagsStringLike) != 0 {
 		return t


### PR DESCRIPTION
…ate behavior

Previously, the compiler used utf8.DecodeRuneInString during template literal inference, which consumed the entire 4-byte sequence for supplementary characters (like emojis). This caused inference to fail when matching against standard tsc, which iterates over 2-byte UTF-16 code units. This patch intercepts characters > 0xFFFF and splits them into 2-byte halves to achieve byte-for-byte parity with TypeScript's internal string representation.