### PR TITLE
Switch LSP VS discriminator prop to string literals

### DIFF
--- a/internal/ls/displaypartswriter.go
+++ b/internal/ls/displaypartswriter.go
@@ -35,7 +35,6 @@ func (w *displayPartsWriter) addRun(classification lsproto.ClassificationTypeNam
 		w.runs = append(w.runs, &lsproto.ClassifiedTextRun{
 			ClassificationTypeName: string(classification),
 			Text:                   text,
-			VSType:                 "ClassifiedTextRun",
 		})
 	}
 	w.lastWritten = text

--- a/internal/ls/findallreferences.go
+++ b/internal/ls/findallreferences.go
@@ -797,8 +797,7 @@ func (l *LanguageService) definitionToReferencedSymbolDefinitionInfo(ctx context
 			node:     node,
 			location: loc,
 			displayText: &lsproto.ClassifiedTextElement{
-				Runs:   []*lsproto.ClassifiedTextRun{{Text: node.Text(), ClassificationTypeName: string(lsproto.ClassificationTypeNameText), VSType: "ClassifiedTextRun"}},
-				VSType: "ClassifiedTextElement",
+				Runs: []*lsproto.ClassifiedTextRun{{Text: node.Text(), ClassificationTypeName: string(lsproto.ClassificationTypeNameText)}},
 			},
 		}
 
@@ -813,8 +812,7 @@ func (l *LanguageService) definitionToReferencedSymbolDefinitionInfo(ctx context
 			node:     node,
 			location: loc,
 			displayText: &lsproto.ClassifiedTextElement{
-				Runs:   []*lsproto.ClassifiedTextRun{{Text: name, ClassificationTypeName: string(lsproto.ClassificationTypeNameKeyword), VSType: "ClassifiedTextRun"}},
-				VSType: "ClassifiedTextElement",
+				Runs: []*lsproto.ClassifiedTextRun{{Text: name, ClassificationTypeName: string(lsproto.ClassificationTypeNameKeyword)}},
 			},
 		}
 
@@ -845,8 +843,7 @@ func (l *LanguageService) definitionToReferencedSymbolDefinitionInfo(ctx context
 			node:     node,
 			location: loc,
 			displayText: &lsproto.ClassifiedTextElement{
-				Runs:   []*lsproto.ClassifiedTextRun{{Text: node.Text(), ClassificationTypeName: string(lsproto.ClassificationTypeNameString), VSType: "ClassifiedTextRun"}},
-				VSType: "ClassifiedTextElement",
+				Runs: []*lsproto.ClassifiedTextRun{{Text: node.Text(), ClassificationTypeName: string(lsproto.ClassificationTypeNameString)}},
 			},
 		}
 
@@ -860,8 +857,7 @@ func (l *LanguageService) definitionToReferencedSymbolDefinitionInfo(ctx context
 			node:     node,
 			location: loc,
 			displayText: &lsproto.ClassifiedTextElement{
-				Runs:   []*lsproto.ClassifiedTextRun{{Text: `"` + def.tripleSlashFileRef.reference.FileName + `"`, ClassificationTypeName: string(lsproto.ClassificationTypeNameString), VSType: "ClassifiedTextRun"}},
-				VSType: "ClassifiedTextElement",
+				Runs: []*lsproto.ClassifiedTextRun{{Text: `"` + def.tripleSlashFileRef.reference.FileName + `"`, ClassificationTypeName: string(lsproto.ClassificationTypeNameString)}},
 			},
 		}
 
@@ -881,13 +877,12 @@ func (l *LanguageService) getDefinitionKindAndDisplayParts(ctx context.Context, 
 	info := getQuickInfoAndDeclarationAtLocation(c, symbol, originalNode, nil, vsCapability, meaning)
 
 	if vsCapability {
-		return &lsproto.ClassifiedTextElement{Runs: info.displayParts.GetRuns(), VSType: "ClassifiedTextElement"}
+		return &lsproto.ClassifiedTextElement{Runs: info.displayParts.GetRuns()}
 	}
 	// Fallback: single unclassified run with the full text
 	text := info.displayParts.String()
 	return &lsproto.ClassifiedTextElement{
-		Runs:   []*lsproto.ClassifiedTextRun{{Text: text, ClassificationTypeName: string(lsproto.ClassificationTypeNameText), VSType: "ClassifiedTextRun"}},
-		VSType: "ClassifiedTextElement",
+		Runs: []*lsproto.ClassifiedTextRun{{Text: text, ClassificationTypeName: string(lsproto.ClassificationTypeNameText)}},
 	}
 }
 

