### PR TITLE
fix: error on private property access in generic intersection types

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -26783,11 +26783,13 @@ func (c *Checker) getIndexedAccessTypeOrUndefined(objectType *Type, indexType *T
 	if objectType.flags&TypeFlagsIntersection != 0 && objectType.flags&TypeFlagsNever == 0 {
 		props := c.getPropertiesOfUnionOrIntersectionType(objectType)
 		for _, prop := range props {
-			if c.isConflictingPrivateProperty(prop) && accessNode != nil {
-				declaringClass := c.getDeclaringClass(prop)
-				if declaringClass != nil {
-					c.error(accessNode, diagnostics.Property_0_is_private_and_only_accessible_within_class_1, 
-						c.symbolToString(prop), c.TypeToString(c.getTypeOfSymbol(declaringClass)))
+			if c.isConflictingPrivateProperty(prop) {
+				if accessNode != nil {
+					declaringClass := c.getDeclaringClass(prop)
+					if declaringClass != nil {
+						c.error(accessNode, diagnostics.Property_0_is_private_and_only_accessible_within_class_1,
+							c.symbolToString(prop), c.TypeToString(c.getTypeOfSymbol(declaringClass)))
+					}
 				}
 				return nil
 			}

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -26778,6 +26778,21 @@ func (c *Checker) getIndexedAccessTypeOrUndefined(objectType *Type, indexType *T
 		return c.wildcardType
 	}
 	objectType = c.getReducedType(objectType)
+	// If the object type is an intersection with conflicting private properties,
+	// report an error — we shouldn't be able to access those properties via T["key"]
+	if objectType.flags&TypeFlagsIntersection != 0 && objectType.flags&TypeFlagsNever == 0 {
+		props := c.getPropertiesOfUnionOrIntersectionType(objectType)
+		for _, prop := range props {
+			if c.isConflictingPrivateProperty(prop) && accessNode != nil {
+				declaringClass := c.getDeclaringClass(prop)
+				if declaringClass != nil {
+					c.error(accessNode, diagnostics.Property_0_is_private_and_only_accessible_within_class_1, 
+						c.symbolToString(prop), c.TypeToString(c.getTypeOfSymbol(declaringClass)))
+				}
+				return nil
+			}
+		}
+	}
 	// If the object type has a string index signature and no other members we know that the result will
 	// always be the type of that index signature and we can simplify accordingly.
 	if c.isStringIndexSignatureOnlyType(objectType) && indexType.flags&TypeFlagsNullable == 0 && c.isTypeAssignableToKind(indexType, TypeFlagsString|TypeFlagsNumber) {


### PR DESCRIPTION
When two classes have conflicting private properties, accessing them 
via indexed access on their intersection should report an error, 
consistent with union behavior.

This is the Go implementation of the fix originally submitted to 
microsoft/TypeScript#63548 (closed — JS codebase is winding down).

## Root Cause
`getIndexedAccessTypeOrUndefined` did not check for conflicting 
private properties in intersection types before resolving indexed access.

## Fix
Added check after `getReducedType()` to detect conflicting private 
properties and report 
`Property_0_is_private_and_only_accessible_within_class_1`.

## Before
```ts
type Z<T extends A & B> = T["a"];         // no error ❌
type Z3<T extends A, T2 extends B> = (T & T2)["a"];  // no error ❌
```

## After
```ts
type Z<T extends A & B> = T["a"];         // Error ✅
type Z3<T extends A, T2 extends B> = (T & T2)["a"];  // Error ✅
```

## Related
- microsoft/TypeScript#62294 (original issue)
- microsoft/TypeScript#63548 (JS version — closed)
- PR #37762 (original intersection reduction logic)

Closes microsoft/TypeScript#62294