### PR TITLE
Use fire and forget client request to avoid deadlocks

### DIFF
--- a/internal/lsp/progress.go
+++ b/internal/lsp/progress.go
@@ -44,7 +44,7 @@ func (r *serverProgressReporter) localize(msg *diagnostics.Message, args ...any)
 }
 
 func (r *serverProgressReporter) createWorkDoneProgress(token string) {
-	_, _ = sendClientRequest(r.server.backgroundCtx, r.server, lsproto.WindowWorkDoneProgressCreateInfo, &lsproto.WorkDoneProgressCreateParams{
+	_ = sendClientRequestFireAndForget(r.server, lsproto.WindowWorkDoneProgressCreateInfo, &lsproto.WorkDoneProgressCreateParams{
 		Token: lsproto.IntegerOrString{String: &token},
 	})
 }

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -305,7 +305,7 @@ func (s *Server) RefreshInlayHints(ctx context.Context) error {
 		return nil
 	}
 
-	if _, err := sendClientRequest(ctx, s, lsproto.WorkspaceInlayHintRefreshInfo, lsproto.NoParams{}); err != nil {
+	if err := sendClientRequestFireAndForget(s, lsproto.WorkspaceInlayHintRefreshInfo, lsproto.NoParams{}); err != nil {
 		return fmt.Errorf("failed to refresh inlay hints: %w", err)
 	}
 	return nil
@@ -316,7 +316,7 @@ func (s *Server) RefreshCodeLens(ctx context.Context) error {
 		return nil
 	}
 
-	if _, err := sendClientRequest(ctx, s, lsproto.WorkspaceCodeLensRefreshInfo, lsproto.NoParams{}); err != nil {
+	if err := sendClientRequestFireAndForget(s, lsproto.WorkspaceCodeLensRefreshInfo, lsproto.NoParams{}); err != nil {
 		return fmt.Errorf("failed to refresh code lens: %w", err)
 	}
 	return nil
@@ -565,6 +565,8 @@ func (s *Server) writeLoop(ctx context.Context) error {
 	}
 }
 
+// WARNING: this should only be called in the async portion of a request handler,
+// otherwise a deadlock can occur.
 func sendClientRequest[Req, Resp any](ctx context.Context, s *Server, info lsproto.RequestInfo[Req, Resp], params Req) (Resp, error) {
 	id := jsonrpc.NewIDString(fmt.Sprintf("ts%d", s.clientSeq.Add(1)))
 	req := info.NewRequestMessage(id, params)


### PR DESCRIPTION
Fixes #4035.

The deadlock scenario this PR fixes is:
- Client sends many requests at once (e.g. when doing a rename that affects a bunch of files, all of them will be opened by the client), enough that the server's request queue is filled and the server's read loop blocks on sending requests to that queue
- Server's dispatch loop sends a request to the client during synchronous handling of a request, and blocks waiting for a response. The client response is never processed because the server's read loop is blocked waiting for the request queue to be drained.

The fix in this PR is to never send a request to the client during the sync parts of request handling, instead using `sendClientRequestFireAndForget`. The only places left that use `sendClientRequest` are config-related requests during initialization, and file watching update requests which are processed async by a task in the session's background queue.