### PR TITLE
Fix redundant undefined wrapping in optional parameter declaration emit

### DIFF
--- a/internal/checker/nodebuilderimpl.go
+++ b/internal/checker/nodebuilderimpl.go
@@ -470,16 +470,16 @@ func typesAreSameReference(a, b *Type) bool {
 	return a == b || a.symbol != nil && a.symbol == b.symbol || a.alias != nil && a.alias == b.alias
 }
 
-func pseudoTypeCouldAlreadyReferToUndefined(b *NodeBuilderImpl, t *pseudochecker.PseudoType) bool {
+func (b *NodeBuilderImpl) pseudoTypeCouldAlreadyReferToUndefined(t *pseudochecker.PseudoType) bool {
 	switch t.Kind {
 	case pseudochecker.PseudoTypeKindNoResult,
 		pseudochecker.PseudoTypeKindInferred:
 		return true
 	case pseudochecker.PseudoTypeKindMaybeConstLocation:
-		return pseudoTypeCouldAlreadyReferToUndefined(b, t.AsPseudoTypeMaybeConstLocation().RegularType)
+		return b.pseudoTypeCouldAlreadyReferToUndefined(t.AsPseudoTypeMaybeConstLocation().RegularType)
 	case pseudochecker.PseudoTypeKindUnion:
 		return core.Some(t.AsPseudoTypeUnion().Types, func(t *pseudochecker.PseudoType) bool {
-			return pseudoTypeCouldAlreadyReferToUndefined(b, t)
+			return b.pseudoTypeCouldAlreadyReferToUndefined(t)
 		})
 	default:
 		if type_ := b.pseudoTypeToType(t); type_ != nil {
@@ -491,7 +491,12 @@ func pseudoTypeCouldAlreadyReferToUndefined(b *NodeBuilderImpl, t *pseudochecker
 
 func (b *NodeBuilderImpl) tryCreatePrimitiveUnionWithUndefinedTypeNode(declaration *ast.Node) *ast.Node {
 	typeNode := declaration.Type()
-	if typeNode == nil || !ast.IsUnionTypeNode(typeNode) || !core.Every(typeNode.AsUnionTypeNode().Types.Nodes, func(node *ast.Node) bool {
+	if typeNode == nil || !ast.IsUnionTypeNode(typeNode) {
+		return nil
+	}
+
+	unionType := typeNode.AsUnionTypeNode()
+	if !core.Every(unionType.Types.Nodes, func(node *ast.Node) bool {
 		switch node.Kind {
 		case ast.KindBigIntKeyword,
 			ast.KindBooleanKeyword,
@@ -510,8 +515,12 @@ func (b *NodeBuilderImpl) tryCreatePrimitiveUnionWithUndefinedTypeNode(declarati
 	}) {
 		return nil
 	}
-	types := make([]*ast.Node, 0, len(typeNode.AsUnionTypeNode().Types.Nodes)+1)
-	for _, node := range typeNode.AsUnionTypeNode().Types.Nodes {
+
+	types := make([]*ast.Node, 0, len(unionType.Types.Nodes)+1)
+	for _, node := range unionType.Types.Nodes {
+		if node.Kind == ast.KindUndefinedKeyword {
+			return typeNode
+		}
 		types = append(types, b.reuseTypeNode(node))
 	}
 	types = append(types, b.f.NewKeywordTypeNode(ast.KindUndefinedKeyword))
@@ -2280,7 +2289,7 @@ func (b *NodeBuilderImpl) serializeTypeForDeclaration(declaration *ast.Declarati
 			// see: canReuseTypeNodeAnnotation in strada for context
 			ptt := b.pseudoTypeToType(pt)
 			if ptt != nil && requiresAddingUndefined && containsNonMissingUndefinedType(b.ch, t) && !containsNonMissingUndefinedType(b.ch, ptt) {
-				if !pseudoTypeCouldAlreadyReferToUndefined(b, pt) {
+				if !b.pseudoTypeCouldAlreadyReferToUndefined(pt) {
 					pt = pseudochecker.NewPseudoTypeUnion([]*pseudochecker.PseudoType{pt, pseudochecker.PseudoTypeUndefined})
 				}
 			}
@@ -2291,7 +2300,7 @@ func (b *NodeBuilderImpl) serializeTypeForDeclaration(declaration *ast.Declarati
 			// typeToTypeNode serialization (mirroring the suppression that
 			// pseudoTypeToNodeWithCheckerFallback provides).
 			reportedInferenceFallback = reportErrors && pt.Kind == pseudochecker.PseudoTypeKindInferred && len(pt.AsPseudoTypeInferred().ErrorNodes) > 0
-			if requiresAddingUndefined && !pseudoTypeCouldAlreadyReferToUndefined(b, pt) {
+			if requiresAddingUndefined && !b.pseudoTypeCouldAlreadyReferToUndefined(pt) {
 				pt = pseudochecker.NewPseudoTypeUnion([]*pseudochecker.PseudoType{pt, pseudochecker.PseudoTypeUndefined})
 				if b.pseudoTypeEquivalentToType(pt, t, false, reportErrors) {
 					result = b.pseudoTypeToNodeWithCheckerFallback(pt, t)

--- a/internal/checker/nodebuilderimpl.go
+++ b/internal/checker/nodebuilderimpl.go
@@ -470,6 +470,54 @@ func typesAreSameReference(a, b *Type) bool {
 	return a == b || a.symbol != nil && a.symbol == b.symbol || a.alias != nil && a.alias == b.alias
 }
 
+func pseudoTypeCouldAlreadyReferToUndefined(b *NodeBuilderImpl, t *pseudochecker.PseudoType) bool {
+	switch t.Kind {
+	case pseudochecker.PseudoTypeKindNoResult,
+		pseudochecker.PseudoTypeKindInferred:
+		return true
+	case pseudochecker.PseudoTypeKindMaybeConstLocation:
+		return pseudoTypeCouldAlreadyReferToUndefined(b, t.AsPseudoTypeMaybeConstLocation().RegularType)
+	case pseudochecker.PseudoTypeKindUnion:
+		return core.Some(t.AsPseudoTypeUnion().Types, func(t *pseudochecker.PseudoType) bool {
+			return pseudoTypeCouldAlreadyReferToUndefined(b, t)
+		})
+	default:
+		if type_ := b.pseudoTypeToType(t); type_ != nil {
+			return containsNonMissingUndefinedType(b.ch, type_)
+		}
+		return false
+	}
+}
+
+func (b *NodeBuilderImpl) tryCreatePrimitiveUnionWithUndefinedTypeNode(declaration *ast.Node) *ast.Node {
+	typeNode := declaration.Type()
+	if typeNode == nil || !ast.IsUnionTypeNode(typeNode) || !core.Every(typeNode.AsUnionTypeNode().Types.Nodes, func(node *ast.Node) bool {
+		switch node.Kind {
+		case ast.KindBigIntKeyword,
+			ast.KindBooleanKeyword,
+			ast.KindNullKeyword,
+			ast.KindNumberKeyword,
+			ast.KindStringKeyword,
+			ast.KindSymbolKeyword,
+			ast.KindUndefinedKeyword:
+			return true
+		case ast.KindLiteralType:
+			literal := node.AsLiteralTypeNode().Literal
+			return literal.Kind == ast.KindNullKeyword || ast.IsLiteralExpression(literal)
+		default:
+			return false
+		}
+	}) {
+		return nil
+	}
+	types := make([]*ast.Node, 0, len(typeNode.AsUnionTypeNode().Types.Nodes)+1)
+	for _, node := range typeNode.AsUnionTypeNode().Types.Nodes {
+		types = append(types, b.reuseTypeNode(node))
+	}
+	types = append(types, b.f.NewKeywordTypeNode(ast.KindUndefinedKeyword))
+	return b.f.NewUnionTypeNode(b.f.NewNodeList(types))
+}
+
 func (b *NodeBuilderImpl) setCommentRange(node *ast.Node, range_ *ast.Node) {
 	if range_ != nil && b.ctx.enclosingFile != nil && b.ctx.enclosingFile == ast.GetSourceFileOfNode(range_) {
 		// Copy comments to node for declaration emit
@@ -2203,6 +2251,9 @@ func (b *NodeBuilderImpl) serializeTypeForDeclaration(declaration *ast.Declarati
 	requiresAddingUndefined := declaration != nil && (ast.IsParameterDeclaration(declaration) || ast.IsPropertySignatureDeclaration(declaration) || ast.IsPropertyDeclaration(declaration)) && b.ch.GetEmitResolver().requiresAddingImplicitUndefined(declaration, symbol, b.ctx.enclosingDeclaration)
 	addUndefinedForParameter := requiresAddingUndefined && (ast.IsParameterDeclaration(declaration) /*|| ast.IsJSDocParameterTag(declaration)*/)
 	if addUndefinedForParameter {
+		if typeNode := b.tryCreatePrimitiveUnionWithUndefinedTypeNode(declaration); typeNode != nil {
+			return typeNode
+		}
 		t = b.ch.getOptionalType(t, false)
 	}
 
@@ -2229,7 +2280,9 @@ func (b *NodeBuilderImpl) serializeTypeForDeclaration(declaration *ast.Declarati
 			// see: canReuseTypeNodeAnnotation in strada for context
 			ptt := b.pseudoTypeToType(pt)
 			if ptt != nil && requiresAddingUndefined && containsNonMissingUndefinedType(b.ch, t) && !containsNonMissingUndefinedType(b.ch, ptt) {
-				pt = pseudochecker.NewPseudoTypeUnion([]*pseudochecker.PseudoType{pt, pseudochecker.PseudoTypeUndefined})
+				if !pseudoTypeCouldAlreadyReferToUndefined(b, pt) {
+					pt = pseudochecker.NewPseudoTypeUnion([]*pseudochecker.PseudoType{pt, pseudochecker.PseudoTypeUndefined})
+				}
 			}
 			result = b.pseudoTypeToNodeWithCheckerFallback(pt, t)
 		} else {
@@ -2238,7 +2291,7 @@ func (b *NodeBuilderImpl) serializeTypeForDeclaration(declaration *ast.Declarati
 			// typeToTypeNode serialization (mirroring the suppression that
 			// pseudoTypeToNodeWithCheckerFallback provides).
 			reportedInferenceFallback = reportErrors && pt.Kind == pseudochecker.PseudoTypeKindInferred && len(pt.AsPseudoTypeInferred().ErrorNodes) > 0
-			if requiresAddingUndefined {
+			if requiresAddingUndefined && !pseudoTypeCouldAlreadyReferToUndefined(b, pt) {
 				pt = pseudochecker.NewPseudoTypeUnion([]*pseudochecker.PseudoType{pt, pseudochecker.PseudoTypeUndefined})
 				if b.pseudoTypeEquivalentToType(pt, t, false, reportErrors) {
 					result = b.pseudoTypeToNodeWithCheckerFallback(pt, t)

--- a/testdata/baselines/reference/compiler/declarationEmitOptionalParameterUndefined.js
+++ b/testdata/baselines/reference/compiler/declarationEmitOptionalParameterUndefined.js
@@ -1,0 +1,58 @@
+//// [tests/cases/compiler/declarationEmitOptionalParameterUndefined.ts] ////
+
+//// [declarationEmitOptionalParameterUndefined.ts]
+export function simple_primitive(
+    foo: number | boolean | null = 2,
+    _: string,
+) {}
+
+export function simple_primitive_with_explicit_undefined(
+    foo: number | boolean | null | undefined = 2,
+    _: string,
+) {}
+
+export function simple_nonPrimitive(
+    foo: number | RegExp | null = 2,
+    _: string,
+) {}
+
+export function simple_nonPrimitive_with_explicit_undefined(
+    foo: number | RegExp | null | undefined = 2,
+    _: string,
+) {}
+
+export function curry(
+    foo: number | RegExp | null = 2,
+    _: string,
+) {
+    return (bar = foo, _: string) => (buzz = bar, _: string) => {}
+}
+
+export function curry_with_explicit_undefined(
+    foo: number | RegExp | null | undefined = 2,
+    _: string,
+) {
+    return (bar = foo, _: string) => (buzz = bar, _: string) => {}
+}
+
+
+//// [declarationEmitOptionalParameterUndefined.js]
+export function simple_primitive(foo = 2, _) { }
+export function simple_primitive_with_explicit_undefined(foo = 2, _) { }
+export function simple_nonPrimitive(foo = 2, _) { }
+export function simple_nonPrimitive_with_explicit_undefined(foo = 2, _) { }
+export function curry(foo = 2, _) {
+    return (bar = foo, _) => (buzz = bar, _) => { };
+}
+export function curry_with_explicit_undefined(foo = 2, _) {
+    return (bar = foo, _) => (buzz = bar, _) => { };
+}
+
+
+//// [declarationEmitOptionalParameterUndefined.d.ts]
+export declare function simple_primitive(foo: number | boolean | null | undefined, _: string): void;
+export declare function simple_primitive_with_explicit_undefined(foo: number | boolean | null | undefined, _: string): void;
+export declare function simple_nonPrimitive(foo: (number | RegExp | null) | undefined, _: string): void;
+export declare function simple_nonPrimitive_with_explicit_undefined(foo: number | RegExp | null | undefined, _: string): void;
+export declare function curry(foo: (number | RegExp | null) | undefined, _: string): (bar: number | RegExp | null | undefined, _: string) => (buzz: number | RegExp | null | undefined, _: string) => void;
+export declare function curry_with_explicit_undefined(foo: number | RegExp | null | undefined, _: string): (bar: number | RegExp | null | undefined, _: string) => (buzz: number | RegExp | null | undefined, _: string) => void;

--- a/testdata/baselines/reference/compiler/declarationEmitOptionalParameterUndefined.symbols
+++ b/testdata/baselines/reference/compiler/declarationEmitOptionalParameterUndefined.symbols
@@ -1,0 +1,89 @@
+//// [tests/cases/compiler/declarationEmitOptionalParameterUndefined.ts] ////
+
+=== declarationEmitOptionalParameterUndefined.ts ===
+export function simple_primitive(
+>simple_primitive : Symbol(simple_primitive, Decl(declarationEmitOptionalParameterUndefined.ts, 0, 0))
+
+    foo: number | boolean | null = 2,
+>foo : Symbol(foo, Decl(declarationEmitOptionalParameterUndefined.ts, 0, 33))
+
+    _: string,
+>_ : Symbol(_, Decl(declarationEmitOptionalParameterUndefined.ts, 1, 37))
+
+) {}
+
+export function simple_primitive_with_explicit_undefined(
+>simple_primitive_with_explicit_undefined : Symbol(simple_primitive_with_explicit_undefined, Decl(declarationEmitOptionalParameterUndefined.ts, 3, 4))
+
+    foo: number | boolean | null | undefined = 2,
+>foo : Symbol(foo, Decl(declarationEmitOptionalParameterUndefined.ts, 5, 57))
+
+    _: string,
+>_ : Symbol(_, Decl(declarationEmitOptionalParameterUndefined.ts, 6, 49))
+
+) {}
+
+export function simple_nonPrimitive(
+>simple_nonPrimitive : Symbol(simple_nonPrimitive, Decl(declarationEmitOptionalParameterUndefined.ts, 8, 4))
+
+    foo: number | RegExp | null = 2,
+>foo : Symbol(foo, Decl(declarationEmitOptionalParameterUndefined.ts, 10, 36))
+>RegExp : Symbol(RegExp, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.regexp.d.ts, --, --) ... and 3 more)
+
+    _: string,
+>_ : Symbol(_, Decl(declarationEmitOptionalParameterUndefined.ts, 11, 36))
+
+) {}
+
+export function simple_nonPrimitive_with_explicit_undefined(
+>simple_nonPrimitive_with_explicit_undefined : Symbol(simple_nonPrimitive_with_explicit_undefined, Decl(declarationEmitOptionalParameterUndefined.ts, 13, 4))
+
+    foo: number | RegExp | null | undefined = 2,
+>foo : Symbol(foo, Decl(declarationEmitOptionalParameterUndefined.ts, 15, 60))
+>RegExp : Symbol(RegExp, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.regexp.d.ts, --, --) ... and 3 more)
+
+    _: string,
+>_ : Symbol(_, Decl(declarationEmitOptionalParameterUndefined.ts, 16, 48))
+
+) {}
+
+export function curry(
+>curry : Symbol(curry, Decl(declarationEmitOptionalParameterUndefined.ts, 18, 4))
+
+    foo: number | RegExp | null = 2,
+>foo : Symbol(foo, Decl(declarationEmitOptionalParameterUndefined.ts, 20, 22))
+>RegExp : Symbol(RegExp, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.regexp.d.ts, --, --) ... and 3 more)
+
+    _: string,
+>_ : Symbol(_, Decl(declarationEmitOptionalParameterUndefined.ts, 21, 36))
+
+) {
+    return (bar = foo, _: string) => (buzz = bar, _: string) => {}
+>bar : Symbol(bar, Decl(declarationEmitOptionalParameterUndefined.ts, 24, 12))
+>foo : Symbol(foo, Decl(declarationEmitOptionalParameterUndefined.ts, 20, 22))
+>_ : Symbol(_, Decl(declarationEmitOptionalParameterUndefined.ts, 24, 22))
+>buzz : Symbol(buzz, Decl(declarationEmitOptionalParameterUndefined.ts, 24, 38))
+>bar : Symbol(bar, Decl(declarationEmitOptionalParameterUndefined.ts, 24, 12))
+>_ : Symbol(_, Decl(declarationEmitOptionalParameterUndefined.ts, 24, 49))
+}
+
+export function curry_with_explicit_undefined(
+>curry_with_explicit_undefined : Symbol(curry_with_explicit_undefined, Decl(declarationEmitOptionalParameterUndefined.ts, 25, 1))
+
+    foo: number | RegExp | null | undefined = 2,
+>foo : Symbol(foo, Decl(declarationEmitOptionalParameterUndefined.ts, 27, 46))
+>RegExp : Symbol(RegExp, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.regexp.d.ts, --, --) ... and 3 more)
+
+    _: string,
+>_ : Symbol(_, Decl(declarationEmitOptionalParameterUndefined.ts, 28, 48))
+
+) {
+    return (bar = foo, _: string) => (buzz = bar, _: string) => {}
+>bar : Symbol(bar, Decl(declarationEmitOptionalParameterUndefined.ts, 31, 12))
+>foo : Symbol(foo, Decl(declarationEmitOptionalParameterUndefined.ts, 27, 46))
+>_ : Symbol(_, Decl(declarationEmitOptionalParameterUndefined.ts, 31, 22))
+>buzz : Symbol(buzz, Decl(declarationEmitOptionalParameterUndefined.ts, 31, 38))
+>bar : Symbol(bar, Decl(declarationEmitOptionalParameterUndefined.ts, 31, 12))
+>_ : Symbol(_, Decl(declarationEmitOptionalParameterUndefined.ts, 31, 49))
+}
+

--- a/testdata/baselines/reference/compiler/declarationEmitOptionalParameterUndefined.types
+++ b/testdata/baselines/reference/compiler/declarationEmitOptionalParameterUndefined.types
@@ -1,0 +1,95 @@
+//// [tests/cases/compiler/declarationEmitOptionalParameterUndefined.ts] ////
+
+=== declarationEmitOptionalParameterUndefined.ts ===
+export function simple_primitive(
+>simple_primitive : (foo: number | boolean | null | undefined, _: string) => void
+
+    foo: number | boolean | null = 2,
+>foo : number | boolean | null
+>2 : 2
+
+    _: string,
+>_ : string
+
+) {}
+
+export function simple_primitive_with_explicit_undefined(
+>simple_primitive_with_explicit_undefined : (foo: number | boolean | null | undefined, _: string) => void
+
+    foo: number | boolean | null | undefined = 2,
+>foo : number | boolean | null | undefined
+>2 : 2
+
+    _: string,
+>_ : string
+
+) {}
+
+export function simple_nonPrimitive(
+>simple_nonPrimitive : (foo: (number | RegExp | null) | undefined, _: string) => void
+
+    foo: number | RegExp | null = 2,
+>foo : number | RegExp | null
+>2 : 2
+
+    _: string,
+>_ : string
+
+) {}
+
+export function simple_nonPrimitive_with_explicit_undefined(
+>simple_nonPrimitive_with_explicit_undefined : (foo: number | RegExp | null | undefined, _: string) => void
+
+    foo: number | RegExp | null | undefined = 2,
+>foo : number | RegExp | null | undefined
+>2 : 2
+
+    _: string,
+>_ : string
+
+) {}
+
+export function curry(
+>curry : (foo: (number | RegExp | null) | undefined, _: string) => (bar: number | RegExp | null | undefined, _: string) => (buzz: number | RegExp | null | undefined, _: string) => void
+
+    foo: number | RegExp | null = 2,
+>foo : number | RegExp | null
+>2 : 2
+
+    _: string,
+>_ : string
+
+) {
+    return (bar = foo, _: string) => (buzz = bar, _: string) => {}
+>(bar = foo, _: string) => (buzz = bar, _: string) => {} : (bar: number | RegExp | null | undefined, _: string) => (buzz: number | RegExp | null | undefined, _: string) => void
+>bar : number | RegExp | null
+>foo : number | RegExp | null
+>_ : string
+>(buzz = bar, _: string) => {} : (buzz: number | RegExp | null | undefined, _: string) => void
+>buzz : number | RegExp | null
+>bar : number | RegExp | null
+>_ : string
+}
+
+export function curry_with_explicit_undefined(
+>curry_with_explicit_undefined : (foo: number | RegExp | null | undefined, _: string) => (bar: number | RegExp | null | undefined, _: string) => (buzz: number | RegExp | null | undefined, _: string) => void
+
+    foo: number | RegExp | null | undefined = 2,
+>foo : number | RegExp | null | undefined
+>2 : 2
+
+    _: string,
+>_ : string
+
+) {
+    return (bar = foo, _: string) => (buzz = bar, _: string) => {}
+>(bar = foo, _: string) => (buzz = bar, _: string) => {} : (bar: number | RegExp | null | undefined, _: string) => (buzz: number | RegExp | null | undefined, _: string) => void
+>bar : number | RegExp | null
+>foo : number | RegExp | null
+>_ : string
+>(buzz = bar, _: string) => {} : (buzz: number | RegExp | null | undefined, _: string) => void
+>buzz : number | RegExp | null
+>bar : number | RegExp | null
+>_ : string
+}
+

--- a/testdata/tests/cases/compiler/declarationEmitOptionalParameterUndefined.ts
+++ b/testdata/tests/cases/compiler/declarationEmitOptionalParameterUndefined.ts
@@ -1,0 +1,37 @@
+// @declaration: true
+// @strict: true
+// @stableTypeOrdering: true
+
+export function simple_primitive(
+    foo: number | boolean | null = 2,
+    _: string,
+) {}
+
+export function simple_primitive_with_explicit_undefined(
+    foo: number | boolean | null | undefined = 2,
+    _: string,
+) {}
+
+export function simple_nonPrimitive(
+    foo: number | RegExp | null = 2,
+    _: string,
+) {}
+
+export function simple_nonPrimitive_with_explicit_undefined(
+    foo: number | RegExp | null | undefined = 2,
+    _: string,
+) {}
+
+export function curry(
+    foo: number | RegExp | null = 2,
+    _: string,
+) {
+    return (bar = foo, _: string) => (buzz = bar, _: string) => {}
+}
+
+export function curry_with_explicit_undefined(
+    foo: number | RegExp | null | undefined = 2,
+    _: string,
+) {
+    return (bar = foo, _: string) => (buzz = bar, _: string) => {}
+}


### PR DESCRIPTION
Fixes #4079

Updates declaration emit for optional/defaulted parameters so `tsgo` avoids adding a redundant `| undefined` wrapper when the type can already refer to `undefined`.

The new regression test covers the issue examples, including nested curry signatures, and updates the declaration emit baselines to match the expected `tsc`-style output.

Tests:

* `go test -run TestLocal/declarationEmitOptionalParameterUndefined ./internal/testrunner`
* `go test ./internal/checker`
* `go test ./internal/testrunner`
