### PR TITLE
VS enhanced hover support

### DIFF
--- a/internal/fourslash/baselineutil.go
+++ b/internal/fourslash/baselineutil.go
@@ -27,6 +27,7 @@ const (
 	documentHighlightsCmd       baselineCommand = "documentHighlights"
 	findAllReferencesCmd        baselineCommand = "findAllReferences"
 	vsFindAllReferencesCmd      baselineCommand = "vsFindAllReferences"
+	vsHoverCmd                  baselineCommand = "vsHover"
 	goToDefinitionCmd           baselineCommand = "goToDefinition"
 	goToImplementationCmd       baselineCommand = "goToImplementation"
 	goToSourceDefinitionCmd     baselineCommand = "goToSourceDefinition"
@@ -79,7 +80,7 @@ func getBaselineFileName(t *testing.T, command baselineCommand) string {
 
 func getBaselineExtension(command baselineCommand) string {
 	switch command {
-	case quickInfoCmd, signatureHelpCmd, smartSelectionCmd, inlayHintsCmd, nonSuggestionDiagnosticsCmd, documentSymbolsCmd, closingTagCmd, vsFindAllReferencesCmd:
+	case quickInfoCmd, signatureHelpCmd, smartSelectionCmd, inlayHintsCmd, nonSuggestionDiagnosticsCmd, documentSymbolsCmd, closingTagCmd, vsFindAllReferencesCmd, vsHoverCmd:
 		return "baseline"
 	case callHierarchyCmd:
 		return "callHierarchy.txt"

--- a/internal/fourslash/fourslash.go
+++ b/internal/fourslash/fourslash.go
@@ -2422,6 +2422,61 @@ func (f *FourslashTest) VerifyBaselineVSFindAllReferences(
 	}
 }
 
+func (f *FourslashTest) VerifyBaselineVSHover(t *testing.T) {
+	markersAndItems := core.MapFiltered(f.Markers(), func(marker *Marker) (markerAndItem[*lsproto.Hover], bool) {
+		if marker.Name == nil {
+			return markerAndItem[*lsproto.Hover]{}, false
+		}
+
+		params := &lsproto.HoverParams{
+			TextDocument: lsproto.TextDocumentIdentifier{
+				Uri: lsconv.FileNameToDocumentURI(marker.fileName),
+			},
+			Position: marker.LSPosition,
+		}
+
+		result := sendRequest(t, f, lsproto.TextDocumentHoverInfo, params)
+		return markerAndItem[*lsproto.Hover]{Marker: marker, Item: result.Hover}, true
+	})
+
+	getRange := func(item *lsproto.Hover) *lsproto.Range {
+		if item == nil || item.Range == nil {
+			return nil
+		}
+		return item.Range
+	}
+
+	getTooltipLines := func(item, _prev *lsproto.Hover) []string {
+		var result []string
+		if item.Contents.MarkupContent != nil {
+			result = strings.Split(item.Contents.MarkupContent.Value, "\n")
+		}
+		if item.Contents.String != nil {
+			result = strings.Split(*item.Contents.String, "\n")
+		}
+		if item.Contents.MarkedStringWithLanguage != nil {
+			result = appendLinesForMarkedStringWithLanguage(result, item.Contents.MarkedStringWithLanguage)
+		}
+		if item.Contents.MarkedStrings != nil {
+			for _, ms := range *item.Contents.MarkedStrings {
+				if ms.MarkedStringWithLanguage != nil {
+					result = appendLinesForMarkedStringWithLanguage(result, ms.MarkedStringWithLanguage)
+				} else {
+					result = append(result, *ms.String)
+				}
+			}
+		}
+		return result
+	}
+
+	f.addResultToBaseline(t, vsHoverCmd, annotateContentWithTooltips(t, f, markersAndItems, "vshover", getRange, getTooltipLines))
+	if jsonStr, err := core.StringifyJson(markersAndItems, "", "  "); err == nil {
+		f.writeToBaseline(vsHoverCmd, jsonStr)
+	} else {
+		t.Fatalf("Failed to stringify VS hover result for baseline: %v", err)
+	}
+}
+
 func (f *FourslashTest) VerifyBaselineCodeLens(t *testing.T, preferences *lsutil.UserPreferences) {
 	if preferences != nil {
 		reset := f.ConfigureWithReset(t, *preferences)

--- a/internal/fourslash/tests/quickInfoAliasVS_test.go
+++ b/internal/fourslash/tests/quickInfoAliasVS_test.go
@@ -1,0 +1,39 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestQuickInfoAliasVS(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `// @Filename: /a.ts
+/**
+ * Doc
+ * @tag Tag text
+ */
+export const x = 0;
+// @Filename: /b.ts
+import { x } from "./a";
+x/*b*/;
+// @Filename: /c.ts
+/**
+ * Doc 2
+ * @tag Tag text 2
+ */
+import {
+    /**
+     * Doc 3
+     * @tag Tag text 3
+     */
+    x
+} from "./a";
+x/*c*/;`
+	f, done := fourslash.NewFourslash(t, &lsproto.ClientCapabilities{VSSupportsVisualStudioExtensions: new(true)}, content)
+	defer done()
+	f.VerifyBaselineVSHover(t)
+}

--- a/internal/fourslash/tests/quickInfoCommentsFunctionDeclarationVS_test.go
+++ b/internal/fourslash/tests/quickInfoCommentsFunctionDeclarationVS_test.go
@@ -1,0 +1,34 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestQuickInfoCommentsFunctionDeclarationVS(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `/** This comment should appear for foo*/
+function f/*1*/oo() {
+}
+f/*2*/oo();
+/** This is comment for function signature*/
+function fo/*5*/oWithParameters(/** this is comment about a*/a: string,
+    /** this is comment for b*/
+    b: number) {
+    var /*6*/d = a;
+}
+fooWithParam/*8*/eters("a",10);
+/**
+* Does something
+* @param a a string
+*/
+declare function fn(a: string);
+fn("hello");`
+	f, done := fourslash.NewFourslash(t, &lsproto.ClientCapabilities{VSSupportsVisualStudioExtensions: new(true)}, content)
+	defer done()
+	f.VerifyBaselineVSHover(t)
+}

--- a/internal/fourslash/tests/quickInfoDisplayPartsClassMethodVS_test.go
+++ b/internal/fourslash/tests/quickInfoDisplayPartsClassMethodVS_test.go
@@ -1,0 +1,36 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestQuickInfoDisplayPartsClassMethodVS(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `class c {
+    public /*1*/publicMethod() { }
+    private /*2*/privateMethod() { }
+    protected /*21*/protectedMethod() { }
+    static /*3*/staticMethod() { }
+    private static /*4*/privateStaticMethod() { }
+    protected static /*41*/protectedStaticMethod() { }
+    method() {
+        this./*5*/publicMethod();
+        this./*6*/privateMethod();
+        this./*61*/protectedMethod();
+        c./*7*/staticMethod();
+        c./*8*/privateStaticMethod();
+        c./*81*/protectedStaticMethod();
+    }
+}
+var cInstance = new c();
+/*9*/cInstance./*10*/publicMethod();
+/*11*/c./*12*/staticMethod();`
+	f, done := fourslash.NewFourslash(t, &lsproto.ClientCapabilities{VSSupportsVisualStudioExtensions: new(true)}, content)
+	defer done()
+	f.VerifyBaselineVSHover(t)
+}

--- a/internal/fourslash/tests/quickInfoDisplayPartsClassPropertyVS_test.go
+++ b/internal/fourslash/tests/quickInfoDisplayPartsClassPropertyVS_test.go
@@ -1,0 +1,36 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestQuickInfoDisplayPartsClassPropertyVS(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `class c {
+    public /*1*/publicProperty: string;
+    private /*2*/privateProperty: string;
+    protected /*21*/protectedProperty: string;
+    static /*3*/staticProperty: string;
+    private static /*4*/privateStaticProperty: string;
+    protected static /*41*/protectedStaticProperty: string;
+    method() {
+        this./*5*/publicProperty;
+        this./*6*/privateProperty;
+        this./*61*/protectedProperty;
+        c./*7*/staticProperty;
+        c./*8*/privateStaticProperty;
+        c./*81*/protectedStaticProperty;
+    }
+}
+var cInstance = new c();
+/*9*/cInstance./*10*/publicProperty;
+/*11*/c./*12*/staticProperty;`
+	f, done := fourslash.NewFourslash(t, &lsproto.ClientCapabilities{VSSupportsVisualStudioExtensions: new(true)}, content)
+	defer done()
+	f.VerifyBaselineVSHover(t)
+}

--- a/internal/fourslash/tests/quickInfoDisplayPartsFunctionVS_test.go
+++ b/internal/fourslash/tests/quickInfoDisplayPartsFunctionVS_test.go
@@ -1,0 +1,36 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestQuickInfoDisplayPartsFunctionVS(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `function /*1*/foo(param: string, optionalParam?: string, paramWithInitializer = "hello", ...restParam: string[]) {
+}
+function /*2*/foowithoverload(a: string): string;
+function /*3*/foowithoverload(a: number): number;
+function /*4*/foowithoverload(a: any): any {
+    return a;
+}
+function /*5*/foowith3overload(a: string): string;
+function /*6*/foowith3overload(a: number): number;
+function /*7*/foowith3overload(a: boolean): boolean;
+function /*8*/foowith3overload(a: any): any {
+    return a;
+}
+/*9*/foo("hello");
+/*10*/foowithoverload("hello");
+/*11*/foowithoverload(10);
+/*12*/foowith3overload("hello");
+/*13*/foowith3overload(10);
+/*14*/foowith3overload(true);`
+	f, done := fourslash.NewFourslash(t, &lsproto.ClientCapabilities{VSSupportsVisualStudioExtensions: new(true)}, content)
+	defer done()
+	f.VerifyBaselineVSHover(t)
+}

--- a/internal/ls/completions.go
+++ b/internal/ls/completions.go
@@ -5063,7 +5063,7 @@ func (l *LanguageService) createCompletionDetailsForSymbol(
 	position int,
 	docFormat lsproto.MarkupKind,
 ) *lsproto.CompletionItem {
-	quickInfo, documentation := l.getQuickInfoAndDocumentationForSymbol(checker, symbol, location, docFormat, nil)
+	quickInfo, documentation, _ := l.getQuickInfoAndDocumentationForSymbol(checker, symbol, location, docFormat, nil, false /*vsCapability*/)
 	return createCompletionDetails(item, quickInfo, documentation, docFormat)
 }
 

--- a/internal/ls/hover.go
+++ b/internal/ls/hover.go
@@ -11,6 +11,8 @@ import (
 	"github.com/microsoft/typescript-go/internal/checker"
 	"github.com/microsoft/typescript-go/internal/collections"
 	"github.com/microsoft/typescript-go/internal/core"
+	"github.com/microsoft/typescript-go/internal/json"
+	"github.com/microsoft/typescript-go/internal/ls/lsutil"
 	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
 	"github.com/microsoft/typescript-go/internal/nodebuilder"
 	"github.com/microsoft/typescript-go/internal/printer"
@@ -55,7 +57,9 @@ func (l *LanguageService) ProvideHover(ctx context.Context, params *lsproto.Hove
 		MaxTruncationLength: maxTruncLen,
 	}
 
-	quickInfo, documentation := l.getQuickInfoAndDocumentationForSymbol(c, symbol, rangeNode, contentFormat, vc)
+	vsCapability := caps.VSSupportsVisualStudioExtensions
+
+	quickInfo, documentation, info := l.getQuickInfoAndDocumentationForSymbol(c, symbol, rangeNode, contentFormat, vc, vsCapability)
 	if quickInfo == "" {
 		return lsproto.HoverOrNull{}, nil
 	}
@@ -78,6 +82,47 @@ func (l *LanguageService) ProvideHover(ctx context.Context, params *lsproto.Hove
 		Range: &hoverRange,
 	}
 
+	if vsCapability {
+		signatureElement := &lsproto.VSClassifiedTextElement{
+			Runs:   info.displayParts.GetRuns(),
+			VSType: lsproto.StringLiteralClassifiedTextElement{},
+		}
+		elements := []*lsproto.VSClassifiedTextElement{signatureElement}
+		if documentation != "" {
+			docElement := &lsproto.VSClassifiedTextElement{
+				Runs:   []*lsproto.VSClassifiedTextRun{{Text: documentation, ClassificationTypeName: string(lsproto.ClassificationTypeNameText), VSType: lsproto.StringLiteralClassifiedTextRun{}}},
+				VSType: lsproto.StringLiteralClassifiedTextElement{},
+			}
+			elements = append(elements, docElement)
+		}
+
+		// Determine image ID for the symbol icon
+		var imageId *vsImageId
+		if symbol != nil {
+			location := node
+			if info.declaration != nil {
+				location = info.declaration
+			}
+			// If this is an alias (e.g. an imported name), follow it to the
+			// underlying symbol so the icon matches the real entity (function,
+			// class, etc.) instead of a generic alias fallback. Matches the
+			// behavior users see in VS Code.
+			iconSymbol := symbol
+			if iconSymbol.Flags&ast.SymbolFlagsAlias != 0 {
+				if resolved := c.GetAliasedSymbol(iconSymbol); resolved != nil && resolved != c.GetUnknownSymbol() {
+					iconSymbol = resolved
+				}
+			}
+			kind := lsutil.GetSymbolKind(c, iconSymbol, location)
+			modifiers := lsutil.GetSymbolModifiers(c, iconSymbol)
+			imageId = getVSImageId(kind, modifiers)
+		}
+
+		// Build the _vs_rawContent JSON with icon
+		rawContent := buildVSRawContent(elements, imageId)
+		hover.VSRawContent = &rawContent
+	}
+
 	if caps.Experimental.HoverVerbosityLevel {
 		hover.CanIncreaseVerbosity = vc.CanIncreaseVerbosity && !vc.Truncated
 	}
@@ -85,24 +130,24 @@ func (l *LanguageService) ProvideHover(ctx context.Context, params *lsproto.Hove
 	return lsproto.HoverOrNull{Hover: hover}, nil
 }
 
-func (l *LanguageService) getQuickInfoAndDocumentationForSymbol(c *checker.Checker, symbol *ast.Symbol, node *ast.Node, contentFormat lsproto.MarkupKind, vc *checker.VerbosityContext) (string, string) {
-	info := getQuickInfoAndDeclarationAtLocation(c, symbol, node, vc, false /*vsCapability*/, getMeaningFromLocation(node))
+func (l *LanguageService) getQuickInfoAndDocumentationForSymbol(c *checker.Checker, symbol *ast.Symbol, node *ast.Node, contentFormat lsproto.MarkupKind, vc *checker.VerbosityContext, vsCapability bool) (string, string, symbolDisplayInfo) {
+	info := getQuickInfoAndDeclarationAtLocation(c, symbol, node, vc, vsCapability, getMeaningFromLocation(node))
 	quickInfo := info.displayParts.String()
 	if quickInfo == "" {
-		return "", ""
+		return "", "", info
 	}
 
 	documentation := l.documentationFromSignature(c, symbol, getCallOrNewExpression(node), node, contentFormat, false /*commentOnly*/)
 	if documentation != "" {
-		return quickInfo, documentation
+		return quickInfo, documentation, info
 	}
 
 	documentation = l.getDocumentationFromDeclaration(c, symbol, info.declaration, node, contentFormat, false /*commentOnly*/)
 	if documentation != "" {
-		return quickInfo, documentation
+		return quickInfo, documentation, info
 	}
 
-	return quickInfo, l.documentationFromAlias(c, symbol, node, contentFormat)
+	return quickInfo, l.documentationFromAlias(c, symbol, node, contentFormat), info
 }
 
 func (l *LanguageService) documentationFromSignature(c *checker.Checker, symbol *ast.Symbol, node *ast.Node, location *ast.Node, contentFormat lsproto.MarkupKind, commentOnly bool) string {
@@ -1130,4 +1175,237 @@ func writeEntityNameParts(b *strings.Builder, node *ast.Node) {
 	case ast.KindJSDocNameReference:
 		writeEntityNameParts(b, node.Name())
 	}
+}
+
+// VS Image Catalog GUID. This is Microsoft.VisualStudio.Imaging.KnownImageIds.ImageCatalogGuid,
+// the public identifier of the VS shared image catalog. Hardcoded because Go can't reference
+// Microsoft.VisualStudio.ImageCatalog.dll directly.
+const imageCatalogGuid = "ae27a6b0-e345-4288-96df-5eaf394ee369"
+
+// KnownImageIds constants from Microsoft.VisualStudio.Imaging.KnownImageIds. Hardcoded
+// because Go can't reference Microsoft.VisualStudio.ImageCatalog.dll directly. Each constant
+// name mirrors the corresponding C# KnownImageIds member.
+// Reference: https://learn.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.imaging.knownimageids
+const (
+	imgIntellisenseWarning = 1591
+	imgIntellisenseKeyword = 1589
+	imgNamespace           = 1951
+	imgAssembly            = 196
+	imgType                = 3233
+	imgLabel               = 1661
+	imgLocalVariable       = 1747
+	imgEnumMember          = 1125 // EnumerationItemPublic
+
+	imgModulePrivate      = 1917
+	imgModuleProtected    = 1918
+	imgModulePublic       = 1919
+	imgClassPrivate       = 471
+	imgClassProtected     = 472
+	imgClassPublic        = 473
+	imgInterfacePrivate   = 1606
+	imgInterfaceProtected = 1607
+	imgInterfacePublic    = 1608
+	imgEnumPrivate        = 1129 // EnumerationPrivate
+	imgEnumProtected      = 1130 // EnumerationProtected
+	imgEnumPublic         = 1131 // EnumerationPublic
+	imgConstantPrivate    = 618
+	imgConstantProtected  = 619
+	imgConstantPublic     = 620
+	imgPropertyPrivate    = 2434
+	imgPropertyProtected  = 2435
+	imgPropertyPublic     = 2436
+	imgMethodPrivate      = 1878
+	imgMethodProtected    = 1879
+	imgMethodPublic       = 1880
+)
+
+// vsImageId represents a VS ImageId with Guid and numeric Id.
+type vsImageId struct {
+	Guid string
+	Id   int
+}
+
+// getVSImageId maps a ScriptElementKind + modifiers to a VS KnownImageIds value.
+func getVSImageId(kind lsutil.ScriptElementKind, modifiers lsutil.ScriptElementKindModifier) *vsImageId {
+	// No isInternal arm: *Internal VS icons carry a chevron overlay that conveys
+	// C# assembly-scoped visibility, which doesn't apply to TypeScript.
+	isPrivate := modifiers&lsutil.ScriptElementKindModifierPrivate != 0
+	isProtected := modifiers&lsutil.ScriptElementKindModifierProtected != 0
+
+	var id int
+	switch kind {
+	case lsutil.ScriptElementKindWarning:
+		id = imgIntellisenseWarning
+	case lsutil.ScriptElementKindKeyword:
+		id = imgIntellisenseKeyword
+	case lsutil.ScriptElementKindScriptElement:
+		switch {
+		case isPrivate:
+			id = imgModulePrivate
+		case isProtected:
+			id = imgModuleProtected
+		default:
+			id = imgModulePublic
+		}
+	case lsutil.ScriptElementKindModuleElement:
+		id = imgNamespace
+	case lsutil.ScriptElementKindClassElement, lsutil.ScriptElementKindLocalClassElement,
+		lsutil.ScriptElementKindTypeElement, lsutil.ScriptElementKindConstructorImplementationElement:
+		switch {
+		case isPrivate:
+			id = imgClassPrivate
+		case isProtected:
+			id = imgClassProtected
+		default:
+			id = imgClassPublic
+		}
+	case lsutil.ScriptElementKindInterfaceElement:
+		switch {
+		case isPrivate:
+			id = imgInterfacePrivate
+		case isProtected:
+			id = imgInterfaceProtected
+		default:
+			id = imgInterfacePublic
+		}
+	case lsutil.ScriptElementKindEnumElement:
+		switch {
+		case isPrivate:
+			id = imgEnumPrivate
+		case isProtected:
+			id = imgEnumProtected
+		default:
+			id = imgEnumPublic
+		}
+	case lsutil.ScriptElementKindEnumMemberElement:
+		id = imgEnumMember
+	case lsutil.ScriptElementKindParameterElement:
+		id = imgLocalVariable
+	case lsutil.ScriptElementKindVariableElement, lsutil.ScriptElementKindLocalVariableElement,
+		lsutil.ScriptElementKindLetElement:
+		id = imgLocalVariable
+	case lsutil.ScriptElementKindConstElement:
+		switch {
+		case isPrivate:
+			id = imgConstantPrivate
+		case isProtected:
+			id = imgConstantProtected
+		default:
+			id = imgConstantPublic
+		}
+	case lsutil.ScriptElementKindMemberGetAccessorElement, lsutil.ScriptElementKindMemberSetAccessorElement,
+		lsutil.ScriptElementKindMemberVariableElement:
+		switch {
+		case isPrivate:
+			id = imgPropertyPrivate
+		case isProtected:
+			id = imgPropertyProtected
+		default:
+			id = imgPropertyPublic
+		}
+	case lsutil.ScriptElementKindFunctionElement, lsutil.ScriptElementKindLocalFunctionElement,
+		lsutil.ScriptElementKindMemberFunctionElement, lsutil.ScriptElementKindCallSignatureElement,
+		lsutil.ScriptElementKindIndexSignatureElement, lsutil.ScriptElementKindConstructSignatureElement:
+		switch {
+		case isPrivate:
+			id = imgMethodPrivate
+		case isProtected:
+			id = imgMethodProtected
+		default:
+			id = imgMethodPublic
+		}
+	case lsutil.ScriptElementKindTypeParameterElement, lsutil.ScriptElementKindPrimitiveType:
+		id = imgType
+	case lsutil.ScriptElementKindLabel:
+		id = imgLabel
+	case lsutil.ScriptElementKindAlias:
+		// Fallback for unresolvable aliases (rare; alias dereferencing in ProvideHover
+		// usually resolves to the underlying entity before reaching this point).
+		id = imgAssembly
+	default:
+		return nil
+	}
+
+	return &vsImageId{Guid: imageCatalogGuid, Id: id}
+}
+
+// vsRawContainer is a ContainerElement with heterogeneous Elements for _vs_rawContent.
+type vsRawContainer struct {
+	Elements []json.Value `json:"Elements"`
+	Style    int32        `json:"Style"`
+	VSType   string       `json:"_vs_type"`
+}
+
+// vsImageElement represents an ImageElement for VS hover icons.
+type vsImageElement struct {
+	ImageId vsImageIdJSON `json:"ImageId"`
+	VSType  string        `json:"_vs_type"`
+}
+
+// vsImageIdJSON is the JSON representation of a VS ImageId.
+type vsImageIdJSON struct {
+	Guid string `json:"Guid"`
+	Id   int    `json:"Id"`
+}
+
+// buildVSRawContent constructs the _vs_rawContent JSON bytes.
+// If imageId is provided, the first element is wrapped in a ContainerElement(Wrapped)
+// with [ImageElement, ClassifiedTextElement], matching Strada's hover layout.
+func buildVSRawContent(elements []*lsproto.VSClassifiedTextElement, imageId *vsImageId) json.Value {
+	var topElements []json.Value
+
+	if imageId != nil && len(elements) > 0 {
+		// Serialize the ImageElement
+		imgElem := vsImageElement{
+			ImageId: vsImageIdJSON{Guid: imageId.Guid, Id: imageId.Id},
+			VSType:  "ImageElement",
+		}
+		imgBytes, _ := json.Marshal(imgElem)
+
+		// Serialize the first ClassifiedTextElement
+		firstElemBytes, _ := json.Marshal(elements[0])
+
+		// Build the inner Wrapped container with [ImageElement, ClassifiedTextElement]
+		wrappedContainer := vsRawContainer{
+			Elements: []json.Value{json.Value(imgBytes), json.Value(firstElemBytes)},
+			Style:    0, // Wrapped — renders icon inline with signature
+			VSType:   "ContainerElement",
+		}
+		wrappedBytes, _ := json.Marshal(wrappedContainer)
+		topElements = append(topElements, json.Value(wrappedBytes))
+
+		// Add remaining elements
+		for _, e := range elements[1:] {
+			elemBytes, _ := json.Marshal(e)
+			topElements = append(topElements, json.Value(elemBytes))
+		}
+	} else {
+		for _, e := range elements {
+			elemBytes, _ := json.Marshal(e)
+			topElements = append(topElements, json.Value(elemBytes))
+		}
+	}
+
+	// If there's only one element, return it directly (no extra Stacked wrapper)
+	if len(topElements) == 1 {
+		return topElements[0]
+	}
+
+	// Outer Stacked container for multiple elements
+	container := vsRawContainer{
+		Elements: topElements,
+		Style:    1, // Stacked — places documentation on a new line below the signature
+		VSType:   "ContainerElement",
+	}
+
+	bytes, err := json.Marshal(container)
+	if err != nil {
+		// Fallback: return without icon
+		fallback := &lsproto.ContainerElement{
+			Elements: elements,
+			Style:    0,
+		}
+		bytes, _ = json.Marshal(fallback)
+	}
+	return json.Value(bytes)
 }

--- a/internal/lsp/lsproto/_generate/generate.mts
+++ b/internal/lsp/lsproto/_generate/generate.mts
@@ -607,6 +607,22 @@ const customStructures: Structure[] = [
         ],
         documentation: "A classified text element containing an array of classified text runs, used for colorized labels in VS.",
     },
+    {
+        name: "ContainerElement",
+        properties: [
+            {
+                name: "Elements",
+                type: { kind: "array", element: { kind: "reference", name: "VSClassifiedTextElement" } },
+                documentation: "The child elements of this container.",
+            },
+            {
+                name: "Style",
+                type: { kind: "base", name: "integer" },
+                documentation: "The container style (0=Stacked, 1=Wrapped).",
+            },
+        ],
+        documentation: "A container element that holds child content elements with a layout style, used for VS hover display.",
+    },
 ];
 
 const customEnumerations: Enumeration[] = [
@@ -958,7 +974,7 @@ function patchAndPreprocessModel() {
             });
         }
 
-        // Patch Hover to add canIncreaseVerbosity
+        // Patch Hover to add canIncreaseVerbosity and _vs_rawContent
         if (structure.name === "Hover") {
             structure.properties.push(
                 {
@@ -966,6 +982,12 @@ function patchAndPreprocessModel() {
                     type: { kind: "base", name: "boolean" },
                     omitzeroValue: true,
                     documentation: "Whether the verbosity level can be increased for this hover.",
+                },
+                {
+                    name: "_vs_rawContent",
+                    type: { kind: "reference", name: "JSONRawValue" },
+                    optional: true,
+                    documentation: "VS-specific rich content for hover display, containing classified text elements.",
                 },
             );
         }
@@ -1655,6 +1677,7 @@ const typeAliasOverrides = new Map([
     ["LSPArray", { name: "[]any", needsPointer: false }],
     ["LSPObject", { name: "map[string]any", needsPointer: false }],
     ["uint64", { name: "uint64", needsPointer: false }],
+    ["JSONRawValue", { name: "json.Value", needsPointer: false }],
 ]);
 
 // These type aliases are intentionally not resolved to their underlying types.

--- a/internal/lsp/lsproto/lsp_generated.go
+++ b/internal/lsp/lsproto/lsp_generated.go
@@ -8496,6 +8496,9 @@ type Hover struct {
 
 	// Whether the verbosity level can be increased for this hover.
 	CanIncreaseVerbosity bool `json:"canIncreaseVerbosity,omitzero"`
+
+	// VS-specific rich content for hover display, containing classified text elements.
+	VSRawContent *json.Value `json:"_vs_rawContent,omitzero"`
 }
 
 var _ json.UnmarshalerFrom = (*Hover)(nil)
@@ -8534,6 +8537,13 @@ func (s *Hover) UnmarshalJSONFrom(dec *json.Decoder) error {
 			}
 		case `"canIncreaseVerbosity"`:
 			if err := json.UnmarshalDecode(dec, &s.CanIncreaseVerbosity); err != nil {
+				return err
+			}
+		case `"_vs_rawContent"`:
+			if dec.PeekKind() == 'n' {
+				return errNull("_vs_rawContent")
+			}
+			if err := json.UnmarshalDecode(dec, &s.VSRawContent); err != nil {
 				return err
 			}
 		default:
@@ -29977,6 +29987,76 @@ func (s *VSClassifiedTextElement) UnmarshalJSONFrom(dec *json.Decoder) error {
 		}
 		if missing&missingVSType != 0 {
 			missingProps = append(missingProps, "_vs_type")
+		}
+		return errMissing(missingProps)
+	}
+
+	return nil
+}
+
+// A container element that holds child content elements with a layout style, used for VS hover display.
+type ContainerElement struct {
+	// The child elements of this container.
+	Elements []*VSClassifiedTextElement `json:"Elements"`
+
+	// The container style (0=Stacked, 1=Wrapped).
+	Style int32 `json:"Style"`
+}
+
+var _ json.UnmarshalerFrom = (*ContainerElement)(nil)
+
+func (s *ContainerElement) UnmarshalJSONFrom(dec *json.Decoder) error {
+	const (
+		missingElements uint = 1 << iota
+		missingStyle
+		_missingLast
+	)
+	missing := _missingLast - 1
+
+	if k := dec.PeekKind(); k != '{' {
+		return errNotObject(k)
+	}
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	for dec.PeekKind() != '}' {
+		name, err := dec.ReadValue()
+		if err != nil {
+			return err
+		}
+		switch string(name) {
+		case `"Elements"`:
+			missing &^= missingElements
+			if dec.PeekKind() == 'n' {
+				return errNull("Elements")
+			}
+			if err := json.UnmarshalDecode(dec, &s.Elements); err != nil {
+				return err
+			}
+		case `"Style"`:
+			missing &^= missingStyle
+			if err := json.UnmarshalDecode(dec, &s.Style); err != nil {
+				return err
+			}
+		default:
+			if err := dec.SkipValue(); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return err
+	}
+
+	if missing != 0 {
+		var missingProps []string
+		if missing&missingElements != 0 {
+			missingProps = append(missingProps, "Elements")
+		}
+		if missing&missingStyle != 0 {
+			missingProps = append(missingProps, "Style")
 		}
 		return errMissing(missingProps)
 	}

--- a/testdata/baselines/reference/fourslash/vsHover/quickInfoAliasVS.baseline
+++ b/testdata/baselines/reference/fourslash/vsHover/quickInfoAliasVS.baseline
@@ -1,0 +1,233 @@
+// === vsHover ===
+=== /b.ts ===
+// import { x } from "./a";
+// x;
+// ^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (alias) const x: 0
+// | ```
+// | Doc
+// | 
+// | *@tag* — Tag text
+// | 
+// | ----------------------------------------------------------------------
+=== /c.ts ===
+// /**
+//  * Doc 2
+//  * @tag Tag text 2
+//  */
+// import {
+//     /**
+//      * Doc 3
+//      * @tag Tag text 3
+//      */
+//     x
+// } from "./a";
+// x;
+// ^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (alias) const x: 0
+// | ```
+// | Doc
+// | 
+// | *@tag* — Tag text
+// | 
+// | ----------------------------------------------------------------------
+
+
+[
+  {
+    "marker": {
+      "Position": 26,
+      "LSPosition": {
+        "line": 1,
+        "character": 1
+      },
+      "Name": "b",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(alias) const x: 0\n```\nDoc\n\n*@tag* — Tag text\n"
+      },
+      "range": {
+        "start": {
+          "line": 1,
+          "character": 0
+        },
+        "end": {
+          "line": 1,
+          "character": 1
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "Elements": [
+              {
+                "ImageId": {
+                  "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+                  "Id": 620
+                },
+                "_vs_type": "ImageElement"
+              },
+              {
+                "Runs": [
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": "(",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "text",
+                    "Text": "alias",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ") ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "keyword",
+                    "Text": "const ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "local name",
+                    "Text": "x",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ": ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "string",
+                    "Text": "0",
+                    "_vs_type": "ClassifiedTextRun"
+                  }
+                ],
+                "_vs_type": "ClassifiedTextElement"
+              }
+            ],
+            "Style": 0,
+            "_vs_type": "ContainerElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "text",
+                "Text": "Doc\n\n*@tag* — Tag text\n",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 1,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 118,
+      "LSPosition": {
+        "line": 11,
+        "character": 1
+      },
+      "Name": "c",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(alias) const x: 0\n```\nDoc\n\n*@tag* — Tag text\n"
+      },
+      "range": {
+        "start": {
+          "line": 11,
+          "character": 0
+        },
+        "end": {
+          "line": 11,
+          "character": 1
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "Elements": [
+              {
+                "ImageId": {
+                  "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+                  "Id": 620
+                },
+                "_vs_type": "ImageElement"
+              },
+              {
+                "Runs": [
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": "(",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "text",
+                    "Text": "alias",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ") ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "keyword",
+                    "Text": "const ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "local name",
+                    "Text": "x",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ": ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "string",
+                    "Text": "0",
+                    "_vs_type": "ClassifiedTextRun"
+                  }
+                ],
+                "_vs_type": "ClassifiedTextElement"
+              }
+            ],
+            "Style": 0,
+            "_vs_type": "ContainerElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "text",
+                "Text": "Doc\n\n*@tag* — Tag text\n",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 1,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  }
+]

--- a/testdata/baselines/reference/fourslash/vsHover/quickInfoCommentsFunctionDeclarationVS.baseline
+++ b/testdata/baselines/reference/fourslash/vsHover/quickInfoCommentsFunctionDeclarationVS.baseline
@@ -1,0 +1,625 @@
+// === vsHover ===
+=== /quickInfoCommentsFunctionDeclarationVS.ts ===
+// /** This comment should appear for foo*/
+// function foo() {
+//          ^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | function foo(): void;
+// | ```
+// | This comment should appear for foo
+// | ----------------------------------------------------------------------
+// }
+// foo();
+// ^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | function foo(): void;
+// | ```
+// | This comment should appear for foo
+// | ----------------------------------------------------------------------
+// /** This is comment for function signature*/
+// function fooWithParameters(/** this is comment about a*/a: string,
+//          ^^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | function fooWithParameters(a: string, b: number): void;
+// | ```
+// | This is comment for function signature
+// | ----------------------------------------------------------------------
+//     /** this is comment for b*/
+//     b: number) {
+//     var d = a;
+//         ^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | var d: string
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+// }
+// fooWithParameters("a",10);
+// ^^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | function fooWithParameters(a: string, b: number): void;
+// | ```
+// | This is comment for function signature
+// | ----------------------------------------------------------------------
+// /**
+// * Does something
+// * @param a a string
+// */
+// declare function fn(a: string);
+// fn("hello");
+[
+  {
+    "marker": {
+      "Position": 51,
+      "LSPosition": {
+        "line": 1,
+        "character": 10
+      },
+      "Name": "1",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foo(): void;\n```\nThis comment should appear for foo"
+      },
+      "range": {
+        "start": {
+          "line": 1,
+          "character": 9
+        },
+        "end": {
+          "line": 1,
+          "character": 12
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "Elements": [
+              {
+                "ImageId": {
+                  "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+                  "Id": 1880
+                },
+                "_vs_type": "ImageElement"
+              },
+              {
+                "Runs": [
+                  {
+                    "ClassificationTypeName": "keyword",
+                    "Text": "function ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "method name",
+                    "Text": "foo",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": "(",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ")",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ":",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "whitespace",
+                    "Text": " ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "keyword",
+                    "Text": "void",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ";",
+                    "_vs_type": "ClassifiedTextRun"
+                  }
+                ],
+                "_vs_type": "ClassifiedTextElement"
+              }
+            ],
+            "Style": 0,
+            "_vs_type": "ContainerElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "text",
+                "Text": "This comment should appear for foo",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 1,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 61,
+      "LSPosition": {
+        "line": 3,
+        "character": 1
+      },
+      "Name": "2",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foo(): void;\n```\nThis comment should appear for foo"
+      },
+      "range": {
+        "start": {
+          "line": 3,
+          "character": 0
+        },
+        "end": {
+          "line": 3,
+          "character": 3
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "Elements": [
+              {
+                "ImageId": {
+                  "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+                  "Id": 1880
+                },
+                "_vs_type": "ImageElement"
+              },
+              {
+                "Runs": [
+                  {
+                    "ClassificationTypeName": "keyword",
+                    "Text": "function ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "method name",
+                    "Text": "foo",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": "(",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ")",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ":",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "whitespace",
+                    "Text": " ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "keyword",
+                    "Text": "void",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ";",
+                    "_vs_type": "ClassifiedTextRun"
+                  }
+                ],
+                "_vs_type": "ClassifiedTextElement"
+              }
+            ],
+            "Style": 0,
+            "_vs_type": "ContainerElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "text",
+                "Text": "This comment should appear for foo",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 1,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 123,
+      "LSPosition": {
+        "line": 5,
+        "character": 11
+      },
+      "Name": "5",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction fooWithParameters(a: string, b: number): void;\n```\nThis is comment for function signature"
+      },
+      "range": {
+        "start": {
+          "line": 5,
+          "character": 9
+        },
+        "end": {
+          "line": 5,
+          "character": 26
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "Elements": [
+              {
+                "ImageId": {
+                  "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+                  "Id": 1880
+                },
+                "_vs_type": "ImageElement"
+              },
+              {
+                "Runs": [
+                  {
+                    "ClassificationTypeName": "keyword",
+                    "Text": "function ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "method name",
+                    "Text": "fooWithParameters",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": "(",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "parameter name",
+                    "Text": "a",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ":",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "whitespace",
+                    "Text": " ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "keyword",
+                    "Text": "string",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ",",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "whitespace",
+                    "Text": " ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "parameter name",
+                    "Text": "b",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ":",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "whitespace",
+                    "Text": " ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "keyword",
+                    "Text": "number",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ")",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ":",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "whitespace",
+                    "Text": " ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "keyword",
+                    "Text": "void",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ";",
+                    "_vs_type": "ClassifiedTextRun"
+                  }
+                ],
+                "_vs_type": "ClassifiedTextElement"
+              }
+            ],
+            "Style": 0,
+            "_vs_type": "ContainerElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "text",
+                "Text": "This is comment for function signature",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 1,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 236,
+      "LSPosition": {
+        "line": 8,
+        "character": 8
+      },
+      "Name": "6",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nvar d: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 8,
+          "character": 8
+        },
+        "end": {
+          "line": 8,
+          "character": 9
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1747
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "var ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "local name",
+                "Text": "d",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 257,
+      "LSPosition": {
+        "line": 10,
+        "character": 12
+      },
+      "Name": "8",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction fooWithParameters(a: string, b: number): void;\n```\nThis is comment for function signature"
+      },
+      "range": {
+        "start": {
+          "line": 10,
+          "character": 0
+        },
+        "end": {
+          "line": 10,
+          "character": 17
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "Elements": [
+              {
+                "ImageId": {
+                  "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+                  "Id": 1880
+                },
+                "_vs_type": "ImageElement"
+              },
+              {
+                "Runs": [
+                  {
+                    "ClassificationTypeName": "keyword",
+                    "Text": "function ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "method name",
+                    "Text": "fooWithParameters",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": "(",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "parameter name",
+                    "Text": "a",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ":",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "whitespace",
+                    "Text": " ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "keyword",
+                    "Text": "string",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ",",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "whitespace",
+                    "Text": " ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "parameter name",
+                    "Text": "b",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ":",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "whitespace",
+                    "Text": " ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "keyword",
+                    "Text": "number",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ")",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ":",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "whitespace",
+                    "Text": " ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "keyword",
+                    "Text": "void",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ";",
+                    "_vs_type": "ClassifiedTextRun"
+                  }
+                ],
+                "_vs_type": "ClassifiedTextElement"
+              }
+            ],
+            "Style": 0,
+            "_vs_type": "ContainerElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "text",
+                "Text": "This is comment for function signature",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 1,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  }
+]

--- a/testdata/baselines/reference/fourslash/vsHover/quickInfoDisplayPartsClassMethodVS.baseline
+++ b/testdata/baselines/reference/fourslash/vsHover/quickInfoDisplayPartsClassMethodVS.baseline
@@ -1,0 +1,1586 @@
+// === vsHover ===
+=== /quickInfoDisplayPartsClassMethodVS.ts ===
+// class c {
+//     public publicMethod() { }
+//            ^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (method) c.publicMethod(): void;
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//     private privateMethod() { }
+//             ^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (method) c.privateMethod(): void;
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//     protected protectedMethod() { }
+//               ^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (method) c.protectedMethod(): void;
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//     static staticMethod() { }
+//            ^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (method) c.staticMethod(): void;
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//     private static privateStaticMethod() { }
+//                    ^^^^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (method) c.privateStaticMethod(): void;
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//     protected static protectedStaticMethod() { }
+//                      ^^^^^^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (method) c.protectedStaticMethod(): void;
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//     method() {
+//         this.publicMethod();
+//              ^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (method) c.publicMethod(): void;
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//         this.privateMethod();
+//              ^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (method) c.privateMethod(): void;
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//         this.protectedMethod();
+//              ^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (method) c.protectedMethod(): void;
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//         c.staticMethod();
+//           ^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (method) c.staticMethod(): void;
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//         c.privateStaticMethod();
+//           ^^^^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (method) c.privateStaticMethod(): void;
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//         c.protectedStaticMethod();
+//           ^^^^^^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (method) c.protectedStaticMethod(): void;
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//     }
+// }
+// var cInstance = new c();
+// cInstance.publicMethod();
+// ^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | var cInstance: c
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//           ^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (method) c.publicMethod(): void;
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+// c.staticMethod();
+// ^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | class c
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//   ^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (method) c.staticMethod(): void;
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+[
+  {
+    "marker": {
+      "Position": 21,
+      "LSPosition": {
+        "line": 1,
+        "character": 11
+      },
+      "Name": "1",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) c.publicMethod(): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 1,
+          "character": 11
+        },
+        "end": {
+          "line": 1,
+          "character": 23
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "method",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "c.publicMethod",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 52,
+      "LSPosition": {
+        "line": 2,
+        "character": 12
+      },
+      "Name": "2",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) c.privateMethod(): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 2,
+          "character": 12
+        },
+        "end": {
+          "line": 2,
+          "character": 25
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1878
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "method",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "c.privateMethod",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 86,
+      "LSPosition": {
+        "line": 3,
+        "character": 14
+      },
+      "Name": "21",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) c.protectedMethod(): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 3,
+          "character": 14
+        },
+        "end": {
+          "line": 3,
+          "character": 29
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1879
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "method",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "c.protectedMethod",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 119,
+      "LSPosition": {
+        "line": 4,
+        "character": 11
+      },
+      "Name": "3",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) c.staticMethod(): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 4,
+          "character": 11
+        },
+        "end": {
+          "line": 4,
+          "character": 23
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "method",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "c.staticMethod",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 157,
+      "LSPosition": {
+        "line": 5,
+        "character": 19
+      },
+      "Name": "4",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) c.privateStaticMethod(): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 5,
+          "character": 19
+        },
+        "end": {
+          "line": 5,
+          "character": 38
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1878
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "method",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "c.privateStaticMethod",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 204,
+      "LSPosition": {
+        "line": 6,
+        "character": 21
+      },
+      "Name": "41",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) c.protectedStaticMethod(): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 21
+        },
+        "end": {
+          "line": 6,
+          "character": 42
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1879
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "method",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "c.protectedStaticMethod",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 260,
+      "LSPosition": {
+        "line": 8,
+        "character": 13
+      },
+      "Name": "5",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) c.publicMethod(): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 8,
+          "character": 13
+        },
+        "end": {
+          "line": 8,
+          "character": 25
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "method",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "c.publicMethod",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 289,
+      "LSPosition": {
+        "line": 9,
+        "character": 13
+      },
+      "Name": "6",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) c.privateMethod(): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 9,
+          "character": 13
+        },
+        "end": {
+          "line": 9,
+          "character": 26
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1878
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "method",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "c.privateMethod",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 319,
+      "LSPosition": {
+        "line": 10,
+        "character": 13
+      },
+      "Name": "61",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) c.protectedMethod(): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 10,
+          "character": 13
+        },
+        "end": {
+          "line": 10,
+          "character": 28
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1879
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "method",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "c.protectedMethod",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 348,
+      "LSPosition": {
+        "line": 11,
+        "character": 10
+      },
+      "Name": "7",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) c.staticMethod(): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 11,
+          "character": 10
+        },
+        "end": {
+          "line": 11,
+          "character": 22
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "method",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "c.staticMethod",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 374,
+      "LSPosition": {
+        "line": 12,
+        "character": 10
+      },
+      "Name": "8",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) c.privateStaticMethod(): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 10
+        },
+        "end": {
+          "line": 12,
+          "character": 29
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1878
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "method",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "c.privateStaticMethod",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 407,
+      "LSPosition": {
+        "line": 13,
+        "character": 10
+      },
+      "Name": "81",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) c.protectedStaticMethod(): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 13,
+          "character": 10
+        },
+        "end": {
+          "line": 13,
+          "character": 31
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1879
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "method",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "c.protectedStaticMethod",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 465,
+      "LSPosition": {
+        "line": 17,
+        "character": 0
+      },
+      "Name": "9",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nvar cInstance: c\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 17,
+          "character": 0
+        },
+        "end": {
+          "line": 17,
+          "character": 9
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1747
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "var ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "local name",
+                "Text": "cInstance",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "class name",
+                "Text": "c",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 475,
+      "LSPosition": {
+        "line": 17,
+        "character": 10
+      },
+      "Name": "10",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) c.publicMethod(): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 17,
+          "character": 10
+        },
+        "end": {
+          "line": 17,
+          "character": 22
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "method",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "c.publicMethod",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 491,
+      "LSPosition": {
+        "line": 18,
+        "character": 0
+      },
+      "Name": "11",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nclass c\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 18,
+          "character": 0
+        },
+        "end": {
+          "line": 18,
+          "character": 1
+        }
+      },
+      "canIncreaseVerbosity": true,
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 473
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "class ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "class name",
+                "Text": "c",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 493,
+      "LSPosition": {
+        "line": 18,
+        "character": 2
+      },
+      "Name": "12",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) c.staticMethod(): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 18,
+          "character": 2
+        },
+        "end": {
+          "line": 18,
+          "character": 14
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "method",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "c.staticMethod",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  }
+]

