### PR TITLE
Dedupe cjs export assignments

### DIFF
--- a/internal/checker/nodebuilderimpl.go
+++ b/internal/checker/nodebuilderimpl.go
@@ -2166,6 +2166,10 @@ func (b *NodeBuilderImpl) indexInfoToIndexSignatureDeclarationHelper(indexInfo *
 	return b.f.NewIndexSignatureDeclaration(modifiers, b.f.NewNodeList([]*ast.Node{indexingParameter}), typeNode)
 }
 
+func hasTypeAnnotation(declaration *ast.Declaration) bool {
+	return declaration != nil && declaration.Type() != nil
+}
+
 /**
 * Unlike `typeToTypeNodeHelper`, this handles setting up the `AllowUniqueESSymbolType` flag
 * so a `unique symbol` is returned when appropriate for the input symbol, rather than `typeof sym`
@@ -2222,6 +2226,12 @@ func (b *NodeBuilderImpl) serializeTypeForDeclaration(declaration *ast.Declarati
 			pt = b.pc.GetTypeOfAccessor(declaration)
 		} else {
 			pt = b.pc.GetTypeOfDeclaration(declaration)
+		}
+		if (pt == nil || pt.Kind == pseudochecker.PseudoTypeKindNoResult) && ast.IsBinaryExpression(declaration) {
+			if decl := core.Find(symbol.Declarations, hasTypeAnnotation); decl != nil {
+				// Binary expressions have a first-in-wins type annotation system. The first one with an annotation supplies the type for the rest.
+				pt = b.pc.GetTypeOfDeclaration(decl)
+			}
 		}
 		reportErrors := !b.ctx.suppressReportInferenceFallback
 		if b.pseudoTypeEquivalentToType(pt, t, !requiresAddingUndefined && (ast.IsParameterDeclaration(declaration) || ast.IsPropertySignatureDeclaration(declaration) || ast.IsPropertyDeclaration(declaration)) && isOptionalDeclaration(declaration), reportErrors) {

--- a/internal/transformers/declarations/transform.go
+++ b/internal/transformers/declarations/transform.go
@@ -59,6 +59,7 @@ type DeclarationTransformer struct {
 	enclosingDeclaration             *ast.Node
 	resultHasExternalModuleIndicator bool
 	suppressNewDiagnosticContexts    bool
+	witnessedCjsExports              map[string]struct{}
 	lateStatementReplacementMap      map[ast.NodeId]*ast.Node
 	expandoHosts                     map[ast.NodeId]*ast.Node   // store the result of transforming expando hosts so they can be inserted later if the host is actually referenced
 	expandoMembers                   map[ast.NodeId][]*ast.Node // store any found expando _members_ after transforming them so *if* the host is referenced, they can be emitted alongside it
@@ -269,6 +270,7 @@ func (tx *DeclarationTransformer) visitSourceFile(node *ast.SourceFile) *ast.Nod
 	tx.rawReferencedFiles = make([]ReferencedFilePair, 0)
 	tx.rawTypeReferenceDirectives = make([]*ast.FileReference, 0)
 	tx.rawLibReferenceDirectives = make([]*ast.FileReference, 0)
+	tx.witnessedCjsExports = make(map[string]struct{})
 	tx.state.currentSourceFile = node
 	tx.collectFileReferences(node)
 	tx.resolver.PrecalculateDeclarationEmitVisibility(node)
@@ -1128,6 +1130,18 @@ func (tx *DeclarationTransformer) transformExportAssignment(input *ast.Node, ass
 }
 
 func (tx *DeclarationTransformer) transformCommonJSExport(input *ast.Node, name *ast.Node) *ast.Node {
+	var nameText string
+	if ast.IsIdentifier(name) {
+		nameText = name.Text()
+	} else if ast.IsStringLiteral(name) {
+		nameText = name.Text()
+	} else {
+		nameText = ""
+	}
+	if _, ok := tx.witnessedCjsExports[nameText]; ok && nameText != "" {
+		return nil // Already emitted this export name
+	}
+	tx.witnessedCjsExports[nameText] = struct{}{}
 	tx.resultHasExternalModuleIndicator = true
 	tx.resultHasScopeMarker = true
 	if isCommonJSAliasExport(input) {

--- a/internal/transformers/declarations/transform.go
+++ b/internal/transformers/declarations/transform.go
@@ -59,7 +59,7 @@ type DeclarationTransformer struct {
 	enclosingDeclaration             *ast.Node
 	resultHasExternalModuleIndicator bool
 	suppressNewDiagnosticContexts    bool
-	witnessedCjsExports              map[string]struct{}
+	witnessedCjsExports              collections.Set[string]
 	lateStatementReplacementMap      map[ast.NodeId]*ast.Node
 	expandoHosts                     map[ast.NodeId]*ast.Node   // store the result of transforming expando hosts so they can be inserted later if the host is actually referenced
 	expandoMembers                   map[ast.NodeId][]*ast.Node // store any found expando _members_ after transforming them so *if* the host is referenced, they can be emitted alongside it
@@ -270,7 +270,7 @@ func (tx *DeclarationTransformer) visitSourceFile(node *ast.SourceFile) *ast.Nod
 	tx.rawReferencedFiles = make([]ReferencedFilePair, 0)
 	tx.rawTypeReferenceDirectives = make([]*ast.FileReference, 0)
 	tx.rawLibReferenceDirectives = make([]*ast.FileReference, 0)
-	tx.witnessedCjsExports = make(map[string]struct{})
+	tx.witnessedCjsExports.Clear()
 	tx.state.currentSourceFile = node
 	tx.collectFileReferences(node)
 	tx.resolver.PrecalculateDeclarationEmitVisibility(node)
@@ -1134,10 +1134,10 @@ func (tx *DeclarationTransformer) transformCommonJSExport(input *ast.Node, name 
 	if ast.IsIdentifier(name) || ast.IsStringLiteral(name) {
 		nameText = name.Text()
 	}
-	if _, ok := tx.witnessedCjsExports[nameText]; ok && nameText != "" {
+	if tx.witnessedCjsExports.Has(nameText) && nameText != "" {
 		return nil // Already emitted this export name
 	}
-	tx.witnessedCjsExports[nameText] = struct{}{}
+	tx.witnessedCjsExports.Add(nameText)
 	tx.resultHasExternalModuleIndicator = true
 	tx.resultHasScopeMarker = true
 	if isCommonJSAliasExport(input) {

--- a/internal/transformers/declarations/transform.go
+++ b/internal/transformers/declarations/transform.go
@@ -1131,12 +1131,8 @@ func (tx *DeclarationTransformer) transformExportAssignment(input *ast.Node, ass
 
 func (tx *DeclarationTransformer) transformCommonJSExport(input *ast.Node, name *ast.Node) *ast.Node {
 	var nameText string
-	if ast.IsIdentifier(name) {
+	if ast.IsIdentifier(name) || ast.IsStringLiteral(name) {
 		nameText = name.Text()
-	} else if ast.IsStringLiteral(name) {
-		nameText = name.Text()
-	} else {
-		nameText = ""
 	}
 	if _, ok := tx.witnessedCjsExports[nameText]; ok && nameText != "" {
 		return nil // Already emitted this export name

--- a/testdata/baselines/reference/compiler/cjsExportsDuplication.errors.txt
+++ b/testdata/baselines/reference/compiler/cjsExportsDuplication.errors.txt
@@ -1,0 +1,19 @@
+file2.js(1,1): error TS2322: Type 'number' is not assignable to type 'string'.
+file2.js(5,1): error TS2322: Type 'boolean' is not assignable to type 'string'.
+
+
+==== file.js (0 errors) ====
+    exports.foo = 42
+    exports.foo = "hello"
+    exports.foo = true
+    
+==== file2.js (2 errors) ====
+    exports.foo = 42
+    ~~~~~~~~~~~
+!!! error TS2322: Type 'number' is not assignable to type 'string'.
+    /** @type {string} */
+    exports.foo = "hello"
+    /** @type {boolean} */
+    exports.foo = true
+    ~~~~~~~~~~~
+!!! error TS2322: Type 'boolean' is not assignable to type 'string'.

