### PR TITLE
Allow lone & in Unicode sets regexp classes

### DIFF
--- a/internal/scanner/regexp.go
+++ b/internal/scanner/regexp.go
@@ -604,8 +604,6 @@ func (p *regExpParser) scanClassSetExpression() {
 			expressionMayContainStrings = p.mayContainStrings
 			p.mayContainStrings = !isCharacterComplement && expressionMayContainStrings
 			return
-		} else {
-			p.error(diagnostics.Unexpected_0_Did_you_mean_to_escape_it_with_backslash, p.pos(), 1, string(ch))
 		}
 	default:
 		if isCharacterComplement && p.mayContainStrings {
@@ -650,20 +648,17 @@ func (p *regExpParser) scanClassSetExpression() {
 				}
 			}
 		case '&':
-			start = p.pos()
-			p.incPos(1)
-			if p.char() == '&' {
-				p.incPos(1)
+			if p.pos()+1 < p.end && p.charAt(p.pos()+1) == '&' {
+				start = p.pos()
+				p.incPos(2)
 				p.error(diagnostics.Operators_must_not_be_mixed_within_a_character_class_Wrap_it_in_a_nested_class_instead, p.pos()-2, 2)
 				if p.char() == '&' {
 					p.error(diagnostics.Unexpected_0_Did_you_mean_to_escape_it_with_backslash, p.pos(), 1, string(ch))
 					p.incPos(1)
 				}
-			} else {
-				p.error(diagnostics.Unexpected_0_Did_you_mean_to_escape_it_with_backslash, p.pos()-1, 1, string(ch))
+				operand = p.text()[start:p.pos()]
+				continue
 			}
-			operand = p.text()[start:p.pos()]
-			continue
 		}
 		if p.isClassContentExit(p.char()) {
 			break

--- a/testdata/baselines/reference/compiler/regularExpressionUnicodeSetsLoneAmpersand.js
+++ b/testdata/baselines/reference/compiler/regularExpressionUnicodeSetsLoneAmpersand.js
@@ -1,0 +1,17 @@
+//// [tests/cases/compiler/regularExpressionUnicodeSetsLoneAmpersand.ts] ////
+
+//// [regularExpressionUnicodeSetsLoneAmpersand.ts]
+const regexes: RegExp[] = [
+	/[?&]/v,
+	/[a&]/v,
+	/[&a]/v,
+];
+
+
+//// [regularExpressionUnicodeSetsLoneAmpersand.js]
+"use strict";
+const regexes = [
+    /[?&]/v,
+    /[a&]/v,
+    /[&a]/v,
+];

--- a/testdata/baselines/reference/compiler/regularExpressionUnicodeSetsLoneAmpersand.symbols
+++ b/testdata/baselines/reference/compiler/regularExpressionUnicodeSetsLoneAmpersand.symbols
@@ -1,0 +1,12 @@
+//// [tests/cases/compiler/regularExpressionUnicodeSetsLoneAmpersand.ts] ////
+
+=== regularExpressionUnicodeSetsLoneAmpersand.ts ===
+const regexes: RegExp[] = [
+>regexes : Symbol(regexes, Decl(regularExpressionUnicodeSetsLoneAmpersand.ts, 0, 5))
+>RegExp : Symbol(RegExp, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.regexp.d.ts, --, --) ... and 3 more)
+
+	/[?&]/v,
+	/[a&]/v,
+	/[&a]/v,
+];
+

--- a/testdata/baselines/reference/compiler/regularExpressionUnicodeSetsLoneAmpersand.types
+++ b/testdata/baselines/reference/compiler/regularExpressionUnicodeSetsLoneAmpersand.types
@@ -1,0 +1,18 @@
+//// [tests/cases/compiler/regularExpressionUnicodeSetsLoneAmpersand.ts] ////
+
+=== regularExpressionUnicodeSetsLoneAmpersand.ts ===
+const regexes: RegExp[] = [
+>regexes : RegExp[]
+>[	/[?&]/v,	/[a&]/v,	/[&a]/v,] : RegExp[]
+
+	/[?&]/v,
+>/[?&]/v : RegExp
+
+	/[a&]/v,
+>/[a&]/v : RegExp
+
+	/[&a]/v,
+>/[&a]/v : RegExp
+
+];
+

--- a/testdata/tests/cases/compiler/regularExpressionUnicodeSetsLoneAmpersand.ts
+++ b/testdata/tests/cases/compiler/regularExpressionUnicodeSetsLoneAmpersand.ts
@@ -1,0 +1,7 @@
+// @target: esnext
+
+const regexes: RegExp[] = [
+	/[?&]/v,
+	/[a&]/v,
+	/[&a]/v,
+];


### PR DESCRIPTION
Fixes microsoft/TypeScript#62707

port of microsoft/TypeScript#63535.

This updates the native scanner to allow a lone `&` in Unicode Sets regexp character classes while also preserving `&&` handling for class set intersection.

AI assistance disclosure: I used Codex to help port and test this change. Of course went over everything myself afterwards.

Validation:
- go test ./internal/testrunner -run 'TestLocal/regularExpressionUnicodeSetsLoneAmpersand'
- go test ./internal/testrunner -run 'TestSubmodule/regularExpressionScanning'
- npx hereby format
- npx hereby check:format
- npx hereby lint
- npx hereby build
- npx hereby test failed only in internal/fswatch because local Windows symlink privileges are unavailable
- go test all packages except internal/fswatch passed locally