### PR TITLE
API: Fix nil panic for instantiated types

### DIFF
--- a/_packages/native-preview/src/api/async/api.ts
+++ b/_packages/native-preview/src/api/async/api.ts
@@ -96,8 +96,8 @@ export type { APIOptions, ClientSocketOptions, ClientSpawnOptions, DocumentIdent
 export type { AssertsIdentifierTypePredicate, AssertsThisTypePredicate, ConditionalType, Diagnostic, FreshableType, IdentifierTypePredicate, IndexedAccessType, IndexInfo, IndexType, InterfaceType, IntersectionType, IntrinsicType, LiteralType, ObjectType, StringMappingType, SubstitutionType, TemplateLiteralType, ThisTypePredicate, TupleType, Type, TypeParameter, TypePredicate, TypePredicateBase, TypeReference, UnionOrIntersectionType, UnionType };
 export { documentURIToFileName, fileNameToDocumentURI } from "../path.ts";
 
-/** Type alias for the snapshot-scoped object registry */
-type SnapshotObjectRegistry = ObjectRegistry<Symbol, TypeObject, Signature>;
+/** Type alias for the project-scoped object registry */
+type ProjectObjectRegistry = ObjectRegistry<Symbol, TypeObject, Signature>;
 
 export class API<FromLSP extends boolean = false> {
     private client: Client;
@@ -227,7 +227,6 @@ export class Snapshot {
     private projectMap: Map<Path, Project>;
     private toPath: (fileName: string) => Path;
     private client: Client;
-    private objectRegistry: SnapshotObjectRegistry;
     private disposed: boolean = false;
     private onDispose: () => void;
 
@@ -243,16 +242,10 @@ export class Snapshot {
         this.toPath = toPath;
         this.onDispose = onDispose;
 
-        this.objectRegistry = new ObjectRegistry<Symbol, TypeObject, Signature>({
-            createSymbol: symbolData => new Symbol(symbolData, this.client, this.id, this.objectRegistry),
-            createType: typeData => new TypeObject(typeData, this.client, this.id, this.objectRegistry),
-            createSignature: sigData => new Signature(sigData, this.objectRegistry),
-        });
-
         // Create projects
         this.projectMap = new Map();
         for (const projData of data.projects) {
-            const project = new Project(projData, this.id, client, this.objectRegistry, sourceFileCache, toPath);
+            const project = new Project(projData, this.id, client, sourceFileCache, toPath);
             this.projectMap.set(toPath(projData.configFileName), project);
         }
     }
@@ -284,7 +277,9 @@ export class Snapshot {
     async dispose(): Promise<void> {
         if (this.disposed) return;
         this.disposed = true;
-        this.objectRegistry.clear();
+        for (const project of this.projectMap.values()) {
+            project.dispose();
+        }
         this.onDispose();
         await this.client.apiRequest("release", { snapshot: this.id });
     }
@@ -310,12 +305,12 @@ export class Project {
     readonly checker: Checker;
     readonly emitter: Emitter;
     private client: Client;
+    private objectRegistry: ProjectObjectRegistry;
 
     constructor(
         data: ProjectResponse,
         snapshotId: number,
         client: Client,
-        objectRegistry: SnapshotObjectRegistry,
         sourceFileCache: SourceFileCache,
         toPath: (fileName: string) => Path,
     ) {
@@ -324,6 +319,13 @@ export class Project {
         this.compilerOptions = data.compilerOptions;
         this.rootFiles = data.rootFiles;
         this.client = client;
+
+        this.objectRegistry = new ObjectRegistry<Symbol, TypeObject, Signature>({
+            createSymbol: symbolData => new Symbol(symbolData, this.client, snapshotId, this.id, this.objectRegistry),
+            createType: typeData => new TypeObject(typeData, this.client, snapshotId, this.id, this.objectRegistry),
+            createSignature: sigData => new Signature(sigData, this.objectRegistry),
+        });
+
         this.program = new Program(
             snapshotId,
             this.id,
@@ -335,9 +337,14 @@ export class Project {
             snapshotId,
             this.id,
             client,
-            objectRegistry,
+            this.objectRegistry,
         );
         this.emitter = new Emitter(client);
+    }
+
+    /** @internal Clears the project's object registry. Called by the owning snapshot on dispose. */
+    dispose(): void {
+        this.objectRegistry.clear();
     }
 }
 
@@ -460,13 +467,13 @@ export class Checker {
     private snapshotId: number;
     private projectId: string;
     private client: Client;
-    private objectRegistry: SnapshotObjectRegistry;
+    private objectRegistry: ProjectObjectRegistry;
 
     constructor(
         snapshotId: number,
         projectId: string,
         client: Client,
-        objectRegistry: SnapshotObjectRegistry,
+        objectRegistry: ProjectObjectRegistry,
     ) {
         this.snapshotId = snapshotId;
         this.projectId = projectId;
@@ -993,7 +1000,8 @@ export interface SignatureUsage {
 export class Symbol {
     private client: Client;
     private snapshotId: number;
-    private objectRegistry: SnapshotObjectRegistry;
+    private projectId: string;
+    private objectRegistry: ProjectObjectRegistry;
 
     readonly id: number;
     readonly name: string;
@@ -1002,9 +1010,10 @@ export class Symbol {
     readonly declarations: readonly NodeHandle[];
     readonly valueDeclaration: NodeHandle | undefined;
 
-    constructor(data: SymbolResponse, client: Client, snapshotId: number, objectRegistry: SnapshotObjectRegistry) {
+    constructor(data: SymbolResponse, client: Client, snapshotId: number, projectId: string, objectRegistry: ProjectObjectRegistry) {
         this.client = client;
         this.snapshotId = snapshotId;
+        this.projectId = projectId;
         this.objectRegistry = objectRegistry;
 
         this.id = data.id;
@@ -1016,22 +1025,22 @@ export class Symbol {
     }
 
     async getParent(): Promise<Symbol | undefined> {
-        const data = await this.client.apiRequest<SymbolResponse | null>("getParentOfSymbol", { snapshot: this.snapshotId, symbol: this.id });
+        const data = await this.client.apiRequest<SymbolResponse | null>("getParentOfSymbol", { snapshot: this.snapshotId, project: this.projectId, symbol: this.id });
         return data ? this.objectRegistry.getOrCreateSymbol(data) : undefined;
     }
 
     async getMembers(): Promise<readonly Symbol[]> {
-        const data = await this.client.apiRequest<SymbolResponse[] | null>("getMembersOfSymbol", { snapshot: this.snapshotId, symbol: this.id });
+        const data = await this.client.apiRequest<SymbolResponse[] | null>("getMembersOfSymbol", { snapshot: this.snapshotId, project: this.projectId, symbol: this.id });
         return data ? data.map(d => this.objectRegistry.getOrCreateSymbol(d)) : [];
     }
 
     async getExports(): Promise<readonly Symbol[]> {
-        const data = await this.client.apiRequest<SymbolResponse[] | null>("getExportsOfSymbol", { snapshot: this.snapshotId, symbol: this.id });
+        const data = await this.client.apiRequest<SymbolResponse[] | null>("getExportsOfSymbol", { snapshot: this.snapshotId, project: this.projectId, symbol: this.id });
         return data ? data.map(d => this.objectRegistry.getOrCreateSymbol(d)) : [];
     }
 
     async getExportSymbol(): Promise<Symbol> {
-        const data = await this.client.apiRequest<SymbolResponse>("getExportSymbolOfSymbol", { snapshot: this.snapshotId, symbol: this.id });
+        const data = await this.client.apiRequest<SymbolResponse>("getExportSymbolOfSymbol", { snapshot: this.snapshotId, project: this.projectId, symbol: this.id });
         return this.objectRegistry.getOrCreateSymbol(data);
     }
 }
@@ -1039,7 +1048,8 @@ export class Symbol {
 class TypeObject implements Type {
     private client: Client;
     private snapshotId: number;
-    private objectRegistry: SnapshotObjectRegistry;
+    private projectId: string;
+    private objectRegistry: ProjectObjectRegistry;
 
     readonly id: number;
     readonly flags: TypeFlags;
@@ -1066,9 +1076,10 @@ class TypeObject implements Type {
     readonly baseType!: number;
     readonly substConstraint!: number;
 
-    constructor(data: TypeResponse, client: Client, snapshotId: number, objectRegistry: SnapshotObjectRegistry) {
+    constructor(data: TypeResponse, client: Client, snapshotId: number, projectId: string, objectRegistry: ProjectObjectRegistry) {
         this.client = client;
         this.snapshotId = snapshotId;
+        this.projectId = projectId;
         this.objectRegistry = objectRegistry;
 
         this.id = data.id;
@@ -1098,7 +1109,7 @@ class TypeObject implements Type {
     }
 
     async getSymbol(): Promise<Symbol | undefined> {
-        const data = await this.client.apiRequest<SymbolResponse | null>("getSymbolOfType", { snapshot: this.snapshotId, type: this.id });
+        const data = await this.client.apiRequest<SymbolResponse | null>("getSymbolOfType", { snapshot: this.snapshotId, project: this.projectId, type: this.id });
         return data ? this.objectRegistry.getOrCreateSymbol(data) : undefined;
     }
 
@@ -1106,7 +1117,7 @@ class TypeObject implements Type {
         if (!this.aliasSymbol) return undefined;
         const cached = this.objectRegistry.getSymbol(this.aliasSymbol);
         if (cached) return cached;
-        const data = await this.client.apiRequest<SymbolResponse | null>("getAliasSymbolOfType", { snapshot: this.snapshotId, type: this.id });
+        const data = await this.client.apiRequest<SymbolResponse | null>("getAliasSymbolOfType", { snapshot: this.snapshotId, project: this.projectId, type: this.id });
         return data ? this.objectRegistry.getOrCreateSymbol(data) : undefined;
     }
 
@@ -1197,7 +1208,7 @@ export class Signature {
     readonly thisParameter?: Symbol | undefined;
     readonly target?: Signature | undefined;
 
-    constructor(data: SignatureResponse, objectRegistry: SnapshotObjectRegistry) {
+    constructor(data: SignatureResponse, objectRegistry: ProjectObjectRegistry) {
         this.id = data.id;
         this.flags = data.flags;
         this.declaration = data.declaration ? new NodeHandle(data.declaration) : undefined;

--- a/_packages/native-preview/src/api/sync/api.ts
+++ b/_packages/native-preview/src/api/sync/api.ts
@@ -104,8 +104,8 @@ export type { APIOptions, ClientSocketOptions, ClientSpawnOptions, DocumentIdent
 export type { AssertsIdentifierTypePredicate, AssertsThisTypePredicate, ConditionalType, Diagnostic, FreshableType, IdentifierTypePredicate, IndexedAccessType, IndexInfo, IndexType, InterfaceType, IntersectionType, IntrinsicType, LiteralType, ObjectType, StringMappingType, SubstitutionType, TemplateLiteralType, ThisTypePredicate, TupleType, Type, TypeParameter, TypePredicate, TypePredicateBase, TypeReference, UnionOrIntersectionType, UnionType };
 export { documentURIToFileName, fileNameToDocumentURI } from "../path.ts";
 
-/** Type alias for the snapshot-scoped object registry */
-type SnapshotObjectRegistry = ObjectRegistry<Symbol, TypeObject, Signature>;
+/** Type alias for the project-scoped object registry */
+type ProjectObjectRegistry = ObjectRegistry<Symbol, TypeObject, Signature>;
 
 export class API<FromLSP extends boolean = false> {
     private client: Client;
@@ -235,7 +235,6 @@ export class Snapshot {
     private projectMap: Map<Path, Project>;
     private toPath: (fileName: string) => Path;
     private client: Client;
-    private objectRegistry: SnapshotObjectRegistry;
     private disposed: boolean = false;
     private onDispose: () => void;
 
@@ -251,16 +250,10 @@ export class Snapshot {
         this.toPath = toPath;
         this.onDispose = onDispose;
 
-        this.objectRegistry = new ObjectRegistry<Symbol, TypeObject, Signature>({
-            createSymbol: symbolData => new Symbol(symbolData, this.client, this.id, this.objectRegistry),
-            createType: typeData => new TypeObject(typeData, this.client, this.id, this.objectRegistry),
-            createSignature: sigData => new Signature(sigData, this.objectRegistry),
-        });
-
         // Create projects
         this.projectMap = new Map();
         for (const projData of data.projects) {
-            const project = new Project(projData, this.id, client, this.objectRegistry, sourceFileCache, toPath);
+            const project = new Project(projData, this.id, client, sourceFileCache, toPath);
             this.projectMap.set(toPath(projData.configFileName), project);
         }
     }
@@ -292,7 +285,9 @@ export class Snapshot {
     dispose(): void {
         if (this.disposed) return;
         this.disposed = true;
-        this.objectRegistry.clear();
+        for (const project of this.projectMap.values()) {
+            project.dispose();
+        }
         this.onDispose();
         this.client.apiRequest("release", { snapshot: this.id });
     }
@@ -318,12 +313,12 @@ export class Project {
     readonly checker: Checker;
     readonly emitter: Emitter;
     private client: Client;
+    private objectRegistry: ProjectObjectRegistry;
 
     constructor(
         data: ProjectResponse,
         snapshotId: number,
         client: Client,
-        objectRegistry: SnapshotObjectRegistry,
         sourceFileCache: SourceFileCache,
         toPath: (fileName: string) => Path,
     ) {
@@ -332,6 +327,13 @@ export class Project {
         this.compilerOptions = data.compilerOptions;
         this.rootFiles = data.rootFiles;
         this.client = client;
+
+        this.objectRegistry = new ObjectRegistry<Symbol, TypeObject, Signature>({
+            createSymbol: symbolData => new Symbol(symbolData, this.client, snapshotId, this.id, this.objectRegistry),
+            createType: typeData => new TypeObject(typeData, this.client, snapshotId, this.id, this.objectRegistry),
+            createSignature: sigData => new Signature(sigData, this.objectRegistry),
+        });
+
         this.program = new Program(
             snapshotId,
             this.id,
@@ -343,9 +345,14 @@ export class Project {
             snapshotId,
             this.id,
             client,
-            objectRegistry,
+            this.objectRegistry,
         );
         this.emitter = new Emitter(client);
+    }
+
+    /** @internal Clears the project's object registry. Called by the owning snapshot on dispose. */
+    dispose(): void {
+        this.objectRegistry.clear();
     }
 }
 
@@ -468,13 +475,13 @@ export class Checker {
     private snapshotId: number;
     private projectId: string;
     private client: Client;
-    private objectRegistry: SnapshotObjectRegistry;
+    private objectRegistry: ProjectObjectRegistry;
 
     constructor(
         snapshotId: number,
         projectId: string,
         client: Client,
-        objectRegistry: SnapshotObjectRegistry,
+        objectRegistry: ProjectObjectRegistry,
     ) {
         this.snapshotId = snapshotId;
         this.projectId = projectId;
@@ -1001,7 +1008,8 @@ export interface SignatureUsage {
 export class Symbol {
     private client: Client;
     private snapshotId: number;
-    private objectRegistry: SnapshotObjectRegistry;
+    private projectId: string;
+    private objectRegistry: ProjectObjectRegistry;
 
     readonly id: number;
     readonly name: string;
@@ -1010,9 +1018,10 @@ export class Symbol {
     readonly declarations: readonly NodeHandle[];
     readonly valueDeclaration: NodeHandle | undefined;
 
-    constructor(data: SymbolResponse, client: Client, snapshotId: number, objectRegistry: SnapshotObjectRegistry) {
+    constructor(data: SymbolResponse, client: Client, snapshotId: number, projectId: string, objectRegistry: ProjectObjectRegistry) {
         this.client = client;
         this.snapshotId = snapshotId;
+        this.projectId = projectId;
         this.objectRegistry = objectRegistry;
 
         this.id = data.id;
@@ -1024,22 +1033,22 @@ export class Symbol {
     }
 
     getParent(): Symbol | undefined {
-        const data = this.client.apiRequest<SymbolResponse | null>("getParentOfSymbol", { snapshot: this.snapshotId, symbol: this.id });
+        const data = this.client.apiRequest<SymbolResponse | null>("getParentOfSymbol", { snapshot: this.snapshotId, project: this.projectId, symbol: this.id });
         return data ? this.objectRegistry.getOrCreateSymbol(data) : undefined;
     }
 
     getMembers(): readonly Symbol[] {
-        const data = this.client.apiRequest<SymbolResponse[] | null>("getMembersOfSymbol", { snapshot: this.snapshotId, symbol: this.id });
+        const data = this.client.apiRequest<SymbolResponse[] | null>("getMembersOfSymbol", { snapshot: this.snapshotId, project: this.projectId, symbol: this.id });
         return data ? data.map(d => this.objectRegistry.getOrCreateSymbol(d)) : [];
     }
 
     getExports(): readonly Symbol[] {
-        const data = this.client.apiRequest<SymbolResponse[] | null>("getExportsOfSymbol", { snapshot: this.snapshotId, symbol: this.id });
+        const data = this.client.apiRequest<SymbolResponse[] | null>("getExportsOfSymbol", { snapshot: this.snapshotId, project: this.projectId, symbol: this.id });
         return data ? data.map(d => this.objectRegistry.getOrCreateSymbol(d)) : [];
     }
 
     getExportSymbol(): Symbol {
-        const data = this.client.apiRequest<SymbolResponse>("getExportSymbolOfSymbol", { snapshot: this.snapshotId, symbol: this.id });
+        const data = this.client.apiRequest<SymbolResponse>("getExportSymbolOfSymbol", { snapshot: this.snapshotId, project: this.projectId, symbol: this.id });
         return this.objectRegistry.getOrCreateSymbol(data);
     }
 }
@@ -1047,7 +1056,8 @@ export class Symbol {
 class TypeObject implements Type {
     private client: Client;
     private snapshotId: number;
-    private objectRegistry: SnapshotObjectRegistry;
+    private projectId: string;
+    private objectRegistry: ProjectObjectRegistry;
 
     readonly id: number;
     readonly flags: TypeFlags;
@@ -1074,9 +1084,10 @@ class TypeObject implements Type {
     readonly baseType!: number;
     readonly substConstraint!: number;
 
-    constructor(data: TypeResponse, client: Client, snapshotId: number, objectRegistry: SnapshotObjectRegistry) {
+    constructor(data: TypeResponse, client: Client, snapshotId: number, projectId: string, objectRegistry: ProjectObjectRegistry) {
         this.client = client;
         this.snapshotId = snapshotId;
+        this.projectId = projectId;
         this.objectRegistry = objectRegistry;
 
         this.id = data.id;
@@ -1106,7 +1117,7 @@ class TypeObject implements Type {
     }
 
     getSymbol(): Symbol | undefined {
-        const data = this.client.apiRequest<SymbolResponse | null>("getSymbolOfType", { snapshot: this.snapshotId, type: this.id });
+        const data = this.client.apiRequest<SymbolResponse | null>("getSymbolOfType", { snapshot: this.snapshotId, project: this.projectId, type: this.id });
         return data ? this.objectRegistry.getOrCreateSymbol(data) : undefined;
     }
 
@@ -1114,7 +1125,7 @@ class TypeObject implements Type {
         if (!this.aliasSymbol) return undefined;
         const cached = this.objectRegistry.getSymbol(this.aliasSymbol);
         if (cached) return cached;
-        const data = this.client.apiRequest<SymbolResponse | null>("getAliasSymbolOfType", { snapshot: this.snapshotId, type: this.id });
+        const data = this.client.apiRequest<SymbolResponse | null>("getAliasSymbolOfType", { snapshot: this.snapshotId, project: this.projectId, type: this.id });
         return data ? this.objectRegistry.getOrCreateSymbol(data) : undefined;
     }
 
@@ -1205,7 +1216,7 @@ export class Signature {
     readonly thisParameter?: Symbol | undefined;
     readonly target?: Signature | undefined;
 
-    constructor(data: SignatureResponse, objectRegistry: SnapshotObjectRegistry) {
+    constructor(data: SignatureResponse, objectRegistry: ProjectObjectRegistry) {
         this.id = data.id;
         this.flags = data.flags;
         this.declaration = data.declaration ? new NodeHandle(data.declaration) : undefined;

--- a/internal/api/proto.go
+++ b/internal/api/proto.go
@@ -329,7 +329,7 @@ var unmarshalers = map[Method]func([]byte) (any, error){
 	MethodGetOuterTypeParametersOfType:      unmarshallerFor[GetTypePropertyParams],
 	MethodGetLocalTypeParametersOfType:      unmarshallerFor[GetTypePropertyParams],
 	MethodGetAliasTypeArgumentsOfType:       unmarshallerFor[GetTypePropertyParams],
-	MethodGetAliasSymbolOfType:              unmarshallerFor[GetTypePropertyParams],
+	MethodGetAliasSymbolOfType:              unmarshallerFor[GetAliasSymbolOfTypeParams],
 	MethodGetObjectTypeOfType:               unmarshallerFor[GetTypePropertyParams],
 	MethodGetIndexTypeOfType:                unmarshallerFor[GetTypePropertyParams],
 	MethodGetCheckTypeOfType:                unmarshallerFor[GetTypePropertyParams],
@@ -684,26 +684,37 @@ type ResolveNameParams struct {
 
 type GetParentOfSymbolParams struct {
 	Snapshot SnapshotID `json:"snapshot"`
+	Project  ProjectID  `json:"project"`
 	Symbol   SymbolID   `json:"symbol"`
 }
 
 type GetMembersOfSymbolParams struct {
 	Snapshot SnapshotID `json:"snapshot"`
+	Project  ProjectID  `json:"project"`
 	Symbol   SymbolID   `json:"symbol"`
 }
 
 type GetExportsOfSymbolParams struct {
 	Snapshot SnapshotID `json:"snapshot"`
+	Project  ProjectID  `json:"project"`
 	Symbol   SymbolID   `json:"symbol"`
 }
 
 type GetExportSymbolOfSymbolParams struct {
 	Snapshot SnapshotID `json:"snapshot"`
+	Project  ProjectID  `json:"project"`
 	Symbol   SymbolID   `json:"symbol"`
 }
 
 type GetSymbolOfTypeParams struct {
 	Snapshot SnapshotID `json:"snapshot"`
+	Project  ProjectID  `json:"project"`
+	Type     TypeID     `json:"type"`
+}
+
+type GetAliasSymbolOfTypeParams struct {
+	Snapshot SnapshotID `json:"snapshot"`
+	Project  ProjectID  `json:"project"`
 	Type     TypeID     `json:"type"`
 }
 

--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -38,6 +38,8 @@ type snapshotData struct {
 
 	symbolRegistry   map[SymbolID]*ast.Symbol
 	symbolRegistryMu sync.RWMutex
+	symbolTargets    map[SymbolID]*ast.Symbol
+	symbolTargetsMu  sync.RWMutex
 
 	typeRegistry   map[TypeID]*checker.Type
 	typeRegistryMu sync.RWMutex
@@ -95,7 +97,8 @@ func (sd *snapshotData) nodeHandleFrom(node *ast.Node) NodeHandle {
 }
 
 // registerSymbol registers a symbol in this snapshot's registry and returns the response.
-func (sd *snapshotData) registerSymbol(symbol *ast.Symbol) *SymbolResponse {
+// c is the checker that produced the symbol.
+func (sd *snapshotData) registerSymbol(symbol *ast.Symbol, c *checker.Checker) *SymbolResponse {
 	if symbol == nil {
 		return nil
 	}
@@ -112,6 +115,14 @@ func (sd *snapshotData) registerSymbol(symbol *ast.Symbol) *SymbolResponse {
 	sd.symbolRegistryMu.Lock()
 	sd.symbolRegistry[resp.Id] = symbol
 	sd.symbolRegistryMu.Unlock()
+
+	if symbol.CheckFlags&ast.CheckFlagsInstantiated != 0 {
+		if target := c.GetTargetSymbol(symbol); target != nil && target != symbol {
+			sd.symbolTargetsMu.Lock()
+			sd.symbolTargets[resp.Id] = target
+			sd.symbolTargetsMu.Unlock()
+		}
+	}
 
 	return resp
 }
@@ -131,7 +142,9 @@ func (sd *snapshotData) registerType(t *checker.Type) *TypeResponse {
 }
 
 // resolveSymbolHandle resolves a symbol handle to a symbol within this snapshot.
-func (sd *snapshotData) resolveSymbolHandle(handle SymbolID) (*ast.Symbol, error) {
+// c is the checker that will use the symbol. When the symbol is instantiated, the stored
+// target is restored into the checker's valueSymbolLinks so GetTypeOfSymbol works across checkers.
+func (sd *snapshotData) resolveSymbolHandle(handle SymbolID, c *checker.Checker) (*ast.Symbol, error) {
 	if handle == 0 {
 		return nil, fmt.Errorf("%w: empty symbol handle", ErrClientError)
 	}
@@ -142,6 +155,15 @@ func (sd *snapshotData) resolveSymbolHandle(handle SymbolID) (*ast.Symbol, error
 
 	if !ok {
 		return nil, fmt.Errorf("%w: symbol handle %d not found in snapshot registry", ErrClientError, handle)
+	}
+
+	if symbol.CheckFlags&ast.CheckFlagsInstantiated != 0 {
+		sd.symbolTargetsMu.RLock()
+		target := sd.symbolTargets[handle]
+		sd.symbolTargetsMu.RUnlock()
+		if target != nil {
+			c.EnsureInstantiatedSymbolTarget(symbol, target)
+		}
 	}
 
 	return symbol, nil
@@ -441,7 +463,7 @@ func (s *Session) HandleRequest(ctx context.Context, method string, params json.
 	case string(MethodGetAliasTypeArgumentsOfType):
 		return s.handleGetAliasTypeArgumentsOfType(ctx, parsed.(*GetTypePropertyParams))
 	case string(MethodGetAliasSymbolOfType):
-		return s.handleGetAliasSymbolOfType(ctx, parsed.(*GetTypePropertyParams))
+		return s.handleGetAliasSymbolOfType(ctx, parsed.(*GetAliasSymbolOfTypeParams))
 	case string(MethodGetObjectTypeOfType):
 		return s.handleGetObjectTypeOfType(ctx, parsed.(*GetTypePropertyParams))
 	case string(MethodGetIndexTypeOfType):
@@ -632,6 +654,7 @@ func (s *Session) handleUpdateSnapshot(ctx context.Context, params *UpdateSnapsh
 			snapshot:          snapshot,
 			refCount:          1,
 			symbolRegistry:    make(map[SymbolID]*ast.Symbol),
+			symbolTargets:     make(map[SymbolID]*ast.Symbol),
 			typeRegistry:      make(map[TypeID]*checker.Type),
 			signatureRegistry: make(map[SignatureID]*checker.Signature),
 			nodeTablesByPath:  make(map[tspath.Path]*encoder.NodeIndexTable),
@@ -803,7 +826,7 @@ func (s *Session) handleGetSymbolAtPosition(ctx context.Context, params *GetSymb
 		return nil, nil
 	}
 
-	return setup.sd.registerSymbol(symbol), nil
+	return setup.sd.registerSymbol(symbol, setup.checker), nil
 }
 
 // handleGetSymbolsAtPositions returns symbols at multiple positions in a file.
@@ -828,7 +851,7 @@ func (s *Session) handleGetSymbolsAtPositions(ctx context.Context, params *GetSy
 		}
 		symbol := setup.checker.GetSymbolAtLocation(node)
 		if symbol != nil {
-			results[i] = setup.sd.registerSymbol(symbol)
+			results[i] = setup.sd.registerSymbol(symbol, setup.checker)
 		}
 	}
 
@@ -856,7 +879,7 @@ func (s *Session) handleGetSymbolAtLocation(ctx context.Context, params *GetSymb
 		return nil, nil
 	}
 
-	return setup.sd.registerSymbol(symbol), nil
+	return setup.sd.registerSymbol(symbol, setup.checker), nil
 }
 
 // handleGetSymbolsAtLocations returns symbols at multiple node locations.
@@ -878,7 +901,7 @@ func (s *Session) handleGetSymbolsAtLocations(ctx context.Context, params *GetSy
 		}
 		symbol := setup.checker.GetSymbolAtLocation(node)
 		if symbol != nil {
-			results[i] = setup.sd.registerSymbol(symbol)
+			results[i] = setup.sd.registerSymbol(symbol, setup.checker)
 		}
 	}
 
@@ -893,7 +916,7 @@ func (s *Session) handleGetTypeOfSymbol(ctx context.Context, params *GetTypeOfSy
 	}
 	defer setup.done()
 
-	symbol, err := setup.sd.resolveSymbolHandle(params.Symbol)
+	symbol, err := setup.sd.resolveSymbolHandle(params.Symbol, setup.checker)
 	if err != nil {
 		return nil, err
 	}
@@ -919,7 +942,7 @@ func (s *Session) handleGetTypesOfSymbols(ctx context.Context, params *GetTypesO
 
 	results := make([]*TypeResponse, len(params.Symbols))
 	for i, symHandle := range params.Symbols {
-		symbol, err := setup.sd.resolveSymbolHandle(symHandle)
+		symbol, err := setup.sd.resolveSymbolHandle(symHandle, setup.checker)
 		if err != nil {
 			return nil, err
 		}
@@ -943,7 +966,7 @@ func (s *Session) handleGetDeclaredTypeOfSymbol(ctx context.Context, params *Get
 	}
 	defer setup.done()
 
-	symbol, err := setup.sd.resolveSymbolHandle(params.Symbol)
+	symbol, err := setup.sd.resolveSymbolHandle(params.Symbol, setup.checker)
 	if err != nil {
 		return nil, err
 	}
@@ -987,17 +1010,18 @@ func (s *Session) handleResolveName(ctx context.Context, params *ResolveNamePara
 		return nil, nil
 	}
 
-	return setup.sd.registerSymbol(symbol), nil
+	return setup.sd.registerSymbol(symbol, setup.checker), nil
 }
 
 // handleGetParentOfSymbol returns the parent of a symbol.
 func (s *Session) handleGetParentOfSymbol(ctx context.Context, params *GetParentOfSymbolParams) (*SymbolResponse, error) {
-	sd, err := s.getSnapshotData(params.Snapshot)
+	setup, err := s.setupChecker(ctx, params.Snapshot, params.Project)
 	if err != nil {
 		return nil, err
 	}
+	defer setup.done()
 
-	symbol, err := sd.resolveSymbolHandle(params.Symbol)
+	symbol, err := setup.sd.resolveSymbolHandle(params.Symbol, setup.checker)
 	if err != nil {
 		return nil, err
 	}
@@ -1007,17 +1031,18 @@ func (s *Session) handleGetParentOfSymbol(ctx context.Context, params *GetParent
 		return nil, nil
 	}
 
-	return sd.registerSymbol(parent), nil
+	return setup.sd.registerSymbol(parent, setup.checker), nil
 }
 
 // handleGetMembersOfSymbol returns the members of a symbol.
 func (s *Session) handleGetMembersOfSymbol(ctx context.Context, params *GetMembersOfSymbolParams) ([]*SymbolResponse, error) {
-	sd, err := s.getSnapshotData(params.Snapshot)
+	setup, err := s.setupChecker(ctx, params.Snapshot, params.Project)
 	if err != nil {
 		return nil, err
 	}
+	defer setup.done()
 
-	symbol, err := sd.resolveSymbolHandle(params.Symbol)
+	symbol, err := setup.sd.resolveSymbolHandle(params.Symbol, setup.checker)
 	if err != nil {
 		return nil, err
 	}
@@ -1028,7 +1053,7 @@ func (s *Session) handleGetMembersOfSymbol(ctx context.Context, params *GetMembe
 
 	results := make([]*SymbolResponse, 0, len(symbol.Members))
 	for _, member := range symbol.Members {
-		results = append(results, sd.registerSymbol(member))
+		results = append(results, setup.sd.registerSymbol(member, setup.checker))
 	}
 
 	return results, nil
@@ -1036,12 +1061,13 @@ func (s *Session) handleGetMembersOfSymbol(ctx context.Context, params *GetMembe
 
 // handleGetExportsOfSymbol returns the exports of a symbol.
 func (s *Session) handleGetExportsOfSymbol(ctx context.Context, params *GetExportsOfSymbolParams) ([]*SymbolResponse, error) {
-	sd, err := s.getSnapshotData(params.Snapshot)
+	setup, err := s.setupChecker(ctx, params.Snapshot, params.Project)
 	if err != nil {
 		return nil, err
 	}
+	defer setup.done()
 
-	symbol, err := sd.resolveSymbolHandle(params.Symbol)
+	symbol, err := setup.sd.resolveSymbolHandle(params.Symbol, setup.checker)
 	if err != nil {
 		return nil, err
 	}
@@ -1052,7 +1078,7 @@ func (s *Session) handleGetExportsOfSymbol(ctx context.Context, params *GetExpor
 
 	results := make([]*SymbolResponse, 0, len(symbol.Exports))
 	for _, exp := range symbol.Exports {
-		results = append(results, sd.registerSymbol(exp))
+		results = append(results, setup.sd.registerSymbol(exp, setup.checker))
 	}
 
 	return results, nil
@@ -1060,31 +1086,33 @@ func (s *Session) handleGetExportsOfSymbol(ctx context.Context, params *GetExpor
 
 // handleGetExportSymbolOfSymbol returns the export symbol of a symbol.
 func (s *Session) handleGetExportSymbolOfSymbol(ctx context.Context, params *GetExportSymbolOfSymbolParams) (*SymbolResponse, error) {
-	sd, err := s.getSnapshotData(params.Snapshot)
+	setup, err := s.setupChecker(ctx, params.Snapshot, params.Project)
 	if err != nil {
 		return nil, err
 	}
+	defer setup.done()
 
-	symbol, err := sd.resolveSymbolHandle(params.Symbol)
+	symbol, err := setup.sd.resolveSymbolHandle(params.Symbol, setup.checker)
 	if err != nil {
 		return nil, err
 	}
 
 	if symbol.ExportSymbol != nil {
-		return sd.registerSymbol(symbol.ExportSymbol), nil
+		return setup.sd.registerSymbol(symbol.ExportSymbol, setup.checker), nil
 	}
 
-	return sd.registerSymbol(symbol), nil
+	return setup.sd.registerSymbol(symbol, setup.checker), nil
 }
 
 // handleGetSymbolOfType returns the symbol associated with a type.
 func (s *Session) handleGetSymbolOfType(ctx context.Context, params *GetSymbolOfTypeParams) (*SymbolResponse, error) {
-	sd, err := s.getSnapshotData(params.Snapshot)
+	setup, err := s.setupChecker(ctx, params.Snapshot, params.Project)
 	if err != nil {
 		return nil, err
 	}
+	defer setup.done()
 
-	t, err := sd.resolveTypeHandle(params.Type)
+	t, err := setup.sd.resolveTypeHandle(params.Type)
 	if err != nil {
 		return nil, err
 	}
@@ -1094,7 +1122,7 @@ func (s *Session) handleGetSymbolOfType(ctx context.Context, params *GetSymbolOf
 		return nil, nil
 	}
 
-	return sd.registerSymbol(symbol), nil
+	return setup.sd.registerSymbol(symbol, setup.checker), nil
 }
 
 // handleGetSignaturesOfType returns the call or construct signatures of a type.
@@ -1342,13 +1370,14 @@ func (s *Session) handleGetAliasTypeArgumentsOfType(_ context.Context, params *G
 	})
 }
 
-func (s *Session) handleGetAliasSymbolOfType(_ context.Context, params *GetTypePropertyParams) (*SymbolResponse, error) {
-	sd, err := s.getSnapshotData(params.Snapshot)
+func (s *Session) handleGetAliasSymbolOfType(ctx context.Context, params *GetAliasSymbolOfTypeParams) (*SymbolResponse, error) {
+	setup, err := s.setupChecker(ctx, params.Snapshot, params.Project)
 	if err != nil {
 		return nil, err
 	}
+	defer setup.done()
 
-	t, err := sd.resolveTypeHandle(params.Type)
+	t, err := setup.sd.resolveTypeHandle(params.Type)
 	if err != nil {
 		return nil, err
 	}
@@ -1357,7 +1386,7 @@ func (s *Session) handleGetAliasSymbolOfType(_ context.Context, params *GetTypeP
 		return nil, nil
 	}
 
-	return sd.registerSymbol(t.Alias().Symbol()), nil
+	return setup.sd.registerSymbol(t.Alias().Symbol(), setup.checker), nil
 }
 
 func (s *Session) handleGetObjectTypeOfType(_ context.Context, params *GetTypePropertyParams) (*TypeResponse, error) {
@@ -1589,7 +1618,7 @@ func (s *Session) handleGetShorthandAssignmentValueSymbol(ctx context.Context, p
 		return nil, nil
 	}
 
-	return setup.sd.registerSymbol(symbol), nil
+	return setup.sd.registerSymbol(symbol, setup.checker), nil
 }
 
 // handleGetTypeOfSymbolAtLocation returns the narrowed type of a symbol at a specific location.
@@ -1600,7 +1629,7 @@ func (s *Session) handleGetTypeOfSymbolAtLocation(ctx context.Context, params *G
 	}
 	defer setup.done()
 
-	symbol, err := setup.sd.resolveSymbolHandle(params.Symbol)
+	symbol, err := setup.sd.resolveSymbolHandle(params.Symbol, setup.checker)
 	if err != nil {
 		return nil, err
 	}
@@ -1901,7 +1930,7 @@ func (s *Session) handleGetPropertiesOfType(ctx context.Context, params *Checker
 
 	results := make([]*SymbolResponse, len(props))
 	for i, prop := range props {
-		results[i] = setup.sd.registerSymbol(prop)
+		results[i] = setup.sd.registerSymbol(prop, setup.checker)
 	}
 
 	return results, nil
@@ -2242,7 +2271,7 @@ func (s *Session) handleGetReferencesToSymbolInFile(ctx context.Context, params 
 	}
 	defer setup.done()
 
-	symbol, err := setup.sd.resolveSymbolHandle(params.Symbol)
+	symbol, err := setup.sd.resolveSymbolHandle(params.Symbol, setup.checker)
 	if err != nil {
 		return nil, err
 	}
@@ -2306,16 +2335,13 @@ func (s *Session) handleGetSignatureUsages(ctx context.Context, params *GetSigna
 
 // handleGetReferencedSymbolsForNode returns node handles for all references found at a node.
 func (s *Session) handleGetReferencedSymbolsForNode(ctx context.Context, params *GetReferencedSymbolsForNodeParams) ([]ReferencedSymbolEntry, error) {
-	sd, err := s.getSnapshotData(params.Snapshot)
+	setup, err := s.setupChecker(ctx, params.Snapshot, params.Project)
 	if err != nil {
 		return nil, err
 	}
-	program, err := sd.getProgram(params.Project)
-	if err != nil {
-		return nil, err
-	}
+	defer setup.done()
 
-	node, err := sd.resolveNodeHandle(program, params.Node)
+	node, err := setup.sd.resolveNodeHandle(setup.program, params.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -2323,12 +2349,12 @@ func (s *Session) handleGetReferencedSymbolsForNode(ctx context.Context, params 
 		return nil, nil
 	}
 
-	langSvc, err := s.setupLanguageService(sd, program, params.Project, "")
+	langSvc, err := s.setupLanguageService(setup.sd, setup.program, params.Project, "")
 	if err != nil {
 		return nil, err
 	}
 
-	sourceFiles := program.GetSourceFiles()
+	sourceFiles := setup.program.GetSourceFiles()
 	entries := langSvc.GetReferencedSymbolsForNode(ctx, params.Position, node, sourceFiles)
 	if entries == nil {
 		return nil, nil
@@ -2343,15 +2369,15 @@ func (s *Session) handleGetReferencedSymbolsForNode(ctx context.Context, params 
 		var refs []NodeHandle
 		for _, ref := range entry.References() {
 			if ref.IsNodeEntry() {
-				refs = append(refs, sd.nodeHandleFrom(ref.Node()))
+				refs = append(refs, setup.sd.nodeHandleFrom(ref.Node()))
 			}
 		}
 		re := ReferencedSymbolEntry{
-			Definition: sd.nodeHandleFrom(defNode),
+			Definition: setup.sd.nodeHandleFrom(defNode),
 			References: refs,
 		}
 		if sym := entry.DefinitionSymbol(); sym != nil {
-			re.Symbol = sd.registerSymbol(sym)
+			re.Symbol = setup.sd.registerSymbol(sym, setup.checker)
 		}
 		result = append(result, re)
 	}

--- a/internal/checker/exports.go
+++ b/internal/checker/exports.go
@@ -165,6 +165,25 @@ func (c *Checker) GetTypeOfSymbol(symbol *ast.Symbol) *Type {
 	return c.getTypeOfSymbol(symbol)
 }
 
+// GetTargetSymbol returns the original non-instantiated symbol for an instantiated
+// symbol, or the symbol itself if not instantiated.
+func (c *Checker) GetTargetSymbol(symbol *ast.Symbol) *ast.Symbol {
+	return c.getTargetSymbol(symbol)
+}
+
+// EnsureInstantiatedSymbolTarget restores a known target into this checker's
+// valueSymbolLinks for an instantiated symbol whose target is not yet known
+// to this checker (e.g. the symbol was created by a different checker in the pool).
+// Safe to call when the target is already set — it only writes if target is nil.
+func (c *Checker) EnsureInstantiatedSymbolTarget(symbol *ast.Symbol, target *ast.Symbol) {
+	if symbol.CheckFlags&ast.CheckFlagsInstantiated != 0 {
+		links := c.valueSymbolLinks.Get(symbol)
+		if links.target == nil {
+			links.target = target
+		}
+	}
+}
+
 func (c *Checker) GetConstraintOfTypeParameter(typeParameter *Type) *Type {
 	return c.getConstraintOfTypeParameter(typeParameter)
 }


### PR DESCRIPTION
This PR fixes an issue we've encountered when running our test suite against TS GO with JS API proxy:
```
Error: panic: runtime error: invalid memory address or nil pointer dereference
goroutine 347 [running]:
runtime/debug.Stack()
	runtime/debug/stack.go:26 +0x64
github.com/microsoft/typescript-go/internal/api.(*AsyncConn).handleRequest.func1()
	github.com/microsoft/typescript-go/internal/api/conn_async.go:96 +0x44
panic({0x103c0c280?, 0x104011fe0?})
	runtime/panic.go:860 +0x12c
github.com/microsoft/typescript-go/internal/checker.(*Checker).getTypeOfSymbol(0x2a31fbe51bd8?, 0x103e7cfe0?)
	github.com/microsoft/typescript-go/internal/checker/checker.go:16382 +0x18
github.com/microsoft/typescript-go/internal/checker.(*Checker).getTypeOfInstantiatedSymbol(0x2a31fbe51308, 0x2a31fbde0788?)
	github.com/microsoft/typescript-go/internal/checker/checker.go:16419 +0x4c
github.com/microsoft/typescript-go/internal/checker.(*Checker).getTypeOfSymbol(0x2a31fc68b680?, 0x18?)
	github.com/microsoft/typescript-go/internal/checker/checker.go:16386 +0xd8
github.com/microsoft/typescript-go/internal/checker.(*Checker).GetTypeOfSymbol(...)
	github.com/microsoft/typescript-go/internal/checker/exports.go:165
github.com/microsoft/typescript-go/internal/api.(*Session).handleGetTypeOfSymbol(0x2a31fbb9e260?, {0x103e754d0?, 0x2a31fe032140?}, 0x2a31fe022580)
	github.com/microsoft/typescript-go/internal/api/session.go:904 +0x80
github.com/microsoft/typescript-go/internal/api.(*Session).HandleRequest(0x2a31fc6841e0, {0x103e754d0, 0x2a31fe032140}, {0x2a31fbb9e260, 0xf}, {0x2a31fbdbce40?, 0x2a31fbc4f380?, 0x2a31fbdfc008?})
	github.com/microsoft/typescript-go/internal/api/session.go:398 +0xdc4
github.com/microsoft/typescript-go/internal/api.(*AsyncConn).handleRequest(0x2a31fe032190, {0x103e754d0?, 0x2a31fe032140?}, 0x2a31fc71c5f0)
	github.com/microsoft/typescript-go/internal/api/conn_async.go:112 +0x78
created by github.com/microsoft/typescript-go/internal/api.(*AsyncConn).Run in goroutine 226
	github.com/microsoft/typescript-go/internal/api/conn_async.go:66 +0xe0
```

The issue is caused by the fact, that a different type checker may be used to get the type of an instantiated symbol than the one, which created it and the link target may be empty. The solution is to store the target symbol in a map and ensure that the target symbol is always set, regardless of the TypeChecker. This approach requires the `Symbol` on the client API side to carry the `projectId` and pass it to some of the API calls. As far as I understand the symbols are bound to a project anywhere, i.e. they can't be reused between projects, so moving the object registry to the project level is a natural way of ensuring that symbols have projectId. 