### PR TITLE
Fix stack overflow crash in base constraint resolution

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -27383,7 +27383,20 @@ func (c *Checker) computeBaseConstraint(t *Type, stack []RecursionId) *Type {
 		}
 		return c.getNextBaseConstraint(c.getIndexedAccessTypeOrUndefined(baseObjectType, baseIndexType, t.AsIndexedAccessType().accessFlags, nil, nil), stack)
 	case t.flags&TypeFlagsConditional != 0:
-		return c.getNextBaseConstraint(c.getConstraintFromConditionalType(t), stack)
+		d := t.AsConditionalType()
+		if d.root.isDistributive && c.cachedTypes[CachedTypeKey{kind: CachedTypeKindRestrictiveInstantiation, typeId: t.id}] != t {
+			constraint := c.getSimplifiedType(d.checkType, false /*writing*/)
+			if constraint == d.checkType {
+				constraint = c.getNextBaseConstraint(constraint, stack)
+			}
+			if constraint != nil && constraint != d.checkType {
+				instantiated := c.getConditionalTypeInstantiation(t, prependTypeMapping(d.root.checkType, constraint, d.mapper), true /*forConstraint*/, nil)
+				if instantiated.flags&TypeFlagsNever == 0 {
+					return c.getNextBaseConstraint(instantiated, stack)
+				}
+			}
+		}
+		return c.getNextBaseConstraint(c.getDefaultConstraintOfConditionalType(t), stack)
 	case t.flags&TypeFlagsSubstitution != 0:
 		return c.getNextBaseConstraint(c.getSubstitutionIntersection(t), stack)
 	case c.isGenericTupleType(t):

--- a/testdata/baselines/reference/compiler/infiniteConstraints2.symbols
+++ b/testdata/baselines/reference/compiler/infiniteConstraints2.symbols
@@ -1,0 +1,58 @@
+//// [tests/cases/compiler/infiniteConstraints2.ts] ////
+
+=== infiniteConstraints2.ts ===
+// https://github.com/microsoft/TypeScript/issues/63269
+
+export type Prepend<Elm, T extends unknown[]> =
+>Prepend : Symbol(Prepend, Decl(infiniteConstraints2.ts, 0, 0))
+>Elm : Symbol(Elm, Decl(infiniteConstraints2.ts, 2, 20))
+>T : Symbol(T, Decl(infiniteConstraints2.ts, 2, 24))
+
+ T extends unknown ?
+>T : Symbol(T, Decl(infiniteConstraints2.ts, 2, 24))
+
+ ((arg: Elm, ...rest: T) => void) extends ((...args: infer T2) => void) ? T2 : 
+>arg : Symbol(arg, Decl(infiniteConstraints2.ts, 4, 3))
+>Elm : Symbol(Elm, Decl(infiniteConstraints2.ts, 2, 20))
+>rest : Symbol(rest, Decl(infiniteConstraints2.ts, 4, 12))
+>T : Symbol(T, Decl(infiniteConstraints2.ts, 2, 24))
+>args : Symbol(args, Decl(infiniteConstraints2.ts, 4, 44))
+>T2 : Symbol(T2, Decl(infiniteConstraints2.ts, 4, 58))
+>T2 : Symbol(T2, Decl(infiniteConstraints2.ts, 4, 58))
+
+ never :
+ never;
+export type ExactExtract<T, U> = (T extends U ? U extends T ? T : never : never) & string;
+>ExactExtract : Symbol(ExactExtract, Decl(infiniteConstraints2.ts, 6, 7))
+>T : Symbol(T, Decl(infiniteConstraints2.ts, 7, 25))
+>U : Symbol(U, Decl(infiniteConstraints2.ts, 7, 27))
+>T : Symbol(T, Decl(infiniteConstraints2.ts, 7, 25))
+>U : Symbol(U, Decl(infiniteConstraints2.ts, 7, 27))
+>U : Symbol(U, Decl(infiniteConstraints2.ts, 7, 27))
+>T : Symbol(T, Decl(infiniteConstraints2.ts, 7, 25))
+>T : Symbol(T, Decl(infiniteConstraints2.ts, 7, 25))
+
+type Conv<T, U = T> = {
+>Conv : Symbol(Conv, Decl(infiniteConstraints2.ts, 7, 90))
+>T : Symbol(T, Decl(infiniteConstraints2.ts, 8, 10))
+>U : Symbol(U, Decl(infiniteConstraints2.ts, 8, 12))
+>T : Symbol(T, Decl(infiniteConstraints2.ts, 8, 10))
+
+    0: [T];
+>0 : Symbol(0, Decl(infiniteConstraints2.ts, 8, 23))
+>T : Symbol(T, Decl(infiniteConstraints2.ts, 8, 10))
+
+    1: Prepend<T, Conv<ExactExtract<U, T>, {a: number}>>;
+>1 : Symbol(1, Decl(infiniteConstraints2.ts, 9, 11))
+>Prepend : Symbol(Prepend, Decl(infiniteConstraints2.ts, 0, 0))
+>T : Symbol(T, Decl(infiniteConstraints2.ts, 8, 10))
+>Conv : Symbol(Conv, Decl(infiniteConstraints2.ts, 7, 90))
+>ExactExtract : Symbol(ExactExtract, Decl(infiniteConstraints2.ts, 6, 7))
+>U : Symbol(U, Decl(infiniteConstraints2.ts, 8, 12))
+>T : Symbol(T, Decl(infiniteConstraints2.ts, 8, 10))
+>a : Symbol(a, Decl(infiniteConstraints2.ts, 10, 44))
+
+}[U extends T ? 0 : 1];
+>U : Symbol(U, Decl(infiniteConstraints2.ts, 8, 12))
+>T : Symbol(T, Decl(infiniteConstraints2.ts, 8, 10))
+