--- a/testdata/baselines/reference/fourslash/vsHover/quickInfoDisplayPartsClassPropertyVS.baseline
+++ b/testdata/baselines/reference/fourslash/vsHover/quickInfoDisplayPartsClassPropertyVS.baseline
@@ -1,0 +1,1306 @@
+// === vsHover ===
+=== /quickInfoDisplayPartsClassPropertyVS.ts ===
+// class c {
+//     public publicProperty: string;
+//            ^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (property) c.publicProperty: string
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//     private privateProperty: string;
+//             ^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (property) c.privateProperty: string
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//     protected protectedProperty: string;
+//               ^^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (property) c.protectedProperty: string
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//     static staticProperty: string;
+//            ^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (property) c.staticProperty: string
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//     private static privateStaticProperty: string;
+//                    ^^^^^^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (property) c.privateStaticProperty: string
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//     protected static protectedStaticProperty: string;
+//                      ^^^^^^^^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (property) c.protectedStaticProperty: string
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//     method() {
+//         this.publicProperty;
+//              ^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (property) c.publicProperty: string
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//         this.privateProperty;
+//              ^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (property) c.privateProperty: string
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//         this.protectedProperty;
+//              ^^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (property) c.protectedProperty: string
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//         c.staticProperty;
+//           ^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (property) c.staticProperty: string
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//         c.privateStaticProperty;
+//           ^^^^^^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (property) c.privateStaticProperty: string
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//         c.protectedStaticProperty;
+//           ^^^^^^^^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (property) c.protectedStaticProperty: string
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//     }
+// }
+// var cInstance = new c();
+// cInstance.publicProperty;
+// ^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | var cInstance: c
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//           ^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (property) c.publicProperty: string
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+// c.staticProperty;
+// ^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | class c
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//   ^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | (property) c.staticProperty: string
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+[
+  {
+    "marker": {
+      "Position": 21,
+      "LSPosition": {
+        "line": 1,
+        "character": 11
+      },
+      "Name": "1",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(property) c.publicProperty: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 1,
+          "character": 11
+        },
+        "end": {
+          "line": 1,
+          "character": 25
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 2436
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "property",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "property name",
+                "Text": "c.publicProperty",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 57,
+      "LSPosition": {
+        "line": 2,
+        "character": 12
+      },
+      "Name": "2",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(property) c.privateProperty: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 2,
+          "character": 12
+        },
+        "end": {
+          "line": 2,
+          "character": 27
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 2434
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "property",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "property name",
+                "Text": "c.privateProperty",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 96,
+      "LSPosition": {
+        "line": 3,
+        "character": 14
+      },
+      "Name": "21",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(property) c.protectedProperty: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 3,
+          "character": 14
+        },
+        "end": {
+          "line": 3,
+          "character": 31
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 2435
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "property",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "property name",
+                "Text": "c.protectedProperty",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 134,
+      "LSPosition": {
+        "line": 4,
+        "character": 11
+      },
+      "Name": "3",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(property) c.staticProperty: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 4,
+          "character": 11
+        },
+        "end": {
+          "line": 4,
+          "character": 25
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 2436
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "property",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "property name",
+                "Text": "c.staticProperty",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 177,
+      "LSPosition": {
+        "line": 5,
+        "character": 19
+      },
+      "Name": "4",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(property) c.privateStaticProperty: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 5,
+          "character": 19
+        },
+        "end": {
+          "line": 5,
+          "character": 40
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 2434
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "property",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "property name",
+                "Text": "c.privateStaticProperty",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 229,
+      "LSPosition": {
+        "line": 6,
+        "character": 21
+      },
+      "Name": "41",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(property) c.protectedStaticProperty: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 21
+        },
+        "end": {
+          "line": 6,
+          "character": 44
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 2435
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "property",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "property name",
+                "Text": "c.protectedStaticProperty",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 290,
+      "LSPosition": {
+        "line": 8,
+        "character": 13
+      },
+      "Name": "5",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(property) c.publicProperty: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 8,
+          "character": 13
+        },
+        "end": {
+          "line": 8,
+          "character": 27
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 2436
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "property",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "property name",
+                "Text": "c.publicProperty",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 319,
+      "LSPosition": {
+        "line": 9,
+        "character": 13
+      },
+      "Name": "6",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(property) c.privateProperty: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 9,
+          "character": 13
+        },
+        "end": {
+          "line": 9,
+          "character": 28
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 2434
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "property",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "property name",
+                "Text": "c.privateProperty",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 349,
+      "LSPosition": {
+        "line": 10,
+        "character": 13
+      },
+      "Name": "61",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(property) c.protectedProperty: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 10,
+          "character": 13
+        },
+        "end": {
+          "line": 10,
+          "character": 30
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 2435
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "property",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "property name",
+                "Text": "c.protectedProperty",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 378,
+      "LSPosition": {
+        "line": 11,
+        "character": 10
+      },
+      "Name": "7",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(property) c.staticProperty: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 11,
+          "character": 10
+        },
+        "end": {
+          "line": 11,
+          "character": 24
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 2436
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "property",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "property name",
+                "Text": "c.staticProperty",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 404,
+      "LSPosition": {
+        "line": 12,
+        "character": 10
+      },
+      "Name": "8",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(property) c.privateStaticProperty: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 10
+        },
+        "end": {
+          "line": 12,
+          "character": 31
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 2434
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "property",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "property name",
+                "Text": "c.privateStaticProperty",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 437,
+      "LSPosition": {
+        "line": 13,
+        "character": 10
+      },
+      "Name": "81",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(property) c.protectedStaticProperty: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 13,
+          "character": 10
+        },
+        "end": {
+          "line": 13,
+          "character": 33
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 2435
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "property",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "property name",
+                "Text": "c.protectedStaticProperty",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 495,
+      "LSPosition": {
+        "line": 17,
+        "character": 0
+      },
+      "Name": "9",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nvar cInstance: c\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 17,
+          "character": 0
+        },
+        "end": {
+          "line": 17,
+          "character": 9
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1747
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "var ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "local name",
+                "Text": "cInstance",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "class name",
+                "Text": "c",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 505,
+      "LSPosition": {
+        "line": 17,
+        "character": 10
+      },
+      "Name": "10",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(property) c.publicProperty: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 17,
+          "character": 10
+        },
+        "end": {
+          "line": 17,
+          "character": 24
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 2436
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "property",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "property name",
+                "Text": "c.publicProperty",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 521,
+      "LSPosition": {
+        "line": 18,
+        "character": 0
+      },
+      "Name": "11",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nclass c\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 18,
+          "character": 0
+        },
+        "end": {
+          "line": 18,
+          "character": 1
+        }
+      },
+      "canIncreaseVerbosity": true,
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 473
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "class ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "class name",
+                "Text": "c",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 523,
+      "LSPosition": {
+        "line": 18,
+        "character": 2
+      },
+      "Name": "12",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(property) c.staticProperty: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 18,
+          "character": 2
+        },
+        "end": {
+          "line": 18,
+          "character": 16
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 2436
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "property",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "property name",
+                "Text": "c.staticProperty",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  }
+]

