### PR TITLE
Watcher performance improvements

### DIFF
--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -286,6 +286,25 @@ func NewProgram(opts ProgramOptions) *Program {
 // host-side parse caches must release this exact pointer when the old program could not be
 // reused, since it was acquired speculatively before that decision was made.
 func (p *Program) UpdateProgram(changedFilePath tspath.Path, newHost CompilerHost, createCheckerPool func(*Program) CheckerPool) (*Program, *ast.SourceFile, bool) {
+	if result, newFile, reused := p.ReuseProgram(changedFilePath, newHost, createCheckerPool); reused {
+		return result, newFile, true
+	} else {
+		newOpts := p.opts
+		newOpts.Host = newHost
+		if createCheckerPool != nil {
+			newOpts.CreateCheckerPool = createCheckerPool
+		}
+		return NewProgram(newOpts), newFile, false
+	}
+}
+
+// ReuseProgram attempts to produce a new program by replacing only
+// changedFilePath in place, reusing the rest of p. It returns
+// (newProgram, newFile, true) on success, or (nil, newFile, false) when the
+// file cannot be replaced in place. Unlike UpdateProgram, it never constructs a
+// full fallback program, so callers that build their own fallback (e.g. with a
+// different host) do not pay for a discarded program build.
+func (p *Program) ReuseProgram(changedFilePath tspath.Path, newHost CompilerHost, createCheckerPool func(*Program) CheckerPool) (*Program, *ast.SourceFile, bool) {
 	newOpts := p.opts
 	newOpts.Host = newHost
 	if createCheckerPool != nil {
@@ -301,14 +320,14 @@ func (p *Program) UpdateProgram(changedFilePath tspath.Path, newHost CompilerHos
 	_, inRedirectFiles := p.redirectFilesByPath[changedFilePath]
 	_, isRedirectTarget := p.redirectTargetsMap[changedFilePath]
 	if inRedirectFiles || isRedirectTarget {
-		return NewProgram(newOpts), newFile, false
+		return nil, newFile, false
 	}
 
 	if !canReplaceFileInProgram(oldFile, newFile) {
-		return NewProgram(newOpts), newFile, false
+		return nil, newFile, false
 	}
 	if oldNeedsImportHelpers := p.importHelpersImportSpecifiers[oldFile.Path()] != nil; oldNeedsImportHelpers != p.needsImportHelpersImportSpecifier(newFile) {
-		return NewProgram(newOpts), newFile, false
+		return nil, newFile, false
 	}
 	// TODO: reverify compiler options when config has changed?
 	result := &Program{

--- a/internal/execute/tsctests/mock_watch_backend.go
+++ b/internal/execute/tsctests/mock_watch_backend.go
@@ -107,6 +107,23 @@ func (m *MockWatchBackend) SendEvents(events []fswatch.Event) {
 	}
 }
 
+// SendOverflow simulates a kernel event-queue overflow by invoking every
+// active watch callback with fswatch.ErrOverflow. The watch manager treats
+// this as a signal that events were dropped and a full rebuild is required.
+func (m *MockWatchBackend) SendOverflow() {
+	m.mu.Lock()
+	var cbs []fswatch.WatchCallback
+	for _, w := range m.Dirs {
+		if !w.Closed {
+			cbs = append(cbs, w.Callback)
+		}
+	}
+	m.mu.Unlock()
+	for _, cb := range cbs {
+		cb(nil, fswatch.ErrOverflow)
+	}
+}
+
 // SendChangedPaths converts a list of file changes into fswatch
 // events with appropriate event kinds and routes them through
 // registered watches via SendEvents. For new/modified files, it also

--- a/internal/execute/tsctests/watcher_race_test.go
+++ b/internal/execute/tsctests/watcher_race_test.go
@@ -3,12 +3,14 @@ package tsctests
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/microsoft/typescript-go/internal/execute"
 	"github.com/microsoft/typescript-go/internal/execute/tsc"
+	"github.com/microsoft/typescript-go/internal/fswatch"
 	"gotest.tools/v3/assert"
 )
 
@@ -292,45 +294,58 @@ func TestBuildWatchStopsWhenContextIsCancelled(t *testing.T) {
 }
 
 // TestWatcherUpdateProgramFastPath verifies that the UpdateProgram optimization
-// produces correct compilation results for body-only edits and correctly falls
-// back to full NewProgram when imports change.
+// produces correct compilation results for body-only edits (fast path) and
+// correctly falls back to full NewProgram when imports change.
 func TestWatcherUpdateProgramFastPath(t *testing.T) {
 	t.Parallel()
-	w, sys := createTestWatcher(t)
 
-	_ = sys.fsFromFileMap().WriteFile(
-		"/home/src/workspaces/project/a.ts",
-		`const a: number = 2;`,
-	)
-	w.DoCycle()
+	input := &tscInput{
+		files: FileMap{
+			"/home/src/workspaces/project/a.ts":          `export const a: number = 1;`,
+			"/home/src/workspaces/project/b.ts":          `import { a } from "./a"; export const b = a;`,
+			"/home/src/workspaces/project/tsconfig.json": `{}`,
+		},
+		commandLineArgs: []string{"--watch"},
+	}
+	sys := newTestSys(input, false)
+	result := execute.CommandLine(context.Background(), sys, []string{"--watch"}, sys)
+	if result.Watcher == nil {
+		t.Fatal("expected Watcher to be non-nil in watch mode")
+	}
+	w := result.Watcher.(*execute.Watcher)
 
-	_ = sys.fsFromFileMap().WriteFile(
-		"/home/src/workspaces/project/a.ts",
-		`const a: number = "not a number";`,
-	)
-	w.DoCycle()
+	// Helper to write a file, send the event, cycle, and return output
+	editAndCycle := func(path, content string) string {
+		sys.currentWrite.Reset()
+		_ = sys.fsFromFileMap().WriteFile(path, content)
+		sys.mockWatchBackend.SendEvents([]fswatch.Event{
+			{Kind: fswatch.EventUpdate, Path: path},
+		})
+		w.DoCycle()
+		return sys.currentWrite.String()
+	}
 
-	_ = sys.fsFromFileMap().WriteFile(
-		"/home/src/workspaces/project/a.ts",
-		`const a: number = 3;`,
-	)
-	w.DoCycle()
+	// Body-only edit — should use UpdateProgram fast path, no errors
+	out := editAndCycle("/home/src/workspaces/project/a.ts", `export const a: number = 2;`)
+	assert.Assert(t, strings.Contains(out, "Found 0 errors"), "expected 0 errors after body edit, got: %s", out)
 
-	_ = sys.fsFromFileMap().WriteFile(
-		"/home/src/workspaces/project/a.ts",
-		`export const a: number = 3; export const c: number = 4;`,
-	)
-	w.DoCycle()
+	// Introduce a type error via body-only edit — fast path should detect it
+	out = editAndCycle("/home/src/workspaces/project/a.ts", `export const a: number = "not a number";`)
+	assert.Assert(t, !strings.Contains(out, "Found 0 errors"), "expected errors after type error, got: %s", out)
 
-	_ = sys.fsFromFileMap().WriteFile(
-		"/home/src/workspaces/project/b.ts",
-		`import { a, c } from "./a"; export const b = a + c;`,
-	)
-	w.DoCycle()
+	// Fix the type error — fast path should clear it
+	out = editAndCycle("/home/src/workspaces/project/a.ts", `export const a: number = 3;`)
+	assert.Assert(t, strings.Contains(out, "Found 0 errors"), "expected 0 errors after fix, got: %s", out)
 
-	_ = sys.fsFromFileMap().WriteFile(
-		"/home/src/workspaces/project/b.ts",
-		`import { a, c } from "./a"; export const b = a + c + 1;`,
-	)
-	w.DoCycle()
+	// Add a new export — import structure changes, falls back to NewProgram
+	out = editAndCycle("/home/src/workspaces/project/a.ts", `export const a: number = 3; export const c: number = 4;`)
+	assert.Assert(t, strings.Contains(out, "Found 0 errors"), "expected 0 errors after export addition, got: %s", out)
+
+	// Import the new export — import change forces full rebuild
+	out = editAndCycle("/home/src/workspaces/project/b.ts", `import { a, c } from "./a"; export const b = a + c;`)
+	assert.Assert(t, strings.Contains(out, "Found 0 errors"), "expected 0 errors after import change, got: %s", out)
+
+	// Body edit after import change — should use fast path again, no errors
+	out = editAndCycle("/home/src/workspaces/project/b.ts", `import { a, c } from "./a"; export const b = a + c + 1;`)
+	assert.Assert(t, strings.Contains(out, "Found 0 errors"), "expected 0 errors after body edit post-import-change, got: %s", out)
 }

--- a/internal/execute/tsctests/watcher_race_test.go
+++ b/internal/execute/tsctests/watcher_race_test.go
@@ -293,6 +293,64 @@ func TestBuildWatchStopsWhenContextIsCancelled(t *testing.T) {
 	}
 }
 
+func TestWatcherStartsFromExistingBuildInfo(t *testing.T) {
+	t.Parallel()
+	input := &tscInput{
+		files: FileMap{
+			"/home/src/workspaces/project/index.ts":      `export const x: number = 1;`,
+			"/home/src/workspaces/project/tsconfig.json": `{"compilerOptions":{"composite":true},"files":["index.ts"]}`,
+		},
+	}
+	sys := newTestSys(input, false)
+
+	result := execute.CommandLine(context.Background(), sys, []string{"-p", "tsconfig.json", "--pretty", "false"}, sys)
+	assert.Equal(t, result.Status, tsc.ExitStatusSuccess)
+	assert.Assert(t, sys.fsFromFileMap().FileExists("/home/src/workspaces/project/tsconfig.tsbuildinfo"))
+
+	sys.clearOutput()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("watch startup with existing build info panicked: %v", r)
+		}
+	}()
+	result = execute.CommandLine(context.Background(), sys, []string{"--watch", "--noEmit", "--pretty", "false"}, sys)
+	assert.Equal(t, result.Status, tsc.ExitStatusSuccess)
+	assert.Assert(t, result.Watcher != nil)
+}
+
+func TestWatcherRebuildsWhenJsxImportSourcePragmaChanges(t *testing.T) {
+	t.Parallel()
+	input := &tscInput{
+		files: FileMap{
+			"/home/src/workspaces/project/index.tsx": `/** @jsxImportSource foo */
+export const x = <div />;`,
+			"/home/src/workspaces/project/tsconfig.json": `{
+				"compilerOptions":{"jsx":"react-jsx","module":"esnext","moduleResolution":"bundler","noEmit":true},
+				"files":["index.tsx"]
+			}`,
+		},
+		commandLineArgs: []string{"--watch"},
+	}
+	sys := newTestSys(input, false)
+	result := execute.CommandLine(context.Background(), sys, []string{"--watch", "--pretty", "false"}, sys)
+	if result.Watcher == nil {
+		t.Fatal("expected Watcher to be non-nil in watch mode")
+	}
+	w := result.Watcher.(*execute.Watcher)
+
+	sys.currentWrite.Reset()
+	_ = sys.fsFromFileMap().WriteFile("/home/src/workspaces/project/index.tsx", `/** @jsxImportSource bar */
+export const x = <div />;`)
+	sys.mockWatchBackend.SendEvents([]fswatch.Event{
+		{Kind: fswatch.EventUpdate, Path: "/home/src/workspaces/project/index.tsx"},
+	})
+	w.DoCycle()
+
+	out := sys.currentWrite.String()
+	assert.Assert(t, strings.Contains(out, "bar/jsx-runtime"), "expected updated JSX runtime diagnostic, got: %s", out)
+	assert.Assert(t, !strings.Contains(out, "foo/jsx-runtime"), "expected stale JSX runtime diagnostic to be gone, got: %s", out)
+}
+
 // TestWatcherUpdateProgramFastPath verifies that the UpdateProgram optimization
 // produces correct compilation results for body-only edits (fast path) and
 // correctly falls back to full NewProgram when imports change.

