### PR TITLE
Invalidate `--build` incremental cache when non-root program inputs like node_modules files change

### DIFF
--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -152,6 +152,12 @@ func (p *Program) GetPackageJsonInfo(pkgJsonPath string) *packagejson.InfoCacheE
 	return nil
 }
 
+// PackageJsonLookups returns the sorted file names of the package.json files that exist
+// and were consulted during module resolution.
+func (p *Program) PackageJsonLookups() []string {
+	return p.resolver.PackageJsonLookups()
+}
+
 // GetRedirectTargets returns the list of file paths that redirect to the given path.
 // These are files from the same package (same name@version) installed in different locations.
 func (p *Program) GetRedirectTargets(path tspath.Path) []string {

--- a/internal/execute/build/buildtask.go
+++ b/internal/execute/build/buildtask.go
@@ -437,6 +437,21 @@ func (t *BuildTask) getUpToDateStatus(orchestrator *Orchestrator, configPath tsp
 	// https://github.com/microsoft/typescript-go/issues/2666
 	if buildInfo.IsIncremental() {
 		buildInfoDirectory := tspath.GetDirectoryPath(tspath.GetNormalizedAbsolutePath(buildInfoPath, orchestrator.comparePathsOptions.CurrentDirectory))
+		libDirectory := orchestrator.host.DefaultLibraryPath()
+		toInputFileName := func(buildInfoFileName string) (string, bool) {
+			if strings.HasPrefix(buildInfoFileName, ".") {
+				return tspath.GetNormalizedAbsolutePath(buildInfoFileName, buildInfoDirectory), true
+			}
+			// Names that are not relative are either bundled lib files or absolute paths that
+			// could not be made relative to the build info directory (eg: on another drive)
+			fileName := tspath.CombinePaths(libDirectory, buildInfoFileName)
+			if tspath.ContainsPath(libDirectory, fileName, orchestrator.comparePathsOptions) {
+				// Lib files bundled with the compiler can change only with the version of the
+				// compiler, which is already verified with buildInfo.Version
+				return "", false
+			}
+			return fileName, true
+		}
 		var resolvedRoots collections.Set[tspath.Path]
 		for root := range buildInfoRootInfoReader.Roots() {
 			if _, resolved := buildInfoRootInfoReader.GetBuildInfoFileInfo(root); resolved != "" {
@@ -444,13 +459,10 @@ func (t *BuildTask) getUpToDateStatus(orchestrator *Orchestrator, configPath tsp
 			}
 		}
 		for index, buildInfoFileInfo := range buildInfo.FileInfos {
-			buildInfoFileName := buildInfo.FileNames[index]
-			// Lib files bundled with the compiler can change only with the version of the compiler,
-			// which is already verified with buildInfo.Version
-			if !strings.HasPrefix(buildInfoFileName, ".") {
+			inputFile, ok := toInputFileName(buildInfo.FileNames[index])
+			if !ok {
 				continue
 			}
-			inputFile := tspath.GetNormalizedAbsolutePath(buildInfoFileName, buildInfoDirectory)
 			inputPath := orchestrator.toPath(inputFile)
 			// Root files are already checked
 			if seenRoots.Has(inputPath) || resolvedRoots.Has(inputPath) {
@@ -473,6 +485,26 @@ func (t *BuildTask) getUpToDateStatus(orchestrator *Orchestrator, configPath tsp
 					return &upToDateStatus{kind: upToDateStatusTypeInputFileNewer, data: &inputOutputName{inputFile, buildInfoPath}}
 				}
 				inputTextUnchanged = true
+			}
+		}
+
+		// Check the package.json files that were used during module resolution since changing
+		// them can redirect resolution to different files without changing any program input
+		// (eg: changing "types" or "exports" in a dependency's package.json). The contents are
+		// compared by hash instead of timestamps so updates that preserve timestamps (eg: a
+		// symlinked dependency pointing at a different target) are detected too.
+		for _, lookup := range buildInfo.PackageJsonLookups {
+			inputFile, ok := toInputFileName(buildInfo.FileNames[lookup.FileId-1])
+			if !ok {
+				continue
+			}
+			currentVersion, found := orchestrator.host.packageJsonVersion(inputFile)
+			if !found {
+				// package.json that was used during module resolution is missing
+				return &upToDateStatus{kind: upToDateStatusTypeInputFileMissing, data: inputFile}
+			}
+			if currentVersion != lookup.Version {
+				return &upToDateStatus{kind: upToDateStatusTypeInputFileNewer, data: &inputOutputName{inputFile, buildInfoPath}}
 			}
 		}
 	}
@@ -552,15 +584,6 @@ func (t *BuildTask) getUpToDateStatus(orchestrator *Orchestrator, configPath tsp
 			return extendedConfigStatus
 		}
 	}
-
-	// !!! sheetal TODO : watch??
-	// // Check package file time
-	// const packageJsonLookups = state.lastCachedPackageJsonLookups.get(resolvedPath);
-	// const dependentPackageFileStatus = packageJsonLookups && forEachKey(
-	//     packageJsonLookups,
-	//     path => checkConfigFileUpToDateStatus(state, path, oldestOutputFileTime, oldestOutputFileName),
-	// );
-	// if (dependentPackageFileStatus) return dependentPackageFileStatus;
 
 	return &upToDateStatus{
 		kind: core.IfElse(

--- a/internal/execute/build/buildtask.go
+++ b/internal/execute/build/buildtask.go
@@ -431,6 +431,52 @@ func (t *BuildTask) getUpToDateStatus(orchestrator *Orchestrator, configPath tsp
 		}
 	}
 
+	// Check the program files that are not roots (eg: files from node_modules) since they
+	// are not part of config file names and can change without any change to the root files
+	// (eg: when dependencies in node_modules are updated)
+	// https://github.com/microsoft/typescript-go/issues/2666
+	if buildInfo.IsIncremental() {
+		buildInfoDirectory := tspath.GetDirectoryPath(tspath.GetNormalizedAbsolutePath(buildInfoPath, orchestrator.comparePathsOptions.CurrentDirectory))
+		var resolvedRoots collections.Set[tspath.Path]
+		for root := range buildInfoRootInfoReader.Roots() {
+			if _, resolved := buildInfoRootInfoReader.GetBuildInfoFileInfo(root); resolved != "" {
+				resolvedRoots.Add(resolved)
+			}
+		}
+		for index, buildInfoFileInfo := range buildInfo.FileInfos {
+			buildInfoFileName := buildInfo.FileNames[index]
+			// Lib files bundled with the compiler can change only with the version of the compiler,
+			// which is already verified with buildInfo.Version
+			if !strings.HasPrefix(buildInfoFileName, ".") {
+				continue
+			}
+			inputFile := tspath.GetNormalizedAbsolutePath(buildInfoFileName, buildInfoDirectory)
+			inputPath := orchestrator.toPath(inputFile)
+			// Root files are already checked
+			if seenRoots.Has(inputPath) || resolvedRoots.Has(inputPath) {
+				continue
+			}
+			inputTime := orchestrator.host.GetMTime(inputFile)
+			if inputTime.IsZero() {
+				// Input file that was part of the program is missing (eg: dependency was removed)
+				return &upToDateStatus{kind: upToDateStatusTypeInputFileMissing, data: inputFile}
+			}
+			if inputTime.After(oldestOutputFileAndTime.time) {
+				var currentVersion string
+				version := buildInfoFileInfo.GetFileInfo().Version()
+				if version != "" {
+					if text, ok := orchestrator.host.FS().ReadFile(inputFile); ok {
+						currentVersion = incremental.ComputeHash(text, orchestrator.opts.Testing != nil)
+					}
+				}
+				if version == "" || version != currentVersion {
+					return &upToDateStatus{kind: upToDateStatusTypeInputFileNewer, data: &inputOutputName{inputFile, buildInfoPath}}
+				}
+				inputTextUnchanged = true
+			}
+		}
+	}
+
 	if !t.resolved.CompilerOptions().IsIncremental() {
 		// Check output file stamps
 		for outputFile := range t.resolved.GetOutputFileNames() {

--- a/internal/execute/build/host.go
+++ b/internal/execute/build/host.go
@@ -22,6 +22,7 @@ type host struct {
 	extendedConfigCache tsc.ExtendedConfigCache
 	sourceFiles         parseCache[ast.SourceFileParseOptions, *ast.SourceFile]
 	configTimes         collections.SyncMap[tspath.Path, time.Duration]
+	packageJsonVersions collections.SyncMap[tspath.Path, string]
 
 	// caches that stay as long as they are needed
 	resolvedReferences parseCache[tspath.Path, *tsoptions.ParsedCommandLine]
@@ -112,6 +113,21 @@ func (h *host) loadOrStoreMTime(file string, oldCache *collections.SyncMap[tspat
 func (h *host) storeMTime(file string, mTime time.Time) {
 	path := h.orchestrator.toPath(file)
 	h.mTimes.Store(path, mTime)
+}
+
+// packageJsonVersion returns the hash of the contents of the package.json file,
+// or false if the file does not exist. The result is cached for the build cycle.
+func (h *host) packageJsonVersion(fileName string) (string, bool) {
+	path := h.orchestrator.toPath(fileName)
+	if existing, loaded := h.packageJsonVersions.Load(path); loaded {
+		return existing, existing != ""
+	}
+	var version string
+	if text, ok := h.FS().ReadFile(fileName); ok {
+		version = incremental.ComputeHash(text, h.orchestrator.opts.Testing != nil)
+	}
+	version, _ = h.packageJsonVersions.LoadOrStore(path, version)
+	return version, version != ""
 }
 
 func (h *host) storeMTimeFromOldCache(file string, oldCache *collections.SyncMap[tspath.Path, time.Time]) {

--- a/internal/execute/build/orchestrator.go
+++ b/internal/execute/build/orchestrator.go
@@ -257,6 +257,7 @@ func (o *Orchestrator) resetCaches() {
 	o.host.extendedConfigCache = tsc.ExtendedConfigCache{}
 	o.host.sourceFiles.reset()
 	o.host.configTimes = collections.SyncMap[tspath.Path, time.Duration]{}
+	o.host.packageJsonVersions = collections.SyncMap[tspath.Path, string]{}
 }
 
 func (o *Orchestrator) DoCycle() {

--- a/internal/execute/incremental/buildInfo.go
+++ b/internal/execute/incremental/buildInfo.go
@@ -438,6 +438,41 @@ func (b *BuildInfoEmitSignature) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// BuildInfoPackageJsonLookup is (fileId, version) tuple of a package.json file that
+// was consulted during module resolution and the hash of its contents when the
+// program was created
+type BuildInfoPackageJsonLookup struct {
+	FileId  BuildInfoFileId
+	Version string
+}
+
+func (b *BuildInfoPackageJsonLookup) MarshalJSON() ([]byte, error) {
+	return json.Marshal([2]any{b.FileId, b.Version})
+}
+
+func (b *BuildInfoPackageJsonLookup) UnmarshalJSON(data []byte) error {
+	var fileIdAndVersion []any
+	if err := json.Unmarshal(data, &fileIdAndVersion); err != nil {
+		return fmt.Errorf("invalid BuildInfoPackageJsonLookup: %s", data)
+	}
+	if len(fileIdAndVersion) != 2 {
+		return fmt.Errorf("invalid BuildInfoPackageJsonLookup: expected 2 elements, got %d", len(fileIdAndVersion))
+	}
+	fileId, ok := fileIdAndVersion[0].(float64)
+	if !ok {
+		return fmt.Errorf("invalid fileId in BuildInfoPackageJsonLookup: expected number, got %T", fileIdAndVersion[0])
+	}
+	version, ok := fileIdAndVersion[1].(string)
+	if !ok {
+		return fmt.Errorf("invalid version in BuildInfoPackageJsonLookup: expected string, got %T", fileIdAndVersion[1])
+	}
+	*b = BuildInfoPackageJsonLookup{
+		FileId:  BuildInfoFileId(fileId),
+		Version: version,
+	}
+	return nil
+}
+
 type BuildInfoResolvedRoot struct {
 	Resolved BuildInfoFileId
 	Root     BuildInfoFileId
@@ -480,6 +515,7 @@ type BuildInfo struct {
 	LatestChangedDtsFile       string                               `json:"latestChangedDtsFile,omitzero"` // Because this is only output file in the program, we dont need fileId to deduplicate name
 	EmitSignatures             []*BuildInfoEmitSignature            `json:"emitSignatures,omitzero"`
 	ResolvedRoot               []*BuildInfoResolvedRoot             `json:"resolvedRoot,omitzero"`
+	PackageJsonLookups         []*BuildInfoPackageJsonLookup        `json:"packageJsonLookups,omitzero"`
 
 	// NonIncrementalProgram info
 	SemanticErrors bool `json:"semanticErrors,omitzero"`

--- a/internal/execute/incremental/snapshottobuildinfo.go
+++ b/internal/execute/incremental/snapshottobuildinfo.go
@@ -46,6 +46,7 @@ func snapshotToBuildInfo(snapshot *snapshot, program *compiler.Program, buildInf
 		if snapshot.latestChangedDtsFile != "" {
 			buildInfo.LatestChangedDtsFile = to.relativeToBuildInfo(snapshot.latestChangedDtsFile)
 		}
+		to.setPackageJsonLookups()
 	} else {
 		to.setRootOfNonIncrementalProgram()
 	}
@@ -358,6 +359,20 @@ func (t *toBuildInfo) setAffectedFilesPendingEmit() {
 		t.buildInfo.AffectedFilesPendingEmit = append(t.buildInfo.AffectedFilesPendingEmit, &BuildInfoFilePendingEmit{
 			FileId:   t.toFileId(filePath),
 			EmitKind: core.IfElse(pendingEmit == fullEmitKind, 0, pendingEmit),
+		})
+	}
+}
+
+func (t *toBuildInfo) setPackageJsonLookups() {
+	fs := t.program.Host().FS()
+	for _, fileName := range t.program.PackageJsonLookups() {
+		text, ok := fs.ReadFile(fileName)
+		if !ok {
+			continue
+		}
+		t.buildInfo.PackageJsonLookups = append(t.buildInfo.PackageJsonLookups, &BuildInfoPackageJsonLookup{
+			FileId:  t.toFileId(tspath.ToPath(fileName, t.comparePathsOptions.CurrentDirectory, t.comparePathsOptions.UseCaseSensitiveFileNames)),
+			Version: ComputeHash(text, t.snapshot.hashWithText),
 		})
 	}
 }

--- a/internal/execute/tsctests/readablebuildinfo.go
+++ b/internal/execute/tsctests/readablebuildinfo.go
@@ -33,6 +33,7 @@ type readableBuildInfo struct {
 	LatestChangedDtsFile       string                                    `json:"latestChangedDtsFile,omitzero"` // Because this is only output file in the program, we dont need fileId to deduplicate name
 	EmitSignatures             []*readableBuildInfoEmitSignature         `json:"emitSignatures,omitzero"`
 	ResolvedRoot               []*readableBuildInfoResolvedRoot          `json:"resolvedRoot,omitzero"`
+	PackageJsonLookups         []*readableBuildInfoPackageJsonLookup     `json:"packageJsonLookups,omitzero"`
 	Size                       int                                       `json:"size,omitzero"` // Size of the build info file
 
 	// NonIncrementalProgram info
@@ -183,6 +184,11 @@ type readableBuildInfoEmitSignature struct {
 	Original            *incremental.BuildInfoEmitSignature `json:"original,omitzero"`
 }
 
+type readableBuildInfoPackageJsonLookup struct {
+	FileName string `json:"fileName,omitzero"`
+	Version  string `json:"version,omitzero"`
+}
+
 type readableBuildInfoResolvedRoot struct {
 	Resolved string
 	Root     string
@@ -226,6 +232,7 @@ func toReadableBuildInfo(buildInfo *incremental.BuildInfo, buildInfoText string)
 	readable.setAffectedFilesPendingEmit()
 	readable.setEmitSignatures()
 	readable.setResolvedRoot()
+	readable.setPackageJsonLookups()
 	contents, err := json.MarshalIndent(&readable, "", "  ")
 	if err != nil {
 		panic("readableBuildInfo: failed to marshal readable build info: " + err.Error())
@@ -418,6 +425,15 @@ func (r *readableBuildInfo) setResolvedRoot() {
 		return &readableBuildInfoResolvedRoot{
 			Resolved: r.toFilePath(original.Resolved),
 			Root:     r.toFilePath(original.Root),
+		}
+	})
+}
+
+func (r *readableBuildInfo) setPackageJsonLookups() {
+	r.PackageJsonLookups = core.Map(r.buildInfo.PackageJsonLookups, func(original *incremental.BuildInfoPackageJsonLookup) *readableBuildInfoPackageJsonLookup {
+		return &readableBuildInfoPackageJsonLookup{
+			FileName: r.toFilePath(original.FileId),
+			Version:  original.Version,
 		}
 	})
 }

--- a/internal/execute/tsctests/tscbuild_test.go
+++ b/internal/execute/tsctests/tscbuild_test.go
@@ -969,6 +969,74 @@ func TestBuildFileDelete(t *testing.T) {
 	}
 }
 
+func TestBuildDependencyUpdate(t *testing.T) {
+	t.Parallel()
+	testCases := []*tscInput{
+		{
+			// https://github.com/microsoft/typescript-go/issues/2666
+			subScenario: "rebuilds when dependency in node_modules is updated",
+			files: FileMap{
+				"/home/src/workspaces/project/tsconfig.json": stringtestutil.Dedent(`
+					{
+						"compilerOptions": {
+							"composite": true,
+							"outDir": "dist",
+							"strict": true
+						},
+						"include": ["src/**/*"]
+					}
+				`),
+				"/home/src/workspaces/project/src/index.ts": stringtestutil.Dedent(`
+					import { myValue } from "my-dep";
+					export const value: string = myValue;
+				`),
+				"/home/src/workspaces/project/node_modules/my-dep/package.json": stringtestutil.Dedent(`
+					{
+						"name": "my-dep",
+						"version": "1.0.0",
+						"types": "index.d.ts"
+					}
+				`),
+				"/home/src/workspaces/project/node_modules/my-dep/index.d.ts": "export declare const myValue: string;",
+			},
+			cwd:             "/home/src/workspaces/project",
+			commandLineArgs: []string{"--b", "--verbose"},
+			edits: []*tscEdit{
+				noChange,
+				{
+					caption: "update dependency d.ts with breaking type change",
+					edit: func(sys *TestSys) {
+						sys.writeFileNoError("/home/src/workspaces/project/node_modules/my-dep/index.d.ts", "export declare const myValue: number;")
+					},
+				},
+				{
+					caption: "restore dependency d.ts",
+					edit: func(sys *TestSys) {
+						sys.writeFileNoError("/home/src/workspaces/project/node_modules/my-dep/index.d.ts", "export declare const myValue: string;")
+					},
+				},
+				{
+					caption: "update dependency d.ts timestamp without changing text",
+					edit: func(sys *TestSys) {
+						sys.writeFileNoError("/home/src/workspaces/project/node_modules/my-dep/index.d.ts", "export declare const myValue: string;")
+					},
+				},
+				noChange,
+				{
+					caption: "delete dependency d.ts",
+					edit: func(sys *TestSys) {
+						sys.removeNoError("/home/src/workspaces/project/node_modules/my-dep/index.d.ts")
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		test.run(t, "dependencyUpdate")
+	}
+}
+
 func TestBuildInferredTypeFromTransitiveModule(t *testing.T) {
 	t.Parallel()
 	getBuildInferredTypeFromTransitiveModuleMap := func(isolatedModules bool, lazyExtraContents string) FileMap {

--- a/internal/execute/tsctests/tscbuild_test.go
+++ b/internal/execute/tsctests/tscbuild_test.go
@@ -1030,6 +1030,79 @@ func TestBuildDependencyUpdate(t *testing.T) {
 				},
 			},
 		},
+		{
+			subScenario: "rebuilds when dependency package json redirects to a different declaration file",
+			files: FileMap{
+				"/home/src/workspaces/project/tsconfig.json": stringtestutil.Dedent(`
+					{
+						"compilerOptions": {
+							"composite": true,
+							"outDir": "dist",
+							"strict": true
+						},
+						"include": ["src/**/*"]
+					}
+				`),
+				"/home/src/workspaces/project/src/index.ts": stringtestutil.Dedent(`
+					import { myValue } from "my-dep";
+					export const value: string = myValue;
+				`),
+				"/home/src/workspaces/project/node_modules/my-dep/package.json": stringtestutil.Dedent(`
+					{
+						"name": "my-dep",
+						"version": "1.0.0",
+						"types": "index.d.ts"
+					}
+				`),
+				"/home/src/workspaces/project/node_modules/my-dep/index.d.ts": "export declare const myValue: string;",
+				"/home/src/workspaces/project/node_modules/my-dep/alt.d.ts":   "export declare const myValue: number;",
+			},
+			cwd:             "/home/src/workspaces/project",
+			commandLineArgs: []string{"--b", "--verbose"},
+			edits: []*tscEdit{
+				{
+					caption: "redirect package types to a declaration file with a breaking type change",
+					edit: func(sys *TestSys) {
+						sys.replaceFileText("/home/src/workspaces/project/node_modules/my-dep/package.json", "index.d.ts", "alt.d.ts")
+					},
+				},
+			},
+		},
+		{
+			subScenario: "rebuilds when absolute non-root dependency is updated",
+			files: FileMap{
+				"C:/work/project/tsconfig.json": stringtestutil.Dedent(`
+					{
+						"compilerOptions": {
+							"composite": true,
+							"outDir": "dist",
+							"paths": {
+								"abs-dep": ["D:/deps/dep.d.ts"]
+							},
+							"strict": true
+						},
+						"include": ["src/**/*"]
+					}
+				`),
+				"C:/work/project/src/index.ts": stringtestutil.Dedent(`
+					import { myValue } from "abs-dep";
+					export const value: string = myValue;
+				`),
+				"D:/deps/dep.d.ts": "export declare const myValue: string;",
+			},
+			cwd:              "C:/work/project",
+			windowsStyleRoot: "C:/",
+			ignoreCase:       true,
+			commandLineArgs:  []string{"--b", "--verbose"},
+			edits: []*tscEdit{
+				{
+					caption: "update absolute non-root dependency with breaking type change",
+					edit: func(sys *TestSys) {
+						sys.writeFileNoError("D:/deps/dep.d.ts", "export declare const myValue: number;")
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range testCases {

--- a/internal/module/resolver.go
+++ b/internal/module/resolver.go
@@ -212,6 +212,20 @@ func (r *Resolver) GetPackageScopeForPath(directory string) *packagejson.InfoCac
 	return (&resolutionState{compilerOptions: r.compilerOptions, resolver: r}).getPackageScopeForPath(directory)
 }
 
+// PackageJsonLookups returns the sorted file names of the package.json files that exist
+// and were consulted during module resolution.
+func (r *Resolver) PackageJsonLookups() []string {
+	var fileNames []string
+	r.packageJsonInfoCache.Range(func(_ tspath.Path, entry *packagejson.InfoCacheEntry) bool {
+		if entry.Exists() {
+			fileNames = append(fileNames, tspath.CombinePaths(entry.PackageDirectory, "package.json"))
+		}
+		return true
+	})
+	slices.Sort(fileNames)
+	return fileNames
+}
+
 func (r *tracer) traceResolutionUsingProjectReference(redirectedReference ResolvedProjectReference) {
 	if redirectedReference != nil && redirectedReference.CompilerOptions() != nil {
 		r.write(diagnostics.Using_compiler_options_of_project_reference_redirect_0, redirectedReference.ConfigName())

--- a/internal/packagejson/cache.go
+++ b/internal/packagejson/cache.go
@@ -192,3 +192,9 @@ func (p *InfoCache) Set(packageJsonPath string, info *InfoCacheEntry) *InfoCache
 	actual, _ := p.cache.LoadOrStore(key, info)
 	return actual
 }
+
+// Range calls f sequentially for each package.json path and entry in the cache.
+// If f returns false, Range stops the iteration.
+func (p *InfoCache) Range(f func(path tspath.Path, entry *InfoCacheEntry) bool) {
+	p.cache.Range(f)
+}

--- a/testdata/baselines/reference/tsbuild/commandLine/emitDeclarationOnly-on-commandline.js
+++ b/testdata/baselines/reference/tsbuild/commandLine/emitDeclarationOnly-on-commandline.js
@@ -500,7 +500,7 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project 'project1/src/tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Project 'project2/src/tsconfig.json' is out of date because output 'project2/src/tsconfig.tsbuildinfo' is older than input 'project1/src'
+[[90mHH:MM:SS AM[0m] Project 'project2/src/tsconfig.json' is out of date because output 'project2/src/tsconfig.tsbuildinfo' is older than input 'project1/src/a.d.ts'
 
 [[90mHH:MM:SS AM[0m] Building project 'project2/src/tsconfig.json'...
 
@@ -1329,7 +1329,7 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project 'project1/src/tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Project 'project2/src/tsconfig.json' is out of date because output 'project2/src/tsconfig.tsbuildinfo' is older than input 'project1/src'
+[[90mHH:MM:SS AM[0m] Project 'project2/src/tsconfig.json' is out of date because output 'project2/src/tsconfig.tsbuildinfo' is older than input 'project1/src/b.d.ts'
 
 [[90mHH:MM:SS AM[0m] Building project 'project2/src/tsconfig.json'...
 

--- a/testdata/baselines/reference/tsbuild/declarationEmit/reports-dts-generation-errors-with-incremental.js
+++ b/testdata/baselines/reference/tsbuild/declarationEmit/reports-dts-generation-errors-with-incremental.js
@@ -89,7 +89,7 @@ import ky from 'ky';
 export const api = ky.extend({});
 
 //// [/home/src/workspaces/project/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","root":[3],"fileNames":["lib.es2025.full.d.ts","./node_modules/ky/distribution/index.d.ts","./index.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"b9b50c37c18e43d94b0dd4fb43967f10-type KyInstance = {\n    extend(options: Record<string,unknown>): KyInstance;\n}\ndeclare const ky: KyInstance;\nexport default ky;","impliedNodeFormat":99},{"version":"0f5091e963c17913313e4969c59e6eb4-import ky from 'ky';\nexport const api = ky.extend({});","impliedNodeFormat":99}],"fileIdsList":[[2]],"options":{"composite":false,"declaration":true,"module":199,"skipLibCheck":true,"skipDefaultLibCheck":true},"referencedMap":[[3,1]],"emitDiagnosticsPerFile":[[3,[{"pos":34,"end":37,"code":4023,"category":1,"messageKey":"Exported_variable_0_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named_4023","messageArgs":["api","KyInstance","\"/home/src/workspaces/project/node_modules/ky/distribution/index\""]}]]]}
+{"version":"FakeTSVersion","root":[3],"fileNames":["lib.es2025.full.d.ts","./node_modules/ky/distribution/index.d.ts","./index.ts","./node_modules/ky/package.json","./package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"b9b50c37c18e43d94b0dd4fb43967f10-type KyInstance = {\n    extend(options: Record<string,unknown>): KyInstance;\n}\ndeclare const ky: KyInstance;\nexport default ky;","impliedNodeFormat":99},{"version":"0f5091e963c17913313e4969c59e6eb4-import ky from 'ky';\nexport const api = ky.extend({});","impliedNodeFormat":99}],"fileIdsList":[[2]],"options":{"composite":false,"declaration":true,"module":199,"skipLibCheck":true,"skipDefaultLibCheck":true},"referencedMap":[[3,1]],"emitDiagnosticsPerFile":[[3,[{"pos":34,"end":37,"code":4023,"category":1,"messageKey":"Exported_variable_0_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named_4023","messageArgs":["api","KyInstance","\"/home/src/workspaces/project/node_modules/ky/distribution/index\""]}]]],"packageJsonLookups":[[4,"bee3a88c1c92b0fd5be9ed3068366b12-{\n    \"name\": \"ky\",\n    \"type\": \"module\",\n    \"main\": \"./distribution/index.js\"\n}"],[5,"5e6623570a1a33021797cbd4e9eba0ae-{\n    \"type\": \"module\"\n}"]]}
 //// [/home/src/workspaces/project/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
@@ -104,7 +104,9 @@ export const api = ky.extend({});
   "fileNames": [
     "lib.es2025.full.d.ts",
     "./node_modules/ky/distribution/index.d.ts",
-    "./index.ts"
+    "./index.ts",
+    "./node_modules/ky/package.json",
+    "./package.json"
   ],
   "fileInfos": [
     {
@@ -176,7 +178,17 @@ export const api = ky.extend({});
       ]
     ]
   ],
-  "size": 1686
+  "packageJsonLookups": [
+    {
+      "fileName": "./node_modules/ky/package.json",
+      "version": "bee3a88c1c92b0fd5be9ed3068366b12-{\n    \"name\": \"ky\",\n    \"type\": \"module\",\n    \"main\": \"./distribution/index.js\"\n}"
+    },
+    {
+      "fileName": "./package.json",
+      "version": "5e6623570a1a33021797cbd4e9eba0ae-{\n    \"type\": \"module\"\n}"
+    }
+  ],
+  "size": 1966
 }
 
 tsconfig.json::

--- a/testdata/baselines/reference/tsbuild/declarationEmitForReferencedProjectTypesSubpath/declaration-emit-names-referenced-project-type-via-types-subpath.js
+++ b/testdata/baselines/reference/tsbuild/declarationEmitForReferencedProjectTypesSubpath/declaration-emit-names-referenced-project-type-via-types-subpath.js
@@ -107,7 +107,7 @@ interface Symbol {
 }
 declare const console: { log(msg: any): void; };
 //// [/home/src/workspaces/solution/packages/consumer/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","root":[5],"fileNames":["lib.es2025.full.d.ts","../dep/types/themes/componentTypes/formFieldLayout.d.ts","../dep/types/themes/componentTypes/index.d.ts","../dep/types/index.d.ts","./src/index.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"2265bb6aae4ea44359eda1a1333669d7-export type FormFieldLayout = {\n    textColor: string;\n    fontSize: string;\n};\nexport default FormFieldLayout;\n","262c77b15a9433c1a517a42af08dabc4-import type FormFieldLayout from \"./formFieldLayout.js\";\nexport type ComponentTypes = {\n    formFieldLayout: () => FormFieldLayout;\n};\n","8c960f82affa27b6eaa999ea3cdac3e7-import type { ComponentTypes as NewComponentTypes } from \"./themes/componentTypes/index.js\";\nexport type { NewComponentTypes };\n",{"version":"0eb11471bc41fb5a80fd0098368e8295-import type { NewComponentTypes } from \"@scope/dep\"\ndeclare const c: NewComponentTypes\nexport const style = c.formFieldLayout()","signature":"9cca47ad36e3ee3df7f98a27c15d37b0-export declare const style: import(\"@scope/dep/types/themes/componentTypes/formFieldLayout.js\").FormFieldLayout;\n","impliedNodeFormat":1}],"fileIdsList":[[4],[3],[2]],"options":{"composite":true,"emitDeclarationOnly":true,"declaration":true,"declarationDir":"./types","module":99,"outDir":"./types","rootDir":"./src","strict":true},"referencedMap":[[5,1],[4,2],[3,3]],"latestChangedDtsFile":"./types/index.d.ts"}
+{"version":"FakeTSVersion","root":[5],"fileNames":["lib.es2025.full.d.ts","../dep/types/themes/componentTypes/formFieldLayout.d.ts","../dep/types/themes/componentTypes/index.d.ts","../dep/types/index.d.ts","./src/index.ts","../../node_modules/@scope/dep/package.json","./package.json","../dep/package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"2265bb6aae4ea44359eda1a1333669d7-export type FormFieldLayout = {\n    textColor: string;\n    fontSize: string;\n};\nexport default FormFieldLayout;\n","262c77b15a9433c1a517a42af08dabc4-import type FormFieldLayout from \"./formFieldLayout.js\";\nexport type ComponentTypes = {\n    formFieldLayout: () => FormFieldLayout;\n};\n","8c960f82affa27b6eaa999ea3cdac3e7-import type { ComponentTypes as NewComponentTypes } from \"./themes/componentTypes/index.js\";\nexport type { NewComponentTypes };\n",{"version":"0eb11471bc41fb5a80fd0098368e8295-import type { NewComponentTypes } from \"@scope/dep\"\ndeclare const c: NewComponentTypes\nexport const style = c.formFieldLayout()","signature":"9cca47ad36e3ee3df7f98a27c15d37b0-export declare const style: import(\"@scope/dep/types/themes/componentTypes/formFieldLayout.js\").FormFieldLayout;\n","impliedNodeFormat":1}],"fileIdsList":[[4],[3],[2]],"options":{"composite":true,"emitDeclarationOnly":true,"declaration":true,"declarationDir":"./types","module":99,"outDir":"./types","rootDir":"./src","strict":true},"referencedMap":[[5,1],[4,2],[3,3]],"latestChangedDtsFile":"./types/index.d.ts","packageJsonLookups":[[6,"e3f45831f6620697ebe5b12473413a28-{\n    \"name\": \"@scope/dep\",\n    \"version\": \"1.0.0\",\n    \"exports\": {\n        \"./src/*\": \"./src/*\",\n        \"./types/*\": \"./types/*\",\n        \".\": { \"types\": \"./types/index.d.ts\", \"default\": \"./src/index.ts\" }\n    }\n}"],[7,"dd8ed07077b60e0e8c96ef40035d17c8-{\n    \"name\": \"@scope/consumer\",\n    \"version\": \"1.0.0\"\n}"],[8,"e3f45831f6620697ebe5b12473413a28-{\n    \"name\": \"@scope/dep\",\n    \"version\": \"1.0.0\",\n    \"exports\": {\n        \"./src/*\": \"./src/*\",\n        \"./types/*\": \"./types/*\",\n        \".\": { \"types\": \"./types/index.d.ts\", \"default\": \"./src/index.ts\" }\n    }\n}"]]}
 //// [/home/src/workspaces/solution/packages/consumer/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
@@ -124,7 +124,10 @@ declare const console: { log(msg: any): void; };
     "../dep/types/themes/componentTypes/formFieldLayout.d.ts",
     "../dep/types/themes/componentTypes/index.d.ts",
     "../dep/types/index.d.ts",
-    "./src/index.ts"
+    "./src/index.ts",
+    "../../node_modules/@scope/dep/package.json",
+    "./package.json",
+    "../dep/package.json"
   ],
   "fileInfos": [
     {
@@ -202,13 +205,27 @@ declare const console: { log(msg: any): void; };
     ]
   },
   "latestChangedDtsFile": "./types/index.d.ts",
-  "size": 2144
+  "packageJsonLookups": [
+    {
+      "fileName": "../../node_modules/@scope/dep/package.json",
+      "version": "e3f45831f6620697ebe5b12473413a28-{\n    \"name\": \"@scope/dep\",\n    \"version\": \"1.0.0\",\n    \"exports\": {\n        \"./src/*\": \"./src/*\",\n        \"./types/*\": \"./types/*\",\n        \".\": { \"types\": \"./types/index.d.ts\", \"default\": \"./src/index.ts\" }\n    }\n}"
+    },
+    {
+      "fileName": "./package.json",
+      "version": "dd8ed07077b60e0e8c96ef40035d17c8-{\n    \"name\": \"@scope/consumer\",\n    \"version\": \"1.0.0\"\n}"
+    },
+    {
+      "fileName": "../dep/package.json",
+      "version": "e3f45831f6620697ebe5b12473413a28-{\n    \"name\": \"@scope/dep\",\n    \"version\": \"1.0.0\",\n    \"exports\": {\n        \"./src/*\": \"./src/*\",\n        \"./types/*\": \"./types/*\",\n        \".\": { \"types\": \"./types/index.d.ts\", \"default\": \"./src/index.ts\" }\n    }\n}"
+    }
+  ],
+  "size": 2943
 }
 //// [/home/src/workspaces/solution/packages/consumer/types/index.d.ts] *new* 
 export declare const style: import("@scope/dep/types/themes/componentTypes/formFieldLayout.js").FormFieldLayout;
 
 //// [/home/src/workspaces/solution/packages/dep/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","root":[[2,4]],"fileNames":["lib.es2025.full.d.ts","./src/themes/componentTypes/formFieldLayout.ts","./src/themes/componentTypes/index.ts","./src/index.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"d384c9df99c755540ca5330780b4f5e5-export type FormFieldLayout = {\n    textColor: string\n    fontSize: string\n}\nexport default FormFieldLayout","signature":"2265bb6aae4ea44359eda1a1333669d7-export type FormFieldLayout = {\n    textColor: string;\n    fontSize: string;\n};\nexport default FormFieldLayout;\n","impliedNodeFormat":1},{"version":"7e5adf3645b6325e5ba90d41821e4802-import type FormFieldLayout from \"./formFieldLayout.js\"\nexport type ComponentTypes = {\n    formFieldLayout: () => FormFieldLayout\n}","signature":"262c77b15a9433c1a517a42af08dabc4-import type FormFieldLayout from \"./formFieldLayout.js\";\nexport type ComponentTypes = {\n    formFieldLayout: () => FormFieldLayout;\n};\n","impliedNodeFormat":1},{"version":"aac956f8322a5530cde691c46bad3b7d-import type { ComponentTypes as NewComponentTypes } from \"./themes/componentTypes/index.js\"\nexport type { NewComponentTypes }","signature":"8c960f82affa27b6eaa999ea3cdac3e7-import type { ComponentTypes as NewComponentTypes } from \"./themes/componentTypes/index.js\";\nexport type { NewComponentTypes };\n","impliedNodeFormat":1}],"fileIdsList":[[3],[2]],"options":{"composite":true,"emitDeclarationOnly":true,"declaration":true,"declarationDir":"./types","module":99,"outDir":"./types","rootDir":"./src","strict":true},"referencedMap":[[4,1],[3,2]],"latestChangedDtsFile":"./types/index.d.ts"}
+{"version":"FakeTSVersion","root":[[2,4]],"fileNames":["lib.es2025.full.d.ts","./src/themes/componentTypes/formFieldLayout.ts","./src/themes/componentTypes/index.ts","./src/index.ts","./package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"d384c9df99c755540ca5330780b4f5e5-export type FormFieldLayout = {\n    textColor: string\n    fontSize: string\n}\nexport default FormFieldLayout","signature":"2265bb6aae4ea44359eda1a1333669d7-export type FormFieldLayout = {\n    textColor: string;\n    fontSize: string;\n};\nexport default FormFieldLayout;\n","impliedNodeFormat":1},{"version":"7e5adf3645b6325e5ba90d41821e4802-import type FormFieldLayout from \"./formFieldLayout.js\"\nexport type ComponentTypes = {\n    formFieldLayout: () => FormFieldLayout\n}","signature":"262c77b15a9433c1a517a42af08dabc4-import type FormFieldLayout from \"./formFieldLayout.js\";\nexport type ComponentTypes = {\n    formFieldLayout: () => FormFieldLayout;\n};\n","impliedNodeFormat":1},{"version":"aac956f8322a5530cde691c46bad3b7d-import type { ComponentTypes as NewComponentTypes } from \"./themes/componentTypes/index.js\"\nexport type { NewComponentTypes }","signature":"8c960f82affa27b6eaa999ea3cdac3e7-import type { ComponentTypes as NewComponentTypes } from \"./themes/componentTypes/index.js\";\nexport type { NewComponentTypes };\n","impliedNodeFormat":1}],"fileIdsList":[[3],[2]],"options":{"composite":true,"emitDeclarationOnly":true,"declaration":true,"declarationDir":"./types","module":99,"outDir":"./types","rootDir":"./src","strict":true},"referencedMap":[[4,1],[3,2]],"latestChangedDtsFile":"./types/index.d.ts","packageJsonLookups":[[5,"e3f45831f6620697ebe5b12473413a28-{\n    \"name\": \"@scope/dep\",\n    \"version\": \"1.0.0\",\n    \"exports\": {\n        \"./src/*\": \"./src/*\",\n        \"./types/*\": \"./types/*\",\n        \".\": { \"types\": \"./types/index.d.ts\", \"default\": \"./src/index.ts\" }\n    }\n}"]]}
 //// [/home/src/workspaces/solution/packages/dep/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
@@ -229,7 +246,8 @@ export declare const style: import("@scope/dep/types/themes/componentTypes/formF
     "lib.es2025.full.d.ts",
     "./src/themes/componentTypes/formFieldLayout.ts",
     "./src/themes/componentTypes/index.ts",
-    "./src/index.ts"
+    "./src/index.ts",
+    "./package.json"
   ],
   "fileInfos": [
     {
@@ -305,7 +323,13 @@ export declare const style: import("@scope/dep/types/themes/componentTypes/formF
     ]
   },
   "latestChangedDtsFile": "./types/index.d.ts",
-  "size": 2350
+  "packageJsonLookups": [
+    {
+      "fileName": "./package.json",
+      "version": "e3f45831f6620697ebe5b12473413a28-{\n    \"name\": \"@scope/dep\",\n    \"version\": \"1.0.0\",\n    \"exports\": {\n        \"./src/*\": \"./src/*\",\n        \"./types/*\": \"./types/*\",\n        \".\": { \"types\": \"./types/index.d.ts\", \"default\": \"./src/index.ts\" }\n    }\n}"
+    }
+  ],
+  "size": 2682
 }
 //// [/home/src/workspaces/solution/packages/dep/types/index.d.ts] *new* 
 import type { ComponentTypes as NewComponentTypes } from "./themes/componentTypes/index.js";

--- a/testdata/baselines/reference/tsbuild/dependencyUpdate/rebuilds-when-absolute-non-root-dependency-is-updated.js
+++ b/testdata/baselines/reference/tsbuild/dependencyUpdate/rebuilds-when-absolute-non-root-dependency-is-updated.js
@@ -1,0 +1,254 @@
+currentDirectory::C:/work/project
+useCaseSensitiveFileNames::false
+Input::
+//// [C:/work/project/src/index.ts] *new* 
+import { myValue } from "abs-dep";
+export const value: string = myValue;
+//// [C:/work/project/tsconfig.json] *new* 
+{
+    "compilerOptions": {
+        "composite": true,
+        "outDir": "dist",
+        "paths": {
+            "abs-dep": ["D:/deps/dep.d.ts"]
+        },
+        "strict": true
+    },
+    "include": ["src/**/*"]
+}
+//// [D:/deps/dep.d.ts] *new* 
+export declare const myValue: string;
+
+tsgo --b --verbose
+ExitStatus:: Success
+Output::
+[[90mHH:MM:SS AM[0m] Projects in this build: 
+    * tsconfig.json
+
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output file 'dist/tsconfig.tsbuildinfo' does not exist
+
+[[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
+
+//// [C:/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts] *Lib*
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+interface SymbolConstructor {
+    (desc?: string | number): symbol;
+    for(name: string): symbol;
+    readonly toStringTag: symbol;
+}
+declare var Symbol: SymbolConstructor;
+interface Symbol {
+    readonly [Symbol.toStringTag]: string;
+}
+declare const console: { log(msg: any): void; };
+//// [C:/work/project/dist/src/index.d.ts] *new* 
+export declare const value: string;
+
+//// [C:/work/project/dist/src/index.js] *new* 
+import { myValue } from "abs-dep";
+export const value = myValue;
+
+//// [C:/work/project/dist/tsconfig.tsbuildinfo] *new* 
+{"version":"FakeTSVersion","root":[3],"fileNames":["lib.es2025.full.d.ts","d:/deps/dep.d.ts","../src/index.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"4384f7716e1c7cc875e39624007cccc9-export declare const myValue: string;",{"version":"6c77917c7b17b3698cb1dbdb7227fbff-import { myValue } from \"abs-dep\";\nexport const value: string = myValue;","signature":"d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./","strict":true},"referencedMap":[[3,1]],"latestChangedDtsFile":"./src/index.d.ts"}
+//// [C:/work/project/dist/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
+{
+  "version": "FakeTSVersion",
+  "root": [
+    {
+      "files": [
+        "../src/index.ts"
+      ],
+      "original": 3
+    }
+  ],
+  "fileNames": [
+    "lib.es2025.full.d.ts",
+    "d:/deps/dep.d.ts",
+    "../src/index.ts"
+  ],
+  "fileInfos": [
+    {
+      "fileName": "lib.es2025.full.d.ts",
+      "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "signature": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "affectsGlobalScope": true,
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true,
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "d:/deps/dep.d.ts",
+      "version": "4384f7716e1c7cc875e39624007cccc9-export declare const myValue: string;",
+      "signature": "4384f7716e1c7cc875e39624007cccc9-export declare const myValue: string;",
+      "impliedNodeFormat": "CommonJS"
+    },
+    {
+      "fileName": "../src/index.ts",
+      "version": "6c77917c7b17b3698cb1dbdb7227fbff-import { myValue } from \"abs-dep\";\nexport const value: string = myValue;",
+      "signature": "d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "6c77917c7b17b3698cb1dbdb7227fbff-import { myValue } from \"abs-dep\";\nexport const value: string = myValue;",
+        "signature": "d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n",
+        "impliedNodeFormat": 1
+      }
+    }
+  ],
+  "fileIdsList": [
+    [
+      "d:/deps/dep.d.ts"
+    ]
+  ],
+  "options": {
+    "composite": true,
+    "outDir": "./",
+    "strict": true
+  },
+  "referencedMap": {
+    "../src/index.ts": [
+      "d:/deps/dep.d.ts"
+    ]
+  },
+  "latestChangedDtsFile": "./src/index.d.ts",
+  "size": 1342
+}
+
+tsconfig.json::
+SemanticDiagnostics::
+*refresh*    C:/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
+*refresh*    D:/deps/dep.d.ts
+*refresh*    C:/work/project/src/index.ts
+Signatures::
+(stored at emit) C:/work/project/src/index.ts
+
+
+Edit [0]:: update absolute non-root dependency with breaking type change
+//// [D:/deps/dep.d.ts] *modified* 
+export declare const myValue: number;
+
+tsgo --b --verbose
+ExitStatus:: DiagnosticsPresent_OutputsGenerated
+Output::
+[[90mHH:MM:SS AM[0m] Projects in this build: 
+    * tsconfig.json
+
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output 'dist/tsconfig.tsbuildinfo' is older than input 'd:/deps/dep.d.ts'
+
+[[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
+
+[96msrc/index.ts[0m:[93m2[0m:[93m14[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
+
+[7m2[0m export const value: string = myValue;
+[7m [0m [91m             ~~~~~[0m
+
+
+Found 1 error in src/index.ts[90m:2[0m
+
+//// [C:/work/project/dist/src/index.js] *rewrite with same content*
+//// [C:/work/project/dist/tsconfig.tsbuildinfo] *modified* 
+{"version":"FakeTSVersion","root":[3],"fileNames":["lib.es2025.full.d.ts","d:/deps/dep.d.ts","../src/index.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"936f1acf4d15f440cdb2eb27f80fb9c9-export declare const myValue: number;",{"version":"6c77917c7b17b3698cb1dbdb7227fbff-import { myValue } from \"abs-dep\";\nexport const value: string = myValue;","signature":"d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./","strict":true},"referencedMap":[[3,1]],"semanticDiagnosticsPerFile":[[3,[{"pos":48,"end":53,"code":2322,"category":1,"messageKey":"Type_0_is_not_assignable_to_type_1_2322","messageArgs":["number","string"]}]]],"latestChangedDtsFile":"./src/index.d.ts"}
+//// [C:/work/project/dist/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
+{
+  "version": "FakeTSVersion",
+  "root": [
+    {
+      "files": [
+        "../src/index.ts"
+      ],
+      "original": 3
+    }
+  ],
+  "fileNames": [
+    "lib.es2025.full.d.ts",
+    "d:/deps/dep.d.ts",
+    "../src/index.ts"
+  ],
+  "fileInfos": [
+    {
+      "fileName": "lib.es2025.full.d.ts",
+      "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "signature": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "affectsGlobalScope": true,
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true,
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "d:/deps/dep.d.ts",
+      "version": "936f1acf4d15f440cdb2eb27f80fb9c9-export declare const myValue: number;",
+      "signature": "936f1acf4d15f440cdb2eb27f80fb9c9-export declare const myValue: number;",
+      "impliedNodeFormat": "CommonJS"
+    },
+    {
+      "fileName": "../src/index.ts",
+      "version": "6c77917c7b17b3698cb1dbdb7227fbff-import { myValue } from \"abs-dep\";\nexport const value: string = myValue;",
+      "signature": "d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "6c77917c7b17b3698cb1dbdb7227fbff-import { myValue } from \"abs-dep\";\nexport const value: string = myValue;",
+        "signature": "d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n",
+        "impliedNodeFormat": 1
+      }
+    }
+  ],
+  "fileIdsList": [
+    [
+      "d:/deps/dep.d.ts"
+    ]
+  ],
+  "options": {
+    "composite": true,
+    "outDir": "./",
+    "strict": true
+  },
+  "referencedMap": {
+    "../src/index.ts": [
+      "d:/deps/dep.d.ts"
+    ]
+  },
+  "semanticDiagnosticsPerFile": [
+    [
+      "../src/index.ts",
+      [
+        {
+          "pos": 48,
+          "end": 53,
+          "code": 2322,
+          "category": 1,
+          "messageKey": "Type_0_is_not_assignable_to_type_1_2322",
+          "messageArgs": [
+            "number",
+            "string"
+          ]
+        }
+      ]
+    ]
+  ],
+  "latestChangedDtsFile": "./src/index.d.ts",
+  "size": 1513
+}
+
+tsconfig.json::
+SemanticDiagnostics::
+*refresh*    D:/deps/dep.d.ts
+*refresh*    C:/work/project/src/index.ts
+Signatures::
+(used version)   D:/deps/dep.d.ts
+(computed .d.ts) C:/work/project/src/index.ts

--- a/testdata/baselines/reference/tsbuild/dependencyUpdate/rebuilds-when-dependency-in-node_modules-is-updated.js
+++ b/testdata/baselines/reference/tsbuild/dependencyUpdate/rebuilds-when-dependency-in-node_modules-is-updated.js
@@ -63,7 +63,7 @@ import { myValue } from "my-dep";
 export const value = myValue;
 
 //// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","root":[3],"fileNames":["lib.es2025.full.d.ts","../node_modules/my-dep/index.d.ts","../src/index.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"4384f7716e1c7cc875e39624007cccc9-export declare const myValue: string;",{"version":"bae961fec80482368db43a089f169190-import { myValue } from \"my-dep\";\nexport const value: string = myValue;","signature":"d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./","strict":true},"referencedMap":[[3,1]],"latestChangedDtsFile":"./src/index.d.ts"}
+{"version":"FakeTSVersion","root":[3],"fileNames":["lib.es2025.full.d.ts","../node_modules/my-dep/index.d.ts","../src/index.ts","../node_modules/my-dep/package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"4384f7716e1c7cc875e39624007cccc9-export declare const myValue: string;",{"version":"bae961fec80482368db43a089f169190-import { myValue } from \"my-dep\";\nexport const value: string = myValue;","signature":"d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./","strict":true},"referencedMap":[[3,1]],"latestChangedDtsFile":"./src/index.d.ts","packageJsonLookups":[[4,"d8e79ef61801fbfe984887743ca01938-{\n    \"name\": \"my-dep\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\"\n}"]]}
 //// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
@@ -78,7 +78,8 @@ export const value = myValue;
   "fileNames": [
     "lib.es2025.full.d.ts",
     "../node_modules/my-dep/index.d.ts",
-    "../src/index.ts"
+    "../src/index.ts",
+    "../node_modules/my-dep/package.json"
   ],
   "fileInfos": [
     {
@@ -127,7 +128,13 @@ export const value = myValue;
     ]
   },
   "latestChangedDtsFile": "./src/index.d.ts",
-  "size": 1358
+  "packageJsonLookups": [
+    {
+      "fileName": "../node_modules/my-dep/package.json",
+      "version": "d8e79ef61801fbfe984887743ca01938-{\n    \"name\": \"my-dep\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\"\n}"
+    }
+  ],
+  "size": 1550
 }
 
 tsconfig.json::
@@ -176,7 +183,7 @@ Found 1 error in src/index.ts[90m:2[0m
 
 //// [/home/src/workspaces/project/dist/src/index.js] *rewrite with same content*
 //// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo] *modified* 
-{"version":"FakeTSVersion","root":[3],"fileNames":["lib.es2025.full.d.ts","../node_modules/my-dep/index.d.ts","../src/index.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"936f1acf4d15f440cdb2eb27f80fb9c9-export declare const myValue: number;",{"version":"bae961fec80482368db43a089f169190-import { myValue } from \"my-dep\";\nexport const value: string = myValue;","signature":"d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./","strict":true},"referencedMap":[[3,1]],"semanticDiagnosticsPerFile":[[3,[{"pos":47,"end":52,"code":2322,"category":1,"messageKey":"Type_0_is_not_assignable_to_type_1_2322","messageArgs":["number","string"]}]]],"latestChangedDtsFile":"./src/index.d.ts"}
+{"version":"FakeTSVersion","root":[3],"fileNames":["lib.es2025.full.d.ts","../node_modules/my-dep/index.d.ts","../src/index.ts","../node_modules/my-dep/package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"936f1acf4d15f440cdb2eb27f80fb9c9-export declare const myValue: number;",{"version":"bae961fec80482368db43a089f169190-import { myValue } from \"my-dep\";\nexport const value: string = myValue;","signature":"d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./","strict":true},"referencedMap":[[3,1]],"semanticDiagnosticsPerFile":[[3,[{"pos":47,"end":52,"code":2322,"category":1,"messageKey":"Type_0_is_not_assignable_to_type_1_2322","messageArgs":["number","string"]}]]],"latestChangedDtsFile":"./src/index.d.ts","packageJsonLookups":[[4,"d8e79ef61801fbfe984887743ca01938-{\n    \"name\": \"my-dep\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\"\n}"]]}
 //// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
 {
   "version": "FakeTSVersion",
@@ -191,7 +198,8 @@ Found 1 error in src/index.ts[90m:2[0m
   "fileNames": [
     "lib.es2025.full.d.ts",
     "../node_modules/my-dep/index.d.ts",
-    "../src/index.ts"
+    "../src/index.ts",
+    "../node_modules/my-dep/package.json"
   ],
   "fileInfos": [
     {
@@ -258,7 +266,13 @@ Found 1 error in src/index.ts[90m:2[0m
     ]
   ],
   "latestChangedDtsFile": "./src/index.d.ts",
-  "size": 1529
+  "packageJsonLookups": [
+    {
+      "fileName": "../node_modules/my-dep/package.json",
+      "version": "d8e79ef61801fbfe984887743ca01938-{\n    \"name\": \"my-dep\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\"\n}"
+    }
+  ],
+  "size": 1721
 }
 
 tsconfig.json::
@@ -286,7 +300,7 @@ Output::
 
 //// [/home/src/workspaces/project/dist/src/index.js] *rewrite with same content*
 //// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo] *modified* 
-{"version":"FakeTSVersion","root":[3],"fileNames":["lib.es2025.full.d.ts","../node_modules/my-dep/index.d.ts","../src/index.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"4384f7716e1c7cc875e39624007cccc9-export declare const myValue: string;",{"version":"bae961fec80482368db43a089f169190-import { myValue } from \"my-dep\";\nexport const value: string = myValue;","signature":"d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./","strict":true},"referencedMap":[[3,1]],"latestChangedDtsFile":"./src/index.d.ts"}
+{"version":"FakeTSVersion","root":[3],"fileNames":["lib.es2025.full.d.ts","../node_modules/my-dep/index.d.ts","../src/index.ts","../node_modules/my-dep/package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"4384f7716e1c7cc875e39624007cccc9-export declare const myValue: string;",{"version":"bae961fec80482368db43a089f169190-import { myValue } from \"my-dep\";\nexport const value: string = myValue;","signature":"d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./","strict":true},"referencedMap":[[3,1]],"latestChangedDtsFile":"./src/index.d.ts","packageJsonLookups":[[4,"d8e79ef61801fbfe984887743ca01938-{\n    \"name\": \"my-dep\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\"\n}"]]}
 //// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
 {
   "version": "FakeTSVersion",
@@ -301,7 +315,8 @@ Output::
   "fileNames": [
     "lib.es2025.full.d.ts",
     "../node_modules/my-dep/index.d.ts",
-    "../src/index.ts"
+    "../src/index.ts",
+    "../node_modules/my-dep/package.json"
   ],
   "fileInfos": [
     {
@@ -350,7 +365,13 @@ Output::
     ]
   },
   "latestChangedDtsFile": "./src/index.d.ts",
-  "size": 1358
+  "packageJsonLookups": [
+    {
+      "fileName": "../node_modules/my-dep/package.json",
+      "version": "d8e79ef61801fbfe984887743ca01938-{\n    \"name\": \"my-dep\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\"\n}"
+    }
+  ],
+  "size": 1550
 }
 
 tsconfig.json::
@@ -415,7 +436,7 @@ Found 1 error in src/index.ts[90m:1[0m
 
 //// [/home/src/workspaces/project/dist/src/index.js] *rewrite with same content*
 //// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo] *modified* 
-{"version":"FakeTSVersion","root":[2],"fileNames":["lib.es2025.full.d.ts","../src/index.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"bae961fec80482368db43a089f169190-import { myValue } from \"my-dep\";\nexport const value: string = myValue;","signature":"d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n","impliedNodeFormat":1}],"options":{"composite":true,"outDir":"./","strict":true},"semanticDiagnosticsPerFile":[[2,[{"pos":24,"end":32,"code":2307,"category":1,"messageKey":"Cannot_find_module_0_or_its_corresponding_type_declarations_2307","messageArgs":["my-dep"]}]]],"latestChangedDtsFile":"./src/index.d.ts"}
+{"version":"FakeTSVersion","root":[2],"fileNames":["lib.es2025.full.d.ts","../src/index.ts","../node_modules/my-dep/package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"bae961fec80482368db43a089f169190-import { myValue } from \"my-dep\";\nexport const value: string = myValue;","signature":"d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n","impliedNodeFormat":1}],"options":{"composite":true,"outDir":"./","strict":true},"semanticDiagnosticsPerFile":[[2,[{"pos":24,"end":32,"code":2307,"category":1,"messageKey":"Cannot_find_module_0_or_its_corresponding_type_declarations_2307","messageArgs":["my-dep"]}]]],"latestChangedDtsFile":"./src/index.d.ts","packageJsonLookups":[[3,"d8e79ef61801fbfe984887743ca01938-{\n    \"name\": \"my-dep\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\"\n}"]]}
 //// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
 {
   "version": "FakeTSVersion",
@@ -429,7 +450,8 @@ Found 1 error in src/index.ts[90m:1[0m
   ],
   "fileNames": [
     "lib.es2025.full.d.ts",
-    "../src/index.ts"
+    "../src/index.ts",
+    "../node_modules/my-dep/package.json"
   ],
   "fileInfos": [
     {
@@ -479,7 +501,13 @@ Found 1 error in src/index.ts[90m:1[0m
     ]
   ],
   "latestChangedDtsFile": "./src/index.d.ts",
-  "size": 1392
+  "packageJsonLookups": [
+    {
+      "fileName": "../node_modules/my-dep/package.json",
+      "version": "d8e79ef61801fbfe984887743ca01938-{\n    \"name\": \"my-dep\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\"\n}"
+    }
+  ],
+  "size": 1584
 }
 
 tsconfig.json::

--- a/testdata/baselines/reference/tsbuild/dependencyUpdate/rebuilds-when-dependency-in-node_modules-is-updated.js
+++ b/testdata/baselines/reference/tsbuild/dependencyUpdate/rebuilds-when-dependency-in-node_modules-is-updated.js
@@ -1,0 +1,489 @@
+currentDirectory::/home/src/workspaces/project
+useCaseSensitiveFileNames::true
+Input::
+//// [/home/src/workspaces/project/node_modules/my-dep/index.d.ts] *new* 
+export declare const myValue: string;
+//// [/home/src/workspaces/project/node_modules/my-dep/package.json] *new* 
+{
+    "name": "my-dep",
+    "version": "1.0.0",
+    "types": "index.d.ts"
+}
+//// [/home/src/workspaces/project/src/index.ts] *new* 
+import { myValue } from "my-dep";
+export const value: string = myValue;
+//// [/home/src/workspaces/project/tsconfig.json] *new* 
+{
+    "compilerOptions": {
+        "composite": true,
+        "outDir": "dist",
+        "strict": true
+    },
+    "include": ["src/**/*"]
+}
+
+tsgo --b --verbose
+ExitStatus:: Success
+Output::
+[[90mHH:MM:SS AM[0m] Projects in this build: 
+    * tsconfig.json
+
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output file 'dist/tsconfig.tsbuildinfo' does not exist
+
+[[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
+
+//// [/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts] *Lib*
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+interface SymbolConstructor {
+    (desc?: string | number): symbol;
+    for(name: string): symbol;
+    readonly toStringTag: symbol;
+}
+declare var Symbol: SymbolConstructor;
+interface Symbol {
+    readonly [Symbol.toStringTag]: string;
+}
+declare const console: { log(msg: any): void; };
+//// [/home/src/workspaces/project/dist/src/index.d.ts] *new* 
+export declare const value: string;
+
+//// [/home/src/workspaces/project/dist/src/index.js] *new* 
+import { myValue } from "my-dep";
+export const value = myValue;
+
+//// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo] *new* 
+{"version":"FakeTSVersion","root":[3],"fileNames":["lib.es2025.full.d.ts","../node_modules/my-dep/index.d.ts","../src/index.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"4384f7716e1c7cc875e39624007cccc9-export declare const myValue: string;",{"version":"bae961fec80482368db43a089f169190-import { myValue } from \"my-dep\";\nexport const value: string = myValue;","signature":"d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./","strict":true},"referencedMap":[[3,1]],"latestChangedDtsFile":"./src/index.d.ts"}
+//// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
+{
+  "version": "FakeTSVersion",
+  "root": [
+    {
+      "files": [
+        "../src/index.ts"
+      ],
+      "original": 3
+    }
+  ],
+  "fileNames": [
+    "lib.es2025.full.d.ts",
+    "../node_modules/my-dep/index.d.ts",
+    "../src/index.ts"
+  ],
+  "fileInfos": [
+    {
+      "fileName": "lib.es2025.full.d.ts",
+      "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "signature": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "affectsGlobalScope": true,
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true,
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "../node_modules/my-dep/index.d.ts",
+      "version": "4384f7716e1c7cc875e39624007cccc9-export declare const myValue: string;",
+      "signature": "4384f7716e1c7cc875e39624007cccc9-export declare const myValue: string;",
+      "impliedNodeFormat": "CommonJS"
+    },
+    {
+      "fileName": "../src/index.ts",
+      "version": "bae961fec80482368db43a089f169190-import { myValue } from \"my-dep\";\nexport const value: string = myValue;",
+      "signature": "d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "bae961fec80482368db43a089f169190-import { myValue } from \"my-dep\";\nexport const value: string = myValue;",
+        "signature": "d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n",
+        "impliedNodeFormat": 1
+      }
+    }
+  ],
+  "fileIdsList": [
+    [
+      "../node_modules/my-dep/index.d.ts"
+    ]
+  ],
+  "options": {
+    "composite": true,
+    "outDir": "./",
+    "strict": true
+  },
+  "referencedMap": {
+    "../src/index.ts": [
+      "../node_modules/my-dep/index.d.ts"
+    ]
+  },
+  "latestChangedDtsFile": "./src/index.d.ts",
+  "size": 1358
+}
+
+tsconfig.json::
+SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
+*refresh*    /home/src/workspaces/project/node_modules/my-dep/index.d.ts
+*refresh*    /home/src/workspaces/project/src/index.ts
+Signatures::
+(stored at emit) /home/src/workspaces/project/src/index.ts
+
+
+Edit [0]:: no change
+
+tsgo --b --verbose
+ExitStatus:: Success
+Output::
+[[90mHH:MM:SS AM[0m] Projects in this build: 
+    * tsconfig.json
+
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is up to date because newest input 'src/index.ts' is older than output 'dist/tsconfig.tsbuildinfo'
+
+
+
+
+Edit [1]:: update dependency d.ts with breaking type change
+//// [/home/src/workspaces/project/node_modules/my-dep/index.d.ts] *modified* 
+export declare const myValue: number;
+
+tsgo --b --verbose
+ExitStatus:: DiagnosticsPresent_OutputsGenerated
+Output::
+[[90mHH:MM:SS AM[0m] Projects in this build: 
+    * tsconfig.json
+
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output 'dist/tsconfig.tsbuildinfo' is older than input 'node_modules/my-dep/index.d.ts'
+
+[[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
+
+[96msrc/index.ts[0m:[93m2[0m:[93m14[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
+
+[7m2[0m export const value: string = myValue;
+[7m [0m [91m             ~~~~~[0m
+
+
+Found 1 error in src/index.ts[90m:2[0m
+
+//// [/home/src/workspaces/project/dist/src/index.js] *rewrite with same content*
+//// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo] *modified* 
+{"version":"FakeTSVersion","root":[3],"fileNames":["lib.es2025.full.d.ts","../node_modules/my-dep/index.d.ts","../src/index.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"936f1acf4d15f440cdb2eb27f80fb9c9-export declare const myValue: number;",{"version":"bae961fec80482368db43a089f169190-import { myValue } from \"my-dep\";\nexport const value: string = myValue;","signature":"d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./","strict":true},"referencedMap":[[3,1]],"semanticDiagnosticsPerFile":[[3,[{"pos":47,"end":52,"code":2322,"category":1,"messageKey":"Type_0_is_not_assignable_to_type_1_2322","messageArgs":["number","string"]}]]],"latestChangedDtsFile":"./src/index.d.ts"}
+//// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
+{
+  "version": "FakeTSVersion",
+  "root": [
+    {
+      "files": [
+        "../src/index.ts"
+      ],
+      "original": 3
+    }
+  ],
+  "fileNames": [
+    "lib.es2025.full.d.ts",
+    "../node_modules/my-dep/index.d.ts",
+    "../src/index.ts"
+  ],
+  "fileInfos": [
+    {
+      "fileName": "lib.es2025.full.d.ts",
+      "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "signature": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "affectsGlobalScope": true,
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true,
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "../node_modules/my-dep/index.d.ts",
+      "version": "936f1acf4d15f440cdb2eb27f80fb9c9-export declare const myValue: number;",
+      "signature": "936f1acf4d15f440cdb2eb27f80fb9c9-export declare const myValue: number;",
+      "impliedNodeFormat": "CommonJS"
+    },
+    {
+      "fileName": "../src/index.ts",
+      "version": "bae961fec80482368db43a089f169190-import { myValue } from \"my-dep\";\nexport const value: string = myValue;",
+      "signature": "d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "bae961fec80482368db43a089f169190-import { myValue } from \"my-dep\";\nexport const value: string = myValue;",
+        "signature": "d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n",
+        "impliedNodeFormat": 1
+      }
+    }
+  ],
+  "fileIdsList": [
+    [
+      "../node_modules/my-dep/index.d.ts"
+    ]
+  ],
+  "options": {
+    "composite": true,
+    "outDir": "./",
+    "strict": true
+  },
+  "referencedMap": {
+    "../src/index.ts": [
+      "../node_modules/my-dep/index.d.ts"
+    ]
+  },
+  "semanticDiagnosticsPerFile": [
+    [
+      "../src/index.ts",
+      [
+        {
+          "pos": 47,
+          "end": 52,
+          "code": 2322,
+          "category": 1,
+          "messageKey": "Type_0_is_not_assignable_to_type_1_2322",
+          "messageArgs": [
+            "number",
+            "string"
+          ]
+        }
+      ]
+    ]
+  ],
+  "latestChangedDtsFile": "./src/index.d.ts",
+  "size": 1529
+}
+
+tsconfig.json::
+SemanticDiagnostics::
+*refresh*    /home/src/workspaces/project/node_modules/my-dep/index.d.ts
+*refresh*    /home/src/workspaces/project/src/index.ts
+Signatures::
+(used version)   /home/src/workspaces/project/node_modules/my-dep/index.d.ts
+(computed .d.ts) /home/src/workspaces/project/src/index.ts
+
+
+Edit [2]:: restore dependency d.ts
+//// [/home/src/workspaces/project/node_modules/my-dep/index.d.ts] *modified* 
+export declare const myValue: string;
+
+tsgo --b --verbose
+ExitStatus:: Success
+Output::
+[[90mHH:MM:SS AM[0m] Projects in this build: 
+    * tsconfig.json
+
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because buildinfo file 'dist/tsconfig.tsbuildinfo' indicates that program needs to report errors.
+
+[[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
+
+//// [/home/src/workspaces/project/dist/src/index.js] *rewrite with same content*
+//// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo] *modified* 
+{"version":"FakeTSVersion","root":[3],"fileNames":["lib.es2025.full.d.ts","../node_modules/my-dep/index.d.ts","../src/index.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"4384f7716e1c7cc875e39624007cccc9-export declare const myValue: string;",{"version":"bae961fec80482368db43a089f169190-import { myValue } from \"my-dep\";\nexport const value: string = myValue;","signature":"d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./","strict":true},"referencedMap":[[3,1]],"latestChangedDtsFile":"./src/index.d.ts"}
+//// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
+{
+  "version": "FakeTSVersion",
+  "root": [
+    {
+      "files": [
+        "../src/index.ts"
+      ],
+      "original": 3
+    }
+  ],
+  "fileNames": [
+    "lib.es2025.full.d.ts",
+    "../node_modules/my-dep/index.d.ts",
+    "../src/index.ts"
+  ],
+  "fileInfos": [
+    {
+      "fileName": "lib.es2025.full.d.ts",
+      "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "signature": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "affectsGlobalScope": true,
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true,
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "../node_modules/my-dep/index.d.ts",
+      "version": "4384f7716e1c7cc875e39624007cccc9-export declare const myValue: string;",
+      "signature": "4384f7716e1c7cc875e39624007cccc9-export declare const myValue: string;",
+      "impliedNodeFormat": "CommonJS"
+    },
+    {
+      "fileName": "../src/index.ts",
+      "version": "bae961fec80482368db43a089f169190-import { myValue } from \"my-dep\";\nexport const value: string = myValue;",
+      "signature": "d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "bae961fec80482368db43a089f169190-import { myValue } from \"my-dep\";\nexport const value: string = myValue;",
+        "signature": "d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n",
+        "impliedNodeFormat": 1
+      }
+    }
+  ],
+  "fileIdsList": [
+    [
+      "../node_modules/my-dep/index.d.ts"
+    ]
+  ],
+  "options": {
+    "composite": true,
+    "outDir": "./",
+    "strict": true
+  },
+  "referencedMap": {
+    "../src/index.ts": [
+      "../node_modules/my-dep/index.d.ts"
+    ]
+  },
+  "latestChangedDtsFile": "./src/index.d.ts",
+  "size": 1358
+}
+
+tsconfig.json::
+SemanticDiagnostics::
+*refresh*    /home/src/workspaces/project/node_modules/my-dep/index.d.ts
+*refresh*    /home/src/workspaces/project/src/index.ts
+Signatures::
+(used version)   /home/src/workspaces/project/node_modules/my-dep/index.d.ts
+(computed .d.ts) /home/src/workspaces/project/src/index.ts
+
+
+Edit [3]:: update dependency d.ts timestamp without changing text
+//// [/home/src/workspaces/project/node_modules/my-dep/index.d.ts] *mTime changed*
+
+tsgo --b --verbose
+ExitStatus:: Success
+Output::
+[[90mHH:MM:SS AM[0m] Projects in this build: 
+    * tsconfig.json
+
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is up to date but needs to update timestamps of output files that are older than input files
+
+[[90mHH:MM:SS AM[0m] Updating output timestamps of project 'tsconfig.json'...
+
+//// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo] *mTime changed*
+
+
+
+Edit [4]:: no change
+
+tsgo --b --verbose
+ExitStatus:: Success
+Output::
+[[90mHH:MM:SS AM[0m] Projects in this build: 
+    * tsconfig.json
+
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is up to date because newest input 'src/index.ts' is older than output 'dist/tsconfig.tsbuildinfo'
+
+
+
+
+Edit [5]:: delete dependency d.ts
+//// [/home/src/workspaces/project/node_modules/my-dep/index.d.ts] *deleted*
+
+tsgo --b --verbose
+ExitStatus:: DiagnosticsPresent_OutputsGenerated
+Output::
+[[90mHH:MM:SS AM[0m] Projects in this build: 
+    * tsconfig.json
+
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because input 'node_modules/my-dep/index.d.ts' does not exist.
+
+[[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
+
+[96msrc/index.ts[0m:[93m1[0m:[93m25[0m - [91merror[0m[90m TS2307: [0mCannot find module 'my-dep' or its corresponding type declarations.
+
+[7m1[0m import { myValue } from "my-dep";
+[7m [0m [91m                        ~~~~~~~~[0m
+
+
+Found 1 error in src/index.ts[90m:1[0m
+
+//// [/home/src/workspaces/project/dist/src/index.js] *rewrite with same content*
+//// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo] *modified* 
+{"version":"FakeTSVersion","root":[2],"fileNames":["lib.es2025.full.d.ts","../src/index.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"bae961fec80482368db43a089f169190-import { myValue } from \"my-dep\";\nexport const value: string = myValue;","signature":"d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n","impliedNodeFormat":1}],"options":{"composite":true,"outDir":"./","strict":true},"semanticDiagnosticsPerFile":[[2,[{"pos":24,"end":32,"code":2307,"category":1,"messageKey":"Cannot_find_module_0_or_its_corresponding_type_declarations_2307","messageArgs":["my-dep"]}]]],"latestChangedDtsFile":"./src/index.d.ts"}
+//// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
+{
+  "version": "FakeTSVersion",
+  "root": [
+    {
+      "files": [
+        "../src/index.ts"
+      ],
+      "original": 2
+    }
+  ],
+  "fileNames": [
+    "lib.es2025.full.d.ts",
+    "../src/index.ts"
+  ],
+  "fileInfos": [
+    {
+      "fileName": "lib.es2025.full.d.ts",
+      "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "signature": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "affectsGlobalScope": true,
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true,
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "../src/index.ts",
+      "version": "bae961fec80482368db43a089f169190-import { myValue } from \"my-dep\";\nexport const value: string = myValue;",
+      "signature": "d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "bae961fec80482368db43a089f169190-import { myValue } from \"my-dep\";\nexport const value: string = myValue;",
+        "signature": "d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n",
+        "impliedNodeFormat": 1
+      }
+    }
+  ],
+  "options": {
+    "composite": true,
+    "outDir": "./",
+    "strict": true
+  },
+  "semanticDiagnosticsPerFile": [
+    [
+      "../src/index.ts",
+      [
+        {
+          "pos": 24,
+          "end": 32,
+          "code": 2307,
+          "category": 1,
+          "messageKey": "Cannot_find_module_0_or_its_corresponding_type_declarations_2307",
+          "messageArgs": [
+            "my-dep"
+          ]
+        }
+      ]
+    ]
+  ],
+  "latestChangedDtsFile": "./src/index.d.ts",
+  "size": 1392
+}
+
+tsconfig.json::
+SemanticDiagnostics::
+*refresh*    /home/src/workspaces/project/src/index.ts
+Signatures::
+(computed .d.ts) /home/src/workspaces/project/src/index.ts

--- a/testdata/baselines/reference/tsbuild/dependencyUpdate/rebuilds-when-dependency-package-json-redirects-to-a-different-declaration-file.js
+++ b/testdata/baselines/reference/tsbuild/dependencyUpdate/rebuilds-when-dependency-package-json-redirects-to-a-different-declaration-file.js
@@ -1,0 +1,277 @@
+currentDirectory::/home/src/workspaces/project
+useCaseSensitiveFileNames::true
+Input::
+//// [/home/src/workspaces/project/node_modules/my-dep/alt.d.ts] *new* 
+export declare const myValue: number;
+//// [/home/src/workspaces/project/node_modules/my-dep/index.d.ts] *new* 
+export declare const myValue: string;
+//// [/home/src/workspaces/project/node_modules/my-dep/package.json] *new* 
+{
+    "name": "my-dep",
+    "version": "1.0.0",
+    "types": "index.d.ts"
+}
+//// [/home/src/workspaces/project/src/index.ts] *new* 
+import { myValue } from "my-dep";
+export const value: string = myValue;
+//// [/home/src/workspaces/project/tsconfig.json] *new* 
+{
+    "compilerOptions": {
+        "composite": true,
+        "outDir": "dist",
+        "strict": true
+    },
+    "include": ["src/**/*"]
+}
+
+tsgo --b --verbose
+ExitStatus:: Success
+Output::
+[[90mHH:MM:SS AM[0m] Projects in this build: 
+    * tsconfig.json
+
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output file 'dist/tsconfig.tsbuildinfo' does not exist
+
+[[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
+
+//// [/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts] *Lib*
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+interface SymbolConstructor {
+    (desc?: string | number): symbol;
+    for(name: string): symbol;
+    readonly toStringTag: symbol;
+}
+declare var Symbol: SymbolConstructor;
+interface Symbol {
+    readonly [Symbol.toStringTag]: string;
+}
+declare const console: { log(msg: any): void; };
+//// [/home/src/workspaces/project/dist/src/index.d.ts] *new* 
+export declare const value: string;
+
+//// [/home/src/workspaces/project/dist/src/index.js] *new* 
+import { myValue } from "my-dep";
+export const value = myValue;
+
+//// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo] *new* 
+{"version":"FakeTSVersion","root":[3],"fileNames":["lib.es2025.full.d.ts","../node_modules/my-dep/index.d.ts","../src/index.ts","../node_modules/my-dep/package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"4384f7716e1c7cc875e39624007cccc9-export declare const myValue: string;",{"version":"bae961fec80482368db43a089f169190-import { myValue } from \"my-dep\";\nexport const value: string = myValue;","signature":"d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./","strict":true},"referencedMap":[[3,1]],"latestChangedDtsFile":"./src/index.d.ts","packageJsonLookups":[[4,"d8e79ef61801fbfe984887743ca01938-{\n    \"name\": \"my-dep\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\"\n}"]]}
+//// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
+{
+  "version": "FakeTSVersion",
+  "root": [
+    {
+      "files": [
+        "../src/index.ts"
+      ],
+      "original": 3
+    }
+  ],
+  "fileNames": [
+    "lib.es2025.full.d.ts",
+    "../node_modules/my-dep/index.d.ts",
+    "../src/index.ts",
+    "../node_modules/my-dep/package.json"
+  ],
+  "fileInfos": [
+    {
+      "fileName": "lib.es2025.full.d.ts",
+      "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "signature": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "affectsGlobalScope": true,
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true,
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "../node_modules/my-dep/index.d.ts",
+      "version": "4384f7716e1c7cc875e39624007cccc9-export declare const myValue: string;",
+      "signature": "4384f7716e1c7cc875e39624007cccc9-export declare const myValue: string;",
+      "impliedNodeFormat": "CommonJS"
+    },
+    {
+      "fileName": "../src/index.ts",
+      "version": "bae961fec80482368db43a089f169190-import { myValue } from \"my-dep\";\nexport const value: string = myValue;",
+      "signature": "d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "bae961fec80482368db43a089f169190-import { myValue } from \"my-dep\";\nexport const value: string = myValue;",
+        "signature": "d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n",
+        "impliedNodeFormat": 1
+      }
+    }
+  ],
+  "fileIdsList": [
+    [
+      "../node_modules/my-dep/index.d.ts"
+    ]
+  ],
+  "options": {
+    "composite": true,
+    "outDir": "./",
+    "strict": true
+  },
+  "referencedMap": {
+    "../src/index.ts": [
+      "../node_modules/my-dep/index.d.ts"
+    ]
+  },
+  "latestChangedDtsFile": "./src/index.d.ts",
+  "packageJsonLookups": [
+    {
+      "fileName": "../node_modules/my-dep/package.json",
+      "version": "d8e79ef61801fbfe984887743ca01938-{\n    \"name\": \"my-dep\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\"\n}"
+    }
+  ],
+  "size": 1550
+}
+
+tsconfig.json::
+SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
+*refresh*    /home/src/workspaces/project/node_modules/my-dep/index.d.ts
+*refresh*    /home/src/workspaces/project/src/index.ts
+Signatures::
+(stored at emit) /home/src/workspaces/project/src/index.ts
+
+
+Edit [0]:: redirect package types to a declaration file with a breaking type change
+//// [/home/src/workspaces/project/node_modules/my-dep/package.json] *modified* 
+{
+    "name": "my-dep",
+    "version": "1.0.0",
+    "types": "alt.d.ts"
+}
+
+tsgo --b --verbose
+ExitStatus:: DiagnosticsPresent_OutputsGenerated
+Output::
+[[90mHH:MM:SS AM[0m] Projects in this build: 
+    * tsconfig.json
+
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output 'dist/tsconfig.tsbuildinfo' is older than input 'node_modules/my-dep/package.json'
+
+[[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
+
+[96msrc/index.ts[0m:[93m2[0m:[93m14[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
+
+[7m2[0m export const value: string = myValue;
+[7m [0m [91m             ~~~~~[0m
+
+
+Found 1 error in src/index.ts[90m:2[0m
+
+//// [/home/src/workspaces/project/dist/src/index.js] *rewrite with same content*
+//// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo] *modified* 
+{"version":"FakeTSVersion","root":[3],"fileNames":["lib.es2025.full.d.ts","../node_modules/my-dep/alt.d.ts","../src/index.ts","../node_modules/my-dep/package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"936f1acf4d15f440cdb2eb27f80fb9c9-export declare const myValue: number;",{"version":"bae961fec80482368db43a089f169190-import { myValue } from \"my-dep\";\nexport const value: string = myValue;","signature":"d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./","strict":true},"referencedMap":[[3,1]],"semanticDiagnosticsPerFile":[[3,[{"pos":47,"end":52,"code":2322,"category":1,"messageKey":"Type_0_is_not_assignable_to_type_1_2322","messageArgs":["number","string"]}]]],"latestChangedDtsFile":"./src/index.d.ts","packageJsonLookups":[[4,"6030245f91ceb0882af82c4bf929077f-{\n    \"name\": \"my-dep\",\n    \"version\": \"1.0.0\",\n    \"types\": \"alt.d.ts\"\n}"]]}
+//// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
+{
+  "version": "FakeTSVersion",
+  "root": [
+    {
+      "files": [
+        "../src/index.ts"
+      ],
+      "original": 3
+    }
+  ],
+  "fileNames": [
+    "lib.es2025.full.d.ts",
+    "../node_modules/my-dep/alt.d.ts",
+    "../src/index.ts",
+    "../node_modules/my-dep/package.json"
+  ],
+  "fileInfos": [
+    {
+      "fileName": "lib.es2025.full.d.ts",
+      "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "signature": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "affectsGlobalScope": true,
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true,
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "../node_modules/my-dep/alt.d.ts",
+      "version": "936f1acf4d15f440cdb2eb27f80fb9c9-export declare const myValue: number;",
+      "signature": "936f1acf4d15f440cdb2eb27f80fb9c9-export declare const myValue: number;",
+      "impliedNodeFormat": "CommonJS"
+    },
+    {
+      "fileName": "../src/index.ts",
+      "version": "bae961fec80482368db43a089f169190-import { myValue } from \"my-dep\";\nexport const value: string = myValue;",
+      "signature": "d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "bae961fec80482368db43a089f169190-import { myValue } from \"my-dep\";\nexport const value: string = myValue;",
+        "signature": "d704bb9feb766d5360f4081857e4c09e-export declare const value: string;\n",
+        "impliedNodeFormat": 1
+      }
+    }
+  ],
+  "fileIdsList": [
+    [
+      "../node_modules/my-dep/alt.d.ts"
+    ]
+  ],
+  "options": {
+    "composite": true,
+    "outDir": "./",
+    "strict": true
+  },
+  "referencedMap": {
+    "../src/index.ts": [
+      "../node_modules/my-dep/alt.d.ts"
+    ]
+  },
+  "semanticDiagnosticsPerFile": [
+    [
+      "../src/index.ts",
+      [
+        {
+          "pos": 47,
+          "end": 52,
+          "code": 2322,
+          "category": 1,
+          "messageKey": "Type_0_is_not_assignable_to_type_1_2322",
+          "messageArgs": [
+            "number",
+            "string"
+          ]
+        }
+      ]
+    ]
+  ],
+  "latestChangedDtsFile": "./src/index.d.ts",
+  "packageJsonLookups": [
+    {
+      "fileName": "../node_modules/my-dep/package.json",
+      "version": "6030245f91ceb0882af82c4bf929077f-{\n    \"name\": \"my-dep\",\n    \"version\": \"1.0.0\",\n    \"types\": \"alt.d.ts\"\n}"
+    }
+  ],
+  "size": 1717
+}
+
+tsconfig.json::
+SemanticDiagnostics::
+*refresh*    /home/src/workspaces/project/node_modules/my-dep/alt.d.ts
+*refresh*    /home/src/workspaces/project/src/index.ts
+Signatures::
+(used version)   /home/src/workspaces/project/node_modules/my-dep/alt.d.ts
+(computed .d.ts) /home/src/workspaces/project/src/index.ts

--- a/testdata/baselines/reference/tsbuild/inferredTypeFromMonorepoReference/inferred-type-from-referenced-project-that-references-another-project-in-monorepo.js
+++ b/testdata/baselines/reference/tsbuild/inferredTypeFromMonorepoReference/inferred-type-from-referenced-project-that-references-another-project-in-monorepo.js
@@ -178,7 +178,7 @@ declare class MyClass {
 export { MyClass };
 
 //// [/home/src/workspaces/solution/packages/package-a/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","root":[4],"fileNames":["lib.es2022.full.d.ts","../package-c/out/index.d.ts","../package-b/out/index.d.ts","./src/index.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"fda98a6734eab276b5c9c8694ee117da-export interface MyType {\n    id: string;\n    name: string;\n    enabled: boolean;\n}\n","c244312b1cf9f2fd4ddd2d16bb44d0b9-import type { MyType } from \"package-c\";\nexport declare function createThing(input: MyType): MyType;\n",{"version":"1b8e37ecd837c2f357c793c86828b133-import { createThing } from \"package-b\";\n\nclass MyClass {\n    public thing = createThing({ id: \"1\", name: \"test\", enabled: true });\n}\n\nexport { MyClass };","signature":"f0d3d8e75bf995728f62a7d715cdf8a8-declare class MyClass {\n    thing: import(\"package-c\").MyType;\n}\nexport { MyClass };\n","impliedNodeFormat":1}],"fileIdsList":[[3],[2]],"options":{"composite":true,"emitDeclarationOnly":true,"declaration":true,"module":99,"outDir":"./out","rootDir":"./src","target":9},"referencedMap":[[4,1],[3,2]],"latestChangedDtsFile":"./out/index.d.ts"}
+{"version":"FakeTSVersion","root":[4],"fileNames":["lib.es2022.full.d.ts","../package-c/out/index.d.ts","../package-b/out/index.d.ts","./src/index.ts","../../node_modules/package-b/package.json","../../node_modules/package-c/package.json","./package.json","../package-b/package.json","../package-c/package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"fda98a6734eab276b5c9c8694ee117da-export interface MyType {\n    id: string;\n    name: string;\n    enabled: boolean;\n}\n","c244312b1cf9f2fd4ddd2d16bb44d0b9-import type { MyType } from \"package-c\";\nexport declare function createThing(input: MyType): MyType;\n",{"version":"1b8e37ecd837c2f357c793c86828b133-import { createThing } from \"package-b\";\n\nclass MyClass {\n    public thing = createThing({ id: \"1\", name: \"test\", enabled: true });\n}\n\nexport { MyClass };","signature":"f0d3d8e75bf995728f62a7d715cdf8a8-declare class MyClass {\n    thing: import(\"package-c\").MyType;\n}\nexport { MyClass };\n","impliedNodeFormat":1}],"fileIdsList":[[3],[2]],"options":{"composite":true,"emitDeclarationOnly":true,"declaration":true,"module":99,"outDir":"./out","rootDir":"./src","target":9},"referencedMap":[[4,1],[3,2]],"latestChangedDtsFile":"./out/index.d.ts","packageJsonLookups":[[5,"c4feae78c34d450752b49da7aa3533b7-{\n    \"name\": \"package-b\",\n    \"version\": \"1.0.0\",\n    \"private\": true,\n    \"type\": \"module\",\n    \"main\": \"./src/index.ts\",\n    \"types\": \"./src/index.ts\",\n    \"exports\": {\n        \".\": \"./src/index.ts\"\n    },\n    \"dependencies\": {\n        \"package-c\": \"workspace:*\"\n    }\n}"],[6,"fb07b69af10083e97ad2eeb299a82abc-{\n    \"name\": \"package-c\",\n    \"version\": \"1.0.0\",\n    \"private\": true,\n    \"type\": \"module\",\n    \"main\": \"./src/index.ts\",\n    \"types\": \"./src/index.ts\",\n    \"exports\": {\n        \".\": \"./src/index.ts\"\n    }\n}"],[7,"32e3a5ee0544748afb171aa7cdf33e69-{\n    \"name\": \"package-a\",\n    \"version\": \"1.0.0\",\n    \"private\": true,\n    \"type\": \"module\",\n    \"main\": \"./src/index.ts\",\n    \"types\": \"./src/index.ts\",\n    \"exports\": {\n        \".\": \"./src/index.ts\"\n    },\n    \"dependencies\": {\n        \"package-b\": \"workspace:*\"\n    }\n}"],[8,"c4feae78c34d450752b49da7aa3533b7-{\n    \"name\": \"package-b\",\n    \"version\": \"1.0.0\",\n    \"private\": true,\n    \"type\": \"module\",\n    \"main\": \"./src/index.ts\",\n    \"types\": \"./src/index.ts\",\n    \"exports\": {\n        \".\": \"./src/index.ts\"\n    },\n    \"dependencies\": {\n        \"package-c\": \"workspace:*\"\n    }\n}"],[9,"fb07b69af10083e97ad2eeb299a82abc-{\n    \"name\": \"package-c\",\n    \"version\": \"1.0.0\",\n    \"private\": true,\n    \"type\": \"module\",\n    \"main\": \"./src/index.ts\",\n    \"types\": \"./src/index.ts\",\n    \"exports\": {\n        \".\": \"./src/index.ts\"\n    }\n}"]]}
 //// [/home/src/workspaces/solution/packages/package-a/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
@@ -194,7 +194,12 @@ export { MyClass };
     "lib.es2022.full.d.ts",
     "../package-c/out/index.d.ts",
     "../package-b/out/index.d.ts",
-    "./src/index.ts"
+    "./src/index.ts",
+    "../../node_modules/package-b/package.json",
+    "../../node_modules/package-c/package.json",
+    "./package.json",
+    "../package-b/package.json",
+    "../package-c/package.json"
   ],
   "fileInfos": [
     {
@@ -259,14 +264,36 @@ export { MyClass };
     ]
   },
   "latestChangedDtsFile": "./out/index.d.ts",
-  "size": 1806
+  "packageJsonLookups": [
+    {
+      "fileName": "../../node_modules/package-b/package.json",
+      "version": "c4feae78c34d450752b49da7aa3533b7-{\n    \"name\": \"package-b\",\n    \"version\": \"1.0.0\",\n    \"private\": true,\n    \"type\": \"module\",\n    \"main\": \"./src/index.ts\",\n    \"types\": \"./src/index.ts\",\n    \"exports\": {\n        \".\": \"./src/index.ts\"\n    },\n    \"dependencies\": {\n        \"package-c\": \"workspace:*\"\n    }\n}"
+    },
+    {
+      "fileName": "../../node_modules/package-c/package.json",
+      "version": "fb07b69af10083e97ad2eeb299a82abc-{\n    \"name\": \"package-c\",\n    \"version\": \"1.0.0\",\n    \"private\": true,\n    \"type\": \"module\",\n    \"main\": \"./src/index.ts\",\n    \"types\": \"./src/index.ts\",\n    \"exports\": {\n        \".\": \"./src/index.ts\"\n    }\n}"
+    },
+    {
+      "fileName": "./package.json",
+      "version": "32e3a5ee0544748afb171aa7cdf33e69-{\n    \"name\": \"package-a\",\n    \"version\": \"1.0.0\",\n    \"private\": true,\n    \"type\": \"module\",\n    \"main\": \"./src/index.ts\",\n    \"types\": \"./src/index.ts\",\n    \"exports\": {\n        \".\": \"./src/index.ts\"\n    },\n    \"dependencies\": {\n        \"package-b\": \"workspace:*\"\n    }\n}"
+    },
+    {
+      "fileName": "../package-b/package.json",
+      "version": "c4feae78c34d450752b49da7aa3533b7-{\n    \"name\": \"package-b\",\n    \"version\": \"1.0.0\",\n    \"private\": true,\n    \"type\": \"module\",\n    \"main\": \"./src/index.ts\",\n    \"types\": \"./src/index.ts\",\n    \"exports\": {\n        \".\": \"./src/index.ts\"\n    },\n    \"dependencies\": {\n        \"package-c\": \"workspace:*\"\n    }\n}"
+    },
+    {
+      "fileName": "../package-c/package.json",
+      "version": "fb07b69af10083e97ad2eeb299a82abc-{\n    \"name\": \"package-c\",\n    \"version\": \"1.0.0\",\n    \"private\": true,\n    \"type\": \"module\",\n    \"main\": \"./src/index.ts\",\n    \"types\": \"./src/index.ts\",\n    \"exports\": {\n        \".\": \"./src/index.ts\"\n    }\n}"
+    }
+  ],
+  "size": 3644
 }
 //// [/home/src/workspaces/solution/packages/package-b/out/index.d.ts] *new* 
 import type { MyType } from "package-c";
 export declare function createThing(input: MyType): MyType;
 
 //// [/home/src/workspaces/solution/packages/package-b/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","root":[3],"fileNames":["lib.es2022.full.d.ts","../package-c/out/index.d.ts","./src/index.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"fda98a6734eab276b5c9c8694ee117da-export interface MyType {\n    id: string;\n    name: string;\n    enabled: boolean;\n}\n",{"version":"fbb82e716b8d6d09c2f530e11f7c8614-import type { MyType } from \"package-c\";\n\nexport function createThing(input: MyType): MyType {\n    return { ...input };\n}","signature":"c244312b1cf9f2fd4ddd2d16bb44d0b9-import type { MyType } from \"package-c\";\nexport declare function createThing(input: MyType): MyType;\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"emitDeclarationOnly":true,"declaration":true,"module":99,"outDir":"./out","rootDir":"./src","target":9},"referencedMap":[[3,1]],"latestChangedDtsFile":"./out/index.d.ts"}
+{"version":"FakeTSVersion","root":[3],"fileNames":["lib.es2022.full.d.ts","../package-c/out/index.d.ts","./src/index.ts","../../node_modules/package-c/package.json","./package.json","../package-c/package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"fda98a6734eab276b5c9c8694ee117da-export interface MyType {\n    id: string;\n    name: string;\n    enabled: boolean;\n}\n",{"version":"fbb82e716b8d6d09c2f530e11f7c8614-import type { MyType } from \"package-c\";\n\nexport function createThing(input: MyType): MyType {\n    return { ...input };\n}","signature":"c244312b1cf9f2fd4ddd2d16bb44d0b9-import type { MyType } from \"package-c\";\nexport declare function createThing(input: MyType): MyType;\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"emitDeclarationOnly":true,"declaration":true,"module":99,"outDir":"./out","rootDir":"./src","target":9},"referencedMap":[[3,1]],"latestChangedDtsFile":"./out/index.d.ts","packageJsonLookups":[[4,"fb07b69af10083e97ad2eeb299a82abc-{\n    \"name\": \"package-c\",\n    \"version\": \"1.0.0\",\n    \"private\": true,\n    \"type\": \"module\",\n    \"main\": \"./src/index.ts\",\n    \"types\": \"./src/index.ts\",\n    \"exports\": {\n        \".\": \"./src/index.ts\"\n    }\n}"],[5,"c4feae78c34d450752b49da7aa3533b7-{\n    \"name\": \"package-b\",\n    \"version\": \"1.0.0\",\n    \"private\": true,\n    \"type\": \"module\",\n    \"main\": \"./src/index.ts\",\n    \"types\": \"./src/index.ts\",\n    \"exports\": {\n        \".\": \"./src/index.ts\"\n    },\n    \"dependencies\": {\n        \"package-c\": \"workspace:*\"\n    }\n}"],[6,"fb07b69af10083e97ad2eeb299a82abc-{\n    \"name\": \"package-c\",\n    \"version\": \"1.0.0\",\n    \"private\": true,\n    \"type\": \"module\",\n    \"main\": \"./src/index.ts\",\n    \"types\": \"./src/index.ts\",\n    \"exports\": {\n        \".\": \"./src/index.ts\"\n    }\n}"]]}
 //// [/home/src/workspaces/solution/packages/package-b/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
@@ -281,7 +308,10 @@ export declare function createThing(input: MyType): MyType;
   "fileNames": [
     "lib.es2022.full.d.ts",
     "../package-c/out/index.d.ts",
-    "./src/index.ts"
+    "./src/index.ts",
+    "../../node_modules/package-c/package.json",
+    "./package.json",
+    "../package-c/package.json"
   ],
   "fileInfos": [
     {
@@ -334,7 +364,21 @@ export declare function createThing(input: MyType): MyType;
     ]
   },
   "latestChangedDtsFile": "./out/index.d.ts",
-  "size": 1600
+  "packageJsonLookups": [
+    {
+      "fileName": "../../node_modules/package-c/package.json",
+      "version": "fb07b69af10083e97ad2eeb299a82abc-{\n    \"name\": \"package-c\",\n    \"version\": \"1.0.0\",\n    \"private\": true,\n    \"type\": \"module\",\n    \"main\": \"./src/index.ts\",\n    \"types\": \"./src/index.ts\",\n    \"exports\": {\n        \".\": \"./src/index.ts\"\n    }\n}"
+    },
+    {
+      "fileName": "./package.json",
+      "version": "c4feae78c34d450752b49da7aa3533b7-{\n    \"name\": \"package-b\",\n    \"version\": \"1.0.0\",\n    \"private\": true,\n    \"type\": \"module\",\n    \"main\": \"./src/index.ts\",\n    \"types\": \"./src/index.ts\",\n    \"exports\": {\n        \".\": \"./src/index.ts\"\n    },\n    \"dependencies\": {\n        \"package-c\": \"workspace:*\"\n    }\n}"
+    },
+    {
+      "fileName": "../package-c/package.json",
+      "version": "fb07b69af10083e97ad2eeb299a82abc-{\n    \"name\": \"package-c\",\n    \"version\": \"1.0.0\",\n    \"private\": true,\n    \"type\": \"module\",\n    \"main\": \"./src/index.ts\",\n    \"types\": \"./src/index.ts\",\n    \"exports\": {\n        \".\": \"./src/index.ts\"\n    }\n}"
+    }
+  ],
+  "size": 2646
 }
 //// [/home/src/workspaces/solution/packages/package-c/out/index.d.ts] *new* 
 export interface MyType {
@@ -344,7 +388,7 @@ export interface MyType {
 }
 
 //// [/home/src/workspaces/solution/packages/package-c/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","root":[2],"fileNames":["lib.es2022.full.d.ts","./src/index.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"998713b32693f1c4f45ac4bad0f3285c-export interface MyType {\n    id: string;\n    name: string;\n    enabled: boolean;\n}","signature":"fda98a6734eab276b5c9c8694ee117da-export interface MyType {\n    id: string;\n    name: string;\n    enabled: boolean;\n}\n","impliedNodeFormat":1}],"options":{"composite":true,"emitDeclarationOnly":true,"declaration":true,"module":99,"outDir":"./out","rootDir":"./src","target":9},"latestChangedDtsFile":"./out/index.d.ts"}
+{"version":"FakeTSVersion","root":[2],"fileNames":["lib.es2022.full.d.ts","./src/index.ts","./package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"998713b32693f1c4f45ac4bad0f3285c-export interface MyType {\n    id: string;\n    name: string;\n    enabled: boolean;\n}","signature":"fda98a6734eab276b5c9c8694ee117da-export interface MyType {\n    id: string;\n    name: string;\n    enabled: boolean;\n}\n","impliedNodeFormat":1}],"options":{"composite":true,"emitDeclarationOnly":true,"declaration":true,"module":99,"outDir":"./out","rootDir":"./src","target":9},"latestChangedDtsFile":"./out/index.d.ts","packageJsonLookups":[[3,"fb07b69af10083e97ad2eeb299a82abc-{\n    \"name\": \"package-c\",\n    \"version\": \"1.0.0\",\n    \"private\": true,\n    \"type\": \"module\",\n    \"main\": \"./src/index.ts\",\n    \"types\": \"./src/index.ts\",\n    \"exports\": {\n        \".\": \"./src/index.ts\"\n    }\n}"]]}
 //// [/home/src/workspaces/solution/packages/package-c/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
@@ -358,7 +402,8 @@ export interface MyType {
   ],
   "fileNames": [
     "lib.es2022.full.d.ts",
-    "./src/index.ts"
+    "./src/index.ts",
+    "./package.json"
   ],
   "fileInfos": [
     {
@@ -395,7 +440,13 @@ export interface MyType {
     "target": 9
   },
   "latestChangedDtsFile": "./out/index.d.ts",
-  "size": 1345
+  "packageJsonLookups": [
+    {
+      "fileName": "./package.json",
+      "version": "fb07b69af10083e97ad2eeb299a82abc-{\n    \"name\": \"package-c\",\n    \"version\": \"1.0.0\",\n    \"private\": true,\n    \"type\": \"module\",\n    \"main\": \"./src/index.ts\",\n    \"types\": \"./src/index.ts\",\n    \"exports\": {\n        \".\": \"./src/index.ts\"\n    }\n}"
+    }
+  ],
+  "size": 1672
 }
 
 packages/package-c/tsconfig.json::

--- a/testdata/baselines/reference/tsbuild/moduleResolution/resolves-specifier-in-output-declaration-file-from-referenced-project-correctly-with-preserveSymlinks.js
+++ b/testdata/baselines/reference/tsbuild/moduleResolution/resolves-specifier-in-output-declaration-file-from-referenced-project-correctly-with-preserveSymlinks.js
@@ -151,7 +151,7 @@ export type { TheNum } from 'const';
 export {};
 
 //// [/user/username/projects/myproject/packages/pkg2/build/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","../const.ts","../index.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"be0f939ab1143e4064a3742586332724-export type TheNum = 42;","signature":"56e2d69d2edd1f0edd1a64ecfdf6de0d-export type TheNum = 42;\n","impliedNodeFormat":1},{"version":"0b8e978a1e274cdc446fbbcbc9e78724-export type { TheNum } from 'const';","signature":"1a74e021c93cb748502ffc92156e3427-export type { TheNum } from 'const';\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./"},"referencedMap":[[3,1]],"latestChangedDtsFile":"./index.d.ts"}
+{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","../const.ts","../index.ts","../package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"be0f939ab1143e4064a3742586332724-export type TheNum = 42;","signature":"56e2d69d2edd1f0edd1a64ecfdf6de0d-export type TheNum = 42;\n","impliedNodeFormat":1},{"version":"0b8e978a1e274cdc446fbbcbc9e78724-export type { TheNum } from 'const';","signature":"1a74e021c93cb748502ffc92156e3427-export type { TheNum } from 'const';\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./"},"referencedMap":[[3,1]],"latestChangedDtsFile":"./index.d.ts","packageJsonLookups":[[4,"754b3f84a4868af09079d100c0ad1bc4-{\n    \"name\": \"pkg2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"build/index.js\"\n}"]]}
 //// [/user/username/projects/myproject/packages/pkg2/build/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
@@ -170,7 +170,8 @@ export {};
   "fileNames": [
     "lib.es2025.full.d.ts",
     "../const.ts",
-    "../index.ts"
+    "../index.ts",
+    "../package.json"
   ],
   "fileInfos": [
     {
@@ -223,7 +224,13 @@ export {};
     ]
   },
   "latestChangedDtsFile": "./index.d.ts",
-  "size": 1376
+  "packageJsonLookups": [
+    {
+      "fileName": "../package.json",
+      "version": "754b3f84a4868af09079d100c0ad1bc4-{\n    \"name\": \"pkg2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"build/index.js\"\n}"
+    }
+  ],
+  "size": 1549
 }
 
 packages/pkg2/tsconfig.json::

--- a/testdata/baselines/reference/tsbuild/moduleResolution/resolves-specifier-in-output-declaration-file-from-referenced-project-correctly.js
+++ b/testdata/baselines/reference/tsbuild/moduleResolution/resolves-specifier-in-output-declaration-file-from-referenced-project-correctly.js
@@ -152,7 +152,7 @@ export type { TheNum } from 'const';
 export {};
 
 //// [/user/username/projects/myproject/packages/pkg2/build/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","../const.ts","../index.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"be0f939ab1143e4064a3742586332724-export type TheNum = 42;","signature":"56e2d69d2edd1f0edd1a64ecfdf6de0d-export type TheNum = 42;\n","impliedNodeFormat":1},{"version":"0b8e978a1e274cdc446fbbcbc9e78724-export type { TheNum } from 'const';","signature":"1a74e021c93cb748502ffc92156e3427-export type { TheNum } from 'const';\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./"},"referencedMap":[[3,1]],"latestChangedDtsFile":"./index.d.ts"}
+{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","../const.ts","../index.ts","../package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"be0f939ab1143e4064a3742586332724-export type TheNum = 42;","signature":"56e2d69d2edd1f0edd1a64ecfdf6de0d-export type TheNum = 42;\n","impliedNodeFormat":1},{"version":"0b8e978a1e274cdc446fbbcbc9e78724-export type { TheNum } from 'const';","signature":"1a74e021c93cb748502ffc92156e3427-export type { TheNum } from 'const';\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./"},"referencedMap":[[3,1]],"latestChangedDtsFile":"./index.d.ts","packageJsonLookups":[[4,"754b3f84a4868af09079d100c0ad1bc4-{\n    \"name\": \"pkg2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"build/index.js\"\n}"]]}
 //// [/user/username/projects/myproject/packages/pkg2/build/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
@@ -171,7 +171,8 @@ export {};
   "fileNames": [
     "lib.es2025.full.d.ts",
     "../const.ts",
-    "../index.ts"
+    "../index.ts",
+    "../package.json"
   ],
   "fileInfos": [
     {
@@ -224,7 +225,13 @@ export {};
     ]
   },
   "latestChangedDtsFile": "./index.d.ts",
-  "size": 1376
+  "packageJsonLookups": [
+    {
+      "fileName": "../package.json",
+      "version": "754b3f84a4868af09079d100c0ad1bc4-{\n    \"name\": \"pkg2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"build/index.js\"\n}"
+    }
+  ],
+  "size": 1549
 }
 
 packages/pkg2/tsconfig.json::

--- a/testdata/baselines/reference/tsbuild/moduleResolution/shared-resolution-should-not-report-error.js
+++ b/testdata/baselines/reference/tsbuild/moduleResolution/shared-resolution-should-not-report-error.js
@@ -145,7 +145,7 @@ export declare const a = "a";
 import 'a';
 
 //// [/home/src/workspaces/project/packages/a/types/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","../index.js","../test/index.js"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"fb6f7bce1e97f6455fc2f6a3fc00ca67-export const a = 'a';","signature":"410f445844ca5e1f83239796f66520a1-export declare const a = \"a\";\n","impliedNodeFormat":99},{"version":"25c2781885c8232d7ba0f67afa33aa44-import 'a';","signature":"518d564eba22abfaf340ce3ae18a4763-import 'a';\n","impliedNodeFormat":99}],"fileIdsList":[[2]],"options":{"checkJs":true,"composite":true,"emitDeclarationOnly":true,"declaration":true,"module":199,"outDir":"./"},"referencedMap":[[3,1]],"latestChangedDtsFile":"./test/index.d.ts"}
+{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","../index.js","../test/index.js","../package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"fb6f7bce1e97f6455fc2f6a3fc00ca67-export const a = 'a';","signature":"410f445844ca5e1f83239796f66520a1-export declare const a = \"a\";\n","impliedNodeFormat":99},{"version":"25c2781885c8232d7ba0f67afa33aa44-import 'a';","signature":"518d564eba22abfaf340ce3ae18a4763-import 'a';\n","impliedNodeFormat":99}],"fileIdsList":[[2]],"options":{"checkJs":true,"composite":true,"emitDeclarationOnly":true,"declaration":true,"module":199,"outDir":"./"},"referencedMap":[[3,1]],"latestChangedDtsFile":"./test/index.d.ts","packageJsonLookups":[[4,"26a83c25f9995938e1b8f890c8babb38-{\n    \"name\": \"a\",\n    \"version\": \"0.0.0\",\n    \"type\": \"module\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./types/index.d.ts\",\n            \"default\": \"./index.js\"\n        }\n    }\n}"]]}
 //// [/home/src/workspaces/project/packages/a/types/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
@@ -164,7 +164,8 @@ import 'a';
   "fileNames": [
     "lib.es2025.full.d.ts",
     "../index.js",
-    "../test/index.js"
+    "../test/index.js",
+    "../package.json"
   ],
   "fileInfos": [
     {
@@ -221,7 +222,13 @@ import 'a';
     ]
   },
   "latestChangedDtsFile": "./test/index.d.ts",
-  "size": 1416
+  "packageJsonLookups": [
+    {
+      "fileName": "../package.json",
+      "version": "26a83c25f9995938e1b8f890c8babb38-{\n    \"name\": \"a\",\n    \"version\": \"0.0.0\",\n    \"type\": \"module\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./types/index.d.ts\",\n            \"default\": \"./index.js\"\n        }\n    }\n}"
+    }
+  ],
+  "size": 1724
 }
 //// [/home/src/workspaces/project/packages/b/tsconfig.tsbuildinfo] *new* 
 {"version":"FakeTSVersion","root":["./index.js"]}

--- a/testdata/baselines/reference/tsbuild/moduleResolution/when-resolution-is-not-shared.js
+++ b/testdata/baselines/reference/tsbuild/moduleResolution/when-resolution-is-not-shared.js
@@ -114,7 +114,7 @@ export declare const a = "a";
 import 'a';
 
 //// [/home/src/workspaces/project/packages/a/types/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","../index.js","../test/index.js"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"fb6f7bce1e97f6455fc2f6a3fc00ca67-export const a = 'a';","signature":"410f445844ca5e1f83239796f66520a1-export declare const a = \"a\";\n","impliedNodeFormat":99},{"version":"25c2781885c8232d7ba0f67afa33aa44-import 'a';","signature":"518d564eba22abfaf340ce3ae18a4763-import 'a';\n","impliedNodeFormat":99}],"fileIdsList":[[2]],"options":{"checkJs":true,"composite":true,"emitDeclarationOnly":true,"declaration":true,"module":199,"outDir":"./"},"referencedMap":[[3,1]],"latestChangedDtsFile":"./test/index.d.ts"}
+{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","../index.js","../test/index.js","../package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"fb6f7bce1e97f6455fc2f6a3fc00ca67-export const a = 'a';","signature":"410f445844ca5e1f83239796f66520a1-export declare const a = \"a\";\n","impliedNodeFormat":99},{"version":"25c2781885c8232d7ba0f67afa33aa44-import 'a';","signature":"518d564eba22abfaf340ce3ae18a4763-import 'a';\n","impliedNodeFormat":99}],"fileIdsList":[[2]],"options":{"checkJs":true,"composite":true,"emitDeclarationOnly":true,"declaration":true,"module":199,"outDir":"./"},"referencedMap":[[3,1]],"latestChangedDtsFile":"./test/index.d.ts","packageJsonLookups":[[4,"26a83c25f9995938e1b8f890c8babb38-{\n    \"name\": \"a\",\n    \"version\": \"0.0.0\",\n    \"type\": \"module\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./types/index.d.ts\",\n            \"default\": \"./index.js\"\n        }\n    }\n}"]]}
 //// [/home/src/workspaces/project/packages/a/types/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
@@ -133,7 +133,8 @@ import 'a';
   "fileNames": [
     "lib.es2025.full.d.ts",
     "../index.js",
-    "../test/index.js"
+    "../test/index.js",
+    "../package.json"
   ],
   "fileInfos": [
     {
@@ -190,7 +191,13 @@ import 'a';
     ]
   },
   "latestChangedDtsFile": "./test/index.d.ts",
-  "size": 1416
+  "packageJsonLookups": [
+    {
+      "fileName": "../package.json",
+      "version": "26a83c25f9995938e1b8f890c8babb38-{\n    \"name\": \"a\",\n    \"version\": \"0.0.0\",\n    \"type\": \"module\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./types/index.d.ts\",\n            \"default\": \"./index.js\"\n        }\n    }\n}"
+    }
+  ],
+  "size": 1724
 }
 
 packages/a/tsconfig.json::

--- a/testdata/baselines/reference/tsbuild/moduleSpecifiers/synthesized-module-specifiers-across-projects-resolve-correctly.js
+++ b/testdata/baselines/reference/tsbuild/moduleSpecifiers/synthesized-module-specifiers-across-projects-resolve-correctly.js
@@ -170,7 +170,7 @@ export class LassieDog extends Dog {
 }
 
 //// [/home/src/workspaces/packages/src-dogs/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","root":[[4,8]],"fileNames":["lib.es2025.full.d.ts","../src-types/dogconfig.d.ts","../src-types/index.d.ts","./dogconfig.ts","./dog.ts","./lassie/lassieconfig.ts","./lassie/lassiedog.ts","./index.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"a71e22ebb89c8c5bea7cef8d090ace25-export interface DogConfig {\n    name: string;\n}\n","impliedNodeFormat":99},{"version":"3c21c50da3a1aea8b6fafa5aa595f160-export * from './dogconfig.js';\n","impliedNodeFormat":99},{"version":"a8c9e5169f1e05ea3fd4da563dc779b7-import { DogConfig } from 'src-types';\n\nexport const DOG_CONFIG: DogConfig = {\n    name: 'Default dog',\n};","signature":"55c35bfb192d26f7ab56e9447864b637-import { DogConfig } from 'src-types';\nexport declare const DOG_CONFIG: DogConfig;\n","impliedNodeFormat":99},{"version":"4ef4eb6072aff36903b09b7e1fa75eea-import { DogConfig } from 'src-types';\nimport { DOG_CONFIG } from './dogconfig.js';\n\nexport abstract class Dog {\n\n    public static getCapabilities(): DogConfig {\n        return DOG_CONFIG;\n    }\n}","signature":"1130c09f22ac69e13b25f0c42f3a9379-import { DogConfig } from 'src-types';\nexport declare abstract class Dog {\n    static getCapabilities(): DogConfig;\n}\n","impliedNodeFormat":99},{"version":"37fa5afea0e398a9cc485818c902b71c-import { DogConfig } from 'src-types';\n\nexport const LASSIE_CONFIG: DogConfig = { name: 'Lassie' };","signature":"2ef44fffbc07bb77765462af9f6df2a2-import { DogConfig } from 'src-types';\nexport declare const LASSIE_CONFIG: DogConfig;\n","impliedNodeFormat":99},{"version":"16f2a31a47590452f19f34bb56d0345f-import { Dog } from '../dog.js';\nimport { LASSIE_CONFIG } from './lassieconfig.js';\n\nexport class LassieDog extends Dog {\n    protected static getDogConfig = () => LASSIE_CONFIG;\n}","signature":"e1943411d89cafd8c6f5a028539f5775-import { Dog } from '../dog.js';\nexport declare class LassieDog extends Dog {\n    protected static getDogConfig: () => import(\"src-types\").DogConfig;\n}\n","impliedNodeFormat":99},{"version":"099983d5c3c8b20233df02ca964ad12f-export * from 'src-types';\nexport * from './lassie/lassiedog.js';","signature":"0fb03f7b5b8061b0e2cd78a4131e3df7-export * from 'src-types';\nexport * from './lassie/lassiedog.js';\n","impliedNodeFormat":99}],"fileIdsList":[[3,4],[3],[3,7],[5,6],[2]],"options":{"composite":true,"declaration":true,"module":100},"referencedMap":[[5,1],[4,2],[8,3],[6,2],[7,4],[3,5]],"latestChangedDtsFile":"./index.d.ts"}
+{"version":"FakeTSVersion","root":[[4,8]],"fileNames":["lib.es2025.full.d.ts","../src-types/dogconfig.d.ts","../src-types/index.d.ts","./dogconfig.ts","./dog.ts","./lassie/lassieconfig.ts","./lassie/lassiedog.ts","./index.ts","./node_modules/src-types/package.json","./package.json","../src-types/package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"a71e22ebb89c8c5bea7cef8d090ace25-export interface DogConfig {\n    name: string;\n}\n","impliedNodeFormat":99},{"version":"3c21c50da3a1aea8b6fafa5aa595f160-export * from './dogconfig.js';\n","impliedNodeFormat":99},{"version":"a8c9e5169f1e05ea3fd4da563dc779b7-import { DogConfig } from 'src-types';\n\nexport const DOG_CONFIG: DogConfig = {\n    name: 'Default dog',\n};","signature":"55c35bfb192d26f7ab56e9447864b637-import { DogConfig } from 'src-types';\nexport declare const DOG_CONFIG: DogConfig;\n","impliedNodeFormat":99},{"version":"4ef4eb6072aff36903b09b7e1fa75eea-import { DogConfig } from 'src-types';\nimport { DOG_CONFIG } from './dogconfig.js';\n\nexport abstract class Dog {\n\n    public static getCapabilities(): DogConfig {\n        return DOG_CONFIG;\n    }\n}","signature":"1130c09f22ac69e13b25f0c42f3a9379-import { DogConfig } from 'src-types';\nexport declare abstract class Dog {\n    static getCapabilities(): DogConfig;\n}\n","impliedNodeFormat":99},{"version":"37fa5afea0e398a9cc485818c902b71c-import { DogConfig } from 'src-types';\n\nexport const LASSIE_CONFIG: DogConfig = { name: 'Lassie' };","signature":"2ef44fffbc07bb77765462af9f6df2a2-import { DogConfig } from 'src-types';\nexport declare const LASSIE_CONFIG: DogConfig;\n","impliedNodeFormat":99},{"version":"16f2a31a47590452f19f34bb56d0345f-import { Dog } from '../dog.js';\nimport { LASSIE_CONFIG } from './lassieconfig.js';\n\nexport class LassieDog extends Dog {\n    protected static getDogConfig = () => LASSIE_CONFIG;\n}","signature":"e1943411d89cafd8c6f5a028539f5775-import { Dog } from '../dog.js';\nexport declare class LassieDog extends Dog {\n    protected static getDogConfig: () => import(\"src-types\").DogConfig;\n}\n","impliedNodeFormat":99},{"version":"099983d5c3c8b20233df02ca964ad12f-export * from 'src-types';\nexport * from './lassie/lassiedog.js';","signature":"0fb03f7b5b8061b0e2cd78a4131e3df7-export * from 'src-types';\nexport * from './lassie/lassiedog.js';\n","impliedNodeFormat":99}],"fileIdsList":[[3,4],[3],[3,7],[5,6],[2]],"options":{"composite":true,"declaration":true,"module":100},"referencedMap":[[5,1],[4,2],[8,3],[6,2],[7,4],[3,5]],"latestChangedDtsFile":"./index.d.ts","packageJsonLookups":[[9,"860f969e1c94c6c45355511d24374f32-{\n    \"type\": \"module\",\n    \"exports\": \"./index.js\"\n}"],[10,"860f969e1c94c6c45355511d24374f32-{\n    \"type\": \"module\",\n    \"exports\": \"./index.js\"\n}"],[11,"860f969e1c94c6c45355511d24374f32-{\n    \"type\": \"module\",\n    \"exports\": \"./index.js\"\n}"]]}
 //// [/home/src/workspaces/packages/src-dogs/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
@@ -197,7 +197,10 @@ export class LassieDog extends Dog {
     "./dog.ts",
     "./lassie/lassieconfig.ts",
     "./lassie/lassiedog.ts",
-    "./index.ts"
+    "./index.ts",
+    "./node_modules/src-types/package.json",
+    "./package.json",
+    "../src-types/package.json"
   ],
   "fileInfos": [
     {
@@ -337,7 +340,21 @@ export class LassieDog extends Dog {
     ]
   },
   "latestChangedDtsFile": "./index.d.ts",
-  "size": 3216
+  "packageJsonLookups": [
+    {
+      "fileName": "./node_modules/src-types/package.json",
+      "version": "860f969e1c94c6c45355511d24374f32-{\n    \"type\": \"module\",\n    \"exports\": \"./index.js\"\n}"
+    },
+    {
+      "fileName": "./package.json",
+      "version": "860f969e1c94c6c45355511d24374f32-{\n    \"type\": \"module\",\n    \"exports\": \"./index.js\"\n}"
+    },
+    {
+      "fileName": "../src-types/package.json",
+      "version": "860f969e1c94c6c45355511d24374f32-{\n    \"type\": \"module\",\n    \"exports\": \"./index.js\"\n}"
+    }
+  ],
+  "size": 3638
 }
 //// [/home/src/workspaces/packages/src-types/dogconfig.d.ts] *new* 
 export interface DogConfig {
@@ -354,7 +371,7 @@ export * from './dogconfig.js';
 export * from './dogconfig.js';
 
 //// [/home/src/workspaces/packages/src-types/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./dogconfig.ts","./index.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"d8b224befa78d5f27814a6eb4da56079-export interface DogConfig {\n    name: string;\n}","signature":"a71e22ebb89c8c5bea7cef8d090ace25-export interface DogConfig {\n    name: string;\n}\n","impliedNodeFormat":99},{"version":"ac3890d1bb11659994f68e147333e98e-export * from './dogconfig.js';","signature":"3c21c50da3a1aea8b6fafa5aa595f160-export * from './dogconfig.js';\n","impliedNodeFormat":99}],"fileIdsList":[[2]],"options":{"composite":true,"declaration":true,"module":100},"referencedMap":[[3,1]],"latestChangedDtsFile":"./index.d.ts"}
+{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./dogconfig.ts","./index.ts","./package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"d8b224befa78d5f27814a6eb4da56079-export interface DogConfig {\n    name: string;\n}","signature":"a71e22ebb89c8c5bea7cef8d090ace25-export interface DogConfig {\n    name: string;\n}\n","impliedNodeFormat":99},{"version":"ac3890d1bb11659994f68e147333e98e-export * from './dogconfig.js';","signature":"3c21c50da3a1aea8b6fafa5aa595f160-export * from './dogconfig.js';\n","impliedNodeFormat":99}],"fileIdsList":[[2]],"options":{"composite":true,"declaration":true,"module":100},"referencedMap":[[3,1]],"latestChangedDtsFile":"./index.d.ts","packageJsonLookups":[[4,"860f969e1c94c6c45355511d24374f32-{\n    \"type\": \"module\",\n    \"exports\": \"./index.js\"\n}"]]}
 //// [/home/src/workspaces/packages/src-types/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
@@ -373,7 +390,8 @@ export * from './dogconfig.js';
   "fileNames": [
     "lib.es2025.full.d.ts",
     "./dogconfig.ts",
-    "./index.ts"
+    "./index.ts",
+    "./package.json"
   ],
   "fileInfos": [
     {
@@ -427,7 +445,13 @@ export * from './dogconfig.js';
     ]
   },
   "latestChangedDtsFile": "./index.d.ts",
-  "size": 1440
+  "packageJsonLookups": [
+    {
+      "fileName": "./package.json",
+      "version": "860f969e1c94c6c45355511d24374f32-{\n    \"type\": \"module\",\n    \"exports\": \"./index.js\"\n}"
+    }
+  ],
+  "size": 1584
 }
 
 src-types/tsconfig.json::

--- a/testdata/baselines/reference/tsbuild/projectReferenceRedirect/uses-correct-project-reference-redirect-when-file-belongs-to-multiple-sub-projects.js
+++ b/testdata/baselines/reference/tsbuild/projectReferenceRedirect/uses-correct-project-reference-redirect-when-file-belongs-to-multiple-sub-projects.js
@@ -129,7 +129,7 @@ export declare const platform: "web";
 export declare const platform: "native";
 
 //// [/home/src/workspaces/project/pkg/dist/tsconfig.native.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","root":[[2,4]],"fileNames":["lib.es2025.full.d.ts","../src/util.native.ts","../index.native.ts","../src/util.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"c1f8db351239c175fbb3960262e28684-export const platform = \"native\" as const;","signature":"1f876b2eee633f65aa2e7817bfee737a-export declare const platform: \"native\";\n","impliedNodeFormat":1},{"version":"0a747b719fd37e7b799139c5f607d76b-export { platform } from \"./src/util\";","signature":"b065ccf77d7f1159c74552524b8d4d2b-export { platform } from \"./src/util\";\n","impliedNodeFormat":1},{"version":"7941de8fb997b556c0afef2b586d7205-export const platform = \"web\" as const;","signature":"5082e4a38cc5cc308625a8754198c0e3-export declare const platform: \"web\";\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"emitDeclarationOnly":true,"declaration":true,"module":99,"outDir":"./","strict":true},"referencedMap":[[3,1]],"latestChangedDtsFile":"./src/util.d.ts"}
+{"version":"FakeTSVersion","root":[[2,4]],"fileNames":["lib.es2025.full.d.ts","../src/util.native.ts","../index.native.ts","../src/util.ts","../package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"c1f8db351239c175fbb3960262e28684-export const platform = \"native\" as const;","signature":"1f876b2eee633f65aa2e7817bfee737a-export declare const platform: \"native\";\n","impliedNodeFormat":1},{"version":"0a747b719fd37e7b799139c5f607d76b-export { platform } from \"./src/util\";","signature":"b065ccf77d7f1159c74552524b8d4d2b-export { platform } from \"./src/util\";\n","impliedNodeFormat":1},{"version":"7941de8fb997b556c0afef2b586d7205-export const platform = \"web\" as const;","signature":"5082e4a38cc5cc308625a8754198c0e3-export declare const platform: \"web\";\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"emitDeclarationOnly":true,"declaration":true,"module":99,"outDir":"./","strict":true},"referencedMap":[[3,1]],"latestChangedDtsFile":"./src/util.d.ts","packageJsonLookups":[[5,"795503d9617cc95beca2d200469e30b4-{\n    \"name\": \"pkg\",\n    \"exports\": {\n        \".\": {\n            \"react-native\": \"./index.native.ts\",\n            \"types\": \"./index.ts\",\n            \"default\": \"./index.ts\"\n        }\n    }\n}"]]}
 //// [/home/src/workspaces/project/pkg/dist/tsconfig.native.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
@@ -150,7 +150,8 @@ export declare const platform: "native";
     "lib.es2025.full.d.ts",
     "../src/util.native.ts",
     "../index.native.ts",
-    "../src/util.ts"
+    "../src/util.ts",
+    "../package.json"
   ],
   "fileInfos": [
     {
@@ -218,10 +219,16 @@ export declare const platform: "native";
     ]
   },
   "latestChangedDtsFile": "./src/util.d.ts",
-  "size": 1731
+  "packageJsonLookups": [
+    {
+      "fileName": "../package.json",
+      "version": "795503d9617cc95beca2d200469e30b4-{\n    \"name\": \"pkg\",\n    \"exports\": {\n        \".\": {\n            \"react-native\": \"./index.native.ts\",\n            \"types\": \"./index.ts\",\n            \"default\": \"./index.ts\"\n        }\n    }\n}"
+    }
+  ],
+  "size": 2031
 }
 //// [/home/src/workspaces/project/pkg/dist/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","root":[[2,5]],"fileNames":["lib.es2025.full.d.ts","./src/util.native.d.ts","./index.native.d.ts","./src/util.d.ts","../index.ts","../src/util.native.ts","../index.native.ts","../src/util.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"1f876b2eee633f65aa2e7817bfee737a-export declare const platform: \"native\";\n","b065ccf77d7f1159c74552524b8d4d2b-export { platform } from \"./src/util\";\n","5082e4a38cc5cc308625a8754198c0e3-export declare const platform: \"web\";\n",{"version":"0a747b719fd37e7b799139c5f607d76b-export { platform } from \"./src/util\";","signature":"b065ccf77d7f1159c74552524b8d4d2b-export { platform } from \"./src/util\";\n","impliedNodeFormat":1}],"fileIdsList":[[2],[4]],"options":{"composite":true,"emitDeclarationOnly":true,"declaration":true,"module":99,"outDir":"./","strict":true},"referencedMap":[[3,1],[5,2]],"latestChangedDtsFile":"./index.d.ts","resolvedRoot":[[2,6],[3,7],[4,8]]}
+{"version":"FakeTSVersion","root":[[2,5]],"fileNames":["lib.es2025.full.d.ts","./src/util.native.d.ts","./index.native.d.ts","./src/util.d.ts","../index.ts","../src/util.native.ts","../index.native.ts","../src/util.ts","../package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"1f876b2eee633f65aa2e7817bfee737a-export declare const platform: \"native\";\n","b065ccf77d7f1159c74552524b8d4d2b-export { platform } from \"./src/util\";\n","5082e4a38cc5cc308625a8754198c0e3-export declare const platform: \"web\";\n",{"version":"0a747b719fd37e7b799139c5f607d76b-export { platform } from \"./src/util\";","signature":"b065ccf77d7f1159c74552524b8d4d2b-export { platform } from \"./src/util\";\n","impliedNodeFormat":1}],"fileIdsList":[[2],[4]],"options":{"composite":true,"emitDeclarationOnly":true,"declaration":true,"module":99,"outDir":"./","strict":true},"referencedMap":[[3,1],[5,2]],"latestChangedDtsFile":"./index.d.ts","resolvedRoot":[[2,6],[3,7],[4,8]],"packageJsonLookups":[[9,"795503d9617cc95beca2d200469e30b4-{\n    \"name\": \"pkg\",\n    \"exports\": {\n        \".\": {\n            \"react-native\": \"./index.native.ts\",\n            \"types\": \"./index.ts\",\n            \"default\": \"./index.ts\"\n        }\n    }\n}"]]}
 //// [/home/src/workspaces/project/pkg/dist/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
@@ -247,7 +254,8 @@ export declare const platform: "native";
     "../index.ts",
     "../src/util.native.ts",
     "../index.native.ts",
-    "../src/util.ts"
+    "../src/util.ts",
+    "../package.json"
   ],
   "fileInfos": [
     {
@@ -331,7 +339,13 @@ export declare const platform: "native";
       "../src/util.ts"
     ]
   ],
-  "size": 1681
+  "packageJsonLookups": [
+    {
+      "fileName": "../package.json",
+      "version": "795503d9617cc95beca2d200469e30b4-{\n    \"name\": \"pkg\",\n    \"exports\": {\n        \".\": {\n            \"react-native\": \"./index.native.ts\",\n            \"types\": \"./index.ts\",\n            \"default\": \"./index.ts\"\n        }\n    }\n}"
+    }
+  ],
+  "size": 1981
 }
 //// [/home/src/workspaces/project/tsconfig.tsbuildinfo] *new* 
 {"version":"FakeTSVersion","root":["./app.ts"]}

--- a/testdata/baselines/reference/tsbuild/sample/explainFiles.js
+++ b/testdata/baselines/reference/tsbuild/sample/explainFiles.js
@@ -489,7 +489,7 @@ core/index.ts
    Matched by default include pattern '**/*'
 core/some_decl.d.ts
    Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Project 'logic/tsconfig.json' is out of date because output 'logic/tsconfig.tsbuildinfo' is older than input 'core'
+[[90mHH:MM:SS AM[0m] Project 'logic/tsconfig.json' is out of date because output 'logic/tsconfig.tsbuildinfo' is older than input 'core/index.d.ts'
 
 [[90mHH:MM:SS AM[0m] Building project 'logic/tsconfig.json'...
 
@@ -503,7 +503,7 @@ core/anotherModule.d.ts
    File is output of project reference source 'core/anotherModule.ts'
 logic/index.ts
    Matched by default include pattern '**/*'
-[[90mHH:MM:SS AM[0m] Project 'tests/tsconfig.json' is out of date because output 'tests/tsconfig.tsbuildinfo' is older than input 'core'
+[[90mHH:MM:SS AM[0m] Project 'tests/tsconfig.json' is out of date because output 'tests/tsconfig.tsbuildinfo' is older than input 'core/index.d.ts'
 
 [[90mHH:MM:SS AM[0m] Building project 'tests/tsconfig.json'...
 

--- a/testdata/baselines/reference/tsbuild/sample/sample.js
+++ b/testdata/baselines/reference/tsbuild/sample/sample.js
@@ -449,11 +449,11 @@ Output::
 
 [[90mHH:MM:SS AM[0m] Building project 'core/tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Project 'logic/tsconfig.json' is out of date because output 'logic/tsconfig.tsbuildinfo' is older than input 'core'
+[[90mHH:MM:SS AM[0m] Project 'logic/tsconfig.json' is out of date because output 'logic/tsconfig.tsbuildinfo' is older than input 'core/index.d.ts'
 
 [[90mHH:MM:SS AM[0m] Building project 'logic/tsconfig.json'...
 
-[[90mHH:MM:SS AM[0m] Project 'tests/tsconfig.json' is out of date because output 'tests/tsconfig.tsbuildinfo' is older than input 'core'
+[[90mHH:MM:SS AM[0m] Project 'tests/tsconfig.json' is out of date because output 'tests/tsconfig.tsbuildinfo' is older than input 'core/index.d.ts'
 
 [[90mHH:MM:SS AM[0m] Building project 'tests/tsconfig.json'...
 

--- a/testdata/baselines/reference/tsbuildWatch/moduleResolution/build-mode-watches-for-changes-to-package-json-main-fields.js
+++ b/testdata/baselines/reference/tsbuildWatch/moduleResolution/build-mode-watches-for-changes-to-package-json-main-fields.js
@@ -155,7 +155,7 @@ export type TheStr = string;
 export {};
 
 //// [/user/username/projects/myproject/packages/pkg2/build/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","root":[[2,4]],"fileNames":["lib.es2025.full.d.ts","../const.ts","../index.ts","../other.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"be0f939ab1143e4064a3742586332724-export type TheNum = 42;","signature":"56e2d69d2edd1f0edd1a64ecfdf6de0d-export type TheNum = 42;\n","impliedNodeFormat":1},{"version":"c95c354b23966e289caeaece40bb8d0a-export type { TheNum } from './const.js';","signature":"f257912cfebb94a04c6ba4e8f754166a-export type { TheNum } from './const.js';\n","impliedNodeFormat":1},{"version":"dfadcd1940a5dc36721d3311ebd8eb8b-export type TheStr = string;","signature":"9551f60bc06319547b96535db4cb8520-export type TheStr = string;\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./"},"referencedMap":[[3,1]],"latestChangedDtsFile":"./other.d.ts"}
+{"version":"FakeTSVersion","root":[[2,4]],"fileNames":["lib.es2025.full.d.ts","../const.ts","../index.ts","../other.ts","../package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"be0f939ab1143e4064a3742586332724-export type TheNum = 42;","signature":"56e2d69d2edd1f0edd1a64ecfdf6de0d-export type TheNum = 42;\n","impliedNodeFormat":1},{"version":"c95c354b23966e289caeaece40bb8d0a-export type { TheNum } from './const.js';","signature":"f257912cfebb94a04c6ba4e8f754166a-export type { TheNum } from './const.js';\n","impliedNodeFormat":1},{"version":"dfadcd1940a5dc36721d3311ebd8eb8b-export type TheStr = string;","signature":"9551f60bc06319547b96535db4cb8520-export type TheStr = string;\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./"},"referencedMap":[[3,1]],"latestChangedDtsFile":"./other.d.ts","packageJsonLookups":[[5,"754b3f84a4868af09079d100c0ad1bc4-{\n    \"name\": \"pkg2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"build/index.js\"\n}"]]}
 //// [/user/username/projects/myproject/packages/pkg2/build/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
@@ -176,7 +176,8 @@ export {};
     "lib.es2025.full.d.ts",
     "../const.ts",
     "../index.ts",
-    "../other.ts"
+    "../other.ts",
+    "../package.json"
   ],
   "fileInfos": [
     {
@@ -240,7 +241,13 @@ export {};
     ]
   },
   "latestChangedDtsFile": "./other.d.ts",
-  "size": 1576
+  "packageJsonLookups": [
+    {
+      "fileName": "../package.json",
+      "version": "754b3f84a4868af09079d100c0ad1bc4-{\n    \"name\": \"pkg2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"build/index.js\"\n}"
+    }
+  ],
+  "size": 1749
 }
 
 packages/pkg2/tsconfig.json::

--- a/testdata/baselines/reference/tsbuildWatch/moduleResolution/resolves-specifier-in-output-declaration-file-from-referenced-project-correctly-with-cts-and-mts-extensions.js
+++ b/testdata/baselines/reference/tsbuildWatch/moduleResolution/resolves-specifier-in-output-declaration-file-from-referenced-project-correctly-with-cts-and-mts-extensions.js
@@ -149,7 +149,7 @@ export type { TheNum } from './const.cjs';
 export {};
 
 //// [/user/username/projects/myproject/packages/pkg2/build/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","../const.cts","../index.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"be0f939ab1143e4064a3742586332724-export type TheNum = 42;","signature":"56e2d69d2edd1f0edd1a64ecfdf6de0d-export type TheNum = 42;\n","impliedNodeFormat":1},{"version":"7bb214373f4d1876e9a0040d287d1b6e-export type { TheNum } from './const.cjs';","signature":"2c7786a1f125eb57a4db00a4d58e384a-export type { TheNum } from './const.cjs';\n","impliedNodeFormat":99}],"fileIdsList":[[2]],"options":{"composite":true,"module":100,"outDir":"./"},"referencedMap":[[3,1]],"latestChangedDtsFile":"./index.d.ts"}
+{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","../const.cts","../index.ts","../package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"be0f939ab1143e4064a3742586332724-export type TheNum = 42;","signature":"56e2d69d2edd1f0edd1a64ecfdf6de0d-export type TheNum = 42;\n","impliedNodeFormat":1},{"version":"7bb214373f4d1876e9a0040d287d1b6e-export type { TheNum } from './const.cjs';","signature":"2c7786a1f125eb57a4db00a4d58e384a-export type { TheNum } from './const.cjs';\n","impliedNodeFormat":99}],"fileIdsList":[[2]],"options":{"composite":true,"module":100,"outDir":"./"},"referencedMap":[[3,1]],"latestChangedDtsFile":"./index.d.ts","packageJsonLookups":[[4,"2e82fd5089d2bcbc548b2f5d4c6ef64e-{\n    \"name\": \"pkg2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"build/index.js\",\n    \"type\": \"module\"\n}"]]}
 //// [/user/username/projects/myproject/packages/pkg2/build/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
@@ -168,7 +168,8 @@ export {};
   "fileNames": [
     "lib.es2025.full.d.ts",
     "../const.cts",
-    "../index.ts"
+    "../index.ts",
+    "../package.json"
   ],
   "fileInfos": [
     {
@@ -222,7 +223,13 @@ export {};
     ]
   },
   "latestChangedDtsFile": "./index.d.ts",
-  "size": 1403
+  "packageJsonLookups": [
+    {
+      "fileName": "../package.json",
+      "version": "2e82fd5089d2bcbc548b2f5d4c6ef64e-{\n    \"name\": \"pkg2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"build/index.js\",\n    \"type\": \"module\"\n}"
+    }
+  ],
+  "size": 1603
 }
 
 packages/pkg2/tsconfig.json::
@@ -406,7 +413,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 export type { TheNum } from './const.cjs';
 
 //// [/user/username/projects/myproject/packages/pkg2/build/tsconfig.tsbuildinfo] *modified* 
-{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","../const.cts","../index.cts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"be0f939ab1143e4064a3742586332724-export type TheNum = 42;","signature":"56e2d69d2edd1f0edd1a64ecfdf6de0d-export type TheNum = 42;\n","impliedNodeFormat":1},{"version":"7bb214373f4d1876e9a0040d287d1b6e-export type { TheNum } from './const.cjs';","signature":"2c7786a1f125eb57a4db00a4d58e384a-export type { TheNum } from './const.cjs';\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"module":100,"outDir":"./"},"referencedMap":[[3,1]],"latestChangedDtsFile":"./index.d.cts"}
+{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","../const.cts","../index.cts","../package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"be0f939ab1143e4064a3742586332724-export type TheNum = 42;","signature":"56e2d69d2edd1f0edd1a64ecfdf6de0d-export type TheNum = 42;\n","impliedNodeFormat":1},{"version":"7bb214373f4d1876e9a0040d287d1b6e-export type { TheNum } from './const.cjs';","signature":"2c7786a1f125eb57a4db00a4d58e384a-export type { TheNum } from './const.cjs';\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"module":100,"outDir":"./"},"referencedMap":[[3,1]],"latestChangedDtsFile":"./index.d.cts","packageJsonLookups":[[4,"852008c4f4f69965bc09191e42c68dd3-{\n    \"name\": \"pkg2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"build/index.cjs\",\n    \"type\": \"module\"\n}"]]}
 //// [/user/username/projects/myproject/packages/pkg2/build/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
 {
   "version": "FakeTSVersion",
@@ -425,7 +432,8 @@ export type { TheNum } from './const.cjs';
   "fileNames": [
     "lib.es2025.full.d.ts",
     "../const.cts",
-    "../index.cts"
+    "../index.cts",
+    "../package.json"
   ],
   "fileInfos": [
     {
@@ -479,7 +487,13 @@ export type { TheNum } from './const.cjs';
     ]
   },
   "latestChangedDtsFile": "./index.d.cts",
-  "size": 1404
+  "packageJsonLookups": [
+    {
+      "fileName": "../package.json",
+      "version": "852008c4f4f69965bc09191e42c68dd3-{\n    \"name\": \"pkg2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"build/index.cjs\",\n    \"type\": \"module\"\n}"
+    }
+  ],
+  "size": 1605
 }
 
 packages/pkg2/tsconfig.json::

--- a/testdata/baselines/reference/tsc/composite/synthetic-jsx-import-of-ESM-module-from-CJS-module-error-on-jsx-element.js
+++ b/testdata/baselines/reference/tsc/composite/synthetic-jsx-import-of-ESM-module-from-CJS-module-error-on-jsx-element.js
@@ -45,7 +45,7 @@ const jsx_runtime_1 = require("solid-js/jsx-runtime");
 exports.default = (0, jsx_runtime_1.jsx)("div", {});
 
 //// [/home/src/projects/project/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","root":[3],"fileNames":["lib.es2025.full.d.ts","./node_modules/solid-js/jsx-runtime.d.ts","./src/main.tsx"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"00e459cbb1596f8c4bdf988b0589433f-export namespace JSX {\n    type IntrinsicElements = { div: {}; };\n}","impliedNodeFormat":99},{"version":"5af15af7f9b4d97300f8dcfb2bf5b7c4-export default <div/>;","signature":"ca37c00363f904fe93e299b145186400-declare const _default: any;\nexport default _default;\n","impliedNodeFormat":1}],"options":{"composite":true,"jsx":4,"jsxImportSource":"solid-js","module":100},"semanticDiagnosticsPerFile":[[3,[{"pos":15,"end":21,"code":1479,"category":1,"messageKey":"The_current_file_is_a_CommonJS_module_whose_imports_will_produce_require_calls_however_the_reference_1479","messageArgs":["solid-js/jsx-runtime"],"messageChain":[{"pos":15,"end":21,"code":1483,"category":3,"messageKey":"To_convert_this_file_to_an_ECMAScript_module_create_a_local_package_json_file_with_type_Colon_module_1483","repopulateInfo":{"kind":1}}]}]]],"latestChangedDtsFile":"./src/main.d.ts"}
+{"version":"FakeTSVersion","root":[3],"fileNames":["lib.es2025.full.d.ts","./node_modules/solid-js/jsx-runtime.d.ts","./src/main.tsx","./node_modules/solid-js/package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"00e459cbb1596f8c4bdf988b0589433f-export namespace JSX {\n    type IntrinsicElements = { div: {}; };\n}","impliedNodeFormat":99},{"version":"5af15af7f9b4d97300f8dcfb2bf5b7c4-export default <div/>;","signature":"ca37c00363f904fe93e299b145186400-declare const _default: any;\nexport default _default;\n","impliedNodeFormat":1}],"options":{"composite":true,"jsx":4,"jsxImportSource":"solid-js","module":100},"semanticDiagnosticsPerFile":[[3,[{"pos":15,"end":21,"code":1479,"category":1,"messageKey":"The_current_file_is_a_CommonJS_module_whose_imports_will_produce_require_calls_however_the_reference_1479","messageArgs":["solid-js/jsx-runtime"],"messageChain":[{"pos":15,"end":21,"code":1483,"category":3,"messageKey":"To_convert_this_file_to_an_ECMAScript_module_create_a_local_package_json_file_with_type_Colon_module_1483","repopulateInfo":{"kind":1}}]}]]],"latestChangedDtsFile":"./src/main.d.ts","packageJsonLookups":[[4,"f7281dbdfdc056509713302125e0f706-{\n    \"name\": \"solid-js\",\n    \"type\": \"module\"\n}"]]}
 //// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
@@ -60,7 +60,8 @@ exports.default = (0, jsx_runtime_1.jsx)("div", {});
   "fileNames": [
     "lib.es2025.full.d.ts",
     "./node_modules/solid-js/jsx-runtime.d.ts",
-    "./src/main.tsx"
+    "./src/main.tsx",
+    "./node_modules/solid-js/package.json"
   ],
   "fileInfos": [
     {
@@ -130,7 +131,13 @@ exports.default = (0, jsx_runtime_1.jsx)("div", {});
     ]
   ],
   "latestChangedDtsFile": "./src/main.d.ts",
-  "size": 1828
+  "packageJsonLookups": [
+    {
+      "fileName": "./node_modules/solid-js/package.json",
+      "version": "f7281dbdfdc056509713302125e0f706-{\n    \"name\": \"solid-js\",\n    \"type\": \"module\"\n}"
+    }
+  ],
+  "size": 1989
 }
 //// [/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts] *Lib*
 /// <reference no-default-lib="true"/>

--- a/testdata/baselines/reference/tsc/declarationEmit/reports-dts-generation-errors-with-incremental.js
+++ b/testdata/baselines/reference/tsc/declarationEmit/reports-dts-generation-errors-with-incremental.js
@@ -82,7 +82,7 @@ import ky from 'ky';
 export const api = ky.extend({});
 
 //// [/home/src/workspaces/project/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","root":[3],"fileNames":["lib.es2025.full.d.ts","./node_modules/ky/distribution/index.d.ts","./index.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"b9b50c37c18e43d94b0dd4fb43967f10-type KyInstance = {\n    extend(options: Record<string,unknown>): KyInstance;\n}\ndeclare const ky: KyInstance;\nexport default ky;","impliedNodeFormat":99},{"version":"0f5091e963c17913313e4969c59e6eb4-import ky from 'ky';\nexport const api = ky.extend({});","impliedNodeFormat":99}],"fileIdsList":[[2]],"options":{"composite":true,"declaration":true,"module":199,"skipLibCheck":true,"skipDefaultLibCheck":true},"referencedMap":[[3,1]],"emitDiagnosticsPerFile":[[3,[{"pos":34,"end":37,"code":4023,"category":1,"messageKey":"Exported_variable_0_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named_4023","messageArgs":["api","KyInstance","\"/home/src/workspaces/project/node_modules/ky/distribution/index\""]}]]],"emitSignatures":[3]}
+{"version":"FakeTSVersion","root":[3],"fileNames":["lib.es2025.full.d.ts","./node_modules/ky/distribution/index.d.ts","./index.ts","./node_modules/ky/package.json","./package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"b9b50c37c18e43d94b0dd4fb43967f10-type KyInstance = {\n    extend(options: Record<string,unknown>): KyInstance;\n}\ndeclare const ky: KyInstance;\nexport default ky;","impliedNodeFormat":99},{"version":"0f5091e963c17913313e4969c59e6eb4-import ky from 'ky';\nexport const api = ky.extend({});","impliedNodeFormat":99}],"fileIdsList":[[2]],"options":{"composite":true,"declaration":true,"module":199,"skipLibCheck":true,"skipDefaultLibCheck":true},"referencedMap":[[3,1]],"emitDiagnosticsPerFile":[[3,[{"pos":34,"end":37,"code":4023,"category":1,"messageKey":"Exported_variable_0_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named_4023","messageArgs":["api","KyInstance","\"/home/src/workspaces/project/node_modules/ky/distribution/index\""]}]]],"emitSignatures":[3],"packageJsonLookups":[[4,"bee3a88c1c92b0fd5be9ed3068366b12-{\n    \"name\": \"ky\",\n    \"type\": \"module\",\n    \"main\": \"./distribution/index.js\"\n}"],[5,"5e6623570a1a33021797cbd4e9eba0ae-{\n    \"type\": \"module\"\n}"]]}
 //// [/home/src/workspaces/project/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
@@ -97,7 +97,9 @@ export const api = ky.extend({});
   "fileNames": [
     "lib.es2025.full.d.ts",
     "./node_modules/ky/distribution/index.d.ts",
-    "./index.ts"
+    "./index.ts",
+    "./node_modules/ky/package.json",
+    "./package.json"
   ],
   "fileInfos": [
     {
@@ -175,7 +177,17 @@ export const api = ky.extend({});
       "original": 3
     }
   ],
-  "size": 1706
+  "packageJsonLookups": [
+    {
+      "fileName": "./node_modules/ky/package.json",
+      "version": "bee3a88c1c92b0fd5be9ed3068366b12-{\n    \"name\": \"ky\",\n    \"type\": \"module\",\n    \"main\": \"./distribution/index.js\"\n}"
+    },
+    {
+      "fileName": "./package.json",
+      "version": "5e6623570a1a33021797cbd4e9eba0ae-{\n    \"type\": \"module\"\n}"
+    }
+  ],
+  "size": 1986
 }
 
 tsconfig.json::

--- a/testdata/baselines/reference/tsc/incremental/Compile-incremental-with-case-insensitive-file-names.js
+++ b/testdata/baselines/reference/tsc/incremental/Compile-incremental-with-case-insensitive-file-names.js
@@ -64,7 +64,7 @@ export const foo1 = { foo: "a" };
 export const foo2 = { foo: "b" };
 
 //// [/home/project/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","errors":true,"root":[6],"fileNames":["lib.es2025.full.d.ts","../node_modules/otherlib/index.d.ts","../node_modules/somelib/index.d.ts","../node_modules/lib1/index.d.ts","../node_modules/lib2/index.d.ts","./src/index.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"1fe659ed0634bb57b6dc25e9062f1162-export type Str = string;","12e112ff6e2744bb42d8e0b511e44117-import type { Str } from 'otherLib';\nexport type Foo = { foo: Str; };","b6305455d920a6729c435e6acf45eff6-import type { Foo } from 'someLib';\nexport type { Foo as Foo1 };","a5393e550a9c20a242a120bf6410db48-import type { Foo } from 'somelib';\nexport type { Foo as Foo2 };\nexport declare const foo2: Foo;","42aef197ff5f079223e2c29fb2e77cc5-import type { Foo1 } from 'lib1';\nimport type { Foo2 } from 'lib2';\nexport const foo1: Foo1 = { foo: \"a\" };\nexport const foo2: Foo2 = { foo: \"b\" };"],"fileIdsList":[[3],[2],[4,5]],"referencedMap":[[4,1],[5,1],[3,2],[6,3]]}
+{"version":"FakeTSVersion","errors":true,"root":[6],"fileNames":["lib.es2025.full.d.ts","../node_modules/otherlib/index.d.ts","../node_modules/somelib/index.d.ts","../node_modules/lib1/index.d.ts","../node_modules/lib2/index.d.ts","./src/index.ts","../node_modules/lib1/package.json","../node_modules/lib2/package.json","../node_modules/otherlib/package.json","../node_modules/somelib/package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"1fe659ed0634bb57b6dc25e9062f1162-export type Str = string;","12e112ff6e2744bb42d8e0b511e44117-import type { Str } from 'otherLib';\nexport type Foo = { foo: Str; };","b6305455d920a6729c435e6acf45eff6-import type { Foo } from 'someLib';\nexport type { Foo as Foo1 };","a5393e550a9c20a242a120bf6410db48-import type { Foo } from 'somelib';\nexport type { Foo as Foo2 };\nexport declare const foo2: Foo;","42aef197ff5f079223e2c29fb2e77cc5-import type { Foo1 } from 'lib1';\nimport type { Foo2 } from 'lib2';\nexport const foo1: Foo1 = { foo: \"a\" };\nexport const foo2: Foo2 = { foo: \"b\" };"],"fileIdsList":[[3],[2],[4,5]],"referencedMap":[[4,1],[5,1],[3,2],[6,3]],"packageJsonLookups":[[7,"a24c96c743e9cb48c64eca6a8b5b551e-{\n    \"name\": \"lib1\"\n}"],[8,"bc59f79aa07dfed1e057917f361f101a-{\n    \"name\": \"lib2\"\n}"],[9,"9c8cdfa4b5c11c1e6383a3e0554eb39b-{\n    \"name\": \"otherlib\"\n}"],[10,"c2afa57e6030c59149dd6ea9a38aba8c-{\n    \"name\": \"somelib\"\n}"]]}
 //// [/home/project/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
@@ -83,7 +83,11 @@ export const foo2 = { foo: "b" };
     "../node_modules/somelib/index.d.ts",
     "../node_modules/lib1/index.d.ts",
     "../node_modules/lib2/index.d.ts",
-    "./src/index.ts"
+    "./src/index.ts",
+    "../node_modules/lib1/package.json",
+    "../node_modules/lib2/package.json",
+    "../node_modules/otherlib/package.json",
+    "../node_modules/somelib/package.json"
   ],
   "fileInfos": [
     {
@@ -156,7 +160,25 @@ export const foo2 = { foo: "b" };
       "../node_modules/lib2/index.d.ts"
     ]
   },
-  "size": 1697
+  "packageJsonLookups": [
+    {
+      "fileName": "../node_modules/lib1/package.json",
+      "version": "a24c96c743e9cb48c64eca6a8b5b551e-{\n    \"name\": \"lib1\"\n}"
+    },
+    {
+      "fileName": "../node_modules/lib2/package.json",
+      "version": "bc59f79aa07dfed1e057917f361f101a-{\n    \"name\": \"lib2\"\n}"
+    },
+    {
+      "fileName": "../node_modules/otherlib/package.json",
+      "version": "9c8cdfa4b5c11c1e6383a3e0554eb39b-{\n    \"name\": \"otherlib\"\n}"
+    },
+    {
+      "fileName": "../node_modules/somelib/package.json",
+      "version": "c2afa57e6030c59149dd6ea9a38aba8c-{\n    \"name\": \"somelib\"\n}"
+    }
+  ],
+  "size": 2151
 }
 //// [/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts] *Lib*
 /// <reference no-default-lib="true"/>

--- a/testdata/baselines/reference/tsc/moduleResolution/alternateResult.js
+++ b/testdata/baselines/reference/tsc/moduleResolution/alternateResult.js
@@ -319,7 +319,7 @@ Found 2 errors in the same file, starting at: index.mts[90m:1[0m
 export {};
 
 //// [/home/src/projects/project/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","root":[4],"fileNames":["lib.es2025.full.d.ts","./node_modules/foo2/index.d.ts","./node_modules/@types/bar2/index.d.ts","./index.mts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"165b91a7791663df5931f0b63ebf9ce2-export declare const foo2: number;","da9728b78f5d24b38c00844e001b4953-export declare const bar2: number;",{"version":"eee0814e4a127747fb836acc50eaeb5a-import { foo } from \"foo\";\nimport { bar } from \"bar\";\nimport { foo2 } from \"foo2\";\nimport { bar2 } from \"bar2\";","impliedNodeFormat":99}],"fileIdsList":[[2,3]],"options":{"module":100,"strict":true},"referencedMap":[[4,1]],"semanticDiagnosticsPerFile":[[4,[{"pos":20,"end":25,"code":7016,"category":1,"messageKey":"Could_not_find_a_declaration_file_for_module_0_1_implicitly_has_an_any_type_7016","messageArgs":["foo","/home/src/projects/project/node_modules/foo/index.mjs"],"messageChain":[{"pos":20,"end":25,"code":6278,"category":3,"messageKey":"There_are_types_at_0_but_this_result_could_not_be_resolved_when_respecting_package_json_exports_The__6278","messageArgs":["/home/src/projects/project/node_modules/foo/index.d.ts","foo"],"repopulateInfo":{"kind":2,"moduleReference":"foo","mode":99}}]},{"pos":47,"end":52,"code":7016,"category":1,"messageKey":"Could_not_find_a_declaration_file_for_module_0_1_implicitly_has_an_any_type_7016","messageArgs":["bar","/home/src/projects/project/node_modules/bar/index.mjs"],"messageChain":[{"pos":47,"end":52,"code":6278,"category":3,"messageKey":"There_are_types_at_0_but_this_result_could_not_be_resolved_when_respecting_package_json_exports_The__6278","messageArgs":["/home/src/projects/project/node_modules/@types/bar/index.d.ts","@types/bar"],"repopulateInfo":{"kind":2,"moduleReference":"bar","mode":99}}]}]]]}
+{"version":"FakeTSVersion","root":[4],"fileNames":["lib.es2025.full.d.ts","./node_modules/foo2/index.d.ts","./node_modules/@types/bar2/index.d.ts","./index.mts","./node_modules/@types/bar/package.json","./node_modules/@types/bar2/package.json","./node_modules/bar/package.json","./node_modules/bar2/package.json","./node_modules/foo/package.json","./node_modules/foo2/package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"165b91a7791663df5931f0b63ebf9ce2-export declare const foo2: number;","da9728b78f5d24b38c00844e001b4953-export declare const bar2: number;",{"version":"eee0814e4a127747fb836acc50eaeb5a-import { foo } from \"foo\";\nimport { bar } from \"bar\";\nimport { foo2 } from \"foo2\";\nimport { bar2 } from \"bar2\";","impliedNodeFormat":99}],"fileIdsList":[[2,3]],"options":{"module":100,"strict":true},"referencedMap":[[4,1]],"semanticDiagnosticsPerFile":[[4,[{"pos":20,"end":25,"code":7016,"category":1,"messageKey":"Could_not_find_a_declaration_file_for_module_0_1_implicitly_has_an_any_type_7016","messageArgs":["foo","/home/src/projects/project/node_modules/foo/index.mjs"],"messageChain":[{"pos":20,"end":25,"code":6278,"category":3,"messageKey":"There_are_types_at_0_but_this_result_could_not_be_resolved_when_respecting_package_json_exports_The__6278","messageArgs":["/home/src/projects/project/node_modules/foo/index.d.ts","foo"],"repopulateInfo":{"kind":2,"moduleReference":"foo","mode":99}}]},{"pos":47,"end":52,"code":7016,"category":1,"messageKey":"Could_not_find_a_declaration_file_for_module_0_1_implicitly_has_an_any_type_7016","messageArgs":["bar","/home/src/projects/project/node_modules/bar/index.mjs"],"messageChain":[{"pos":47,"end":52,"code":6278,"category":3,"messageKey":"There_are_types_at_0_but_this_result_could_not_be_resolved_when_respecting_package_json_exports_The__6278","messageArgs":["/home/src/projects/project/node_modules/@types/bar/index.d.ts","@types/bar"],"repopulateInfo":{"kind":2,"moduleReference":"bar","mode":99}}]}]]],"packageJsonLookups":[[5,"9468a7ec586948705dfd37f9f778a5a0-{\n    \"name\": \"@types/bar\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n\n            \"require\": \"./index.d.ts\"\n        }\n    }\n}"],[6,"2f6530e060ae71a6b32fe264128644c5-{\n    \"name\": \"@types/bar2\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./index.d.ts\",\n            \"require\": \"./index.d.ts\"\n        }\n    }\n}"],[7,"5d4b63cd2f7a4e8d2f4b99a206b1cef7-{\n    \"name\": \"bar\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n\n    \"exports\": {\n        \".\": {\n\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"],[8,"1fc90d9c461330bf9ad3cd8aa0fcaf25-{\n    \"name\": \"bar2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n\n    \"exports\": {\n        \".\": {\n\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"],[9,"32b480d4a8e34ee854ee84cd74179539-{\n    \"name\": \"foo\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"],[10,"ccd27560d6db00006c1734549a253ce4-{\n    \"name\": \"foo2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./index.d.ts\",\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"]]}
 //// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
@@ -335,7 +335,13 @@ export {};
     "lib.es2025.full.d.ts",
     "./node_modules/foo2/index.d.ts",
     "./node_modules/@types/bar2/index.d.ts",
-    "./index.mts"
+    "./index.mts",
+    "./node_modules/@types/bar/package.json",
+    "./node_modules/@types/bar2/package.json",
+    "./node_modules/bar/package.json",
+    "./node_modules/bar2/package.json",
+    "./node_modules/foo/package.json",
+    "./node_modules/foo2/package.json"
   ],
   "fileInfos": [
     {
@@ -444,7 +450,33 @@ export {};
       ]
     ]
   ],
-  "size": 2501
+  "packageJsonLookups": [
+    {
+      "fileName": "./node_modules/@types/bar/package.json",
+      "version": "9468a7ec586948705dfd37f9f778a5a0-{\n    \"name\": \"@types/bar\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n\n            \"require\": \"./index.d.ts\"\n        }\n    }\n}"
+    },
+    {
+      "fileName": "./node_modules/@types/bar2/package.json",
+      "version": "2f6530e060ae71a6b32fe264128644c5-{\n    \"name\": \"@types/bar2\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./index.d.ts\",\n            \"require\": \"./index.d.ts\"\n        }\n    }\n}"
+    },
+    {
+      "fileName": "./node_modules/bar/package.json",
+      "version": "5d4b63cd2f7a4e8d2f4b99a206b1cef7-{\n    \"name\": \"bar\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n\n    \"exports\": {\n        \".\": {\n\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"
+    },
+    {
+      "fileName": "./node_modules/bar2/package.json",
+      "version": "1fc90d9c461330bf9ad3cd8aa0fcaf25-{\n    \"name\": \"bar2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n\n    \"exports\": {\n        \".\": {\n\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"
+    },
+    {
+      "fileName": "./node_modules/foo/package.json",
+      "version": "32b480d4a8e34ee854ee84cd74179539-{\n    \"name\": \"foo\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"
+    },
+    {
+      "fileName": "./node_modules/foo2/package.json",
+      "version": "ccd27560d6db00006c1734549a253ce4-{\n    \"name\": \"foo2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./index.d.ts\",\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"
+    }
+  ],
+  "size": 4439
 }
 //// [/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts] *Lib*
 /// <reference no-default-lib="true"/>
@@ -1488,7 +1520,7 @@ Found 1 error in index.mts[90m:1[0m
 
 //// [/home/src/projects/project/index.mjs] *rewrite with same content*
 //// [/home/src/projects/project/tsconfig.tsbuildinfo] *modified* 
-{"version":"FakeTSVersion","root":[5],"fileNames":["lib.es2025.full.d.ts","./node_modules/@types/bar/index.d.ts","./node_modules/foo2/index.d.ts","./node_modules/@types/bar2/index.d.ts","./index.mts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"78bc7ca8c840e090086811119f6d6ba9-export declare const bar: number;","165b91a7791663df5931f0b63ebf9ce2-export declare const foo2: number;","da9728b78f5d24b38c00844e001b4953-export declare const bar2: number;",{"version":"eee0814e4a127747fb836acc50eaeb5a-import { foo } from \"foo\";\nimport { bar } from \"bar\";\nimport { foo2 } from \"foo2\";\nimport { bar2 } from \"bar2\";","signature":"abe7d9981d6018efb6b2b794f40a1607-export {};\n","impliedNodeFormat":99}],"fileIdsList":[[2,3,4]],"options":{"module":100,"strict":true},"referencedMap":[[5,1]],"semanticDiagnosticsPerFile":[[5,[{"pos":20,"end":25,"code":7016,"category":1,"messageKey":"Could_not_find_a_declaration_file_for_module_0_1_implicitly_has_an_any_type_7016","messageArgs":["foo","/home/src/projects/project/node_modules/foo/index.mjs"],"messageChain":[{"pos":20,"end":25,"code":6278,"category":3,"messageKey":"There_are_types_at_0_but_this_result_could_not_be_resolved_when_respecting_package_json_exports_The__6278","messageArgs":["/home/src/projects/project/node_modules/foo/index.d.ts","foo"],"repopulateInfo":{"kind":2,"moduleReference":"foo","mode":99}}]}]]]}
+{"version":"FakeTSVersion","root":[5],"fileNames":["lib.es2025.full.d.ts","./node_modules/@types/bar/index.d.ts","./node_modules/foo2/index.d.ts","./node_modules/@types/bar2/index.d.ts","./index.mts","./node_modules/@types/bar/package.json","./node_modules/@types/bar2/package.json","./node_modules/bar/package.json","./node_modules/bar2/package.json","./node_modules/foo/package.json","./node_modules/foo2/package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"78bc7ca8c840e090086811119f6d6ba9-export declare const bar: number;","165b91a7791663df5931f0b63ebf9ce2-export declare const foo2: number;","da9728b78f5d24b38c00844e001b4953-export declare const bar2: number;",{"version":"eee0814e4a127747fb836acc50eaeb5a-import { foo } from \"foo\";\nimport { bar } from \"bar\";\nimport { foo2 } from \"foo2\";\nimport { bar2 } from \"bar2\";","signature":"abe7d9981d6018efb6b2b794f40a1607-export {};\n","impliedNodeFormat":99}],"fileIdsList":[[2,3,4]],"options":{"module":100,"strict":true},"referencedMap":[[5,1]],"semanticDiagnosticsPerFile":[[5,[{"pos":20,"end":25,"code":7016,"category":1,"messageKey":"Could_not_find_a_declaration_file_for_module_0_1_implicitly_has_an_any_type_7016","messageArgs":["foo","/home/src/projects/project/node_modules/foo/index.mjs"],"messageChain":[{"pos":20,"end":25,"code":6278,"category":3,"messageKey":"There_are_types_at_0_but_this_result_could_not_be_resolved_when_respecting_package_json_exports_The__6278","messageArgs":["/home/src/projects/project/node_modules/foo/index.d.ts","foo"],"repopulateInfo":{"kind":2,"moduleReference":"foo","mode":99}}]}]]],"packageJsonLookups":[[6,"98684280318116b3ab197ebba8bfe8e9-{\n    \"name\": \"@types/bar\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./index.d.ts\",\n            \"require\": \"./index.d.ts\"\n        }\n    }\n}"],[7,"2f6530e060ae71a6b32fe264128644c5-{\n    \"name\": \"@types/bar2\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./index.d.ts\",\n            \"require\": \"./index.d.ts\"\n        }\n    }\n}"],[8,"5d4b63cd2f7a4e8d2f4b99a206b1cef7-{\n    \"name\": \"bar\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n\n    \"exports\": {\n        \".\": {\n\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"],[9,"1fc90d9c461330bf9ad3cd8aa0fcaf25-{\n    \"name\": \"bar2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n\n    \"exports\": {\n        \".\": {\n\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"],[10,"32b480d4a8e34ee854ee84cd74179539-{\n    \"name\": \"foo\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"],[11,"ccd27560d6db00006c1734549a253ce4-{\n    \"name\": \"foo2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./index.d.ts\",\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"]]}
 //// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
 {
   "version": "FakeTSVersion",
@@ -1505,7 +1537,13 @@ Found 1 error in index.mts[90m:1[0m
     "./node_modules/@types/bar/index.d.ts",
     "./node_modules/foo2/index.d.ts",
     "./node_modules/@types/bar2/index.d.ts",
-    "./index.mts"
+    "./index.mts",
+    "./node_modules/@types/bar/package.json",
+    "./node_modules/@types/bar2/package.json",
+    "./node_modules/bar/package.json",
+    "./node_modules/bar2/package.json",
+    "./node_modules/foo/package.json",
+    "./node_modules/foo2/package.json"
   ],
   "fileInfos": [
     {
@@ -1599,7 +1637,33 @@ Found 1 error in index.mts[90m:1[0m
       ]
     ]
   ],
-  "size": 2114
+  "packageJsonLookups": [
+    {
+      "fileName": "./node_modules/@types/bar/package.json",
+      "version": "98684280318116b3ab197ebba8bfe8e9-{\n    \"name\": \"@types/bar\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./index.d.ts\",\n            \"require\": \"./index.d.ts\"\n        }\n    }\n}"
+    },
+    {
+      "fileName": "./node_modules/@types/bar2/package.json",
+      "version": "2f6530e060ae71a6b32fe264128644c5-{\n    \"name\": \"@types/bar2\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./index.d.ts\",\n            \"require\": \"./index.d.ts\"\n        }\n    }\n}"
+    },
+    {
+      "fileName": "./node_modules/bar/package.json",
+      "version": "5d4b63cd2f7a4e8d2f4b99a206b1cef7-{\n    \"name\": \"bar\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n\n    \"exports\": {\n        \".\": {\n\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"
+    },
+    {
+      "fileName": "./node_modules/bar2/package.json",
+      "version": "1fc90d9c461330bf9ad3cd8aa0fcaf25-{\n    \"name\": \"bar2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n\n    \"exports\": {\n        \".\": {\n\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"
+    },
+    {
+      "fileName": "./node_modules/foo/package.json",
+      "version": "32b480d4a8e34ee854ee84cd74179539-{\n    \"name\": \"foo\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"
+    },
+    {
+      "fileName": "./node_modules/foo2/package.json",
+      "version": "ccd27560d6db00006c1734549a253ce4-{\n    \"name\": \"foo2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./index.d.ts\",\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"
+    }
+  ],
+  "size": 4093
 }
 
 tsconfig.json::
@@ -1732,7 +1796,7 @@ Resolving real path for '/home/src/projects/project/node_modules/@types/bar2/ind
 ======== Module name 'bar2' was successfully resolved to '/home/src/projects/project/node_modules/@types/bar2/index.d.ts' with Package ID '@types/bar2/index.d.ts@1.0.0'. ========
 //// [/home/src/projects/project/index.mjs] *rewrite with same content*
 //// [/home/src/projects/project/tsconfig.tsbuildinfo] *modified* 
-{"version":"FakeTSVersion","root":[6],"fileNames":["lib.es2025.full.d.ts","./node_modules/foo/index.d.ts","./node_modules/@types/bar/index.d.ts","./node_modules/foo2/index.d.ts","./node_modules/@types/bar2/index.d.ts","./index.mts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"2a914bfad3bba77712486af8a4cdc415-export declare const foo: number;","78bc7ca8c840e090086811119f6d6ba9-export declare const bar: number;","165b91a7791663df5931f0b63ebf9ce2-export declare const foo2: number;","da9728b78f5d24b38c00844e001b4953-export declare const bar2: number;",{"version":"eee0814e4a127747fb836acc50eaeb5a-import { foo } from \"foo\";\nimport { bar } from \"bar\";\nimport { foo2 } from \"foo2\";\nimport { bar2 } from \"bar2\";","signature":"abe7d9981d6018efb6b2b794f40a1607-export {};\n","impliedNodeFormat":99}],"fileIdsList":[[2,3,4,5]],"options":{"module":100,"strict":true},"referencedMap":[[6,1]]}
+{"version":"FakeTSVersion","root":[6],"fileNames":["lib.es2025.full.d.ts","./node_modules/foo/index.d.ts","./node_modules/@types/bar/index.d.ts","./node_modules/foo2/index.d.ts","./node_modules/@types/bar2/index.d.ts","./index.mts","./node_modules/@types/bar/package.json","./node_modules/@types/bar2/package.json","./node_modules/bar/package.json","./node_modules/bar2/package.json","./node_modules/foo/package.json","./node_modules/foo2/package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"2a914bfad3bba77712486af8a4cdc415-export declare const foo: number;","78bc7ca8c840e090086811119f6d6ba9-export declare const bar: number;","165b91a7791663df5931f0b63ebf9ce2-export declare const foo2: number;","da9728b78f5d24b38c00844e001b4953-export declare const bar2: number;",{"version":"eee0814e4a127747fb836acc50eaeb5a-import { foo } from \"foo\";\nimport { bar } from \"bar\";\nimport { foo2 } from \"foo2\";\nimport { bar2 } from \"bar2\";","signature":"abe7d9981d6018efb6b2b794f40a1607-export {};\n","impliedNodeFormat":99}],"fileIdsList":[[2,3,4,5]],"options":{"module":100,"strict":true},"referencedMap":[[6,1]],"packageJsonLookups":[[7,"98684280318116b3ab197ebba8bfe8e9-{\n    \"name\": \"@types/bar\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./index.d.ts\",\n            \"require\": \"./index.d.ts\"\n        }\n    }\n}"],[8,"2f6530e060ae71a6b32fe264128644c5-{\n    \"name\": \"@types/bar2\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./index.d.ts\",\n            \"require\": \"./index.d.ts\"\n        }\n    }\n}"],[9,"5d4b63cd2f7a4e8d2f4b99a206b1cef7-{\n    \"name\": \"bar\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n\n    \"exports\": {\n        \".\": {\n\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"],[10,"1fc90d9c461330bf9ad3cd8aa0fcaf25-{\n    \"name\": \"bar2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n\n    \"exports\": {\n        \".\": {\n\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"],[11,"64750892349c68814e7acb96ebad2f21-{\n    \"name\": \"foo\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./index.d.ts\",\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"],[12,"ccd27560d6db00006c1734549a253ce4-{\n    \"name\": \"foo2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./index.d.ts\",\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"]]}
 //// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
 {
   "version": "FakeTSVersion",
@@ -1750,7 +1814,13 @@ Resolving real path for '/home/src/projects/project/node_modules/@types/bar2/ind
     "./node_modules/@types/bar/index.d.ts",
     "./node_modules/foo2/index.d.ts",
     "./node_modules/@types/bar2/index.d.ts",
-    "./index.mts"
+    "./index.mts",
+    "./node_modules/@types/bar/package.json",
+    "./node_modules/@types/bar2/package.json",
+    "./node_modules/bar/package.json",
+    "./node_modules/bar2/package.json",
+    "./node_modules/foo/package.json",
+    "./node_modules/foo2/package.json"
   ],
   "fileInfos": [
     {
@@ -1821,7 +1891,33 @@ Resolving real path for '/home/src/projects/project/node_modules/@types/bar2/ind
       "./node_modules/@types/bar2/index.d.ts"
     ]
   },
-  "size": 1637
+  "packageJsonLookups": [
+    {
+      "fileName": "./node_modules/@types/bar/package.json",
+      "version": "98684280318116b3ab197ebba8bfe8e9-{\n    \"name\": \"@types/bar\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./index.d.ts\",\n            \"require\": \"./index.d.ts\"\n        }\n    }\n}"
+    },
+    {
+      "fileName": "./node_modules/@types/bar2/package.json",
+      "version": "2f6530e060ae71a6b32fe264128644c5-{\n    \"name\": \"@types/bar2\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./index.d.ts\",\n            \"require\": \"./index.d.ts\"\n        }\n    }\n}"
+    },
+    {
+      "fileName": "./node_modules/bar/package.json",
+      "version": "5d4b63cd2f7a4e8d2f4b99a206b1cef7-{\n    \"name\": \"bar\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n\n    \"exports\": {\n        \".\": {\n\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"
+    },
+    {
+      "fileName": "./node_modules/bar2/package.json",
+      "version": "1fc90d9c461330bf9ad3cd8aa0fcaf25-{\n    \"name\": \"bar2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n\n    \"exports\": {\n        \".\": {\n\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"
+    },
+    {
+      "fileName": "./node_modules/foo/package.json",
+      "version": "64750892349c68814e7acb96ebad2f21-{\n    \"name\": \"foo\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./index.d.ts\",\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"
+    },
+    {
+      "fileName": "./node_modules/foo2/package.json",
+      "version": "ccd27560d6db00006c1734549a253ce4-{\n    \"name\": \"foo2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./index.d.ts\",\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"
+    }
+  ],
+  "size": 3657
 }
 
 tsconfig.json::
@@ -2004,7 +2100,7 @@ Found 1 error in index.mts[90m:4[0m
 
 //// [/home/src/projects/project/index.mjs] *rewrite with same content*
 //// [/home/src/projects/project/tsconfig.tsbuildinfo] *modified* 
-{"version":"FakeTSVersion","root":[5],"fileNames":["lib.es2025.full.d.ts","./node_modules/foo/index.d.ts","./node_modules/@types/bar/index.d.ts","./node_modules/foo2/index.d.ts","./index.mts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"2a914bfad3bba77712486af8a4cdc415-export declare const foo: number;","78bc7ca8c840e090086811119f6d6ba9-export declare const bar: number;","165b91a7791663df5931f0b63ebf9ce2-export declare const foo2: number;",{"version":"eee0814e4a127747fb836acc50eaeb5a-import { foo } from \"foo\";\nimport { bar } from \"bar\";\nimport { foo2 } from \"foo2\";\nimport { bar2 } from \"bar2\";","signature":"abe7d9981d6018efb6b2b794f40a1607-export {};\n","impliedNodeFormat":99}],"fileIdsList":[[2,3,4]],"options":{"module":100,"strict":true},"referencedMap":[[5,1]],"semanticDiagnosticsPerFile":[[5,[{"pos":104,"end":110,"code":7016,"category":1,"messageKey":"Could_not_find_a_declaration_file_for_module_0_1_implicitly_has_an_any_type_7016","messageArgs":["bar2","/home/src/projects/project/node_modules/bar2/index.mjs"],"messageChain":[{"pos":104,"end":110,"code":6278,"category":3,"messageKey":"There_are_types_at_0_but_this_result_could_not_be_resolved_when_respecting_package_json_exports_The__6278","messageArgs":["/home/src/projects/project/node_modules/@types/bar2/index.d.ts","@types/bar2"],"repopulateInfo":{"kind":2,"moduleReference":"bar2","mode":99}}]}]]]}
+{"version":"FakeTSVersion","root":[5],"fileNames":["lib.es2025.full.d.ts","./node_modules/foo/index.d.ts","./node_modules/@types/bar/index.d.ts","./node_modules/foo2/index.d.ts","./index.mts","./node_modules/@types/bar/package.json","./node_modules/@types/bar2/package.json","./node_modules/bar/package.json","./node_modules/bar2/package.json","./node_modules/foo/package.json","./node_modules/foo2/package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"2a914bfad3bba77712486af8a4cdc415-export declare const foo: number;","78bc7ca8c840e090086811119f6d6ba9-export declare const bar: number;","165b91a7791663df5931f0b63ebf9ce2-export declare const foo2: number;",{"version":"eee0814e4a127747fb836acc50eaeb5a-import { foo } from \"foo\";\nimport { bar } from \"bar\";\nimport { foo2 } from \"foo2\";\nimport { bar2 } from \"bar2\";","signature":"abe7d9981d6018efb6b2b794f40a1607-export {};\n","impliedNodeFormat":99}],"fileIdsList":[[2,3,4]],"options":{"module":100,"strict":true},"referencedMap":[[5,1]],"semanticDiagnosticsPerFile":[[5,[{"pos":104,"end":110,"code":7016,"category":1,"messageKey":"Could_not_find_a_declaration_file_for_module_0_1_implicitly_has_an_any_type_7016","messageArgs":["bar2","/home/src/projects/project/node_modules/bar2/index.mjs"],"messageChain":[{"pos":104,"end":110,"code":6278,"category":3,"messageKey":"There_are_types_at_0_but_this_result_could_not_be_resolved_when_respecting_package_json_exports_The__6278","messageArgs":["/home/src/projects/project/node_modules/@types/bar2/index.d.ts","@types/bar2"],"repopulateInfo":{"kind":2,"moduleReference":"bar2","mode":99}}]}]]],"packageJsonLookups":[[6,"98684280318116b3ab197ebba8bfe8e9-{\n    \"name\": \"@types/bar\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./index.d.ts\",\n            \"require\": \"./index.d.ts\"\n        }\n    }\n}"],[7,"aaa39ef8c52dbb1390bec26bd525213d-{\n    \"name\": \"@types/bar2\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n\n            \"require\": \"./index.d.ts\"\n        }\n    }\n}"],[8,"5d4b63cd2f7a4e8d2f4b99a206b1cef7-{\n    \"name\": \"bar\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n\n    \"exports\": {\n        \".\": {\n\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"],[9,"1fc90d9c461330bf9ad3cd8aa0fcaf25-{\n    \"name\": \"bar2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n\n    \"exports\": {\n        \".\": {\n\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"],[10,"64750892349c68814e7acb96ebad2f21-{\n    \"name\": \"foo\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./index.d.ts\",\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"],[11,"ccd27560d6db00006c1734549a253ce4-{\n    \"name\": \"foo2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./index.d.ts\",\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"]]}
 //// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
 {
   "version": "FakeTSVersion",
@@ -2021,7 +2117,13 @@ Found 1 error in index.mts[90m:4[0m
     "./node_modules/foo/index.d.ts",
     "./node_modules/@types/bar/index.d.ts",
     "./node_modules/foo2/index.d.ts",
-    "./index.mts"
+    "./index.mts",
+    "./node_modules/@types/bar/package.json",
+    "./node_modules/@types/bar2/package.json",
+    "./node_modules/bar/package.json",
+    "./node_modules/bar2/package.json",
+    "./node_modules/foo/package.json",
+    "./node_modules/foo2/package.json"
   ],
   "fileInfos": [
     {
@@ -2115,7 +2217,33 @@ Found 1 error in index.mts[90m:4[0m
       ]
     ]
   ],
-  "size": 2128
+  "packageJsonLookups": [
+    {
+      "fileName": "./node_modules/@types/bar/package.json",
+      "version": "98684280318116b3ab197ebba8bfe8e9-{\n    \"name\": \"@types/bar\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./index.d.ts\",\n            \"require\": \"./index.d.ts\"\n        }\n    }\n}"
+    },
+    {
+      "fileName": "./node_modules/@types/bar2/package.json",
+      "version": "aaa39ef8c52dbb1390bec26bd525213d-{\n    \"name\": \"@types/bar2\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n\n            \"require\": \"./index.d.ts\"\n        }\n    }\n}"
+    },
+    {
+      "fileName": "./node_modules/bar/package.json",
+      "version": "5d4b63cd2f7a4e8d2f4b99a206b1cef7-{\n    \"name\": \"bar\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n\n    \"exports\": {\n        \".\": {\n\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"
+    },
+    {
+      "fileName": "./node_modules/bar2/package.json",
+      "version": "1fc90d9c461330bf9ad3cd8aa0fcaf25-{\n    \"name\": \"bar2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n\n    \"exports\": {\n        \".\": {\n\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"
+    },
+    {
+      "fileName": "./node_modules/foo/package.json",
+      "version": "64750892349c68814e7acb96ebad2f21-{\n    \"name\": \"foo\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./index.d.ts\",\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"
+    },
+    {
+      "fileName": "./node_modules/foo2/package.json",
+      "version": "ccd27560d6db00006c1734549a253ce4-{\n    \"name\": \"foo2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./index.d.ts\",\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"
+    }
+  ],
+  "size": 4107
 }
 
 tsconfig.json::
@@ -2335,7 +2463,7 @@ Found 2 errors in the same file, starting at: index.mts[90m:3[0m
 
 //// [/home/src/projects/project/index.mjs] *rewrite with same content*
 //// [/home/src/projects/project/tsconfig.tsbuildinfo] *modified* 
-{"version":"FakeTSVersion","root":[4],"fileNames":["lib.es2025.full.d.ts","./node_modules/foo/index.d.ts","./node_modules/@types/bar/index.d.ts","./index.mts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"2a914bfad3bba77712486af8a4cdc415-export declare const foo: number;","78bc7ca8c840e090086811119f6d6ba9-export declare const bar: number;",{"version":"eee0814e4a127747fb836acc50eaeb5a-import { foo } from \"foo\";\nimport { bar } from \"bar\";\nimport { foo2 } from \"foo2\";\nimport { bar2 } from \"bar2\";","signature":"abe7d9981d6018efb6b2b794f40a1607-export {};\n","impliedNodeFormat":99}],"fileIdsList":[[2,3]],"options":{"module":100,"strict":true},"referencedMap":[[4,1]],"semanticDiagnosticsPerFile":[[4,[{"pos":75,"end":81,"code":7016,"category":1,"messageKey":"Could_not_find_a_declaration_file_for_module_0_1_implicitly_has_an_any_type_7016","messageArgs":["foo2","/home/src/projects/project/node_modules/foo2/index.mjs"],"messageChain":[{"pos":75,"end":81,"code":6278,"category":3,"messageKey":"There_are_types_at_0_but_this_result_could_not_be_resolved_when_respecting_package_json_exports_The__6278","messageArgs":["/home/src/projects/project/node_modules/foo2/index.d.ts","foo2"],"repopulateInfo":{"kind":2,"moduleReference":"foo2","mode":99}}]},{"pos":104,"end":110,"code":7016,"category":1,"messageKey":"Could_not_find_a_declaration_file_for_module_0_1_implicitly_has_an_any_type_7016","messageArgs":["bar2","/home/src/projects/project/node_modules/bar2/index.mjs"],"messageChain":[{"pos":104,"end":110,"code":6278,"category":3,"messageKey":"There_are_types_at_0_but_this_result_could_not_be_resolved_when_respecting_package_json_exports_The__6278","messageArgs":["/home/src/projects/project/node_modules/@types/bar2/index.d.ts","@types/bar2"],"repopulateInfo":{"kind":2,"moduleReference":"bar2","mode":99}}]}]]]}
+{"version":"FakeTSVersion","root":[4],"fileNames":["lib.es2025.full.d.ts","./node_modules/foo/index.d.ts","./node_modules/@types/bar/index.d.ts","./index.mts","./node_modules/@types/bar/package.json","./node_modules/@types/bar2/package.json","./node_modules/bar/package.json","./node_modules/bar2/package.json","./node_modules/foo/package.json","./node_modules/foo2/package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"2a914bfad3bba77712486af8a4cdc415-export declare const foo: number;","78bc7ca8c840e090086811119f6d6ba9-export declare const bar: number;",{"version":"eee0814e4a127747fb836acc50eaeb5a-import { foo } from \"foo\";\nimport { bar } from \"bar\";\nimport { foo2 } from \"foo2\";\nimport { bar2 } from \"bar2\";","signature":"abe7d9981d6018efb6b2b794f40a1607-export {};\n","impliedNodeFormat":99}],"fileIdsList":[[2,3]],"options":{"module":100,"strict":true},"referencedMap":[[4,1]],"semanticDiagnosticsPerFile":[[4,[{"pos":75,"end":81,"code":7016,"category":1,"messageKey":"Could_not_find_a_declaration_file_for_module_0_1_implicitly_has_an_any_type_7016","messageArgs":["foo2","/home/src/projects/project/node_modules/foo2/index.mjs"],"messageChain":[{"pos":75,"end":81,"code":6278,"category":3,"messageKey":"There_are_types_at_0_but_this_result_could_not_be_resolved_when_respecting_package_json_exports_The__6278","messageArgs":["/home/src/projects/project/node_modules/foo2/index.d.ts","foo2"],"repopulateInfo":{"kind":2,"moduleReference":"foo2","mode":99}}]},{"pos":104,"end":110,"code":7016,"category":1,"messageKey":"Could_not_find_a_declaration_file_for_module_0_1_implicitly_has_an_any_type_7016","messageArgs":["bar2","/home/src/projects/project/node_modules/bar2/index.mjs"],"messageChain":[{"pos":104,"end":110,"code":6278,"category":3,"messageKey":"There_are_types_at_0_but_this_result_could_not_be_resolved_when_respecting_package_json_exports_The__6278","messageArgs":["/home/src/projects/project/node_modules/@types/bar2/index.d.ts","@types/bar2"],"repopulateInfo":{"kind":2,"moduleReference":"bar2","mode":99}}]}]]],"packageJsonLookups":[[5,"98684280318116b3ab197ebba8bfe8e9-{\n    \"name\": \"@types/bar\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./index.d.ts\",\n            \"require\": \"./index.d.ts\"\n        }\n    }\n}"],[6,"aaa39ef8c52dbb1390bec26bd525213d-{\n    \"name\": \"@types/bar2\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n\n            \"require\": \"./index.d.ts\"\n        }\n    }\n}"],[7,"5d4b63cd2f7a4e8d2f4b99a206b1cef7-{\n    \"name\": \"bar\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n\n    \"exports\": {\n        \".\": {\n\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"],[8,"1fc90d9c461330bf9ad3cd8aa0fcaf25-{\n    \"name\": \"bar2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n\n    \"exports\": {\n        \".\": {\n\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"],[9,"64750892349c68814e7acb96ebad2f21-{\n    \"name\": \"foo\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./index.d.ts\",\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"],[10,"ed5fb8b9b0617ccaa38f9349c5dba363-{\n    \"name\": \"foo2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"]]}
 //// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
 {
   "version": "FakeTSVersion",
@@ -2351,7 +2479,13 @@ Found 2 errors in the same file, starting at: index.mts[90m:3[0m
     "lib.es2025.full.d.ts",
     "./node_modules/foo/index.d.ts",
     "./node_modules/@types/bar/index.d.ts",
-    "./index.mts"
+    "./index.mts",
+    "./node_modules/@types/bar/package.json",
+    "./node_modules/@types/bar2/package.json",
+    "./node_modules/bar/package.json",
+    "./node_modules/bar2/package.json",
+    "./node_modules/foo/package.json",
+    "./node_modules/foo2/package.json"
   ],
   "fileInfos": [
     {
@@ -2461,7 +2595,33 @@ Found 2 errors in the same file, starting at: index.mts[90m:3[0m
       ]
     ]
   ],
-  "size": 2571
+  "packageJsonLookups": [
+    {
+      "fileName": "./node_modules/@types/bar/package.json",
+      "version": "98684280318116b3ab197ebba8bfe8e9-{\n    \"name\": \"@types/bar\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./index.d.ts\",\n            \"require\": \"./index.d.ts\"\n        }\n    }\n}"
+    },
+    {
+      "fileName": "./node_modules/@types/bar2/package.json",
+      "version": "aaa39ef8c52dbb1390bec26bd525213d-{\n    \"name\": \"@types/bar2\",\n    \"version\": \"1.0.0\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n\n            \"require\": \"./index.d.ts\"\n        }\n    }\n}"
+    },
+    {
+      "fileName": "./node_modules/bar/package.json",
+      "version": "5d4b63cd2f7a4e8d2f4b99a206b1cef7-{\n    \"name\": \"bar\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n\n    \"exports\": {\n        \".\": {\n\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"
+    },
+    {
+      "fileName": "./node_modules/bar2/package.json",
+      "version": "1fc90d9c461330bf9ad3cd8aa0fcaf25-{\n    \"name\": \"bar2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n\n    \"exports\": {\n        \".\": {\n\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"
+    },
+    {
+      "fileName": "./node_modules/foo/package.json",
+      "version": "64750892349c68814e7acb96ebad2f21-{\n    \"name\": \"foo\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n            \"types\": \"./index.d.ts\",\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"
+    },
+    {
+      "fileName": "./node_modules/foo2/package.json",
+      "version": "ed5fb8b9b0617ccaa38f9349c5dba363-{\n    \"name\": \"foo2\",\n    \"version\": \"1.0.0\",\n    \"main\": \"index.js\",\n    \"types\": \"index.d.ts\",\n    \"exports\": {\n        \".\": {\n\n            \"import\": \"./index.mjs\",\n            \"require\": \"./index.js\"\n        }\n    }\n}"
+    }
+  ],
+  "size": 4509
 }
 
 tsconfig.json::

--- a/testdata/baselines/reference/tsc/moduleResolution/package-json-scope.js
+++ b/testdata/baselines/reference/tsc/moduleResolution/package-json-scope.js
@@ -106,7 +106,7 @@ exports.x = void 0;
 exports.x = 10;
 
 //// [/home/src/workspaces/project/src/tsconfig.tsbuildinfo] *new* 
-{"version":"FakeTSVersion","root":[[2,4]],"fileNames":["lib.es2016.full.d.ts","./main.ts","./fileB.mts","./fileA.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"28e8748a7acd58f4f59388926e914f86-export const x = 10;","signature":"f9b4154a9a5944099ecf197d4519d083-export declare const x = 10;\n","impliedNodeFormat":1},{"version":"d03690d860e74c03bcacf63f0dd68b93-export function foo() {}","signature":"7ffb4ea6089b1a385965a214ba412941-export declare function foo(): void;\n","impliedNodeFormat":99},{"version":"cc520ca096f0b81d18073ba8a9776fe3-import { foo } from \"./fileB.mjs\";\nfoo();","signature":"abe7d9981d6018efb6b2b794f40a1607-export {};\n","impliedNodeFormat":1}],"fileIdsList":[[3]],"options":{"composite":true,"module":100,"target":3},"referencedMap":[[4,1]],"semanticDiagnosticsPerFile":[[4,[{"pos":20,"end":33,"code":1479,"category":1,"messageKey":"The_current_file_is_a_CommonJS_module_whose_imports_will_produce_require_calls_however_the_reference_1479","messageArgs":["./fileB.mjs"],"messageChain":[{"pos":20,"end":33,"code":1481,"category":3,"messageKey":"To_convert_this_file_to_an_ECMAScript_module_change_its_file_extension_to_0_or_add_the_field_type_Co_1481","messageArgs":[".mts","/home/src/workspaces/project/package.json"],"repopulateInfo":{"kind":1}}]}]]],"latestChangedDtsFile":"./fileA.d.ts"}
+{"version":"FakeTSVersion","root":[[2,4]],"fileNames":["lib.es2016.full.d.ts","./main.ts","./fileB.mts","./fileA.ts","../package.json"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"28e8748a7acd58f4f59388926e914f86-export const x = 10;","signature":"f9b4154a9a5944099ecf197d4519d083-export declare const x = 10;\n","impliedNodeFormat":1},{"version":"d03690d860e74c03bcacf63f0dd68b93-export function foo() {}","signature":"7ffb4ea6089b1a385965a214ba412941-export declare function foo(): void;\n","impliedNodeFormat":99},{"version":"cc520ca096f0b81d18073ba8a9776fe3-import { foo } from \"./fileB.mjs\";\nfoo();","signature":"abe7d9981d6018efb6b2b794f40a1607-export {};\n","impliedNodeFormat":1}],"fileIdsList":[[3]],"options":{"composite":true,"module":100,"target":3},"referencedMap":[[4,1]],"semanticDiagnosticsPerFile":[[4,[{"pos":20,"end":33,"code":1479,"category":1,"messageKey":"The_current_file_is_a_CommonJS_module_whose_imports_will_produce_require_calls_however_the_reference_1479","messageArgs":["./fileB.mjs"],"messageChain":[{"pos":20,"end":33,"code":1481,"category":3,"messageKey":"To_convert_this_file_to_an_ECMAScript_module_change_its_file_extension_to_0_or_add_the_field_type_Co_1481","messageArgs":[".mts","/home/src/workspaces/project/package.json"],"repopulateInfo":{"kind":1}}]}]]],"latestChangedDtsFile":"./fileA.d.ts","packageJsonLookups":[[5,"c6ede67c2701bad0597a0bf0057d46b0-{\n    \"name\": \"app\",\n    \"version\": \"1.0.0\"\n}"]]}
 //// [/home/src/workspaces/project/src/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
 {
   "version": "FakeTSVersion",
@@ -127,7 +127,8 @@ exports.x = 10;
     "lib.es2016.full.d.ts",
     "./main.ts",
     "./fileB.mts",
-    "./fileA.ts"
+    "./fileA.ts",
+    "../package.json"
   ],
   "fileInfos": [
     {
@@ -222,7 +223,13 @@ exports.x = 10;
     ]
   ],
   "latestChangedDtsFile": "./fileA.d.ts",
-  "size": 2071
+  "packageJsonLookups": [
+    {
+      "fileName": "../package.json",
+      "version": "c6ede67c2701bad0597a0bf0057d46b0-{\n    \"name\": \"app\",\n    \"version\": \"1.0.0\"\n}"
+    }
+  ],
+  "size": 2208
 }
 
 src/tsconfig.json::


### PR DESCRIPTION
Addresses #2666: `tsgo --build` reports a project as up to date after a dependency in `node_modules` is updated, even though the updated declaration files introduce type errors.

### Root cause

The up-to-date check in `getUpToDateStatus` only verifies the timestamps of the config root files (`t.resolved.FileNames()`). All other program inputs recorded in the buildinfo, such as `.d.ts` files resolved from `node_modules`, are never checked, so the incremental cache is not invalidated when they change. The buildinfo already records content hashes for every program file in `fileInfos`; they were just never consulted for non-root files. Resolution-affecting `package.json` files are not recorded at all (the strada port has a commented out `lastCachedPackageJsonLookups` TODO).

### Fix

After the existing root file checks, the up-to-date check now also verifies:

1. **Non-root program files recorded in the buildinfo.** A missing file (eg a removed or pruned package) marks the project out of date. A file newer than the buildinfo is re-hashed and compared against the recorded version; a mismatch marks the project out of date, while unchanged text only updates output timestamps (same pseudo-build treatment as root files). Bundled lib files are skipped since they only change with the compiler version, which `buildInfo.Version` already validates. File names that cannot be made relative to the buildinfo directory (eg on another drive) are resolved the same way the buildinfo reader resolves them, so they are checked rather than mistaken for lib files.

2. **`package.json` files used during module resolution.** The buildinfo now records the package.json files that exist and were consulted during resolution (a new `packageJsonLookups` field) along with a hash of their contents. The check compares contents by hash instead of timestamps, so it catches edits that redirect resolution (eg changing `types` or `exports`) as well as updates that keep old timestamps, such as an `npm install` repointing a `file:` symlink at a different target (the exact flavor in the minimal repro repo). Hashes are cached per build cycle so a package.json shared by many projects is only read once per invocation.

### Before / after

Repro from the issue (dependency `.d.ts` changes `myValue: string` to `myValue: number` while `dist/tsconfig.tsbuildinfo` exists):

```
# before (main)
$ tsgo --build tsconfig.json     # after dependency update
exit 0                           # bug: reports up to date, error never surfaces

# after (this PR)
$ tsgo --build tsconfig.json     # after dependency update
index.ts(2,14): error TS2322: Type 'number' is not assignable to type 'string'.
exit 2
```

The reproduction repo from https://github.com/rubenferreira97/tsgo_build_bug (npm `file:` symlink retarget) now also fails the incremental build correctly, caught by the package.json contents check.

A newer mtime with unchanged contents only triggers a timestamp update, and a no-op rebuild still reports up to date, so unchanged projects do not rebuild.

### Tests

`TestBuildDependencyUpdate` covers: dependency update with a breaking type change, restore, touch without text change, deletion of a dependency file, plus the two review cases: a package.json `types` redirect to a different declaration file, and an absolute (cross-drive) non-root dependency update.

Existing baseline changes are additive (`packageJsonLookups` in buildinfo) apart from three message-text improvements where the out-of-date status now names the precise changed upstream `.d.ts` instead of the referenced project directory.

### Not covered

- A package.json appearing at a location that was previously probed and missing (only existing package.json files are recorded, to keep the buildinfo small).
- Non-incremental `--build` projects, whose buildinfo does not record program file names, keep the existing roots-only behavior.
- Watch mode dependency watching is being reworked separately in #3670.

### Notes

- Cost for an up-to-date incremental project is one extra stat per recorded non-root program file, plus one read+hash per consulted package.json (cached per build cycle across projects). Program files are only read and hashed when their mtime is newer than the buildinfo.

