### PR TITLE
API: make it possible to open file in inferred projects through API 

### DIFF
--- a/_packages/native-preview/src/api/proto.ts
+++ b/_packages/native-preview/src/api/proto.ts
@@ -66,6 +66,12 @@ export interface ConfigResponse {
 export interface LSPUpdateSnapshotParams {
     /** Path to a tsconfig.json file to open in the new snapshot */
     openProject?: string;
+    /**
+     * Files to load into the inferred project if no configured project already contains them.
+     * Use this for files (e.g. d.ts in node_modules) not in any project's import graph.
+     * After calling updateSnapshot with openFiles, getDefaultProjectForFile will return the inferred project.
+     */
+    openFiles?: DocumentIdentifier[];
 }
 
 export interface FileChangeSummary {

--- a/_packages/native-preview/test/async/api.test.ts
+++ b/_packages/native-preview/test/async/api.test.ts
@@ -3456,6 +3456,42 @@ describe("Checker - getSignatureUsage", () => {
     });
 });
 
+describe("getDefaultProjectForFile", () => {
+    test("finds inferred project for d.ts in node_modules after openFiles", async () => {
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/index.ts": `export const x = 1;`,
+            "/node_modules/my-lib/package.json": JSON.stringify({ name: "my-lib", types: "./index.d.ts" }),
+            "/node_modules/my-lib/index.d.ts": `export declare const foo: string;`,
+        });
+        try {
+            const snapshot = await api.updateSnapshot({ openProject: "/tsconfig.json" });
+            const project = snapshot.getProject("/tsconfig.json")!;
+
+            // The d.ts is not imported, so it is not in the project's program
+            const dtsSf = await project.program.getSourceFile("/node_modules/my-lib/index.d.ts");
+            assert.equal(dtsSf, undefined, "d.ts not in import graph should not be found via project.program.getSourceFile");
+
+            // Before opening the file, getDefaultProjectForFile returns undefined (no error)
+            const noProject = await snapshot.getDefaultProjectForFile("/node_modules/my-lib/index.d.ts");
+            assert.equal(noProject, undefined, "getDefaultProjectForFile returns undefined for unloaded file");
+
+            // Load the file into the inferred project via updateSnapshot openFiles
+            const snapshot2 = await api.updateSnapshot({ openFiles: ["/node_modules/my-lib/index.d.ts"] });
+            const defaultProject = await snapshot2.getDefaultProjectForFile("/node_modules/my-lib/index.d.ts");
+            assert.ok(defaultProject, "getDefaultProjectForFile should find inferred project after openFiles");
+
+            const fooPos = `export declare const foo: string;`.indexOf("foo");
+            const fooType = await defaultProject.checker.getTypeAtPosition("/node_modules/my-lib/index.d.ts", fooPos);
+            assert.ok(fooType);
+            assert.ok(fooType.flags & TypeFlags.String);
+        }
+        finally {
+            await api.close();
+        }
+    });
+});
+
 test("Benchmarks", async () => {
     await runBenchmarks({ singleIteration: true });
 });

--- a/_packages/native-preview/test/sync/api.test.ts
+++ b/_packages/native-preview/test/sync/api.test.ts
@@ -3464,6 +3464,42 @@ describe("Checker - getSignatureUsage", () => {
     });
 });
 
+describe("getDefaultProjectForFile", () => {
+    test("finds inferred project for d.ts in node_modules after openFiles", () => {
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/index.ts": `export const x = 1;`,
+            "/node_modules/my-lib/package.json": JSON.stringify({ name: "my-lib", types: "./index.d.ts" }),
+            "/node_modules/my-lib/index.d.ts": `export declare const foo: string;`,
+        });
+        try {
+            const snapshot = api.updateSnapshot({ openProject: "/tsconfig.json" });
+            const project = snapshot.getProject("/tsconfig.json")!;
+
+            // The d.ts is not imported, so it is not in the project's program
+            const dtsSf = project.program.getSourceFile("/node_modules/my-lib/index.d.ts");
+            assert.equal(dtsSf, undefined, "d.ts not in import graph should not be found via project.program.getSourceFile");
+
+            // Before opening the file, getDefaultProjectForFile returns undefined (no error)
+            const noProject = snapshot.getDefaultProjectForFile("/node_modules/my-lib/index.d.ts");
+            assert.equal(noProject, undefined, "getDefaultProjectForFile returns undefined for unloaded file");
+
+            // Load the file into the inferred project via updateSnapshot openFiles
+            const snapshot2 = api.updateSnapshot({ openFiles: ["/node_modules/my-lib/index.d.ts"] });
+            const defaultProject = snapshot2.getDefaultProjectForFile("/node_modules/my-lib/index.d.ts");
+            assert.ok(defaultProject, "getDefaultProjectForFile should find inferred project after openFiles");
+
+            const fooPos = `export declare const foo: string;`.indexOf("foo");
+            const fooType = defaultProject.checker.getTypeAtPosition("/node_modules/my-lib/index.d.ts", fooPos);
+            assert.ok(fooType);
+            assert.ok(fooType.flags & TypeFlags.String);
+        }
+        finally {
+            api.close();
+        }
+    });
+});
+
 test("Benchmarks", () => {
     runBenchmarks({ singleIteration: true });
 });

