### PR TITLE
Obtain JSDoc from contextual type when available

### DIFF
--- a/internal/fourslash/tests/quickInfoContextualObjectMethodJSDoc_test.go
+++ b/internal/fourslash/tests/quickInfoContextualObjectMethodJSDoc_test.go
@@ -1,0 +1,31 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestQuickInfoContextualObjectMethodJSDoc(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `
+interface I {
+    /**
+     * Description of func.
+     * @param arg Description of arg.
+     */
+    func(arg: number): void
+}
+
+class Foo {
+    constructor(i: I) {}
+}
+
+new Foo({ func/*1*/() {} })
+`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyQuickInfoAt(t, "1", "(method) I.func(arg: number): void", "Description of func.\n\n*@param* `arg` — Description of arg.\n")
+}

--- a/internal/ls/hover.go
+++ b/internal/ls/hover.go
@@ -3,6 +3,7 @@ package ls
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/microsoft/typescript-go/internal/ast"
@@ -617,7 +618,7 @@ func getQuickInfoAndDeclarationAtLocation(c *checker.Checker, symbol *ast.Symbol
 		if flags&(ast.SymbolFlagsFunction|ast.SymbolFlagsMethod) != 0 {
 			isMethod := flags&ast.SymbolFlagsMethod != 0
 			prefix := core.IfElse(isMethod, "method", "function ")
-			if ast.IsIdentifier(node) && (ast.IsFunctionLikeDeclaration(node.Parent) || ast.IsMethodSignatureDeclaration(node.Parent)) && node.Parent.Name() == node {
+			if ast.IsIdentifier(node) && (ast.IsFunctionLikeDeclaration(node.Parent) || ast.IsMethodSignatureDeclaration(node.Parent)) && node.Parent.Name() == node && slices.Contains(symbol.Declarations, node.Parent) {
 				setDeclaration(node.Parent)
 				signatures := []*checker.Signature{c.GetSignatureFromDeclaration(node.Parent)}
 				writeSignatures(signatures, prefix, isMethod, symbol)


### PR DESCRIPTION
This PR ensures we obtain Quick Info information from the contextual type of a method when available. Specifically, we only display information from the declaration node being hovered on when the associated symbol contains that declaration (which it won't when the symbol comes from a contextual type).

Fixes #4174.