### PR TITLE
Default to GOGC=50

### DIFF
--- a/cmd/tsgo/main.go
+++ b/cmd/tsgo/main.go
@@ -16,6 +16,8 @@ func main() {
 
 func runMain() int {
 	core.ApplyDebugStackLimit()
+	core.ApplyDefaultGOGC()
+
 	args := os.Args[1:]
 	if len(args) > 0 {
 		switch args[0] {

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -33,6 +33,14 @@ func ApplyDebugStackLimit() {
 	rtdebug.SetMaxStack(n)
 }
 
+func ApplyDefaultGOGC() {
+	v := os.Getenv("GOGC") //nolint:forbidigo
+	if v != "" {
+		return
+	}
+	rtdebug.SetGCPercent(50)
+}
+
 func Filter[T any](slice []T, f func(T) bool) []T {
 	for i, value := range slice {
 		if !f(value) {


### PR DESCRIPTION
I had copilot do an analysis of a spread of GOGC values, building an LSP harness and testing it on the old compiler source, and then a `tsc` run on the old compiler and VS Code. https://gist.github.com/jakebailey/1fb4a89bead2dcef0f51e7a4cbdcdec7

The gist is that GOGC=50 seems to provide a reasonable peak memory savings without too much extra CPU time. Wall time is in general unaffected, just since Go's GC is concurrent, so can do work while idle.

This needs more testing, but it seems like 50 is probably a good default.