### PR TITLE
fix(watcher): prevent bundled library paths from being watched in resolution lookup

### DIFF
--- a/internal/project/watch.go
+++ b/internal/project/watch.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/microsoft/typescript-go/internal/bundled"
 	"github.com/microsoft/typescript-go/internal/collections"
 	"github.com/microsoft/typescript-go/internal/core"
 	"github.com/microsoft/typescript-go/internal/ls/lsconv"
@@ -297,7 +298,9 @@ func createResolutionLookupGlobMapper(workspaceDirectory string, libDirectory st
 				} else if currentDirectoryPath.ContainsPath(path) {
 					includeRoot = true
 				} else if libDirectoryPath.ContainsPath(path) {
-					includeLib = true
+					if !bundled.IsBundled(string(libDirectoryPath)) {
+						includeLib = true
+					}
 				} else if idx := strings.Index(string(path), "/node_modules/"); idx != -1 {
 					nodeModulesDirectories.Add(path[:idx+len("/node_modules")])
 				} else {

--- a/internal/project/watch_test.go
+++ b/internal/project/watch_test.go
@@ -3,6 +3,9 @@ package project
 import (
 	"testing"
 
+	"github.com/microsoft/typescript-go/internal/bundled"
+	"github.com/microsoft/typescript-go/internal/collections"
+	"github.com/microsoft/typescript-go/internal/tspath"
 	"gotest.tools/v3/assert"
 )
 
@@ -25,4 +28,31 @@ func TestNilWatchedFilesClone(t *testing.T) {
 	var w *WatchedFiles[int]
 	result := w.Clone(42)
 	assert.Assert(t, result == nil, "clone on a nil `WatchedFiles` should return nil")
+}
+
+func TestCreateResolutionLookupGlobMapperSkipsBundledLibs(t *testing.T) {
+	t.Parallel()
+	if !bundled.Embedded {
+		t.Skip("bundled files are not embedded")
+	}
+
+	data := &collections.SyncSet[tspath.Path]{}
+	data.Add(tspath.Path("bundled:///libs/lib.d.ts"))
+
+	mapper := createResolutionLookupGlobMapper("/workspace", bundled.LibPath(), "/workspace", true)
+	result := mapper(data)
+
+	assert.DeepEqual(t, result.patternsInsideWorkspace, []string(nil))
+}
+
+func TestCreateResolutionLookupGlobMapperWatchesRealLibDirectory(t *testing.T) {
+	t.Parallel()
+
+	data := &collections.SyncSet[tspath.Path]{}
+	data.Add(tspath.Path("/ts/lib/lib.d.ts"))
+
+	mapper := createResolutionLookupGlobMapper("/workspace", "/ts/lib", "/workspace", true)
+	result := mapper(data)
+
+	assert.DeepEqual(t, result.patternsInsideWorkspace, []string{"/ts/lib/**/*"})
 }


### PR DESCRIPTION
## Summary

This change prevents bundled library paths from being included in the glob-based resolution lookup for file watching. This ensures that the file watcher only watches actual project files, not bundled library files, which resolves issues where file watching would incorrectly include or be affected by bundled library paths.

## Changes

- **fix(project): skip bundled library paths in resolution lookup glob mapper**
  - Updated `internal/project/watch.go` to filter out bundled library paths from the glob mapper
  - Added test coverage in `internal/project/watch_test.go` to verify bundled library paths are skipped

## Testing

- New unit tests verify that bundled library paths are correctly skipped in the resolution lookup
- Existing tests continue to pass