### PR TITLE
Mark imports in `ast.generated.ts` and `ast.ts‎` as type-only

### DIFF
--- a/_packages/native-preview/src/ast/ast.generated.ts
+++ b/_packages/native-preview/src/ast/ast.generated.ts
@@ -2,8 +2,8 @@
 
 import type { ModifierFlags } from "#enums/modifierFlags";
 import type { NodeFlags } from "#enums/nodeFlags";
-import { SyntaxKind } from "#enums/syntaxKind";
-import { TokenFlags } from "#enums/tokenFlags";
+import type { SyntaxKind } from "#enums/syntaxKind";
+import type { TokenFlags } from "#enums/tokenFlags";
 import type {
     Node,
     NodeArray,

--- a/_packages/native-preview/src/ast/ast.ts
+++ b/_packages/native-preview/src/ast/ast.ts
@@ -4,7 +4,7 @@
 import type { LanguageVariant } from "#enums/languageVariant";
 import type { NodeFlags } from "#enums/nodeFlags";
 import type { ScriptKind } from "#enums/scriptKind";
-import { SyntaxKind } from "#enums/syntaxKind";
+import type { SyntaxKind } from "#enums/syntaxKind";
 import type {
     EndOfFile,
     EntityName,

--- a/_scripts/generate-ts-ast.ts
+++ b/_scripts/generate-ts-ast.ts
@@ -8,10 +8,10 @@
  * Usage: node --experimental-strip-types _scripts/generate-ts-ast.ts
  */
 
-import { execaSync } from "execa";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+import { execaSync } from "execa";
 import type {
     MemberInfo,
     NodeType,
@@ -288,8 +288,8 @@ function generateAstGenerated(): string {
 
 import type { ModifierFlags } from "#enums/modifierFlags";
 import type { NodeFlags } from "#enums/nodeFlags";
-import { SyntaxKind } from "#enums/syntaxKind";
-import { TokenFlags } from "#enums/tokenFlags";
+import type { SyntaxKind } from "#enums/syntaxKind";
+import type { TokenFlags } from "#enums/tokenFlags";
 import type { Node, NodeArray } from "./ast.ts";`);
 
     // ── SyntaxKind union aliases from schema ──

--- a/_scripts/generate-ts-ast.ts
+++ b/_scripts/generate-ts-ast.ts
@@ -8,10 +8,10 @@
  * Usage: node --experimental-strip-types _scripts/generate-ts-ast.ts
  */
 
+import { execaSync } from "execa";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { execaSync } from "execa";
 import type {
     MemberInfo,
     NodeType,


### PR DESCRIPTION
This PR updates `generate-ts-ast.ts` so that it emits imports of `SyntaxKind` and `TokenFlags` enums marked as type-only. Similar to other enum type imports in `_packages/native-preview/src/ast/ast.generated.ts`.