--- a/internal/ls/signaturehelp.go
+++ b/internal/ls/signaturehelp.go
@@ -365,8 +365,7 @@ func (l *LanguageService) createSignatureHelpItems(ctx context.Context, candidat
 		// Set VS-specific colorized label if we have classified runs
 		if len(item.ColorizedRuns) > 0 {
 			sigInfo.VSColorizedLabel = &lsproto.ClassifiedTextElement{
-				Runs:   item.ColorizedRuns,
-				VSType: "ClassifiedTextElement",
+				Runs: item.ColorizedRuns,
 			}
 		}
 

--- a/internal/lsp/lsproto/_generate/fetchModel.mts
+++ b/internal/lsp/lsproto/_generate/fetchModel.mts
@@ -36,10 +36,4 @@ metaModelSchema = metaModelSchema.replace(
     `$1\n\n\t/**\n\t * Whether this property uses omitzero without being a pointer.\n\t * Custom extension for special value types.\n\t */\n\tomitzeroValue?: boolean;\n}`,
 );
 
-// Patch the schema to add vsTypeDiscriminator property to Structure type
-metaModelSchema = metaModelSchema.replace(
-    /(export type Structure = \{[\s\S]*?\tdeprecated\?: string;)\n}/m,
-    `$1\n\n\t/**\n\t * If set, adds a _vs_type field with this value as a type discriminator\n\t * for VS client-side deserialization.\n\t */\n\tvsTypeDiscriminator?: string;\n}`,
-);
-
 fs.writeFileSync(metaModelSchemaPath, metaModelSchema);

--- a/internal/lsp/lsproto/_generate/generate.mts
+++ b/internal/lsp/lsproto/_generate/generate.mts
@@ -536,9 +536,13 @@ const customStructures: Structure[] = [
                 omitzeroValue: true,
                 documentation: "The style of this text run.",
             },
+            {
+                name: "_vs_type",
+                type: { kind: "stringLiteral", value: "ClassifiedTextRun" },
+                documentation: "VS type discriminator required by ObjectContentConverter for deserialization.",
+            },
         ],
         documentation: "A classified text run with text and classification type, used for colorized display in VS.",
-        vsTypeDiscriminator: "ClassifiedTextRun",
     },
     {
         name: "ClassifiedTextElement",
@@ -548,9 +552,13 @@ const customStructures: Structure[] = [
                 type: { kind: "array", element: { kind: "reference", name: "ClassifiedTextRun" } },
                 documentation: "The classified text runs that make up this element.",
             },
+            {
+                name: "_vs_type",
+                type: { kind: "stringLiteral", value: "ClassifiedTextElement" },
+                documentation: "VS type discriminator required by ObjectContentConverter for deserialization.",
+            },
         ],
         documentation: "A classified text element containing an array of classified text runs, used for colorized labels in VS.",
-        vsTypeDiscriminator: "ClassifiedTextElement",
     },
 ];
 
@@ -2222,13 +2230,6 @@ function generateCode() {
                 if (includeDocumentation) {
                     writeLine("");
                 }
-            }
-
-            // Special: add _vs_type discriminator field for VS ObjectContentConverter
-            if ((structure as any).vsTypeDiscriminator) {
-                writeLine("");
-                writeLine(`\t// VS type discriminator required by ObjectContentConverter for deserialization.`);
-                writeLine(`\tVSType string \`json:"_vs_type"\``);
             }
 
             // Special: add RegisterOptions field to Registration

