### PR TITLE
Fix lint in darwin-only build file

### DIFF
--- a/internal/fswatch/kqueue.go
+++ b/internal/fswatch/kqueue.go
@@ -668,8 +668,8 @@ func (b *kqueueBackend) compareDir(_ int, path string, touched map[*dirWatch]str
 					if p == fullPath {
 						return nil // already handled above
 					}
-					e := &dirEntry{path: p, isDir: pIsDir}
-					entries[p] = e
+					entry := &dirEntry{path: p, isDir: pIsDir}
+					entries[p] = entry
 					sub.dirWatch.events.create(p)
 					b.watchPath(sub.dirWatch, p, entries)
 					return nil


### PR DESCRIPTION
I assumed for the last week that something about my local linter state was messed up, until I finally figured out that I’m the only one who’s regularly linting this file locally, and the macOS CI lint job is disabled 😄 