### PR TITLE
fix(4187): avoid decorator signature panic on invalid targets

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -8733,6 +8733,10 @@ func (c *Checker) resolveDecorator(node *ast.Node, candidatesOutArray *[]*Signat
 		c.invocationErrorRecovery(apparentType, SignatureKindCall, diag)
 		return c.resolveErrorCall(node)
 	}
+	decoratorSignature := c.getDecoratorCallSignature(node)
+	if decoratorSignature == nil {
+		return c.resolveErrorCall(node)
+	}
 	return c.resolveCall(node, callSignatures, candidatesOutArray, checkMode, SignatureFlagsNone, headMessage)
 }
 

--- a/internal/fourslash/tests/goToDefinitionOnInvalidParameterDecorator_test.go
+++ b/internal/fourslash/tests/goToDefinitionOnInvalidParameterDecorator_test.go
@@ -1,0 +1,19 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestGoToDefinitionOnInvalidParameterDecorator(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `function f(@/*1*/f) {}`
+
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+
+	f.VerifyBaselineGoToDefinition(t, true, "1")
+}

--- a/testdata/baselines/reference/fourslash/goToDefinition/goToDefinitionOnInvalidParameterDecorator.baseline.jsonc
+++ b/testdata/baselines/reference/fourslash/goToDefinition/goToDefinitionOnInvalidParameterDecorator.baseline.jsonc
@@ -1,0 +1,3 @@
+// === goToDefinition ===
+// === /goToDefinitionOnInvalidParameterDecorator.ts ===
+// <|function [|f|](@/*GOTO DEF*/f) {}|>


### PR DESCRIPTION
Fixes #4187