### PR TITLE
fix exact optional argument diagnostic

### DIFF
--- a/internal/checker/relater.go
+++ b/internal/checker/relater.go
@@ -4769,6 +4769,8 @@ func (r *Relater) reportRelationError(message *diagnostics.Message, source *Type
 			}
 			message = diagnostics.Type_0_is_not_assignable_to_type_1
 		}
+	} else if message == diagnostics.Argument_of_type_0_is_not_assignable_to_parameter_of_type_1 && r.c.exactOptionalPropertyTypes && len(r.c.getExactOptionalUnassignableProperties(source, target)) > 0 {
+		message = diagnostics.Argument_of_type_0_is_not_assignable_to_parameter_of_type_1_with_exactOptionalPropertyTypes_Colon_true_Consider_adding_undefined_to_the_types_of_the_target_s_properties
 	}
 	switch r.getChainMessage(0) {
 	// Suppress if next message is an excess property error

--- a/testdata/baselines/reference/compiler/exactOptionalPropertyTypesArgumentError.errors.txt
+++ b/testdata/baselines/reference/compiler/exactOptionalPropertyTypesArgumentError.errors.txt
@@ -1,0 +1,13 @@
+exactOptionalPropertyTypesArgumentError.ts(2,3): error TS2379: Argument of type '{ y: undefined; }' is not assignable to parameter of type '{ y?: string; }' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
+  Types of property 'y' are incompatible.
+    Type 'undefined' is not assignable to type 'string'.
+
+
+==== exactOptionalPropertyTypesArgumentError.ts (1 errors) ====
+    declare function f(o: { y?: string }): void;
+    f({ y: undefined });
+      ~~~~~~~~~~~~~~~~
+!!! error TS2379: Argument of type '{ y: undefined; }' is not assignable to parameter of type '{ y?: string; }' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
+!!! error TS2379:   Types of property 'y' are incompatible.
+!!! error TS2379:     Type 'undefined' is not assignable to type 'string'.
+    

--- a/testdata/baselines/reference/compiler/exactOptionalPropertyTypesArgumentError.symbols
+++ b/testdata/baselines/reference/compiler/exactOptionalPropertyTypesArgumentError.symbols
@@ -1,0 +1,13 @@
+//// [tests/cases/compiler/exactOptionalPropertyTypesArgumentError.ts] ////
+
+=== exactOptionalPropertyTypesArgumentError.ts ===
+declare function f(o: { y?: string }): void;
+>f : Symbol(f, Decl(exactOptionalPropertyTypesArgumentError.ts, 0, 0))
+>o : Symbol(o, Decl(exactOptionalPropertyTypesArgumentError.ts, 0, 19))
+>y : Symbol(y, Decl(exactOptionalPropertyTypesArgumentError.ts, 0, 23))
+
+f({ y: undefined });
+>f : Symbol(f, Decl(exactOptionalPropertyTypesArgumentError.ts, 0, 0))
+>y : Symbol(y, Decl(exactOptionalPropertyTypesArgumentError.ts, 1, 3))
+>undefined : Symbol(undefined)
+

--- a/testdata/baselines/reference/compiler/exactOptionalPropertyTypesArgumentError.types
+++ b/testdata/baselines/reference/compiler/exactOptionalPropertyTypesArgumentError.types
@@ -1,0 +1,15 @@
+//// [tests/cases/compiler/exactOptionalPropertyTypesArgumentError.ts] ////
+
+=== exactOptionalPropertyTypesArgumentError.ts ===
+declare function f(o: { y?: string }): void;
+>f : (o: { y?: string; }) => void
+>o : { y?: string; }
+>y : string | undefined
+
+f({ y: undefined });
+>f({ y: undefined }) : void
+>f : (o: { y?: string; }) => void
+>{ y: undefined } : { y: undefined; }
+>y : undefined
+>undefined : undefined
+

--- a/testdata/tests/cases/compiler/exactOptionalPropertyTypesArgumentError.ts
+++ b/testdata/tests/cases/compiler/exactOptionalPropertyTypesArgumentError.ts
@@ -1,0 +1,6 @@
+// @strictNullChecks: true
+// @exactOptionalPropertyTypes: true
+// @noEmit: true
+
+declare function f(o: { y?: string }): void;
+f({ y: undefined });


### PR DESCRIPTION
Fixes #4221

---

```ts
else if (
    message === Diagnostics.Argument_of_type_0_is_not_assignable_to_parameter_of_type_1
    && exactOptionalPropertyTypes
    && getExactOptionalUnassignableProperties(source, target).length
) {
    message = Diagnostics.Argument_of_type_0_is_not_assignable_to_parameter_of_type_1_with_exactOptionalPropertyTypes_Colon_true_Consider_adding_undefined_to_the_types_of_the_target_s_properties;
}
```