### PR TITLE
Use an expanding dynamic queue for LSP messages

### DIFF
--- a/internal/lsp/dynamic_queue.go
+++ b/internal/lsp/dynamic_queue.go
@@ -2,7 +2,6 @@ package lsp
 
 import (
 	"context"
-	"slices"
 )
 
 // Inspired by Brian C. Mills' "Rethinking Classical Concurrency Patterns" talk:
@@ -52,7 +51,9 @@ func (q *dynamicQueue[T]) Get(ctx context.Context) (T, error) {
 	}
 
 	item := state.items[0]
-	state.items = slices.Delete(state.items, 0, 1)
+	var zero T
+	state.items[0] = zero
+	state.items = state.items[1:]
 
 	if len(state.items) == 0 {
 		q.idle <- state

--- a/internal/lsp/dynamic_queue.go
+++ b/internal/lsp/dynamic_queue.go
@@ -33,6 +33,10 @@ func newDynamicQueue[T any]() *dynamicQueue[T] {
 }
 
 func (q *dynamicQueue[T]) Put(ctx context.Context, item T) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	state, err := q.getAny(ctx)
 	if err != nil {
 		return err
@@ -44,6 +48,11 @@ func (q *dynamicQueue[T]) Put(ctx context.Context, item T) error {
 }
 
 func (q *dynamicQueue[T]) Get(ctx context.Context) (T, error) {
+	if err := ctx.Err(); err != nil {
+		var zero T
+		return zero, err
+	}
+
 	state, err := q.getReady(ctx)
 	if err != nil {
 		var zero T
@@ -56,6 +65,7 @@ func (q *dynamicQueue[T]) Get(ctx context.Context) (T, error) {
 	state.items = state.items[1:]
 
 	if len(state.items) == 0 {
+		state.items = nil
 		q.idle <- state
 	} else {
 		q.ready <- state

--- a/internal/lsp/dynamic_queue.go
+++ b/internal/lsp/dynamic_queue.go
@@ -1,0 +1,83 @@
+package lsp
+
+import (
+	"context"
+	"slices"
+)
+
+// Inspired by Brian C. Mills' "Rethinking Classical Concurrency Patterns" talk:
+// https://www.youtube.com/watch?v=5zXAHh5tJqQ
+//
+// This queue is a state machine, where each state is a channel, "idle" or "ready".
+// Only one caller ever has the actual state struct at a time. The Get function
+// will wait until the the "ready" channel holds the state. Putting an item
+// means grabbing the state from any any channel, modifying it, and putting it
+// back on the "ready" channel. Since this is all managed via contexts, any method
+// can be cancelled while waiting for the state.
+
+type dynamicQueue[T any] struct {
+	idle  chan *dynamicQueueState[T]
+	ready chan *dynamicQueueState[T]
+}
+
+type dynamicQueueState[T any] struct {
+	items []T
+}
+
+func newDynamicQueue[T any]() *dynamicQueue[T] {
+	q := &dynamicQueue[T]{
+		idle:  make(chan *dynamicQueueState[T], 1),
+		ready: make(chan *dynamicQueueState[T], 1),
+	}
+	q.idle <- &dynamicQueueState[T]{}
+	return q
+}
+
+func (q *dynamicQueue[T]) Put(ctx context.Context, item T) error {
+	state, err := q.getAny(ctx)
+	if err != nil {
+		return err
+	}
+
+	state.items = append(state.items, item)
+	q.ready <- state
+	return nil
+}
+
+func (q *dynamicQueue[T]) Get(ctx context.Context) (T, error) {
+	state, err := q.getReady(ctx)
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+
+	item := state.items[0]
+	state.items = slices.Delete(state.items, 0, 1)
+
+	if len(state.items) == 0 {
+		q.idle <- state
+	} else {
+		q.ready <- state
+	}
+	return item, nil
+}
+
+func (q *dynamicQueue[T]) getAny(ctx context.Context) (*dynamicQueueState[T], error) {
+	select {
+	case state := <-q.idle:
+		return state, nil
+	case state := <-q.ready:
+		return state, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (q *dynamicQueue[T]) getReady(ctx context.Context) (*dynamicQueueState[T], error) {
+	select {
+	case state := <-q.ready:
+		return state, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}

--- a/internal/lsp/dynamic_queue.go
+++ b/internal/lsp/dynamic_queue.go
@@ -9,8 +9,8 @@ import (
 //
 // This queue is a state machine, where each state is a channel, "idle" or "ready".
 // Only one caller ever has the actual state struct at a time. The Get function
-// will wait until the the "ready" channel holds the state. Putting an item
-// means grabbing the state from any any channel, modifying it, and putting it
+// will wait until the "ready" channel holds the state. Putting an item
+// means grabbing the state from any channel, modifying it, and putting it
 // back on the "ready" channel. Since this is all managed via contexts, any method
 // can be cancelled while waiting for the state.
 

--- a/internal/lsp/dynamic_queue_test.go
+++ b/internal/lsp/dynamic_queue_test.go
@@ -1,0 +1,78 @@
+package lsp
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestDynamicQueueFIFO(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	q := newDynamicQueue[int]()
+
+	for i := range 1000 {
+		if err := q.Put(ctx, i); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for i := range 1000 {
+		got, err := q.Get(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != i {
+			t.Fatalf("Get() = %d, want %d", got, i)
+		}
+	}
+}
+
+func TestDynamicQueueGetCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	q := newDynamicQueue[int]()
+	got, err := q.Get(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Get() error = %v, want %v", err, context.Canceled)
+	}
+	if got != 0 {
+		t.Fatalf("Get() = %d, want zero value", got)
+	}
+}
+
+func TestDynamicQueuePutCancellationWhileStateUnavailable(t *testing.T) {
+	t.Parallel()
+
+	q := newDynamicQueue[int]()
+	state, err := q.getAny(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	putErr := q.Put(ctx, 1)
+	if !errors.Is(putErr, context.Canceled) {
+		t.Fatalf("Put() error = %v, want %v", putErr, context.Canceled)
+	}
+
+	q.idle <- state
+
+	err = q.Put(t.Context(), 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := q.Get(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 2 {
+		t.Fatalf("Get() = %d, want 2", got)
+	}
+}

--- a/internal/lsp/logger.go
+++ b/internal/lsp/logger.go
@@ -37,11 +37,10 @@ func (l *logger) sendLogMessage(msgType lsproto.MessageType, message string) {
 		Message: message,
 	})
 
-	select {
-	case l.server.outgoingQueue <- notification.Message():
-		// sent
-	case <-l.server.backgroundCtx.Done():
-		fmt.Fprintln(l.server.stderr, message)
+	if err := l.server.outgoingQueue.Put(l.server.backgroundCtx, notification.Message()); err != nil {
+		if l.server.backgroundCtx.Err() != nil {
+			fmt.Fprintln(l.server.stderr, message)
+		}
 	}
 }
 

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -57,8 +57,8 @@ func NewServer(opts *ServerOptions) *Server {
 		r:                     opts.In,
 		w:                     opts.Out,
 		stderr:                opts.Err,
-		requestQueue:          make(chan *lsproto.RequestMessage, 100),
-		outgoingQueue:         make(chan *lsproto.Message, 100),
+		requestQueue:          newDynamicQueue[*lsproto.RequestMessage](),
+		outgoingQueue:         newDynamicQueue[*lsproto.Message](),
 		pendingClientRequests: make(map[jsonrpc.ID]pendingClientRequest),
 		pendingServerRequests: make(map[jsonrpc.ID]chan *lsproto.ResponseMessage),
 		cwd:                   opts.Cwd,
@@ -158,8 +158,8 @@ type Server struct {
 	logger                  *logger
 	initStarted             atomic.Bool
 	clientSeq               atomic.Int32
-	requestQueue            chan *lsproto.RequestMessage
-	outgoingQueue           chan *lsproto.Message
+	requestQueue            *dynamicQueue[*lsproto.RequestMessage]
+	outgoingQueue           *dynamicQueue[*lsproto.Message]
 	pendingClientRequests   map[jsonrpc.ID]pendingClientRequest
 	pendingClientRequestsMu sync.Mutex
 	pendingServerRequests   map[jsonrpc.ID]chan *lsproto.ResponseMessage
@@ -471,7 +471,9 @@ func (s *Server) readLoop(ctx context.Context) error {
 			if req.Method == lsproto.MethodCancelRequest {
 				s.cancelRequest(req.Params.(*lsproto.CancelParams).Id)
 			} else {
-				s.requestQueue <- req
+				if err := s.requestQueue.Put(ctx, req); err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -495,72 +497,71 @@ func (s *Server) dispatchLoop(ctx context.Context) error {
 	ctx, lspExit := context.WithCancelCause(ctx)
 	defer lspExit(nil)
 	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case req := <-s.requestQueue:
-			s.lastRequestTimeMs.Store(time.Now().UnixMilli())
-			requestCtx := locale.WithLocale(ctx, s.locale)
-			var cancel context.CancelFunc
-			if req.ID != nil {
-				requestCtx, cancel = context.WithCancel(core.WithRequestID(requestCtx, req.ID.String()))
-				s.pendingClientRequestsMu.Lock()
-				s.pendingClientRequests[*req.ID] = pendingClientRequest{
-					req:    req,
-					cancel: cancel,
-				}
-				s.pendingClientRequestsMu.Unlock()
-			}
+		req, err := s.requestQueue.Get(ctx)
+		if err != nil {
+			return err
+		}
 
-			handleError := func(err error) {
-				if errors.Is(err, context.Canceled) {
-					if err := s.sendError(req.ID, lsproto.ErrorCodeRequestCancelled); err != nil {
-						lspExit(err)
-					}
-				} else if errors.Is(err, io.EOF) {
-					lspExit(nil)
-				} else {
-					if err := s.sendError(req.ID, err); err != nil {
-						lspExit(err)
-					}
-				}
+		s.lastRequestTimeMs.Store(time.Now().UnixMilli())
+		requestCtx := locale.WithLocale(ctx, s.locale)
+		var cancel context.CancelFunc
+		if req.ID != nil {
+			requestCtx, cancel = context.WithCancel(core.WithRequestID(requestCtx, req.ID.String()))
+			s.pendingClientRequestsMu.Lock()
+			s.pendingClientRequests[*req.ID] = pendingClientRequest{
+				req:    req,
+				cancel: cancel,
 			}
+			s.pendingClientRequestsMu.Unlock()
+		}
 
-			removeRequest := func() {
-				if req.ID != nil {
-					defer cancel()
-					s.pendingClientRequestsMu.Lock()
-					defer s.pendingClientRequestsMu.Unlock()
-					delete(s.pendingClientRequests, *req.ID)
+		handleError := func(err error) {
+			if errors.Is(err, context.Canceled) {
+				if err := s.sendError(req.ID, lsproto.ErrorCodeRequestCancelled); err != nil {
+					lspExit(err)
 				}
-			}
-
-			if doAsyncWork, err := s.handleRequestOrNotification(requestCtx, req); err != nil {
-				handleError(err)
-				removeRequest()
-			} else if doAsyncWork != nil {
-				go func() {
-					if lsError := doAsyncWork(); lsError != nil {
-						handleError(lsError)
-					}
-					removeRequest()
-				}()
+			} else if errors.Is(err, io.EOF) {
+				lspExit(nil)
 			} else {
-				removeRequest()
+				if err := s.sendError(req.ID, err); err != nil {
+					lspExit(err)
+				}
 			}
+		}
+
+		removeRequest := func() {
+			if req.ID != nil {
+				defer cancel()
+				s.pendingClientRequestsMu.Lock()
+				defer s.pendingClientRequestsMu.Unlock()
+				delete(s.pendingClientRequests, *req.ID)
+			}
+		}
+
+		if doAsyncWork, err := s.handleRequestOrNotification(requestCtx, req); err != nil {
+			handleError(err)
+			removeRequest()
+		} else if doAsyncWork != nil {
+			go func() {
+				if lsError := doAsyncWork(); lsError != nil {
+					handleError(lsError)
+				}
+				removeRequest()
+			}()
+		} else {
+			removeRequest()
 		}
 	}
 }
 
 func (s *Server) writeLoop(ctx context.Context) error {
 	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case msg := <-s.outgoingQueue:
-			if err := s.w.Write(msg); err != nil {
-				return fmt.Errorf("failed to write message: %w", err)
-			}
+		msg, err := s.outgoingQueue.Get(ctx)
+		if err != nil {
+			return err
+		}
+		if err := s.w.Write(msg); err != nil {
+			return fmt.Errorf("failed to write message: %w", err)
 		}
 	}
 }
@@ -651,12 +652,7 @@ func (s *Server) sendResponse(resp *lsproto.ResponseMessage) error {
 
 // send writes a message to the outgoing queue, respecting context cancellation.
 func (s *Server) send(msg *lsproto.Message) error {
-	select {
-	case s.outgoingQueue <- msg:
-		return nil
-	case <-s.backgroundCtx.Done():
-		return s.backgroundCtx.Err()
-	}
+	return s.outgoingQueue.Put(s.backgroundCtx, msg)
 }
 
 // handleRequestOrNotification looks up the handler for the given request or notification, executes its synchronous work

--- a/internal/lsp/server_shutdown_test.go
+++ b/internal/lsp/server_shutdown_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/microsoft/typescript-go/internal/bundled"
 	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
@@ -75,21 +76,6 @@ func TestServerShutdownNoDeadlock(t *testing.T) {
 	cancel()
 	<-writeLoopDone
 
-	// Fill the queue so any logging attempt would block
-	dummyMsg := lsproto.WindowLogMessageInfo.NewNotificationMessage(&lsproto.LogMessageParams{
-		Type:    lsproto.MessageTypeInfo,
-		Message: "fill",
-	}).Message()
-
-	for range cap(server.outgoingQueue) {
-		select {
-		case server.outgoingQueue <- dummyMsg:
-			// filled one slot
-		default:
-			// queue full
-		}
-	}
-
 	// Trigger operations that would log (these should not block)
 	server.session.DidChangeFile(ctx, "file:///test/index.ts", 2, []lsproto.TextDocumentContentChangePartialOrWholeDocument{
 		{
@@ -102,4 +88,41 @@ func TestServerShutdownNoDeadlock(t *testing.T) {
 	server.session.WaitForBackgroundTasks()
 
 	server.session.Close()
+}
+
+func TestServerOutgoingQueueDoesNotBlockWithoutWriter(t *testing.T) {
+	t.Parallel()
+
+	server := NewServer(&ServerOptions{
+		In:  shutdownTestReader{},
+		Out: shutdownTestWriter{},
+		Err: io.Discard,
+		Cwd: "/test",
+	})
+	server.backgroundCtx = t.Context()
+
+	msg := lsproto.WindowLogMessageInfo.NewNotificationMessage(&lsproto.LogMessageParams{
+		Type:    lsproto.MessageTypeInfo,
+		Message: "queued",
+	}).Message()
+
+	done := make(chan error, 1)
+	go func() {
+		for range 1000 {
+			if err := server.send(msg); err != nil {
+				done <- err
+				return
+			}
+		}
+		done <- nil
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("sending outgoing messages blocked without a writer")
+	}
 }

--- a/internal/lsp/server_shutdown_test.go
+++ b/internal/lsp/server_shutdown_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"testing"
-	"time"
 
 	"github.com/microsoft/typescript-go/internal/bundled"
 	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
@@ -122,7 +121,7 @@ func TestServerOutgoingQueueDoesNotBlockWithoutWriter(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-	case <-time.After(time.Second):
+	case <-t.Context().Done():
 		t.Fatal("sending outgoing messages blocked without a writer")
 	}
 }


### PR DESCRIPTION
This tricky code is based on a talk I watched a while back (https://www.youtube.com/watch?v=5zXAHh5tJqQ, great talk). It effectively makes a queue that has unbounded size without any locks, instead using a state machine comprised of channels, which means it can play nicely with context cancellation.

We can then replace our message queues with this and prevent deadlocks from back and forth messaging, at the cost of potentially unbound queues, but, I don't see a way to avoid that.

Best viewed like: https://github.com/microsoft/typescript-go/pull/4151/changes?w=1