--- a/internal/execute/tsctests/watcher_race_test.go
+++ b/internal/execute/tsctests/watcher_race_test.go
@@ -290,3 +290,47 @@ func TestBuildWatchStopsWhenContextIsCancelled(t *testing.T) {
 		t.Fatal("build watch did not stop after context cancellation")
 	}
 }
+
+// TestWatcherUpdateProgramFastPath verifies that the UpdateProgram optimization
+// produces correct compilation results for body-only edits and correctly falls
+// back to full NewProgram when imports change.
+func TestWatcherUpdateProgramFastPath(t *testing.T) {
+	t.Parallel()
+	w, sys := createTestWatcher(t)
+
+	_ = sys.fsFromFileMap().WriteFile(
+		"/home/src/workspaces/project/a.ts",
+		`const a: number = 2;`,
+	)
+	w.DoCycle()
+
+	_ = sys.fsFromFileMap().WriteFile(
+		"/home/src/workspaces/project/a.ts",
+		`const a: number = "not a number";`,
+	)
+	w.DoCycle()
+
+	_ = sys.fsFromFileMap().WriteFile(
+		"/home/src/workspaces/project/a.ts",
+		`const a: number = 3;`,
+	)
+	w.DoCycle()
+
+	_ = sys.fsFromFileMap().WriteFile(
+		"/home/src/workspaces/project/a.ts",
+		`export const a: number = 3; export const c: number = 4;`,
+	)
+	w.DoCycle()
+
+	_ = sys.fsFromFileMap().WriteFile(
+		"/home/src/workspaces/project/b.ts",
+		`import { a, c } from "./a"; export const b = a + c;`,
+	)
+	w.DoCycle()
+
+	_ = sys.fsFromFileMap().WriteFile(
+		"/home/src/workspaces/project/b.ts",
+		`import { a, c } from "./a"; export const b = a + c + 1;`,
+	)
+	w.DoCycle()
+}

