### PR TITLE
Fix tsdk selection issues

### DIFF
--- a/_extension/package.json
+++ b/_extension/package.json
@@ -63,6 +63,7 @@
                     },
                     "typescript.native-preview.tsdk": {
                         "type": "string",
+                        "scope": "window",
                         "description": "Path to the @typescript/native-preview package or tsgo binary directory. If not specified, the extension will look for it in the default location.",
                         "tags": [
                             "experimental"

--- a/_extension/src/session.ts
+++ b/_extension/src/session.ts
@@ -10,8 +10,10 @@ import { TelemetryReporter } from "./telemetryReporting";
 import {
     getBuiltinExePath,
     getExe,
+    resolveTsdkPath,
     resolveTsdkPathToExe,
     useWorkspaceTsdkStorageKey,
+    workspaceConfigBase,
 } from "./util";
 
 /**
@@ -346,7 +348,7 @@ interface VersionQuickPickItem extends vscode.QuickPickItem {
 }
 
 interface DetectedVersion {
-    label: string;
+    folder: vscode.WorkspaceFolder;
     version: string;
     tsdkPath: string;
     exePath: string;
@@ -359,13 +361,42 @@ async function findWorkspaceNativePreviewPackages(): Promise<DetectedVersion[]> 
         const resolved = await resolveTsdkPathToExe(path.normalize(packagePath.fsPath));
         if (!resolved) continue;
         results.push({
-            label: folder.name,
+            folder,
             version: resolved?.version ?? "unknown",
             tsdkPath: path.normalize(packagePath.fsPath),
             exePath: resolved?.path ?? "",
         });
     }
     return results;
+}
+
+/**
+ * Compute the tsdk path to persist in workspace config. Uses a path relative
+ * to the workspace config base directory (the `.code-workspace` file's parent
+ * in multi-root, or the lone workspace folder in single-root). Falls back to
+ * the absolute path if there is no workspace.
+ */
+function tsdkPathForConfig(detected: DetectedVersion): string {
+    const base = workspaceConfigBase();
+    if (!base) {
+        return detected.tsdkPath;
+    }
+    return path.relative(base.fsPath, detected.tsdkPath);
+}
+
+/**
+ * Update the tsdk config to point at the detected version, but only if the
+ * existing value doesn't already resolve to the same absolute path (avoiding
+ * unnecessary config churn from formatting differences like absolute vs
+ * relative, leading ./, etc.).
+ */
+async function updateTsdkConfig(config: vscode.WorkspaceConfiguration, detected: DetectedVersion): Promise<void> {
+    const currentValue = config.inspect<string>("tsdk")?.workspaceValue;
+    const newValue = tsdkPathForConfig(detected);
+    if (currentValue !== undefined && resolveTsdkPath(currentValue) === resolveTsdkPath(newValue)) {
+        return;
+    }
+    await config.update("tsdk", newValue, vscode.ConfigurationTarget.Workspace);
 }
 
 async function promptSelectVersion(context: vscode.ExtensionContext, client: Client, outputChannel: vscode.LogOutputChannel): Promise<void> {
@@ -383,7 +414,6 @@ async function promptSelectVersion(context: vscode.ExtensionContext, client: Cli
         detail: builtinExe.path,
         run: async () => {
             await context.workspaceState.update(useWorkspaceTsdkStorageKey, false);
-            await config.update("tsdk", undefined, vscode.ConfigurationTarget.Workspace);
             outputChannel.appendLine("Switched to bundled tsgo version.");
         },
     });
@@ -391,14 +421,14 @@ async function promptSelectVersion(context: vscode.ExtensionContext, client: Cli
     // Workspace versions
     if (vscode.workspace.isTrusted) {
         for (const wsVersion of workspaceVersions) {
-            const isActive = currentExePath === wsVersion.tsdkPath;
+            const isActive = currentExePath === wsVersion.exePath;
             items.push({
                 label: (isActive ? "• " : "") + "Use Workspace Version",
                 description: wsVersion.version,
                 detail: wsVersion.tsdkPath,
                 run: async () => {
                     await context.workspaceState.update(useWorkspaceTsdkStorageKey, true);
-                    await config.update("tsdk", wsVersion.tsdkPath, vscode.ConfigurationTarget.Workspace);
+                    await updateTsdkConfig(config, wsVersion);
                     outputChannel.appendLine(`Switched to workspace tsgo version (${wsVersion.version}).`);
                 },
             });
@@ -457,9 +487,9 @@ async function promptSelectVersion(context: vscode.ExtensionContext, client: Cli
 }
 
 /**
- * If the workspace has `@typescript/native-preview` installed and the user
- * hasn't already opted in or dismissed the prompt, ask whether they'd like
- * to use the workspace version.
+ * If the workspace has a tsdk setting pending consent, or has
+ * `@typescript/native-preview` installed in node_modules, prompt the user
+ * to allow using it.
  */
 export async function promptUseWorkspaceVersion(context: vscode.ExtensionContext): Promise<void> {
     if (!vscode.workspace.isTrusted) return;
@@ -470,30 +500,63 @@ export async function promptUseWorkspaceVersion(context: vscode.ExtensionContext
     const suppressKey = "typescript.native-preview.suppressPromptWorkspaceTsdk";
     if (context.workspaceState.get<boolean>(suppressKey, false)) return;
 
-    const workspaceVersions = await findWorkspaceNativePreviewPackages();
-    if (workspaceVersions.length === 0) return;
+    const config = vscode.workspace.getConfiguration("typescript.native-preview");
+    const tsdkInspection = config.inspect<string>("tsdk");
+    const workspaceTsdk = tsdkInspection?.workspaceValue;
 
-    const wsVersion = workspaceVersions[0];
-    const allow = "Allow";
-    const dismiss = "Dismiss";
-    const suppress = "Never in this Workspace";
+    if (workspaceTsdk !== undefined) {
+        // The workspace config already specifies a tsdk location, but the
+        // user hasn't consented to using it. Just need their approval.
+        const resolved = await resolveTsdkPathToExe(workspaceTsdk);
+        if (!resolved) return;
 
-    const result = await vscode.window.showInformationMessage(
-        `This workspace contains a TypeScript Native Preview version (${wsVersion.version}). Would you like to use the workspace version?`,
-        allow,
-        dismiss,
-        suppress,
-    );
+        const allow = "Allow";
+        const dismiss = "Dismiss";
+        const suppress = "Never in this Workspace";
 
-    if (result === allow) {
-        if (!vscode.workspace.isTrusted) return;
-        await context.workspaceState.update(useWorkspaceTsdkStorageKey, true);
-        const config = vscode.workspace.getConfiguration("typescript.native-preview");
-        await config.update("tsdk", wsVersion.tsdkPath, vscode.ConfigurationTarget.Workspace);
-        await vscode.commands.executeCommand("typescript.native-preview.restart");
+        const result = await vscode.window.showInformationMessage(
+            `This workspace has a TypeScript Native Preview tsdk configured (${resolved.version}). Would you like to use it?`,
+            allow,
+            dismiss,
+            suppress,
+        );
+
+        if (result === allow) {
+            if (!vscode.workspace.isTrusted) return;
+            await context.workspaceState.update(useWorkspaceTsdkStorageKey, true);
+            await vscode.commands.executeCommand("typescript.native-preview.restart");
+        }
+        else if (result === suppress) {
+            await context.workspaceState.update(suppressKey, true);
+        }
     }
-    else if (result === suppress) {
-        await context.workspaceState.update(suppressKey, true);
+    else {
+        // No workspace tsdk config, but check if native-preview is installed
+        // in the workspace's node_modules.
+        const workspaceVersions = await findWorkspaceNativePreviewPackages();
+        if (workspaceVersions.length === 0) return;
+
+        const wsVersion = workspaceVersions[0];
+        const allow = "Use Workspace Version";
+        const dismiss = "Dismiss";
+        const suppress = "Never in this Workspace";
+
+        const result = await vscode.window.showInformationMessage(
+            `This workspace has TypeScript Native Preview installed (${wsVersion.version}). Would you like to use it?`,
+            allow,
+            dismiss,
+            suppress,
+        );
+
+        if (result === allow) {
+            if (!vscode.workspace.isTrusted) return;
+            await context.workspaceState.update(useWorkspaceTsdkStorageKey, true);
+            await updateTsdkConfig(config, wsVersion);
+            await vscode.commands.executeCommand("typescript.native-preview.restart");
+        }
+        else if (result === suppress) {
+            await context.workspaceState.update(suppressKey, true);
+        }
     }
 }
 

--- a/_extension/src/util.ts
+++ b/_extension/src/util.ts
@@ -53,17 +53,46 @@ export async function getBuiltinExePath(context: vscode.ExtensionContext): Promi
     };
 }
 
+/**
+ * Returns the base directory for resolving relative paths in workspace config.
+ * - Multi-root workspace: the directory containing the `.code-workspace` file.
+ * - Single-root workspace: the lone workspace folder.
+ * - No workspace: undefined.
+ */
+export function workspaceConfigBase(): vscode.Uri | undefined {
+    const wsFile = vscode.workspace.workspaceFile;
+    if (wsFile && wsFile.scheme === "file") {
+        return vscode.Uri.file(path.dirname(wsFile.fsPath));
+    }
+    if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
+        return vscode.workspace.workspaceFolders[0].uri;
+    }
+    return undefined;
+}
+
 function workspaceResolve(relativePath: string): vscode.Uri {
     if (path.isAbsolute(relativePath)) {
         return vscode.Uri.file(relativePath);
     }
-    if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
-        const workspaceFolder = vscode.workspace.workspaceFolders[0];
-        return vscode.Uri.joinPath(workspaceFolder.uri, relativePath);
+    const base = workspaceConfigBase();
+    if (base) {
+        return vscode.Uri.joinPath(base, relativePath);
     }
     return vscode.Uri.file(relativePath);
 }
 
+/**
+ * Memento used to control whether the user has opted into using a tsdk location defined
+ * in workspace settings. This is *not* a trust boundary - workspace trust is required
+ * before the extension will prompt to set this memento to true. This setting is here to
+ * provide users a way to opt out of using the workspace-provided tsdk without changing
+ * committed workspace settings, e.g. when the workspace tsdk is very outdated or the user
+ * is trialing a nightly TS version. Since the stored value is only a boolean, it does not
+ * protect against executing a different tsdk than the one the user originally opted into
+ * if the workspace settings or node_modules content changes - that's why workspace trust
+ * is always required, and why the prompts that set this value should not be interpreted
+ * as indicating trust for a specific tsdk installation.
+ */
 export const useWorkspaceTsdkStorageKey = "typescript.native-preview.useWorkspaceTsdk";
 
 export async function getExe(context: vscode.ExtensionContext): Promise<ExeInfo> {
@@ -72,11 +101,11 @@ export async function getExe(context: vscode.ExtensionContext): Promise<ExeInfo>
     let tsdk = config.get<string>("tsdk");
     const exeInspection = config.inspect<string>("tsdk");
 
-    // If tsdk is set at the workspace level, require the user to have
-    // explicitly opted in via the version picker (stored in workspace state).
-    if (tsdk && (exeInspection?.workspaceValue !== undefined || exeInspection?.workspaceFolderValue !== undefined)) {
-        const useWorkspaceTsdk = context.workspaceState.get<boolean>(useWorkspaceTsdkStorageKey, false);
-        if (!useWorkspaceTsdk) {
+    // If tsdk is set at the workspace level, require both workspace trust and
+    // explicit user opt-in. Workspace trust can be revoked after the memento is
+    // set, so we must always check both.
+    if (tsdk && exeInspection?.workspaceValue !== undefined) {
+        if (!vscode.workspace.isTrusted || !context.workspaceState.get<boolean>(useWorkspaceTsdkStorageKey, false)) {
             tsdk = exeInspection.globalValue;
         }
     }
@@ -91,14 +120,25 @@ export async function getExe(context: vscode.ExtensionContext): Promise<ExeInfo>
     return getBuiltinExePath(context);
 }
 
+/**
+ * Resolve a tsdk path (which may be relative) to a normalized absolute path.
+ */
+export function resolveTsdkPath(tsdkPath: string): string {
+    return path.normalize(workspaceResolve(tsdkPath).fsPath);
+}
+
 export async function resolveTsdkPathToExe(tsdkPath: string): Promise<{ path: string; version: string; } | undefined> {
     if (tsdkPath.endsWith("/@typescript/native-preview")) {
         try {
             const packagePath = workspaceResolve(tsdkPath);
             const packageJsonPath = vscode.Uri.joinPath(packagePath, "package.json");
             const packageJson = JSON.parse(await vscode.workspace.fs.readFile(packageJsonPath).then(buffer => buffer.toString()));
-            const getExePath = (await import(vscode.Uri.joinPath(packagePath, "lib", "getExePath.js").toString())).default;
-            return { path: getExePath(), version: packageJson.version };
+            // NOTE: Keep in sync with _packages/native-preview/lib/getExePath.js.
+            const exeName = `tsgo${process.platform === "win32" ? ".exe" : ""}`;
+            const platformPackage = `native-preview-${process.platform}-${process.arch}`;
+            const exePath = vscode.Uri.joinPath(packagePath, "..", platformPackage, "lib", exeName);
+            await vscode.workspace.fs.stat(exePath);
+            return { path: exePath.fsPath, version: packageJson.version };
         }
         catch {}
     }

--- a/_extension/src/util.ts
+++ b/_extension/src/util.ts
@@ -128,7 +128,7 @@ export function resolveTsdkPath(tsdkPath: string): string {
 }
 
 export async function resolveTsdkPathToExe(tsdkPath: string): Promise<{ path: string; version: string; } | undefined> {
-    if (tsdkPath.endsWith("/@typescript/native-preview")) {
+    if (tsdkPath.endsWith("/@typescript/native-preview") || tsdkPath.endsWith("\\@typescript\\native-preview")) {
         try {
             const packagePath = workspaceResolve(tsdkPath);
             const packageJsonPath = vscode.Uri.joinPath(packagePath, "package.json");

--- a/_extension/src/util.ts
+++ b/_extension/src/util.ts
@@ -138,16 +138,23 @@ export async function resolveTsdkPathToExe(tsdkPath: string): Promise<{ path: st
             const platformPackage = `native-preview-${process.platform}-${process.arch}`;
             const exePath = vscode.Uri.joinPath(packagePath, "..", platformPackage, "lib", exeName);
             await vscode.workspace.fs.stat(exePath);
-            return { path: exePath.fsPath, version: packageJson.version };
+            return { path: withLongPathPrefix(exePath.fsPath), version: packageJson.version };
         }
         catch {}
     }
     try {
         const exePath = workspaceResolve(path.join(tsdkPath, `tsgo${process.platform === "win32" ? ".exe" : ""}`));
         await vscode.workspace.fs.stat(exePath);
-        return { path: exePath.fsPath, version: "(local)" };
+        return { path: withLongPathPrefix(exePath.fsPath), version: "(local)" };
     }
     catch {}
+}
+
+function withLongPathPrefix(exePath: string): string {
+    if (process.platform === "win32" && exePath.length >= 248 && !exePath.startsWith("\\\\?\\")) {
+        return "\\\\?\\" + exePath;
+    }
+    return exePath;
 }
 
 export function getLanguageForUri(uri: vscode.Uri): string | undefined {

--- a/_packages/native-preview/lib/getExePath.js
+++ b/_packages/native-preview/lib/getExePath.js
@@ -3,6 +3,7 @@ import module from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+// NOTE: Keep VS Code extension's resolveTsdkPathToExe in sync with this function.
 export default function getExePath() {
     const __dirname = path.dirname(fileURLToPath(import.meta.url));
     const normalizedDirname = __dirname.replace(/\\/g, "/");


### PR DESCRIPTION
- Fixes #4070
- Initial prompt now differentiates between the two scenarios where it fires: (1) workspace settings already specify a tsdk, and (2) workspace settings don't specify a tsdk but an installation is detected in the workspace.
- Fixes relative path resolution base in workspace settings in multi-folder workspaces
- Avoids executing getExePath.js from workspace-provided packages (N.B. nobody could have hit this in an untrusted workspace without debugging the extension from source, because the one we publish to the marketplace doesn't yet activate in untrusted workspaces)
- Ensures we don't keep using a workspace-provided tsdk after user revokes workspace trust
- Adds some doc comments explaining that the prompt to use a workspace version is not actually about trust, since Copilot keeps assuming it is

Supersedes #4072