--- a/internal/api/proto.go
+++ b/internal/api/proto.go
@@ -272,6 +272,10 @@ type UpdateSnapshotParams struct {
 	OpenProject string `json:"openProject,omitempty"`
 	// FileChanges describes file system changes since the last snapshot.
 	FileChanges *APIFileChanges `json:"fileChanges,omitempty"`
+	// OpenFiles lists files to load into the inferred project if no configured project
+	// already contains them. Mirrors old tsserver's openClientFile for orphan files such
+	// as node_modules d.ts files that are not in any project's import graph.
+	OpenFiles []DocumentIdentifier `json:"openFiles,omitempty"`
 }
 
 // ProjectFileChanges describes what source files changed within a single project.

--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -18,6 +18,7 @@ import (
 	"github.com/microsoft/typescript-go/internal/core"
 	"github.com/microsoft/typescript-go/internal/json"
 	"github.com/microsoft/typescript-go/internal/ls"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
 	"github.com/microsoft/typescript-go/internal/nodebuilder"
 	"github.com/microsoft/typescript-go/internal/pprof"
 	"github.com/microsoft/typescript-go/internal/printer"
@@ -636,11 +637,15 @@ func (s *Session) handleUpdateSnapshot(ctx context.Context, params *UpdateSnapsh
 		}
 		snapshot = newSnapshot
 	} else {
+		var openFileURIs []lsproto.DocumentUri
+		for _, f := range params.OpenFiles {
+			openFileURIs = append(openFileURIs, f.ToURI())
+		}
 		// Even when fileChanges is empty, APIUpdateWithFileChanges ensures all projects
 		// opened by the API are up to date. For an API connected to an LSP server, this
 		// brings the API state up to date with the LSP state and ensures projects the
 		// API cares about are ready to be queried.
-		snapshot = s.projectSession.APIUpdateWithFileChanges(ctx, fileChanges)
+		snapshot = s.projectSession.APIUpdateWithFileChanges(ctx, fileChanges, openFileURIs)
 	}
 
 	// Create or ref-count snapshot data.
@@ -717,7 +722,8 @@ func (s *Session) handleRelease(ctx context.Context, params *ReleaseParams) (any
 	return true, nil
 }
 
-// handleGetDefaultProjectForFile returns the default project for a given file.
+// handleGetDefaultProjectForFile returns the default project for a given file,
+// or null if no project currently contains the file.
 func (s *Session) handleGetDefaultProjectForFile(ctx context.Context, params *GetDefaultProjectForFileParams) (*ProjectResponse, error) {
 	sd, err := s.getSnapshotData(params.Snapshot)
 	if err != nil {
@@ -727,7 +733,7 @@ func (s *Session) handleGetDefaultProjectForFile(ctx context.Context, params *Ge
 	uri := params.File.ToURI()
 	proj := sd.snapshot.GetDefaultProject(uri)
 	if proj == nil {
-		return nil, fmt.Errorf("%w: no project found for file %v", ErrClientError, params.File)
+		return nil, nil
 	}
 
 	return NewProjectResponse(proj), nil

--- a/internal/project/api.go
+++ b/internal/project/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/microsoft/typescript-go/internal/collections"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
 )
 
 // APIOpenProject opens a project and returns a ref'd snapshot.
@@ -36,8 +37,10 @@ func (s *Session) APIOpenProject(ctx context.Context, configFileName string, api
 }
 
 // APIUpdateWithFileChanges creates a new snapshot incorporating the given
-// file changes. Returns a ref'd snapshot; caller must Deref when done.
-func (s *Session) APIUpdateWithFileChanges(ctx context.Context, apiFileChanges FileChangeSummary) *Snapshot {
+// file changes. Documents are URIs that should be loaded into the inferred project
+// if no configured project already contains them.
+// Returns a ref'd snapshot; caller must Deref when done.
+func (s *Session) APIUpdateWithFileChanges(ctx context.Context, apiFileChanges FileChangeSummary, documents []lsproto.DocumentUri) *Snapshot {
 	s.snapshotUpdateMu.Lock()
 	defer s.snapshotUpdateMu.Unlock()
 	s.cancelScheduledSnapshotUpdate()
@@ -46,8 +49,9 @@ func (s *Session) APIUpdateWithFileChanges(ctx context.Context, apiFileChanges F
 	mergeFileChangeSummary(&fileChanges, apiFileChanges)
 
 	return s.updateSnapshotRef(ctx, overlays, SnapshotChange{
-		apiRequest:  &APISnapshotRequest{},
-		fileChanges: fileChanges,
-		ataChanges:  ataChanges,
+		ResourceRequest: ResourceRequest{Documents: documents},
+		apiRequest:      &APISnapshotRequest{},
+		fileChanges:     fileChanges,
+		ataChanges:      ataChanges,
 	})
 }


### PR DESCRIPTION
It makes possible to open a project for files from `node_modules`, which are not in import graph