--- a/internal/lsp/lsproto/_generate/metaModelSchema.mts
+++ b/internal/lsp/lsproto/_generate/metaModelSchema.mts
@@ -403,12 +403,6 @@ export type Structure = {
 	 * the property contains the deprecation message.
 	 */
 	deprecated?: string;
-
-	/**
-	 * If set, adds a _vs_type field with this value as a type discriminator
-	 * for VS client-side deserialization.
-	 */
-	vsTypeDiscriminator?: string;
 };
 
 /**

--- a/internal/lsp/lsproto/lsp_generated.go
+++ b/internal/lsp/lsproto/lsp_generated.go
@@ -29742,7 +29742,7 @@ type ClassifiedTextRun struct {
 	Style int32 `json:"Style,omitzero"`
 
 	// VS type discriminator required by ObjectContentConverter for deserialization.
-	VSType string `json:"_vs_type"`
+	VSType StringLiteralClassifiedTextRun `json:"_vs_type"`
 }
 
 var _ json.UnmarshalerFrom = (*ClassifiedTextRun)(nil)
@@ -29751,6 +29751,7 @@ func (s *ClassifiedTextRun) UnmarshalJSONFrom(dec *json.Decoder) error {
 	const (
 		missingClassificationTypeName uint = 1 << iota
 		missingText
+		missingVSType
 		_missingLast
 	)
 	missing := _missingLast - 1
@@ -29789,6 +29790,11 @@ func (s *ClassifiedTextRun) UnmarshalJSONFrom(dec *json.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Style); err != nil {
 				return err
 			}
+		case `"_vs_type"`:
+			missing &^= missingVSType
+			if err := json.UnmarshalDecode(dec, &s.VSType); err != nil {
+				return err
+			}
 		default:
 			if err := dec.SkipValue(); err != nil {
 				return err
@@ -29808,6 +29814,9 @@ func (s *ClassifiedTextRun) UnmarshalJSONFrom(dec *json.Decoder) error {
 		if missing&missingText != 0 {
 			missingProps = append(missingProps, "Text")
 		}
+		if missing&missingVSType != 0 {
+			missingProps = append(missingProps, "_vs_type")
+		}
 		return errMissing(missingProps)
 	}
 
@@ -29820,7 +29829,7 @@ type ClassifiedTextElement struct {
 	Runs []*ClassifiedTextRun `json:"Runs"`
 
 	// VS type discriminator required by ObjectContentConverter for deserialization.
-	VSType string `json:"_vs_type"`
+	VSType StringLiteralClassifiedTextElement `json:"_vs_type"`
 }
 
 var _ json.UnmarshalerFrom = (*ClassifiedTextElement)(nil)
@@ -29828,6 +29837,7 @@ var _ json.UnmarshalerFrom = (*ClassifiedTextElement)(nil)
 func (s *ClassifiedTextElement) UnmarshalJSONFrom(dec *json.Decoder) error {
 	const (
 		missingRuns uint = 1 << iota
+		missingVSType
 		_missingLast
 	)
 	missing := _missingLast - 1
@@ -29853,6 +29863,11 @@ func (s *ClassifiedTextElement) UnmarshalJSONFrom(dec *json.Decoder) error {
 			if err := json.UnmarshalDecode(dec, &s.Runs); err != nil {
 				return err
 			}
+		case `"_vs_type"`:
+			missing &^= missingVSType
+			if err := json.UnmarshalDecode(dec, &s.VSType); err != nil {
+				return err
+			}
 		default:
 			if err := dec.SkipValue(); err != nil {
 				return err
@@ -29868,6 +29883,9 @@ func (s *ClassifiedTextElement) UnmarshalJSONFrom(dec *json.Decoder) error {
 		var missingProps []string
 		if missing&missingRuns != 0 {
 			missingProps = append(missingProps, "Runs")
+		}
+		if missing&missingVSType != 0 {
+			missingProps = append(missingProps, "_vs_type")
 		}
 		return errMissing(missingProps)
 	}
@@ -36566,6 +36584,50 @@ func (o *StringLiteralLanguageServerProjectInfo) UnmarshalJSONFrom(dec *json.Dec
 	}
 	if string(v) != `"languageServer.projectInfo"` {
 		return errLiteralMismatch("StringLiteralLanguageServerProjectInfo", `"languageServer.projectInfo"`, v)
+	}
+	return nil
+}
+
+// StringLiteralClassifiedTextRun is a literal type for "ClassifiedTextRun"
+type StringLiteralClassifiedTextRun struct{}
+
+var _ json.MarshalerTo = StringLiteralClassifiedTextRun{}
+
+func (o StringLiteralClassifiedTextRun) MarshalJSONTo(enc *json.Encoder) error {
+	return enc.WriteValue(json.Value(`"ClassifiedTextRun"`))
+}
+
+var _ json.UnmarshalerFrom = &StringLiteralClassifiedTextRun{}
+
+func (o *StringLiteralClassifiedTextRun) UnmarshalJSONFrom(dec *json.Decoder) error {
+	v, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
+	if string(v) != `"ClassifiedTextRun"` {
+		return errLiteralMismatch("StringLiteralClassifiedTextRun", `"ClassifiedTextRun"`, v)
+	}
+	return nil
+}
+
+// StringLiteralClassifiedTextElement is a literal type for "ClassifiedTextElement"
+type StringLiteralClassifiedTextElement struct{}
+
+var _ json.MarshalerTo = StringLiteralClassifiedTextElement{}
+
+func (o StringLiteralClassifiedTextElement) MarshalJSONTo(enc *json.Encoder) error {
+	return enc.WriteValue(json.Value(`"ClassifiedTextElement"`))
+}
+
+var _ json.UnmarshalerFrom = &StringLiteralClassifiedTextElement{}
+
+func (o *StringLiteralClassifiedTextElement) UnmarshalJSONFrom(dec *json.Decoder) error {
+	v, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
+	if string(v) != `"ClassifiedTextElement"` {
+		return errLiteralMismatch("StringLiteralClassifiedTextElement", `"ClassifiedTextElement"`, v)
 	}
 	return nil
 }


### PR DESCRIPTION
This avoids patching the model and avoids need to remember to set it to a value. This is okay to not do conditionally because these types are only ever used as VS.

Probably, these types should have been prefixed with "VS" but I haven't done that (yet?)