### PR TITLE
Several performance optimizations for the scanner's hot path

### DIFF
--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -738,7 +738,7 @@ func (s *Scanner) Scan() ast.Kind {
 			s.pos++
 			s.token = ast.KindSemicolonToken
 		case '<':
-			if isConflictMarkerTrivia(s.text, s.pos) {
+			if s.charAt(1) == '<' && isConflictMarkerTrivia(s.text, s.pos) {
 				s.pos = scanConflictMarkerTrivia(s.text, s.pos, s.errorAt)
 				if s.skipTrivia {
 					continue
@@ -766,7 +766,7 @@ func (s *Scanner) Scan() ast.Kind {
 				s.token = ast.KindLessThanToken
 			}
 		case '=':
-			if isConflictMarkerTrivia(s.text, s.pos) {
+			if s.charAt(1) == '=' && isConflictMarkerTrivia(s.text, s.pos) {
 				s.pos = scanConflictMarkerTrivia(s.text, s.pos, s.errorAt)
 				if s.skipTrivia {
 					continue
@@ -791,7 +791,7 @@ func (s *Scanner) Scan() ast.Kind {
 				s.token = ast.KindEqualsToken
 			}
 		case '>':
-			if isConflictMarkerTrivia(s.text, s.pos) {
+			if s.charAt(1) == '>' && isConflictMarkerTrivia(s.text, s.pos) {
 				s.pos = scanConflictMarkerTrivia(s.text, s.pos, s.errorAt)
 				if s.skipTrivia {
 					continue
@@ -836,7 +836,7 @@ func (s *Scanner) Scan() ast.Kind {
 			s.pos++
 			s.token = ast.KindOpenBraceToken
 		case '|':
-			if isConflictMarkerTrivia(s.text, s.pos) {
+			if s.charAt(1) == '|' && isConflictMarkerTrivia(s.text, s.pos) {
 				s.pos = scanConflictMarkerTrivia(s.text, s.pos, s.errorAt)
 				if s.skipTrivia {
 					continue
@@ -2380,12 +2380,20 @@ func isConflictMarkerTrivia(text string, pos int) bool {
 		panic("pos < 0")
 	}
 
-	// Conflict markers must be at the start of a line.
-	var prev rune
-	if pos >= 2 {
-		prev, _ = utf8.DecodeLastRuneInString(text[:pos-2])
+	// Fast reject: a conflict marker is the same byte repeated seven times. If the
+	// second byte differs (the overwhelmingly common case for `<`, `>`, `=`, `|`
+	// tokens), it cannot be a marker, so skip the line-start check entirely.
+	if pos+1 >= len(text) || text[pos+1] != text[pos] {
+		return false
 	}
-	if pos == 0 || stringutil.IsLineBreak(prev) || pos >= 1 && stringutil.IsLineBreak(rune(text[pos-1])) {
+
+	// Conflict markers must be at the start of a line.
+	atLineStart := pos == 0 || stringutil.IsLineBreak(rune(text[pos-1]))
+	if !atLineStart && pos >= 2 {
+		prev, _ := utf8.DecodeLastRuneInString(text[:pos-2])
+		atLineStart = stringutil.IsLineBreak(prev)
+	}
+	if atLineStart {
 		ch := text[pos]
 
 		if (pos + mergeConflictMarkerLength) < len(text) {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -491,8 +491,8 @@ func (s *Scanner) Scan() ast.Kind {
 	s.fullStartPos = s.pos
 	s.tokenFlags = ast.TokenFlagsNone
 	for {
-		s.tokenStart = s.pos
 		ch := s.char()
+		s.tokenStart = s.pos
 
 		switch ch {
 		case '\t', '\v', '\f', ' ':

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1036,29 +1036,33 @@ func (s *Scanner) ReScanLessThanToken() ast.Kind {
 
 func (s *Scanner) ReScanGreaterThanToken() ast.Kind {
 	if s.token == ast.KindGreaterThanToken {
-		s.pos = s.tokenStart + 1
-		if s.char() == '>' {
-			if s.charAt(1) == '>' {
-				if s.charAt(2) == '=' {
-					s.pos += 3
-					s.token = ast.KindGreaterThanGreaterThanGreaterThanEqualsToken
-				} else {
-					s.pos += 2
-					s.token = ast.KindGreaterThanGreaterThanGreaterThanToken
-				}
-			} else if s.charAt(1) == '=' {
-				s.pos += 2
-				s.token = ast.KindGreaterThanGreaterThanEqualsToken
-			} else {
-				s.pos++
-				s.token = ast.KindGreaterThanGreaterThanToken
-			}
-		} else if s.char() == '=' {
-			s.pos++
-			s.token = ast.KindGreaterThanEqualsToken
-		}
+		s.reScanGreaterThanTokenInner()
 	}
 	return s.token
+}
+
+func (s *Scanner) reScanGreaterThanTokenInner() {
+	s.pos = s.tokenStart + 1
+	if s.char() == '>' {
+		if s.charAt(1) == '>' {
+			if s.charAt(2) == '=' {
+				s.pos += 3
+				s.token = ast.KindGreaterThanGreaterThanGreaterThanEqualsToken
+			} else {
+				s.pos += 2
+				s.token = ast.KindGreaterThanGreaterThanGreaterThanToken
+			}
+		} else if s.charAt(1) == '=' {
+			s.pos += 2
+			s.token = ast.KindGreaterThanGreaterThanEqualsToken
+		} else {
+			s.pos++
+			s.token = ast.KindGreaterThanGreaterThanToken
+		}
+	} else if s.char() == '=' {
+		s.pos++
+		s.token = ast.KindGreaterThanEqualsToken
+	}
 }
 
 func (s *Scanner) ReScanTemplateToken(isTaggedTemplate bool) ast.Kind {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -456,6 +456,14 @@ func (s *Scanner) charAt(offset int) rune {
 }
 
 func (s *Scanner) charAndSize() (rune, int) {
+	// Fast path: a single ASCII byte. The vast majority of source bytes are
+	// ASCII; handling them here avoids constructing a string slice header and
+	// calling the non-inlined utf8.DecodeRuneInString on every byte.
+	if s.pos < s.end {
+		if b := s.text[s.pos]; b < utf8.RuneSelf {
+			return rune(b), 1
+		}
+	}
 	r, size := utf8.DecodeRuneInString(s.text[s.pos:])
 	if size > 1 {
 		s.containsNonASCII = true

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -550,7 +550,8 @@ func (s *Scanner) Scan() ast.Kind {
 				s.token = ast.KindPercentToken
 			}
 		case '&':
-			if s.charAt(1) == '&' {
+			next := s.charAt(1)
+			if next == '&' {
 				if s.charAt(2) == '=' {
 					s.pos += 3
 					s.token = ast.KindAmpersandAmpersandEqualsToken
@@ -558,7 +559,7 @@ func (s *Scanner) Scan() ast.Kind {
 					s.pos += 2
 					s.token = ast.KindAmpersandAmpersandToken
 				}
-			} else if s.charAt(1) == '=' {
+			} else if next == '=' {
 				s.pos += 2
 				s.token = ast.KindAmpersandEqualsToken
 			} else {
@@ -572,10 +573,11 @@ func (s *Scanner) Scan() ast.Kind {
 			s.pos++
 			s.token = ast.KindCloseParenToken
 		case '*':
-			if s.charAt(1) == '=' {
+			next := s.charAt(1)
+			if next == '=' {
 				s.pos += 2
 				s.token = ast.KindAsteriskEqualsToken
-			} else if s.charAt(1) == '*' {
+			} else if next == '*' {
 				if s.charAt(2) == '=' {
 					s.pos += 3
 					s.token = ast.KindAsteriskAsteriskEqualsToken
@@ -594,10 +596,11 @@ func (s *Scanner) Scan() ast.Kind {
 				s.token = ast.KindAsteriskToken
 			}
 		case '+':
-			if s.charAt(1) == '=' {
+			next := s.charAt(1)
+			if next == '=' {
 				s.pos += 2
 				s.token = ast.KindPlusEqualsToken
-			} else if s.charAt(1) == '+' {
+			} else if next == '+' {
 				s.pos += 2
 				s.token = ast.KindPlusPlusToken
 			} else {
@@ -608,10 +611,11 @@ func (s *Scanner) Scan() ast.Kind {
 			s.pos++
 			s.token = ast.KindCommaToken
 		case '-':
-			if s.charAt(1) == '=' {
+			next := s.charAt(1)
+			if next == '=' {
 				s.pos += 2
 				s.token = ast.KindMinusEqualsToken
-			} else if s.charAt(1) == '-' {
+			} else if next == '-' {
 				s.pos += 2
 				s.token = ast.KindMinusMinusToken
 			} else {
@@ -619,9 +623,10 @@ func (s *Scanner) Scan() ast.Kind {
 				s.token = ast.KindMinusToken
 			}
 		case '.':
-			if stringutil.IsDigit(s.charAt(1)) {
+			next := s.charAt(1)
+			if stringutil.IsDigit(next) {
 				s.token = s.scanNumber()
-			} else if s.charAt(1) == '.' && s.charAt(2) == '.' {
+			} else if next == '.' && s.charAt(2) == '.' {
 				s.pos += 3
 				s.token = ast.KindDotDotDotToken
 			} else {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -471,6 +471,22 @@ func (s *Scanner) charAndSize() (rune, int) {
 	return r, size
 }
 
+// scanASCIIWhile advances s.pos over the longest run of ASCII bytes for which
+// pred returns true. It stops at end-of-text, the first non-ASCII byte, or the
+// first byte where pred is false.
+func (s *Scanner) scanASCIIWhile(pred func(byte) bool) {
+	text := s.text[s.pos:s.end]
+	i := 0
+	for i < len(text) {
+		b := text[i]
+		if b >= utf8.RuneSelf || !pred(b) {
+			break
+		}
+		i++
+	}
+	s.pos += i
+}
+
 func (s *Scanner) Scan() ast.Kind {
 	s.fullStartPos = s.pos
 	s.tokenFlags = ast.TokenFlagsNone
@@ -496,6 +512,9 @@ func (s *Scanner) Scan() ast.Kind {
 			s.tokenFlags |= ast.TokenFlagsPrecedingLineBreak
 			if s.skipTrivia {
 				s.pos++
+				s.scanASCIIWhile(func(b byte) bool {
+					return b == ' ' || (b >= '\t' && b <= '\r')
+				})
 				continue
 			}
 			if ch == '\r' && s.charAt(1) == '\n' {
@@ -615,6 +634,9 @@ func (s *Scanner) Scan() ast.Kind {
 				s.pos += 2
 
 				for {
+					s.scanASCIIWhile(func(b byte) bool {
+						return b != '\n' && b != '\r'
+					})
 					ch1, size := s.charAndSize()
 					if size == 0 || stringutil.IsLineBreak(ch1) {
 						break
@@ -638,6 +660,9 @@ func (s *Scanner) Scan() ast.Kind {
 				commentClosed := false
 				lastLineStart := s.tokenStart
 				for {
+					s.scanASCIIWhile(func(b byte) bool {
+						return b != '*' && b != '\n' && b != '\r'
+					})
 					ch1, size := s.charAndSize()
 					if size == 0 {
 						break
@@ -1517,13 +1542,11 @@ func (s *Scanner) scanIdentifier(prefixLength int) bool {
 	ch := s.char()
 	// Fast path for simple ASCII identifiers
 	if stringutil.IsASCIILetter(ch) || ch == '_' || ch == '$' {
-		for {
-			s.pos++
-			ch = s.char()
-			if !(isWordCharacter(ch) || ch == '$') {
-				break
-			}
-		}
+		s.pos++
+		s.scanASCIIWhile(func(b byte) bool {
+			return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_' || b == '$'
+		})
+		ch = s.char()
 		if ch < utf8.RuneSelf && ch != '\\' {
 			s.tokenValue = s.text[start:s.pos]
 			return true
@@ -1630,6 +1653,9 @@ func (s *Scanner) scanTemplateAndSetTokenValue(shouldEmitInvalidEscapeError bool
 	parts := make([]string, 0, 4)
 	var token ast.Kind
 	for {
+		s.scanASCIIWhile(func(b byte) bool {
+			return b != '`' && b != '$' && b != '\\' && b != '\r'
+		})
 		ch := s.char()
 		if ch < 0 || ch == '`' {
 			parts = append(parts, s.text[start:s.pos])
@@ -1997,6 +2023,14 @@ func (s *Scanner) scanNumberFragment() string {
 	isPreviousTokenSeparator := false
 	var result strings.Builder
 	for {
+		before := s.pos
+		s.scanASCIIWhile(func(b byte) bool {
+			return b >= '0' && b <= '9'
+		})
+		if s.pos > before {
+			allowSeparator = true
+			isPreviousTokenSeparator = false
+		}
 		ch := s.char()
 		if ch == '_' {
 			s.tokenFlags |= ast.TokenFlagsContainsSeparator
@@ -2014,12 +2048,6 @@ func (s *Scanner) scanNumberFragment() string {
 			}
 			s.pos++
 			start = s.pos
-			continue
-		}
-		if stringutil.IsDigit(ch) {
-			allowSeparator = true
-			isPreviousTokenSeparator = false
-			s.pos++
 			continue
 		}
 		break

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -2065,6 +2065,9 @@ func (s *Scanner) scanNumberFragment() string {
 		s.tokenFlags |= ast.TokenFlagsContainsInvalidSeparator
 		s.errorAt(diagnostics.Numeric_separators_are_not_allowed_here, s.pos-1, 1)
 	}
+	if result.Len() == 0 {
+		return s.text[start:s.pos]
+	}
 	result.WriteString(s.text[start:s.pos])
 	return result.String()
 }

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1611,14 +1611,15 @@ func (s *Scanner) scanString(jsxAttributeString bool) string {
 	}
 	s.pos++
 	// Fast path for simple strings without escape sequences.
-	strLen := strings.IndexRune(s.text[s.pos:], quote)
+	strLen := strings.IndexByte(s.text[s.pos:], byte(quote))
 	if strLen == 0 {
 		s.pos++
 		return ""
 	}
 	if strLen > 0 {
 		str := s.text[s.pos : s.pos+strLen]
-		if !jsxAttributeString && !strings.ContainsAny(str, "\r\n\\") {
+		if jsxAttributeString ||
+			strings.IndexByte(str, '\\') < 0 && strings.IndexByte(str, '\r') < 0 && strings.IndexByte(str, '\n') < 0 {
 			s.pos += strLen + 1
 			return str
 		}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -2893,13 +2893,10 @@ func iterateCommentRanges(f *ast.NodeFactory, text string, pos int, trailing boo
 							pos += s
 						}
 					} else {
-						for pos < len(text) {
-							c, s := utf8.DecodeRuneInString(text[pos:])
-							if c == '*' && pos+1 < len(text) && text[pos+1] == '/' {
-								pos += 2
-								break
-							}
-							pos += s
+						if i := strings.Index(text[pos:], "*/"); i >= 0 {
+							pos += i + 2
+						} else {
+							pos = len(text)
 						}
 					}
 


### PR DESCRIPTION
This PR implements various performance optimizations on the scanner's hot path. I've broken each optimization out into its own commit and would recommend a per-commit review.

This PR was assisted by Claude Code.

## Performance

```text
                                                      │   old.txt   │               new.txt               │
                                                      │   sec/op    │   sec/op     vs base                │
Parse/empty.ts-64                                       859.7n ± 1%   866.9n ± 1%   +0.84% (p=0.045 n=25)
Parse/checker.ts-64                                     44.13m ± 1%   39.52m ± 1%  -10.46% (p=0.000 n=25)
Parse/dom.generated.d.ts-64                             18.13m ± 1%   14.78m ± 1%  -18.46% (p=0.000 n=25)
Parse/Herebyfile.mjs-64                                 781.6µ ± 0%   734.4µ ± 0%   -6.04% (p=0.000 n=25)
Parse/jsxComplexSignatureHasApplicabilityError.tsx-64   220.3µ ± 0%   194.8µ ± 1%  -11.55% (p=0.000 n=25)
geomean                                                 652.7µ        591.6µ        -9.36%

                                                      │   old.txt    │                new.txt                │
                                                      │     B/op     │     B/op      vs base                 │
Parse/empty.ts-64                                       1.051Ki ± 0%   1.051Ki ± 0%       ~ (p=1.000 n=25) ¹
Parse/checker.ts-64                                     26.44Mi ± 0%   26.44Mi ± 0%  -0.03% (p=0.000 n=25)
Parse/dom.generated.d.ts-64                             11.09Mi ± 0%   11.09Mi ± 0%       ~ (p=0.407 n=25)
Parse/Herebyfile.mjs-64                                 473.5Ki ± 0%   473.4Ki ± 0%  -0.00% (p=0.001 n=25)
Parse/jsxComplexSignatureHasApplicabilityError.tsx-64   175.7Ki ± 0%   175.7Ki ± 0%  +0.00% (p=0.013 n=25)
geomean                                                 485.2Ki        485.1Ki       -0.01%
¹ all samples are equal

                                                      │   old.txt   │                new.txt                │
                                                      │  allocs/op  │  allocs/op   vs base                  │
Parse/empty.ts-64                                        4.000 ± 0%    4.000 ± 0%        ~ (p=1.000 n=25) ¹
Parse/checker.ts-64                                     12.96k ± 0%   12.02k ± 0%   -7.30% (p=0.000 n=25)
Parse/dom.generated.d.ts-64                             3.255k ± 0%   2.864k ± 0%  -12.01% (p=0.000 n=25)
Parse/Herebyfile.mjs-64                                 1.772k ± 0%   1.770k ± 0%   -0.11% (p=0.000 n=25)
Parse/jsxComplexSignatureHasApplicabilityError.tsx-64    196.0 ± 0%    196.0 ± 0%        ~ (p=1.000 n=25) ¹
geomean                                                  567.0         544.3        -4.01%
¹ all samples are equal
```