### PR TITLE
API: Add declaration property to IndexInfo.

### DIFF
--- a/_packages/native-preview/src/api/async/api.ts
+++ b/_packages/native-preview/src/api/async/api.ts
@@ -902,6 +902,7 @@ export class Checker {
             keyType: this.objectRegistry.getOrCreateType(d.keyType),
             valueType: this.objectRegistry.getOrCreateType(d.valueType),
             isReadonly: d.isReadonly ?? false,
+            declaration: d.declaration ? new NodeHandle(d.declaration) : undefined,
         }));
     }
 

--- a/_packages/native-preview/src/api/async/types.ts
+++ b/_packages/native-preview/src/api/async/types.ts
@@ -3,7 +3,10 @@ import type { ElementFlags } from "#enums/elementFlags";
 import type { ObjectFlags } from "#enums/objectFlags";
 import type { TypeFlags } from "#enums/typeFlags";
 import type { TypePredicateKind } from "#enums/typePredicateKind";
-import type { Symbol } from "./api.ts";
+import type {
+    NodeHandle,
+    Symbol,
+} from "./api.ts";
 
 /**
  * A TypeScript type.
@@ -198,6 +201,8 @@ export interface IndexInfo {
     readonly valueType: Type;
     /** Whether the index signature is readonly */
     readonly isReadonly: boolean;
+    /** The index signature declaration, if any */
+    readonly declaration?: NodeHandle;
 }
 
 /**

--- a/_packages/native-preview/src/api/proto.ts
+++ b/_packages/native-preview/src/api/proto.ts
@@ -184,6 +184,7 @@ export interface IndexInfoResponse {
     keyType: TypeResponse;
     valueType: TypeResponse;
     isReadonly?: boolean;
+    declaration?: string;
 }
 
 export interface ProfileParams {

--- a/_packages/native-preview/src/api/sync/api.ts
+++ b/_packages/native-preview/src/api/sync/api.ts
@@ -910,6 +910,7 @@ export class Checker {
             keyType: this.objectRegistry.getOrCreateType(d.keyType),
             valueType: this.objectRegistry.getOrCreateType(d.valueType),
             isReadonly: d.isReadonly ?? false,
+            declaration: d.declaration ? new NodeHandle(d.declaration) : undefined,
         }));
     }
 

--- a/_packages/native-preview/src/api/sync/types.ts
+++ b/_packages/native-preview/src/api/sync/types.ts
@@ -11,7 +11,10 @@ import type { ElementFlags } from "#enums/elementFlags";
 import type { ObjectFlags } from "#enums/objectFlags";
 import type { TypeFlags } from "#enums/typeFlags";
 import type { TypePredicateKind } from "#enums/typePredicateKind";
-import type { Symbol } from "./api.ts";
+import type {
+    NodeHandle,
+    Symbol,
+} from "./api.ts";
 
 /**
  * A TypeScript type.
@@ -206,6 +209,8 @@ export interface IndexInfo {
     readonly valueType: Type;
     /** Whether the index signature is readonly */
     readonly isReadonly: boolean;
+    /** The index signature declaration, if any */
+    readonly declaration?: NodeHandle;
 }
 
 /**

--- a/internal/api/proto.go
+++ b/internal/api/proto.go
@@ -911,9 +911,10 @@ type TypePredicateResponse struct {
 
 // IndexInfoResponse represents a single index signature.
 type IndexInfoResponse struct {
-	KeyType    TypeResponse `json:"keyType"`
-	ValueType  TypeResponse `json:"valueType"`
-	IsReadonly bool         `json:"isReadonly,omitempty"`
+	KeyType     TypeResponse `json:"keyType"`
+	ValueType   TypeResponse `json:"valueType"`
+	IsReadonly  bool         `json:"isReadonly,omitempty"`
+	Declaration NodeHandle   `json:"declaration,omitempty"`
 }
 
 // SourceFileResponse contains the binary-encoded AST data for a source file.

--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -1932,6 +1932,9 @@ func (s *Session) handleGetIndexInfosOfType(ctx context.Context, params *Checker
 			ValueType:  *setup.sd.registerType(info.ValueType()),
 			IsReadonly: info.IsReadonly(),
 		}
+		if info.Declaration() != nil {
+			results[i].Declaration = setup.sd.nodeHandleFrom(info.Declaration())
+		}
 	}
 
 	return results, nil

--- a/internal/checker/types.go
+++ b/internal/checker/types.go
@@ -1378,6 +1378,10 @@ func (info *IndexInfo) IsReadonly() bool {
 	return info.isReadonly
 }
 
+func (info *IndexInfo) Declaration() *ast.Node {
+	return info.declaration
+}
+
 /**
  * Ternary values are defined such that
  * x & y picks the lesser in the order False < Unknown < Maybe < True, and


### PR DESCRIPTION
I've found out one more missing API for WebStorm integration - lack of `declaration` property on the `IndexInfo` object.