### PR TITLE
Fix CFA stack overflow crash in for loops where initializer throws

### DIFF
--- a/internal/binder/binder.go
+++ b/internal/binder/binder.go
@@ -1883,6 +1883,16 @@ func (b *Binder) bindForStatement(node *ast.Node) {
 	preIncrementorLabel := b.createBranchLabel()
 	postLoopLabel := b.createBranchLabel()
 	b.bind(stmt.Initializer)
+	if b.currentFlow == b.unreachableFlow {
+		// If the initializer makes flow unreachable (e.g. a throwing IIFE), bail out early
+		// to avoid creating a disconnected cycle in the flow graph. We still bind children to ensure
+		// AST completion, using bindIterativeStatement so unreachable break/continue statements
+		// in the body bind locally and don't leak to outer loops.
+		b.bind(stmt.Condition)
+		b.bindIterativeStatement(stmt.Statement, postLoopLabel, preIncrementorLabel)
+		b.bind(stmt.Incrementor)
+		return
+	}
 	b.addAntecedent(preLoopLabel, b.currentFlow)
 	b.currentFlow = preLoopLabel
 	b.bindCondition(stmt.Condition, preBodyLabel, postLoopLabel)

--- a/internal/binder/binder.go
+++ b/internal/binder/binder.go
@@ -1886,13 +1886,12 @@ func (b *Binder) bindForStatement(node *ast.Node) {
 	if b.currentFlow == b.unreachableFlow {
 		// If the initializer makes flow unreachable (e.g. a throwing IIFE), bail out early
 		// to avoid creating a disconnected cycle in the flow graph. We still bind children to ensure
-		// AST completion, but bind them under a disconnected start flow so break/continue/labels
-		// are still processed without polluting the containing CFG.
-		b.currentFlow = b.newFlowNode(ast.FlowFlagsStart)
+		// AST completion, but bind them with isolated break/continue targets so they don't leak outward.
+		dummyBreakTarget := b.createBranchLabel()
+		dummyContinueTarget := b.createBranchLabel()
 		b.bind(stmt.Condition)
-		b.bindIterativeStatement(stmt.Statement, postLoopLabel, preIncrementorLabel)
+		b.bindIterativeStatement(stmt.Statement, dummyBreakTarget, dummyContinueTarget)
 		b.bind(stmt.Incrementor)
-		b.currentFlow = b.unreachableFlow
 		return
 	}
 	b.addAntecedent(preLoopLabel, b.currentFlow)

--- a/internal/binder/binder.go
+++ b/internal/binder/binder.go
@@ -1886,8 +1886,9 @@ func (b *Binder) bindForStatement(node *ast.Node) {
 	if b.currentFlow == b.unreachableFlow {
 		// If the initializer makes flow unreachable (e.g. a throwing IIFE), bail out early
 		// to avoid creating a disconnected cycle in the flow graph. We still bind children to ensure
-		// AST completion, using bindIterativeStatement so unreachable break/continue statements
-		// in the body bind locally and don't leak to outer loops.
+		// AST completion, but bind them under a disconnected start flow so break/continue/labels
+		// are still processed without polluting the containing CFG.
+		b.currentFlow = b.newFlowNode(ast.FlowFlagsStart)
 		b.bind(stmt.Condition)
 		b.bindIterativeStatement(stmt.Statement, postLoopLabel, preIncrementorLabel)
 		b.bind(stmt.Incrementor)

--- a/internal/binder/binder.go
+++ b/internal/binder/binder.go
@@ -1891,6 +1891,7 @@ func (b *Binder) bindForStatement(node *ast.Node) {
 		b.bind(stmt.Condition)
 		b.bindIterativeStatement(stmt.Statement, postLoopLabel, preIncrementorLabel)
 		b.bind(stmt.Incrementor)
+		b.currentFlow = b.unreachableFlow
 		return
 	}
 	b.addAntecedent(preLoopLabel, b.currentFlow)

--- a/testdata/baselines/reference/compiler/forLoopInitializerAlwaysThrowsInTryCatch.js
+++ b/testdata/baselines/reference/compiler/forLoopInitializerAlwaysThrowsInTryCatch.js
@@ -1,0 +1,117 @@
+//// [tests/cases/compiler/forLoopInitializerAlwaysThrowsInTryCatch.ts] ////
+
+//// [forLoopInitializerAlwaysThrowsInTryCatch.ts]
+// Test 1: The original crash case
+function test1() {
+    try {
+        for ((() => { throw new Error(); })(); ;) {
+        }
+    } catch (e) {
+    }
+}
+
+// Test 2: Unlabelled break and continue inside the unreachable body
+function test2() {
+    try {
+        for ((() => { throw new Error(); })(); ;) {
+            if (Math.random()) {
+                break;
+            } else {
+                continue;
+            }
+        }
+    } catch (e) {
+    }
+}
+
+// Test 3: Nested loops where inner loop has unreachable body with break/continue
+// Verifies that break/continue don't leak and pollute the outer loop's CFG
+function test3() {
+    while (true) {
+        try {
+            for ((() => { throw new Error(); })(); ;) {
+                if (Math.random()) {
+                    break;
+                } else {
+                    continue;
+                }
+            }
+        } catch (e) {
+        }
+    }
+}
+
+// Test 4: Labeled break and continue inside the unreachable body
+function test4() {
+    try {
+        label1: for ((() => { throw new Error(); })(); ;) {
+            if (Math.random()) {
+                break label1;
+            } else {
+                continue label1;
+            }
+        }
+    } catch (e) {
+    }
+}
+
+
+//// [forLoopInitializerAlwaysThrowsInTryCatch.js]
+"use strict";
+// Test 1: The original crash case
+function test1() {
+    try {
+        for ((() => { throw new Error(); })();;) {
+        }
+    }
+    catch (e) {
+    }
+}
+// Test 2: Unlabelled break and continue inside the unreachable body
+function test2() {
+    try {
+        for ((() => { throw new Error(); })();;) {
+            if (Math.random()) {
+                break;
+            }
+            else {
+                continue;
+            }
+        }
+    }
+    catch (e) {
+    }
+}
+// Test 3: Nested loops where inner loop has unreachable body with break/continue
+// Verifies that break/continue don't leak and pollute the outer loop's CFG
+function test3() {
+    while (true) {
+        try {
+            for ((() => { throw new Error(); })();;) {
+                if (Math.random()) {
+                    break;
+                }
+                else {
+                    continue;
+                }
+            }
+        }
+        catch (e) {
+        }
+    }
+}
+// Test 4: Labeled break and continue inside the unreachable body
+function test4() {
+    try {
+        label1: for ((() => { throw new Error(); })();;) {
+            if (Math.random()) {
+                break label1;
+            }
+            else {
+                continue label1;
+            }
+        }
+    }
+    catch (e) {
+    }
+}

--- a/testdata/baselines/reference/compiler/forLoopInitializerAlwaysThrowsInTryCatch.symbols
+++ b/testdata/baselines/reference/compiler/forLoopInitializerAlwaysThrowsInTryCatch.symbols
@@ -1,0 +1,88 @@
+//// [tests/cases/compiler/forLoopInitializerAlwaysThrowsInTryCatch.ts] ////
+
+=== forLoopInitializerAlwaysThrowsInTryCatch.ts ===
+// Test 1: The original crash case
+function test1() {
+>test1 : Symbol(test1, Decl(forLoopInitializerAlwaysThrowsInTryCatch.ts, 0, 0))
+
+    try {
+        for ((() => { throw new Error(); })(); ;) {
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
+        }
+    } catch (e) {
+>e : Symbol(e, Decl(forLoopInitializerAlwaysThrowsInTryCatch.ts, 5, 13))
+    }
+}
+
+// Test 2: Unlabelled break and continue inside the unreachable body
+function test2() {
+>test2 : Symbol(test2, Decl(forLoopInitializerAlwaysThrowsInTryCatch.ts, 7, 1))
+
+    try {
+        for ((() => { throw new Error(); })(); ;) {
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
+
+            if (Math.random()) {
+>Math.random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2025.float16.d.ts, --, --))
+>random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+
+                break;
+            } else {
+                continue;
+            }
+        }
+    } catch (e) {
+>e : Symbol(e, Decl(forLoopInitializerAlwaysThrowsInTryCatch.ts, 19, 13))
+    }
+}
+
+// Test 3: Nested loops where inner loop has unreachable body with break/continue
+// Verifies that break/continue don't leak and pollute the outer loop's CFG
+function test3() {
+>test3 : Symbol(test3, Decl(forLoopInitializerAlwaysThrowsInTryCatch.ts, 21, 1))
+
+    while (true) {
+        try {
+            for ((() => { throw new Error(); })(); ;) {
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
+
+                if (Math.random()) {
+>Math.random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2025.float16.d.ts, --, --))
+>random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+
+                    break;
+                } else {
+                    continue;
+                }
+            }
+        } catch (e) {
+>e : Symbol(e, Decl(forLoopInitializerAlwaysThrowsInTryCatch.ts, 35, 17))
+        }
+    }
+}
+
+// Test 4: Labeled break and continue inside the unreachable body
+function test4() {
+>test4 : Symbol(test4, Decl(forLoopInitializerAlwaysThrowsInTryCatch.ts, 38, 1))
+
+    try {
+        label1: for ((() => { throw new Error(); })(); ;) {
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
+
+            if (Math.random()) {
+>Math.random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2025.float16.d.ts, --, --))
+>random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+
+                break label1;
+            } else {
+                continue label1;
+            }
+        }
+    } catch (e) {
+>e : Symbol(e, Decl(forLoopInitializerAlwaysThrowsInTryCatch.ts, 50, 13))
+    }
+}
+

