### PR TITLE
Convert `valueSymbolLinks` and `symbolNodeLinks` to id-paged arrays

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -662,7 +662,7 @@ type Checker struct {
 	factory                                     ast.NodeFactory
 	nodeLinks                                   core.LinkStore[*ast.Node, NodeLinks]
 	signatureLinks                              core.LinkStore[*ast.Node, SignatureLinks]
-	symbolNodeLinks                             core.LinkStore[*ast.Node, SymbolNodeLinks]
+	symbolNodeLinks                             nodeLinkStore[SymbolNodeLinks]
 	typeNodeLinks                               core.LinkStore[*ast.Node, TypeNodeLinks]
 	enumMemberLinks                             core.LinkStore[*ast.Node, EnumMemberLinks]
 	assertionLinks                              core.LinkStore[*ast.Node, AssertionLinks]
@@ -670,7 +670,7 @@ type Checker struct {
 	switchStatementLinks                        core.LinkStore[*ast.Node, SwitchStatementLinks]
 	jsxElementLinks                             core.LinkStore[*ast.Node, JsxElementLinks]
 	symbolReferenceLinks                        core.LinkStore[*ast.Symbol, SymbolReferenceLinks]
-	valueSymbolLinks                            core.LinkStore[*ast.Symbol, ValueSymbolLinks]
+	valueSymbolLinks                            symbolLinkStore[ValueSymbolLinks]
 	mappedSymbolLinks                           core.LinkStore[*ast.Symbol, MappedSymbolLinks]
 	deferredSymbolLinks                         core.LinkStore[*ast.Symbol, DeferredSymbolLinks]
 	aliasSymbolLinks                            core.LinkStore[*ast.Symbol, AliasSymbolLinks]

--- a/internal/checker/links.go
+++ b/internal/checker/links.go
@@ -1,0 +1,41 @@
+package checker
+
+import (
+	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/core"
+)
+
+// symbolLinkStore is a links store keyed by symbol id rather than by symbol pointer.
+// Indexing by id avoids map overhead in the hottest link stores.
+type symbolLinkStore[V any] struct {
+	store core.IdLinkStore[V]
+}
+
+func (s *symbolLinkStore[V]) Get(symbol *ast.Symbol) *V {
+	return s.store.Get(uint64(ast.GetSymbolId(symbol)))
+}
+
+func (s *symbolLinkStore[V]) Has(symbol *ast.Symbol) bool {
+	return s.store.Has(uint64(ast.GetSymbolId(symbol)))
+}
+
+func (s *symbolLinkStore[V]) TryGet(symbol *ast.Symbol) *V {
+	return s.store.TryGet(uint64(ast.GetSymbolId(symbol)))
+}
+
+// nodeLinkStore is a links store keyed by node id rather than by node pointer.
+type nodeLinkStore[V any] struct {
+	store core.IdLinkStore[V]
+}
+
+func (s *nodeLinkStore[V]) Get(node *ast.Node) *V {
+	return s.store.Get(uint64(ast.GetNodeId(node)))
+}
+
+func (s *nodeLinkStore[V]) Has(node *ast.Node) bool {
+	return s.store.Has(uint64(ast.GetNodeId(node)))
+}
+
+func (s *nodeLinkStore[V]) TryGet(node *ast.Node) *V {
+	return s.store.TryGet(uint64(ast.GetNodeId(node)))
+}

--- a/internal/core/linkstore.go
+++ b/internal/core/linkstore.go
@@ -28,3 +28,59 @@ func (s *LinkStore[K, V]) Has(key K) bool {
 func (s *LinkStore[K, V]) TryGet(key K) *V {
 	return s.entries[key]
 }
+
+// Id-indexed links store
+
+const (
+	idLinkPageShift = 8
+	idLinkPageSize  = 1 << idLinkPageShift
+	idLinkPageMask  = idLinkPageSize - 1
+)
+
+// IdLinkStore is a links store keyed by a dense uint64 id. It uses a paged array indexed by id
+// instead of a map, which is significantly cheaper for the hottest stores.
+type IdLinkStore[V any] struct {
+	pages [][]*V // pages[id>>idLinkPageShift][id&idLinkPageMask]
+	arena Arena[V]
+}
+
+func (s *IdLinkStore[V]) Get(id uint64) *V {
+	page := id >> idLinkPageShift
+	if page < uint64(len(s.pages)) {
+		if p := s.pages[page]; p != nil {
+			if value := p[id&idLinkPageMask]; value != nil {
+				return value
+			}
+		}
+	}
+	return s.getSlow(id)
+}
+
+func (s *IdLinkStore[V]) getSlow(id uint64) *V {
+	page := id >> idLinkPageShift
+	if page >= uint64(len(s.pages)) {
+		s.pages = append(s.pages, make([][]*V, page+1-uint64(len(s.pages)))...)
+	}
+	if s.pages[page] == nil {
+		s.pages[page] = make([]*V, idLinkPageSize)
+	}
+	slot := &s.pages[page][id&idLinkPageMask]
+	if *slot == nil {
+		*slot = s.arena.New()
+	}
+	return *slot
+}
+
+func (s *IdLinkStore[V]) Has(id uint64) bool {
+	return s.TryGet(id) != nil
+}
+
+func (s *IdLinkStore[V]) TryGet(id uint64) *V {
+	page := id >> idLinkPageShift
+	if page < uint64(len(s.pages)) {
+		if p := s.pages[page]; p != nil {
+			return p[id&idLinkPageMask]
+		}
+	}
+	return nil
+}

--- a/internal/core/linkstore.go
+++ b/internal/core/linkstore.go
@@ -59,7 +59,7 @@ func (s *IdLinkStore[V]) Get(id uint64) *V {
 func (s *IdLinkStore[V]) getSlow(id uint64) *V {
 	page := id >> idLinkPageShift
 	if page >= uint64(len(s.pages)) {
-		s.pages = append(s.pages, make([][]*V, page+1-uint64(len(s.pages)))...)
+		s.pages = append(s.pages, make([][]*V, int(page)+1-len(s.pages))...)
 	}
 	if s.pages[page] == nil {
 		s.pages[page] = make([]*V, idLinkPageSize)


### PR DESCRIPTION
## Context

The checker keeps per-symbol and per-node side tables as `core.LinkStore[K, V]`, a `map[K]*V` backed by an arena. The two hottest of these, `valueSymbolLinks` and `symbolNodeLinks`, dominate the `mapaccess1_fast64` profile of a full check.

Symbols and nodes already carry a lazily-assigned dense `uint64 id`, so these two stores can become paged arrays indexed by `id`. Lookup becomes a length check plus two slice indexes on the fast path, avoiding the hash, bucket probe, and pointer chase of a map lookup.

## This PR

This change adds `core.IdLinkStore[V]`, a 256-entry-per-page paged array with the same `Get` / `Has` / `TryGet` surface as `LinkStore`, plus thin `symbolLinkStore[V]` and `nodeLinkStore[V]` wrappers in the checker that key by `ast.GetSymbolId` / `ast.GetNodeId`.

Note that I only converted the two hottest stores. Sparser stores stay map-backed to prevent memory usage from increasing too much. If increased memory usage is an acceptable tradeoff for better performance, other stores can adopt paged arrays as well.

<img width="1335" height="810" alt="linkstore-tradeoff" src="https://github.com/user-attachments/assets/c2f1579d-95a0-4d9e-b894-4af1f8e211f4" />

This PR was assisted by Claude Code.

## Performance

On my machine, I'm seeing a nice performance win when typechecking the VS Code `src` project:

`--noEmit` and single-threaded:

| Metric                                  | Before    | After    | Δ       |
|-----------------------------------------|-----------|----------|---------|
| `instructions:u` (GOGC=off, min-of-3)   | 100.18 G  | 94.22 G  | −5.9%   |
| Wall (n=14 interleaved, median)         | 20.14 s   | 17.28 s  | −14.2%  |
| Memory used                             | 3584 M    | 3429 M   | −4.3%   |

`--noEmit` and parallel (default):
| Metric                                  | Before    | After    | Δ       |
|-----------------------------------------|-----------|----------|---------|
| Wall (n=14 interleaved, median)         | 6.16 s    | 5.61 s   | −9.0%   |
| Memory used                             | 4181 M    | 4257 M   | +1.8%   |