--- a/testdata/baselines/reference/compiler/cjsExportsDuplication.js
+++ b/testdata/baselines/reference/compiler/cjsExportsDuplication.js
@@ -1,0 +1,11 @@
+//// [tests/cases/compiler/cjsExportsDuplication.ts] ////
+
+//// [file.js]
+exports.foo = 42
+exports.foo = "hello"
+exports.foo = true
+
+
+
+//// [file.d.ts]
+export declare var foo: "hello" | 42 | true;

--- a/testdata/baselines/reference/compiler/cjsExportsDuplication.js
+++ b/testdata/baselines/reference/compiler/cjsExportsDuplication.js
@@ -5,7 +5,16 @@ exports.foo = 42
 exports.foo = "hello"
 exports.foo = true
 
+//// [file2.js]
+exports.foo = 42
+/** @type {string} */
+exports.foo = "hello"
+/** @type {boolean} */
+exports.foo = true
+
 
 
 //// [file.d.ts]
 export declare var foo: "hello" | 42 | true;
+//// [file2.d.ts]
+export declare var foo: string;

--- a/testdata/baselines/reference/compiler/cjsExportsDuplication.symbols
+++ b/testdata/baselines/reference/compiler/cjsExportsDuplication.symbols
@@ -16,3 +16,21 @@ exports.foo = true
 >exports : Symbol(exports, Decl(file.js, 0, 0))
 >foo : Symbol(foo, Decl(file.js, 0, 0), Decl(file.js, 0, 16), Decl(file.js, 1, 21))
 
