### PR TITLE
Better fix bug with this types and instantiateSymbol

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -20669,7 +20669,7 @@ func (c *Checker) instantiateSymbol(symbol *ast.Symbol, m *TypeMapper) *ast.Symb
 	return result
 }
 
-// Returns true if the class or interface member given by the symbol is free of "this" references. The
+// Returns true if the parameter or class/interface member given by the symbol is free of "this" references. The
 // function may return false for symbols that are actually free of "this" references because it is not
 // feasible to perform a complete analysis in all cases. In particular, property members with types
 // inferred from their initializers and function members with inferred return types are conservatively

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -14289,12 +14289,7 @@ func (c *Checker) recordMergedSymbol(target *ast.Symbol, source *ast.Symbol) {
 }
 
 func (c *Checker) getSymbolIfSameReference(s1 *ast.Symbol, s2 *ast.Symbol) *ast.Symbol {
-	// An instantiated symbol (e.g. a parameter of a signature instantiated to substitute `this`)
-	// refers to the same declaration as its instantiation target. Whether a given context yields the
-	// original symbol or an instantiated copy can depend on incidental checker cache state (see
-	// instantiateSymbol, whose reuse shortcut is gated on the type already being resolved), so unwrap
-	// instantiations here to keep "same reference" answers deterministic.
-	if c.getMergedSymbol(c.resolveSymbol(c.getMergedSymbol(c.getTargetSymbol(s1)))) == c.getMergedSymbol(c.resolveSymbol(c.getMergedSymbol(c.getTargetSymbol(s2)))) {
+	if c.getMergedSymbol(c.resolveSymbol(c.getMergedSymbol(s1))) == c.getMergedSymbol(c.resolveSymbol(c.getMergedSymbol(s2))) {
 		return s1
 	}
 	return nil
@@ -19003,7 +18998,7 @@ func (c *Checker) resolveObjectTypeMembers(t *Type, source *Type, typeParameters
 	} else {
 		instantiated = true
 		mapper = newTypeMapper(typeParameters, typeArguments)
-		members = c.instantiateSymbolTable(resolved.declaredMembers, mapper, len(typeParameters) == 1 /*mappingThisOnly*/)
+		members = c.instantiateSymbolTable(resolved.declaredMembers, mapper)
 		callSignatures = c.instantiateSignatures(resolved.declaredCallSignatures, mapper)
 		constructSignatures = c.instantiateSignatures(resolved.declaredConstructSignatures, mapper)
 		indexInfos = c.instantiateIndexInfos(resolved.declaredIndexInfos, mapper)
@@ -20610,8 +20605,6 @@ func (c *Checker) resolveAnonymousTypeMembers(t *Type) {
 	}
 }
 
-// The mappingThisOnly flag indicates that the only type parameter being mapped is "this". When the flag is true,
-// we check symbols to see if we can quickly conclude they are free of "this" references, thus needing no instantiation.
 func (c *Checker) createInstantiatedSymbolTable(symbols []*ast.Symbol, m *TypeMapper) ast.SymbolTable {
 	if len(symbols) == 0 {
 		return nil
@@ -20623,20 +20616,14 @@ func (c *Checker) createInstantiatedSymbolTable(symbols []*ast.Symbol, m *TypeMa
 	return result
 }
 
-// The mappingThisOnly flag indicates that the only type parameter being mapped is "this". When the flag is true,
-// we check symbols to see if we can quickly conclude they are free of "this" references, thus needing no instantiation.
-func (c *Checker) instantiateSymbolTable(symbols ast.SymbolTable, m *TypeMapper, mappingThisOnly bool) ast.SymbolTable {
+func (c *Checker) instantiateSymbolTable(symbols ast.SymbolTable, m *TypeMapper) ast.SymbolTable {
 	if len(symbols) == 0 {
 		return nil
 	}
 	result := make(ast.SymbolTable, len(symbols))
 	for id, symbol := range symbols {
 		if c.isNamedMember(symbol, id) {
-			if mappingThisOnly && isThisless(symbol) {
-				result[id] = symbol
-			} else {
-				result[id] = c.instantiateSymbol(symbol, m)
-			}
+			result[id] = c.instantiateSymbol(symbol, m)
 		}
 	}
 	return result
@@ -20647,6 +20634,9 @@ func (c *Checker) instantiateSymbol(symbol *ast.Symbol, m *TypeMapper) *ast.Symb
 		return nil
 	}
 	links := c.valueSymbolLinks.Get(symbol)
+	if m != nil && m.MapsThisOnly() && isThisless(symbol) {
+		return symbol
+	}
 	// If the type of the symbol is already resolved, and if that type could not possibly
 	// be affected by instantiation, simply return the symbol itself.
 	if links.resolvedType != nil && !c.couldContainTypeVariables(links.resolvedType) {
@@ -20689,6 +20679,8 @@ func isThisless(symbol *ast.Symbol) bool {
 		declaration := symbol.Declarations[0]
 		if declaration != nil {
 			switch declaration.Kind {
+			case ast.KindParameter:
+				return isThislessVariableLikeDeclaration(declaration)
 			case ast.KindPropertyDeclaration, ast.KindPropertySignature:
 				return isThislessVariableLikeDeclaration(declaration)
 			case ast.KindMethodDeclaration, ast.KindMethodSignature, ast.KindConstructor, ast.KindGetAccessor, ast.KindSetAccessor:

--- a/internal/checker/mapper.go
+++ b/internal/checker/mapper.go
@@ -25,12 +25,14 @@ type TypeMapper struct {
 
 func (m *TypeMapper) Map(t *Type) *Type    { return m.data.Map(t) }
 func (m *TypeMapper) Kind() TypeMapperKind { return m.data.Kind() }
+func (m *TypeMapper) MapsThisOnly() bool   { return m.data.MapsThisOnly() }
 
 // TypeMapperData
 
 type TypeMapperData interface {
 	Map(t *Type) *Type
 	Kind() TypeMapperKind
+	MapsThisOnly() bool
 }
 
 // Factory functions
@@ -88,6 +90,7 @@ type TypeMapperBase struct {
 
 func (m *TypeMapperBase) Map(t *Type) *Type    { return t }
 func (m *TypeMapperBase) Kind() TypeMapperKind { return TypeMapperKindUnknown }
+func (m *TypeMapperBase) MapsThisOnly() bool   { return false }
 
 // SimpleTypeMapper
 
@@ -114,6 +117,10 @@ func (m *SimpleTypeMapper) Map(t *Type) *Type {
 
 func (m *SimpleTypeMapper) Kind() TypeMapperKind {
 	return TypeMapperKindSimple
+}
+
+func (m *SimpleTypeMapper) MapsThisOnly() bool {
+	return isThisTypeParameter(m.source)
 }
 
 // ArrayTypeMapper
@@ -145,6 +152,10 @@ func (m *ArrayTypeMapper) Kind() TypeMapperKind {
 	return TypeMapperKindArray
 }
 
+func (m *ArrayTypeMapper) MapsThisOnly() bool {
+	return len(m.sources) == 1 && isThisTypeParameter(m.sources[0])
+}
+
 // ArrayToSingleTypeMapper
 
 type ArrayToSingleTypeMapper struct {
@@ -166,6 +177,10 @@ func (m *ArrayToSingleTypeMapper) Map(t *Type) *Type {
 		return m.target
 	}
 	return t
+}
+
+func (m *ArrayToSingleTypeMapper) MapsThisOnly() bool {
+	return len(m.sources) == 1 && isThisTypeParameter(m.sources[0])
 }
 
 // DeferredTypeMapper
@@ -191,6 +206,10 @@ func (m *DeferredTypeMapper) Map(t *Type) *Type {
 		}
 	}
 	return t
+}
+
+func (m *DeferredTypeMapper) MapsThisOnly() bool {
+	return len(m.sources) == 1 && isThisTypeParameter(m.sources[0])
 }
 
 // FunctionTypeMapper


### PR DESCRIPTION
#3435 contained a silly fix for a deeper root cause; a conflict between https://github.com/microsoft/TypeScript/pull/4910 and an optimization introduced in https://github.com/microsoft/TypeScript/pull/21470 causing differing behavior depending on caching.

Undo my bad change and instead change the way we do the thisless type optimization in instantiateSymbol.