--- a/testdata/baselines/reference/fourslash/vsHover/quickInfoDisplayPartsFunctionVS.baseline
+++ b/testdata/baselines/reference/fourslash/vsHover/quickInfoDisplayPartsFunctionVS.baseline
@@ -1,0 +1,1821 @@
+// === vsHover ===
+=== /quickInfoDisplayPartsFunctionVS.ts ===
+// function foo(param: string, optionalParam?: string, paramWithInitializer = "hello", ...restParam: string[]) {
+//          ^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | function foo(param: string, optionalParam?: string, paramWithInitializer?: string, ...restParam: string[]): void;
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+// }
+// function foowithoverload(a: string): string;
+//          ^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | function foowithoverload(a: string): string;
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+// function foowithoverload(a: number): number;
+//          ^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | function foowithoverload(a: number): number;
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+// function foowithoverload(a: any): any {
+//          ^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | function foowithoverload(a: any): any;
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//     return a;
+// }
+// function foowith3overload(a: string): string;
+//          ^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | function foowith3overload(a: string): string;
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+// function foowith3overload(a: number): number;
+//          ^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | function foowith3overload(a: number): number;
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+// function foowith3overload(a: boolean): boolean;
+//          ^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | function foowith3overload(a: boolean): boolean;
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+// function foowith3overload(a: any): any {
+//          ^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | function foowith3overload(a: any): any;
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+//     return a;
+// }
+// foo("hello");
+// ^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | function foo(param: string, optionalParam?: string, paramWithInitializer?: string, ...restParam: string[]): void;
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+// foowithoverload("hello");
+// ^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | function foowithoverload(a: string): string;
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+// foowithoverload(10);
+// ^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | function foowithoverload(a: number): number;
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+// foowith3overload("hello");
+// ^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | function foowith3overload(a: string): string;
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+// foowith3overload(10);
+// ^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | function foowith3overload(a: number): number;
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+// foowith3overload(true);
+// ^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | function foowith3overload(a: boolean): boolean;
+// | ```
+// | 
+// | ----------------------------------------------------------------------
+[
+  {
+    "marker": {
+      "Position": 9,
+      "LSPosition": {
+        "line": 0,
+        "character": 9
+      },
+      "Name": "1",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foo(param: string, optionalParam?: string, paramWithInitializer?: string, ...restParam: string[]): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 9
+        },
+        "end": {
+          "line": 0,
+          "character": 12
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "function ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "foo",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "param",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ",",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "optionalParam",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "?",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ",",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "paramWithInitializer",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "?",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ",",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "...",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "restParam",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "[",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "]",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 121,
+      "LSPosition": {
+        "line": 2,
+        "character": 9
+      },
+      "Name": "2",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foowithoverload(a: string): string;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 2,
+          "character": 9
+        },
+        "end": {
+          "line": 2,
+          "character": 24
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "function ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "foowithoverload",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "a",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 166,
+      "LSPosition": {
+        "line": 3,
+        "character": 9
+      },
+      "Name": "3",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foowithoverload(a: number): number;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 3,
+          "character": 9
+        },
+        "end": {
+          "line": 3,
+          "character": 24
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "function ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "foowithoverload",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "a",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "number",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "number",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 211,
+      "LSPosition": {
+        "line": 4,
+        "character": 9
+      },
+      "Name": "4",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foowithoverload(a: any): any;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 4,
+          "character": 9
+        },
+        "end": {
+          "line": 4,
+          "character": 24
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "function ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "foowithoverload",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "a",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "any",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "any",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 267,
+      "LSPosition": {
+        "line": 7,
+        "character": 9
+      },
+      "Name": "5",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foowith3overload(a: string): string;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 7,
+          "character": 9
+        },
+        "end": {
+          "line": 7,
+          "character": 25
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "function ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "foowith3overload",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "a",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 313,
+      "LSPosition": {
+        "line": 8,
+        "character": 9
+      },
+      "Name": "6",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foowith3overload(a: number): number;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 8,
+          "character": 9
+        },
+        "end": {
+          "line": 8,
+          "character": 25
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "function ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "foowith3overload",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "a",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "number",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "number",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 359,
+      "LSPosition": {
+        "line": 9,
+        "character": 9
+      },
+      "Name": "7",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foowith3overload(a: boolean): boolean;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 9,
+          "character": 9
+        },
+        "end": {
+          "line": 9,
+          "character": 25
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "function ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "foowith3overload",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "a",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "boolean",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "boolean",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 407,
+      "LSPosition": {
+        "line": 10,
+        "character": 9
+      },
+      "Name": "8",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foowith3overload(a: any): any;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 10,
+          "character": 9
+        },
+        "end": {
+          "line": 10,
+          "character": 25
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "function ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "foowith3overload",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "a",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "any",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "any",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 455,
+      "LSPosition": {
+        "line": 13,
+        "character": 0
+      },
+      "Name": "9",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foo(param: string, optionalParam?: string, paramWithInitializer?: string, ...restParam: string[]): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 13,
+          "character": 0
+        },
+        "end": {
+          "line": 13,
+          "character": 3
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "function ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "foo",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "param",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ",",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "optionalParam",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "?",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ",",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "paramWithInitializer",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "?",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ",",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "...",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "restParam",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "[",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "]",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 469,
+      "LSPosition": {
+        "line": 14,
+        "character": 0
+      },
+      "Name": "10",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foowithoverload(a: string): string;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 14,
+          "character": 0
+        },
+        "end": {
+          "line": 14,
+          "character": 15
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "function ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "foowithoverload",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "a",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 495,
+      "LSPosition": {
+        "line": 15,
+        "character": 0
+      },
+      "Name": "11",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foowithoverload(a: number): number;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 15,
+          "character": 0
+        },
+        "end": {
+          "line": 15,
+          "character": 15
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "function ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "foowithoverload",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "a",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "number",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "number",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 516,
+      "LSPosition": {
+        "line": 16,
+        "character": 0
+      },
+      "Name": "12",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foowith3overload(a: string): string;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 16,
+          "character": 0
+        },
+        "end": {
+          "line": 16,
+          "character": 16
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "function ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "foowith3overload",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "a",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 543,
+      "LSPosition": {
+        "line": 17,
+        "character": 0
+      },
+      "Name": "13",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foowith3overload(a: number): number;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 17,
+          "character": 0
+        },
+        "end": {
+          "line": 17,
+          "character": 16
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "function ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "foowith3overload",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "a",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "number",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "number",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 565,
+      "LSPosition": {
+        "line": 18,
+        "character": 0
+      },
+      "Name": "14",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foowith3overload(a: boolean): boolean;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 18,
+          "character": 0
+        },
+        "end": {
+          "line": 18,
+          "character": 16
+        }
+      },
+      "_vs_rawContent": {
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "function ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "foowith3overload",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "a",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "boolean",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "boolean",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "Style": 0,
+        "_vs_type": "ContainerElement"
+      }
+    }
+  }
+]