--- a/testdata/baselines/reference/compiler/infiniteConstraints2.types
+++ b/testdata/baselines/reference/compiler/infiniteConstraints2.types
@@ -1,0 +1,31 @@
+//// [tests/cases/compiler/infiniteConstraints2.ts] ////
+
+=== infiniteConstraints2.ts ===
+// https://github.com/microsoft/TypeScript/issues/63269
+
+export type Prepend<Elm, T extends unknown[]> =
+>Prepend : Prepend<Elm, T>
+
+ T extends unknown ?
+ ((arg: Elm, ...rest: T) => void) extends ((...args: infer T2) => void) ? T2 : 
+>arg : Elm
+>rest : T
+>args : T2
+
+ never :
+ never;
+export type ExactExtract<T, U> = (T extends U ? U extends T ? T : never : never) & string;
+>ExactExtract : ExactExtract<T, U>
+
+type Conv<T, U = T> = {
+>Conv : Conv<T, U>
+
+    0: [T];
+>0 : [T]
+
+    1: Prepend<T, Conv<ExactExtract<U, T>, {a: number}>>;
+>1 : Prepend<T, Conv<ExactExtract<U, T>, { a: number; }>>
+>a : number
+
+}[U extends T ? 0 : 1];
+

--- a/testdata/baselines/reference/submodule/compiler/infiniteConstraints.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/infiniteConstraints.errors.txt
@@ -1,13 +1,19 @@
+infiniteConstraints.ts(3,37): error TS2321: Excessive stack depth comparing types '"val"' and 'keyof Extract<B[Exclude<keyof B, K>], { val: string; }>'.
+infiniteConstraints.ts(3,37): error TS2536: Type '"val"' cannot be used to index type 'Extract<B[Exclude<keyof B, K>], { val: string; }>'.
 infiniteConstraints.ts(4,37): error TS2536: Type '"val"' cannot be used to index type 'B[Exclude<keyof B, K>]'.
 infiniteConstraints.ts(31,43): error TS2322: Type 'Value<"dup">' is not assignable to type 'never'.
 infiniteConstraints.ts(31,63): error TS2322: Type 'Value<"dup">' is not assignable to type 'never'.
 infiniteConstraints.ts(36,71): error TS2536: Type '"foo"' cannot be used to index type 'T[keyof T]'.
 
 
