### PR TITLE
Resolve symlinked project-reference directory (`index.ts`) subpaths to source

### DIFF
--- a/internal/compiler/projectreferencedtsfakinghost.go
+++ b/internal/compiler/projectreferencedtsfakinghost.go
@@ -162,6 +162,31 @@ func (fs *projectReferenceDtsFakingVfs) handleDirectoryCouldBeSymlink(directory 
 	})
 }
 
+// registerNodeModulesSymlinkFromAncestor walks up from a node_modules path to
+// the nearest ancestor directory that actually exists on disk and, if that
+// directory is a symlink (e.g. a symlinked package root in a workspace install),
+// records it in knownSymlinks. This handles the case where the resolver probes a
+// path inside an unbuilt package before directory-probing the package root, so
+// handleDirectoryCouldBeSymlink has not fired for it yet.
+func (fs *projectReferenceDtsFakingVfs) registerNodeModulesSymlinkFromAncestor(fileOrDirectory string) {
+	if !strings.Contains(fileOrDirectory, "/node_modules/") {
+		return
+	}
+	realFS := fs.projectReferenceFileMapper.opts.Host.FS()
+	dir := tspath.GetDirectoryPath(fileOrDirectory)
+	for strings.Contains(dir+"/", "/node_modules/") {
+		if realFS.DirectoryExists(dir) {
+			fs.handleDirectoryCouldBeSymlink(dir)
+			return
+		}
+		parent := tspath.GetDirectoryPath(dir)
+		if parent == dir {
+			return
+		}
+		dir = parent
+	}
+}
+
 func (fs *projectReferenceDtsFakingVfs) fileOrDirectoryExistsUsingSource(fileOrDirectory string, isFile bool) bool {
 	fileOrDirectoryExistsUsingSource := core.IfElse(isFile, fs.fileExistsIfProjectReferenceDts, fs.directoryExistsIfProjectReferenceDeclDir)
 	// Check current directory or file
@@ -169,6 +194,13 @@ func (fs *projectReferenceDtsFakingVfs) fileOrDirectoryExistsUsingSource(fileOrD
 	if result != core.TSUnknown {
 		return result == core.TSTrue
 	}
+
+	// The resolver can probe a path inside an unbuilt referenced package (whose
+	// declaration outputs do not exist on disk) before it ever directory-probes
+	// that package's symlinked root, so the symlink may not be in knownSymlinks
+	// yet. Discover and register it on demand from the nearest existing ancestor
+	// directory, then fall through to the existing symlink-aware lookup.
+	fs.registerNodeModulesSymlinkFromAncestor(fileOrDirectory)
 
 	knownDirectoryLinks := fs.knownSymlinks.Directories()
 	if knownDirectoryLinks.Size() == 0 {

--- a/internal/project/projectreferencesprogram_test.go
+++ b/internal/project/projectreferencesprogram_test.go
@@ -250,6 +250,24 @@ func TestProjectReferencesProgram(t *testing.T) {
 		assert.Assert(t, barFile != nil)
 	})
 
+	t.Run("references through symlink to a directory subpath (index file)", func(t *testing.T) {
+		t.Parallel()
+		files, aTest, bIndex := filesForSymlinkReferencesToDirectoryIndexSubpath("")
+		session, _ := projecttestutil.Setup(files)
+
+		uri := lsconv.FileNameToDocumentURI(aTest)
+		session.DidOpenFile(context.Background(), uri, 1, files[aTest].(string), lsproto.LanguageKindTypeScript)
+
+		snapshot := session.Snapshot()
+		projects := snapshot.ProjectCollection.Projects()
+		assert.Equal(t, len(projects), 1)
+		p := projects[0]
+		assert.Equal(t, p.Kind, project.KindConfigured)
+
+		indexFile := p.Program.GetSourceFile(bIndex)
+		assert.Assert(t, indexFile != nil)
+	})
+
 	t.Run("when new file is added to referenced project", func(t *testing.T) {
 		t.Parallel()
 		files := filesForReferencedProjectProgram(false)
@@ -358,6 +376,27 @@ func filesForSymlinkReferencesInSubfolder(preserveSymlinks bool, scope string) (
 	addConfigForPackage(files, "A", preserveSymlinks, []string{"../B"})
 	addConfigForPackage(files, "B", preserveSymlinks, nil)
 	return files, aTest, bFoo, bBar
+}
+
+// filesForSymlinkReferencesToDirectoryIndexSubpath imports a directory subpath
+// (`b/lib/File`, whose source is `B/src/File/index.ts`) of a symlinked,
+// unbuilt referenced project. The resolver directory-probes the unbuilt subpath
+// before the package root, so the redirect must still map it to source.
+func filesForSymlinkReferencesToDirectoryIndexSubpath(scope string) (files map[string]any, aTest string, bIndex string) {
+	aTest = "/user/username/projects/myproject/packages/A/src/test.ts"
+	bIndex = "/user/username/projects/myproject/packages/B/src/File/index.ts"
+	files = map[string]any{
+		"/user/username/projects/myproject/packages/B/package.json": `{}`,
+		aTest: fmt.Sprintf(`
+			import { helper } from '%sb/lib/File';
+			helper();
+		`, scope),
+		bIndex: `export function helper() { }`,
+		fmt.Sprintf(`/user/username/projects/myproject/node_modules/%sb`, scope): vfstest.Symlink("/user/username/projects/myproject/packages/B"),
+	}
+	addConfigForPackage(files, "A", false, []string{"../B"})
+	addConfigForPackage(files, "B", false, nil)
+	return files, aTest, bIndex
 }
 
 func addConfigForPackage(files map[string]any, packageName string, preserveSymlinks bool, references []string) {


### PR DESCRIPTION
Fixes #4373. This is a **6.0 → 7.0 regression**: TypeScript 6.0.3 resolves the same project from source; the native compiler reports `TS2307` (details + runnable repro in the issue).

The source-of-project-reference redirect failed to resolve a **directory subpath** import (e.g. `b/lib/File` where the source is `b/src/File/index.ts`) when the referenced package is reached through a **symlinked `node_modules`** entry and its `lib/` is **unbuilt**.

### Cause

The dts faking host resolves symlinked paths through `knownSymlinks`, which is populated lazily by `handleDirectoryCouldBeSymlink` — and only when an *existing* directory is probed. For a directory subpath the resolver `DirectoryExists`-probes the unbuilt subpath (`node_modules/b/lib/File`) **before** it ever directory-probes the package root (`node_modules/b`), so the package symlink isn't in `knownSymlinks` yet, the lookup misses, and the cached negative sticks. (File subpaths happen to probe the package root first, which is why the existing symlink tests pass.)

### Fix

On a `node_modules` miss in `fileOrDirectoryExistsUsingSource`, discover and register the package symlink on demand: walk up to the nearest existing ancestor directory and reuse the existing `handleDirectoryCouldBeSymlink`. The existing symlink-aware fallback then resolves the subpath to source. It only runs on a miss, so built/normal resolution is unaffected.

### Test

Added `internal/project` `TestProjectReferencesProgram` / "references through symlink to a directory subpath (index file)", which fails without the change (`indexFile is nil`) and passes with it. `internal/project` and `internal/compiler` suites are green.

### AI assistance

This change was authored with AI assistance (Claude Code). I investigated the bug, directed and reviewed the work, understand the change, and will shepherd it through review and respond to feedback myself.
