### PR TITLE
perf(checker): defer orderedSet map allocation until >16 elements

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -25907,7 +25907,6 @@ func (c *Checker) getIntersectionType(types []*Type) *Type {
 func (c *Checker) getIntersectionTypeEx(types []*Type, flags IntersectionFlags, alias *TypeAlias) *Type {
 	var orderedTypes orderedSet[*Type]
 	orderedTypes.values = make([]*Type, 0, len(types))
-	orderedTypes.valuesByKey = make(map[*Type]struct{}, len(types))
 	includes := c.addTypesToIntersection(&orderedTypes, 0, types)
 	typeSet := orderedTypes.values
 	objectFlags := ObjectFlagsNone

--- a/internal/checker/utilities.go
+++ b/internal/checker/utilities.go
@@ -812,16 +812,27 @@ type orderedSet[T comparable] struct {
 }
 
 func (s *orderedSet[T]) contains(value T) bool {
+	if s.valuesByKey == nil {
+		return slices.Contains(s.values, value)
+	}
 	_, ok := s.valuesByKey[value]
 	return ok
 }
 
 func (s *orderedSet[T]) add(value T) {
+	s.values = append(s.values, value)
+	// Small sets are served by a linear scan over values; only materialize the map once the set
+	// grows large enough for hashing to win.
 	if s.valuesByKey == nil {
-		s.valuesByKey = make(map[T]struct{})
+		if len(s.values) <= 16 {
+			return
+		}
+		s.valuesByKey = make(map[T]struct{}, len(s.values))
+		for _, v := range s.values[:len(s.values)-1] {
+			s.valuesByKey[v] = struct{}{}
+		}
 	}
 	s.valuesByKey[value] = struct{}{}
-	s.values = append(s.values, value)
 }
 
 func getContainingFunctionOrClassStaticBlock(node *ast.Node) *ast.Node {

--- a/internal/checker/utilities.go
+++ b/internal/checker/utilities.go
@@ -806,6 +806,10 @@ func isDeclarationReadonly(declaration *ast.Node) bool {
 	return ast.GetCombinedModifierFlags(declaration)&ast.ModifierFlagsReadonly != 0 && !ast.IsParameterPropertyDeclaration(declaration, declaration.Parent)
 }
 
+// orderedSetMapThreshold is the size at which an orderedSet materializes its dedup map.
+// Below this, contains() scans the values slice.
+const orderedSetMapThreshold = 16
+
 type orderedSet[T comparable] struct {
 	valuesByKey map[T]struct{}
 	values      []T
@@ -824,7 +828,7 @@ func (s *orderedSet[T]) add(value T) {
 	// Small sets are served by a linear scan over values; only materialize the map once the set
 	// grows large enough for hashing to win.
 	if s.valuesByKey == nil {
-		if len(s.values) <= 16 {
+		if len(s.values) <= orderedSetMapThreshold {
 			return
 		}
 		s.valuesByKey = make(map[T]struct{}, len(s.values))


### PR DESCRIPTION
## Context

`getIntersectionTypeEx` builds an `orderedSet` of constituent types and previously allocated a dedup map up front on every call. The vast majority of intersections only have a handful of constituents (2-8 in the VS Code codebase, for example), where a linear scan over the values slice (pointer compare) is faster than hashing and avoids the `map[T]struct{}` allocation entirely.

## This PR

`orderedSet.contains` now falls back to `slices.Contains` while the map is `nil`; `add()` materializes the map (seeding it from the existing slice) only once the set first exceeds 16 elements. Iteration order is the values slice and is unchanged.

## Performance

We're seeing a noticeable reduction in allocations when running `--singleThreaded --diagnostics` against the TypeScript codebase:

| Before | After | Delta |
|--|--|--|
| 1,857,777 | 1,684,634 | –173,143 (–9.32%) |

As a result, wall time is down slightly as well. Here are the hyperfine results from a `--singleThreaded --noEmit` run against the TypeScript codebase:

```
Benchmark 1: main
  Time (mean ± σ):      1.918 s ±  0.011 s    [User: 2.168 s, System: 0.183 s]
  Range (min … max):    1.900 s …  1.943 s    20 runs

Benchmark 2: branch
  Time (mean ± σ):      1.903 s ±  0.014 s    [User: 2.138 s, System: 0.193 s]
  Range (min … max):    1.883 s …  1.936 s    20 runs

Summary
  branch ran 1.01 ± 0.01 times faster than main
```