-==== infiniteConstraints.ts (4 errors) ====
+==== infiniteConstraints.ts (6 errors) ====
     // Both of the following types trigger the recursion limiter in getImmediateBaseConstraint
     
     type T1<B extends { [K in keyof B]: Extract<B[Exclude<keyof B, K>], { val: string }>["val"] }> = B;
+                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2321: Excessive stack depth comparing types '"val"' and 'keyof Extract<B[Exclude<keyof B, K>], { val: string; }>'.
+                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2536: Type '"val"' cannot be used to index type 'Extract<B[Exclude<keyof B, K>], { val: string; }>'.
     type T2<B extends { [K in keyof B]: B[Exclude<keyof B, K>]["val"] }> = B;
                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2536: Type '"val"' cannot be used to index type 'B[Exclude<keyof B, K>]'.

--- a/testdata/baselines/reference/submodule/compiler/infiniteConstraints.errors.txt.diff
+++ b/testdata/baselines/reference/submodule/compiler/infiniteConstraints.errors.txt.diff
@@ -1,0 +1,23 @@
+--- old.infiniteConstraints.errors.txt
++++ new.infiniteConstraints.errors.txt
+@@= skipped -0, +0 lines =@@
++infiniteConstraints.ts(3,37): error TS2321: Excessive stack depth comparing types '"val"' and 'keyof Extract<B[Exclude<keyof B, K>], { val: string; }>'.
++infiniteConstraints.ts(3,37): error TS2536: Type '"val"' cannot be used to index type 'Extract<B[Exclude<keyof B, K>], { val: string; }>'.
+ infiniteConstraints.ts(4,37): error TS2536: Type '"val"' cannot be used to index type 'B[Exclude<keyof B, K>]'.
+ infiniteConstraints.ts(31,43): error TS2322: Type 'Value<"dup">' is not assignable to type 'never'.
+ infiniteConstraints.ts(31,63): error TS2322: Type 'Value<"dup">' is not assignable to type 'never'.
+ infiniteConstraints.ts(36,71): error TS2536: Type '"foo"' cannot be used to index type 'T[keyof T]'.
+
+
+-==== infiniteConstraints.ts (4 errors) ====
++==== infiniteConstraints.ts (6 errors) ====
+     // Both of the following types trigger the recursion limiter in getImmediateBaseConstraint
+     
+     type T1<B extends { [K in keyof B]: Extract<B[Exclude<keyof B, K>], { val: string }>["val"] }> = B;
++                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
++!!! error TS2321: Excessive stack depth comparing types '"val"' and 'keyof Extract<B[Exclude<keyof B, K>], { val: string; }>'.
++                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
++!!! error TS2536: Type '"val"' cannot be used to index type 'Extract<B[Exclude<keyof B, K>], { val: string; }>'.
+     type T2<B extends { [K in keyof B]: B[Exclude<keyof B, K>]["val"] }> = B;
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ !!! error TS2536: Type '"val"' cannot be used to index type 'B[Exclude<keyof B, K>]'.

--- a/testdata/tests/cases/compiler/infiniteConstraints2.ts
+++ b/testdata/tests/cases/compiler/infiniteConstraints2.ts
@@ -1,0 +1,14 @@
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/63269
+
+export type Prepend<Elm, T extends unknown[]> =
+ T extends unknown ?
+ ((arg: Elm, ...rest: T) => void) extends ((...args: infer T2) => void) ? T2 : 
+ never :
+ never;
+export type ExactExtract<T, U> = (T extends U ? U extends T ? T : never : never) & string;
+type Conv<T, U = T> = {
+    0: [T];
+    1: Prepend<T, Conv<ExactExtract<U, T>, {a: number}>>;
+}[U extends T ? 0 : 1];


### PR DESCRIPTION
This PR modifies base constraint resolution for conditional types to ensure the logic is protected by the recursion limiter in `getResolvedBaseConstraint`.

Fixes https://github.com/microsoft/TypeScript/issues/63269.
Fixes https://github.com/microsoft/TypeScript/issues/62966.