### PR TITLE
Deduplicate declaration emit for this-assigned methods

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -14255,7 +14255,7 @@ func getExcludedSymbolFlags(flags ast.SymbolFlags) ast.SymbolFlags {
 		result |= ast.SymbolFlagsAliasExcludes
 	}
 	if flags&ast.SymbolFlagsReplaceableByMethod != 0 {
-		result &= ^ast.SymbolFlagsMethod
+		result &^= ast.SymbolFlagsMethod
 	}
 	return result
 }

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -16010,7 +16010,7 @@ func (c *Checker) addDeclarationToLateBoundSymbol(symbol *ast.Symbol, member *as
 		// Remove all replacable-by-method members, along with their flags.
 		symbol.Declarations = append(core.Filter(symbol.Declarations, isNotReplacableByMethod), member)
 		oldFlags := symbol.Flags
-		symbol.Flags |= ast.SymbolFlagsNone
+		symbol.Flags = ast.SymbolFlagsNone
 		for _, d := range symbol.Declarations {
 			symbol.Flags |= d.Symbol().Flags
 		}

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -14254,6 +14254,9 @@ func getExcludedSymbolFlags(flags ast.SymbolFlags) ast.SymbolFlags {
 	if flags&ast.SymbolFlagsAlias != 0 {
 		result |= ast.SymbolFlagsAliasExcludes
 	}
+	if flags&ast.SymbolFlagsReplaceableByMethod != 0 {
+		result &= ^ast.SymbolFlagsMethod
+	}
 	return result
 }
 
@@ -15990,15 +15993,30 @@ func (c *Checker) lateBindIndexSignature(parent *ast.Symbol, earlySymbols ast.Sy
 	}
 }
 
