### PR TITLE
Fix infinite recursion caused by CFA in loop with destructuring

### DIFF
--- a/internal/checker/flow.go
+++ b/internal/checker/flow.go
@@ -1737,16 +1737,11 @@ func (c *Checker) tryGetNameFromEntityNameExpression(node *ast.Node) (string, bo
 			return name, true
 		}
 	}
-	if hasOnlyExpressionInitializer(declaration) && c.isBlockScopedNameDeclaredBeforeUse(declaration, node) {
-		initializer := declaration.Initializer()
-		if initializer != nil {
-			var initializerType *Type
-			if ast.IsBindingPattern(declaration.Parent) {
-				initializerType = c.getTypeForBindingElement(declaration)
-			} else {
-				initializerType = c.getTypeOfExpression(initializer)
-			}
-			if initializerType != nil {
+	// We exclude binding elements because their initializers don't solely determine their types and resolving
+	// full types can cause circularities (see https://github.com/microsoft/TypeScript/issues/63192).
+	if hasOnlyExpressionInitializer(declaration) && !ast.IsBindingElement(declaration) && c.isBlockScopedNameDeclaredBeforeUse(declaration, node) {
+		if initializer := declaration.Initializer(); initializer != nil {
+			if initializerType := c.getTypeOfExpression(initializer); initializerType != nil {
 				return tryGetNameFromType(initializerType)
 			}
 		} else if ast.IsEnumMember(declaration) {

--- a/testdata/baselines/reference/compiler/infiniteRecursionDestructuringLoop.errors.txt
+++ b/testdata/baselines/reference/compiler/infiniteRecursionDestructuringLoop.errors.txt
@@ -1,0 +1,46 @@
+infiniteRecursionDestructuringLoop.ts(11,17): error TS7022: 'children' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
+infiniteRecursionDestructuringLoop.ts(11,27): error TS7022: 'index' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
+infiniteRecursionDestructuringLoop.ts(27,17): error TS7022: 'children' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
+infiniteRecursionDestructuringLoop.ts(27,27): error TS7022: 'index' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
+
+
+==== infiniteRecursionDestructuringLoop.ts (4 errors) ====
+    // Repro from https://github.com/microsoft/TypeScript/issues/63192
+    
+    interface Node {
+        children?: readonly Node[];
+        index?: number;
+    }
+    
+    function IterateNodes(data: { node: Node }) {
+        let node: Node | undefined = data.node;
+        while (node) {
+            const { children, index = -1 } = node;
+                    ~~~~~~~~
+!!! error TS7022: 'children' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
+                              ~~~~~
+!!! error TS7022: 'index' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
+            const activeNode: Node | undefined = index != -1 && children ? children[index] : undefined;
+    
+            node = activeNode;
+        }
+    }
+    
+    // Simplified repro
+    interface MyNode {
+        children: MyNode[];
+        index?: number;
+    }
+    
+    function f(init: MyNode) {
+        let node: MyNode | undefined = init;
+        while (node) {
+            const { children, index = 0 } = node;
+                    ~~~~~~~~
+!!! error TS7022: 'children' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
+                              ~~~~~
+!!! error TS7022: 'index' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
+            node = children[index];
+        }
+    }
+    

--- a/testdata/baselines/reference/compiler/infiniteRecursionDestructuringLoop.symbols
+++ b/testdata/baselines/reference/compiler/infiniteRecursionDestructuringLoop.symbols
@@ -1,0 +1,89 @@
+//// [tests/cases/compiler/infiniteRecursionDestructuringLoop.ts] ////
+
+=== infiniteRecursionDestructuringLoop.ts ===
+// Repro from https://github.com/microsoft/TypeScript/issues/63192
+
+interface Node {
+>Node : Symbol(Node, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(infiniteRecursionDestructuringLoop.ts, 0, 0))
+
+    children?: readonly Node[];
+>children : Symbol(Node.children, Decl(infiniteRecursionDestructuringLoop.ts, 2, 16))
+>Node : Symbol(Node, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(infiniteRecursionDestructuringLoop.ts, 0, 0))
+
+    index?: number;
+>index : Symbol(Node.index, Decl(infiniteRecursionDestructuringLoop.ts, 3, 31))
+}
+
+function IterateNodes(data: { node: Node }) {
+>IterateNodes : Symbol(IterateNodes, Decl(infiniteRecursionDestructuringLoop.ts, 5, 1))
+>data : Symbol(data, Decl(infiniteRecursionDestructuringLoop.ts, 7, 22))
+>node : Symbol(node, Decl(infiniteRecursionDestructuringLoop.ts, 7, 29))
+>Node : Symbol(Node, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(infiniteRecursionDestructuringLoop.ts, 0, 0))
+
+    let node: Node | undefined = data.node;
+>node : Symbol(node, Decl(infiniteRecursionDestructuringLoop.ts, 8, 7))
+>Node : Symbol(Node, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(infiniteRecursionDestructuringLoop.ts, 0, 0))
+>data.node : Symbol(node, Decl(infiniteRecursionDestructuringLoop.ts, 7, 29))
+>data : Symbol(data, Decl(infiniteRecursionDestructuringLoop.ts, 7, 22))
+>node : Symbol(node, Decl(infiniteRecursionDestructuringLoop.ts, 7, 29))
+
+    while (node) {
+>node : Symbol(node, Decl(infiniteRecursionDestructuringLoop.ts, 8, 7))
+
+        const { children, index = -1 } = node;
+>children : Symbol(children, Decl(infiniteRecursionDestructuringLoop.ts, 10, 15))
+>index : Symbol(index, Decl(infiniteRecursionDestructuringLoop.ts, 10, 25))
+>node : Symbol(node, Decl(infiniteRecursionDestructuringLoop.ts, 8, 7))
+
+        const activeNode: Node | undefined = index != -1 && children ? children[index] : undefined;
+>activeNode : Symbol(activeNode, Decl(infiniteRecursionDestructuringLoop.ts, 11, 13))
+>Node : Symbol(Node, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(infiniteRecursionDestructuringLoop.ts, 0, 0))
+>index : Symbol(index, Decl(infiniteRecursionDestructuringLoop.ts, 10, 25))
+>children : Symbol(children, Decl(infiniteRecursionDestructuringLoop.ts, 10, 15))
+>children : Symbol(children, Decl(infiniteRecursionDestructuringLoop.ts, 10, 15))
+>index : Symbol(index, Decl(infiniteRecursionDestructuringLoop.ts, 10, 25))
+>undefined : Symbol(undefined)
+
+        node = activeNode;
+>node : Symbol(node, Decl(infiniteRecursionDestructuringLoop.ts, 8, 7))
+>activeNode : Symbol(activeNode, Decl(infiniteRecursionDestructuringLoop.ts, 11, 13))
+    }
+}
+
+// Simplified repro
+interface MyNode {
+>MyNode : Symbol(MyNode, Decl(infiniteRecursionDestructuringLoop.ts, 15, 1))
+
+    children: MyNode[];
+>children : Symbol(MyNode.children, Decl(infiniteRecursionDestructuringLoop.ts, 18, 18))
+>MyNode : Symbol(MyNode, Decl(infiniteRecursionDestructuringLoop.ts, 15, 1))
+
+    index?: number;
+>index : Symbol(MyNode.index, Decl(infiniteRecursionDestructuringLoop.ts, 19, 23))
+}
+
+function f(init: MyNode) {
+>f : Symbol(f, Decl(infiniteRecursionDestructuringLoop.ts, 21, 1))
+>init : Symbol(init, Decl(infiniteRecursionDestructuringLoop.ts, 23, 11))
+>MyNode : Symbol(MyNode, Decl(infiniteRecursionDestructuringLoop.ts, 15, 1))
+
+    let node: MyNode | undefined = init;
+>node : Symbol(node, Decl(infiniteRecursionDestructuringLoop.ts, 24, 7))
+>MyNode : Symbol(MyNode, Decl(infiniteRecursionDestructuringLoop.ts, 15, 1))
+>init : Symbol(init, Decl(infiniteRecursionDestructuringLoop.ts, 23, 11))
+
+    while (node) {
+>node : Symbol(node, Decl(infiniteRecursionDestructuringLoop.ts, 24, 7))
+
+        const { children, index = 0 } = node;
+>children : Symbol(children, Decl(infiniteRecursionDestructuringLoop.ts, 26, 15))
+>index : Symbol(index, Decl(infiniteRecursionDestructuringLoop.ts, 26, 25))
+>node : Symbol(node, Decl(infiniteRecursionDestructuringLoop.ts, 24, 7))
+
+        node = children[index];
+>node : Symbol(node, Decl(infiniteRecursionDestructuringLoop.ts, 24, 7))
+>children : Symbol(children, Decl(infiniteRecursionDestructuringLoop.ts, 26, 15))
+>index : Symbol(index, Decl(infiniteRecursionDestructuringLoop.ts, 26, 25))
+    }
+}
+

--- a/testdata/baselines/reference/compiler/infiniteRecursionDestructuringLoop.types
+++ b/testdata/baselines/reference/compiler/infiniteRecursionDestructuringLoop.types
@@ -1,0 +1,90 @@
+//// [tests/cases/compiler/infiniteRecursionDestructuringLoop.ts] ////
+
+=== infiniteRecursionDestructuringLoop.ts ===
+// Repro from https://github.com/microsoft/TypeScript/issues/63192
+
+interface Node {
+    children?: readonly Node[];
+>children : readonly Node[] | undefined
+
+    index?: number;
+>index : number | undefined
+}
+
+function IterateNodes(data: { node: Node }) {
+>IterateNodes : (data: { node: Node; }) => void
+>data : { node: Node; }
+>node : Node
+
+    let node: Node | undefined = data.node;
+>node : Node | undefined
+>data.node : Node
+>data : { node: Node; }
+>node : Node
+
+    while (node) {
+>node : Node | undefined
+
+        const { children, index = -1 } = node;
+>children : any
+>index : any
+>-1 : -1
+>1 : 1
+>node : Node
+
+        const activeNode: Node | undefined = index != -1 && children ? children[index] : undefined;
+>activeNode : Node | undefined
+>index != -1 && children ? children[index] : undefined : any
+>index != -1 && children : any
+>index != -1 : boolean
+>index : any
+>-1 : -1
+>1 : 1
+>children : any
+>children[index] : any
+>children : any
+>index : any
+>undefined : undefined
+
+        node = activeNode;
+>node = activeNode : Node | undefined
+>node : Node | undefined
+>activeNode : Node | undefined
+    }
+}
+
+// Simplified repro
+interface MyNode {
+    children: MyNode[];
+>children : MyNode[]
+
+    index?: number;
+>index : number | undefined
+}
+
+function f(init: MyNode) {
+>f : (init: MyNode) => void
+>init : MyNode
+
+    let node: MyNode | undefined = init;
+>node : MyNode | undefined
+>init : MyNode
+
+    while (node) {
+>node : MyNode | undefined
+
+        const { children, index = 0 } = node;
+>children : any
+>index : any
+>0 : 0
+>node : MyNode
+
+        node = children[index];
+>node = children[index] : any
+>node : MyNode | undefined
+>children[index] : any
+>children : any
+>index : any
+    }
+}
+

--- a/testdata/tests/cases/compiler/infiniteRecursionDestructuringLoop.ts
+++ b/testdata/tests/cases/compiler/infiniteRecursionDestructuringLoop.ts
@@ -1,0 +1,32 @@
+// @noEmit: true
+
+// Repro from https://github.com/microsoft/TypeScript/issues/63192
+
+interface Node {
+    children?: readonly Node[];
+    index?: number;
+}
+
+function IterateNodes(data: { node: Node }) {
+    let node: Node | undefined = data.node;
+    while (node) {
+        const { children, index = -1 } = node;
+        const activeNode: Node | undefined = index != -1 && children ? children[index] : undefined;
+
+        node = activeNode;
+    }
+}
+
+// Simplified repro
+interface MyNode {
+    children: MyNode[];
+    index?: number;
+}
+
+function f(init: MyNode) {
+    let node: MyNode | undefined = init;
+    while (node) {
+        const { children, index = 0 } = node;
+        node = children[index];
+    }
+}


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/TypeScript/issues/63192, the original cause of which is https://github.com/microsoft/TypeScript/pull/56347.

The fix is to exclude binding elements in `tryGetNameFromEntityNameExpression`, which is used to extract a property name computed by a literal expression. For example, when performing CFA for a reference like `obj[prop]`, if `prop` has a type annotation with a literal type or an initializer that computes a value of a literal type, we can extract the property name from the type of `prop`. However, we need to be very conservative in this extraction because of the potential for circularities, and the changes in https://github.com/microsoft/TypeScript/pull/56347 were simply too ambitious. It makes a lot more sense to just exclude binding elements, since really the scenarios we care about there are when `prop` is declared as a simple `const` with a literal string value or a unique symbol.

This PR supercedes https://github.com/microsoft/typescript-go/pull/2907.