### PR TITLE
Release the speculatively acquired dirty file by its own key

### DIFF
--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -281,7 +281,10 @@ func NewProgram(opts ProgramOptions) *Program {
 // In addition to a new program, return a boolean indicating whether the data of the old program was reused.
 // createCheckerPool, if non-nil, overrides the CreateCheckerPool stored in the old program's options,
 // ensuring each caller uses a fresh closure and avoiding data races on captured variables.
-func (p *Program) UpdateProgram(changedFilePath tspath.Path, newHost CompilerHost, createCheckerPool func(*Program) CheckerPool) (*Program, bool) {
+// The returned *ast.SourceFile is the changed file as acquired through newHost (or nil if it
+// could not be read). Callers that manage host-side parse caches must release this file when
+// the old program could not be reused, since it was acquired speculatively before that decision.
+func (p *Program) UpdateProgram(changedFilePath tspath.Path, newHost CompilerHost, createCheckerPool func(*Program) CheckerPool) (*Program, *ast.SourceFile, bool) {
 	newOpts := p.opts
 	newOpts.Host = newHost
 	if createCheckerPool != nil {
@@ -297,11 +300,11 @@ func (p *Program) UpdateProgram(changedFilePath tspath.Path, newHost CompilerHos
 	_, inRedirectFiles := p.redirectFilesByPath[changedFilePath]
 	_, isRedirectTarget := p.redirectTargetsMap[changedFilePath]
 	if inRedirectFiles || isRedirectTarget {
-		return NewProgram(newOpts), false
+		return NewProgram(newOpts), newFile, false
 	}
 
 	if !canReplaceFileInProgram(oldFile, newFile) {
-		return NewProgram(newOpts), false
+		return NewProgram(newOpts), newFile, false
 	}
 	// TODO: reverify compiler options when config has changed?
 	result := &Program{
@@ -322,7 +325,7 @@ func (p *Program) UpdateProgram(changedFilePath tspath.Path, newHost CompilerHos
 	result.filesByPath = maps.Clone(result.filesByPath)
 	result.filesByPath[newFile.Path()] = newFile
 	updateFileIncludeProcessor(result)
-	return result, true
+	return result, newFile, true
 }
 
 func (p *Program) initCheckerPool() {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -366,11 +366,12 @@ func (p *Project) CreateProgram() CreateProgramResult {
 	commandLine := p.getCommandLineWithTypingsFiles()
 
 	if p.dirtyFilePath != "" && p.Program != nil && p.Program.CommandLine() == commandLine {
-		newProgram, programCloned = p.Program.UpdateProgram(p.dirtyFilePath, p.host, createCheckerPool)
+		var dirtyFile *ast.SourceFile
+		newProgram, dirtyFile, programCloned = p.Program.UpdateProgram(p.dirtyFilePath, p.host, createCheckerPool)
 		if programCloned {
 			updateKind = ProgramUpdateKindCloned
 			for _, file := range newProgram.SourceFiles() {
-				if file.Path() != p.dirtyFilePath {
+				if file != dirtyFile {
 					// UpdateProgram acquired the changed file only, so we need to ref everything else
 					p.host.builder.parseCache.Ref(NewParseCacheKey(file.ParseOptions(), file.Hash, file.ScriptKind))
 				}
@@ -378,11 +379,11 @@ func (p *Project) CreateProgram() CreateProgramResult {
 			for _, file := range newProgram.DuplicateSourceFiles() {
 				p.host.builder.parseCache.Ref(NewParseCacheKey(file.ParseOptions, file.Hash, file.ScriptKind))
 			}
-		} else if newFile := newProgram.GetSourceFileByPath(p.dirtyFilePath); newFile != nil {
+		} else if dirtyFile != nil {
 			// UpdateProgram always acquires the dirty file before deciding whether it can
 			// reuse the old program. If it falls back to a full rebuild, release that
 			// speculative acquire so the rebuilt program is the only remaining owner.
-			p.host.builder.parseCache.Deref(NewParseCacheKey(newFile.ParseOptions(), newFile.Hash, newFile.ScriptKind))
+			p.host.builder.parseCache.Deref(NewParseCacheKey(dirtyFile.ParseOptions(), dirtyFile.Hash, dirtyFile.ScriptKind))
 		}
 	} else {
 		var typingsLocation string


### PR DESCRIPTION
This hopefully fixes #4259.

## Context

`UpdateProgram` acquires the changed file through the host before deciding whether the old program can be reused. When it falls back to a full rebuild, `CreateProgram` releases that speculative acquire so the rebuilt program is the sole owner. The release was being computed from `newProgram.GetSourceFileByPath(dirtyFilePath)`, which can return a different file than the one that was acquired (package redirect mapping, or freshly computed parse options). That over-derefs a file the rebuilt program still owns and leaks the speculative one, eventually surfacing as 'panic: cache entry not found' on the next single-file clone.

## This PR

Return the acquired file from `UpdateProgram` and use it directly for both the ref-skip in the cloned path and the compensating deref in the fallback path, so the same key is used on both sides.