--- a/testdata/baselines/reference/compiler/forLoopInitializerAlwaysThrowsInTryCatch.types
+++ b/testdata/baselines/reference/compiler/forLoopInitializerAlwaysThrowsInTryCatch.types
@@ -1,0 +1,113 @@
+//// [tests/cases/compiler/forLoopInitializerAlwaysThrowsInTryCatch.ts] ////
+
+=== forLoopInitializerAlwaysThrowsInTryCatch.ts ===
+// Test 1: The original crash case
+function test1() {
+>test1 : () => void
+
+    try {
+        for ((() => { throw new Error(); })(); ;) {
+>(() => { throw new Error(); })() : never
+>(() => { throw new Error(); }) : () => never
+>() => { throw new Error(); } : () => never
+>new Error() : Error
+>Error : ErrorConstructor
+        }
+    } catch (e) {
+>e : unknown
+    }
+}
+
+// Test 2: Unlabelled break and continue inside the unreachable body
+function test2() {
+>test2 : () => void
+
+    try {
+        for ((() => { throw new Error(); })(); ;) {
+>(() => { throw new Error(); })() : never
+>(() => { throw new Error(); }) : () => never
+>() => { throw new Error(); } : () => never
+>new Error() : Error
+>Error : ErrorConstructor
+
+            if (Math.random()) {
+>Math.random() : number
+>Math.random : () => number
+>Math : Math
+>random : () => number
+
+                break;
+            } else {
+                continue;
+            }
+        }
+    } catch (e) {
+>e : unknown
+    }
+}
+
+// Test 3: Nested loops where inner loop has unreachable body with break/continue
+// Verifies that break/continue don't leak and pollute the outer loop's CFG
+function test3() {
+>test3 : () => void
+
+    while (true) {
+>true : true
+
+        try {
+            for ((() => { throw new Error(); })(); ;) {
+>(() => { throw new Error(); })() : never
+>(() => { throw new Error(); }) : () => never
+>() => { throw new Error(); } : () => never
+>new Error() : Error
+>Error : ErrorConstructor
+
+                if (Math.random()) {
+>Math.random() : number
+>Math.random : () => number
+>Math : Math
+>random : () => number
+
+                    break;
+                } else {
+                    continue;
+                }
+            }
+        } catch (e) {
+>e : unknown
+        }
+    }
+}
+
+// Test 4: Labeled break and continue inside the unreachable body
+function test4() {
+>test4 : () => void
+
+    try {
+        label1: for ((() => { throw new Error(); })(); ;) {
+>label1 : any
+>(() => { throw new Error(); })() : never
+>(() => { throw new Error(); }) : () => never
+>() => { throw new Error(); } : () => never
+>new Error() : Error
+>Error : ErrorConstructor
+
+            if (Math.random()) {
+>Math.random() : number
+>Math.random : () => number
+>Math : Math
+>random : () => number
+
+                break label1;
+>label1 : any
+
+            } else {
+                continue label1;
+>label1 : any
+            }
+        }
+    } catch (e) {
+>e : unknown
+    }
+}
+

