### PR TITLE
Don't add global diags when not checking a file

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -611,7 +611,7 @@ type Checker struct {
 	exactOptionalPropertyTypes                  bool
 	canCollectSymbolAliasAccessibilityData      bool
 	wasCanceled                                 bool
-	saveDeferredDiagnostics                     bool
+	checkingSourceFile                          bool
 	arrayVariances                              []VarianceFlags
 	globals                                     ast.SymbolTable
 	evaluate                                    evaluator.Evaluator
@@ -2180,7 +2180,7 @@ func (c *Checker) checkSourceFile(ctx context.Context, sourceFile *ast.SourceFil
 	c.ctx = ctx
 	links := c.sourceFileLinks.Get(sourceFile)
 	if !links.typeChecked {
-		c.saveDeferredDiagnostics = true
+		c.checkingSourceFile = true
 		if tr := c.tracer; tr != nil {
 			defer tr.Push(tracing.PhaseCheck, "checkSourceFile", map[string]any{"path": sourceFile.FileName()}, true)()
 		}
@@ -2196,7 +2196,7 @@ func (c *Checker) checkSourceFile(ctx context.Context, sourceFile *ast.SourceFil
 		if !sourceFile.IsDeclarationFile && !c.isCanceled() {
 			c.checkUnusedRenamedBindingElements()
 		}
-		c.saveDeferredDiagnostics = false
+		c.checkingSourceFile = false
 		c.produceDeferredDiagnostics()
 		c.reportedUnreachableNodes.Clear()
 		links.typeChecked = true
@@ -13893,7 +13893,7 @@ func (c *Checker) GetGlobalDiagnostics() []*ast.Diagnostic {
 }
 
 func (c *Checker) addDeferredDiagnostic(callback func()) {
-	if c.saveDeferredDiagnostics {
+	if c.checkingSourceFile {
 		c.deferredDiagnosticCallbacks = append(c.deferredDiagnosticCallbacks, callback)
 	}
 }
@@ -13907,9 +13907,15 @@ func (c *Checker) produceDeferredDiagnostics() {
 
 func (c *Checker) addDiagnostic(diagnostic *ast.Diagnostic) {
 	// Discard diagnostics created while at the maximum number of recursive TypeToString invocations.
-	if c.serializationLevel < maxSerializationLevel {
-		c.diagnostics.Add(diagnostic)
+	if c.serializationLevel >= maxSerializationLevel {
+		return
 	}
+	// Global diagnostics (those not associated with a file) should only be collected
+	// while a source file is actively being checked.
+	if diagnostic.File() == nil && !c.checkingSourceFile {
+		return
+	}
+	c.diagnostics.Add(diagnostic)
 }
 
 func (c *Checker) addSuggestionDiagnostic(diagnostic *ast.Diagnostic) {

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -2196,8 +2196,8 @@ func (c *Checker) checkSourceFile(ctx context.Context, sourceFile *ast.SourceFil
 		if !sourceFile.IsDeclarationFile && !c.isCanceled() {
 			c.checkUnusedRenamedBindingElements()
 		}
-		c.checkingSourceFile = false
 		c.produceDeferredDiagnostics()
+		c.checkingSourceFile = false
 		c.reportedUnreachableNodes.Clear()
 		links.typeChecked = true
 	}

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -2196,8 +2196,8 @@ func (c *Checker) checkSourceFile(ctx context.Context, sourceFile *ast.SourceFil
 		if !sourceFile.IsDeclarationFile && !c.isCanceled() {
 			c.checkUnusedRenamedBindingElements()
 		}
-		c.produceDeferredDiagnostics()
 		c.checkingSourceFile = false
+		c.produceDeferredDiagnostics()
 		c.reportedUnreachableNodes.Clear()
 		links.typeChecked = true
 	}


### PR DESCRIPTION
Perf optimization; if we aren't checking a file, we don't want the global diags. Don't bother saving them. They can only be spurious.