+=== file2.js ===
+exports.foo = 42
+>exports.foo : Symbol(foo, Decl(file2.js, 0, 0), Decl(file2.js, 0, 16), Decl(file2.js, 2, 21))
+>exports : Symbol(exports, Decl(file2.js, 0, 0))
+>foo : Symbol(foo, Decl(file2.js, 0, 0), Decl(file2.js, 0, 16), Decl(file2.js, 2, 21))
+
+/** @type {string} */
+exports.foo = "hello"
+>exports.foo : Symbol(foo, Decl(file2.js, 0, 0), Decl(file2.js, 0, 16), Decl(file2.js, 2, 21))
+>exports : Symbol(exports, Decl(file2.js, 0, 0))
+>foo : Symbol(foo, Decl(file2.js, 0, 0), Decl(file2.js, 0, 16), Decl(file2.js, 2, 21))
+
+/** @type {boolean} */
+exports.foo = true
+>exports.foo : Symbol(foo, Decl(file2.js, 0, 0), Decl(file2.js, 0, 16), Decl(file2.js, 2, 21))
+>exports : Symbol(exports, Decl(file2.js, 0, 0))
+>foo : Symbol(foo, Decl(file2.js, 0, 0), Decl(file2.js, 0, 16), Decl(file2.js, 2, 21))
+

--- a/testdata/baselines/reference/compiler/cjsExportsDuplication.symbols
+++ b/testdata/baselines/reference/compiler/cjsExportsDuplication.symbols
@@ -1,0 +1,18 @@
+//// [tests/cases/compiler/cjsExportsDuplication.ts] ////
+
+=== file.js ===
+exports.foo = 42
+>exports.foo : Symbol(foo, Decl(file.js, 0, 0), Decl(file.js, 0, 16), Decl(file.js, 1, 21))
+>exports : Symbol(exports, Decl(file.js, 0, 0))
+>foo : Symbol(foo, Decl(file.js, 0, 0), Decl(file.js, 0, 16), Decl(file.js, 1, 21))
+
+exports.foo = "hello"
+>exports.foo : Symbol(foo, Decl(file.js, 0, 0), Decl(file.js, 0, 16), Decl(file.js, 1, 21))
+>exports : Symbol(exports, Decl(file.js, 0, 0))
+>foo : Symbol(foo, Decl(file.js, 0, 0), Decl(file.js, 0, 16), Decl(file.js, 1, 21))
+
+exports.foo = true
+>exports.foo : Symbol(foo, Decl(file.js, 0, 0), Decl(file.js, 0, 16), Decl(file.js, 1, 21))
+>exports : Symbol(exports, Decl(file.js, 0, 0))
+>foo : Symbol(foo, Decl(file.js, 0, 0), Decl(file.js, 0, 16), Decl(file.js, 1, 21))
+