### PR DESCRIPTION
What tsserver used to send:

The language server returned hover data as a QuickInfo object containing displayParts plus a separate documentation parts array and a kind / kindModifiers pair. The TypeScript Language Service for VS consumed those parts directly: it mapped each SymbolDisplayPartKind to a VS classification type to produce the colored signature, and combined kind + kindModifiers (e.g. method + private) to look up a KnownImageIds entry for the icon shown beside it.

What Corsa was sending

The Corsa server only returned a flattened markdown string via the standard LSP Hover.contents field. VS has no way to recover classifications from rendered markdown, and there was no signal at all about which icon belonged to the symbol — so VS fell back to plain unstyled text with no leading image.

What this PR sends now

When the client advertises VSSupportsVisualStudioExtensions, the server attaches a _vs_rawContent payload to the hover response containing a ContainerElement graph:

 - An inner Wrapped row holding an ImageElement (carrying the VS image-catalog GUID + Id for the symbol) followed by a ClassifiedTextElement whose Runs mirror the displayParts structure tsserver used to emit — one run per token, each labeled with the LSP classification name (keyword, type, identifier, etc.).
 - An outer Stacked container that places the JSDoc body underneath the signature row, matching the layout VS produces for C# hovers.

This is the same shape Strada was already producing on the wire; we're restoring the contract that the VS-side TypeScript Language Service was written against.

Why the icon mapping has to live server-side

Picking the icon requires the symbol's kind + access modifiers + a few flags (alias, static, deprecated, etc.). All of that is checker state — GetSymbolKind, GetSymbolModifiers, and GetAliasedSymbol all need the active program. The LSP client only sees the rendered string, so any client-side mapping would have to reparse the signature and guess. Strada solved this the same way: the language service computed kind + kindModifiers and the VS TypeScript adapter then translated them to KnownImageIds. With Corsa we collapse those two steps into one — the server resolves the symbol once and emits the image-catalog Id directly, so VS can render it without re-deriving anything.