--- a/testdata/tests/cases/compiler/forLoopInitializerAlwaysThrowsInTryCatch.ts
+++ b/testdata/tests/cases/compiler/forLoopInitializerAlwaysThrowsInTryCatch.ts
@@ -1,0 +1,56 @@
+// @strict: true
+// @target: esnext
+
+// Test 1: The original crash case
+function test1() {
+    try {
+        for ((() => { throw new Error(); })(); ;) {
+        }
+    } catch (e) {
+    }
+}
+
+// Test 2: Unlabelled break and continue inside the unreachable body
+function test2() {
+    try {
+        for ((() => { throw new Error(); })(); ;) {
+            if (Math.random()) {
+                break;
+            } else {
+                continue;
+            }
+        }
+    } catch (e) {
+    }
+}
+
+// Test 3: Nested loops where inner loop has unreachable body with break/continue
+// Verifies that break/continue don't leak and pollute the outer loop's CFG
+function test3() {
+    while (true) {
+        try {
+            for ((() => { throw new Error(); })(); ;) {
+                if (Math.random()) {
+                    break;
+                } else {
+                    continue;
+                }
+            }
+        } catch (e) {
+        }
+    }
+}
+
+// Test 4: Labeled break and continue inside the unreachable body
+function test4() {
+    try {
+        label1: for ((() => { throw new Error(); })(); ;) {
+            if (Math.random()) {
+                break label1;
+            } else {
+                continue label1;
+            }
+        }
+    } catch (e) {
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/TypeScript/issues/63092

## Analysis

Unlike `while` or `do-while`, a `for`-loop's initializer is bound before the loop's flow graph is constructed. If the initializer makes the control flow unreachable (e.g. an IIFE with a `throw`), `addAntecedent` filters out the unreachable entry to `preLoopLabel`, leaving only the back-edge from the incrementor. This creates a cycle with no exit that causes `isReachableFlowNodeWorker` to loop infinitely and overflow the stack.

## Fix

Bail out early in `bindForStatement` if the initializer makes the control flow unreachable, and bind the remaining children as unreachable without constructing the cyclic loop flow graph.

## Checklist

- [x] Includes test case
- [x] No regressions in existing tests
- [x] Code formatted with `npx hereby format`
- [x] Linted with `npx hereby lint`

> [!NOTE]
> This PR was developed with AI assistance (Gemini).