--- a/testdata/baselines/reference/compiler/cjsExportsDuplication.types
+++ b/testdata/baselines/reference/compiler/cjsExportsDuplication.types
@@ -22,3 +22,27 @@ exports.foo = true
 >foo : "hello" | 42 | true
 >true : true
 
+=== file2.js ===
+exports.foo = 42
+>exports.foo = 42 : 42
+>exports.foo : string
+>exports : typeof import("./file2")
+>foo : string
+>42 : 42
+
+/** @type {string} */
+exports.foo = "hello"
+>exports.foo = "hello" : "hello"
+>exports.foo : string
+>exports : typeof import("./file2")
+>foo : string
+>"hello" : "hello"
+
+/** @type {boolean} */
+exports.foo = true
+>exports.foo = true : true
+>exports.foo : string
+>exports : typeof import("./file2")
+>foo : string
+>true : true
+

--- a/testdata/baselines/reference/compiler/cjsExportsDuplication.types
+++ b/testdata/baselines/reference/compiler/cjsExportsDuplication.types
@@ -1,0 +1,24 @@
+//// [tests/cases/compiler/cjsExportsDuplication.ts] ////
+
+=== file.js ===
+exports.foo = 42
+>exports.foo = 42 : 42
+>exports.foo : "hello" | 42 | true
+>exports : typeof import("./file")
+>foo : "hello" | 42 | true
+>42 : 42
+
+exports.foo = "hello"
+>exports.foo = "hello" : "hello"
+>exports.foo : "hello" | 42 | true
+>exports : typeof import("./file")
+>foo : "hello" | 42 | true
+>"hello" : "hello"
+
+exports.foo = true
+>exports.foo = true : true
+>exports.foo : "hello" | 42 | true
+>exports : typeof import("./file")
+>foo : "hello" | 42 | true
+>true : true
+

--- a/testdata/baselines/reference/compiler/numericExportNameDeclaration.js
+++ b/testdata/baselines/reference/compiler/numericExportNameDeclaration.js
@@ -11,31 +11,3 @@ Object.defineProperty(exports, 1, {});
 //// [bug.d.ts]
 declare const _exported: any;
 export { _exported as "1" };
-declare const _exported_1: any;
-export { _exported_1 as "1" };
-declare const _exported_2: any;
-export { _exported_2 as "1" };
-
-
-//// [DtsFileErrors]
-
-
-bug.d.ts(2,23): error TS2300: Duplicate identifier '"1"'.
-bug.d.ts(4,25): error TS2300: Duplicate identifier '"1"'.
-bug.d.ts(6,25): error TS2300: Duplicate identifier '"1"'.
-
-
-==== bug.d.ts (3 errors) ====
-    declare const _exported: any;
-    export { _exported as "1" };
-                          ~~~
-!!! error TS2300: Duplicate identifier '"1"'.
-    declare const _exported_1: any;
-    export { _exported_1 as "1" };
-                            ~~~
-!!! error TS2300: Duplicate identifier '"1"'.
-    declare const _exported_2: any;
-    export { _exported_2 as "1" };
-                            ~~~
-!!! error TS2300: Duplicate identifier '"1"'.
-    

--- a/testdata/baselines/reference/submodule/conformance/moduleExportDuplicateAlias.js
+++ b/testdata/baselines/reference/submodule/conformance/moduleExportDuplicateAlias.js
@@ -28,6 +28,5 @@ apply();
 //// [moduleExportAliasDuplicateAlias.d.ts]
 export declare var apply: typeof a;
 declare function a(): void;
-export declare var apply: typeof a;
 //// [test.d.ts]
 export {};

