### PR TITLE
Consistently name VS types with prefix VS

### DIFF
--- a/internal/fourslash/fourslash.go
+++ b/internal/fourslash/fourslash.go
@@ -2354,9 +2354,9 @@ func (f *FourslashTest) VerifyBaselineVsFindAllReferences(
 		}
 		result := sendRequest(t, f, lsproto.TextDocumentVSReferencesInfo, params)
 		// Sort cross-project results for deterministic baselines
-		if result.VsReferenceItems != nil && len(*result.VsReferenceItems) > 0 {
-			items := *result.VsReferenceItems
-			slices.SortStableFunc(items, func(a, b *lsproto.VsReferenceItem) int {
+		if result.VSReferenceItems != nil && len(*result.VSReferenceItems) > 0 {
+			items := *result.VSReferenceItems
+			slices.SortStableFunc(items, func(a, b *lsproto.VSReferenceItem) int {
 				ap, bp := "", ""
 				if a.VSProjectName != nil {
 					ap = *a.VSProjectName
@@ -2396,8 +2396,8 @@ func (f *FourslashTest) VerifyBaselineVsFindAllReferences(
 		}
 		// Include file contents with markers
 		var locations []lsproto.Location
-		if result.VsReferenceItems != nil {
-			for _, item := range *result.VsReferenceItems {
+		if result.VSReferenceItems != nil {
+			for _, item := range *result.VSReferenceItems {
 				locations = append(locations, item.VSLocation)
 			}
 		}
@@ -3960,7 +3960,7 @@ func (f *FourslashTest) VerifyQuickInfoIs(t *testing.T, expectedText string, exp
 func (f *FourslashTest) VerifyJsxClosingTag(t *testing.T, markersToNewText map[string]*string) {
 	for marker, expectedText := range markersToNewText {
 		f.GoToMarker(t, marker)
-		params := &lsproto.VsOnAutoInsertParams{
+		params := &lsproto.VSOnAutoInsertParams{
 			VSTextDocument: lsproto.TextDocumentIdentifier{
 				Uri: lsconv.FileNameToDocumentURI(f.activeFilename),
 			},
@@ -3971,7 +3971,7 @@ func (f *FourslashTest) VerifyJsxClosingTag(t *testing.T, markersToNewText map[s
 		requestResult := sendRequest(t, f, lsproto.TextDocumentVSOnAutoInsertInfo, params)
 
 		var actualText *string
-		if item := requestResult.VsOnAutoInsertResponseItem; item != nil && item.VSTextEdit != nil {
+		if item := requestResult.VSOnAutoInsertResponseItem; item != nil && item.VSTextEdit != nil {
 			newText := item.VSTextEdit.NewText
 			if item.VSTextEditFormat == lsproto.InsertTextFormatSnippet {
 				var ok bool
@@ -3990,12 +3990,12 @@ func (f *FourslashTest) VerifyJsxClosingTag(t *testing.T, markersToNewText map[s
 func (f *FourslashTest) VerifyBaselineClosingTags(t *testing.T) {
 	t.Helper()
 
-	markersAndItems := core.MapFiltered(f.Markers(), func(marker *Marker) (markerAndItem[*lsproto.VsOnAutoInsertResponseItem], bool) {
+	markersAndItems := core.MapFiltered(f.Markers(), func(marker *Marker) (markerAndItem[*lsproto.VSOnAutoInsertResponseItem], bool) {
 		if marker.Name == nil {
-			return markerAndItem[*lsproto.VsOnAutoInsertResponseItem]{}, false
+			return markerAndItem[*lsproto.VSOnAutoInsertResponseItem]{}, false
 		}
 
-		params := &lsproto.VsOnAutoInsertParams{
+		params := &lsproto.VSOnAutoInsertParams{
 			VSTextDocument: lsproto.TextDocumentIdentifier{
 				Uri: lsconv.FileNameToDocumentURI(marker.FileName()),
 			},
@@ -4004,17 +4004,17 @@ func (f *FourslashTest) VerifyBaselineClosingTags(t *testing.T) {
 		}
 
 		result := sendRequest(t, f, lsproto.TextDocumentVSOnAutoInsertInfo, params)
-		return markerAndItem[*lsproto.VsOnAutoInsertResponseItem]{Marker: marker, Item: result.VsOnAutoInsertResponseItem}, true
+		return markerAndItem[*lsproto.VSOnAutoInsertResponseItem]{Marker: marker, Item: result.VSOnAutoInsertResponseItem}, true
 	})
 
-	getRange := func(item *lsproto.VsOnAutoInsertResponseItem) *lsproto.Range {
+	getRange := func(item *lsproto.VSOnAutoInsertResponseItem) *lsproto.Range {
 		// Returning nil lets annotateContentWithTooltips render the caret marker at
 		// the marker position. The text edit's range is zero-width at the cursor,
 		// which would render as an empty underline.
 		return nil
 	}
 
-	getTooltipLines := func(item, _prev *lsproto.VsOnAutoInsertResponseItem) []string {
+	getTooltipLines := func(item, _prev *lsproto.VSOnAutoInsertResponseItem) []string {
 		if item == nil || item.VSTextEdit == nil {
 			return []string{"No closing tag"}
 		}

--- a/internal/fourslash/fourslash.go
+++ b/internal/fourslash/fourslash.go
@@ -2334,7 +2334,7 @@ func (f *FourslashTest) VerifyBaselineFindAllReferences(
 	}
 }
 
-func (f *FourslashTest) VerifyBaselineVsFindAllReferences(
+func (f *FourslashTest) VerifyBaselineVSFindAllReferences(
 	t *testing.T,
 	markers ...string,
 ) {

--- a/internal/fourslash/tests/constructorFindAllReferences1VS_test.go
+++ b/internal/fourslash/tests/constructorFindAllReferences1VS_test.go
@@ -19,5 +19,5 @@ func TestConstructorFindAllReferences1VS(t *testing.T) {
 new C().foo();`
 	f, done := fourslash.NewFourslash(t, &lsproto.ClientCapabilities{VSSupportsVisualStudioExtensions: new(true)}, content)
 	defer done()
-	f.VerifyBaselineVsFindAllReferences(t, "")
+	f.VerifyBaselineVSFindAllReferences(t, "")
 }

--- a/internal/fourslash/tests/findAllRefsForDefaultExportVS_test.go
+++ b/internal/fourslash/tests/findAllRefsForDefaultExportVS_test.go
@@ -20,5 +20,5 @@ import /*deg*/g from "./a";
 import { f } from "./a";`
 	f, done := fourslash.NewFourslash(t, &lsproto.ClientCapabilities{VSSupportsVisualStudioExtensions: new(true)}, content)
 	defer done()
-	f.VerifyBaselineVsFindAllReferences(t, "def", "deg")
+	f.VerifyBaselineVSFindAllReferences(t, "def", "deg")
 }

--- a/internal/fourslash/tests/findAllRefsInheritedProperties1VS_test.go
+++ b/internal/fourslash/tests/findAllRefsInheritedProperties1VS_test.go
@@ -21,5 +21,5 @@ v./*3*/doStuff();
 v./*4*/propName;`
 	f, done := fourslash.NewFourslash(t, &lsproto.ClientCapabilities{VSSupportsVisualStudioExtensions: new(true)}, content)
 	defer done()
-	f.VerifyBaselineVsFindAllReferences(t, "1", "2", "3", "4")
+	f.VerifyBaselineVSFindAllReferences(t, "1", "2", "3", "4")
 }

--- a/internal/fourslash/tests/findReferencesAcrossMultipleProjectsVS_test.go
+++ b/internal/fourslash/tests/findReferencesAcrossMultipleProjectsVS_test.go
@@ -21,5 +21,5 @@ func TestFindReferencesAcrossMultipleProjectsVS(t *testing.T) {
 /*4*/x++;`
 	f, done := fourslash.NewFourslash(t, &lsproto.ClientCapabilities{VSSupportsVisualStudioExtensions: new(true)}, content)
 	defer done()
-	f.VerifyBaselineVsFindAllReferences(t, "1", "2", "3", "4")
+	f.VerifyBaselineVSFindAllReferences(t, "1", "2", "3", "4")
 }

--- a/internal/fourslash/tests/tsxFindAllReferences1VS_test.go
+++ b/internal/fourslash/tests/tsxFindAllReferences1VS_test.go
@@ -25,5 +25,5 @@ declare namespace JSX {
 var x = /*2*/</*3*/div />;`
 	f, done := fourslash.NewFourslash(t, &lsproto.ClientCapabilities{VSSupportsVisualStudioExtensions: new(true)}, content)
 	defer done()
-	f.VerifyBaselineVsFindAllReferences(t, "1", "2", "3")
+	f.VerifyBaselineVSFindAllReferences(t, "1", "2", "3")
 }

--- a/internal/ls/autoinsert.go
+++ b/internal/ls/autoinsert.go
@@ -9,9 +9,9 @@ import (
 	"github.com/microsoft/typescript-go/internal/scanner"
 )
 
-func (l *LanguageService) ProvideOnAutoInsert(ctx context.Context, params *lsproto.VsOnAutoInsertParams) (lsproto.VsOnAutoInsertResponse, error) {
+func (l *LanguageService) ProvideOnAutoInsert(ctx context.Context, params *lsproto.VSOnAutoInsertParams) (lsproto.VSOnAutoInsertResponse, error) {
 	if params.VSCh != ">" {
-		return lsproto.VsOnAutoInsertResponse{}, nil
+		return lsproto.VSOnAutoInsertResponse{}, nil
 	}
 
 	_, sourceFile := l.getProgramAndFile(params.VSTextDocument.Uri)
@@ -19,7 +19,7 @@ func (l *LanguageService) ProvideOnAutoInsert(ctx context.Context, params *lspro
 
 	token := astnav.FindPrecedingToken(sourceFile, int(position))
 	if token == nil {
-		return lsproto.VsOnAutoInsertResponse{}, nil
+		return lsproto.VSOnAutoInsertResponse{}, nil
 	}
 
 	var closingText string
@@ -48,11 +48,11 @@ func (l *LanguageService) ProvideOnAutoInsert(ctx context.Context, params *lspro
 	}
 
 	if closingText == "" {
-		return lsproto.VsOnAutoInsertResponse{}, nil
+		return lsproto.VSOnAutoInsertResponse{}, nil
 	}
 
-	return lsproto.VsOnAutoInsertResponse{
-		VsOnAutoInsertResponseItem: &lsproto.VsOnAutoInsertResponseItem{
+	return lsproto.VSOnAutoInsertResponse{
+		VSOnAutoInsertResponseItem: &lsproto.VSOnAutoInsertResponseItem{
 			VSTextEditFormat: lsproto.InsertTextFormatSnippet,
 			VSTextEdit: &lsproto.TextEdit{
 				Range: lsproto.Range{Start: params.VSPosition, End: params.VSPosition},

--- a/internal/ls/crossproject.go
+++ b/internal/ls/crossproject.go
@@ -308,17 +308,17 @@ func combineReferences(results iter.Seq[lsproto.ReferencesResponse]) lsproto.Ref
 	return lsproto.LocationsOrNull{Locations: combineResponseLocations(results)}
 }
 
-func combineVsReferences(results iter.Seq[lsproto.VsReferencesResponse]) lsproto.VsReferencesResponse {
-	var combined []*lsproto.VsReferenceItem
+func combineVsReferences(results iter.Seq[lsproto.VSReferencesResponse]) lsproto.VSReferencesResponse {
+	var combined []*lsproto.VSReferenceItem
 	// Re-number IDs across projects to maintain unique IDs and correct definition references
 	nextId := int32(0)
 	for resp := range results {
-		if resp.VsReferenceItems == nil {
+		if resp.VSReferenceItems == nil {
 			continue
 		}
 		// Map old IDs to new IDs for this batch
 		idMap := make(map[int32]int32)
-		for _, item := range *resp.VsReferenceItems {
+		for _, item := range *resp.VSReferenceItems {
 			oldId := item.VSId
 			newId := nextId
 			idMap[oldId] = newId
@@ -333,7 +333,7 @@ func combineVsReferences(results iter.Seq[lsproto.VsReferencesResponse]) lsproto
 			combined = append(combined, &newItem)
 		}
 	}
-	return lsproto.VsReferencesResponse{VsReferenceItems: &combined}
+	return lsproto.VSReferencesResponse{VSReferenceItems: &combined}
 }
 
 func combineImplementations(results iter.Seq[lsproto.ImplementationResponse]) lsproto.ImplementationResponse {

--- a/internal/ls/crossproject.go
+++ b/internal/ls/crossproject.go
@@ -308,7 +308,7 @@ func combineReferences(results iter.Seq[lsproto.ReferencesResponse]) lsproto.Ref
 	return lsproto.LocationsOrNull{Locations: combineResponseLocations(results)}
 }
 
-func combineVsReferences(results iter.Seq[lsproto.VSReferencesResponse]) lsproto.VSReferencesResponse {
+func combineVSReferences(results iter.Seq[lsproto.VSReferencesResponse]) lsproto.VSReferencesResponse {
 	var combined []*lsproto.VSReferenceItem
 	// Re-number IDs across projects to maintain unique IDs and correct definition references
 	nextId := int32(0)

--- a/internal/ls/displaypartswriter.go
+++ b/internal/ls/displaypartswriter.go
@@ -18,7 +18,7 @@ var _ printer.EmitTextWriter = &displayPartsWriter{}
 // When vsCapability is false, only the plain string is built; runs are skipped.
 type displayPartsWriter struct {
 	builder      strings.Builder
-	runs         []*lsproto.ClassifiedTextRun
+	runs         []*lsproto.VSClassifiedTextRun
 	vsCapability bool
 	lastWritten  string
 }
@@ -32,7 +32,7 @@ func (w *displayPartsWriter) addRun(classification lsproto.ClassificationTypeNam
 		return
 	}
 	if w.vsCapability {
-		w.runs = append(w.runs, &lsproto.ClassifiedTextRun{
+		w.runs = append(w.runs, &lsproto.VSClassifiedTextRun{
 			ClassificationTypeName: string(classification),
 			Text:                   text,
 		})
@@ -57,7 +57,7 @@ func (w *displayPartsWriter) WriteFrom(other *displayPartsWriter) {
 	}
 }
 
-func (w *displayPartsWriter) GetRuns() []*lsproto.ClassifiedTextRun {
+func (w *displayPartsWriter) GetRuns() []*lsproto.VSClassifiedTextRun {
 	return w.runs
 }
 

--- a/internal/ls/findallreferences.go
+++ b/internal/ls/findallreferences.go
@@ -669,7 +669,7 @@ func (l *LanguageService) ProvideReferences(ctx context.Context, params *lsproto
 	)
 }
 
-func (l *LanguageService) ProvideVsReferences(ctx context.Context, params *lsproto.ReferenceParams, orchestrator CrossProjectOrchestrator) (lsproto.VsReferencesResponse, error) {
+func (l *LanguageService) ProvideVsReferences(ctx context.Context, params *lsproto.ReferenceParams, orchestrator CrossProjectOrchestrator) (lsproto.VSReferencesResponse, error) {
 	return handleCrossProject(
 		l,
 		ctx,
@@ -691,10 +691,10 @@ func (l *LanguageService) symbolAndEntriesToReferences(ctx context.Context, para
 	return lsproto.LocationsOrNull{Locations: &locations}, nil
 }
 
-func (l *LanguageService) symbolAndEntriesToVsReferences(ctx context.Context, params *lsproto.ReferenceParams, data SymbolAndEntriesData, options symbolEntryTransformOptions) (lsproto.VsReferencesResponse, error) {
+func (l *LanguageService) symbolAndEntriesToVsReferences(ctx context.Context, params *lsproto.ReferenceParams, data SymbolAndEntriesData, options symbolEntryTransformOptions) (lsproto.VSReferencesResponse, error) {
 	caps := lsproto.GetClientCapabilities(ctx)
 	vsCapability := caps.VSSupportsVisualStudioExtensions
-	var items []*lsproto.VsReferenceItem
+	var items []*lsproto.VSReferenceItem
 	id := int32(0)
 	projectName := string(l.projectPath)
 
@@ -712,11 +712,11 @@ func (l *LanguageService) symbolAndEntriesToVsReferences(ctx context.Context, pa
 		// Create the definition item
 		definitionId := id
 		emptyStr := ""
-		defItem := &lsproto.VsReferenceItem{
+		defItem := &lsproto.VSReferenceItem{
 			VSId:             definitionId,
 			VSLocation:       defInfo.location,
 			VSDefinitionText: defInfo.displayText,
-			VSKind:           &[]lsproto.VsReferenceKind{lsproto.VsReferenceKindUnknown},
+			VSKind:           &[]lsproto.VSReferenceKind{lsproto.VSReferenceKindUnknown},
 			VSProjectName:    &projectName,
 			VSContainingType: &emptyStr,
 		}
@@ -733,16 +733,16 @@ func (l *LanguageService) symbolAndEntriesToVsReferences(ctx context.Context, pa
 			refLocation := l.getLocationOfEntry(ref)
 
 			// Determine read/write kind
-			kind := lsproto.VsReferenceKindRead
+			kind := lsproto.VSReferenceKindRead
 			if ref.kind != entryKindRange && ref.node != nil && ast.IsWriteAccessForReference(ref.node) {
-				kind = lsproto.VsReferenceKindWrite
+				kind = lsproto.VSReferenceKindWrite
 			}
 
-			refItem := &lsproto.VsReferenceItem{
+			refItem := &lsproto.VSReferenceItem{
 				VSId:           id,
 				VSDefinitionId: &definitionId,
 				VSLocation:     refLocation,
-				VSKind:         &[]lsproto.VsReferenceKind{kind},
+				VSKind:         &[]lsproto.VSReferenceKind{kind},
 				VSProjectName:  &projectName,
 			}
 			items = append(items, refItem)
@@ -750,14 +750,14 @@ func (l *LanguageService) symbolAndEntriesToVsReferences(ctx context.Context, pa
 		}
 	}
 
-	return lsproto.VsReferencesResponse{VsReferenceItems: &items}, nil
+	return lsproto.VSReferencesResponse{VSReferenceItems: &items}, nil
 }
 
 // referencedSymbolDefinitionInfo holds the computed info for a definition
 type referencedSymbolDefinitionInfo struct {
 	node        *ast.Node
 	location    lsproto.Location
-	displayText *lsproto.ClassifiedTextElement
+	displayText *lsproto.VSClassifiedTextElement
 }
 
 // definitionToReferencedSymbolDefinitionInfo converts a Definition to display info
@@ -796,8 +796,8 @@ func (l *LanguageService) definitionToReferencedSymbolDefinitionInfo(ctx context
 		return &referencedSymbolDefinitionInfo{
 			node:     node,
 			location: loc,
-			displayText: &lsproto.ClassifiedTextElement{
-				Runs: []*lsproto.ClassifiedTextRun{{Text: node.Text(), ClassificationTypeName: string(lsproto.ClassificationTypeNameText)}},
+			displayText: &lsproto.VSClassifiedTextElement{
+				Runs: []*lsproto.VSClassifiedTextRun{{Text: node.Text(), ClassificationTypeName: string(lsproto.ClassificationTypeNameText)}},
 			},
 		}
 
@@ -811,8 +811,8 @@ func (l *LanguageService) definitionToReferencedSymbolDefinitionInfo(ctx context
 		return &referencedSymbolDefinitionInfo{
 			node:     node,
 			location: loc,
-			displayText: &lsproto.ClassifiedTextElement{
-				Runs: []*lsproto.ClassifiedTextRun{{Text: name, ClassificationTypeName: string(lsproto.ClassificationTypeNameKeyword)}},
+			displayText: &lsproto.VSClassifiedTextElement{
+				Runs: []*lsproto.VSClassifiedTextRun{{Text: name, ClassificationTypeName: string(lsproto.ClassificationTypeNameKeyword)}},
 			},
 		}
 
@@ -842,8 +842,8 @@ func (l *LanguageService) definitionToReferencedSymbolDefinitionInfo(ctx context
 		return &referencedSymbolDefinitionInfo{
 			node:     node,
 			location: loc,
-			displayText: &lsproto.ClassifiedTextElement{
-				Runs: []*lsproto.ClassifiedTextRun{{Text: node.Text(), ClassificationTypeName: string(lsproto.ClassificationTypeNameString)}},
+			displayText: &lsproto.VSClassifiedTextElement{
+				Runs: []*lsproto.VSClassifiedTextRun{{Text: node.Text(), ClassificationTypeName: string(lsproto.ClassificationTypeNameString)}},
 			},
 		}
 
@@ -856,8 +856,8 @@ func (l *LanguageService) definitionToReferencedSymbolDefinitionInfo(ctx context
 		return &referencedSymbolDefinitionInfo{
 			node:     node,
 			location: loc,
-			displayText: &lsproto.ClassifiedTextElement{
-				Runs: []*lsproto.ClassifiedTextRun{{Text: `"` + def.tripleSlashFileRef.reference.FileName + `"`, ClassificationTypeName: string(lsproto.ClassificationTypeNameString)}},
+			displayText: &lsproto.VSClassifiedTextElement{
+				Runs: []*lsproto.VSClassifiedTextRun{{Text: `"` + def.tripleSlashFileRef.reference.FileName + `"`, ClassificationTypeName: string(lsproto.ClassificationTypeNameString)}},
 			},
 		}
 
@@ -867,7 +867,7 @@ func (l *LanguageService) definitionToReferencedSymbolDefinitionInfo(ctx context
 }
 
 // getDefinitionKindAndDisplayParts returns the classified display text for a symbol definition.
-func (l *LanguageService) getDefinitionKindAndDisplayParts(ctx context.Context, symbol *ast.Symbol, originalNode *ast.Node, vsCapability bool) *lsproto.ClassifiedTextElement {
+func (l *LanguageService) getDefinitionKindAndDisplayParts(ctx context.Context, symbol *ast.Symbol, originalNode *ast.Node, vsCapability bool) *lsproto.VSClassifiedTextElement {
 	program := l.GetProgram()
 	c, done := program.GetTypeChecker(ctx)
 	defer done()
@@ -877,12 +877,12 @@ func (l *LanguageService) getDefinitionKindAndDisplayParts(ctx context.Context, 
 	info := getQuickInfoAndDeclarationAtLocation(c, symbol, originalNode, nil, vsCapability, meaning)
 
 	if vsCapability {
-		return &lsproto.ClassifiedTextElement{Runs: info.displayParts.GetRuns()}
+		return &lsproto.VSClassifiedTextElement{Runs: info.displayParts.GetRuns()}
 	}
 	// Fallback: single unclassified run with the full text
 	text := info.displayParts.String()
-	return &lsproto.ClassifiedTextElement{
-		Runs: []*lsproto.ClassifiedTextRun{{Text: text, ClassificationTypeName: string(lsproto.ClassificationTypeNameText)}},
+	return &lsproto.VSClassifiedTextElement{
+		Runs: []*lsproto.VSClassifiedTextRun{{Text: text, ClassificationTypeName: string(lsproto.ClassificationTypeNameText)}},
 	}
 }
 

--- a/internal/ls/findallreferences.go
+++ b/internal/ls/findallreferences.go
@@ -669,14 +669,14 @@ func (l *LanguageService) ProvideReferences(ctx context.Context, params *lsproto
 	)
 }
 
-func (l *LanguageService) ProvideVsReferences(ctx context.Context, params *lsproto.ReferenceParams, orchestrator CrossProjectOrchestrator) (lsproto.VSReferencesResponse, error) {
+func (l *LanguageService) ProvideVSReferences(ctx context.Context, params *lsproto.ReferenceParams, orchestrator CrossProjectOrchestrator) (lsproto.VSReferencesResponse, error) {
 	return handleCrossProject(
 		l,
 		ctx,
 		params,
 		orchestrator,
-		(*LanguageService).symbolAndEntriesToVsReferences,
-		combineVsReferences,
+		(*LanguageService).symbolAndEntriesToVSReferences,
+		combineVSReferences,
 		false, /*isRename*/
 		false, /*implementations*/
 		symbolEntryTransformOptions{},
@@ -691,7 +691,7 @@ func (l *LanguageService) symbolAndEntriesToReferences(ctx context.Context, para
 	return lsproto.LocationsOrNull{Locations: &locations}, nil
 }
 
-func (l *LanguageService) symbolAndEntriesToVsReferences(ctx context.Context, params *lsproto.ReferenceParams, data SymbolAndEntriesData, options symbolEntryTransformOptions) (lsproto.VSReferencesResponse, error) {
+func (l *LanguageService) symbolAndEntriesToVSReferences(ctx context.Context, params *lsproto.ReferenceParams, data SymbolAndEntriesData, options symbolEntryTransformOptions) (lsproto.VSReferencesResponse, error) {
 	caps := lsproto.GetClientCapabilities(ctx)
 	vsCapability := caps.VSSupportsVisualStudioExtensions
 	var items []*lsproto.VSReferenceItem

--- a/internal/ls/signaturehelp.go
+++ b/internal/ls/signaturehelp.go
@@ -364,7 +364,7 @@ func (l *LanguageService) createSignatureHelpItems(ctx context.Context, candidat
 
 		// Set VS-specific colorized label if we have classified runs
 		if len(item.ColorizedRuns) > 0 {
-			sigInfo.VSColorizedLabel = &lsproto.ClassifiedTextElement{
+			sigInfo.VSColorizedLabel = &lsproto.VSClassifiedTextElement{
 				Runs: item.ColorizedRuns,
 			}
 		}
@@ -699,7 +699,7 @@ type signatureInformation struct {
 	// Needed only here, not in lsp
 	IsVariadic bool
 	// Classified text runs for VS colorized label
-	ColorizedRuns []*lsproto.ClassifiedTextRun
+	ColorizedRuns []*lsproto.VSClassifiedTextRun
 }
 
 type signatureHelpItemInfo struct {

--- a/internal/lsp/lsproto/_generate/generate.mts
+++ b/internal/lsp/lsproto/_generate/generate.mts
@@ -167,7 +167,7 @@ const customStructures: Structure[] = [
         ],
     },
     {
-        name: "VsOnAutoInsertOptions",
+        name: "VSOnAutoInsertOptions",
         properties: [
             {
                 name: "_vs_triggerCharacters",
@@ -178,7 +178,7 @@ const customStructures: Structure[] = [
         documentation: "Options for the textDocument/_vs_onAutoInsert provider capability.",
     },
     {
-        name: "VsReferenceItem",
+        name: "VSReferenceItem",
         properties: [
             {
                 name: "_vs_id",
@@ -193,7 +193,7 @@ const customStructures: Structure[] = [
             },
             {
                 name: "_vs_kind",
-                type: { kind: "array", element: { kind: "reference", name: "VsReferenceKind" } },
+                type: { kind: "array", element: { kind: "reference", name: "VSReferenceKind" } },
                 optional: true,
                 documentation: "The kind(s) of this reference (read, write, etc.).",
             },
@@ -204,7 +204,7 @@ const customStructures: Structure[] = [
             },
             {
                 name: "_vs_definitionText",
-                type: { kind: "reference", name: "ClassifiedTextElement" },
+                type: { kind: "reference", name: "VSClassifiedTextElement" },
                 optional: true,
                 documentation: "Classified display text for the definition (used for grouping headers in the UI).",
             },
@@ -224,7 +224,7 @@ const customStructures: Structure[] = [
         documentation: "A VS-specific reference item with grouping support for Find All References.",
     },
     {
-        name: "VsOnAutoInsertParams",
+        name: "VSOnAutoInsertParams",
         properties: [
             {
                 name: "_vs_textDocument",
@@ -245,7 +245,7 @@ const customStructures: Structure[] = [
         documentation: "Parameters for the textDocument/_vs_onAutoInsert request.",
     },
     {
-        name: "VsOnAutoInsertResponseItem",
+        name: "VSOnAutoInsertResponseItem",
         properties: [
             {
                 name: "_vs_textEditFormat",
@@ -511,7 +511,7 @@ const customStructures: Structure[] = [
         documentation: "Parameters for the custom/textDocument/multiDocumentHighlight request.",
     },
     {
-        name: "ClassifiedTextRun",
+        name: "VSClassifiedTextRun",
         properties: [
             {
                 name: "ClassificationTypeName",
@@ -545,11 +545,11 @@ const customStructures: Structure[] = [
         documentation: "A classified text run with text and classification type, used for colorized display in VS.",
     },
     {
-        name: "ClassifiedTextElement",
+        name: "VSClassifiedTextElement",
         properties: [
             {
                 name: "Runs",
-                type: { kind: "array", element: { kind: "reference", name: "ClassifiedTextRun" } },
+                type: { kind: "array", element: { kind: "reference", name: "VSClassifiedTextRun" } },
                 documentation: "The classified text runs that make up this element.",
             },
             {
@@ -564,7 +564,7 @@ const customStructures: Structure[] = [
 
 const customEnumerations: Enumeration[] = [
     {
-        name: "VsReferenceKind",
+        name: "VSReferenceKind",
         type: { kind: "base", name: "integer" },
         values: [
             { name: "Inactive", value: 0 },
@@ -740,12 +740,12 @@ const customRequests: Request[] = [
     },
     {
         method: "textDocument/_vs_onAutoInsert",
-        typeName: "VsOnAutoInsertRequest",
-        params: { kind: "reference", name: "VsOnAutoInsertParams" },
+        typeName: "VSOnAutoInsertRequest",
+        params: { kind: "reference", name: "VSOnAutoInsertParams" },
         result: {
             kind: "or",
             items: [
-                { kind: "reference", name: "VsOnAutoInsertResponseItem" },
+                { kind: "reference", name: "VSOnAutoInsertResponseItem" },
                 { kind: "base", name: "null" },
             ],
         },
@@ -754,12 +754,12 @@ const customRequests: Request[] = [
     },
     {
         method: "textDocument/_vs_references",
-        typeName: "VsReferencesRequest",
+        typeName: "VSReferencesRequest",
         params: { kind: "reference", name: "ReferenceParams" },
         result: {
             kind: "or",
             items: [
-                { kind: "array", element: { kind: "reference", name: "VsReferenceItem" } },
+                { kind: "array", element: { kind: "reference", name: "VSReferenceItem" } },
                 { kind: "base", name: "null" },
             ],
         },
@@ -872,7 +872,7 @@ function patchAndPreprocessModel() {
             });
             structure.properties.push({
                 name: "_vs_onAutoInsertProvider",
-                type: { kind: "reference", name: "VsOnAutoInsertOptions" },
+                type: { kind: "reference", name: "VSOnAutoInsertOptions" },
                 optional: true,
                 documentation: "Provider options for the VS auto-insert feature via textDocument/_vs_onAutoInsert.",
             });
@@ -956,7 +956,7 @@ function patchAndPreprocessModel() {
         if (structure.name === "SignatureInformation") {
             structure.properties.push({
                 name: "_vs_colorizedLabel",
-                type: { kind: "reference", name: "ClassifiedTextElement" },
+                type: { kind: "reference", name: "VSClassifiedTextElement" },
                 optional: true,
                 documentation: "A colorized label for the signature, providing classified text runs for VS syntax coloring.",
             });

--- a/internal/lsp/lsproto/lsp_generated.go
+++ b/internal/lsp/lsproto/lsp_generated.go
@@ -17184,7 +17184,7 @@ type ServerCapabilities struct {
 	CustomSourceDefinitionProvider *bool `json:"customSourceDefinitionProvider,omitzero"`
 
 	// Provider options for the VS auto-insert feature via textDocument/_vs_onAutoInsert.
-	VSOnAutoInsertProvider *VsOnAutoInsertOptions `json:"_vs_onAutoInsertProvider,omitzero"`
+	VSOnAutoInsertProvider *VSOnAutoInsertOptions `json:"_vs_onAutoInsertProvider,omitzero"`
 
 	// The server provides VS-specific grouped references via textDocument/_vs_references.
 	VSReferencesProvider *bool `json:"_vs_referencesProvider,omitzero"`
@@ -18640,7 +18640,7 @@ type SignatureInformation struct {
 	ActiveParameter *UintegerOrNull `json:"activeParameter,omitzero"`
 
 	// A colorized label for the signature, providing classified text runs for VS syntax coloring.
-	VSColorizedLabel *ClassifiedTextElement `json:"_vs_colorizedLabel,omitzero"`
+	VSColorizedLabel *VSClassifiedTextElement `json:"_vs_colorizedLabel,omitzero"`
 }
 
 var _ json.UnmarshalerFrom = (*SignatureInformation)(nil)
@@ -28446,14 +28446,14 @@ func (s *CodeLensData) UnmarshalJSONFrom(dec *json.Decoder) error {
 }
 
 // Options for the textDocument/_vs_onAutoInsert provider capability.
-type VsOnAutoInsertOptions struct {
+type VSOnAutoInsertOptions struct {
 	// List of trigger characters that trigger auto-insert.
 	VSTriggerCharacters []string `json:"_vs_triggerCharacters"`
 }
 
-var _ json.UnmarshalerFrom = (*VsOnAutoInsertOptions)(nil)
+var _ json.UnmarshalerFrom = (*VSOnAutoInsertOptions)(nil)
 
-func (s *VsOnAutoInsertOptions) UnmarshalJSONFrom(dec *json.Decoder) error {
+func (s *VSOnAutoInsertOptions) UnmarshalJSONFrom(dec *json.Decoder) error {
 	const (
 		missingVSTriggerCharacters uint = 1 << iota
 		_missingLast
@@ -28504,7 +28504,7 @@ func (s *VsOnAutoInsertOptions) UnmarshalJSONFrom(dec *json.Decoder) error {
 }
 
 // A VS-specific reference item with grouping support for Find All References.
-type VsReferenceItem struct {
+type VSReferenceItem struct {
 	// Unique identifier for this reference item.
 	VSId int32 `json:"_vs_id"`
 
@@ -28512,13 +28512,13 @@ type VsReferenceItem struct {
 	VSDefinitionId *int32 `json:"_vs_definitionId,omitzero"`
 
 	// The kind(s) of this reference (read, write, etc.).
-	VSKind *[]VsReferenceKind `json:"_vs_kind,omitzero"`
+	VSKind *[]VSReferenceKind `json:"_vs_kind,omitzero"`
 
 	// The location of this reference.
 	VSLocation Location `json:"_vs_location"`
 
 	// Classified display text for the definition (used for grouping headers in the UI).
-	VSDefinitionText *ClassifiedTextElement `json:"_vs_definitionText,omitzero"`
+	VSDefinitionText *VSClassifiedTextElement `json:"_vs_definitionText,omitzero"`
 
 	// The project name for this reference.
 	VSProjectName *string `json:"_vs_projectName,omitzero"`
@@ -28527,9 +28527,9 @@ type VsReferenceItem struct {
 	VSContainingType *string `json:"_vs_containingType,omitzero"`
 }
 
-var _ json.UnmarshalerFrom = (*VsReferenceItem)(nil)
+var _ json.UnmarshalerFrom = (*VSReferenceItem)(nil)
 
-func (s *VsReferenceItem) UnmarshalJSONFrom(dec *json.Decoder) error {
+func (s *VSReferenceItem) UnmarshalJSONFrom(dec *json.Decoder) error {
 	const (
 		missingVSId uint = 1 << iota
 		missingVSLocation
@@ -28621,7 +28621,7 @@ func (s *VsReferenceItem) UnmarshalJSONFrom(dec *json.Decoder) error {
 }
 
 // Parameters for the textDocument/_vs_onAutoInsert request.
-type VsOnAutoInsertParams struct {
+type VSOnAutoInsertParams struct {
 	// The text document.
 	VSTextDocument TextDocumentIdentifier `json:"_vs_textDocument"`
 
@@ -28632,17 +28632,17 @@ type VsOnAutoInsertParams struct {
 	VSCh string `json:"_vs_ch"`
 }
 
-func (s *VsOnAutoInsertParams) TextDocumentURI() DocumentUri {
+func (s *VSOnAutoInsertParams) TextDocumentURI() DocumentUri {
 	return s.VSTextDocument.Uri
 }
 
-func (s *VsOnAutoInsertParams) TextDocumentPosition() Position {
+func (s *VSOnAutoInsertParams) TextDocumentPosition() Position {
 	return s.VSPosition
 }
 
-var _ json.UnmarshalerFrom = (*VsOnAutoInsertParams)(nil)
+var _ json.UnmarshalerFrom = (*VSOnAutoInsertParams)(nil)
 
-func (s *VsOnAutoInsertParams) UnmarshalJSONFrom(dec *json.Decoder) error {
+func (s *VSOnAutoInsertParams) UnmarshalJSONFrom(dec *json.Decoder) error {
 	const (
 		missingVSTextDocument uint = 1 << iota
 		missingVSPosition
@@ -28708,7 +28708,7 @@ func (s *VsOnAutoInsertParams) UnmarshalJSONFrom(dec *json.Decoder) error {
 }
 
 // Response item for the textDocument/_vs_onAutoInsert request.
-type VsOnAutoInsertResponseItem struct {
+type VSOnAutoInsertResponseItem struct {
 	// The format of the text edit (plaintext or snippet).
 	VSTextEditFormat InsertTextFormat `json:"_vs_textEditFormat"`
 
@@ -28716,9 +28716,9 @@ type VsOnAutoInsertResponseItem struct {
 	VSTextEdit *TextEdit `json:"_vs_textEdit"`
 }
 
-var _ json.UnmarshalerFrom = (*VsOnAutoInsertResponseItem)(nil)
+var _ json.UnmarshalerFrom = (*VSOnAutoInsertResponseItem)(nil)
 
-func (s *VsOnAutoInsertResponseItem) UnmarshalJSONFrom(dec *json.Decoder) error {
+func (s *VSOnAutoInsertResponseItem) UnmarshalJSONFrom(dec *json.Decoder) error {
 	const (
 		missingVSTextEditFormat uint = 1 << iota
 		missingVSTextEdit
@@ -29728,7 +29728,7 @@ func (s *MultiDocumentHighlightParams) UnmarshalJSONFrom(dec *json.Decoder) erro
 }
 
 // A classified text run with text and classification type, used for colorized display in VS.
-type ClassifiedTextRun struct {
+type VSClassifiedTextRun struct {
 	// The classification type name (e.g. 'keyword', 'class name', 'parameter name').
 	ClassificationTypeName string `json:"ClassificationTypeName"`
 
@@ -29745,9 +29745,9 @@ type ClassifiedTextRun struct {
 	VSType StringLiteralClassifiedTextRun `json:"_vs_type"`
 }
 
-var _ json.UnmarshalerFrom = (*ClassifiedTextRun)(nil)
+var _ json.UnmarshalerFrom = (*VSClassifiedTextRun)(nil)
 
-func (s *ClassifiedTextRun) UnmarshalJSONFrom(dec *json.Decoder) error {
+func (s *VSClassifiedTextRun) UnmarshalJSONFrom(dec *json.Decoder) error {
 	const (
 		missingClassificationTypeName uint = 1 << iota
 		missingText
@@ -29824,17 +29824,17 @@ func (s *ClassifiedTextRun) UnmarshalJSONFrom(dec *json.Decoder) error {
 }
 
 // A classified text element containing an array of classified text runs, used for colorized labels in VS.
-type ClassifiedTextElement struct {
+type VSClassifiedTextElement struct {
 	// The classified text runs that make up this element.
-	Runs []*ClassifiedTextRun `json:"Runs"`
+	Runs []*VSClassifiedTextRun `json:"Runs"`
 
 	// VS type discriminator required by ObjectContentConverter for deserialization.
 	VSType StringLiteralClassifiedTextElement `json:"_vs_type"`
 }
 
-var _ json.UnmarshalerFrom = (*ClassifiedTextElement)(nil)
+var _ json.UnmarshalerFrom = (*VSClassifiedTextElement)(nil)
 
-func (s *ClassifiedTextElement) UnmarshalJSONFrom(dec *json.Decoder) error {
+func (s *VSClassifiedTextElement) UnmarshalJSONFrom(dec *json.Decoder) error {
 	const (
 		missingRuns uint = 1 << iota
 		missingVSType
@@ -31032,39 +31032,39 @@ const (
 	TokenFormatRelative TokenFormat = "relative"
 )
 
-type VsReferenceKind int32
+type VSReferenceKind int32
 
 const (
-	VsReferenceKindInactive       VsReferenceKind = 0
-	VsReferenceKindComment        VsReferenceKind = 1
-	VsReferenceKindString         VsReferenceKind = 2
-	VsReferenceKindRead           VsReferenceKind = 3
-	VsReferenceKindWrite          VsReferenceKind = 4
-	VsReferenceKindReference      VsReferenceKind = 5
-	VsReferenceKindName           VsReferenceKind = 6
-	VsReferenceKindQualified      VsReferenceKind = 7
-	VsReferenceKindTypeArgument   VsReferenceKind = 8
-	VsReferenceKindTypeConstraint VsReferenceKind = 9
-	VsReferenceKindBaseType       VsReferenceKind = 10
-	VsReferenceKindConstructor    VsReferenceKind = 11
-	VsReferenceKindDestructor     VsReferenceKind = 12
-	VsReferenceKindImport         VsReferenceKind = 13
-	VsReferenceKindDeclaration    VsReferenceKind = 14
-	VsReferenceKindAddressOf      VsReferenceKind = 15
-	VsReferenceKindNotReference   VsReferenceKind = 16
-	VsReferenceKindUnknown        VsReferenceKind = 17
+	VSReferenceKindInactive       VSReferenceKind = 0
+	VSReferenceKindComment        VSReferenceKind = 1
+	VSReferenceKindString         VSReferenceKind = 2
+	VSReferenceKindRead           VSReferenceKind = 3
+	VSReferenceKindWrite          VSReferenceKind = 4
+	VSReferenceKindReference      VSReferenceKind = 5
+	VSReferenceKindName           VSReferenceKind = 6
+	VSReferenceKindQualified      VSReferenceKind = 7
+	VSReferenceKindTypeArgument   VSReferenceKind = 8
+	VSReferenceKindTypeConstraint VSReferenceKind = 9
+	VSReferenceKindBaseType       VSReferenceKind = 10
+	VSReferenceKindConstructor    VSReferenceKind = 11
+	VSReferenceKindDestructor     VSReferenceKind = 12
+	VSReferenceKindImport         VSReferenceKind = 13
+	VSReferenceKindDeclaration    VSReferenceKind = 14
+	VSReferenceKindAddressOf      VSReferenceKind = 15
+	VSReferenceKindNotReference   VSReferenceKind = 16
+	VSReferenceKindUnknown        VSReferenceKind = 17
 )
 
-const _VsReferenceKind_name = "InactiveCommentStringReadWriteReferenceNameQualifiedTypeArgumentTypeConstraintBaseTypeConstructorDestructorImportDeclarationAddressOfNotReferenceUnknown"
+const _VSReferenceKind_name = "InactiveCommentStringReadWriteReferenceNameQualifiedTypeArgumentTypeConstraintBaseTypeConstructorDestructorImportDeclarationAddressOfNotReferenceUnknown"
 
-var _VsReferenceKind_index = [...]uint16{0, 8, 15, 21, 25, 30, 39, 43, 52, 64, 78, 86, 97, 107, 113, 124, 133, 145, 152}
+var _VSReferenceKind_index = [...]uint16{0, 8, 15, 21, 25, 30, 39, 43, 52, 64, 78, 86, 97, 107, 113, 124, 133, 145, 152}
 
-func (e VsReferenceKind) String() string {
+func (e VSReferenceKind) String() string {
 	i := int(e) - 0
-	if i < 0 || i >= len(_VsReferenceKind_index)-1 {
-		return fmt.Sprintf("VsReferenceKind(%d)", e)
+	if i < 0 || i >= len(_VSReferenceKind_index)-1 {
+		return fmt.Sprintf("VSReferenceKind(%d)", e)
 	}
-	return _VsReferenceKind_name[_VsReferenceKind_index[i]:_VsReferenceKind_index[i+1]]
+	return _VSReferenceKind_name[_VSReferenceKind_index[i]:_VSReferenceKind_index[i+1]]
 }
 
 type CodeLensKind string
@@ -31359,7 +31359,7 @@ func unmarshalParams(method Method, data []byte) (any, error) {
 	case MethodCustomTextDocumentMultiDocumentHighlight:
 		return unmarshalPtrTo[MultiDocumentHighlightParams](data)
 	case MethodTextDocumentVSOnAutoInsert:
-		return unmarshalPtrTo[VsOnAutoInsertParams](data)
+		return unmarshalPtrTo[VSOnAutoInsertParams](data)
 	case MethodTextDocumentVSReferences:
 		return unmarshalPtrTo[ReferenceParams](data)
 	case MethodWorkspaceDidChangeWorkspaceFolders:
@@ -31570,9 +31570,9 @@ func unmarshalResult(method Method, data []byte) (any, error) {
 	case MethodCustomTextDocumentMultiDocumentHighlight:
 		return unmarshalValue[CustomMultiDocumentHighlightResponse](data)
 	case MethodTextDocumentVSOnAutoInsert:
-		return unmarshalValue[VsOnAutoInsertResponse](data)
+		return unmarshalValue[VSOnAutoInsertResponse](data)
 	case MethodTextDocumentVSReferences:
-		return unmarshalValue[VsReferencesResponse](data)
+		return unmarshalValue[VSReferencesResponse](data)
 	default:
 		return unmarshalAny(data)
 	}
@@ -32451,16 +32451,16 @@ type CustomMultiDocumentHighlightResponse = MultiDocumentHighlightsOrNull
 var CustomTextDocumentMultiDocumentHighlightInfo = RequestInfo[*MultiDocumentHighlightParams, CustomMultiDocumentHighlightResponse]{Method: MethodCustomTextDocumentMultiDocumentHighlight}
 
 // Response type for `textDocument/_vs_onAutoInsert`
-type VsOnAutoInsertResponse = VsOnAutoInsertResponseItemOrNull
+type VSOnAutoInsertResponse = VSOnAutoInsertResponseItemOrNull
 
 // Type mapping info for `textDocument/_vs_onAutoInsert`
-var TextDocumentVSOnAutoInsertInfo = RequestInfo[*VsOnAutoInsertParams, VsOnAutoInsertResponse]{Method: MethodTextDocumentVSOnAutoInsert}
+var TextDocumentVSOnAutoInsertInfo = RequestInfo[*VSOnAutoInsertParams, VSOnAutoInsertResponse]{Method: MethodTextDocumentVSOnAutoInsert}
 
 // Response type for `textDocument/_vs_references`
-type VsReferencesResponse = VsReferenceItemsOrNull
+type VSReferencesResponse = VSReferenceItemsOrNull
 
 // Type mapping info for `textDocument/_vs_references`
-var TextDocumentVSReferencesInfo = RequestInfo[*ReferenceParams, VsReferencesResponse]{Method: MethodTextDocumentVSReferences}
+var TextDocumentVSReferencesInfo = RequestInfo[*ReferenceParams, VSReferencesResponse]{Method: MethodTextDocumentVSReferences}
 
 // Type mapping info for `workspace/didChangeWorkspaceFolders`
 var WorkspaceDidChangeWorkspaceFoldersInfo = NotificationInfo[*DidChangeWorkspaceFoldersParams]{Method: MethodWorkspaceDidChangeWorkspaceFolders}
@@ -36033,63 +36033,63 @@ func (o *MultiDocumentHighlightsOrNull) UnmarshalJSONFrom(dec *json.Decoder) err
 	}
 }
 
-type VsOnAutoInsertResponseItemOrNull struct {
-	VsOnAutoInsertResponseItem *VsOnAutoInsertResponseItem
+type VSOnAutoInsertResponseItemOrNull struct {
+	VSOnAutoInsertResponseItem *VSOnAutoInsertResponseItem
 }
 
-var _ json.MarshalerTo = (*VsOnAutoInsertResponseItemOrNull)(nil)
+var _ json.MarshalerTo = (*VSOnAutoInsertResponseItemOrNull)(nil)
 
-func (o *VsOnAutoInsertResponseItemOrNull) MarshalJSONTo(enc *json.Encoder) error {
-	if o.VsOnAutoInsertResponseItem != nil {
-		return json.MarshalEncode(enc, o.VsOnAutoInsertResponseItem)
+func (o *VSOnAutoInsertResponseItemOrNull) MarshalJSONTo(enc *json.Encoder) error {
+	if o.VSOnAutoInsertResponseItem != nil {
+		return json.MarshalEncode(enc, o.VSOnAutoInsertResponseItem)
 	}
 	return enc.WriteToken(json.Null)
 }
 
-var _ json.UnmarshalerFrom = (*VsOnAutoInsertResponseItemOrNull)(nil)
+var _ json.UnmarshalerFrom = (*VSOnAutoInsertResponseItemOrNull)(nil)
 
-func (o *VsOnAutoInsertResponseItemOrNull) UnmarshalJSONFrom(dec *json.Decoder) error {
-	*o = VsOnAutoInsertResponseItemOrNull{}
+func (o *VSOnAutoInsertResponseItemOrNull) UnmarshalJSONFrom(dec *json.Decoder) error {
+	*o = VSOnAutoInsertResponseItemOrNull{}
 
 	switch dec.PeekKind() {
 	case 'n':
 		_, err := dec.ReadToken()
 		return err
 	case '{':
-		o.VsOnAutoInsertResponseItem = new(VsOnAutoInsertResponseItem)
-		return json.UnmarshalDecode(dec, o.VsOnAutoInsertResponseItem)
+		o.VSOnAutoInsertResponseItem = new(VSOnAutoInsertResponseItem)
+		return json.UnmarshalDecode(dec, o.VSOnAutoInsertResponseItem)
 	default:
-		return errInvalidKind("VsOnAutoInsertResponseItemOrNull", dec.PeekKind())
+		return errInvalidKind("VSOnAutoInsertResponseItemOrNull", dec.PeekKind())
 	}
 }
 
-type VsReferenceItemsOrNull struct {
-	VsReferenceItems *[]*VsReferenceItem
+type VSReferenceItemsOrNull struct {
+	VSReferenceItems *[]*VSReferenceItem
 }
 
-var _ json.MarshalerTo = (*VsReferenceItemsOrNull)(nil)
+var _ json.MarshalerTo = (*VSReferenceItemsOrNull)(nil)
 
-func (o *VsReferenceItemsOrNull) MarshalJSONTo(enc *json.Encoder) error {
-	if o.VsReferenceItems != nil {
-		return json.MarshalEncode(enc, o.VsReferenceItems)
+func (o *VSReferenceItemsOrNull) MarshalJSONTo(enc *json.Encoder) error {
+	if o.VSReferenceItems != nil {
+		return json.MarshalEncode(enc, o.VSReferenceItems)
 	}
 	return enc.WriteToken(json.Null)
 }
 
-var _ json.UnmarshalerFrom = (*VsReferenceItemsOrNull)(nil)
+var _ json.UnmarshalerFrom = (*VSReferenceItemsOrNull)(nil)
 
-func (o *VsReferenceItemsOrNull) UnmarshalJSONFrom(dec *json.Decoder) error {
-	*o = VsReferenceItemsOrNull{}
+func (o *VSReferenceItemsOrNull) UnmarshalJSONFrom(dec *json.Decoder) error {
+	*o = VSReferenceItemsOrNull{}
 
 	switch dec.PeekKind() {
 	case 'n':
 		_, err := dec.ReadToken()
 		return err
 	case '[':
-		o.VsReferenceItems = new([]*VsReferenceItem)
-		return json.UnmarshalDecode(dec, o.VsReferenceItems)
+		o.VSReferenceItems = new([]*VSReferenceItem)
+		return json.UnmarshalDecode(dec, o.VSReferenceItems)
 	default:
-		return errInvalidKind("VsReferenceItemsOrNull", dec.PeekKind())
+		return errInvalidKind("VSReferenceItemsOrNull", dec.PeekKind())
 	}
 }
 

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -747,7 +747,7 @@ var handlers = sync.OnceValue(func() handlerMap {
 	registerLanguageServiceWithAutoImportsRequestHandler(handlers, lsproto.TextDocumentCompletionInfo, (*Server).handleCompletion)
 	registerLanguageServiceWithAutoImportsRequestHandler(handlers, lsproto.TextDocumentCodeActionInfo, (*Server).handleCodeAction)
 
-	registerLanguageServiceDocumentRequestHandler(handlers, lsproto.TextDocumentVSOnAutoInsertInfo, (*Server).handleVsOnAutoInsert)
+	registerLanguageServiceDocumentRequestHandler(handlers, lsproto.TextDocumentVSOnAutoInsertInfo, (*Server).handleVSOnAutoInsert)
 
 	registerMultiProjectReferenceRequestHandler(handlers, lsproto.TextDocumentReferencesInfo, (*ls.LanguageService).ProvideReferences)
 	registerMultiProjectReferenceRequestHandler(handlers, lsproto.TextDocumentVSReferencesInfo, (*ls.LanguageService).ProvideVsReferences)
@@ -1120,7 +1120,7 @@ func (s *Server) handleInitialize(ctx context.Context, params *lsproto.Initializ
 			CustomSourceDefinitionProvider:       new(true),
 			CustomMultiDocumentHighlightProvider: new(true),
 			VSReferencesProvider:                 new(true),
-			VSOnAutoInsertProvider: &lsproto.VsOnAutoInsertOptions{
+			VSOnAutoInsertProvider: &lsproto.VSOnAutoInsertOptions{
 				VSTriggerCharacters: []string{">"},
 			},
 			Workspace: &lsproto.WorkspaceOptions{
@@ -1475,7 +1475,7 @@ func (s *Server) handleFoldingRange(ctx context.Context, ls *ls.LanguageService,
 	return ls.ProvideFoldingRange(ctx, params.TextDocument.Uri)
 }
 
-func (s *Server) handleVsOnAutoInsert(ctx context.Context, ls *ls.LanguageService, params *lsproto.VsOnAutoInsertParams) (lsproto.VsOnAutoInsertResponse, error) {
+func (s *Server) handleVSOnAutoInsert(ctx context.Context, ls *ls.LanguageService, params *lsproto.VSOnAutoInsertParams) (lsproto.VSOnAutoInsertResponse, error) {
 	return ls.ProvideOnAutoInsert(ctx, params)
 }
 

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -750,7 +750,7 @@ var handlers = sync.OnceValue(func() handlerMap {
 	registerLanguageServiceDocumentRequestHandler(handlers, lsproto.TextDocumentVSOnAutoInsertInfo, (*Server).handleVSOnAutoInsert)
 
 	registerMultiProjectReferenceRequestHandler(handlers, lsproto.TextDocumentReferencesInfo, (*ls.LanguageService).ProvideReferences)
-	registerMultiProjectReferenceRequestHandler(handlers, lsproto.TextDocumentVSReferencesInfo, (*ls.LanguageService).ProvideVsReferences)
+	registerMultiProjectReferenceRequestHandler(handlers, lsproto.TextDocumentVSReferencesInfo, (*ls.LanguageService).ProvideVSReferences)
 	registerRequestHandler(handlers, lsproto.TextDocumentRenameInfo, (*Server).handleRename)
 	registerMultiProjectReferenceRequestHandler(handlers, lsproto.TextDocumentImplementationInfo, (*ls.LanguageService).ProvideImplementations)
 

--- a/internal/vfs/vfswatch/vfswatch_race_test.go
+++ b/internal/vfs/vfswatch/vfswatch_race_test.go
@@ -35,10 +35,10 @@ func newWatcherWithState(fs vfs.FS) *vfswatch.FileWatcher {
 	return fw
 }
 
-// TestRaceHasChangesVsUpdateWatchState tests for data races between
+// TestRaceHasChangesVSUpdateWatchState tests for data races between
 // concurrent HasChanges reads and UpdateWatchState writes on the
 // WatchState map.
-func TestRaceHasChangesVsUpdateWatchState(t *testing.T) {
+func TestRaceHasChangesVSUpdateWatchState(t *testing.T) {
 	t.Parallel()
 	fs := newTestFS()
 	fw := newWatcherWithState(fs)


### PR DESCRIPTION
This was missed in review; prefix these so we know they are for VS, and then use the Go-style `VS` prefix as we had in previous code.