### PR TITLE
fix(4315): preserve modifier order when emitting private js methods

### DIFF
--- a/internal/transformers/declarations/transform.go
+++ b/internal/transformers/declarations/transform.go
@@ -1947,7 +1947,9 @@ func (tx *DeclarationTransformer) ensureModifiers(node *ast.Node) *ast.ModifierL
 		if mods == nil {
 			return mods
 		}
-		return tx.Factory().NewModifierList(core.Filter(mods.Nodes, ast.IsModifier))
+		if canReuseModifierNodes(mods.Nodes) {
+			return tx.Factory().NewModifierList(core.Filter(mods.Nodes, ast.IsModifier))
+		}
 	}
 	result := ast.CreateModifiersFromModifierFlags(newFlags, tx.Factory().NewModifier)
 	if len(result) == 0 {

--- a/internal/transformers/declarations/util.go
+++ b/internal/transformers/declarations/util.go
@@ -48,6 +48,15 @@ func canProduceDiagnostics(node *ast.Node) bool {
 	/* ast.IsJSDocTypeAlias(node); */
 }
 
+func canReuseModifierNodes(nodes []*ast.Node) bool {
+	for _, node := range nodes {
+		if ast.IsModifier(node) && node.Flags&ast.NodeFlagsReparsed != 0 {
+			return false
+		}
+	}
+	return true
+}
+
 func isDeclarationAndNotVisible(emitContext *printer.EmitContext, resolver printer.EmitResolver, node *ast.Node) bool {
 	node = emitContext.ParseNode(node)
 	switch node.Kind {

--- a/testdata/baselines/reference/compiler/jsDeclarationEmitPrivateStaticMethod.js
+++ b/testdata/baselines/reference/compiler/jsDeclarationEmitPrivateStaticMethod.js
@@ -1,0 +1,20 @@
+//// [tests/cases/compiler/jsDeclarationEmitPrivateStaticMethod.ts] ////
+
+//// [a.js]
+export class C {
+    /** @private */
+    static foo() {}
+    /** @protected */
+    static bar() {}
+}
+
+
+
+
+//// [a.d.ts]
+export declare class C {
+    /** @private */
+    private static foo;
+    /** @protected */
+    protected static bar(): void;
+}

--- a/testdata/baselines/reference/compiler/jsDeclarationEmitPrivateStaticMethod.symbols
+++ b/testdata/baselines/reference/compiler/jsDeclarationEmitPrivateStaticMethod.symbols
@@ -1,0 +1,15 @@
+//// [tests/cases/compiler/jsDeclarationEmitPrivateStaticMethod.ts] ////
+
+=== a.js ===
+export class C {
+>C : Symbol(C, Decl(a.js, 0, 0))
+
+    /** @private */
+    static foo() {}
+>foo : Symbol(C.foo, Decl(a.js, 0, 16))
+
+    /** @protected */
+    static bar() {}
+>bar : Symbol(C.bar, Decl(a.js, 2, 19))
+}
+

--- a/testdata/baselines/reference/compiler/jsDeclarationEmitPrivateStaticMethod.types
+++ b/testdata/baselines/reference/compiler/jsDeclarationEmitPrivateStaticMethod.types
@@ -1,0 +1,15 @@
+//// [tests/cases/compiler/jsDeclarationEmitPrivateStaticMethod.ts] ////
+
+=== a.js ===
+export class C {
+>C : C
+
+    /** @private */
+    static foo() {}
+>foo : () => void
+
+    /** @protected */
+    static bar() {}
+>bar : () => void
+}
+

--- a/testdata/tests/cases/compiler/jsDeclarationEmitPrivateStaticMethod.ts
+++ b/testdata/tests/cases/compiler/jsDeclarationEmitPrivateStaticMethod.ts
@@ -1,0 +1,11 @@
+// @allowJs: true
+// @checkJs: true
+// @declaration: true
+// @emitDeclarationOnly: true
+// @filename: a.js
+export class C {
+    /** @private */
+    static foo() {}
+    /** @protected */
+    static bar() {}
+}


### PR DESCRIPTION
Fixes #4315