--- a/testdata/baselines/reference/submodule/conformance/moduleExportDuplicateAlias2.js
+++ b/testdata/baselines/reference/submodule/conformance/moduleExportDuplicateAlias2.js
@@ -28,7 +28,5 @@ apply();
 //// [moduleExportAliasDuplicateAlias.d.ts]
 export declare var apply: typeof a;
 declare function a(): void;
-export declare var apply: typeof a;
-export declare var apply: typeof a;
 //// [test.d.ts]
 export {};

--- a/testdata/baselines/reference/submodule/conformance/moduleExportDuplicateAlias3.js
+++ b/testdata/baselines/reference/submodule/conformance/moduleExportDuplicateAlias3.js
@@ -33,10 +33,6 @@ const result = apply.toFixed();
 
 //// [moduleExportAliasDuplicateAlias.d.ts]
 export declare var apply: "ok" | 1 | typeof a | undefined;
-export declare var apply: "ok" | 1 | typeof a | undefined;
 declare function a(): void;
-export declare var apply: "ok" | 1 | typeof a | undefined;
-export declare var apply: "ok" | 1 | typeof a | undefined;
-export declare var apply: "ok" | 1 | typeof a | undefined;
 //// [test.d.ts]
 export {};

--- a/testdata/baselines/reference/submoduleAccepted/conformance/moduleExportDuplicateAlias.js.diff
+++ b/testdata/baselines/reference/submoduleAccepted/conformance/moduleExportDuplicateAlias.js.diff
@@ -7,6 +7,5 @@
 -export { a as apply };
 +export declare var apply: typeof a;
  declare function a(): void;
-+export declare var apply: typeof a;
  //// [test.d.ts]
  export {};

--- a/testdata/baselines/reference/submoduleAccepted/conformance/moduleExportDuplicateAlias2.js.diff
+++ b/testdata/baselines/reference/submoduleAccepted/conformance/moduleExportDuplicateAlias2.js.diff
@@ -7,7 +7,5 @@
 -export { a as apply };
 +export declare var apply: typeof a;
  declare function a(): void;
-+export declare var apply: typeof a;
-+export declare var apply: typeof a;
  //// [test.d.ts]
  export {};

--- a/testdata/baselines/reference/submoduleAccepted/conformance/moduleExportDuplicateAlias3.js.diff
+++ b/testdata/baselines/reference/submoduleAccepted/conformance/moduleExportDuplicateAlias3.js.diff
@@ -7,10 +7,6 @@
 -export const apply: "ok" | 1 | typeof a | undefined;
 -export { a as apply };
 +export declare var apply: "ok" | 1 | typeof a | undefined;
-+export declare var apply: "ok" | 1 | typeof a | undefined;
  declare function a(): void;
-+export declare var apply: "ok" | 1 | typeof a | undefined;
-+export declare var apply: "ok" | 1 | typeof a | undefined;
-+export declare var apply: "ok" | 1 | typeof a | undefined;
  //// [test.d.ts]
  export {};

--- a/testdata/tests/cases/compiler/cjsExportsDuplication.ts
+++ b/testdata/tests/cases/compiler/cjsExportsDuplication.ts
@@ -1,0 +1,8 @@
+// @allowJs: true
+// @checkJs: true
+// @declaration: true
+// @emitDeclarationOnly: true
+// @filename: file.js
+exports.foo = 42
+exports.foo = "hello"
+exports.foo = true

--- a/testdata/tests/cases/compiler/cjsExportsDuplication.ts
+++ b/testdata/tests/cases/compiler/cjsExportsDuplication.ts
@@ -6,3 +6,10 @@
 exports.foo = 42
 exports.foo = "hello"
 exports.foo = true
+
+// @filename: file2.js
+exports.foo = 42
+/** @type {string} */
+exports.foo = "hello"
+/** @type {boolean} */
+exports.foo = true


### PR DESCRIPTION
Fixes #2533

This is weird, since you can end up needing to pull the type node from a different declaration than you actually encounter and emit. It's not insurmountable for other emitters, though (if they do some rudimentary binding...).

It's also just weird in that in TS, we'd have emitted every declaration the user wrote, so the error in the input (if multiple declarations have mismatched types) would persist into the output.