### PR TITLE
Fix RemoteNodeList crash on Array species methods (map/filter/slice)

### DIFF
--- a/_packages/native-preview/src/api/node/node.generated.ts
+++ b/_packages/native-preview/src/api/node/node.generated.ts
@@ -35,6 +35,10 @@ import {
 } from "./protocol.ts";
 
 export class RemoteNodeList extends Array<RemoteNode> implements NodeArray<RemoteNode> {
+    static get [Symbol.species](): ArrayConstructor {
+        return Array;
+    }
+
     parent: RemoteNode;
     hasTrailingComma?: boolean;
     transformFlags: number = 0;

--- a/_packages/native-preview/test/sync/ast.test.ts
+++ b/_packages/native-preview/test/sync/ast.test.ts
@@ -662,3 +662,52 @@ describe("RemoteNode + getSynthesizedDeepClone", () => {
         }
     });
 });
+
+describe("RemoteNodeList + Array species methods", () => {
+    const files = {
+        "/tsconfig.json": "{}",
+        "/src/index.ts": "const a = 1;\nconst b = 2;\nconst c = 3;\n",
+    };
+
+    test("map/filter/slice do not throw and return plain arrays", () => {
+        const api = spawnAPI(files);
+        try {
+            const sf = getRemoteSourceFile(api, "/tsconfig.json", "/src/index.ts");
+            const statements = sf.statements;
+            assert.ok(statements.length >= 3);
+
+            // Species methods must not throw, and must produce a plain Array
+            // (not another RemoteNodeList; its prototype differs from Array.prototype).
+            assert.doesNotThrow(() => statements.map(s => s.kind));
+            const mapped = statements.map(s => s.kind);
+            assert.strictEqual(Object.getPrototypeOf(mapped), Array.prototype);
+            assert.deepStrictEqual(mapped, [...statements].map(s => s.kind));
+
+            const filtered = statements.filter(() => true);
+            assert.strictEqual(Object.getPrototypeOf(filtered), Array.prototype);
+            assert.strictEqual(filtered.length, statements.length);
+
+            const sliced = statements.slice(1);
+            assert.strictEqual(Object.getPrototypeOf(sliced), Array.prototype);
+            assert.strictEqual(sliced.length, statements.length - 1);
+        }
+        finally {
+            api.close();
+        }
+    });
+
+    test("iterator-based access is unaffected", () => {
+        const api = spawnAPI(files);
+        try {
+            const sf = getRemoteSourceFile(api, "/tsconfig.json", "/src/index.ts");
+            const statements = sf.statements;
+
+            assert.strictEqual([...statements].length, statements.length);
+            assert.ok(statements.at(0));
+            assert.ok(statements[0]);
+        }
+        finally {
+            api.close();
+        }
+    });
+});

--- a/_scripts/generate-encoder.ts
+++ b/_scripts/generate-encoder.ts
@@ -1510,6 +1510,10 @@ function emitNodeGeneratedImports(w: CodeWriter) {
 
 function emitRemoteNodeList(w: CodeWriter) {
     w.write(`export class RemoteNodeList extends Array<RemoteNode> implements NodeArray<RemoteNode> {`);
+    w.write(`    static get [Symbol.species](): ArrayConstructor {`);
+    w.write(`        return Array;`);
+    w.write(`    }`);
+    w.write(``);
     w.write(`    parent: RemoteNode;`);
     w.write(`    hasTrailingComma?: boolean;`);
     w.write(`    transformFlags: number = 0;`);


### PR DESCRIPTION
> Disclosure (required by CONTRIBUTING.md): this change was authored alongside AI assistance (Claude Code). I have read and understand the patch and will respond to review myself. I saw a few recent crash fix PRs not link an issue, apologies for jumping the gun here as well.

## Analysis

> _Context: I hit this while verifying whether a custom type-aware lint rule, written in JS against the native-preview API, could read a symbol's JSDoc/doc-comment off the AST, including a tag like @ internal. Calling a normal array method on a decoded node list crashed it._

`RemoteNodeList` (the AST API's lazily-decoded child-node list) extends `Array` but does not override `Symbol.species`. Array methods that build a new collection (`map` / `filter` / `slice` / `concat` / `flat` / `flatMap` / `splice`) go through [`ArraySpeciesCreate`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/species), which reconstructs the result by calling the constructor with the new length:

```js
// effectively, inside .map / .filter / .slice / ...
new RemoteNodeList(length)
```

But the constructor is `constructor(view: DataView, index, parent, sourceFile, offsetNodes)`, so the numeric `length` binds to the first parameter, `view`. The constructor then runs `this.length = this.data`, and the `data` getter calls `this.view.getUint32(...)` on a number, throwing:

```
TypeError: this.view.getUint32 is not a function
```

This crashes on intended, happy-path usage:

```js
import { getSynthesizedDeepClones } from "@typescript/native-preview/unstable/ast/clone";

const sourceFile = project.program.getSourceFile(fileName);

// Any Array species method, .map() in this case, on a decoded node list throws:
sourceFile.statements.map(stmt => stmt.kind);
// TypeError: this.view.getUint32 is not a function

// The exported clone helper hits it too — it calls `nodes.map(...)` internally
// (src/ast/clone.ts):
getSynthesizedDeepClones(sourceFile.statements);
// TypeError: this.view.getUint32 is not a function
```

Iterator-based access is unaffected, because `[Symbol.iterator]` is overridden to walk the children directly:

| Works (iterator / element access) | Threw before this fix (ArraySpeciesCreate) |
|---|---|
| `for…of`, `[...list]`, `Array.from`, `list.at(i)`, `list[i]`, `list.length`, `forEachNode` | `map`, `filter`, `slice`, `concat`, `flat`, `flatMap`, `splice` |

`RemoteNodeList` is the only class that `extends Array` in the client, so it is the only place affected.

## Fix

Override `Symbol.species` to return `Array`, so the species methods build a plain `Array` instead of trying to reconstruct a `RemoteNodeList`:

```ts
static get [Symbol.species](): ArrayConstructor {
    return Array;
}
```

The file is generated, so the change lives in the generator (`_scripts/generate-encoder.ts`) and `node.generated.ts` is regenerated.

This matches the types already shipped: `.map` / `.filter` / `.slice` are declared as returning `RemoteNode[]` (the API does not model `Symbol.species`), so runtime now matches the declared types and there is no type change. The behavior change is that these methods return a plain array instead of throwing.

**An alternative fix:** a numeric-arg guard in the constructor (`if (typeof view === "number") return;`). That keeps the result a `RemoteNodeList`, but a half-initialized one whose `pos` / `end` / `data` getters would crash when touched.... Returning `Array` via `Symbol.species` is the idiomatic fix and it was all I needed. If you would prefer the guard and the result to be a `RemoteNodeList` I could try and investigate what it'd take to properly do so.

A regression test was added in `_packages/native-preview/test/sync/ast.test.ts` that exercises the species methods on a *decoded* `RemoteNodeList` (not a factory-built `NodeArray`, which does not have the bug).

## Agentic Session Checklist

<!-- don't lie! Human edit: I didn't! -->
I successfully ran these commands at the end of my session, and they completed without error:
 * [x] npx hereby build
 * [x] npx hereby test
 * [x] npx hereby lint
 * [x] npx hereby format
