### PR TITLE
Fix top-level await reparsing with following `@typedef`

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -569,12 +569,12 @@ func (p *Parser) reparseTopLevelAwait(sourceFile *ast.SourceFile) *ast.Node {
 				p.nextToken()
 			}
 			if afterAwaitStatement < len(sourceFile.Statements.Nodes) {
-				nonAwaitStatement := sourceFile.Statements.Nodes[afterAwaitStatement]
-				if statement.End() == nonAwaitStatement.Pos() {
+				lastAwaitStatement := sourceFile.Statements.Nodes[afterAwaitStatement-1]
+				if statement.End() == lastAwaitStatement.End() {
 					// done reparsing this section
 					break
 				}
-				if statement.End() > nonAwaitStatement.Pos() {
+				if statement.End() > lastAwaitStatement.End() {
 					// we ate into the next statement, so we must continue reparsing the next span
 					i += 2
 					if i < len(p.possibleAwaitSpans) {

--- a/testdata/baselines/reference/compiler/topLevelAwaitReparseWithTypedef.symbols
+++ b/testdata/baselines/reference/compiler/topLevelAwaitReparseWithTypedef.symbols
@@ -1,0 +1,24 @@
+//// [tests/cases/compiler/topLevelAwaitReparseWithTypedef.ts] ////
+
+=== main.js ===
+// https://github.com/microsoft/typescript-go/issues/4252
+
+const obj = { await: 42 }
+>obj : Symbol(obj, Decl(main.js, 2, 5))
+>await : Symbol(await, Decl(main.js, 2, 13))
+
+export const x = obj.await;
+>x : Symbol(x, Decl(main.js, 3, 12))
+>obj.await : Symbol(await, Decl(main.js, 2, 13))
+>obj : Symbol(obj, Decl(main.js, 2, 5))
+>await : Symbol(await, Decl(main.js, 2, 13))
+
+/**
+ * @typedef {object} Foo
+ * @property {string} name
+ */
+
+/** @type {Foo} foo */
+let foo;
+>foo : Symbol(foo, Decl(main.js, 11, 3))
+

--- a/testdata/baselines/reference/compiler/topLevelAwaitReparseWithTypedef.types
+++ b/testdata/baselines/reference/compiler/topLevelAwaitReparseWithTypedef.types
@@ -1,0 +1,26 @@
+//// [tests/cases/compiler/topLevelAwaitReparseWithTypedef.ts] ////
+
+=== main.js ===
+// https://github.com/microsoft/typescript-go/issues/4252
+
+const obj = { await: 42 }
+>obj : { await: number; }
+>{ await: 42 } : { await: number; }
+>await : number
+>42 : 42
+
+export const x = obj.await;
+>x : number
+>obj.await : number
+>obj : { await: number; }
+>await : number
+
+/**
+ * @typedef {object} Foo
+ * @property {string} name
+ */
+
+/** @type {Foo} foo */
+let foo;
+>foo : Foo
+

--- a/testdata/tests/cases/compiler/topLevelAwaitReparseWithTypedef.ts
+++ b/testdata/tests/cases/compiler/topLevelAwaitReparseWithTypedef.ts
@@ -1,0 +1,16 @@
+// @noEmit: true
+// @checkJs: true
+// @filename: main.js
+
+// https://github.com/microsoft/typescript-go/issues/4252
+
+const obj = { await: 42 }
+export const x = obj.await;
+
+/**
+ * @typedef {object} Foo
+ * @property {string} name
+ */
+
+/** @type {Foo} foo */
+let foo;


### PR DESCRIPTION
Fixes #4252.