### PR TITLE
prevent bundled library paths from being watched in resolution lookup

### DIFF
--- a/internal/project/watch.go
+++ b/internal/project/watch.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/microsoft/typescript-go/internal/bundled"
 	"github.com/microsoft/typescript-go/internal/collections"
 	"github.com/microsoft/typescript-go/internal/core"
 	"github.com/microsoft/typescript-go/internal/ls/lsconv"
@@ -297,7 +298,9 @@ func createResolutionLookupGlobMapper(workspaceDirectory string, libDirectory st
 				} else if currentDirectoryPath.ContainsPath(path) {
 					includeRoot = true
 				} else if libDirectoryPath.ContainsPath(path) {
-					includeLib = true
+					if !bundled.IsBundled(string(libDirectoryPath)) {
+						includeLib = true
+					}
 				} else if idx := strings.Index(string(path), "/node_modules/"); idx != -1 {
 					nodeModulesDirectories.Add(path[:idx+len("/node_modules")])
 				} else {

--- a/internal/project/watch_test.go
+++ b/internal/project/watch_test.go
@@ -3,6 +3,9 @@ package project
 import (
 	"testing"
 
+	"github.com/microsoft/typescript-go/internal/bundled"
+	"github.com/microsoft/typescript-go/internal/collections"
+	"github.com/microsoft/typescript-go/internal/tspath"
 	"gotest.tools/v3/assert"
 )
 
@@ -25,4 +28,31 @@ func TestNilWatchedFilesClone(t *testing.T) {
 	var w *WatchedFiles[int]
 	result := w.Clone(42)
 	assert.Assert(t, result == nil, "clone on a nil `WatchedFiles` should return nil")
+}
+
+func TestCreateResolutionLookupGlobMapperSkipsBundledLibs(t *testing.T) {
+	t.Parallel()
+	if !bundled.Embedded {
+		t.Skip("bundled files are not embedded")
+	}
+
+	data := &collections.SyncSet[tspath.Path]{}
+	data.Add(tspath.Path("bundled:///libs/lib.d.ts"))
+
+	mapper := createResolutionLookupGlobMapper("/workspace", bundled.LibPath(), "/workspace", true)
+	result := mapper(data)
+
+	assert.DeepEqual(t, result.patternsInsideWorkspace, []string(nil))
+}
+
+func TestCreateResolutionLookupGlobMapperWatchesRealLibDirectory(t *testing.T) {
+	t.Parallel()
+
+	data := &collections.SyncSet[tspath.Path]{}
+	data.Add(tspath.Path("/ts/lib/lib.d.ts"))
+
+	mapper := createResolutionLookupGlobMapper("/workspace", "/ts/lib", "/workspace", true)
+	result := mapper(data)
+
+	assert.DeepEqual(t, result.patternsInsideWorkspace, []string{"/ts/lib/**/*"})
 }


### PR DESCRIPTION
## Background

I was setting up the tsgo lsp in my neovim config and ran into this error in a medium sized project managed with turborepo

```
LSP[tsgo]: Error SERVER_REQUEST_HANDLER_ERROR: "...Cellar/neovim/0.12.2/share/nvim/runtime/lua/vim/glob.lua:373: Invalid glob: bundled:///libs/**/*"
```

I found this is because neovim treats `workspace/didChangeWatchedFiles` glob patterns as filesystem globs. As a result neovim rejects `bundled:///libs/**/*` because it's a URI-like, but not a filesystem path.

## Change Details

In `internal/project/watch.go`, `createResolutionLookupGlobMapper` now checks whether the library directory is a bundled path via `bundled.IsBundled()` before setting `includeLib = true`. This prevents the glob mapper from adding watch patterns for embedded `lib.d.ts` files that are not real filesystem paths.

Two test cases were added to `watch_test.go` to verify:
1. Bundled library paths are correctly skipped (when `bundled.Embedded` is true).
2. Real (non-bundled) library directories are still included in the watch patterns.

## AI Disclosure

This patch was authored with the assistance of an AI coding agent. I have reviewed the changes and will personally respond to any review feedback. Admittedly I do not fully understand the scope of this area of the codebase, but to the best of my knowledge I believe it to be safe. 

Additionally, I've tested that it resolves my specific lsp issue in neovim.