### PR TITLE
Replace ForEachReturnStatement closure with direct kind-switched walk

### DIFF
--- a/internal/ast/utilities.go
+++ b/internal/ast/utilities.go
@@ -1120,20 +1120,56 @@ func IsFunctionExpressionOrArrowFunction(node *Node) bool {
 
 // Warning: This has the same semantics as the forEach family of functions in that traversal terminates
 // in the event that 'visitor' returns true.
-func ForEachReturnStatement(body *Node, visitor func(stmt *Node) bool) bool {
-	var traverse func(*Node) bool
-	traverse = func(node *Node) bool {
-		switch node.Kind {
-		case KindReturnStatement:
-			return visitor(node)
-		case KindCaseBlock, KindBlock, KindIfStatement, KindDoStatement, KindWhileStatement, KindForStatement, KindForInStatement,
-			KindForOfStatement, KindWithStatement, KindSwitchStatement, KindCaseClause, KindDefaultClause, KindLabeledStatement,
-			KindTryStatement, KindCatchClause:
-			return node.ForEachChild(traverse)
-		}
+func ForEachReturnStatement(node *Node, visitor func(stmt *Node) bool) bool {
+	if node == nil {
 		return false
 	}
-	return traverse(body)
+	switch node.Kind {
+	case KindReturnStatement:
+		return visitor(node)
+	case KindBlock:
+		return forEachReturnStatementInNodeList(node.AsBlock().Statements, visitor)
+	case KindIfStatement:
+		s := node.AsIfStatement()
+		return ForEachReturnStatement(s.ThenStatement, visitor) || ForEachReturnStatement(s.ElseStatement, visitor)
+	case KindDoStatement:
+		return ForEachReturnStatement(node.AsDoStatement().Statement, visitor)
+	case KindWhileStatement:
+		return ForEachReturnStatement(node.AsWhileStatement().Statement, visitor)
+	case KindForStatement:
+		return ForEachReturnStatement(node.AsForStatement().Statement, visitor)
+	case KindForInStatement, KindForOfStatement:
+		return ForEachReturnStatement(node.AsForInOrOfStatement().Statement, visitor)
+	case KindWithStatement:
+		return ForEachReturnStatement(node.AsWithStatement().Statement, visitor)
+	case KindSwitchStatement:
+		return ForEachReturnStatement(node.AsSwitchStatement().CaseBlock, visitor)
+	case KindCaseBlock:
+		return forEachReturnStatementInNodeList(node.AsCaseBlock().Clauses, visitor)
+	case KindCaseClause, KindDefaultClause:
+		return forEachReturnStatementInNodeList(node.AsCaseOrDefaultClause().Statements, visitor)
+	case KindLabeledStatement:
+		return ForEachReturnStatement(node.AsLabeledStatement().Statement, visitor)
+	case KindTryStatement:
+		s := node.AsTryStatement()
+		return ForEachReturnStatement(s.TryBlock, visitor) ||
+			ForEachReturnStatement(s.CatchClause, visitor) ||
+			ForEachReturnStatement(s.FinallyBlock, visitor)
+	case KindCatchClause:
+		return ForEachReturnStatement(node.AsCatchClause().Block, visitor)
+	}
+	return false
+}
+
+func forEachReturnStatementInNodeList(list *NodeList, visitor func(stmt *Node) bool) bool {
+	if list != nil {
+		for _, n := range list.Nodes {
+			if ForEachReturnStatement(n, visitor) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func GetRootDeclaration(node *Node) *Node {

--- a/internal/ast/utilities_bench_test.go
+++ b/internal/ast/utilities_bench_test.go
@@ -1,0 +1,59 @@
+package ast_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/core"
+	"github.com/microsoft/typescript-go/internal/parser"
+	"github.com/microsoft/typescript-go/internal/testutil/fixtures"
+	"github.com/microsoft/typescript-go/internal/tspath"
+	"github.com/microsoft/typescript-go/internal/vfs/osvfs"
+)
+
+func collectFunctionBodies(node *ast.Node, out *[]*ast.Node) {
+	node.ForEachChild(func(child *ast.Node) bool {
+		if ast.IsFunctionLikeDeclaration(child) {
+			if body := child.Body(); body != nil && body.Kind == ast.KindBlock {
+				*out = append(*out, body)
+			}
+		}
+		collectFunctionBodies(child, out)
+		return false
+	})
+}
+
+func returnStatementVisitor(*ast.Node) bool { return false }
+
+var forEachReturnStatementSink bool
+
+func BenchmarkForEachReturnStatement(b *testing.B) {
+	for _, f := range fixtures.BenchFixtures {
+		b.Run(f.Name(), func(b *testing.B) {
+			f.SkipIfNotExist(b)
+
+			fileName := tspath.GetNormalizedAbsolutePath(f.Path(), "/")
+			path := tspath.ToPath(fileName, "/", osvfs.FS().UseCaseSensitiveFileNames())
+			sourceText := f.ReadFile(b)
+			scriptKind := core.GetScriptKindFromFileName(fileName)
+
+			sf := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: fileName,
+				Path:     path,
+			}, sourceText, scriptKind)
+
+			var bodies []*ast.Node
+			collectFunctionBodies(sf.AsNode(), &bodies)
+			if len(bodies) == 0 {
+				b.Skip("no function bodies")
+			}
+
+			b.ReportAllocs()
+			for b.Loop() {
+				for _, body := range bodies {
+					forEachReturnStatementSink = ast.ForEachReturnStatement(body, returnStatementVisitor)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Context

`ForEachReturnStatement` allocated a self-referential closure on every call and recursed via `ForEachChild`, which dispatches through an interface and visits expression-typed children (conditions, initializers) that the closure immediately rejects.

## This PR

This PR rewrites `ForEachReturnStatement` as a self-recursive package-level function that switches on `Kind` and recurses only into the statement-typed children of each construct. This removes the per-call closure allocation, the `ForEachChild` interface dispatch, and the wasted visits to non-statement children. The set of traversed kinds is unchanged.

This PR was assisted by Claude Code.

## Performance

hyperfine benchmark:

```text
Benchmark 1: ./built/local/tsgo_main --noEmit -p ~/Code/vscode/src/tsconfig.json
  Time (mean ± σ):      5.012 s ±  0.108 s    [User: 25.429 s, System: 1.427 s]
  Range (min … max):    4.825 s …  5.273 s    25 runs

Benchmark 2: ./built/local/tsgo_optimized --noEmit -p ~/Code/vscode/src/tsconfig.json
  Time (mean ± σ):      4.950 s ±  0.099 s    [User: 24.952 s, System: 1.421 s]
  Range (min … max):    4.771 s …  5.158 s    25 runs
```

Memory allocations (measured using `--noEmit --singleThreaded --diagnostics`):

| Before | After | Delta |
|--|--|--|
| 20,918,299 | 20,403,098 | **–2.46%** |

```text
goos: darwin
goarch: arm64
pkg: github.com/microsoft/typescript-go/internal/ast
cpu: Apple M1 Pro
                                                                       │ ./out_before.txt │           ./out_after.txt           │
                                                                       │      sec/op      │   sec/op     vs base                │
ForEachReturnStatement/checker.ts-10                                          402.8µ ± 1%   259.6µ ± 1%  -35.56% (p=0.000 n=10)
ForEachReturnStatement/Herebyfile.mjs-10                                     2328.0n ± 0%   804.1n ± 0%  -65.46% (p=0.000 n=10)
ForEachReturnStatement/jsxComplexSignatureHasApplicabilityError.tsx-10       118.50n ± 0%   24.45n ± 0%  -79.37% (p=0.000 n=10)
geomean                                                                       4.807µ        1.722µ       -64.19%

                                                                       │ ./out_before.txt │              ./out_after.txt              │
                                                                       │       B/op       │     B/op      vs base                     │
ForEachReturnStatement/checker.ts-10                                         83.81Ki ± 0%    0.00Ki ± 0%  -100.00% (p=0.000 n=10)
ForEachReturnStatement/Herebyfile.mjs-10                                     1.281Ki ± 0%   0.000Ki ± 0%  -100.00% (p=0.000 n=10)
ForEachReturnStatement/jsxComplexSignatureHasApplicabilityError.tsx-10         96.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=10)

                                                                       │ ./out_before.txt │             ./out_after.txt              │
                                                                       │    allocs/op     │  allocs/op   vs base                     │
ForEachReturnStatement/checker.ts-10                                          5.364k ± 0%   0.000k ± 0%  -100.00% (p=0.000 n=10)
ForEachReturnStatement/Herebyfile.mjs-10                                       82.00 ± 0%     0.00 ± 0%  -100.00% (p=0.000 n=10)
ForEachReturnStatement/jsxComplexSignatureHasApplicabilityError.tsx-10         6.000 ± 0%    0.000 ± 0%  -100.00% (p=0.000 n=10)
```