--- a/internal/execute/tsctests/watcher_race_test.go
+++ b/internal/execute/tsctests/watcher_race_test.go
@@ -353,7 +353,10 @@ export const x = <div />;`)
 
 // TestWatcherUpdateProgramFastPath verifies that the UpdateProgram optimization
 // produces correct compilation results for body-only edits (fast path) and
-// correctly falls back to full NewProgram when imports change.
+// correctly falls back to full NewProgram when the set of imported modules
+// changes. The build path taken is asserted via FastPathBuilds/FullBuilds so a
+// regression that stops using (or stops falling back from) the fast path is
+// caught, not just a diagnostics difference.
 func TestWatcherUpdateProgramFastPath(t *testing.T) {
 	t.Parallel()
 
@@ -361,6 +364,7 @@ func TestWatcherUpdateProgramFastPath(t *testing.T) {
 		files: FileMap{
 			"/home/src/workspaces/project/a.ts":          `export const a: number = 1;`,
 			"/home/src/workspaces/project/b.ts":          `import { a } from "./a"; export const b = a;`,
+			"/home/src/workspaces/project/c.ts":          `export const c: number = 10;`,
 			"/home/src/workspaces/project/tsconfig.json": `{}`,
 		},
 		commandLineArgs: []string{"--watch"},
@@ -384,26 +388,133 @@ func TestWatcherUpdateProgramFastPath(t *testing.T) {
 	}
 
 	// Body-only edit — should use UpdateProgram fast path, no errors
+	fast, full := w.FastPathBuilds(), w.FullBuilds()
 	out := editAndCycle("/home/src/workspaces/project/a.ts", `export const a: number = 2;`)
 	assert.Assert(t, strings.Contains(out, "Found 0 errors"), "expected 0 errors after body edit, got: %s", out)
+	assert.Equal(t, w.FastPathBuilds(), fast+1, "body-only edit should take the UpdateProgram fast path")
+	assert.Equal(t, w.FullBuilds(), full, "body-only edit should not trigger a full rebuild")
 
 	// Introduce a type error via body-only edit — fast path should detect it
+	fast, full = w.FastPathBuilds(), w.FullBuilds()
 	out = editAndCycle("/home/src/workspaces/project/a.ts", `export const a: number = "not a number";`)
 	assert.Assert(t, !strings.Contains(out, "Found 0 errors"), "expected errors after type error, got: %s", out)
+	assert.Equal(t, w.FastPathBuilds(), fast+1, "type error via body edit should still take the fast path")
+	assert.Equal(t, w.FullBuilds(), full, "type error via body edit should not trigger a full rebuild")
 
 	// Fix the type error — fast path should clear it
 	out = editAndCycle("/home/src/workspaces/project/a.ts", `export const a: number = 3;`)
 	assert.Assert(t, strings.Contains(out, "Found 0 errors"), "expected 0 errors after fix, got: %s", out)
 
-	// Add a new export — import structure changes, falls back to NewProgram
-	out = editAndCycle("/home/src/workspaces/project/a.ts", `export const a: number = 3; export const c: number = 4;`)
-	assert.Assert(t, strings.Contains(out, "Found 0 errors"), "expected 0 errors after export addition, got: %s", out)
-
-	// Import the new export — import change forces full rebuild
-	out = editAndCycle("/home/src/workspaces/project/b.ts", `import { a, c } from "./a"; export const b = a + c;`)
+	// Change b.ts's imported module (./a -> ./c). The set of imported module
+	// specifiers changes, so the file cannot be replaced in place and the build
+	// must fall back to a full NewProgram rebuild.
+	fast, full = w.FastPathBuilds(), w.FullBuilds()
+	out = editAndCycle("/home/src/workspaces/project/b.ts", `import { c } from "./c"; export const b = c;`)
 	assert.Assert(t, strings.Contains(out, "Found 0 errors"), "expected 0 errors after import change, got: %s", out)
+	assert.Equal(t, w.FullBuilds(), full+1, "changing the imported module should fall back to a full NewProgram rebuild")
+	assert.Equal(t, w.FastPathBuilds(), fast, "changing the imported module should not take the fast path")
 
 	// Body edit after import change — should use fast path again, no errors
-	out = editAndCycle("/home/src/workspaces/project/b.ts", `import { a, c } from "./a"; export const b = a + c + 1;`)
+	fast, full = w.FastPathBuilds(), w.FullBuilds()
+	out = editAndCycle("/home/src/workspaces/project/b.ts", `import { c } from "./c"; export const b = c + 1;`)
 	assert.Assert(t, strings.Contains(out, "Found 0 errors"), "expected 0 errors after body edit post-import-change, got: %s", out)
+	assert.Equal(t, w.FastPathBuilds(), fast+1, "body edit after an import change should take the fast path again")
+	assert.Equal(t, w.FullBuilds(), full, "body edit after an import change should not trigger a full rebuild")
+}
+
+// TestWatcherOverflowForcesFullRebuild verifies that an event-queue overflow
+// forces a full NewProgram rebuild rather than reusing the existing program via
+// the single-file UpdateProgram fast path. For a single-file program with an
+// unresolved import, clearing the source-file cache on overflow leaves exactly
+// one cache miss, which the fast path would misread as a lone content edit and
+// reuse the stale (unresolved) program, never discovering a dependency created
+// while events were dropped. Program membership is observed via the emitted
+// output for the dependency.
+func TestWatcherOverflowForcesFullRebuild(t *testing.T) {
+	t.Parallel()
+
+	input := &tscInput{
+		files: FileMap{
+			"/home/src/workspaces/project/index.ts": `import { dep } from "./dep"; export const x = dep;`,
+			"/home/src/workspaces/project/tsconfig.json": `{
+				"compilerOptions":{"noLib":true,"moduleResolution":"bundler","module":"esnext","outDir":"out"},
+				"files":["index.ts"]
+			}`,
+		},
+		commandLineArgs: []string{"--watch"},
+	}
+	sys := newTestSys(input, false)
+	result := execute.CommandLine(context.Background(), sys, []string{"--watch", "--pretty", "false"}, sys)
+	if result.Watcher == nil {
+		t.Fatal("expected Watcher to be non-nil in watch mode")
+	}
+	w := result.Watcher.(*execute.Watcher)
+	fs := sys.fsFromFileMap()
+
+	// The import is initially unresolved, so the dependency is not part of the
+	// program and produces no emitted output.
+	assert.Assert(t, !fs.FileExists("/home/src/workspaces/project/out/dep.js"),
+		"dep.js should not exist while ./dep is unresolved")
+
+	// Create the missing dependency, but deliver an overflow instead of a
+	// precise event (as if the create event were dropped by the kernel queue).
+	_ = fs.WriteFile("/home/src/workspaces/project/dep.ts", `export const dep: number = 1;`)
+	full := w.FullBuilds()
+	sys.mockWatchBackend.SendOverflow()
+	w.DoCycle()
+
+	assert.Equal(t, w.FullBuilds(), full+1, "overflow must force a full rebuild, not the single-file fast path")
+	assert.Assert(t, fs.FileExists("/home/src/workspaces/project/out/dep.js"),
+		"overflow rebuild should rediscover the created dependency and emit dep.js")
+}
+
+// TestWatcherNonSourceDependencyForcesFullRebuild verifies that when a
+// non-source build dependency changes in the same cycle as a source edit, the
+// single-file fast path is rejected. A previously-missing module path is
+// tracked in seenFiles (via failed resolution) but is never stored in the
+// source-file cache, so counting source-cache misses alone would report a lone
+// changed file and reuse stale module resolutions.
+func TestWatcherNonSourceDependencyForcesFullRebuild(t *testing.T) {
+	t.Parallel()
+
+	input := &tscInput{
+		files: FileMap{
+			"/home/src/workspaces/project/index.ts": `import { dep } from "./dep"; export const x = dep;`,
+			"/home/src/workspaces/project/tsconfig.json": `{
+				"compilerOptions":{"noLib":true,"moduleResolution":"bundler","module":"esnext","outDir":"out"},
+				"files":["index.ts"]
+			}`,
+		},
+		commandLineArgs: []string{"--watch"},
+	}
+	sys := newTestSys(input, false)
+	result := execute.CommandLine(context.Background(), sys, []string{"--watch", "--pretty", "false"}, sys)
+	if result.Watcher == nil {
+		t.Fatal("expected Watcher to be non-nil in watch mode")
+	}
+	w := result.Watcher.(*execute.Watcher)
+	fs := sys.fsFromFileMap()
+
+	// "./dep" is unresolved initially; the failed resolution probes dep.ts,
+	// recording it as a (missing) non-source dependency in seenFiles.
+	assert.Assert(t, !fs.FileExists("/home/src/workspaces/project/out/dep.js"),
+		"dep.js should not exist while ./dep is unresolved")
+
+	// In a single cycle, edit index.ts's body (a lone source-cache miss) and
+	// create the previously-missing dependency. The batched dependency change
+	// must reject the fast path so the new module resolution is discovered.
+	_ = fs.WriteFile("/home/src/workspaces/project/index.ts",
+		`import { dep } from "./dep"; export const x = dep + 0;`)
+	_ = fs.WriteFile("/home/src/workspaces/project/dep.ts", `export const dep: number = 1;`)
+	full := w.FullBuilds()
+	sys.mockWatchBackend.SendEvents([]fswatch.Event{
+		{Kind: fswatch.EventUpdate, Path: "/home/src/workspaces/project/index.ts"},
+		{Kind: fswatch.EventUpdate, Path: "/home/src/workspaces/project/dep.ts"},
+	})
+	w.DoCycle()
+
+	assert.Equal(t, w.FullBuilds(), full+1,
+		"a changed non-source dependency must force a full rebuild, not the fast path")
+	assert.Assert(t, fs.FileExists("/home/src/workspaces/project/out/dep.js"),
+		"full rebuild should resolve the created dependency and emit dep.js")
 }

--- a/internal/execute/watcher.go
+++ b/internal/execute/watcher.go
@@ -78,7 +78,7 @@ type Watcher struct {
 	seenFiles     *collections.Set[tspath.Path] // all build dependencies (for event filtering)
 	configMtimes  map[string]time.Time
 	watchSetDirty bool
-	programReady bool
+	programReady  bool
 }
 
 var _ tsc.Watcher = (*Watcher)(nil)

--- a/internal/execute/watcher.go
+++ b/internal/execute/watcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 	"time"
 
 	"github.com/microsoft/typescript-go/internal/ast"
@@ -73,9 +74,10 @@ type Watcher struct {
 
 	sourceFileCache *collections.SyncMap[tspath.Path, *cachedSourceFile]
 
-	wm           *watchmanager.WatchManager
-	seenFiles    *collections.Set[tspath.Path] // all build dependencies (for event filtering)
-	configMtimes map[string]time.Time
+	wm            *watchmanager.WatchManager
+	seenFiles     *collections.Set[tspath.Path] // all build dependencies (for event filtering)
+	configMtimes  map[string]time.Time
+	watchSetDirty bool
 }
 
 var _ tsc.Watcher = (*Watcher)(nil)
@@ -130,6 +132,7 @@ func (w *Watcher) start(ctx context.Context) {
 	}
 
 	w.reportWatchStatus(ast.NewCompilerDiagnostic(diagnostics.Starting_compilation_in_watch_mode))
+	w.watchSetDirty = true
 	if err := w.doBuild(); err != nil {
 		w.wm.ForceOverflow()
 	}
@@ -225,6 +228,21 @@ func (w *Watcher) DoCycle() {
 		// Filter fswatch events against known dependencies
 		if w.isRelevantChange(changedPaths) {
 			w.evictChangedSourceFiles(changedPaths)
+			for eventPath := range changedPaths {
+				if w.sys.FS().DirectoryExists(eventPath) {
+					w.watchSetDirty = true
+					break
+				}
+				if w.config.ConfigFile != nil && w.config.PossiblyMatchesFileName(eventPath) {
+					caseSensitive := w.sys.FS().UseCaseSensitiveFileNames()
+					cwd := w.sys.GetCurrentDirectory()
+					p := tspath.ToPath(eventPath, cwd, caseSensitive)
+					if !w.seenFiles.Has(p) {
+						w.watchSetDirty = true
+						break
+					}
+				}
+			}
 		} else {
 			if w.wm.DebugLog != nil {
 				fmt.Fprintf(w.wm.DebugLog, "[watch] DoCycle: %d event(s) not relevant to compilation, skipping rebuild\n", len(changedPaths))
@@ -237,6 +255,7 @@ func (w *Watcher) DoCycle() {
 	} else if overflow {
 		// Overflow: evict the entire source file cache to force re-build
 		w.sourceFileCache = &collections.SyncMap[tspath.Path, *cachedSourceFile]{}
+		w.watchSetDirty = true
 	} else if !hasEvents && !w.configModified {
 		// No events and no config change
 		if w.wm.DebugLog != nil {
@@ -282,6 +301,48 @@ func (w *Watcher) isRelevantChange(changedPaths map[string]fswatch.EventKind) bo
 func (w *Watcher) doBuild() error {
 	if w.configModified {
 		w.sourceFileCache = &collections.SyncMap[tspath.Path, *cachedSourceFile]{}
+		w.watchSetDirty = true
+	}
+
+	if w.watchSetDirty {
+		if w.config.ConfigFile != nil && len(w.config.WildcardDirectories()) > 0 {
+			newConfig := w.config.ReloadFileNamesOfParsedCommandLine(w.sys.FS())
+			if !slices.Equal(w.config.FileNames(), newConfig.FileNames()) {
+				w.watchSetDirty = true
+			}
+			w.config = newConfig
+		}
+	}
+
+	if w.program != nil && !w.configModified && !w.watchSetDirty {
+		cached := cachedvfs.From(w.sys.FS())
+		innerHost := compiler.NewCompilerHost(w.sys.GetCurrentDirectory(), cached, w.sys.DefaultLibraryPath(), w.extendedConfigCache, getTraceFromSys(w.sys, w.config.Locale(), w.testing))
+		host := &watchCompilerHost{CompilerHost: innerHost, cache: w.sourceFileCache}
+
+		if w.tryUpdateProgram(host) {
+			result := w.compileAndEmit()
+			cached.DisableAndClearCache()
+
+			w.configMtimes = make(map[string]time.Time, len(w.configFilePaths))
+			for _, cfgPath := range w.configFilePaths {
+				if s := w.sys.FS().Stat(cfgPath); s != nil {
+					w.configMtimes[cfgPath] = s.ModTime()
+				}
+			}
+			w.configModified = false
+
+			errorCount := len(result.Diagnostics)
+			if errorCount == 1 {
+				w.reportWatchStatus(ast.NewCompilerDiagnostic(diagnostics.Found_1_error_Watching_for_file_changes))
+			} else {
+				w.reportWatchStatus(ast.NewCompilerDiagnostic(diagnostics.Found_0_errors_Watching_for_file_changes, errorCount))
+			}
+			if w.testing != nil {
+				w.testing.OnProgram(w.program)
+			}
+			return nil
+		}
+		cached.DisableAndClearCache()
 	}
 
 	cached := cachedvfs.From(w.sys.FS())
@@ -289,13 +350,11 @@ func (w *Watcher) doBuild() error {
 	innerHost := compiler.NewCompilerHost(w.sys.GetCurrentDirectory(), tfs, w.sys.DefaultLibraryPath(), w.extendedConfigCache, getTraceFromSys(w.sys, w.config.Locale(), w.testing))
 	host := &watchCompilerHost{CompilerHost: innerHost, cache: w.sourceFileCache}
 
-	var wildcardDirs map[string]bool
 	if w.config.ConfigFile != nil {
-		wildcardDirs = w.config.WildcardDirectories()
-		for dir := range wildcardDirs {
+		for dir := range w.config.WildcardDirectories() {
 			tfs.SeenFiles.Add(dir)
 		}
-		if len(wildcardDirs) > 0 {
+		if !w.watchSetDirty && len(w.config.WildcardDirectories()) > 0 {
 			w.config = w.config.ReloadFileNamesOfParsedCommandLine(w.sys.FS())
 		}
 	}
@@ -330,6 +389,7 @@ func (w *Watcher) doBuild() error {
 		fmt.Fprintf(w.sys.Writer(), "%v\n", err)
 		return err
 	}
+	w.watchSetDirty = false
 	w.configModified = false
 
 	programFiles := w.program.GetProgram().FilesByPath()
@@ -351,6 +411,31 @@ func (w *Watcher) doBuild() error {
 		w.testing.OnProgram(w.program)
 	}
 	return nil
+}
+
+func (w *Watcher) tryUpdateProgram(host *watchCompilerHost) bool {
+	oldProgram := w.program.GetProgram()
+
+	var changedPath tspath.Path
+	var changedCount int
+	for path := range oldProgram.FilesByPath() {
+		if _, ok := w.sourceFileCache.Load(path); !ok {
+			changedPath = path
+			changedCount++
+			if changedCount > 1 {
+				return false
+			}
+		}
+	}
+	if changedCount == 0 {
+		return false
+	}
+
+	newProgram, _, reused := oldProgram.UpdateProgram(changedPath, host, nil)
+	if reused {
+		w.program = incremental.NewProgram(newProgram, w.program, nil, w.testing != nil)
+	}
+	return reused
 }
 
 func (w *Watcher) evictChangedSourceFiles(changedPaths map[string]fswatch.EventKind) {

--- a/internal/execute/watcher.go
+++ b/internal/execute/watcher.go
@@ -78,6 +78,7 @@ type Watcher struct {
 	seenFiles     *collections.Set[tspath.Path] // all build dependencies (for event filtering)
 	configMtimes  map[string]time.Time
 	watchSetDirty bool
+	programReady bool
 }
 
 var _ tsc.Watcher = (*Watcher)(nil)
@@ -318,7 +319,7 @@ func (w *Watcher) doBuild() error {
 		}
 	}
 
-	if w.program != nil && !w.configModified && !w.watchSetDirty {
+	if w.program != nil && w.programReady && !w.configModified && !w.watchSetDirty {
 		cached := cachedvfs.From(w.sys.FS())
 		innerHost := compiler.NewCompilerHost(w.sys.GetCurrentDirectory(), cached, w.sys.DefaultLibraryPath(), w.extendedConfigCache, getTraceFromSys(w.sys, w.config.Locale(), w.testing))
 		host := &watchCompilerHost{CompilerHost: innerHost, cache: w.sourceFileCache}
@@ -370,6 +371,7 @@ func (w *Watcher) doBuild() error {
 		Config: w.config,
 		Host:   host,
 	}), w.program, nil, w.testing != nil)
+	w.programReady = true
 
 	result := w.compileAndEmit()
 	cached.DisableAndClearCache()
@@ -435,11 +437,31 @@ func (w *Watcher) tryUpdateProgram(host *watchCompilerHost) bool {
 		return false
 	}
 
+	if oldFile := oldProgram.FilesByPath()[changedPath]; oldFile != nil {
+		if newFile := host.GetSourceFile(oldFile.ParseOptions()); newFile != nil {
+			if !equalJSXImplicitImport(oldProgram.Options(), oldFile, newFile) {
+				return false
+			}
+		}
+	}
+
 	newProgram, _, reused := oldProgram.UpdateProgram(changedPath, host, nil)
 	if reused {
 		w.program = incremental.NewProgram(newProgram, w.program, nil, w.testing != nil)
 	}
 	return reused
+}
+
+func equalJSXImplicitImport(options *core.CompilerOptions, oldFile *ast.SourceFile, newFile *ast.SourceFile) bool {
+	isJSX := func(file *ast.SourceFile) bool {
+		return file.ScriptKind == core.ScriptKindJSX || file.ScriptKind == core.ScriptKindTSX
+	}
+	if !isJSX(oldFile) && !isJSX(newFile) {
+		return true
+	}
+	oldImport := ast.GetJSXRuntimeImport(ast.GetJSXImplicitImportBase(options, oldFile), options)
+	newImport := ast.GetJSXRuntimeImport(ast.GetJSXImplicitImportBase(options, newFile), options)
+	return oldImport == newImport
 }
 
 func (w *Watcher) evictChangedSourceFiles(changedPaths map[string]fswatch.EventKind) {

--- a/internal/execute/watcher.go
+++ b/internal/execute/watcher.go
@@ -308,9 +308,13 @@ func (w *Watcher) doBuild() error {
 		if w.config.ConfigFile != nil && len(w.config.WildcardDirectories()) > 0 {
 			newConfig := w.config.ReloadFileNamesOfParsedCommandLine(w.sys.FS())
 			if !slices.Equal(w.config.FileNames(), newConfig.FileNames()) {
-				w.watchSetDirty = true
+				w.config = newConfig
+			} else {
+				w.watchSetDirty = false
+				w.config = newConfig
 			}
-			w.config = newConfig
+		} else if !w.configModified {
+			w.watchSetDirty = false
 		}
 	}
 

--- a/internal/execute/watcher.go
+++ b/internal/execute/watcher.go
@@ -78,7 +78,19 @@ type Watcher struct {
 	seenFiles     *collections.Set[tspath.Path] // all build dependencies (for event filtering)
 	configMtimes  map[string]time.Time
 	watchSetDirty bool
-	programReady  bool
+	// forceFullRebuild records a reason that requires a full NewProgram rebuild
+	// (e.g. an event overflow, a mid-cycle watch failure, a newly appeared
+	// project file, or a changed non-source dependency). Unlike watchSetDirty,
+	// which is only raised to recheck wildcard roots and may be cleared once the
+	// file set is confirmed unchanged, this flag is preserved until a full
+	// rebuild actually runs so the single-file fast path cannot silently reuse a
+	// stale program.
+	forceFullRebuild bool
+	programReady     bool
+
+	// Test-only observability of which build path was taken.
+	fastPathBuilds int
+	fullBuilds     int
 }
 
 var _ tsc.Watcher = (*Watcher)(nil)
@@ -229,19 +241,35 @@ func (w *Watcher) DoCycle() {
 		// Filter fswatch events against known dependencies
 		if w.isRelevantChange(changedPaths) {
 			w.evictChangedSourceFiles(changedPaths)
+			caseSensitive := w.sys.FS().UseCaseSensitiveFileNames()
+			cwd := w.sys.GetCurrentDirectory()
+			programFiles := w.program.GetProgram().FilesByPath()
 			for eventPath := range changedPaths {
 				if w.sys.FS().DirectoryExists(eventPath) {
+					// A watched directory changed: the wildcard file set may have
+					// changed, so reload file names on the next build.
 					w.watchSetDirty = true
-					break
+					continue
 				}
+				p := tspath.ToPath(eventPath, cwd, caseSensitive)
 				if w.config.ConfigFile != nil && w.config.PossiblyMatchesFileName(eventPath) {
-					caseSensitive := w.sys.FS().UseCaseSensitiveFileNames()
-					cwd := w.sys.GetCurrentDirectory()
-					p := tspath.ToPath(eventPath, cwd, caseSensitive)
 					if !w.seenFiles.Has(p) {
+						// A file that matches the project but was not previously
+						// seen appeared: a structural change that requires a full
+						// rebuild, not the single-file fast path.
 						w.watchSetDirty = true
-						break
+						w.forceFullRebuild = true
+						continue
 					}
+				}
+				if _, isSource := programFiles[p]; !isSource && w.seenFiles.Has(p) {
+					// A non-source build dependency changed. Such dependencies
+					// (e.g. package.json or a previously-missing module path) are
+					// tracked in seenFiles but are not program source files, so a
+					// missing sourceFileCache entry would not account for them.
+					// Module resolution may now differ, so the single-file fast
+					// path is unsafe; force a full rebuild.
+					w.forceFullRebuild = true
 				}
 			}
 		} else {
@@ -254,9 +282,14 @@ func (w *Watcher) DoCycle() {
 			return
 		}
 	} else if overflow {
-		// Overflow: evict the entire source file cache to force re-build
+		// Overflow: evict the entire source file cache and force a full rebuild.
+		// The fast path must not run here: after clearing the cache a one-file
+		// program would present exactly one cache miss and be misread as a
+		// single-file content edit, silently reusing a stale (e.g. unresolved
+		// import) program instead of rediscovering the file graph.
 		w.sourceFileCache = &collections.SyncMap[tspath.Path, *cachedSourceFile]{}
 		w.watchSetDirty = true
+		w.forceFullRebuild = true
 	} else if !hasEvents && !w.configModified {
 		// No events and no config change
 		if w.wm.DebugLog != nil {
@@ -319,12 +352,13 @@ func (w *Watcher) doBuild() error {
 		}
 	}
 
-	if w.program != nil && w.programReady && !w.configModified && !w.watchSetDirty {
+	if w.program != nil && w.programReady && !w.configModified && !w.watchSetDirty && !w.forceFullRebuild {
 		cached := cachedvfs.From(w.sys.FS())
 		innerHost := compiler.NewCompilerHost(w.sys.GetCurrentDirectory(), cached, w.sys.DefaultLibraryPath(), w.extendedConfigCache, getTraceFromSys(w.sys, w.config.Locale(), w.testing))
 		host := &watchCompilerHost{CompilerHost: innerHost, cache: w.sourceFileCache}
 
 		if w.tryUpdateProgram(host) {
+			w.fastPathBuilds++
 			result := w.compileAndEmit()
 			cached.DisableAndClearCache()
 
@@ -372,6 +406,7 @@ func (w *Watcher) doBuild() error {
 		Host:   host,
 	}), w.program, nil, w.testing != nil)
 	w.programReady = true
+	w.fullBuilds++
 
 	result := w.compileAndEmit()
 	cached.DisableAndClearCache()
@@ -397,6 +432,7 @@ func (w *Watcher) doBuild() error {
 	}
 	w.watchSetDirty = false
 	w.configModified = false
+	w.forceFullRebuild = false
 
 	programFiles := w.program.GetProgram().FilesByPath()
 	w.sourceFileCache.Range(func(path tspath.Path, _ *cachedSourceFile) bool {
@@ -451,6 +487,15 @@ func (w *Watcher) tryUpdateProgram(host *watchCompilerHost) bool {
 	}
 	return reused
 }
+
+// FastPathBuilds reports how many builds reused an existing program via the
+// UpdateProgram single-file fast path. It is intended for tests that need to
+// verify which build path was taken.
+func (w *Watcher) FastPathBuilds() int { return w.fastPathBuilds }
+
+// FullBuilds reports how many builds constructed a full program via NewProgram.
+// It is intended for tests that need to verify which build path was taken.
+func (w *Watcher) FullBuilds() int { return w.fullBuilds }
 
 func equalJSXImplicitImport(options *core.CompilerOptions, oldFile *ast.SourceFile, newFile *ast.SourceFile) bool {
 	isJSX := func(file *ast.SourceFile) bool {

--- a/internal/execute/watcher.go
+++ b/internal/execute/watcher.go
@@ -338,9 +338,11 @@ func (w *Watcher) doBuild() error {
 		w.watchSetDirty = true
 	}
 
+	reloadedFileNames := false
 	if w.watchSetDirty {
 		if w.config.ConfigFile != nil && len(w.config.WildcardDirectories()) > 0 {
 			newConfig := w.config.ReloadFileNamesOfParsedCommandLine(w.sys.FS())
+			reloadedFileNames = true
 			if !slices.Equal(w.config.FileNames(), newConfig.FileNames()) {
 				w.config = newConfig
 			} else {
@@ -393,7 +395,7 @@ func (w *Watcher) doBuild() error {
 		for dir := range w.config.WildcardDirectories() {
 			tfs.SeenFiles.Add(dir)
 		}
-		if !w.watchSetDirty && len(w.config.WildcardDirectories()) > 0 {
+		if !reloadedFileNames && !w.watchSetDirty && len(w.config.WildcardDirectories()) > 0 {
 			w.config = w.config.ReloadFileNamesOfParsedCommandLine(w.sys.FS())
 		}
 	}
@@ -481,7 +483,7 @@ func (w *Watcher) tryUpdateProgram(host *watchCompilerHost) bool {
 		}
 	}
 
-	newProgram, _, reused := oldProgram.UpdateProgram(changedPath, host, nil)
+	newProgram, _, reused := oldProgram.ReuseProgram(changedPath, host, nil)
 	if reused {
 		w.program = incremental.NewProgram(newProgram, w.program, nil, w.testing != nil)
 	}


### PR DESCRIPTION
Added single-file program reuse via `UpdateProgram` and skips other unnecessary operations. Also keeps a `watchSetDirty` flag to track when a full rebuild is required.