+func isNotReplacableByMethod(decl *ast.Node) bool {
+	return decl.Symbol().Flags&ast.SymbolFlagsReplaceableByMethod == 0
+}
+
 // Adds a declaration to a late-bound dynamic member. This performs the same function for
 // late-bound members that `addDeclarationToSymbol` in binder.ts performs for early-bound
 // members.
 func (c *Checker) addDeclarationToLateBoundSymbol(symbol *ast.Symbol, member *ast.Node, symbolFlags ast.SymbolFlags) {
 	debug.Assert(symbol.CheckFlags&ast.CheckFlagsLate != 0, "Expected a late-bound symbol.")
-	symbol.Flags |= symbolFlags
 	c.lateBoundLinks.Get(member.Symbol()).lateSymbol = symbol
 	if len(symbol.Declarations) == 0 || member.Symbol().Flags&ast.SymbolFlagsReplaceableByMethod == 0 {
+		symbol.Flags |= symbolFlags
 		symbol.Declarations = append(symbol.Declarations, member)
+	} else if symbol.Flags&ast.SymbolFlagsReplaceableByMethod != 0 && member.Symbol().Flags&ast.SymbolFlagsMethod != 0 {
+		// Remove all replacable-by-method members, along with their flags.
+		symbol.Declarations = append(core.Filter(symbol.Declarations, isNotReplacableByMethod), member)
+		oldFlags := symbol.Flags
+		symbol.Flags |= ast.SymbolFlagsNone
+		for _, d := range symbol.Declarations {
+			symbol.Flags |= d.Symbol().Flags
+		}
+		if oldFlags&ast.SymbolFlagsAccessor != 0 {
+			symbol.Flags |= ast.SymbolFlagsAccessor
+		}
 	}
 	if symbolFlags&ast.SymbolFlagsValue != 0 {
 		binder.SetValueDeclaration(symbol, member)

--- a/internal/transformers/declarations/transform.go
+++ b/internal/transformers/declarations/transform.go
@@ -2066,7 +2066,8 @@ func (tx *DeclarationTransformer) collectThisPropertyAssignments(classNode *ast.
 	// Pre-populate seen with existing direct member nodes to avoid duplicates
 	for _, member := range members.Nodes {
 		if member.Name() != nil {
-			seen.Add(getThisPropertyAssignmentKey(member.Name(), member, false))
+			isStatic := ast.IsStatic(member)
+			seen.Add(getThisPropertyAssignmentKey(member.Name(), member, isStatic))
 		}
 	}
 	tx.seenProperties = seen

--- a/internal/transformers/declarations/transform.go
+++ b/internal/transformers/declarations/transform.go
@@ -43,6 +43,23 @@ type DeclarationEmitHost interface {
 	GetEmitResolver() printer.EmitResolver
 }
 
+type thisPropertyAssignmentKey struct {
+	name      string
+	node      *ast.Node
+	isStatic  bool
+	isPrivate bool
+}
+
+func getThisPropertyAssignmentKey(name *ast.Node, node *ast.Node, isStatic bool) thisPropertyAssignmentKey {
+	isPrivate := ast.IsPrivateIdentifier(name)
+	if name != nil && !ast.IsDynamicName(name) {
+		if nameText, ok := ast.TryGetTextOfPropertyName(name); ok {
+			return thisPropertyAssignmentKey{name: nameText, isStatic: isStatic, isPrivate: isPrivate}
+		}
+	}
+	return thisPropertyAssignmentKey{node: node, isStatic: isStatic, isPrivate: isPrivate}
+}
+
 type DeclarationTransformer struct {
 	transformers.Transformer
 	host                DeclarationEmitHost
@@ -63,7 +80,7 @@ type DeclarationTransformer struct {
 	lateStatementReplacementMap      map[ast.NodeId]*ast.Node
 	expandoHosts                     map[ast.NodeId]*ast.Node   // store the result of transforming expando hosts so they can be inserted later if the host is actually referenced
 	expandoMembers                   map[ast.NodeId][]*ast.Node // store any found expando _members_ after transforming them so *if* the host is referenced, they can be emitted alongside it
-	seenProperties                   collections.Set[*ast.Node]
+	seenProperties                   collections.Set[thisPropertyAssignmentKey]
 	thisPropertyAssignmentsCollected []*ast.Node
 	rawReferencedFiles               []ReferencedFilePair
 	rawTypeReferenceDirectives       []*ast.FileReference
@@ -1970,10 +1987,11 @@ caseBlock:
 	case ast.JSDeclarationKindThisProperty:
 		name := ast.GetNameOfDeclaration(node)
 		base := tx.resolver.GetReferencedMemberValueDeclaration(node)
-		if base == nil || tx.seenProperties.Has(base) {
+		key := getThisPropertyAssignmentKey(name, node, isStatic)
+		if base == nil || tx.seenProperties.Has(key) {
 			break
 		}
-		tx.seenProperties.Add(base)
+		tx.seenProperties.Add(key)
 
 		// problem: this prop might be overriding a prop from a base type. The checker has special bails for override compat comparisons for binary expression properties,
 		// but what we transform to won't - so we either need to match the base type (for example, if it's a getter/setter) or emit nothing
@@ -2044,11 +2062,11 @@ func isClassExtendingNull(node *ast.Node) bool {
 // of JS classes and synthesizes PropertyDeclaration nodes for each unique property name.
 func (tx *DeclarationTransformer) collectThisPropertyAssignments(classNode *ast.Node) []*ast.Node {
 	members := classNode.ClassLikeData().Members
-	seen := collections.Set[*ast.Node]{}
+	seen := collections.Set[thisPropertyAssignmentKey]{}
 	// Pre-populate seen with existing direct member nodes to avoid duplicates
 	for _, member := range members.Nodes {
 		if member.Name() != nil {
-			seen.Add(member)
+			seen.Add(getThisPropertyAssignmentKey(member.Name(), member, false))
 		}
 	}
 	tx.seenProperties = seen

--- a/testdata/baselines/reference/compiler/jsDeclarationEmitThisAssignmentDuplicatingMethod.js
+++ b/testdata/baselines/reference/compiler/jsDeclarationEmitThisAssignmentDuplicatingMethod.js
@@ -52,6 +52,13 @@ export class G {
     static[sym2]() {}
 }
 
+export class H {
+    static foo = () => {}
+    static {
+        this.foo = this.foo.bind(this);
+    }
+}
+
 
 
 
@@ -70,6 +77,7 @@ export declare class C {
     [sym](): void;
 }
 export declare class D {
+    bar: number;
     constructor();
     static bar(): void;
 }
@@ -84,5 +92,8 @@ export declare class F {
 declare const sym2: unique symbol;
 export declare class G {
     static [sym2](): void;
+}
+export declare class H {
+    static foo: () => void;
 }
 export {};

--- a/testdata/baselines/reference/compiler/jsDeclarationEmitThisAssignmentDuplicatingMethod.js
+++ b/testdata/baselines/reference/compiler/jsDeclarationEmitThisAssignmentDuplicatingMethod.js
@@ -1,0 +1,88 @@
+//// [tests/cases/compiler/jsDeclarationEmitThisAssignmentDuplicatingMethod.ts] ////
+
+//// [main.js]
+export class A {
+    constructor() {
+        this.foo = this.foo.bind(this);
+    }
+    foo() {}
+}
+
+export class B {
+    constructor() {
+        this.#foo = this.#foo.bind(this);
+    }
+    #foo = () => {}
+}
+
+const sym = Symbol();
+export class C {
+    constructor() {
+        this[sym] = this[sym].bind(this);
+    }
+    [sym]() {}
+}
+
+export class D {
+    constructor() {
+        this.bar = 1;
+    }
+    static bar() {}
+}
+
+export class E {
+    static init() {
+        this.baz = 1;
+    }
+    baz() {}
+}
+
+export class F {
+    static #foo = () => {}
+    static {
+        this.#foo = this.#foo.bind(this);
+    }
+}
+
+const sym2 = Symbol();
+export class G {
+    static {
+        this[sym2] = this[sym2].bind(this);
+    }
+    static[sym2]() {}
+}
+
+
+
+
+//// [main.d.ts]
+export declare class A {
+    constructor();
+    foo(): void;
+}
+export declare class B {
+    #private;
+    constructor();
+}
+declare const sym: unique symbol;
+export declare class C {
+    constructor();
+    [sym](): void;
+}
+export declare class D {
+    constructor();
+    static bar(): void;
+}
+export declare class E {
+    static baz: number | undefined;
+    static init(): void;
+    baz(): void;
+}
+export declare class F {
+    #private;
+}
+declare const sym2: unique symbol;
+export declare class G {
+    static [sym2](): void;
+}
+export {};

--- a/testdata/baselines/reference/compiler/jsDeclarationEmitThisAssignmentDuplicatingMethod.symbols
+++ b/testdata/baselines/reference/compiler/jsDeclarationEmitThisAssignmentDuplicatingMethod.symbols
@@ -127,3 +127,23 @@ export class G {
 >sym2 : Symbol(sym2, Decl(main.js, 43, 5))
 }
 
+export class H {
+>H : Symbol(H, Decl(main.js, 49, 1))
+
+    static foo = () => {}
+>foo : Symbol(H.foo, Decl(main.js, 51, 16))
+
+    static {
+        this.foo = this.foo.bind(this);
+>this.foo : Symbol(H.foo, Decl(main.js, 51, 16))
+>this : Symbol(H, Decl(main.js, 49, 1))
+>foo : Symbol(H.foo, Decl(main.js, 51, 16))
+>this.foo.bind : Symbol(CallableFunction.bind, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>this.foo : Symbol(H.foo, Decl(main.js, 51, 16))
+>this : Symbol(H, Decl(main.js, 49, 1))
+>foo : Symbol(H.foo, Decl(main.js, 51, 16))
+>bind : Symbol(CallableFunction.bind, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>this : Symbol(H, Decl(main.js, 49, 1))
+    }
+}
+

--- a/testdata/baselines/reference/compiler/jsDeclarationEmitThisAssignmentDuplicatingMethod.symbols
+++ b/testdata/baselines/reference/compiler/jsDeclarationEmitThisAssignmentDuplicatingMethod.symbols
@@ -1,0 +1,129 @@
+//// [tests/cases/compiler/jsDeclarationEmitThisAssignmentDuplicatingMethod.ts] ////
+
+=== main.js ===
+export class A {
+>A : Symbol(A, Decl(main.js, 0, 0))
+
+    constructor() {
+        this.foo = this.foo.bind(this);
+>this.foo : Symbol(A.foo, Decl(main.js, 3, 5))
+>this : Symbol(A, Decl(main.js, 0, 0))
+>foo : Symbol(A.foo, Decl(main.js, 3, 5))
+>this.foo.bind : Symbol(CallableFunction.bind, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>this.foo : Symbol(A.foo, Decl(main.js, 3, 5))
+>this : Symbol(A, Decl(main.js, 0, 0))
+>foo : Symbol(A.foo, Decl(main.js, 3, 5))
+>bind : Symbol(CallableFunction.bind, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>this : Symbol(A, Decl(main.js, 0, 0))
+    }
+    foo() {}
+>foo : Symbol(A.foo, Decl(main.js, 3, 5))
+}
+
+export class B {
+>B : Symbol(B, Decl(main.js, 5, 1))
+
+    constructor() {
+        this.#foo = this.#foo.bind(this);
+>this.#foo : Symbol(B.#foo, Decl(main.js, 10, 5))
+>this : Symbol(B, Decl(main.js, 5, 1))
+>this.#foo.bind : Symbol(CallableFunction.bind, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>this.#foo : Symbol(B.#foo, Decl(main.js, 10, 5))
+>this : Symbol(B, Decl(main.js, 5, 1))
+>bind : Symbol(CallableFunction.bind, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>this : Symbol(B, Decl(main.js, 5, 1))
+    }
+    #foo = () => {}
+>#foo : Symbol(B.#foo, Decl(main.js, 10, 5))
+}
+
+const sym = Symbol();
+>sym : Symbol(sym, Decl(main.js, 14, 5))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2019.symbol.d.ts, --, --))
+
+export class C {
+>C : Symbol(C, Decl(main.js, 14, 21))
+
+    constructor() {
+        this[sym] = this[sym].bind(this);
+>this : Symbol(C, Decl(main.js, 14, 21))
+>sym : Symbol(sym, Decl(main.js, 14, 5))
+>this[sym].bind : Symbol(CallableFunction.bind, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>this : Symbol(C, Decl(main.js, 14, 21))
+>sym : Symbol(sym, Decl(main.js, 14, 5))
+>bind : Symbol(CallableFunction.bind, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>this : Symbol(C, Decl(main.js, 14, 21))
+    }
+    [sym]() {}
+>[sym] : Symbol(C[sym], Decl(main.js, 18, 5))
+>sym : Symbol(sym, Decl(main.js, 14, 5))
+}
+
+export class D {
+>D : Symbol(D, Decl(main.js, 20, 1))
+
+    constructor() {
+        this.bar = 1;
+>this.bar : Symbol(D.bar, Decl(main.js, 23, 19))
+>this : Symbol(D, Decl(main.js, 20, 1))
+>bar : Symbol(D.bar, Decl(main.js, 23, 19))
+    }
+    static bar() {}
+>bar : Symbol(D.bar, Decl(main.js, 25, 5))
+}
+
+export class E {
+>E : Symbol(E, Decl(main.js, 27, 1))
+
+    static init() {
+>init : Symbol(E.init, Decl(main.js, 29, 16))
+
+        this.baz = 1;
+>this.baz : Symbol(E.baz, Decl(main.js, 30, 19))
+>this : Symbol(E, Decl(main.js, 27, 1))
+>baz : Symbol(E.baz, Decl(main.js, 30, 19))
+    }
+    baz() {}
+>baz : Symbol(E.baz, Decl(main.js, 32, 5))
+}
+
+export class F {
+>F : Symbol(F, Decl(main.js, 34, 1))
+
+    static #foo = () => {}
+>#foo : Symbol(F.#foo, Decl(main.js, 36, 16))
+
+    static {
+        this.#foo = this.#foo.bind(this);
+>this.#foo : Symbol(F.#foo, Decl(main.js, 36, 16))
+>this : Symbol(F, Decl(main.js, 34, 1))
+>this.#foo.bind : Symbol(CallableFunction.bind, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>this.#foo : Symbol(F.#foo, Decl(main.js, 36, 16))
+>this : Symbol(F, Decl(main.js, 34, 1))
+>bind : Symbol(CallableFunction.bind, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>this : Symbol(F, Decl(main.js, 34, 1))
+    }
+}
+
+const sym2 = Symbol();
+>sym2 : Symbol(sym2, Decl(main.js, 43, 5))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2019.symbol.d.ts, --, --))
+
+export class G {
+>G : Symbol(G, Decl(main.js, 43, 22))
+
+    static {
+        this[sym2] = this[sym2].bind(this);
+>this : Symbol(G, Decl(main.js, 43, 22))
+>sym2 : Symbol(sym2, Decl(main.js, 43, 5))
+>this[sym2].bind : Symbol(CallableFunction.bind, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>this : Symbol(G, Decl(main.js, 43, 22))
+>sym2 : Symbol(sym2, Decl(main.js, 43, 5))
+>bind : Symbol(CallableFunction.bind, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>this : Symbol(G, Decl(main.js, 43, 22))
+    }
+    static[sym2]() {}
+>[sym2] : Symbol(G[sym2], Decl(main.js, 47, 5))
+>sym2 : Symbol(sym2, Decl(main.js, 43, 5))
+}
+

--- a/testdata/baselines/reference/compiler/jsDeclarationEmitThisAssignmentDuplicatingMethod.types
+++ b/testdata/baselines/reference/compiler/jsDeclarationEmitThisAssignmentDuplicatingMethod.types
@@ -1,0 +1,151 @@
+//// [tests/cases/compiler/jsDeclarationEmitThisAssignmentDuplicatingMethod.ts] ////
+
+=== main.js ===
+export class A {
+>A : A
+
+    constructor() {
+        this.foo = this.foo.bind(this);
+>this.foo = this.foo.bind(this) : () => void
+>this.foo : () => void
+>this : this
+>foo : () => void
+>this.foo.bind(this) : () => void
+>this.foo.bind : { <T>(this: T, thisArg: ThisParameterType<T>): OmitThisParameter<T>; <T, A extends any[], B extends any[], R>(this: (this: T, ...args: [...A, ...B]) => R, thisArg: T, ...args: A): (...args: B) => R; }
+>this.foo : () => void
+>this : this
+>foo : () => void
+>bind : { <T>(this: T, thisArg: ThisParameterType<T>): OmitThisParameter<T>; <T, A extends any[], B extends any[], R>(this: (this: T, ...args: [...A, ...B]) => R, thisArg: T, ...args: A): (...args: B) => R; }
+>this : this
+    }
+    foo() {}
+>foo : () => void
+}
+
+export class B {
+>B : B
+
+    constructor() {
+        this.#foo = this.#foo.bind(this);
+>this.#foo = this.#foo.bind(this) : () => void
+>this.#foo : () => void
+>this : this
+>this.#foo.bind(this) : () => void
+>this.#foo.bind : { <T>(this: T, thisArg: ThisParameterType<T>): OmitThisParameter<T>; <T, A extends any[], B extends any[], R>(this: (this: T, ...args: [...A, ...B]) => R, thisArg: T, ...args: A): (...args: B) => R; }
+>this.#foo : () => void
+>this : this
+>bind : { <T>(this: T, thisArg: ThisParameterType<T>): OmitThisParameter<T>; <T, A extends any[], B extends any[], R>(this: (this: T, ...args: [...A, ...B]) => R, thisArg: T, ...args: A): (...args: B) => R; }
+>this : this
+    }
+    #foo = () => {}
+>#foo : () => void
+>() => {} : () => void
+}
+
+const sym = Symbol();
+>sym : unique symbol
+>Symbol() : unique symbol
+>Symbol : SymbolConstructor
+
+export class C {
+>C : C
+
+    constructor() {
+        this[sym] = this[sym].bind(this);
+>this[sym] = this[sym].bind(this) : () => void
+>this[sym] : () => void
+>this : this
+>sym : unique symbol
+>this[sym].bind(this) : () => void
+>this[sym].bind : { <T>(this: T, thisArg: ThisParameterType<T>): OmitThisParameter<T>; <T, A extends any[], B extends any[], R>(this: (this: T, ...args: [...A, ...B]) => R, thisArg: T, ...args: A): (...args: B) => R; }
+>this[sym] : () => void
+>this : this
+>sym : unique symbol
+>bind : { <T>(this: T, thisArg: ThisParameterType<T>): OmitThisParameter<T>; <T, A extends any[], B extends any[], R>(this: (this: T, ...args: [...A, ...B]) => R, thisArg: T, ...args: A): (...args: B) => R; }
+>this : this
+    }
+    [sym]() {}
+>[sym] : () => void
+>sym : unique symbol
+}
+
+export class D {
+>D : D
+
+    constructor() {
+        this.bar = 1;
+>this.bar = 1 : 1
+>this.bar : any
+>this : this
+>bar : any
+>1 : 1
+    }
+    static bar() {}
+>bar : () => void
+}
+
+export class E {
+>E : E
+
+    static init() {
+>init : () => void
+
+        this.baz = 1;
+>this.baz = 1 : 1
+>this.baz : number | undefined
+>this : typeof E
+>baz : number | undefined
+>1 : 1
+    }
+    baz() {}
+>baz : () => void
+}
+
+export class F {
+>F : F
+
+    static #foo = () => {}
+>#foo : () => void
+>() => {} : () => void
+
+    static {
+        this.#foo = this.#foo.bind(this);
+>this.#foo = this.#foo.bind(this) : () => void
+>this.#foo : () => void
+>this : typeof F
+>this.#foo.bind(this) : () => void
+>this.#foo.bind : { <T>(this: T, thisArg: ThisParameterType<T>): OmitThisParameter<T>; <T, A extends any[], B extends any[], R>(this: (this: T, ...args: [...A, ...B]) => R, thisArg: T, ...args: A): (...args: B) => R; }
+>this.#foo : () => void
+>this : typeof F
+>bind : { <T>(this: T, thisArg: ThisParameterType<T>): OmitThisParameter<T>; <T, A extends any[], B extends any[], R>(this: (this: T, ...args: [...A, ...B]) => R, thisArg: T, ...args: A): (...args: B) => R; }
+>this : typeof F
+    }
+}
+
+const sym2 = Symbol();
+>sym2 : unique symbol
+>Symbol() : unique symbol
+>Symbol : SymbolConstructor
+
+export class G {
+>G : G
+
+    static {
+        this[sym2] = this[sym2].bind(this);
+>this[sym2] = this[sym2].bind(this) : () => void
+>this[sym2] : () => void
+>this : typeof G
+>sym2 : unique symbol
+>this[sym2].bind(this) : () => void
+>this[sym2].bind : { <T>(this: T, thisArg: ThisParameterType<T>): OmitThisParameter<T>; <T, A extends any[], B extends any[], R>(this: (this: T, ...args: [...A, ...B]) => R, thisArg: T, ...args: A): (...args: B) => R; }
+>this[sym2] : () => void
+>this : typeof G
+>sym2 : unique symbol
+>bind : { <T>(this: T, thisArg: ThisParameterType<T>): OmitThisParameter<T>; <T, A extends any[], B extends any[], R>(this: (this: T, ...args: [...A, ...B]) => R, thisArg: T, ...args: A): (...args: B) => R; }
+>this : typeof G
+    }
+    static[sym2]() {}
+>[sym2] : () => void
+>sym2 : unique symbol
+}
+

--- a/testdata/baselines/reference/compiler/jsDeclarationEmitThisAssignmentDuplicatingMethod.types
+++ b/testdata/baselines/reference/compiler/jsDeclarationEmitThisAssignmentDuplicatingMethod.types
@@ -149,3 +149,26 @@ export class G {
 >sym2 : unique symbol
 }
 
+export class H {
+>H : H
+
+    static foo = () => {}
+>foo : () => void
+>() => {} : () => void
+
+    static {
+        this.foo = this.foo.bind(this);
+>this.foo = this.foo.bind(this) : () => void
+>this.foo : () => void
+>this : typeof H
+>foo : () => void
+>this.foo.bind(this) : () => void
+>this.foo.bind : { <T>(this: T, thisArg: ThisParameterType<T>): OmitThisParameter<T>; <T, A extends any[], B extends any[], R>(this: (this: T, ...args: [...A, ...B]) => R, thisArg: T, ...args: A): (...args: B) => R; }
+>this.foo : () => void
+>this : typeof H
+>foo : () => void
+>bind : { <T>(this: T, thisArg: ThisParameterType<T>): OmitThisParameter<T>; <T, A extends any[], B extends any[], R>(this: (this: T, ...args: [...A, ...B]) => R, thisArg: T, ...args: A): (...args: B) => R; }
+>this : typeof H
+    }
+}
+

--- a/testdata/tests/cases/compiler/jsDeclarationEmitThisAssignmentDuplicatingMethod.ts
+++ b/testdata/tests/cases/compiler/jsDeclarationEmitThisAssignmentDuplicatingMethod.ts
@@ -54,3 +54,10 @@ export class G {
     }
     static[sym2]() {}
 }
+
+export class H {
+    static foo = () => {}
+    static {
+        this.foo = this.foo.bind(this);
+    }
+}

--- a/testdata/tests/cases/compiler/jsDeclarationEmitThisAssignmentDuplicatingMethod.ts
+++ b/testdata/tests/cases/compiler/jsDeclarationEmitThisAssignmentDuplicatingMethod.ts
@@ -1,0 +1,56 @@
+// @allowJs: true
+// @checkJs: true
+// @declaration: true
+// @emitDeclarationOnly: true
+// @target: esnext
+// @filename: main.js
+export class A {
+    constructor() {
+        this.foo = this.foo.bind(this);
+    }
+    foo() {}
+}
+
+export class B {
+    constructor() {
+        this.#foo = this.#foo.bind(this);
+    }
+    #foo = () => {}
+}
+
+const sym = Symbol();
+export class C {
+    constructor() {
+        this[sym] = this[sym].bind(this);
+    }
+    [sym]() {}
+}
+
+export class D {
+    constructor() {
+        this.bar = 1;
+    }
+    static bar() {}
+}
+
+export class E {
+    static init() {
+        this.baz = 1;
+    }
+    baz() {}
+}
+
+export class F {
+    static #foo = () => {}
+    static {
+        this.#foo = this.#foo.bind(this);
+    }
+}
+
+const sym2 = Symbol();
+export class G {
+    static {
+        this[sym2] = this[sym2].bind(this);
+    }
+    static[sym2]() {}
+}


### PR DESCRIPTION
And fix late binding of this-assigned static methods, which had a few problems preventing them from being typechecked correctly - a problem revealed by a slightly broader test for the original issue.

Closes #4331
Fixes #4325