### PR TITLE
Skip mark/rewind in `tryParseTypeArgumentsInExpression` when token isn't `<`

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -5247,8 +5247,14 @@ func (p *Parser) isTemplateStartOfTaggedTemplate() bool {
 
 func (p *Parser) tryParseTypeArgumentsInExpression() *ast.NodeList {
 	// TypeArguments must not be parsed in JavaScript files to avoid ambiguity with binary operators.
+	// Check the cheap preconditions before saving the parser state: unless the current token is `<`
+	// (or `<<`, which reScanLessThanToken would split), there is nothing to speculatively parse and
+	// the mark/rewind would be a no-op.
+	if p.contextFlags&ast.NodeFlagsJavaScriptFile != 0 || (p.token != ast.KindLessThanToken && p.token != ast.KindLessThanLessThanToken) {
+		return nil
+	}
 	state := p.mark()
-	if p.contextFlags&ast.NodeFlagsJavaScriptFile == 0 && p.reScanLessThanToken() == ast.KindLessThanToken {
+	if p.reScanLessThanToken() == ast.KindLessThanToken {
 		p.nextToken()
 		typeArguments := p.parseDelimitedList(PCTypeArguments, (*Parser).parseType)
 		// If it doesn't have the closing `>` then it's definitely not an type argument list.


### PR DESCRIPTION
## Context

`tryParseTypeArgumentsInExpression` is called for every member-access dot and call-expression rest. It currently always saves the full parser/ scanner state, calls `reScanLessThanToken`, and rewinds when no type argument list is present. `reScanLessThanToken` only mutates state when the current token is `<<` (splitting it into `<`). For any other token the mark/rewind pair is a no-op.

## This PR

This PR hoists the JS-file check and a `<`/`<<` token check above `p.mark()` so the common path returns immediately without copying state. The remaining guard only needs the re-scan, since the JS-file condition is already known to be false.

This PR was assisted by Claude Code.

## Performance

```
goos: darwin
goarch: arm64
pkg: github.com/microsoft/typescript-go/internal/parser
cpu: Apple M1 Pro
                                                      │ /tmp/old.txt │            /tmp/new.txt             │
                                                      │    sec/op    │   sec/op     vs base                │
Parse/empty.ts-10                                        387.7n ± 0%   387.8n ± 0%        ~ (p=1.000 n=25)
Parse/checker.ts-10                                      33.78m ± 0%   29.14m ± 0%  -13.74% (p=0.000 n=25)
Parse/dom.generated.d.ts-10                              15.48m ± 0%   15.43m ± 0%   -0.29% (p=0.000 n=25)
Parse/Herebyfile.mjs-10                                  605.8µ ± 0%   557.3µ ± 0%   -8.01% (p=0.000 n=25)
Parse/jsxComplexSignatureHasApplicabilityError.tsx-10    177.0µ ± 0%   175.9µ ± 0%   -0.62% (p=0.000 n=25)
geomean                                                  465.0µ        443.2µ        -4.69%

                                                      │ /tmp/old.txt │             /tmp/new.txt              │
                                                      │     B/op     │     B/op      vs base                 │
Parse/empty.ts-10                                       1.047Ki ± 0%   1.047Ki ± 0%       ~ (p=1.000 n=25) ¹
Parse/checker.ts-10                                     26.44Mi ± 0%   26.44Mi ± 0%  -0.00% (p=0.001 n=25)
Parse/dom.generated.d.ts-10                             11.08Mi ± 0%   11.08Mi ± 0%       ~ (p=0.863 n=25)
Parse/Herebyfile.mjs-10                                 472.4Ki ± 0%   472.4Ki ± 0%       ~ (p=0.255 n=25)
Parse/jsxComplexSignatureHasApplicabilityError.tsx-10   175.5Ki ± 0%   175.5Ki ± 0%       ~ (p=0.869 n=25)
geomean                                                 484.4Ki        484.4Ki       -0.00%
¹ all samples are equal

                                                      │ /tmp/old.txt │             /tmp/new.txt             │
                                                      │  allocs/op   │  allocs/op   vs base                 │
Parse/empty.ts-10                                         4.000 ± 0%    4.000 ± 0%       ~ (p=1.000 n=25) ¹
Parse/checker.ts-10                                      12.96k ± 0%   12.96k ± 0%       ~ (p=0.138 n=25)
Parse/dom.generated.d.ts-10                              3.255k ± 0%   3.255k ± 0%       ~ (p=1.000 n=25)
Parse/Herebyfile.mjs-10                                  1.772k ± 0%   1.772k ± 0%       ~ (p=1.000 n=25) ¹
Parse/jsxComplexSignatureHasApplicabilityError.tsx-10     196.0 ± 0%    196.0 ± 0%       ~ (p=1.000 n=25) ¹
geomean                                                   567.0         567.0       +0.00%
¹ all samples are equal
```