### PR TITLE
Stop parsing constructs that make it impossible to erase `as`/`satisfies`

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -4581,8 +4581,8 @@ func (p *Parser) parseBinaryExpressionRest(precedence ast.OperatorPrecedence, le
 	for {
 		// We either have a binary operator here, or we're finished.  We call
 		// reScanGreaterToken so that we merge token sequences like > and = into >=
-		p.reScanGreaterThanToken()
-		newPrecedence := ast.GetBinaryOperatorPrecedence(p.token)
+		operator := p.reScanGreaterThanToken()
+		newPrecedence := ast.GetBinaryOperatorPrecedence(operator)
 		// Check the precedence to see if we should "take" this operator
 		// - For left associative operator (all operator but **), consume the operator,
 		//   recursively call the function below, and parse binaryExpression as a rightOperand
@@ -4605,7 +4605,7 @@ func (p *Parser) parseBinaryExpressionRest(precedence ast.OperatorPrecedence, le
 		//      a ** b - c
 		//             ^token; leftOperand = b. Return b to the caller as a rightOperand
 		var consumeCurrentOperator bool
-		if p.token == ast.KindAsteriskAsteriskToken {
+		if operator == ast.KindAsteriskAsteriskToken {
 			consumeCurrentOperator = newPrecedence >= precedence
 		} else {
 			consumeCurrentOperator = newPrecedence > precedence
@@ -4613,10 +4613,10 @@ func (p *Parser) parseBinaryExpressionRest(precedence ast.OperatorPrecedence, le
 		if !consumeCurrentOperator {
 			break
 		}
-		if p.token == ast.KindInKeyword && p.inDisallowInContext() {
+		if operator == ast.KindInKeyword && p.inDisallowInContext() {
 			break
 		}
-		if p.token == ast.KindAsKeyword || p.token == ast.KindSatisfiesKeyword {
+		if operator == ast.KindAsKeyword || operator == ast.KindSatisfiesKeyword {
 			// Make sure we *do* perform ASI for constructs like this:
 			//    var x = foo
 			//    as (Bar)
@@ -4625,12 +4625,17 @@ func (p *Parser) parseBinaryExpressionRest(precedence ast.OperatorPrecedence, le
 			if p.hasPrecedingLineBreak() {
 				break
 			} else {
-				keywordKind := p.token
 				p.nextToken()
-				if keywordKind == ast.KindSatisfiesKeyword {
+				if operator == ast.KindSatisfiesKeyword {
 					leftOperand = p.makeSatisfiesExpression(leftOperand, p.parseType())
 				} else {
 					leftOperand = p.makeAsExpression(leftOperand, p.parseType())
+				}
+				// We stop parsing if we have an operator with higher precedence than `as` or `satisfies` because
+				// continuing would make it impossible to erase the `as` or `satisfies` without changing the meaning
+				// of the expression. See https://github.com/microsoft/TypeScript/issues/63527.
+				if ast.GetBinaryOperatorPrecedence(p.token) > ast.OperatorPrecedenceRelational {
+					break
 				}
 			}
 		} else {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -4626,15 +4626,21 @@ func (p *Parser) parseBinaryExpressionRest(precedence ast.OperatorPrecedence, le
 				break
 			} else {
 				p.nextToken()
+				// When we have 'a ## b as SomeType' or 'a ## b satisfies SomeType', where ## is some binary
+				// operator, we want to stop parsing on any following operator with a higher precedence than ##
+				// because continuing would make it impossible to erase the `as` or `satisfies` without changing
+				// the meaning of the expression. See https://github.com/microsoft/TypeScript/issues/63527.
+				leftPrecedence := ast.OperatorPrecedenceHighest
+				if ast.IsBinaryExpression(leftOperand) {
+					leftPrecedence = ast.GetBinaryOperatorPrecedence(leftOperand.AsBinaryExpression().OperatorToken.Kind)
+				}
 				if operator == ast.KindSatisfiesKeyword {
 					leftOperand = p.makeSatisfiesExpression(leftOperand, p.parseType())
 				} else {
 					leftOperand = p.makeAsExpression(leftOperand, p.parseType())
 				}
-				// We stop parsing if we have an operator with higher precedence than `as` or `satisfies` because
-				// continuing would make it impossible to erase the `as` or `satisfies` without changing the meaning
-				// of the expression. See https://github.com/microsoft/TypeScript/issues/63527.
-				if ast.GetBinaryOperatorPrecedence(p.reScanGreaterThanToken()) > ast.OperatorPrecedenceRelational {
+				// Stop if the precedence of the next operator is too high.
+				if ast.GetBinaryOperatorPrecedence(p.reScanGreaterThanToken()) > leftPrecedence {
 					break
 				}
 			}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -4578,6 +4578,7 @@ func (p *Parser) parseBinaryExpressionOrHigher(precedence ast.OperatorPrecedence
 }
 
 func (p *Parser) parseBinaryExpressionRest(precedence ast.OperatorPrecedence, leftOperand *ast.Expression, pos int) *ast.Expression {
+	lastOperand := leftOperand
 	for {
 		// We either have a binary operator here, or we're finished.  We call
 		// reScanGreaterToken so that we merge token sequences like > and = into >=
@@ -4630,9 +4631,9 @@ func (p *Parser) parseBinaryExpressionRest(precedence ast.OperatorPrecedence, le
 				// operator, we want to stop parsing on any following operator with a higher precedence than ##
 				// because continuing would make it impossible to erase the `as` or `satisfies` without changing
 				// the meaning of the expression. See https://github.com/microsoft/TypeScript/issues/63527.
-				leftPrecedence := ast.OperatorPrecedenceHighest
-				if ast.IsBinaryExpression(leftOperand) {
-					leftPrecedence = ast.GetBinaryOperatorPrecedence(leftOperand.AsBinaryExpression().OperatorToken.Kind)
+				lastPrecedence := ast.OperatorPrecedenceHighest
+				if ast.IsBinaryExpression(lastOperand) {
+					lastPrecedence = ast.GetBinaryOperatorPrecedence(lastOperand.AsBinaryExpression().OperatorToken.Kind)
 				}
 				if operator == ast.KindSatisfiesKeyword {
 					leftOperand = p.makeSatisfiesExpression(leftOperand, p.parseType())
@@ -4640,12 +4641,13 @@ func (p *Parser) parseBinaryExpressionRest(precedence ast.OperatorPrecedence, le
 					leftOperand = p.makeAsExpression(leftOperand, p.parseType())
 				}
 				// Stop if the precedence of the next operator is too high.
-				if ast.GetBinaryOperatorPrecedence(p.reScanGreaterThanToken()) > leftPrecedence {
+				if ast.GetBinaryOperatorPrecedence(p.reScanGreaterThanToken()) > lastPrecedence {
 					break
 				}
 			}
 		} else {
 			leftOperand = p.makeBinaryExpression(leftOperand, p.parseTokenNode(), p.parseBinaryExpressionOrHigher(newPrecedence), pos)
+			lastOperand = leftOperand
 		}
 	}
 	return leftOperand

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -4634,7 +4634,7 @@ func (p *Parser) parseBinaryExpressionRest(precedence ast.OperatorPrecedence, le
 				// We stop parsing if we have an operator with higher precedence than `as` or `satisfies` because
 				// continuing would make it impossible to erase the `as` or `satisfies` without changing the meaning
 				// of the expression. See https://github.com/microsoft/TypeScript/issues/63527.
-				if ast.GetBinaryOperatorPrecedence(p.token) > ast.OperatorPrecedenceRelational {
+				if ast.GetBinaryOperatorPrecedence(p.reScanGreaterThanToken()) > ast.OperatorPrecedenceRelational {
 					break
 				}
 			}

--- a/testdata/baselines/reference/compiler/disallowUnerasableAssertion.errors.txt
+++ b/testdata/baselines/reference/compiler/disallowUnerasableAssertion.errors.txt
@@ -1,0 +1,10 @@
+disallowUnerasableAssertion.ts(1,35): error TS1005: ',' expected.
+
+
+==== disallowUnerasableAssertion.ts (1 errors) ====
+    export const c1 = 1 + 1 as number / 2;
+                                      ~
+!!! error TS1005: ',' expected.
+    export const c2 = (1 + 1 as number) / 2;
+    export const c3 = 1 + 1 as number === 2;
+    

--- a/testdata/baselines/reference/compiler/disallowUnerasableAssertion.errors.txt
+++ b/testdata/baselines/reference/compiler/disallowUnerasableAssertion.errors.txt
@@ -1,9 +1,11 @@
-disallowUnerasableAssertion.ts(1,35): error TS1005: ',' expected.
-disallowUnerasableAssertion.ts(6,35): error TS1005: ',' expected.
-disallowUnerasableAssertion.ts(7,35): error TS1005: ',' expected.
+disallowUnerasableAssertion.ts(3,35): error TS1005: ',' expected.
+disallowUnerasableAssertion.ts(10,36): error TS1005: ',' expected.
+disallowUnerasableAssertion.ts(11,36): error TS1005: ',' expected.
 
 
 ==== disallowUnerasableAssertion.ts (3 errors) ====
+    // https://github.com/microsoft/TypeScript/issues/63527
+    
     export const c1 = 1 + 1 as number / 2;
                                       ~
 !!! error TS1005: ',' expected.
@@ -12,9 +14,11 @@ disallowUnerasableAssertion.ts(7,35): error TS1005: ',' expected.
     export const c4 = 1 + 1 as number > 2;
     export const c5 = 1 + 1 as number >= 2;
     export const c6 = 1 + 1 as number >> 2;
-                                      ~~
-!!! error TS1005: ',' expected.
     export const c7 = 1 + 1 as number << 2;
-                                      ~~
+    export const c8 = 1 << 1 as number + 2;
+                                       ~
+!!! error TS1005: ',' expected.
+    export const c9 = 1 >> 1 as number + 2;
+                                       ~
 !!! error TS1005: ',' expected.
     

--- a/testdata/baselines/reference/compiler/disallowUnerasableAssertion.errors.txt
+++ b/testdata/baselines/reference/compiler/disallowUnerasableAssertion.errors.txt
@@ -1,10 +1,20 @@
 disallowUnerasableAssertion.ts(1,35): error TS1005: ',' expected.
+disallowUnerasableAssertion.ts(6,35): error TS1005: ',' expected.
+disallowUnerasableAssertion.ts(7,35): error TS1005: ',' expected.
 
 
-==== disallowUnerasableAssertion.ts (1 errors) ====
+==== disallowUnerasableAssertion.ts (3 errors) ====
     export const c1 = 1 + 1 as number / 2;
                                       ~
 !!! error TS1005: ',' expected.
     export const c2 = (1 + 1 as number) / 2;
     export const c3 = 1 + 1 as number === 2;
+    export const c4 = 1 + 1 as number > 2;
+    export const c5 = 1 + 1 as number >= 2;
+    export const c6 = 1 + 1 as number >> 2;
+                                      ~~
+!!! error TS1005: ',' expected.
+    export const c7 = 1 + 1 as number << 2;
+                                      ~~
+!!! error TS1005: ',' expected.
     

--- a/testdata/baselines/reference/compiler/disallowUnerasableAssertion.errors.txt
+++ b/testdata/baselines/reference/compiler/disallowUnerasableAssertion.errors.txt
@@ -1,25 +1,92 @@
-disallowUnerasableAssertion.ts(4,35): error TS1005: ',' expected.
-disallowUnerasableAssertion.ts(11,36): error TS1005: ',' expected.
-disallowUnerasableAssertion.ts(12,36): error TS1005: ',' expected.
+disallowUnerasableAssertion.ts(9,36): error TS1005: ',' expected.
+disallowUnerasableAssertion.ts(10,43): error TS1005: ',' expected.
+disallowUnerasableAssertion.ts(33,37): error TS1005: ',' expected.
+disallowUnerasableAssertion.ts(34,44): error TS1005: ',' expected.
+disallowUnerasableAssertion.ts(39,43): error TS1005: ',' expected.
+disallowUnerasableAssertion.ts(40,57): error TS1005: ',' expected.
+disallowUnerasableAssertion.ts(63,44): error TS1005: ',' expected.
+disallowUnerasableAssertion.ts(64,58): error TS1005: ',' expected.
 
 
-==== disallowUnerasableAssertion.ts (3 errors) ====
+==== disallowUnerasableAssertion.ts (8 errors) ====
     // https://github.com/microsoft/TypeScript/issues/63527
     
-    export const c0 = 1 as number / 2;
-    export const c1 = 1 + 1 as number / 2;
-                                      ~
-!!! error TS1005: ',' expected.
-    export const c2 = (1 + 1 as number) / 2;
-    export const c3 = 1 + 1 as number === 2;
-    export const c4 = 1 + 1 as number > 2;
-    export const c5 = 1 + 1 as number >= 2;
-    export const c6 = 1 + 1 as number >> 2;
-    export const c7 = 1 + 1 as number << 2;
-    export const c8 = 1 << 1 as number + 2;
+    // Expressions of the form 'a ## b as T $$ c' where ## has lower precedence than $$ are errors
+    // because 'as T' cannot be erased without changing the meaning of the expressions.
+    
+    export const x01 = 1 as number * 2;
+    export const x02 = 1 as any as number * 2;
+    
+    export const x03 = 1 + 1 as number * 2;  // Error
                                        ~
 !!! error TS1005: ',' expected.
-    export const c9 = 1 >> 1 as number + 2;
-                                       ~
+    export const x04 = 1 + 1 as any as number * 2;  // Error
+                                              ~
+!!! error TS1005: ',' expected.
+    export const x05 = 1 as number + 1 * 2;
+    export const x06 = 1 as any as number + 1 * 2;
+    
+    export const x07 = 1 * 1 as number + 2;
+    export const x08 = 1 * 1 as any as number + 2;
+    export const x09 = 1 as number * 1 + 2;
+    export const x10 = 1 as any as number * 1 + 2;
+    
+    export const x11 = (1 + 1 as number) * 2;
+    export const x12 = (1 + 1 as any as number) * 2;
+    export const x13 = (1 as number + 1) * 2;
+    export const x14 = (1 as any as number + 1) * 2;
+    
+    export const x15 = 1 + 1 as number === 2;
+    export const x16 = 1 + 1 as any as number === 2;
+    export const x17 = 1 + 1 as number > 2;
+    export const x18 = 1 + 1 as any as number > 2;
+    export const x19 = 1 + 1 as number >= 2;
+    export const x20 = 1 + 1 as any as number >= 2;
+    
+    export const x21 = 1 + 1 as number >> 2;
+    export const x22 = 1 + 1 as any as number >> 2;
+    export const x23 = 1 >> 1 as number + 2;  // Error
+                                        ~
+!!! error TS1005: ',' expected.
+    export const x24 = 1 >> 1 as any as number + 2;  // Error
+                                               ~
+!!! error TS1005: ',' expected.
+    
+    export const y01 = 1 satisfies number * 2;
+    export const y02 = 1 satisfies any satisfies number * 2;
+    
+    export const y03 = 1 + 1 satisfies number * 2;  // Error
+                                              ~
+!!! error TS1005: ',' expected.
+    export const y04 = 1 + 1 satisfies any satisfies number * 2;  // Error
+                                                            ~
+!!! error TS1005: ',' expected.
+    export const y05 = 1 satisfies number + 1 * 2;
+    export const y06 = 1 satisfies any satisfies number + 1 * 2;
+    
+    export const y07 = 1 * 1 satisfies number + 2;
+    export const y08 = 1 * 1 satisfies any satisfies number + 2;
+    export const y09 = 1 satisfies number * 1 + 2;
+    export const y10 = 1 satisfies any satisfies number * 1 + 2;
+    
+    export const y11 = (1 + 1 satisfies number) * 2;
+    export const y12 = (1 + 1 satisfies any satisfies number) * 2;
+    export const y13 = (1 satisfies number + 1) * 2;
+    export const y14 = (1 satisfies any satisfies number + 1) * 2;
+    
+    export const y15 = 1 + 1 satisfies number === 2;
+    export const y16 = 1 + 1 satisfies any satisfies number === 2;
+    export const y17 = 1 + 1 satisfies number > 2;
+    export const y18 = 1 + 1 satisfies any satisfies number > 2;
+    export const y19 = 1 + 1 satisfies number >= 2;
+    export const y20 = 1 + 1 satisfies any satisfies number >= 2;
+    
+    export const y21 = 1 + 1 satisfies number >> 2;
+    export const y22 = 1 + 1 satisfies any satisfies number >> 2;
+    export const y23 = 1 >> 1 satisfies number + 2;  // Error
+                                               ~
+!!! error TS1005: ',' expected.
+    export const y24 = 1 >> 1 satisfies any satisfies number + 2;  // Error
+                                                             ~
 !!! error TS1005: ',' expected.
     

--- a/testdata/baselines/reference/compiler/disallowUnerasableAssertion.errors.txt
+++ b/testdata/baselines/reference/compiler/disallowUnerasableAssertion.errors.txt
@@ -1,11 +1,12 @@
-disallowUnerasableAssertion.ts(3,35): error TS1005: ',' expected.
-disallowUnerasableAssertion.ts(10,36): error TS1005: ',' expected.
+disallowUnerasableAssertion.ts(4,35): error TS1005: ',' expected.
 disallowUnerasableAssertion.ts(11,36): error TS1005: ',' expected.
+disallowUnerasableAssertion.ts(12,36): error TS1005: ',' expected.
 
 
 ==== disallowUnerasableAssertion.ts (3 errors) ====
     // https://github.com/microsoft/TypeScript/issues/63527
     
+    export const c0 = 1 as number / 2;
     export const c1 = 1 + 1 as number / 2;
                                       ~
 !!! error TS1005: ',' expected.

--- a/testdata/baselines/reference/compiler/disallowUnerasableAssertion.js
+++ b/testdata/baselines/reference/compiler/disallowUnerasableAssertion.js
@@ -1,6 +1,8 @@
 //// [tests/cases/compiler/disallowUnerasableAssertion.ts] ////
 
 //// [disallowUnerasableAssertion.ts]
+// https://github.com/microsoft/TypeScript/issues/63527
+
 export const c1 = 1 + 1 as number / 2;
 export const c2 = (1 + 1 as number) / 2;
 export const c3 = 1 + 1 as number === 2;
@@ -8,16 +10,21 @@ export const c4 = 1 + 1 as number > 2;
 export const c5 = 1 + 1 as number >= 2;
 export const c6 = 1 + 1 as number >> 2;
 export const c7 = 1 + 1 as number << 2;
+export const c8 = 1 << 1 as number + 2;
+export const c9 = 1 >> 1 as number + 2;
 
 
 //// [disallowUnerasableAssertion.js]
+// https://github.com/microsoft/TypeScript/issues/63527
 export const c1 = 1 + 1;
 / 2;
 export const c2 = (1 + 1) / 2;
 export const c3 = 1 + 1 === 2;
 export const c4 = 1 + 1 > 2;
 export const c5 = 1 + 1 >= 2;
-export const c6 = 1 + 1;
- >> 2;
-export const c7 = 1 + 1;
- << 2;
+export const c6 = 1 + 1 >> 2;
+export const c7 = 1 + 1 << 2;
+export const c8 = 1 << 1;
++2;
+export const c9 = 1 >> 1;
++2;

--- a/testdata/baselines/reference/compiler/disallowUnerasableAssertion.js
+++ b/testdata/baselines/reference/compiler/disallowUnerasableAssertion.js
@@ -1,0 +1,13 @@
+//// [tests/cases/compiler/disallowUnerasableAssertion.ts] ////
+
+//// [disallowUnerasableAssertion.ts]
+export const c1 = 1 + 1 as number / 2;
+export const c2 = (1 + 1 as number) / 2;
+export const c3 = 1 + 1 as number === 2;
+
+
+//// [disallowUnerasableAssertion.js]
+export const c1 = 1 + 1;
+/ 2;
+export const c2 = (1 + 1) / 2;
+export const c3 = 1 + 1 === 2;

--- a/testdata/baselines/reference/compiler/disallowUnerasableAssertion.js
+++ b/testdata/baselines/reference/compiler/disallowUnerasableAssertion.js
@@ -4,6 +4,10 @@
 export const c1 = 1 + 1 as number / 2;
 export const c2 = (1 + 1 as number) / 2;
 export const c3 = 1 + 1 as number === 2;
+export const c4 = 1 + 1 as number > 2;
+export const c5 = 1 + 1 as number >= 2;
+export const c6 = 1 + 1 as number >> 2;
+export const c7 = 1 + 1 as number << 2;
 
 
 //// [disallowUnerasableAssertion.js]
@@ -11,3 +15,9 @@ export const c1 = 1 + 1;
 / 2;
 export const c2 = (1 + 1) / 2;
 export const c3 = 1 + 1 === 2;
+export const c4 = 1 + 1 > 2;
+export const c5 = 1 + 1 >= 2;
+export const c6 = 1 + 1;
+ >> 2;
+export const c7 = 1 + 1;
+ << 2;

--- a/testdata/baselines/reference/compiler/disallowUnerasableAssertion.js
+++ b/testdata/baselines/reference/compiler/disallowUnerasableAssertion.js
@@ -3,6 +3,7 @@
 //// [disallowUnerasableAssertion.ts]
 // https://github.com/microsoft/TypeScript/issues/63527
 
+export const c0 = 1 as number / 2;
 export const c1 = 1 + 1 as number / 2;
 export const c2 = (1 + 1 as number) / 2;
 export const c3 = 1 + 1 as number === 2;
@@ -16,6 +17,7 @@ export const c9 = 1 >> 1 as number + 2;
 
 //// [disallowUnerasableAssertion.js]
 // https://github.com/microsoft/TypeScript/issues/63527
+export const c0 = 1 / 2;
 export const c1 = 1 + 1;
 / 2;
 export const c2 = (1 + 1) / 2;

--- a/testdata/baselines/reference/compiler/disallowUnerasableAssertion.js
+++ b/testdata/baselines/reference/compiler/disallowUnerasableAssertion.js
@@ -3,30 +3,127 @@
 //// [disallowUnerasableAssertion.ts]
 // https://github.com/microsoft/TypeScript/issues/63527
 
-export const c0 = 1 as number / 2;
-export const c1 = 1 + 1 as number / 2;
-export const c2 = (1 + 1 as number) / 2;
-export const c3 = 1 + 1 as number === 2;
-export const c4 = 1 + 1 as number > 2;
-export const c5 = 1 + 1 as number >= 2;
-export const c6 = 1 + 1 as number >> 2;
-export const c7 = 1 + 1 as number << 2;
-export const c8 = 1 << 1 as number + 2;
-export const c9 = 1 >> 1 as number + 2;
+// Expressions of the form 'a ## b as T $$ c' where ## has lower precedence than $$ are errors
+// because 'as T' cannot be erased without changing the meaning of the expressions.
+
+export const x01 = 1 as number * 2;
+export const x02 = 1 as any as number * 2;
+
+export const x03 = 1 + 1 as number * 2;  // Error
+export const x04 = 1 + 1 as any as number * 2;  // Error
+export const x05 = 1 as number + 1 * 2;
+export const x06 = 1 as any as number + 1 * 2;
+
+export const x07 = 1 * 1 as number + 2;
+export const x08 = 1 * 1 as any as number + 2;
+export const x09 = 1 as number * 1 + 2;
+export const x10 = 1 as any as number * 1 + 2;
+
+export const x11 = (1 + 1 as number) * 2;
+export const x12 = (1 + 1 as any as number) * 2;
+export const x13 = (1 as number + 1) * 2;
+export const x14 = (1 as any as number + 1) * 2;
+
+export const x15 = 1 + 1 as number === 2;
+export const x16 = 1 + 1 as any as number === 2;
+export const x17 = 1 + 1 as number > 2;
+export const x18 = 1 + 1 as any as number > 2;
+export const x19 = 1 + 1 as number >= 2;
+export const x20 = 1 + 1 as any as number >= 2;
+
+export const x21 = 1 + 1 as number >> 2;
+export const x22 = 1 + 1 as any as number >> 2;
+export const x23 = 1 >> 1 as number + 2;  // Error
+export const x24 = 1 >> 1 as any as number + 2;  // Error
+
+export const y01 = 1 satisfies number * 2;
+export const y02 = 1 satisfies any satisfies number * 2;
+
+export const y03 = 1 + 1 satisfies number * 2;  // Error
+export const y04 = 1 + 1 satisfies any satisfies number * 2;  // Error
+export const y05 = 1 satisfies number + 1 * 2;
+export const y06 = 1 satisfies any satisfies number + 1 * 2;
+
+export const y07 = 1 * 1 satisfies number + 2;
+export const y08 = 1 * 1 satisfies any satisfies number + 2;
+export const y09 = 1 satisfies number * 1 + 2;
+export const y10 = 1 satisfies any satisfies number * 1 + 2;
+
+export const y11 = (1 + 1 satisfies number) * 2;
+export const y12 = (1 + 1 satisfies any satisfies number) * 2;
+export const y13 = (1 satisfies number + 1) * 2;
+export const y14 = (1 satisfies any satisfies number + 1) * 2;
+
+export const y15 = 1 + 1 satisfies number === 2;
+export const y16 = 1 + 1 satisfies any satisfies number === 2;
+export const y17 = 1 + 1 satisfies number > 2;
+export const y18 = 1 + 1 satisfies any satisfies number > 2;
+export const y19 = 1 + 1 satisfies number >= 2;
+export const y20 = 1 + 1 satisfies any satisfies number >= 2;
+
+export const y21 = 1 + 1 satisfies number >> 2;
+export const y22 = 1 + 1 satisfies any satisfies number >> 2;
+export const y23 = 1 >> 1 satisfies number + 2;  // Error
+export const y24 = 1 >> 1 satisfies any satisfies number + 2;  // Error
 
 
 //// [disallowUnerasableAssertion.js]
 // https://github.com/microsoft/TypeScript/issues/63527
-export const c0 = 1 / 2;
-export const c1 = 1 + 1;
-/ 2;
-export const c2 = (1 + 1) / 2;
-export const c3 = 1 + 1 === 2;
-export const c4 = 1 + 1 > 2;
-export const c5 = 1 + 1 >= 2;
-export const c6 = 1 + 1 >> 2;
-export const c7 = 1 + 1 << 2;
-export const c8 = 1 << 1;
-+2;
-export const c9 = 1 >> 1;
-+2;
+// Expressions of the form 'a ## b as T $$ c' where ## has lower precedence than $$ are errors
+// because 'as T' cannot be erased without changing the meaning of the expressions.
+export const x01 = 1 * 2;
+export const x02 = 1 * 2;
+export const x03 = 1 + 1;
+ * 2; // Error
+export const x04 = 1 + 1;
+ * 2; // Error
+export const x05 = 1 + 1 * 2;
+export const x06 = 1 + 1 * 2;
+export const x07 = 1 * 1 + 2;
+export const x08 = 1 * 1 + 2;
+export const x09 = 1 * 1 + 2;
+export const x10 = 1 * 1 + 2;
+export const x11 = (1 + 1) * 2;
+export const x12 = (1 + 1) * 2;
+export const x13 = (1 + 1) * 2;
+export const x14 = (1 + 1) * 2;
+export const x15 = 1 + 1 === 2;
+export const x16 = 1 + 1 === 2;
+export const x17 = 1 + 1 > 2;
+export const x18 = 1 + 1 > 2;
+export const x19 = 1 + 1 >= 2;
+export const x20 = 1 + 1 >= 2;
+export const x21 = 1 + 1 >> 2;
+export const x22 = 1 + 1 >> 2;
+export const x23 = 1 >> 1;
++2; // Error
+export const x24 = 1 >> 1;
++2; // Error
+export const y01 = 1 * 2;
+export const y02 = 1 * 2;
+export const y03 = 1 + 1;
+ * 2; // Error
+export const y04 = 1 + 1;
+ * 2; // Error
+export const y05 = 1 + 1 * 2;
+export const y06 = 1 + 1 * 2;
+export const y07 = 1 * 1 + 2;
+export const y08 = 1 * 1 + 2;
+export const y09 = 1 * 1 + 2;
+export const y10 = 1 * 1 + 2;
+export const y11 = (1 + 1) * 2;
+export const y12 = (1 + 1) * 2;
+export const y13 = (1 + 1) * 2;
+export const y14 = (1 + 1) * 2;
+export const y15 = 1 + 1 === 2;
+export const y16 = 1 + 1 === 2;
+export const y17 = 1 + 1 > 2;
+export const y18 = 1 + 1 > 2;
+export const y19 = 1 + 1 >= 2;
+export const y20 = 1 + 1 >= 2;
+export const y21 = 1 + 1 >> 2;
+export const y22 = 1 + 1 >> 2;
+export const y23 = 1 >> 1;
++2; // Error
+export const y24 = 1 >> 1;
++2; // Error

--- a/testdata/baselines/reference/compiler/disallowUnerasableAssertion.symbols
+++ b/testdata/baselines/reference/compiler/disallowUnerasableAssertion.symbols
@@ -1,24 +1,32 @@
 //// [tests/cases/compiler/disallowUnerasableAssertion.ts] ////
 
 === disallowUnerasableAssertion.ts ===
+// https://github.com/microsoft/TypeScript/issues/63527
+
 export const c1 = 1 + 1 as number / 2;
->c1 : Symbol(c1, Decl(disallowUnerasableAssertion.ts, 0, 12))
+>c1 : Symbol(c1, Decl(disallowUnerasableAssertion.ts, 2, 12))
 
 export const c2 = (1 + 1 as number) / 2;
->c2 : Symbol(c2, Decl(disallowUnerasableAssertion.ts, 1, 12))
+>c2 : Symbol(c2, Decl(disallowUnerasableAssertion.ts, 3, 12))
 
 export const c3 = 1 + 1 as number === 2;
->c3 : Symbol(c3, Decl(disallowUnerasableAssertion.ts, 2, 12))
+>c3 : Symbol(c3, Decl(disallowUnerasableAssertion.ts, 4, 12))
 
 export const c4 = 1 + 1 as number > 2;
->c4 : Symbol(c4, Decl(disallowUnerasableAssertion.ts, 3, 12))
+>c4 : Symbol(c4, Decl(disallowUnerasableAssertion.ts, 5, 12))
 
 export const c5 = 1 + 1 as number >= 2;
->c5 : Symbol(c5, Decl(disallowUnerasableAssertion.ts, 4, 12))
+>c5 : Symbol(c5, Decl(disallowUnerasableAssertion.ts, 6, 12))
 
 export const c6 = 1 + 1 as number >> 2;
->c6 : Symbol(c6, Decl(disallowUnerasableAssertion.ts, 5, 12))
+>c6 : Symbol(c6, Decl(disallowUnerasableAssertion.ts, 7, 12))
 
 export const c7 = 1 + 1 as number << 2;
->c7 : Symbol(c7, Decl(disallowUnerasableAssertion.ts, 6, 12))
+>c7 : Symbol(c7, Decl(disallowUnerasableAssertion.ts, 8, 12))
+
+export const c8 = 1 << 1 as number + 2;
+>c8 : Symbol(c8, Decl(disallowUnerasableAssertion.ts, 9, 12))
+
+export const c9 = 1 >> 1 as number + 2;
+>c9 : Symbol(c9, Decl(disallowUnerasableAssertion.ts, 10, 12))
 

--- a/testdata/baselines/reference/compiler/disallowUnerasableAssertion.symbols
+++ b/testdata/baselines/reference/compiler/disallowUnerasableAssertion.symbols
@@ -3,33 +3,150 @@
 === disallowUnerasableAssertion.ts ===
 // https://github.com/microsoft/TypeScript/issues/63527
 
-export const c0 = 1 as number / 2;
->c0 : Symbol(c0, Decl(disallowUnerasableAssertion.ts, 2, 12))
+// Expressions of the form 'a ## b as T $$ c' where ## has lower precedence than $$ are errors
+// because 'as T' cannot be erased without changing the meaning of the expressions.
 
-export const c1 = 1 + 1 as number / 2;
->c1 : Symbol(c1, Decl(disallowUnerasableAssertion.ts, 3, 12))
+export const x01 = 1 as number * 2;
+>x01 : Symbol(x01, Decl(disallowUnerasableAssertion.ts, 5, 12))
 
-export const c2 = (1 + 1 as number) / 2;
->c2 : Symbol(c2, Decl(disallowUnerasableAssertion.ts, 4, 12))
+export const x02 = 1 as any as number * 2;
+>x02 : Symbol(x02, Decl(disallowUnerasableAssertion.ts, 6, 12))
 
-export const c3 = 1 + 1 as number === 2;
->c3 : Symbol(c3, Decl(disallowUnerasableAssertion.ts, 5, 12))
+export const x03 = 1 + 1 as number * 2;  // Error
+>x03 : Symbol(x03, Decl(disallowUnerasableAssertion.ts, 8, 12))
 
-export const c4 = 1 + 1 as number > 2;
->c4 : Symbol(c4, Decl(disallowUnerasableAssertion.ts, 6, 12))
+export const x04 = 1 + 1 as any as number * 2;  // Error
+>x04 : Symbol(x04, Decl(disallowUnerasableAssertion.ts, 9, 12))
 
-export const c5 = 1 + 1 as number >= 2;
->c5 : Symbol(c5, Decl(disallowUnerasableAssertion.ts, 7, 12))
+export const x05 = 1 as number + 1 * 2;
+>x05 : Symbol(x05, Decl(disallowUnerasableAssertion.ts, 10, 12))
 
-export const c6 = 1 + 1 as number >> 2;
->c6 : Symbol(c6, Decl(disallowUnerasableAssertion.ts, 8, 12))
+export const x06 = 1 as any as number + 1 * 2;
+>x06 : Symbol(x06, Decl(disallowUnerasableAssertion.ts, 11, 12))
 
-export const c7 = 1 + 1 as number << 2;
->c7 : Symbol(c7, Decl(disallowUnerasableAssertion.ts, 9, 12))
+export const x07 = 1 * 1 as number + 2;
+>x07 : Symbol(x07, Decl(disallowUnerasableAssertion.ts, 13, 12))
 
-export const c8 = 1 << 1 as number + 2;
->c8 : Symbol(c8, Decl(disallowUnerasableAssertion.ts, 10, 12))
+export const x08 = 1 * 1 as any as number + 2;
+>x08 : Symbol(x08, Decl(disallowUnerasableAssertion.ts, 14, 12))
 
-export const c9 = 1 >> 1 as number + 2;
->c9 : Symbol(c9, Decl(disallowUnerasableAssertion.ts, 11, 12))
+export const x09 = 1 as number * 1 + 2;
+>x09 : Symbol(x09, Decl(disallowUnerasableAssertion.ts, 15, 12))
+
+export const x10 = 1 as any as number * 1 + 2;
+>x10 : Symbol(x10, Decl(disallowUnerasableAssertion.ts, 16, 12))
+
+export const x11 = (1 + 1 as number) * 2;
+>x11 : Symbol(x11, Decl(disallowUnerasableAssertion.ts, 18, 12))
+
+export const x12 = (1 + 1 as any as number) * 2;
+>x12 : Symbol(x12, Decl(disallowUnerasableAssertion.ts, 19, 12))
+
+export const x13 = (1 as number + 1) * 2;
+>x13 : Symbol(x13, Decl(disallowUnerasableAssertion.ts, 20, 12))
+
+export const x14 = (1 as any as number + 1) * 2;
+>x14 : Symbol(x14, Decl(disallowUnerasableAssertion.ts, 21, 12))
+
+export const x15 = 1 + 1 as number === 2;
+>x15 : Symbol(x15, Decl(disallowUnerasableAssertion.ts, 23, 12))
+
+export const x16 = 1 + 1 as any as number === 2;
+>x16 : Symbol(x16, Decl(disallowUnerasableAssertion.ts, 24, 12))
+
+export const x17 = 1 + 1 as number > 2;
+>x17 : Symbol(x17, Decl(disallowUnerasableAssertion.ts, 25, 12))
+
+export const x18 = 1 + 1 as any as number > 2;
+>x18 : Symbol(x18, Decl(disallowUnerasableAssertion.ts, 26, 12))
+
+export const x19 = 1 + 1 as number >= 2;
+>x19 : Symbol(x19, Decl(disallowUnerasableAssertion.ts, 27, 12))
+
+export const x20 = 1 + 1 as any as number >= 2;
+>x20 : Symbol(x20, Decl(disallowUnerasableAssertion.ts, 28, 12))
+
+export const x21 = 1 + 1 as number >> 2;
+>x21 : Symbol(x21, Decl(disallowUnerasableAssertion.ts, 30, 12))
+
+export const x22 = 1 + 1 as any as number >> 2;
+>x22 : Symbol(x22, Decl(disallowUnerasableAssertion.ts, 31, 12))
+
+export const x23 = 1 >> 1 as number + 2;  // Error
+>x23 : Symbol(x23, Decl(disallowUnerasableAssertion.ts, 32, 12))
+
+export const x24 = 1 >> 1 as any as number + 2;  // Error
+>x24 : Symbol(x24, Decl(disallowUnerasableAssertion.ts, 33, 12))
+
+export const y01 = 1 satisfies number * 2;
+>y01 : Symbol(y01, Decl(disallowUnerasableAssertion.ts, 35, 12))
+
+export const y02 = 1 satisfies any satisfies number * 2;
+>y02 : Symbol(y02, Decl(disallowUnerasableAssertion.ts, 36, 12))
+
+export const y03 = 1 + 1 satisfies number * 2;  // Error
+>y03 : Symbol(y03, Decl(disallowUnerasableAssertion.ts, 38, 12))
+
+export const y04 = 1 + 1 satisfies any satisfies number * 2;  // Error
+>y04 : Symbol(y04, Decl(disallowUnerasableAssertion.ts, 39, 12))
+
+export const y05 = 1 satisfies number + 1 * 2;
+>y05 : Symbol(y05, Decl(disallowUnerasableAssertion.ts, 40, 12))
+
+export const y06 = 1 satisfies any satisfies number + 1 * 2;
+>y06 : Symbol(y06, Decl(disallowUnerasableAssertion.ts, 41, 12))
+
+export const y07 = 1 * 1 satisfies number + 2;
+>y07 : Symbol(y07, Decl(disallowUnerasableAssertion.ts, 43, 12))
+
+export const y08 = 1 * 1 satisfies any satisfies number + 2;
+>y08 : Symbol(y08, Decl(disallowUnerasableAssertion.ts, 44, 12))
+
+export const y09 = 1 satisfies number * 1 + 2;
+>y09 : Symbol(y09, Decl(disallowUnerasableAssertion.ts, 45, 12))
+
+export const y10 = 1 satisfies any satisfies number * 1 + 2;
+>y10 : Symbol(y10, Decl(disallowUnerasableAssertion.ts, 46, 12))
+
+export const y11 = (1 + 1 satisfies number) * 2;
+>y11 : Symbol(y11, Decl(disallowUnerasableAssertion.ts, 48, 12))
+
+export const y12 = (1 + 1 satisfies any satisfies number) * 2;
+>y12 : Symbol(y12, Decl(disallowUnerasableAssertion.ts, 49, 12))
+
+export const y13 = (1 satisfies number + 1) * 2;
+>y13 : Symbol(y13, Decl(disallowUnerasableAssertion.ts, 50, 12))
+
+export const y14 = (1 satisfies any satisfies number + 1) * 2;
+>y14 : Symbol(y14, Decl(disallowUnerasableAssertion.ts, 51, 12))
+
+export const y15 = 1 + 1 satisfies number === 2;
+>y15 : Symbol(y15, Decl(disallowUnerasableAssertion.ts, 53, 12))
+
+export const y16 = 1 + 1 satisfies any satisfies number === 2;
+>y16 : Symbol(y16, Decl(disallowUnerasableAssertion.ts, 54, 12))
+
+export const y17 = 1 + 1 satisfies number > 2;
+>y17 : Symbol(y17, Decl(disallowUnerasableAssertion.ts, 55, 12))
+
+export const y18 = 1 + 1 satisfies any satisfies number > 2;
+>y18 : Symbol(y18, Decl(disallowUnerasableAssertion.ts, 56, 12))
+
+export const y19 = 1 + 1 satisfies number >= 2;
+>y19 : Symbol(y19, Decl(disallowUnerasableAssertion.ts, 57, 12))
+
+export const y20 = 1 + 1 satisfies any satisfies number >= 2;
+>y20 : Symbol(y20, Decl(disallowUnerasableAssertion.ts, 58, 12))
+
+export const y21 = 1 + 1 satisfies number >> 2;
+>y21 : Symbol(y21, Decl(disallowUnerasableAssertion.ts, 60, 12))
+
+export const y22 = 1 + 1 satisfies any satisfies number >> 2;
+>y22 : Symbol(y22, Decl(disallowUnerasableAssertion.ts, 61, 12))
+
+export const y23 = 1 >> 1 satisfies number + 2;  // Error
+>y23 : Symbol(y23, Decl(disallowUnerasableAssertion.ts, 62, 12))
+
+export const y24 = 1 >> 1 satisfies any satisfies number + 2;  // Error
+>y24 : Symbol(y24, Decl(disallowUnerasableAssertion.ts, 63, 12))
 

--- a/testdata/baselines/reference/compiler/disallowUnerasableAssertion.symbols
+++ b/testdata/baselines/reference/compiler/disallowUnerasableAssertion.symbols
@@ -1,0 +1,12 @@
+//// [tests/cases/compiler/disallowUnerasableAssertion.ts] ////
+
+=== disallowUnerasableAssertion.ts ===
+export const c1 = 1 + 1 as number / 2;
+>c1 : Symbol(c1, Decl(disallowUnerasableAssertion.ts, 0, 12))
+
+export const c2 = (1 + 1 as number) / 2;
+>c2 : Symbol(c2, Decl(disallowUnerasableAssertion.ts, 1, 12))
+
+export const c3 = 1 + 1 as number === 2;
+>c3 : Symbol(c3, Decl(disallowUnerasableAssertion.ts, 2, 12))
+

--- a/testdata/baselines/reference/compiler/disallowUnerasableAssertion.symbols
+++ b/testdata/baselines/reference/compiler/disallowUnerasableAssertion.symbols
@@ -3,30 +3,33 @@
 === disallowUnerasableAssertion.ts ===
 // https://github.com/microsoft/TypeScript/issues/63527
 
+export const c0 = 1 as number / 2;
+>c0 : Symbol(c0, Decl(disallowUnerasableAssertion.ts, 2, 12))
+
 export const c1 = 1 + 1 as number / 2;
->c1 : Symbol(c1, Decl(disallowUnerasableAssertion.ts, 2, 12))
+>c1 : Symbol(c1, Decl(disallowUnerasableAssertion.ts, 3, 12))
 
 export const c2 = (1 + 1 as number) / 2;
->c2 : Symbol(c2, Decl(disallowUnerasableAssertion.ts, 3, 12))
+>c2 : Symbol(c2, Decl(disallowUnerasableAssertion.ts, 4, 12))
 
 export const c3 = 1 + 1 as number === 2;
->c3 : Symbol(c3, Decl(disallowUnerasableAssertion.ts, 4, 12))
+>c3 : Symbol(c3, Decl(disallowUnerasableAssertion.ts, 5, 12))
 
 export const c4 = 1 + 1 as number > 2;
->c4 : Symbol(c4, Decl(disallowUnerasableAssertion.ts, 5, 12))
+>c4 : Symbol(c4, Decl(disallowUnerasableAssertion.ts, 6, 12))
 
 export const c5 = 1 + 1 as number >= 2;
->c5 : Symbol(c5, Decl(disallowUnerasableAssertion.ts, 6, 12))
+>c5 : Symbol(c5, Decl(disallowUnerasableAssertion.ts, 7, 12))
 
 export const c6 = 1 + 1 as number >> 2;
->c6 : Symbol(c6, Decl(disallowUnerasableAssertion.ts, 7, 12))
+>c6 : Symbol(c6, Decl(disallowUnerasableAssertion.ts, 8, 12))
 
 export const c7 = 1 + 1 as number << 2;
->c7 : Symbol(c7, Decl(disallowUnerasableAssertion.ts, 8, 12))
+>c7 : Symbol(c7, Decl(disallowUnerasableAssertion.ts, 9, 12))
 
 export const c8 = 1 << 1 as number + 2;
->c8 : Symbol(c8, Decl(disallowUnerasableAssertion.ts, 9, 12))
+>c8 : Symbol(c8, Decl(disallowUnerasableAssertion.ts, 10, 12))
 
 export const c9 = 1 >> 1 as number + 2;
->c9 : Symbol(c9, Decl(disallowUnerasableAssertion.ts, 10, 12))
+>c9 : Symbol(c9, Decl(disallowUnerasableAssertion.ts, 11, 12))
 

--- a/testdata/baselines/reference/compiler/disallowUnerasableAssertion.symbols
+++ b/testdata/baselines/reference/compiler/disallowUnerasableAssertion.symbols
@@ -10,3 +10,15 @@ export const c2 = (1 + 1 as number) / 2;
 export const c3 = 1 + 1 as number === 2;
 >c3 : Symbol(c3, Decl(disallowUnerasableAssertion.ts, 2, 12))
 
+export const c4 = 1 + 1 as number > 2;
+>c4 : Symbol(c4, Decl(disallowUnerasableAssertion.ts, 3, 12))
+
+export const c5 = 1 + 1 as number >= 2;
+>c5 : Symbol(c5, Decl(disallowUnerasableAssertion.ts, 4, 12))
+
+export const c6 = 1 + 1 as number >> 2;
+>c6 : Symbol(c6, Decl(disallowUnerasableAssertion.ts, 5, 12))
+
+export const c7 = 1 + 1 as number << 2;
+>c7 : Symbol(c7, Decl(disallowUnerasableAssertion.ts, 6, 12))
+

--- a/testdata/baselines/reference/compiler/disallowUnerasableAssertion.types
+++ b/testdata/baselines/reference/compiler/disallowUnerasableAssertion.types
@@ -3,24 +3,105 @@
 === disallowUnerasableAssertion.ts ===
 // https://github.com/microsoft/TypeScript/issues/63527
 
-export const c0 = 1 as number / 2;
->c0 : number
->1 as number / 2 : number
+// Expressions of the form 'a ## b as T $$ c' where ## has lower precedence than $$ are errors
+// because 'as T' cannot be erased without changing the meaning of the expressions.
+
+export const x01 = 1 as number * 2;
+>x01 : number
+>1 as number * 2 : number
 >1 as number : number
 >1 : 1
 >2 : 2
 
-export const c1 = 1 + 1 as number / 2;
->c1 : number
+export const x02 = 1 as any as number * 2;
+>x02 : number
+>1 as any as number * 2 : number
+>1 as any as number : number
+>1 as any : any
+>1 : 1
+>2 : 2
+
+export const x03 = 1 + 1 as number * 2;  // Error
+>x03 : number
 >1 + 1 as number : number
 >1 + 1 : number
 >1 : 1
 >1 : 1
->/ 2 : RegExp
+>* 2 : number
+> : any
+>2 : 2
 
-export const c2 = (1 + 1 as number) / 2;
->c2 : number
->(1 + 1 as number) / 2 : number
+export const x04 = 1 + 1 as any as number * 2;  // Error
+>x04 : number
+>1 + 1 as any as number : number
+>1 + 1 as any : any
+>1 + 1 : number
+>1 : 1
+>1 : 1
+>* 2 : number
+> : any
+>2 : 2
+
+export const x05 = 1 as number + 1 * 2;
+>x05 : number
+>1 as number + 1 * 2 : number
+>1 as number : number
+>1 : 1
+>1 * 2 : number
+>1 : 1
+>2 : 2
+
+export const x06 = 1 as any as number + 1 * 2;
+>x06 : number
+>1 as any as number + 1 * 2 : number
+>1 as any as number : number
+>1 as any : any
+>1 : 1
+>1 * 2 : number
+>1 : 1
+>2 : 2
+
+export const x07 = 1 * 1 as number + 2;
+>x07 : number
+>1 * 1 as number + 2 : number
+>1 * 1 as number : number
+>1 * 1 : number
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const x08 = 1 * 1 as any as number + 2;
+>x08 : number
+>1 * 1 as any as number + 2 : number
+>1 * 1 as any as number : number
+>1 * 1 as any : any
+>1 * 1 : number
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const x09 = 1 as number * 1 + 2;
+>x09 : number
+>1 as number * 1 + 2 : number
+>1 as number * 1 : number
+>1 as number : number
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const x10 = 1 as any as number * 1 + 2;
+>x10 : number
+>1 as any as number * 1 + 2 : number
+>1 as any as number * 1 : number
+>1 as any as number : number
+>1 as any : any
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const x11 = (1 + 1 as number) * 2;
+>x11 : number
+>(1 + 1 as number) * 2 : number
 >(1 + 1 as number) : number
 >1 + 1 as number : number
 >1 + 1 : number
@@ -28,8 +109,40 @@ export const c2 = (1 + 1 as number) / 2;
 >1 : 1
 >2 : 2
 
-export const c3 = 1 + 1 as number === 2;
->c3 : boolean
+export const x12 = (1 + 1 as any as number) * 2;
+>x12 : number
+>(1 + 1 as any as number) * 2 : number
+>(1 + 1 as any as number) : number
+>1 + 1 as any as number : number
+>1 + 1 as any : any
+>1 + 1 : number
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const x13 = (1 as number + 1) * 2;
+>x13 : number
+>(1 as number + 1) * 2 : number
+>(1 as number + 1) : number
+>1 as number + 1 : number
+>1 as number : number
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const x14 = (1 as any as number + 1) * 2;
+>x14 : number
+>(1 as any as number + 1) * 2 : number
+>(1 as any as number + 1) : number
+>1 as any as number + 1 : number
+>1 as any as number : number
+>1 as any : any
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const x15 = 1 + 1 as number === 2;
+>x15 : boolean
 >1 + 1 as number === 2 : boolean
 >1 + 1 as number : number
 >1 + 1 : number
@@ -37,8 +150,18 @@ export const c3 = 1 + 1 as number === 2;
 >1 : 1
 >2 : 2
 
-export const c4 = 1 + 1 as number > 2;
->c4 : boolean
+export const x16 = 1 + 1 as any as number === 2;
+>x16 : boolean
+>1 + 1 as any as number === 2 : boolean
+>1 + 1 as any as number : number
+>1 + 1 as any : any
+>1 + 1 : number
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const x17 = 1 + 1 as number > 2;
+>x17 : boolean
 >1 + 1 as number > 2 : boolean
 >1 + 1 as number : number
 >1 + 1 : number
@@ -46,8 +169,18 @@ export const c4 = 1 + 1 as number > 2;
 >1 : 1
 >2 : 2
 
-export const c5 = 1 + 1 as number >= 2;
->c5 : boolean
+export const x18 = 1 + 1 as any as number > 2;
+>x18 : boolean
+>1 + 1 as any as number > 2 : boolean
+>1 + 1 as any as number : number
+>1 + 1 as any : any
+>1 + 1 : number
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const x19 = 1 + 1 as number >= 2;
+>x19 : boolean
 >1 + 1 as number >= 2 : boolean
 >1 + 1 as number : number
 >1 + 1 : number
@@ -55,8 +188,18 @@ export const c5 = 1 + 1 as number >= 2;
 >1 : 1
 >2 : 2
 
-export const c6 = 1 + 1 as number >> 2;
->c6 : number
+export const x20 = 1 + 1 as any as number >= 2;
+>x20 : boolean
+>1 + 1 as any as number >= 2 : boolean
+>1 + 1 as any as number : number
+>1 + 1 as any : any
+>1 + 1 : number
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const x21 = 1 + 1 as number >> 2;
+>x21 : number
 >1 + 1 as number >> 2 : number
 >1 + 1 as number : number
 >1 + 1 : number
@@ -64,27 +207,259 @@ export const c6 = 1 + 1 as number >> 2;
 >1 : 1
 >2 : 2
 
-export const c7 = 1 + 1 as number << 2;
->c7 : number
->1 + 1 as number << 2 : number
->1 + 1 as number : number
+export const x22 = 1 + 1 as any as number >> 2;
+>x22 : number
+>1 + 1 as any as number >> 2 : number
+>1 + 1 as any as number : number
+>1 + 1 as any : any
 >1 + 1 : number
 >1 : 1
 >1 : 1
 >2 : 2
 
-export const c8 = 1 << 1 as number + 2;
->c8 : number
->1 << 1 as number : number
->1 << 1 : number
+export const x23 = 1 >> 1 as number + 2;  // Error
+>x23 : number
+>1 >> 1 as number : number
+>1 >> 1 : number
 >1 : 1
 >1 : 1
 >+ 2 : 2
 >2 : 2
 
-export const c9 = 1 >> 1 as number + 2;
->c9 : number
->1 >> 1 as number : number
+export const x24 = 1 >> 1 as any as number + 2;  // Error
+>x24 : number
+>1 >> 1 as any as number : number
+>1 >> 1 as any : any
+>1 >> 1 : number
+>1 : 1
+>1 : 1
+>+ 2 : 2
+>2 : 2
+
+export const y01 = 1 satisfies number * 2;
+>y01 : number
+>1 satisfies number * 2 : number
+>1 satisfies number : 1
+>1 : 1
+>2 : 2
+
+export const y02 = 1 satisfies any satisfies number * 2;
+>y02 : number
+>1 satisfies any satisfies number * 2 : number
+>1 satisfies any satisfies number : 1
+>1 satisfies any : 1
+>1 : 1
+>2 : 2
+
+export const y03 = 1 + 1 satisfies number * 2;  // Error
+>y03 : number
+>1 + 1 satisfies number : number
+>1 + 1 : number
+>1 : 1
+>1 : 1
+>* 2 : number
+> : any
+>2 : 2
+
+export const y04 = 1 + 1 satisfies any satisfies number * 2;  // Error
+>y04 : number
+>1 + 1 satisfies any satisfies number : number
+>1 + 1 satisfies any : number
+>1 + 1 : number
+>1 : 1
+>1 : 1
+>* 2 : number
+> : any
+>2 : 2
+
+export const y05 = 1 satisfies number + 1 * 2;
+>y05 : number
+>1 satisfies number + 1 * 2 : number
+>1 satisfies number : 1
+>1 : 1
+>1 * 2 : number
+>1 : 1
+>2 : 2
+
+export const y06 = 1 satisfies any satisfies number + 1 * 2;
+>y06 : number
+>1 satisfies any satisfies number + 1 * 2 : number
+>1 satisfies any satisfies number : 1
+>1 satisfies any : 1
+>1 : 1
+>1 * 2 : number
+>1 : 1
+>2 : 2
+
+export const y07 = 1 * 1 satisfies number + 2;
+>y07 : number
+>1 * 1 satisfies number + 2 : number
+>1 * 1 satisfies number : number
+>1 * 1 : number
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const y08 = 1 * 1 satisfies any satisfies number + 2;
+>y08 : number
+>1 * 1 satisfies any satisfies number + 2 : number
+>1 * 1 satisfies any satisfies number : number
+>1 * 1 satisfies any : number
+>1 * 1 : number
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const y09 = 1 satisfies number * 1 + 2;
+>y09 : number
+>1 satisfies number * 1 + 2 : number
+>1 satisfies number * 1 : number
+>1 satisfies number : 1
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const y10 = 1 satisfies any satisfies number * 1 + 2;
+>y10 : number
+>1 satisfies any satisfies number * 1 + 2 : number
+>1 satisfies any satisfies number * 1 : number
+>1 satisfies any satisfies number : 1
+>1 satisfies any : 1
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const y11 = (1 + 1 satisfies number) * 2;
+>y11 : number
+>(1 + 1 satisfies number) * 2 : number
+>(1 + 1 satisfies number) : number
+>1 + 1 satisfies number : number
+>1 + 1 : number
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const y12 = (1 + 1 satisfies any satisfies number) * 2;
+>y12 : number
+>(1 + 1 satisfies any satisfies number) * 2 : number
+>(1 + 1 satisfies any satisfies number) : number
+>1 + 1 satisfies any satisfies number : number
+>1 + 1 satisfies any : number
+>1 + 1 : number
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const y13 = (1 satisfies number + 1) * 2;
+>y13 : number
+>(1 satisfies number + 1) * 2 : number
+>(1 satisfies number + 1) : number
+>1 satisfies number + 1 : number
+>1 satisfies number : 1
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const y14 = (1 satisfies any satisfies number + 1) * 2;
+>y14 : number
+>(1 satisfies any satisfies number + 1) * 2 : number
+>(1 satisfies any satisfies number + 1) : number
+>1 satisfies any satisfies number + 1 : number
+>1 satisfies any satisfies number : 1
+>1 satisfies any : 1
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const y15 = 1 + 1 satisfies number === 2;
+>y15 : boolean
+>1 + 1 satisfies number === 2 : boolean
+>1 + 1 satisfies number : number
+>1 + 1 : number
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const y16 = 1 + 1 satisfies any satisfies number === 2;
+>y16 : boolean
+>1 + 1 satisfies any satisfies number === 2 : boolean
+>1 + 1 satisfies any satisfies number : number
+>1 + 1 satisfies any : number
+>1 + 1 : number
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const y17 = 1 + 1 satisfies number > 2;
+>y17 : boolean
+>1 + 1 satisfies number > 2 : boolean
+>1 + 1 satisfies number : number
+>1 + 1 : number
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const y18 = 1 + 1 satisfies any satisfies number > 2;
+>y18 : boolean
+>1 + 1 satisfies any satisfies number > 2 : boolean
+>1 + 1 satisfies any satisfies number : number
+>1 + 1 satisfies any : number
+>1 + 1 : number
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const y19 = 1 + 1 satisfies number >= 2;
+>y19 : boolean
+>1 + 1 satisfies number >= 2 : boolean
+>1 + 1 satisfies number : number
+>1 + 1 : number
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const y20 = 1 + 1 satisfies any satisfies number >= 2;
+>y20 : boolean
+>1 + 1 satisfies any satisfies number >= 2 : boolean
+>1 + 1 satisfies any satisfies number : number
+>1 + 1 satisfies any : number
+>1 + 1 : number
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const y21 = 1 + 1 satisfies number >> 2;
+>y21 : number
+>1 + 1 satisfies number >> 2 : number
+>1 + 1 satisfies number : number
+>1 + 1 : number
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const y22 = 1 + 1 satisfies any satisfies number >> 2;
+>y22 : number
+>1 + 1 satisfies any satisfies number >> 2 : number
+>1 + 1 satisfies any satisfies number : number
+>1 + 1 satisfies any : number
+>1 + 1 : number
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const y23 = 1 >> 1 satisfies number + 2;  // Error
+>y23 : number
+>1 >> 1 satisfies number : number
+>1 >> 1 : number
+>1 : 1
+>1 : 1
+>+ 2 : 2
+>2 : 2
+
+export const y24 = 1 >> 1 satisfies any satisfies number + 2;  // Error
+>y24 : number
+>1 >> 1 satisfies any satisfies number : number
+>1 >> 1 satisfies any : number
 >1 >> 1 : number
 >1 : 1
 >1 : 1

--- a/testdata/baselines/reference/compiler/disallowUnerasableAssertion.types
+++ b/testdata/baselines/reference/compiler/disallowUnerasableAssertion.types
@@ -28,3 +28,41 @@ export const c3 = 1 + 1 as number === 2;
 >1 : 1
 >2 : 2
 
+export const c4 = 1 + 1 as number > 2;
+>c4 : boolean
+>1 + 1 as number > 2 : boolean
+>1 + 1 as number : number
+>1 + 1 : number
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const c5 = 1 + 1 as number >= 2;
+>c5 : boolean
+>1 + 1 as number >= 2 : boolean
+>1 + 1 as number : number
+>1 + 1 : number
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const c6 = 1 + 1 as number >> 2;
+>c6 : number
+>1 + 1 as number : number
+>1 + 1 : number
+>1 : 1
+>1 : 1
+>>> 2 : number
+> : any
+>2 : 2
+
+export const c7 = 1 + 1 as number << 2;
+>c7 : number
+>1 + 1 as number : number
+>1 + 1 : number
+>1 : 1
+>1 : 1
+><< 2 : number
+> : any
+>2 : 2
+

--- a/testdata/baselines/reference/compiler/disallowUnerasableAssertion.types
+++ b/testdata/baselines/reference/compiler/disallowUnerasableAssertion.types
@@ -3,6 +3,13 @@
 === disallowUnerasableAssertion.ts ===
 // https://github.com/microsoft/TypeScript/issues/63527
 
+export const c0 = 1 as number / 2;
+>c0 : number
+>1 as number / 2 : number
+>1 as number : number
+>1 : 1
+>2 : 2
+
 export const c1 = 1 + 1 as number / 2;
 >c1 : number
 >1 + 1 as number : number

--- a/testdata/baselines/reference/compiler/disallowUnerasableAssertion.types
+++ b/testdata/baselines/reference/compiler/disallowUnerasableAssertion.types
@@ -1,6 +1,8 @@
 //// [tests/cases/compiler/disallowUnerasableAssertion.ts] ////
 
 === disallowUnerasableAssertion.ts ===
+// https://github.com/microsoft/TypeScript/issues/63527
+
 export const c1 = 1 + 1 as number / 2;
 >c1 : number
 >1 + 1 as number : number
@@ -48,21 +50,37 @@ export const c5 = 1 + 1 as number >= 2;
 
 export const c6 = 1 + 1 as number >> 2;
 >c6 : number
+>1 + 1 as number >> 2 : number
 >1 + 1 as number : number
 >1 + 1 : number
 >1 : 1
 >1 : 1
->>> 2 : number
-> : any
 >2 : 2
 
 export const c7 = 1 + 1 as number << 2;
 >c7 : number
+>1 + 1 as number << 2 : number
 >1 + 1 as number : number
 >1 + 1 : number
 >1 : 1
 >1 : 1
-><< 2 : number
-> : any
+>2 : 2
+
+export const c8 = 1 << 1 as number + 2;
+>c8 : number
+>1 << 1 as number : number
+>1 << 1 : number
+>1 : 1
+>1 : 1
+>+ 2 : 2
+>2 : 2
+
+export const c9 = 1 >> 1 as number + 2;
+>c9 : number
+>1 >> 1 as number : number
+>1 >> 1 : number
+>1 : 1
+>1 : 1
+>+ 2 : 2
 >2 : 2
 

--- a/testdata/baselines/reference/compiler/disallowUnerasableAssertion.types
+++ b/testdata/baselines/reference/compiler/disallowUnerasableAssertion.types
@@ -1,0 +1,30 @@
+//// [tests/cases/compiler/disallowUnerasableAssertion.ts] ////
+
+=== disallowUnerasableAssertion.ts ===
+export const c1 = 1 + 1 as number / 2;
+>c1 : number
+>1 + 1 as number : number
+>1 + 1 : number
+>1 : 1
+>1 : 1
+>/ 2 : RegExp
+
+export const c2 = (1 + 1 as number) / 2;
+>c2 : number
+>(1 + 1 as number) / 2 : number
+>(1 + 1 as number) : number
+>1 + 1 as number : number
+>1 + 1 : number
+>1 : 1
+>1 : 1
+>2 : 2
+
+export const c3 = 1 + 1 as number === 2;
+>c3 : boolean
+>1 + 1 as number === 2 : boolean
+>1 + 1 as number : number
+>1 + 1 : number
+>1 : 1
+>1 : 1
+>2 : 2
+

--- a/testdata/tests/cases/compiler/disallowUnerasableAssertion.ts
+++ b/testdata/tests/cases/compiler/disallowUnerasableAssertion.ts
@@ -1,12 +1,64 @@
 // https://github.com/microsoft/TypeScript/issues/63527
 
-export const c0 = 1 as number / 2;
-export const c1 = 1 + 1 as number / 2;
-export const c2 = (1 + 1 as number) / 2;
-export const c3 = 1 + 1 as number === 2;
-export const c4 = 1 + 1 as number > 2;
-export const c5 = 1 + 1 as number >= 2;
-export const c6 = 1 + 1 as number >> 2;
-export const c7 = 1 + 1 as number << 2;
-export const c8 = 1 << 1 as number + 2;
-export const c9 = 1 >> 1 as number + 2;
+// Expressions of the form 'a ## b as T $$ c' where ## has lower precedence than $$ are errors
+// because 'as T' cannot be erased without changing the meaning of the expressions.
+
+export const x01 = 1 as number * 2;
+export const x02 = 1 as any as number * 2;
+
+export const x03 = 1 + 1 as number * 2;  // Error
+export const x04 = 1 + 1 as any as number * 2;  // Error
+export const x05 = 1 as number + 1 * 2;
+export const x06 = 1 as any as number + 1 * 2;
+
+export const x07 = 1 * 1 as number + 2;
+export const x08 = 1 * 1 as any as number + 2;
+export const x09 = 1 as number * 1 + 2;
+export const x10 = 1 as any as number * 1 + 2;
+
+export const x11 = (1 + 1 as number) * 2;
+export const x12 = (1 + 1 as any as number) * 2;
+export const x13 = (1 as number + 1) * 2;
+export const x14 = (1 as any as number + 1) * 2;
+
+export const x15 = 1 + 1 as number === 2;
+export const x16 = 1 + 1 as any as number === 2;
+export const x17 = 1 + 1 as number > 2;
+export const x18 = 1 + 1 as any as number > 2;
+export const x19 = 1 + 1 as number >= 2;
+export const x20 = 1 + 1 as any as number >= 2;
+
+export const x21 = 1 + 1 as number >> 2;
+export const x22 = 1 + 1 as any as number >> 2;
+export const x23 = 1 >> 1 as number + 2;  // Error
+export const x24 = 1 >> 1 as any as number + 2;  // Error
+
+export const y01 = 1 satisfies number * 2;
+export const y02 = 1 satisfies any satisfies number * 2;
+
+export const y03 = 1 + 1 satisfies number * 2;  // Error
+export const y04 = 1 + 1 satisfies any satisfies number * 2;  // Error
+export const y05 = 1 satisfies number + 1 * 2;
+export const y06 = 1 satisfies any satisfies number + 1 * 2;
+
+export const y07 = 1 * 1 satisfies number + 2;
+export const y08 = 1 * 1 satisfies any satisfies number + 2;
+export const y09 = 1 satisfies number * 1 + 2;
+export const y10 = 1 satisfies any satisfies number * 1 + 2;
+
+export const y11 = (1 + 1 satisfies number) * 2;
+export const y12 = (1 + 1 satisfies any satisfies number) * 2;
+export const y13 = (1 satisfies number + 1) * 2;
+export const y14 = (1 satisfies any satisfies number + 1) * 2;
+
+export const y15 = 1 + 1 satisfies number === 2;
+export const y16 = 1 + 1 satisfies any satisfies number === 2;
+export const y17 = 1 + 1 satisfies number > 2;
+export const y18 = 1 + 1 satisfies any satisfies number > 2;
+export const y19 = 1 + 1 satisfies number >= 2;
+export const y20 = 1 + 1 satisfies any satisfies number >= 2;
+
+export const y21 = 1 + 1 satisfies number >> 2;
+export const y22 = 1 + 1 satisfies any satisfies number >> 2;
+export const y23 = 1 >> 1 satisfies number + 2;  // Error
+export const y24 = 1 >> 1 satisfies any satisfies number + 2;  // Error

--- a/testdata/tests/cases/compiler/disallowUnerasableAssertion.ts
+++ b/testdata/tests/cases/compiler/disallowUnerasableAssertion.ts
@@ -1,3 +1,5 @@
+// https://github.com/microsoft/TypeScript/issues/63527
+
 export const c1 = 1 + 1 as number / 2;
 export const c2 = (1 + 1 as number) / 2;
 export const c3 = 1 + 1 as number === 2;
@@ -5,3 +7,5 @@ export const c4 = 1 + 1 as number > 2;
 export const c5 = 1 + 1 as number >= 2;
 export const c6 = 1 + 1 as number >> 2;
 export const c7 = 1 + 1 as number << 2;
+export const c8 = 1 << 1 as number + 2;
+export const c9 = 1 >> 1 as number + 2;

--- a/testdata/tests/cases/compiler/disallowUnerasableAssertion.ts
+++ b/testdata/tests/cases/compiler/disallowUnerasableAssertion.ts
@@ -1,0 +1,3 @@
+export const c1 = 1 + 1 as number / 2;
+export const c2 = (1 + 1 as number) / 2;
+export const c3 = 1 + 1 as number === 2;

--- a/testdata/tests/cases/compiler/disallowUnerasableAssertion.ts
+++ b/testdata/tests/cases/compiler/disallowUnerasableAssertion.ts
@@ -1,3 +1,7 @@
 export const c1 = 1 + 1 as number / 2;
 export const c2 = (1 + 1 as number) / 2;
 export const c3 = 1 + 1 as number === 2;
+export const c4 = 1 + 1 as number > 2;
+export const c5 = 1 + 1 as number >= 2;
+export const c6 = 1 + 1 as number >> 2;
+export const c7 = 1 + 1 as number << 2;

--- a/testdata/tests/cases/compiler/disallowUnerasableAssertion.ts
+++ b/testdata/tests/cases/compiler/disallowUnerasableAssertion.ts
@@ -1,5 +1,6 @@
 // https://github.com/microsoft/TypeScript/issues/63527
 
+export const c0 = 1 as number / 2;
 export const c1 = 1 + 1 as number / 2;
 export const c2 = (1 + 1 as number) / 2;
 export const c3 = 1 + 1 as number === 2;


### PR DESCRIPTION
Fixes https://github.com/microsoft/TypeScript/issues/63527 as discussed [here](https://github.com/microsoft/TypeScript/issues/63527#issuecomment-4615276410).