### PR TITLE
Don't provide auto-imports for non-identifiers

### DIFF
--- a/internal/fourslash/tests/autoImportCompletionsForArbitraryNonIdentifierExports_test.go
+++ b/internal/fourslash/tests/autoImportCompletionsForArbitraryNonIdentifierExports_test.go
@@ -1,0 +1,37 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	util "github.com/microsoft/typescript-go/internal/fourslash/tests/util"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestAutoImportCompletionsForArbitraryNonIdentifierExports(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `
+// @module: esnext
+// @Filename: /a.ts
+const foo = 0;
+export { foo as "foo-bar" };
+export const fooBar = 1;
+
+// @Filename: /b.ts
+foo/**/
+`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+
+	f.VerifyCompletions(t, "", &fourslash.CompletionsExpectedList{
+		Items: &fourslash.CompletionsExpectedItems{
+			Excludes: []string{"foo-bar"},
+			Includes: []fourslash.CompletionsExpectedItem{"fooBar"},
+		},
+		ItemDefaults: &fourslash.CompletionsExpectedItemDefaults{
+			CommitCharacters: &util.DefaultCommitCharacters,
+			EditRange:        util.Ignored,
+		},
+	})
+}

--- a/internal/ls/autoimport/view.go
+++ b/internal/ls/autoimport/view.go
@@ -14,6 +14,7 @@ import (
 	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
 	"github.com/microsoft/typescript-go/internal/module"
 	"github.com/microsoft/typescript-go/internal/modulespecifiers"
+	"github.com/microsoft/typescript-go/internal/scanner"
 	"github.com/microsoft/typescript-go/internal/tspath"
 )
 
@@ -180,6 +181,9 @@ func (v *View) GetCompletions(ctx context.Context, prefix string, position lspro
 outer:
 	for _, e := range results {
 		name := e.Name()
+		if !scanner.IsIdentifierText(name, core.LanguageVariantStandard) {
+			continue
+		}
 		if forJSX && !(unicode.IsUpper(rune(name[0])) || e.IsRenameable()) {
 			continue
 		}


### PR DESCRIPTION
This fixes a regression from Strada which used to have the same filtering.

https://github.com/microsoft/TypeScript/blob/7964e22f2b85f16e520f0e902c7fd7b6f0c15416/src/services/completions.ts#L4178

```ts
if (!isIdentifierText(symbolName, getEmitScriptTarget(host.getCompilationSettings()))) return false;
```

Fixes #4286