### PR TITLE
API: Fix nil panic for instantiated types

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -77,10 +77,11 @@ func (s *StdioServer) Run(ctx context.Context) error {
 		Logger:        nil, // TODO: Add logging support
 		FS:            fs,
 		Options: &project.SessionOptions{
-			CurrentDirectory:   s.options.Cwd,
-			DefaultLibraryPath: s.options.DefaultLibraryPath,
-			PositionEncoding:   lsproto.PositionEncodingKindUTF8,
-			LoggingEnabled:     false,
+			CurrentDirectory:      s.options.Cwd,
+			DefaultLibraryPath:    s.options.DefaultLibraryPath,
+			PositionEncoding:      lsproto.PositionEncodingKindUTF8,
+			LoggingEnabled:        false,
+			MaxCheckersPerProgram: 1,
 		},
 	})
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -353,12 +353,17 @@ func (p *Project) CreateProgram() CreateProgramResult {
 	var checkerPool *CheckerPool
 	var newProgram *compiler.Program
 
+	maxCheckers := p.host.sessionOptions.MaxCheckersPerProgram
+	if maxCheckers <= 0 {
+		maxCheckers = 4
+	}
+
 	// Define a fresh CreateCheckerPool closure for this call. Each invocation of
 	// CreateProgram must use its own closure so that concurrent goroutines cloning
 	// the same project never share a captured variable through a stale closure
 	// stored in the old program's options.
 	createCheckerPool := func(program *compiler.Program) compiler.CheckerPool {
-		checkerPool = newCheckerPool(4, program, nil)
+		checkerPool = newCheckerPool(maxCheckers, program, nil)
 		return checkerPool
 	}
 

--- a/internal/project/session.go
+++ b/internal/project/session.go
@@ -63,6 +63,10 @@ type SessionOptions struct {
 	PushDiagnosticsEnabled bool
 	DebounceDelay          time.Duration
 	Locale                 locale.Locale
+	// MaxCheckersPerProgram caps the number of checkers a program's checker pool
+	// will create. When <= 0, a default of 4 is used. The API server sets this to
+	// 1 so each opened project's program has only a single checker.
+	MaxCheckersPerProgram int
 }
 
 type SessionInit struct {


### PR DESCRIPTION
This PR fixes an issue we've encountered when running our test suite against TS GO with JS API proxy:
```
Error: panic: runtime error: invalid memory address or nil pointer dereference
goroutine 347 [running]:
runtime/debug.Stack()
	runtime/debug/stack.go:26 +0x64
github.com/microsoft/typescript-go/internal/api.(*AsyncConn).handleRequest.func1()
	github.com/microsoft/typescript-go/internal/api/conn_async.go:96 +0x44
panic({0x103c0c280?, 0x104011fe0?})
	runtime/panic.go:860 +0x12c
github.com/microsoft/typescript-go/internal/checker.(*Checker).getTypeOfSymbol(0x2a31fbe51bd8?, 0x103e7cfe0?)
	github.com/microsoft/typescript-go/internal/checker/checker.go:16382 +0x18
github.com/microsoft/typescript-go/internal/checker.(*Checker).getTypeOfInstantiatedSymbol(0x2a31fbe51308, 0x2a31fbde0788?)
	github.com/microsoft/typescript-go/internal/checker/checker.go:16419 +0x4c
github.com/microsoft/typescript-go/internal/checker.(*Checker).getTypeOfSymbol(0x2a31fc68b680?, 0x18?)
	github.com/microsoft/typescript-go/internal/checker/checker.go:16386 +0xd8
github.com/microsoft/typescript-go/internal/checker.(*Checker).GetTypeOfSymbol(...)
	github.com/microsoft/typescript-go/internal/checker/exports.go:165
github.com/microsoft/typescript-go/internal/api.(*Session).handleGetTypeOfSymbol(0x2a31fbb9e260?, {0x103e754d0?, 0x2a31fe032140?}, 0x2a31fe022580)
	github.com/microsoft/typescript-go/internal/api/session.go:904 +0x80
github.com/microsoft/typescript-go/internal/api.(*Session).HandleRequest(0x2a31fc6841e0, {0x103e754d0, 0x2a31fe032140}, {0x2a31fbb9e260, 0xf}, {0x2a31fbdbce40?, 0x2a31fbc4f380?, 0x2a31fbdfc008?})
	github.com/microsoft/typescript-go/internal/api/session.go:398 +0xdc4
github.com/microsoft/typescript-go/internal/api.(*AsyncConn).handleRequest(0x2a31fe032190, {0x103e754d0?, 0x2a31fe032140?}, 0x2a31fc71c5f0)
	github.com/microsoft/typescript-go/internal/api/conn_async.go:112 +0x78
created by github.com/microsoft/typescript-go/internal/api.(*AsyncConn).Run in goroutine 226
	github.com/microsoft/typescript-go/internal/api/conn_async.go:66 +0xe0
```

The issue is caused by the fact, that a different type checker may be used to get the type of an instantiated symbol than the one, which created it and the link target may be empty. Type checkers do not share symbols, or types, even on the same program, so a different checker should not be used to process a symbol coming from another one. The fix limits the checker pool to 1 per program in the API session, virtually limiting any possibility of using a wrong checker. 