### PR TITLE
Inline `GetCombinedNodeFlags` and `GetCombinedModifierFlags` bodies

### DIFF
--- a/internal/ast/utilities.go
+++ b/internal/ast/utilities.go
@@ -1143,32 +1143,36 @@ func GetRootDeclaration(node *Node) *Node {
 	return node
 }
 
-func getCombinedFlags[T ~uint32](node *Node, getFlags func(*Node) T) T {
+func GetCombinedModifierFlags(node *Node) ModifierFlags {
 	node = GetRootDeclaration(node)
-	flags := getFlags(node)
+	flags := node.ModifierFlags()
 	if node.Kind == KindVariableDeclaration {
 		node = node.Parent
 	}
 	if node != nil && node.Kind == KindVariableDeclarationList {
-		flags |= getFlags(node)
+		flags |= node.ModifierFlags()
 		node = node.Parent
 	}
 	if node != nil && node.Kind == KindVariableStatement {
-		flags |= getFlags(node)
+		flags |= node.ModifierFlags()
 	}
 	return flags
 }
 
-func GetCombinedModifierFlags(node *Node) ModifierFlags {
-	return getCombinedFlags(node, (*Node).ModifierFlags)
-}
-
 func GetCombinedNodeFlags(node *Node) NodeFlags {
-	return getCombinedFlags(node, getNodeFlags)
-}
-
-func getNodeFlags(node *Node) NodeFlags {
-	return node.Flags
+	node = GetRootDeclaration(node)
+	flags := node.Flags
+	if node.Kind == KindVariableDeclaration {
+		node = node.Parent
+	}
+	if node != nil && node.Kind == KindVariableDeclarationList {
+		flags |= node.Flags
+		node = node.Parent
+	}
+	if node != nil && node.Kind == KindVariableStatement {
+		flags |= node.Flags
+	}
+	return flags
 }
 
 // Gets whether a bound `VariableDeclaration` or `VariableDeclarationList` is part of an `await using` declaration.

--- a/internal/ast/utilities_bench_test.go
+++ b/internal/ast/utilities_bench_test.go
@@ -1,0 +1,48 @@
+package ast_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/core"
+	"github.com/microsoft/typescript-go/internal/parser"
+	"github.com/microsoft/typescript-go/internal/testutil/fixtures"
+	"github.com/microsoft/typescript-go/internal/tspath"
+	"github.com/microsoft/typescript-go/internal/vfs/osvfs"
+)
+
+func BenchmarkGetCombinedFlags(b *testing.B) {
+	for _, f := range fixtures.BenchFixtures {
+		b.Run(f.Name(), func(b *testing.B) {
+			f.SkipIfNotExist(b)
+
+			fileName := tspath.GetNormalizedAbsolutePath(f.Path(), "/")
+			path := tspath.ToPath(fileName, "/", osvfs.FS().UseCaseSensitiveFileNames())
+			sourceText := f.ReadFile(b)
+			scriptKind := core.GetScriptKindFromFileName(fileName)
+
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: fileName,
+				Path:     path,
+			}, sourceText, scriptKind)
+
+			var decls []*ast.Node
+			var collect ast.Visitor
+			collect = func(n *ast.Node) bool {
+				if ast.IsDeclaration(n) {
+					decls = append(decls, n)
+				}
+				n.ForEachChild(collect)
+				return false
+			}
+			sourceFile.AsNode().ForEachChild(collect)
+
+			for b.Loop() {
+				for _, n := range decls {
+					_ = ast.GetCombinedNodeFlags(n)
+					_ = ast.GetCombinedModifierFlags(n)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR replaces the generic `getCombinedFlags[T]` helper with direct field reads in `GetCombinedNodeFlags` (`node.Flags`) and `GetCombinedModifierFlags` (`node.ModifierFlags()`). The parent-walk and OR-accumulation are unchanged; this just removes the indirect call through a function pointer at each step.

`getCombinedFlags` and the trivial `getNodeFlags` wrapper had no other callers and have been removed. Adds `BenchmarkGetCombinedFlags` over the standard fixture set.

This PR was assisted by Claude Code.

## Performance

```text
goos: darwin
goarch: arm64
pkg: github.com/microsoft/typescript-go/internal/ast
cpu: Apple M1 Pro
                                                                 │ /tmp/baseline.txt │           /tmp/patched.txt           │
                                                                 │      sec/op       │    sec/op     vs base                │
GetCombinedFlags/empty.ts-10                                            1.460n ± 14%   1.458n ± 15%        ~ (p=0.827 n=30)
GetCombinedFlags/checker.ts-10                                          666.9µ ±  0%   504.2µ ±  0%  -24.40% (p=0.000 n=30)
GetCombinedFlags/dom.generated.d.ts-10                                  246.0µ ±  1%   171.8µ ±  0%  -30.16% (p=0.000 n=30)
GetCombinedFlags/Herebyfile.mjs-10                                     11.435µ ±  0%   7.089µ ±  1%  -38.00% (p=0.000 n=30)
GetCombinedFlags/jsxComplexSignatureHasApplicabilityError.tsx-10        2.927µ ±  0%   1.913µ ±  1%  -34.61% (p=0.000 n=30)
geomean                                                                 6.037µ         4.434µ        -26.56%
```