### PR TITLE
feat: add shim packages exposing internal compiler API for psgen (PAR-19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,82 @@
 # TypeScript 7
 
+> [!NOTE]
+> **Parable fork notice.** This is `parable-work/typescript-go`, a fork of
+> [microsoft/typescript-go](https://github.com/microsoft/typescript-go) (Project Corsa). It exists
+> solely to expose the compiler API to Parable's `psgen` TypeScript reader, which drives the
+> compiler in-process from the `parable-platform` Go module. See
+> [Fork policy and upgrade procedure](#fork-policy-and-upgrade-procedure) below.
+
 [Not sure what this is? Read the announcement post!](https://devblogs.microsoft.com/typescript/typescript-native-port/)
+
+## Fork policy and upgrade procedure
+
+### What this fork changes
+
+Upstream keeps its entire Go API under `internal/`, which external modules cannot import. This fork
+adds a `shim/` re-export layer — and nothing else:
+
+- `shim/<pkg>` packages (`compiler`, `checker`, `ast`, `tsoptions`, `vfs`, `vfs/osvfs`, `bundled`,
+  `core`) re-export internal APIs via type aliases (`type Program = compiler.Program`) and var/const
+  bindings (`var NewProgram = compiler.NewProgram`). No wrapper logic. The surface is intentionally
+  minimal and expands only as `psgen` walker code demands.
+- `shim/shim_test.go` is a smoke test that drives the full consumer flow (tsconfig parse → Program
+  → type checker → AST walk) through the shim packages only. It is the canary that catches
+  upstream API moves during a sync.
+- This README section.
+
+**Never touch `internal/`** (or anything else outside the list above) in fork-only commits. That
+discipline is what keeps upstream syncs conflict-free.
+
+The module path intentionally remains `github.com/microsoft/typescript-go` so that upstream merges
+never conflict on import paths.
+
+### How parable-platform consumes this fork
+
+`parable-platform` imports the shim packages under the upstream module path and redirects the
+module to this fork with a `replace` directive pinned to a commit pseudo-version (no tags):
+
+```go
+// go.mod
+require github.com/microsoft/typescript-go v0.0.0
+
+replace github.com/microsoft/typescript-go => github.com/parable-work/typescript-go v0.0.0-20260610201500-abcdef123456
+```
+
+```go
+import (
+    "github.com/microsoft/typescript-go/shim/compiler"
+    "github.com/microsoft/typescript-go/shim/tsoptions"
+)
+```
+
+To pin a new fork commit: `go mod edit -replace github.com/microsoft/typescript-go=github.com/parable-work/typescript-go@<commit-sha>` then `go mod tidy` (Go resolves the SHA to a pseudo-version).
+
+All Corsa API calls in `parable-platform` stay localized to `utils/psgen/internal/loader/tsreader/`;
+nothing else in that repo may import these packages.
+
+### Upgrade procedure (dedicated PR cadence)
+
+Upstream syncs always land as **dedicated PRs** — never mixed with shim surface changes or any
+other work:
+
+1. `git remote add upstream https://github.com/microsoft/typescript-go.git` (first time only).
+2. `git fetch upstream`.
+3. Branch from `main`: `git checkout -b upgrade/upstream-YYYYMMDD`.
+4. `git merge upstream/main` (or a specific upstream tag/commit when pinning to a release).
+   Conflicts should be rare to nonexistent given the fork-change policy above.
+5. Fix any shim compile breaks caused by upstream API moves **in the same PR**, keeping the shim a
+   pure re-export layer.
+6. Verify: `go build ./...` and `go test ./shim/`.
+7. Open the PR, merge to `main`.
+8. In `parable-platform`, bump the `replace` pseudo-version to the new fork commit — also as its own
+   dedicated PR there — and fix any `tsreader` breaks in that PR.
+
+Shim surface expansions (new aliases/bindings demanded by walker code) follow the same rule in
+reverse: they are their own small PRs against fork `main` and never ride along with an upstream
+sync.
+
+---
 
 ## Preview
 

--- a/shim/ast/ast.go
+++ b/shim/ast/ast.go
@@ -1,0 +1,39 @@
+// Package ast re-exports the internal AST API for external consumers of this
+// fork. See package github.com/microsoft/typescript-go/shim for the governing
+// policy.
+package ast
+
+import (
+	"github.com/microsoft/typescript-go/internal/ast"
+)
+
+type (
+	Node       = ast.Node
+	NodeList   = ast.NodeList
+	SourceFile = ast.SourceFile
+	Symbol     = ast.Symbol
+	Diagnostic = ast.Diagnostic
+	Kind       = ast.Kind
+)
+
+// Node kinds the schema walker matches on. Expand as walker code demands.
+const (
+	KindNumericLiteral           = ast.KindNumericLiteral
+	KindStringLiteral            = ast.KindStringLiteral
+	KindIdentifier               = ast.KindIdentifier
+	KindDecorator                = ast.KindDecorator
+	KindPropertyDeclaration      = ast.KindPropertyDeclaration
+	KindMethodDeclaration        = ast.KindMethodDeclaration
+	KindTypeReference            = ast.KindTypeReference
+	KindArrayType                = ast.KindArrayType
+	KindUnionType                = ast.KindUnionType
+	KindObjectLiteralExpression  = ast.KindObjectLiteralExpression
+	KindPropertyAccessExpression = ast.KindPropertyAccessExpression
+	KindCallExpression           = ast.KindCallExpression
+	KindClassDeclaration         = ast.KindClassDeclaration
+	KindInterfaceDeclaration     = ast.KindInterfaceDeclaration
+	KindTypeAliasDeclaration     = ast.KindTypeAliasDeclaration
+	KindEnumDeclaration          = ast.KindEnumDeclaration
+	KindHeritageClause           = ast.KindHeritageClause
+	KindSourceFile               = ast.KindSourceFile
+)

--- a/shim/bundled/bundled.go
+++ b/shim/bundled/bundled.go
@@ -1,0 +1,15 @@
+// Package bundled re-exports access to the embedded lib.d.ts files for
+// external consumers of this fork. See package
+// github.com/microsoft/typescript-go/shim for the governing policy.
+package bundled
+
+import (
+	"github.com/microsoft/typescript-go/internal/bundled"
+)
+
+const Embedded = bundled.Embedded
+
+var (
+	WrapFS  = bundled.WrapFS
+	LibPath = bundled.LibPath
+)

--- a/shim/checker/checker.go
+++ b/shim/checker/checker.go
@@ -1,0 +1,13 @@
+// Package checker re-exports the internal type checker API for external
+// consumers of this fork. See package github.com/microsoft/typescript-go/shim
+// for the governing policy.
+package checker
+
+import (
+	"github.com/microsoft/typescript-go/internal/checker"
+)
+
+type (
+	Checker = checker.Checker
+	Type    = checker.Type
+)

--- a/shim/compiler/compiler.go
+++ b/shim/compiler/compiler.go
@@ -1,0 +1,20 @@
+// Package compiler re-exports the internal compiler API (Program and
+// CompilerHost) for external consumers of this fork. See package
+// github.com/microsoft/typescript-go/shim for the governing policy.
+package compiler
+
+import (
+	"github.com/microsoft/typescript-go/internal/compiler"
+)
+
+type (
+	Program        = compiler.Program
+	ProgramOptions = compiler.ProgramOptions
+	CompilerHost   = compiler.CompilerHost
+)
+
+var (
+	NewProgram              = compiler.NewProgram
+	NewCompilerHost         = compiler.NewCompilerHost
+	NewCachedFSCompilerHost = compiler.NewCachedFSCompilerHost
+)

--- a/shim/core/core.go
+++ b/shim/core/core.go
@@ -1,0 +1,21 @@
+// Package core re-exports internal core types for external consumers of this
+// fork. See package github.com/microsoft/typescript-go/shim for the governing
+// policy.
+package core
+
+import (
+	"github.com/microsoft/typescript-go/internal/core"
+)
+
+type (
+	CompilerOptions = core.CompilerOptions
+	Tristate        = core.Tristate
+	ScriptKind      = core.ScriptKind
+	ScriptTarget    = core.ScriptTarget
+)
+
+const (
+	TSUnknown = core.TSUnknown
+	TSFalse   = core.TSFalse
+	TSTrue    = core.TSTrue
+)

--- a/shim/shim.go
+++ b/shim/shim.go
@@ -1,0 +1,10 @@
+// Package shim and its subpackages re-export the subset of this repository's
+// internal API needed by external consumers of this fork (Parable's psgen
+// TypeScript reader). Each subpackage is a pure veneer over the corresponding
+// internal package: type aliases for types and var/const bindings for
+// functions and constants. No wrapper logic lives here.
+//
+// The surface is intentionally minimal and is expanded only as consumer code
+// demands. See the fork notice in the repository README for the policy
+// governing these packages and the upstream upgrade procedure.
+package shim

--- a/shim/shim_test.go
+++ b/shim/shim_test.go
@@ -1,0 +1,110 @@
+package shim_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/bundled"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/tsoptions"
+	"github.com/microsoft/typescript-go/shim/vfs"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+)
+
+// TestShimSmoke exercises the full external consumer flow through the shim
+// packages only: parse a tsconfig, build a Program against the bundled libs,
+// obtain a type checker, and walk the AST. It is the canary that fails an
+// upstream-sync PR when a re-exported API moves.
+func TestShimSmoke(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.ToSlash(t.TempDir())
+	writeFile(t, filepath.Join(dir, "tsconfig.json"), `{
+		"compilerOptions": {
+			"strict": true,
+			"target": "es2022",
+			"module": "esnext",
+			"noEmit": true
+		},
+		"include": ["**/*.schema.ts"]
+	}`)
+	writeFile(t, filepath.Join(dir, "person.schema.ts"), `
+export class Person {
+	name: string = "";
+	greet(): string {
+		return "hello " + this.name;
+	}
+}
+`)
+
+	var fs vfs.FS = bundled.WrapFS(osvfs.FS())
+	host := compiler.NewCachedFSCompilerHost(dir, fs, bundled.LibPath(), nil, nil)
+
+	configFileName := dir + "/tsconfig.json"
+	config, diags := tsoptions.GetParsedCommandLineOfConfigFile(configFileName, nil, nil, host, nil)
+	if len(diags) != 0 {
+		t.Fatalf("unexpected tsconfig diagnostics: %v", diagnosticMessages(diags))
+	}
+	if config == nil {
+		t.Fatal("expected a parsed command line")
+	}
+
+	program := compiler.NewProgram(compiler.ProgramOptions{
+		Host:           host,
+		Config:         config,
+		SingleThreaded: core.TSTrue,
+	})
+
+	ctx := context.Background()
+	checker, done := program.GetTypeChecker(ctx)
+	defer done()
+	if checker == nil {
+		t.Fatal("expected a type checker")
+	}
+
+	var schemaFile *ast.SourceFile
+	for _, file := range program.SourceFiles() {
+		if filepath.Base(file.FileName()) == "person.schema.ts" {
+			schemaFile = file
+		}
+	}
+	if schemaFile == nil {
+		t.Fatal("expected person.schema.ts in the program")
+	}
+
+	if semDiags := program.GetSemanticDiagnostics(ctx, schemaFile); len(semDiags) != 0 {
+		t.Fatalf("unexpected semantic diagnostics: %v", diagnosticMessages(semDiags))
+	}
+
+	var classNode *ast.Node
+	for _, statement := range schemaFile.Statements.Nodes {
+		if statement.Kind == ast.KindClassDeclaration {
+			classNode = statement
+		}
+	}
+	if classNode == nil {
+		t.Fatal("expected a class declaration in person.schema.ts")
+	}
+	if name := classNode.Name(); name == nil || name.Text() != "Person" {
+		t.Fatalf("expected class named Person, got %v", classNode.Name())
+	}
+}
+
+func writeFile(t *testing.T, path string, contents string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func diagnosticMessages(diags []*ast.Diagnostic) []string {
+	messages := make([]string, 0, len(diags))
+	for _, diag := range diags {
+		messages = append(messages, diag.String())
+	}
+	return messages
+}

--- a/shim/tsoptions/tsoptions.go
+++ b/shim/tsoptions/tsoptions.go
@@ -1,0 +1,16 @@
+// Package tsoptions re-exports the internal tsconfig parsing API for external
+// consumers of this fork. See package github.com/microsoft/typescript-go/shim
+// for the governing policy.
+package tsoptions
+
+import (
+	"github.com/microsoft/typescript-go/internal/tsoptions"
+)
+
+type (
+	ParsedCommandLine   = tsoptions.ParsedCommandLine
+	ParseConfigHost     = tsoptions.ParseConfigHost
+	ExtendedConfigCache = tsoptions.ExtendedConfigCache
+)
+
+var GetParsedCommandLineOfConfigFile = tsoptions.GetParsedCommandLineOfConfigFile

--- a/shim/vfs/osvfs/osvfs.go
+++ b/shim/vfs/osvfs/osvfs.go
@@ -1,0 +1,10 @@
+// Package osvfs re-exports the internal OS-backed file system for external
+// consumers of this fork. See package github.com/microsoft/typescript-go/shim
+// for the governing policy.
+package osvfs
+
+import (
+	"github.com/microsoft/typescript-go/internal/vfs/osvfs"
+)
+
+var FS = osvfs.FS

--- a/shim/vfs/vfs.go
+++ b/shim/vfs/vfs.go
@@ -1,0 +1,10 @@
+// Package vfs re-exports the internal virtual file system API for external
+// consumers of this fork. See package github.com/microsoft/typescript-go/shim
+// for the governing policy.
+package vfs
+
+import (
+	"github.com/microsoft/typescript-go/internal/vfs"
+)
+
+type FS = vfs.FS


### PR DESCRIPTION
Re-export the internals psgen's tsreader needs (compiler, checker, ast, tsoptions, vfs, vfs/osvfs, bundled, core) via type aliases and var bindings, with a smoke test as the upstream-sync canary, and document the fork policy, consumption model, and dedicated-PR upgrade cadence in the README.