### PR TITLE
[api] Flesh out project/file open state management

### DIFF
--- a/_packages/native-preview/src/api/async/api.ts
+++ b/_packages/native-preview/src/api/async/api.ts
@@ -60,7 +60,10 @@ import type {
     UpdateSnapshotParams,
     UpdateSnapshotResponse,
 } from "../proto.ts";
-import { resolveFileName } from "../proto.ts";
+import {
+    resolveFileName,
+    toUpdateSnapshotRequest,
+} from "../proto.ts";
 import { SourceFileCache } from "../sourceFileCache.ts";
 import {
     Client,
@@ -147,11 +150,7 @@ export class API<FromLSP extends boolean = false> {
     async updateSnapshot(params?: FromLSP extends true ? LSPUpdateSnapshotParams : UpdateSnapshotParams): Promise<Snapshot> {
         await this.ensureInitialized();
 
-        const requestParams: UpdateSnapshotParams = params ?? {};
-        if (requestParams.openProject) {
-            requestParams.openProject = resolveFileName(requestParams.openProject);
-        }
-
+        const requestParams = toUpdateSnapshotRequest(params);
         const data = await this.client.apiRequest<UpdateSnapshotResponse>("updateSnapshot", requestParams);
 
         // Retain cached source files from previous snapshot for unchanged files

--- a/_packages/native-preview/src/api/proto.ts
+++ b/_packages/native-preview/src/api/proto.ts
@@ -64,14 +64,37 @@ export interface ConfigResponse {
 }
 
 export interface LSPUpdateSnapshotParams {
-    /** Path to a tsconfig.json file to open in the new snapshot */
+    /**
+     * @deprecated Use {@link openProjects} instead.
+     * Path to a tsconfig.json file to open in the new snapshot.
+     */
     openProject?: string;
     /**
-     * Files to load into the inferred project if no configured project already contains them.
-     * Use this for files (e.g. d.ts in node_modules) not in any project's import graph.
-     * After calling updateSnapshot with openFiles, getDefaultProjectForFile will return the inferred project.
+     * tsconfig.json files to open/load in the new snapshot. Opens are ref-counted
+     * and persist across snapshots until closed via {@link closeProjects}.
+     */
+    openProjects?: DocumentIdentifier[];
+    /**
+     * tsconfig.json files to release in the new snapshot. A project is only unloaded
+     * once every API client that opened it closes it.
+     */
+    closeProjects?: DocumentIdentifier[];
+    /**
+     * Files to keep open for the API client, mirroring LSP's `textDocument/didOpen`.
+     * For each file, ancestor directories are searched for a tsconfig that contains it;
+     * if one is found, that configured project is loaded and becomes the file's default
+     * project. Otherwise the file is loaded into the inferred project (e.g. a d.ts in
+     * node_modules that is not part of any project's import graph). Opens persist across
+     * subsequent snapshots until the file is closed via {@link closeFiles}.
+     * After calling updateSnapshot with openFiles, getDefaultProjectForFile returns the
+     * resolved configured or inferred project.
      */
     openFiles?: DocumentIdentifier[];
+    /**
+     * Files to release in the new snapshot. A file is only fully closed once every
+     * API client that opened it closes it.
+     */
+    closeFiles?: DocumentIdentifier[];
 }
 
 export interface FileChangeSummary {
@@ -87,6 +110,22 @@ export type FileChanges = FileChangeSummary | { invalidateAll: true; };
  */
 export interface UpdateSnapshotParams extends LSPUpdateSnapshotParams {
     fileChanges?: FileChanges;
+}
+
+/**
+ * Builds the wire request for updateSnapshot, applying the deprecated `openProject`
+ * compatibility shim: a single `openProject` is folded into `openProjects` and is
+ * never sent on the wire.
+ */
+export function toUpdateSnapshotRequest(params?: UpdateSnapshotParams): UpdateSnapshotParams {
+    const { openProject, openProjects, ...rest } = params ?? {};
+    const mergedOpenProjects = openProject !== undefined
+        ? [resolveFileName(openProject), ...(openProjects ?? [])]
+        : openProjects;
+    return {
+        ...rest,
+        ...(mergedOpenProjects !== undefined ? { openProjects: mergedOpenProjects } : {}),
+    };
 }
 
 /**

--- a/_packages/native-preview/src/api/proto.ts
+++ b/_packages/native-preview/src/api/proto.ts
@@ -66,6 +66,12 @@ export interface ConfigResponse {
 export interface LSPUpdateSnapshotParams {
     /** Path to a tsconfig.json file to open in the new snapshot */
     openProject?: string;
+    /**
+     * Files to load into the inferred project if no configured project already contains them.
+     * Use this for files (e.g. d.ts in node_modules) not in any project's import graph.
+     * After calling updateSnapshot with openFiles, getDefaultProjectForFile will return the inferred project.
+     */
+    openFiles?: DocumentIdentifier[];
 }
 
 export interface FileChangeSummary {

--- a/_packages/native-preview/src/api/sync/api.ts
+++ b/_packages/native-preview/src/api/sync/api.ts
@@ -68,7 +68,10 @@ import type {
     UpdateSnapshotParams,
     UpdateSnapshotResponse,
 } from "../proto.ts";
-import { resolveFileName } from "../proto.ts";
+import {
+    resolveFileName,
+    toUpdateSnapshotRequest,
+} from "../proto.ts";
 import { SourceFileCache } from "../sourceFileCache.ts";
 import {
     Client,
@@ -155,11 +158,7 @@ export class API<FromLSP extends boolean = false> {
     updateSnapshot(params?: FromLSP extends true ? LSPUpdateSnapshotParams : UpdateSnapshotParams): Snapshot {
         this.ensureInitialized();
 
-        const requestParams: UpdateSnapshotParams = params ?? {};
-        if (requestParams.openProject) {
-            requestParams.openProject = resolveFileName(requestParams.openProject);
-        }
-
+        const requestParams = toUpdateSnapshotRequest(params);
         const data = this.client.apiRequest<UpdateSnapshotResponse>("updateSnapshot", requestParams);
 
         // Retain cached source files from previous snapshot for unchanged files

--- a/_packages/native-preview/test/async/api.test.ts
+++ b/_packages/native-preview/test/async/api.test.ts
@@ -3456,6 +3456,42 @@ describe("Checker - getSignatureUsage", () => {
     });
 });
 
+describe("getDefaultProjectForFile", () => {
+    test("finds inferred project for d.ts in node_modules after openFiles", async () => {
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/index.ts": `export const x = 1;`,
+            "/node_modules/my-lib/package.json": JSON.stringify({ name: "my-lib", types: "./index.d.ts" }),
+            "/node_modules/my-lib/index.d.ts": `export declare const foo: string;`,
+        });
+        try {
+            const snapshot = await api.updateSnapshot({ openProject: "/tsconfig.json" });
+            const project = snapshot.getProject("/tsconfig.json")!;
+
+            // The d.ts is not imported, so it is not in the project's program
+            const dtsSf = await project.program.getSourceFile("/node_modules/my-lib/index.d.ts");
+            assert.equal(dtsSf, undefined, "d.ts not in import graph should not be found via project.program.getSourceFile");
+
+            // Before opening the file, getDefaultProjectForFile returns undefined (no error)
+            const noProject = await snapshot.getDefaultProjectForFile("/node_modules/my-lib/index.d.ts");
+            assert.equal(noProject, undefined, "getDefaultProjectForFile returns undefined for unloaded file");
+
+            // Load the file into the inferred project via updateSnapshot openFiles
+            const snapshot2 = await api.updateSnapshot({ openFiles: ["/node_modules/my-lib/index.d.ts"] });
+            const defaultProject = await snapshot2.getDefaultProjectForFile("/node_modules/my-lib/index.d.ts");
+            assert.ok(defaultProject, "getDefaultProjectForFile should find inferred project after openFiles");
+
+            const fooPos = `export declare const foo: string;`.indexOf("foo");
+            const fooType = await defaultProject.checker.getTypeAtPosition("/node_modules/my-lib/index.d.ts", fooPos);
+            assert.ok(fooType);
+            assert.ok(fooType.flags & TypeFlags.String);
+        }
+        finally {
+            await api.close();
+        }
+    });
+});
+
 test("Benchmarks", async () => {
     await runBenchmarks({ singleIteration: true });
 });

--- a/_packages/native-preview/test/async/api.test.ts
+++ b/_packages/native-preview/test/async/api.test.ts
@@ -3490,6 +3490,102 @@ describe("getDefaultProjectForFile", () => {
             await api.close();
         }
     });
+
+    test("keeps previously opened files open across subsequent openFiles calls", async () => {
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/index.ts": `export const x = 1;`,
+            "/node_modules/my-lib/package.json": JSON.stringify({ name: "my-lib", types: "./index.d.ts" }),
+            "/node_modules/my-lib/index.d.ts": `export declare const foo: string;`,
+            "/node_modules/other-lib/package.json": JSON.stringify({ name: "other-lib", types: "./index.d.ts" }),
+            "/node_modules/other-lib/index.d.ts": `export declare const bar: number;`,
+        });
+        try {
+            await api.updateSnapshot({ openProject: "/tsconfig.json" });
+            await api.updateSnapshot({ openFiles: ["/node_modules/my-lib/index.d.ts"] });
+
+            // Opening a second file in a later snapshot must not close the first one.
+            const snapshot = await api.updateSnapshot({ openFiles: ["/node_modules/other-lib/index.d.ts"] });
+
+            const firstProject = await snapshot.getDefaultProjectForFile("/node_modules/my-lib/index.d.ts");
+            assert.ok(firstProject, "previously opened file should remain in the inferred project");
+            const secondProject = await snapshot.getDefaultProjectForFile("/node_modules/other-lib/index.d.ts");
+            assert.ok(secondProject, "newly opened file should be in the inferred project");
+        }
+        finally {
+            await api.close();
+        }
+    });
+
+    test("opening a file resolves to a configured project via ancestor search", async () => {
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/index.ts": `export const x = 1;`,
+        });
+        try {
+            // Open the file without first opening the project. Like LSP's didOpen, this
+            // should search ancestor directories for a tsconfig that contains the file.
+            const snapshot = await api.updateSnapshot({ openFiles: ["/src/index.ts"] });
+            const defaultProject = await snapshot.getDefaultProjectForFile("/src/index.ts");
+            assert.ok(defaultProject, "should find a project for the opened file");
+            assert.equal(
+                defaultProject.configFileName,
+                "/tsconfig.json",
+                "opened file should resolve to the containing configured project, not the inferred project",
+            );
+        }
+        finally {
+            await api.close();
+        }
+    });
+
+    test("closeProjects releases a project opened via openProjects", async () => {
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/index.ts": `export const x = 1;`,
+        });
+        try {
+            const opened = await api.updateSnapshot({ openProjects: ["/tsconfig.json"] });
+            assert.ok(opened.getProject("/tsconfig.json"), "project should be open after openProjects");
+
+            const closed = await api.updateSnapshot({ closeProjects: ["/tsconfig.json"] });
+            assert.equal(
+                closed.getProject("/tsconfig.json"),
+                undefined,
+                "project should be unloaded after closeProjects",
+            );
+        }
+        finally {
+            await api.close();
+        }
+    });
+
+    test("closeFiles releases a file opened via openFiles", async () => {
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/index.ts": `export const x = 1;`,
+            "/node_modules/my-lib/package.json": JSON.stringify({ name: "my-lib", types: "./index.d.ts" }),
+            "/node_modules/my-lib/index.d.ts": `export declare const foo: string;`,
+        });
+        try {
+            await api.updateSnapshot({ openProject: "/tsconfig.json" });
+            const opened = await api.updateSnapshot({ openFiles: ["/node_modules/my-lib/index.d.ts"] });
+            assert.ok(
+                await opened.getDefaultProjectForFile("/node_modules/my-lib/index.d.ts"),
+                "file should resolve to a project after openFiles",
+            );
+
+            const closed = await api.updateSnapshot({ closeFiles: ["/node_modules/my-lib/index.d.ts"] });
+            assert.equal(
+                await closed.getDefaultProjectForFile("/node_modules/my-lib/index.d.ts"),
+                undefined,
+                "file should no longer resolve to a project after closeFiles",
+            );
+        }
+        finally {
+            await api.close();
+        }
+    });
 });
 
 test("Benchmarks", async () => {

--- a/_packages/native-preview/test/sync/api.test.ts
+++ b/_packages/native-preview/test/sync/api.test.ts
@@ -3498,6 +3498,102 @@ describe("getDefaultProjectForFile", () => {
             api.close();
         }
     });
+
+    test("keeps previously opened files open across subsequent openFiles calls", () => {
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/index.ts": `export const x = 1;`,
+            "/node_modules/my-lib/package.json": JSON.stringify({ name: "my-lib", types: "./index.d.ts" }),
+            "/node_modules/my-lib/index.d.ts": `export declare const foo: string;`,
+            "/node_modules/other-lib/package.json": JSON.stringify({ name: "other-lib", types: "./index.d.ts" }),
+            "/node_modules/other-lib/index.d.ts": `export declare const bar: number;`,
+        });
+        try {
+            api.updateSnapshot({ openProject: "/tsconfig.json" });
+            api.updateSnapshot({ openFiles: ["/node_modules/my-lib/index.d.ts"] });
+
+            // Opening a second file in a later snapshot must not close the first one.
+            const snapshot = api.updateSnapshot({ openFiles: ["/node_modules/other-lib/index.d.ts"] });
+
+            const firstProject = snapshot.getDefaultProjectForFile("/node_modules/my-lib/index.d.ts");
+            assert.ok(firstProject, "previously opened file should remain in the inferred project");
+            const secondProject = snapshot.getDefaultProjectForFile("/node_modules/other-lib/index.d.ts");
+            assert.ok(secondProject, "newly opened file should be in the inferred project");
+        }
+        finally {
+            api.close();
+        }
+    });
+
+    test("opening a file resolves to a configured project via ancestor search", () => {
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/index.ts": `export const x = 1;`,
+        });
+        try {
+            // Open the file without first opening the project. Like LSP's didOpen, this
+            // should search ancestor directories for a tsconfig that contains the file.
+            const snapshot = api.updateSnapshot({ openFiles: ["/src/index.ts"] });
+            const defaultProject = snapshot.getDefaultProjectForFile("/src/index.ts");
+            assert.ok(defaultProject, "should find a project for the opened file");
+            assert.equal(
+                defaultProject.configFileName,
+                "/tsconfig.json",
+                "opened file should resolve to the containing configured project, not the inferred project",
+            );
+        }
+        finally {
+            api.close();
+        }
+    });
+
+    test("closeProjects releases a project opened via openProjects", () => {
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/index.ts": `export const x = 1;`,
+        });
+        try {
+            const opened = api.updateSnapshot({ openProjects: ["/tsconfig.json"] });
+            assert.ok(opened.getProject("/tsconfig.json"), "project should be open after openProjects");
+
+            const closed = api.updateSnapshot({ closeProjects: ["/tsconfig.json"] });
+            assert.equal(
+                closed.getProject("/tsconfig.json"),
+                undefined,
+                "project should be unloaded after closeProjects",
+            );
+        }
+        finally {
+            api.close();
+        }
+    });
+
+    test("closeFiles releases a file opened via openFiles", () => {
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/index.ts": `export const x = 1;`,
+            "/node_modules/my-lib/package.json": JSON.stringify({ name: "my-lib", types: "./index.d.ts" }),
+            "/node_modules/my-lib/index.d.ts": `export declare const foo: string;`,
+        });
+        try {
+            api.updateSnapshot({ openProject: "/tsconfig.json" });
+            const opened = api.updateSnapshot({ openFiles: ["/node_modules/my-lib/index.d.ts"] });
+            assert.ok(
+                opened.getDefaultProjectForFile("/node_modules/my-lib/index.d.ts"),
+                "file should resolve to a project after openFiles",
+            );
+
+            const closed = api.updateSnapshot({ closeFiles: ["/node_modules/my-lib/index.d.ts"] });
+            assert.equal(
+                closed.getDefaultProjectForFile("/node_modules/my-lib/index.d.ts"),
+                undefined,
+                "file should no longer resolve to a project after closeFiles",
+            );
+        }
+        finally {
+            api.close();
+        }
+    });
 });
 
 test("Benchmarks", () => {

--- a/_packages/native-preview/test/sync/api.test.ts
+++ b/_packages/native-preview/test/sync/api.test.ts
@@ -3464,6 +3464,42 @@ describe("Checker - getSignatureUsage", () => {
     });
 });
 
+describe("getDefaultProjectForFile", () => {
+    test("finds inferred project for d.ts in node_modules after openFiles", () => {
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/index.ts": `export const x = 1;`,
+            "/node_modules/my-lib/package.json": JSON.stringify({ name: "my-lib", types: "./index.d.ts" }),
+            "/node_modules/my-lib/index.d.ts": `export declare const foo: string;`,
+        });
+        try {
+            const snapshot = api.updateSnapshot({ openProject: "/tsconfig.json" });
+            const project = snapshot.getProject("/tsconfig.json")!;
+
+            // The d.ts is not imported, so it is not in the project's program
+            const dtsSf = project.program.getSourceFile("/node_modules/my-lib/index.d.ts");
+            assert.equal(dtsSf, undefined, "d.ts not in import graph should not be found via project.program.getSourceFile");
+
+            // Before opening the file, getDefaultProjectForFile returns undefined (no error)
+            const noProject = snapshot.getDefaultProjectForFile("/node_modules/my-lib/index.d.ts");
+            assert.equal(noProject, undefined, "getDefaultProjectForFile returns undefined for unloaded file");
+
+            // Load the file into the inferred project via updateSnapshot openFiles
+            const snapshot2 = api.updateSnapshot({ openFiles: ["/node_modules/my-lib/index.d.ts"] });
+            const defaultProject = snapshot2.getDefaultProjectForFile("/node_modules/my-lib/index.d.ts");
+            assert.ok(defaultProject, "getDefaultProjectForFile should find inferred project after openFiles");
+
+            const fooPos = `export declare const foo: string;`.indexOf("foo");
+            const fooType = defaultProject.checker.getTypeAtPosition("/node_modules/my-lib/index.d.ts", fooPos);
+            assert.ok(fooType);
+            assert.ok(fooType.flags & TypeFlags.String);
+        }
+        finally {
+            api.close();
+        }
+    });
+});
+
 test("Benchmarks", () => {
     runBenchmarks({ singleIteration: true });
 });

--- a/internal/api/proto.go
+++ b/internal/api/proto.go
@@ -227,11 +227,14 @@ func (d DocumentIdentifier) ToFileName() string {
 	return d.FileName
 }
 
-func (d DocumentIdentifier) ToURI() lsproto.DocumentUri {
+// ToURI returns the document URI for this identifier. An explicitly provided URI
+// is returned as-is; a file name is first normalized to an absolute path against
+// cwd before being converted to a URI.
+func (d DocumentIdentifier) ToURI(cwd string) lsproto.DocumentUri {
 	if d.URI != "" {
 		return d.URI
 	}
-	return lsconv.FileNameToDocumentURI(d.FileName)
+	return lsconv.FileNameToDocumentURI(tspath.GetNormalizedAbsolutePath(d.FileName, cwd))
 }
 
 func (d DocumentIdentifier) ToAbsoluteFileName(cwd string) string {

--- a/internal/api/proto.go
+++ b/internal/api/proto.go
@@ -268,14 +268,24 @@ type APIFileChanges struct {
 // UpdateSnapshotParams are the parameters for creating a new snapshot.
 // All fields are optional. With no fields set, the server adopts the latest LSP state.
 type UpdateSnapshotParams struct {
-	// OpenProject is the path to a tsconfig.json file to open/load in the new snapshot.
-	OpenProject string `json:"openProject,omitempty"`
+	// OpenProjects lists tsconfig.json files to open/load in the new snapshot.
+	// Opens are ref-counted and persist across snapshots until closed.
+	OpenProjects []DocumentIdentifier `json:"openProjects,omitempty"`
+	// CloseProjects lists tsconfig.json files to release in the new snapshot.
+	// A project is only unloaded once every API client that opened it closes it.
+	CloseProjects []DocumentIdentifier `json:"closeProjects,omitempty"`
 	// FileChanges describes file system changes since the last snapshot.
 	FileChanges *APIFileChanges `json:"fileChanges,omitempty"`
-	// OpenFiles lists files to load into the inferred project if no configured project
-	// already contains them. Mirrors old tsserver's openClientFile for orphan files such
-	// as node_modules d.ts files that are not in any project's import graph.
+	// OpenFiles lists files to keep open for the API client, mirroring LSP's
+	// textDocument/didOpen. For each file, ancestor directories are searched for a
+	// tsconfig that contains it; if found, that configured project is loaded and
+	// becomes the file's default project. Otherwise the file is loaded into the
+	// inferred project (e.g. a node_modules d.ts not in any project's import graph).
+	// Opens persist across snapshots until the file is closed.
 	OpenFiles []DocumentIdentifier `json:"openFiles,omitempty"`
+	// CloseFiles lists files to release in the new snapshot. A file is only fully
+	// closed once every API client that opened it closes it.
+	CloseFiles []DocumentIdentifier `json:"closeFiles,omitempty"`
 }
 
 // ProjectFileChanges describes what source files changed within a single project.

--- a/internal/api/proto.go
+++ b/internal/api/proto.go
@@ -272,6 +272,10 @@ type UpdateSnapshotParams struct {
 	OpenProject string `json:"openProject,omitempty"`
 	// FileChanges describes file system changes since the last snapshot.
 	FileChanges *APIFileChanges `json:"fileChanges,omitempty"`
+	// OpenFiles lists files to load into the inferred project if no configured project
+	// already contains them. Mirrors old tsserver's openClientFile for orphan files such
+	// as node_modules d.ts files that are not in any project's import graph.
+	OpenFiles []DocumentIdentifier `json:"openFiles,omitempty"`
 }
 
 // ProjectFileChanges describes what source files changed within a single project.

--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -647,7 +647,7 @@ func (s *Session) handleUpdateSnapshot(ctx context.Context, params *UpdateSnapsh
 			continue
 		}
 		if apiRequest.OpenProjects == nil {
-			apiRequest.OpenProjects = &collections.Set[string]{}
+			apiRequest.OpenProjects = collections.NewSetWithSizeHint[string](len(params.OpenProjects))
 		}
 		apiRequest.OpenProjects.Add(configFileName)
 		openedProjects = append(openedProjects, configPath)
@@ -661,7 +661,7 @@ func (s *Session) handleUpdateSnapshot(ctx context.Context, params *UpdateSnapsh
 			continue
 		}
 		if apiRequest.CloseProjects == nil {
-			apiRequest.CloseProjects = &collections.Set[tspath.Path]{}
+			apiRequest.CloseProjects = collections.NewSetWithSizeHint[tspath.Path](len(params.CloseProjects))
 		}
 		apiRequest.CloseProjects.Add(configPath)
 		closedProjects = append(closedProjects, configPath)
@@ -677,7 +677,7 @@ func (s *Session) handleUpdateSnapshot(ctx context.Context, params *UpdateSnapsh
 			continue
 		}
 		if apiRequest.OpenFiles == nil {
-			apiRequest.OpenFiles = &collections.Set[lsproto.DocumentUri]{}
+			apiRequest.OpenFiles = collections.NewSetWithSizeHint[lsproto.DocumentUri](len(params.OpenFiles))
 		}
 		apiRequest.OpenFiles.Add(uri)
 		openedFiles = append(openedFiles, path)
@@ -691,7 +691,7 @@ func (s *Session) handleUpdateSnapshot(ctx context.Context, params *UpdateSnapsh
 			continue
 		}
 		if apiRequest.CloseFiles == nil {
-			apiRequest.CloseFiles = &collections.Set[tspath.Path]{}
+			apiRequest.CloseFiles = collections.NewSetWithSizeHint[tspath.Path](len(params.CloseFiles))
 		}
 		apiRequest.CloseFiles.Add(path)
 		closedFiles = append(closedFiles, path)

--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -2243,7 +2243,8 @@ func (s *Session) Close() {
 
 	s.snapshotsMu.Lock()
 	defer s.snapshotsMu.Unlock()
-	for handle := range s.snapshots {
+	for handle, sd := range s.snapshots {
+		sd.snapshot.Deref(s.projectSession)
 		delete(s.snapshots, handle)
 	}
 }

--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -18,6 +18,7 @@ import (
 	"github.com/microsoft/typescript-go/internal/core"
 	"github.com/microsoft/typescript-go/internal/json"
 	"github.com/microsoft/typescript-go/internal/ls"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
 	"github.com/microsoft/typescript-go/internal/nodebuilder"
 	"github.com/microsoft/typescript-go/internal/pprof"
 	"github.com/microsoft/typescript-go/internal/printer"
@@ -636,11 +637,15 @@ func (s *Session) handleUpdateSnapshot(ctx context.Context, params *UpdateSnapsh
 		}
 		snapshot = newSnapshot
 	} else {
+		var openFileURIs []lsproto.DocumentUri
+		for _, f := range params.OpenFiles {
+			openFileURIs = append(openFileURIs, f.ToURI())
+		}
 		// Even when fileChanges is empty, APIUpdateWithFileChanges ensures all projects
 		// opened by the API are up to date. For an API connected to an LSP server, this
 		// brings the API state up to date with the LSP state and ensures projects the
 		// API cares about are ready to be queried.
-		snapshot = s.projectSession.APIUpdateWithFileChanges(ctx, fileChanges)
+		snapshot = s.projectSession.APIUpdateWithFileChanges(ctx, fileChanges, openFileURIs)
 	}
 
 	// Create or ref-count snapshot data.
@@ -717,7 +722,8 @@ func (s *Session) handleRelease(ctx context.Context, params *ReleaseParams) (any
 	return true, nil
 }
 
-// handleGetDefaultProjectForFile returns the default project for a given file.
+// handleGetDefaultProjectForFile returns the default project for a given file,
+// or null if no project currently contains the file.
 func (s *Session) handleGetDefaultProjectForFile(ctx context.Context, params *GetDefaultProjectForFileParams) (*ProjectResponse, error) {
 	sd, err := s.getSnapshotData(params.Snapshot)
 	if err != nil {
@@ -727,7 +733,7 @@ func (s *Session) handleGetDefaultProjectForFile(ctx context.Context, params *Ge
 	uri := params.File.ToURI()
 	proj := sd.snapshot.GetDefaultProject(uri)
 	if proj == nil {
-		return nil, fmt.Errorf("%w: no project found for file %v", ErrClientError, params.File)
+		return nil, nil
 	}
 
 	return NewProjectResponse(proj), nil

--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -270,21 +270,40 @@ type Session struct {
 	// This is set to true when using MessagePackProtocol.
 	useBinaryResponses bool
 
-	// snapshots maps snapshot handles to their data.
-	// Each snapshot has its own symbol/type registries.
+	// snapshots maps snapshot handles to their data. Each snapshot has its own
+	// symbol/type registries.
+	//
+	// snapshotsMu guards the snapshots map and latestSnapshot. It is held only for
+	// short, map-bounded critical sections, never across slow work like a project
+	// snapshot update or checker queries. Read handlers (getSnapshotData and the
+	// language-service handlers built on it) take it for reading; handleRelease and
+	// the bookkeeping tail of handleUpdateSnapshot take it for writing. This is what
+	// lets queries against an existing snapshot run concurrently with the building of
+	// the next one.
 	snapshots   map[SnapshotID]*snapshotData
 	snapshotsMu sync.RWMutex
 
-	// latestSnapshot tracks the most recently created snapshot for computing diffs.
+	// latestSnapshot tracks the most recently created snapshot, used as the diff base
+	// for the next update. Guarded by snapshotsMu.
 	latestSnapshot SnapshotID
 
 	// openProjects and openFiles track the projects and files this session
 	// currently holds open in the project session's API state. The session holds
 	// at most one ref per project/file (opens are idempotent), so it can release
 	// exactly those refs on Close and never send a close for a ref it doesn't hold.
+	// Guarded by updateMu.
 	openProjects collections.Set[tspath.Path]
 	openFiles    collections.Set[tspath.Path]
-	openMu       sync.Mutex
+
+	// updateMu serializes the whole of handleUpdateSnapshot (and releaseOpenRefs)
+	// against other updates. Unlike snapshotsMu it is held across the slow
+	// projectSession.APIUpdate call, because building the request from
+	// openProjects/openFiles, applying it, committing the ref tracking, and advancing
+	// latestSnapshot must be one atomic step; otherwise concurrent updates could
+	// double-count refs or diff against a non-adjacent snapshot. Read handlers do NOT
+	// take this lock, so an in-flight update never blocks queries against existing
+	// snapshots. Lock ordering is updateMu -> snapshotsMu (never the reverse).
+	updateMu sync.Mutex
 
 	cpuProfiler pprof.CPUProfiler
 }
@@ -633,9 +652,15 @@ func (s *Session) handleInitialize(ctx context.Context) (*InitializeResponse, er
 // project/file, so repeated opens are idempotent and a close only releases a ref
 // the session is actually holding.
 func (s *Session) handleUpdateSnapshot(ctx context.Context, params *UpdateSnapshotParams) (*UpdateSnapshotResponse, error) {
+	// Fully serialize updates: snapshot creation, ref tracking, and the
+	// latestSnapshot/diff bookkeeping must be atomic with respect to other updates,
+	// otherwise concurrent updates could compute diffs against a non-adjacent
+	// snapshot or leave latestSnapshot pointing at a stale snapshot.
+	s.updateMu.Lock()
+	defer s.updateMu.Unlock()
+
 	fileChanges := s.toFileChangeSummary(params.FileChanges)
 
-	s.openMu.Lock()
 	apiRequest := &project.APISnapshotRequest{}
 
 	// Open projects: only take a new ref for projects we aren't already holding open.
@@ -703,7 +728,6 @@ func (s *Session) handleUpdateSnapshot(ctx context.Context, params *UpdateSnapsh
 	// the API cares about are ready to be queried.
 	snapshot, err := s.projectSession.APIUpdate(ctx, fileChanges, apiRequest)
 	if err != nil {
-		s.openMu.Unlock()
 		// APIUpdate returns a ref'd snapshot even on error; release it.
 		snapshot.Deref(s.projectSession)
 		return nil, fmt.Errorf("%w: failed to update snapshot: %w", ErrClientError, err)
@@ -722,11 +746,11 @@ func (s *Session) handleUpdateSnapshot(ctx context.Context, params *UpdateSnapsh
 	for _, path := range closedFiles {
 		s.openFiles.Delete(path)
 	}
-	s.openMu.Unlock()
 
-	// Create or ref-count snapshot data.
-	// If the same snapshot ID is returned (no changes), we increment the
-	// ref count so each client-side Snapshot can be disposed independently.
+	// Create or ref-count snapshot data, then atomically read the previous latest
+	// snapshot (the diff base) and advance latestSnapshot to the new handle.
+	// If the same snapshot ID is returned (no changes), we increment the ref count
+	// so each client-side Snapshot can be disposed independently.
 	handle := snapshotHandle(snapshot)
 	s.snapshotsMu.Lock()
 	sd, exists := s.snapshots[handle]
@@ -745,6 +769,8 @@ func (s *Session) handleUpdateSnapshot(ctx context.Context, params *UpdateSnapsh
 		}
 		s.snapshots[handle] = sd
 	}
+	prevSD := s.snapshots[s.latestSnapshot]
+	s.latestSnapshot = handle
 	s.snapshotsMu.Unlock()
 
 	// Build projects list
@@ -756,17 +782,9 @@ func (s *Session) handleUpdateSnapshot(ctx context.Context, params *UpdateSnapsh
 
 	// Compute changes from the previous latest snapshot
 	var changes *SnapshotChanges
-	s.snapshotsMu.RLock()
-	prevSD := s.snapshots[s.latestSnapshot]
-	s.snapshotsMu.RUnlock()
 	if prevSD != nil {
 		changes = computeSnapshotChanges(prevSD.snapshot, snapshot)
 	}
-
-	// Update the latest snapshot
-	s.snapshotsMu.Lock()
-	s.latestSnapshot = handle
-	s.snapshotsMu.Unlock()
 
 	return &UpdateSnapshotResponse{
 		Snapshot: handle,
@@ -2236,8 +2254,8 @@ func (s *Session) Close() {
 // backing an LSP server), so API-opened projects and files aren't leaked. Only
 // refs the session currently holds are closed, so it never over-releases.
 func (s *Session) releaseOpenRefs() {
-	s.openMu.Lock()
-	defer s.openMu.Unlock()
+	s.updateMu.Lock()
+	defer s.updateMu.Unlock()
 
 	if s.openProjects.Len() == 0 && s.openFiles.Len() == 0 {
 		return

--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -671,7 +671,7 @@ func (s *Session) handleUpdateSnapshot(ctx context.Context, params *UpdateSnapsh
 	// held by at most one API ref from this session.
 	var openedFiles []tspath.Path
 	for _, f := range params.OpenFiles {
-		uri := f.ToURI()
+		uri := f.ToURI(s.projectSession.GetCurrentDirectory())
 		path := s.toPath(uri.FileName())
 		if s.openFiles.Has(path) {
 			continue
@@ -686,7 +686,7 @@ func (s *Session) handleUpdateSnapshot(ctx context.Context, params *UpdateSnapsh
 	// Close files: only release a ref we currently hold.
 	var closedFiles []tspath.Path
 	for _, f := range params.CloseFiles {
-		path := s.toPath(f.ToURI().FileName())
+		path := s.toPath(f.ToURI(s.projectSession.GetCurrentDirectory()).FileName())
 		if !s.openFiles.Has(path) {
 			continue
 		}
@@ -806,7 +806,7 @@ func (s *Session) handleGetDefaultProjectForFile(ctx context.Context, params *Ge
 		return nil, err
 	}
 
-	uri := params.File.ToURI()
+	uri := params.File.ToURI(s.projectSession.GetCurrentDirectory())
 	proj := sd.snapshot.GetDefaultProject(uri)
 	if proj == nil {
 		return nil, nil
@@ -2250,8 +2250,12 @@ func (s *Session) releaseOpenRefs() {
 	if s.openFiles.Len() > 0 {
 		apiRequest.CloseFiles = s.openFiles.Clone()
 	}
-	snapshot, _ := s.projectSession.APIUpdate(context.Background(), project.FileChangeSummary{}, apiRequest)
+	snapshot, err := s.projectSession.APIUpdate(context.Background(), project.FileChangeSummary{}, apiRequest)
+	// APIUpdate returns a ref'd snapshot even on error; always release it.
 	snapshot.Deref(s.projectSession)
+	if err != nil {
+		return
+	}
 
 	s.openProjects.Clear()
 	s.openFiles.Clear()
@@ -2277,16 +2281,17 @@ func (s *Session) toFileChangeSummary(changes *APIFileChanges) project.FileChang
 		summary.IncludesWatchChangeOutsideNodeModules = true
 		return summary
 	}
+	cwd := s.projectSession.GetCurrentDirectory()
 	for _, doc := range changes.Changed {
-		uri := doc.ToURI()
+		uri := doc.ToURI(cwd)
 		summary.Changed.Add(uri)
 	}
 	for _, doc := range changes.Created {
-		uri := doc.ToURI()
+		uri := doc.ToURI(cwd)
 		summary.Created.Add(uri)
 	}
 	for _, doc := range changes.Deleted {
-		uri := doc.ToURI()
+		uri := doc.ToURI(cwd)
 		summary.Deleted.Add(uri)
 	}
 	if summary.Changed.Len()+summary.Created.Len()+summary.Deleted.Len() > 0 {

--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -278,6 +278,14 @@ type Session struct {
 	// latestSnapshot tracks the most recently created snapshot for computing diffs.
 	latestSnapshot SnapshotID
 
+	// openProjects and openFiles track the projects and files this session
+	// currently holds open in the project session's API state. The session holds
+	// at most one ref per project/file (opens are idempotent), so it can release
+	// exactly those refs on Close and never send a close for a ref it doesn't hold.
+	openProjects collections.Set[tspath.Path]
+	openFiles    collections.Set[tspath.Path]
+	openMu       sync.Mutex
+
 	cpuProfiler pprof.CPUProfiler
 }
 
@@ -619,34 +627,102 @@ func (s *Session) handleInitialize(ctx context.Context) (*InitializeResponse, er
 	}, nil
 }
 
-// handleUpdateSnapshot creates a new snapshot, optionally opening a project.
-// With no args, it adopts the latest LSP state.
-// With OpenProject set, it opens the specified project in the new snapshot.
+// handleUpdateSnapshot creates a new snapshot, optionally opening or closing
+// projects and files. With no args, it adopts the latest LSP state. Opens and
+// closes are ref-counted per session: the session holds at most one ref per
+// project/file, so repeated opens are idempotent and a close only releases a ref
+// the session is actually holding.
 func (s *Session) handleUpdateSnapshot(ctx context.Context, params *UpdateSnapshotParams) (*UpdateSnapshotResponse, error) {
-	var snapshot *project.Snapshot
-
 	fileChanges := s.toFileChangeSummary(params.FileChanges)
 
-	if params.OpenProject != "" {
-		configFileName := s.toAbsoluteFileName(params.OpenProject)
-		_, newSnapshot, err := s.projectSession.APIOpenProject(ctx, configFileName, fileChanges)
-		if err != nil {
-			// APIOpenProject returns a ref'd snapshot even on error; release it.
-			newSnapshot.Deref(s.projectSession)
-			return nil, fmt.Errorf("%w: failed to load project: %w", ErrClientError, err)
+	s.openMu.Lock()
+	apiRequest := &project.APISnapshotRequest{}
+
+	// Open projects: only take a new ref for projects we aren't already holding open.
+	var openedProjects []tspath.Path
+	for _, p := range params.OpenProjects {
+		configFileName := p.ToAbsoluteFileName(s.projectSession.GetCurrentDirectory())
+		configPath := s.toPath(configFileName)
+		if s.openProjects.Has(configPath) {
+			continue
 		}
-		snapshot = newSnapshot
-	} else {
-		var openFileURIs []lsproto.DocumentUri
-		for _, f := range params.OpenFiles {
-			openFileURIs = append(openFileURIs, f.ToURI())
+		if apiRequest.OpenProjects == nil {
+			apiRequest.OpenProjects = &collections.Set[string]{}
 		}
-		// Even when fileChanges is empty, APIUpdateWithFileChanges ensures all projects
-		// opened by the API are up to date. For an API connected to an LSP server, this
-		// brings the API state up to date with the LSP state and ensures projects the
-		// API cares about are ready to be queried.
-		snapshot = s.projectSession.APIUpdateWithFileChanges(ctx, fileChanges, openFileURIs)
+		apiRequest.OpenProjects.Add(configFileName)
+		openedProjects = append(openedProjects, configPath)
 	}
+
+	// Close projects: only release a ref we currently hold.
+	var closedProjects []tspath.Path
+	for _, p := range params.CloseProjects {
+		configPath := s.toPath(p.ToAbsoluteFileName(s.projectSession.GetCurrentDirectory()))
+		if !s.openProjects.Has(configPath) {
+			continue
+		}
+		if apiRequest.CloseProjects == nil {
+			apiRequest.CloseProjects = &collections.Set[tspath.Path]{}
+		}
+		apiRequest.CloseProjects.Add(configPath)
+		closedProjects = append(closedProjects, configPath)
+	}
+
+	// Open files: only open files we aren't already holding open, so each file is
+	// held by at most one API ref from this session.
+	var openedFiles []tspath.Path
+	for _, f := range params.OpenFiles {
+		uri := f.ToURI()
+		path := s.toPath(uri.FileName())
+		if s.openFiles.Has(path) {
+			continue
+		}
+		if apiRequest.OpenFiles == nil {
+			apiRequest.OpenFiles = &collections.Set[lsproto.DocumentUri]{}
+		}
+		apiRequest.OpenFiles.Add(uri)
+		openedFiles = append(openedFiles, path)
+	}
+
+	// Close files: only release a ref we currently hold.
+	var closedFiles []tspath.Path
+	for _, f := range params.CloseFiles {
+		path := s.toPath(f.ToURI().FileName())
+		if !s.openFiles.Has(path) {
+			continue
+		}
+		if apiRequest.CloseFiles == nil {
+			apiRequest.CloseFiles = &collections.Set[tspath.Path]{}
+		}
+		apiRequest.CloseFiles.Add(path)
+		closedFiles = append(closedFiles, path)
+	}
+
+	// Even when nothing is opened or closed, APIUpdate ensures all projects and
+	// files opened by the API are up to date. For an API connected to an LSP server,
+	// this brings the API state up to date with the LSP state and ensures projects
+	// the API cares about are ready to be queried.
+	snapshot, err := s.projectSession.APIUpdate(ctx, fileChanges, apiRequest)
+	if err != nil {
+		s.openMu.Unlock()
+		// APIUpdate returns a ref'd snapshot even on error; release it.
+		snapshot.Deref(s.projectSession)
+		return nil, fmt.Errorf("%w: failed to update snapshot: %w", ErrClientError, err)
+	}
+
+	// Commit ref tracking now that the update succeeded.
+	for _, configPath := range openedProjects {
+		s.openProjects.Add(configPath)
+	}
+	for _, configPath := range closedProjects {
+		s.openProjects.Delete(configPath)
+	}
+	for _, path := range openedFiles {
+		s.openFiles.Add(path)
+	}
+	for _, path := range closedFiles {
+		s.openFiles.Delete(path)
+	}
+	s.openMu.Unlock()
 
 	// Create or ref-count snapshot data.
 	// If the same snapshot ID is returned (no changes), we increment the
@@ -723,7 +799,7 @@ func (s *Session) handleRelease(ctx context.Context, params *ReleaseParams) (any
 }
 
 // handleGetDefaultProjectForFile returns the default project for a given file,
-// or null if no project currently contains the file.
+// or nil if no project currently contains the file.
 func (s *Session) handleGetDefaultProjectForFile(ctx context.Context, params *GetDefaultProjectForFileParams) (*ProjectResponse, error) {
 	sd, err := s.getSnapshotData(params.Snapshot)
 	if err != nil {
@@ -2145,6 +2221,8 @@ func computeSnapshotChanges(prev *project.Snapshot, next *project.Snapshot) *Sna
 // Close closes the session and releases all active snapshots,
 // regardless of their ref counts.
 func (s *Session) Close() {
+	s.releaseOpenRefs()
+
 	s.snapshotsMu.Lock()
 	defer s.snapshotsMu.Unlock()
 	for handle := range s.snapshots {
@@ -2152,13 +2230,35 @@ func (s *Session) Close() {
 	}
 }
 
-func formatSessionID(id uint64) string {
-	return fmt.Sprintf("api-session-%d", id)
+// releaseOpenRefs releases every project and file ref this session is holding open
+// in the project session. This keeps the API's ref counts balanced when an API
+// session is shut down while sharing a longer-lived project session (e.g. one
+// backing an LSP server), so API-opened projects and files aren't leaked. Only
+// refs the session currently holds are closed, so it never over-releases.
+func (s *Session) releaseOpenRefs() {
+	s.openMu.Lock()
+	defer s.openMu.Unlock()
+
+	if s.openProjects.Len() == 0 && s.openFiles.Len() == 0 {
+		return
+	}
+
+	apiRequest := &project.APISnapshotRequest{}
+	if s.openProjects.Len() > 0 {
+		apiRequest.CloseProjects = s.openProjects.Clone()
+	}
+	if s.openFiles.Len() > 0 {
+		apiRequest.CloseFiles = s.openFiles.Clone()
+	}
+	snapshot, _ := s.projectSession.APIUpdate(context.Background(), project.FileChangeSummary{}, apiRequest)
+	snapshot.Deref(s.projectSession)
+
+	s.openProjects.Clear()
+	s.openFiles.Clear()
 }
 
-// toAbsoluteFileName converts a file name to an absolute path.
-func (s *Session) toAbsoluteFileName(fileName string) string {
-	return tspath.GetNormalizedAbsolutePath(fileName, s.projectSession.GetCurrentDirectory())
+func formatSessionID(id uint64) string {
+	return fmt.Sprintf("api-session-%d", id)
 }
 
 // toPath converts a file name to a normalized path.

--- a/internal/api/session_apistate_test.go
+++ b/internal/api/session_apistate_test.go
@@ -129,6 +129,13 @@ func TestSessionTracksAndReleasesAPIRefs(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Equal(t, session.openFiles.Len(), 0)
 
+		// Closing the file also tears down the configured project that was
+		// auto-loaded to serve it, instead of leaking it.
+		assert.Assert(t,
+			projectSession.Snapshot().ProjectCollection.ConfiguredProject(tspath.Path("/home/projects/p/tsconfig.json")) == nil,
+			"configured project auto-loaded for the API-opened file should be unloaded after close",
+		)
+
 		session.Close()
 		assert.Equal(t, session.openFiles.Len(), 0)
 	})

--- a/internal/api/session_apistate_test.go
+++ b/internal/api/session_apistate_test.go
@@ -139,4 +139,56 @@ func TestSessionTracksAndReleasesAPIRefs(t *testing.T) {
 		session.Close()
 		assert.Equal(t, session.openFiles.Len(), 0)
 	})
+
+	t.Run("relative file paths normalize consistently for open and close", func(t *testing.T) {
+		t.Parallel()
+		// The project session's current directory is "/", so a relative path
+		// resolves to the corresponding absolute path.
+		files := map[string]any{
+			"/src/tsconfig.json": `{ "compilerOptions": { "strict": true } }`,
+			"/src/index.ts":      `export const x = 1;`,
+		}
+		projectSession, _ := projecttestutil.Setup(files)
+		defer projectSession.Close()
+		session := NewSession(projectSession, nil)
+		defer session.Close()
+
+		// Open via a relative path; it should be tracked under the absolute path
+		// and resolve to the containing configured project.
+		openResp, err := session.handleUpdateSnapshot(context.Background(), &UpdateSnapshotParams{
+			OpenFiles: []DocumentIdentifier{{FileName: "src/index.ts"}},
+		})
+		assert.NilError(t, err)
+		assert.Equal(t, session.openFiles.Len(), 1)
+		assert.Assert(t, session.openFiles.Has(tspath.Path("/src/index.ts")))
+		assert.Assert(t, projectSession.Snapshot().ProjectCollection.ConfiguredProject(tspath.Path("/src/tsconfig.json")) != nil)
+
+		// getDefaultProjectForFile must also resolve a relative path to the same
+		// configured project (it builds a URI from the identifier internally).
+		proj, err := session.handleGetDefaultProjectForFile(context.Background(), &GetDefaultProjectForFileParams{
+			Snapshot: openResp.Snapshot,
+			File:     DocumentIdentifier{FileName: "src/index.ts"},
+		})
+		assert.NilError(t, err)
+		assert.Assert(t, proj != nil, "relative path should resolve to a default project")
+		assert.Equal(t, proj.ConfigFileName, "/src/tsconfig.json")
+
+		// Re-opening via the absolute path must match the relative open (no new ref).
+		_, err = session.handleUpdateSnapshot(context.Background(), &UpdateSnapshotParams{
+			OpenFiles: []DocumentIdentifier{{FileName: "/src/index.ts"}},
+		})
+		assert.NilError(t, err)
+		assert.Equal(t, session.openFiles.Len(), 1)
+
+		// Closing via a relative path must match the path stored when opening.
+		_, err = session.handleUpdateSnapshot(context.Background(), &UpdateSnapshotParams{
+			CloseFiles: []DocumentIdentifier{{FileName: "src/index.ts"}},
+		})
+		assert.NilError(t, err)
+		assert.Equal(t, session.openFiles.Len(), 0)
+		assert.Assert(t,
+			projectSession.Snapshot().ProjectCollection.ConfiguredProject(tspath.Path("/src/tsconfig.json")) == nil,
+			"configured project should be unloaded after closing the relatively-pathed file",
+		)
+	})
 }

--- a/internal/api/session_apistate_test.go
+++ b/internal/api/session_apistate_test.go
@@ -1,0 +1,135 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/bundled"
+	"github.com/microsoft/typescript-go/internal/testutil/projecttestutil"
+	"github.com/microsoft/typescript-go/internal/tspath"
+	"gotest.tools/v3/assert"
+)
+
+// TestSessionTracksAndReleasesAPIRefs verifies that an API session holds at most
+// one ref per opened project/file (opens are idempotent) and releases exactly
+// those refs when the session is closed, so it never leaks or over-releases refs
+// in the underlying (potentially shared) project session.
+func TestSessionTracksAndReleasesAPIRefs(t *testing.T) {
+	t.Parallel()
+	if !bundled.Embedded {
+		t.Skip("bundled files are not embedded")
+	}
+
+	t.Run("project opens are idempotent and released on close", func(t *testing.T) {
+		t.Parallel()
+		const configFileName = "/home/projects/p/tsconfig.json"
+		files := map[string]any{
+			configFileName:                  `{ "compilerOptions": { "strict": true } }`,
+			"/home/projects/p/src/index.ts": `export const x = 1;`,
+		}
+		projectSession, _ := projecttestutil.Setup(files)
+		defer projectSession.Close()
+		session := NewSession(projectSession, nil)
+
+		_, err := session.handleUpdateSnapshot(context.Background(), &UpdateSnapshotParams{
+			OpenProjects: []DocumentIdentifier{{FileName: configFileName}},
+		})
+		assert.NilError(t, err)
+		assert.Equal(t, session.openProjects.Len(), 1)
+
+		// Opening the same project again must not take an additional ref.
+		_, err = session.handleUpdateSnapshot(context.Background(), &UpdateSnapshotParams{
+			OpenProjects: []DocumentIdentifier{{FileName: configFileName}},
+		})
+		assert.NilError(t, err)
+		assert.Equal(t, session.openProjects.Len(), 1)
+
+		assert.Assert(t, projectSession.Snapshot().ProjectCollection.ConfiguredProject(tspath.Path(configFileName)) != nil)
+
+		// Closing the session releases the single API ref, so the project is no
+		// longer kept loaded.
+		session.Close()
+		assert.Equal(t, session.openProjects.Len(), 0)
+		assert.Assert(t, projectSession.Snapshot().ProjectCollection.ConfiguredProject(tspath.Path(configFileName)) == nil)
+	})
+
+	t.Run("explicit close releases the project ref", func(t *testing.T) {
+		t.Parallel()
+		const configFileName = "/home/projects/p/tsconfig.json"
+		files := map[string]any{
+			configFileName:                  `{ "compilerOptions": { "strict": true } }`,
+			"/home/projects/p/src/index.ts": `export const x = 1;`,
+		}
+		projectSession, _ := projecttestutil.Setup(files)
+		defer projectSession.Close()
+		session := NewSession(projectSession, nil)
+		defer session.Close()
+
+		_, err := session.handleUpdateSnapshot(context.Background(), &UpdateSnapshotParams{
+			OpenProjects: []DocumentIdentifier{{FileName: configFileName}},
+		})
+		assert.NilError(t, err)
+		assert.Equal(t, session.openProjects.Len(), 1)
+		assert.Assert(t, projectSession.Snapshot().ProjectCollection.ConfiguredProject(tspath.Path(configFileName)) != nil)
+
+		// Closing a project we hold releases the ref and unloads the project.
+		_, err = session.handleUpdateSnapshot(context.Background(), &UpdateSnapshotParams{
+			CloseProjects: []DocumentIdentifier{{FileName: configFileName}},
+		})
+		assert.NilError(t, err)
+		assert.Equal(t, session.openProjects.Len(), 0)
+		assert.Assert(t, projectSession.Snapshot().ProjectCollection.ConfiguredProject(tspath.Path(configFileName)) == nil)
+
+		// Closing a project we don't hold is a no-op (never over-releases).
+		_, err = session.handleUpdateSnapshot(context.Background(), &UpdateSnapshotParams{
+			CloseProjects: []DocumentIdentifier{{FileName: configFileName}},
+		})
+		assert.NilError(t, err)
+		assert.Equal(t, session.openProjects.Len(), 0)
+	})
+
+	t.Run("file opens are idempotent and released on close", func(t *testing.T) {
+		t.Parallel()
+		const fileName = "/home/projects/p/src/index.ts"
+		files := map[string]any{
+			"/home/projects/p/tsconfig.json": `{ "compilerOptions": { "strict": true } }`,
+			fileName:                         `export const x = 1;`,
+		}
+		projectSession, _ := projecttestutil.Setup(files)
+		defer projectSession.Close()
+		session := NewSession(projectSession, nil)
+
+		_, err := session.handleUpdateSnapshot(context.Background(), &UpdateSnapshotParams{
+			OpenFiles: []DocumentIdentifier{{FileName: fileName}},
+		})
+		assert.NilError(t, err)
+		assert.Equal(t, session.openFiles.Len(), 1)
+
+		// Re-opening the same file must not take an additional ref.
+		_, err = session.handleUpdateSnapshot(context.Background(), &UpdateSnapshotParams{
+			OpenFiles: []DocumentIdentifier{{FileName: fileName}},
+		})
+		assert.NilError(t, err)
+		assert.Equal(t, session.openFiles.Len(), 1)
+
+		// The file should resolve to the configured project via ancestor search.
+		assert.Assert(t, projectSession.Snapshot().ProjectCollection.ConfiguredProject(tspath.Path("/home/projects/p/tsconfig.json")) != nil)
+
+		// Closing a file we don't hold is a no-op (never over-releases).
+		_, err = session.handleUpdateSnapshot(context.Background(), &UpdateSnapshotParams{
+			CloseFiles: []DocumentIdentifier{{FileName: "/home/projects/p/other.ts"}},
+		})
+		assert.NilError(t, err)
+		assert.Equal(t, session.openFiles.Len(), 1)
+
+		// Explicitly closing the held file releases the ref.
+		_, err = session.handleUpdateSnapshot(context.Background(), &UpdateSnapshotParams{
+			CloseFiles: []DocumentIdentifier{{FileName: fileName}},
+		})
+		assert.NilError(t, err)
+		assert.Equal(t, session.openFiles.Len(), 0)
+
+		session.Close()
+		assert.Equal(t, session.openFiles.Len(), 0)
+	})
+}

--- a/internal/project/api.go
+++ b/internal/project/api.go
@@ -2,56 +2,27 @@ package project
 
 import (
 	"context"
-
-	"github.com/microsoft/typescript-go/internal/collections"
-	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
 )
 
-// APIOpenProject opens a project and returns a ref'd snapshot.
-// The caller must call snapshot.Deref(s) when done.
-func (s *Session) APIOpenProject(ctx context.Context, configFileName string, apiFileChanges FileChangeSummary) (*Project, *Snapshot, error) {
+// APIUpdate creates a new snapshot incorporating the given file changes and the
+// supplied API open/close request. The apiRequest may open or close projects and
+// files; opens are tracked in the snapshot (ref-counted) so they persist across
+// future updates, and closes release a previously taken ref. Even an empty
+// apiRequest ensures all API-opened projects and files are kept up to date.
+// Returns a ref'd snapshot (which the caller must Deref when done) and any error
+// encountered while applying the request, e.g. failing to load a project to open.
+func (s *Session) APIUpdate(ctx context.Context, apiFileChanges FileChangeSummary, apiRequest *APISnapshotRequest) (*Snapshot, error) {
 	s.snapshotUpdateMu.Lock()
 	defer s.snapshotUpdateMu.Unlock()
 	s.cancelScheduledSnapshotUpdate()
 
 	fileChanges, overlays, ataChanges, _ := s.flushChanges(ctx)
 	mergeFileChangeSummary(&fileChanges, apiFileChanges)
+
 	newSnapshot := s.updateSnapshotRef(ctx, overlays, SnapshotChange{
+		apiRequest:  apiRequest,
 		fileChanges: fileChanges,
 		ataChanges:  ataChanges,
-		apiRequest: &APISnapshotRequest{
-			OpenProjects: collections.NewSetFromItems(configFileName),
-		},
 	})
-
-	if newSnapshot.apiError != nil {
-		return nil, newSnapshot, newSnapshot.apiError
-	}
-
-	project := newSnapshot.ProjectCollection.ConfiguredProject(s.toPath(configFileName))
-	if project == nil {
-		panic("OpenProject request returned no error but project not present in snapshot")
-	}
-
-	return project, newSnapshot, nil
-}
-
-// APIUpdateWithFileChanges creates a new snapshot incorporating the given
-// file changes. Documents are URIs that should be loaded into the inferred project
-// if no configured project already contains them.
-// Returns a ref'd snapshot; caller must Deref when done.
-func (s *Session) APIUpdateWithFileChanges(ctx context.Context, apiFileChanges FileChangeSummary, documents []lsproto.DocumentUri) *Snapshot {
-	s.snapshotUpdateMu.Lock()
-	defer s.snapshotUpdateMu.Unlock()
-	s.cancelScheduledSnapshotUpdate()
-
-	fileChanges, overlays, ataChanges, _ := s.flushChanges(ctx)
-	mergeFileChangeSummary(&fileChanges, apiFileChanges)
-
-	return s.updateSnapshotRef(ctx, overlays, SnapshotChange{
-		ResourceRequest: ResourceRequest{Documents: documents},
-		apiRequest:      &APISnapshotRequest{},
-		fileChanges:     fileChanges,
-		ataChanges:      ataChanges,
-	})
+	return newSnapshot, newSnapshot.apiError
 }

--- a/internal/project/api.go
+++ b/internal/project/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/microsoft/typescript-go/internal/collections"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
 )
 
 // APIOpenProject opens a project and returns a ref'd snapshot.
@@ -36,8 +37,10 @@ func (s *Session) APIOpenProject(ctx context.Context, configFileName string, api
 }
 
 // APIUpdateWithFileChanges creates a new snapshot incorporating the given
-// file changes. Returns a ref'd snapshot; caller must Deref when done.
-func (s *Session) APIUpdateWithFileChanges(ctx context.Context, apiFileChanges FileChangeSummary) *Snapshot {
+// file changes. Documents are URIs that should be loaded into the inferred project
+// if no configured project already contains them.
+// Returns a ref'd snapshot; caller must Deref when done.
+func (s *Session) APIUpdateWithFileChanges(ctx context.Context, apiFileChanges FileChangeSummary, documents []lsproto.DocumentUri) *Snapshot {
 	s.snapshotUpdateMu.Lock()
 	defer s.snapshotUpdateMu.Unlock()
 	s.cancelScheduledSnapshotUpdate()
@@ -46,8 +49,9 @@ func (s *Session) APIUpdateWithFileChanges(ctx context.Context, apiFileChanges F
 	mergeFileChangeSummary(&fileChanges, apiFileChanges)
 
 	return s.updateSnapshotRef(ctx, overlays, SnapshotChange{
-		apiRequest:  &APISnapshotRequest{},
-		fileChanges: fileChanges,
-		ataChanges:  ataChanges,
+		ResourceRequest: ResourceRequest{Documents: documents},
+		apiRequest:      &APISnapshotRequest{},
+		fileChanges:     fileChanges,
+		ataChanges:      ataChanges,
 	})
 }

--- a/internal/project/projectcollection.go
+++ b/internal/project/projectcollection.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"cmp"
+	"maps"
 	"slices"
 	"sync"
 
@@ -29,12 +30,43 @@ type ProjectCollection struct {
 	// inferredProject is a fallback project that is used when no configured
 	// project can be found for an open file.
 	inferredProject *Project
-	// apiOpenedProjects is the set of projects that should be kept open for
-	// API clients.
-	apiOpenedProjects map[tspath.Path]struct{}
+	// apiState tracks the projects and files that API clients have explicitly
+	// opened so they are kept loaded across snapshots.
+	apiState APIState
 
 	openConfiguredProjectsOnce sync.Once
 	openConfiguredProjects     *collections.Set[tspath.Path]
+}
+
+// APIState tracks the projects and files that API clients have explicitly opened.
+// Opens and closes are ref-counted so multiple API clients don't clobber each
+// other, and it is carried across snapshots so API-opened resources stay loaded.
+type APIState struct {
+	// openProjects is the ref-counted set of projects to keep open for API
+	// clients, keyed by config file path. The value is the number of outstanding
+	// API opens.
+	openProjects map[tspath.Path]int
+	// openFiles is the ref-counted set of files to keep open for API clients,
+	// keyed by file path. Files with no configured project are loaded into the
+	// inferred project.
+	openFiles map[tspath.Path]apiOpenedFile
+}
+
+func (s APIState) clone() APIState {
+	return APIState{
+		openProjects: maps.Clone(s.openProjects),
+		openFiles:    maps.Clone(s.openFiles),
+	}
+}
+
+func (s APIState) equals(other APIState) bool {
+	return maps.Equal(s.openProjects, other.openProjects) && maps.Equal(s.openFiles, other.openFiles)
+}
+
+// apiOpenedFile tracks a file kept open by API clients along with its ref count.
+type apiOpenedFile struct {
+	fileName string
+	refCount int
 }
 
 func (c *ProjectCollection) ConfigFileRegistry() *ConfigFileRegistry { return c.configFileRegistry }
@@ -271,7 +303,7 @@ func (c *ProjectCollection) clone() *ProjectCollection {
 		openFiles:           c.openFiles,
 		inferredProject:     c.inferredProject,
 		fileDefaultProjects: c.fileDefaultProjects,
-		apiOpenedProjects:   c.apiOpenedProjects,
+		apiState:            c.apiState,
 	}
 }
 

--- a/internal/project/projectcollectionbuilder.go
+++ b/internal/project/projectcollectionbuilder.go
@@ -49,7 +49,7 @@ type ProjectCollectionBuilder struct {
 	configuredProjects  *dirty.SyncMap[tspath.Path, *Project]
 	inferredProject     *dirty.Box[*Project]
 
-	apiOpenedProjects map[tspath.Path]struct{}
+	apiState APIState
 }
 
 func newProjectCollectionBuilder(
@@ -58,7 +58,7 @@ func newProjectCollectionBuilder(
 	fs *snapshotFSBuilder,
 	oldProjectCollection *ProjectCollection,
 	oldConfigFileRegistry *ConfigFileRegistry,
-	oldAPIOpenedProjects map[tspath.Path]struct{},
+	oldAPIState APIState,
 	compilerOptionsForInferredProjects *core.CompilerOptions,
 	sessionOptions *SessionOptions,
 	customConfigFileName string,
@@ -79,7 +79,7 @@ func newProjectCollectionBuilder(
 		newSnapshotID:                      newSnapshotID,
 		configuredProjects:                 dirty.NewSyncMap(oldProjectCollection.configuredProjects),
 		inferredProject:                    dirty.NewBox(oldProjectCollection.inferredProject),
-		apiOpenedProjects:                  maps.Clone(oldAPIOpenedProjects),
+		apiState:                           oldAPIState.clone(),
 		client:                             client,
 	}
 }
@@ -120,9 +120,9 @@ func (b *ProjectCollectionBuilder) Finalize(logger *logging.LogTree) (*ProjectCo
 		newProjectCollection.configFileRegistry = configFileRegistry
 	}
 
-	if !maps.Equal(b.apiOpenedProjects, b.base.apiOpenedProjects) {
+	if !b.apiState.equals(b.base.apiState) {
 		ensureCloned()
-		newProjectCollection.apiOpenedProjects = b.apiOpenedProjects
+		newProjectCollection.apiState = b.apiState
 	}
 
 	return newProjectCollection, configFileRegistry
@@ -145,9 +145,18 @@ func (b *ProjectCollectionBuilder) forEachProject(fn func(entry dirty.Value[*Pro
 func (b *ProjectCollectionBuilder) HandleAPIRequest(apiRequest *APISnapshotRequest, logger *logging.LogTree) error {
 	var projectsToClose map[tspath.Path]struct{}
 	if apiRequest.CloseProjects != nil {
-		projectsToClose = maps.Clone(apiRequest.CloseProjects.M)
 		for projectPath := range apiRequest.CloseProjects.Keys() {
-			delete(b.apiOpenedProjects, projectPath)
+			// Ref-counted close: only actually close the project once the last
+			// API client that opened it releases it.
+			if count := b.apiState.openProjects[projectPath]; count > 1 {
+				b.apiState.openProjects[projectPath] = count - 1
+			} else if count == 1 {
+				delete(b.apiState.openProjects, projectPath)
+				if projectsToClose == nil {
+					projectsToClose = make(map[tspath.Path]struct{})
+				}
+				projectsToClose[projectPath] = struct{}{}
+			}
 		}
 	}
 
@@ -155,17 +164,47 @@ func (b *ProjectCollectionBuilder) HandleAPIRequest(apiRequest *APISnapshotReque
 		for configFileName := range apiRequest.OpenProjects.Keys() {
 			configPath := b.toPath(configFileName)
 			if entry := b.findOrCreateProject(configFileName, configPath, projectLoadKindCreate, logger); entry != nil {
-				if b.apiOpenedProjects == nil {
-					b.apiOpenedProjects = make(map[tspath.Path]struct{})
+				if b.apiState.openProjects == nil {
+					b.apiState.openProjects = make(map[tspath.Path]int)
 				}
-				b.apiOpenedProjects[configPath] = struct{}{}
+				b.apiState.openProjects[configPath]++
+				// A project re-opened in the same request shouldn't be closed.
+				delete(projectsToClose, configPath)
 			} else {
 				return fmt.Errorf("project not found for open: %s", configFileName)
 			}
 		}
 	}
 
-	for configPath := range b.apiOpenedProjects {
+	if apiRequest.CloseFiles != nil {
+		for path := range apiRequest.CloseFiles.Keys() {
+			// Ref-counted close mirroring projects above.
+			if entry, ok := b.apiState.openFiles[path]; ok {
+				if entry.refCount > 1 {
+					entry.refCount--
+					b.apiState.openFiles[path] = entry
+				} else {
+					delete(b.apiState.openFiles, path)
+				}
+			}
+		}
+	}
+
+	if apiRequest.OpenFiles != nil {
+		for uri := range apiRequest.OpenFiles.Keys() {
+			fileName := uri.FileName()
+			path := b.toPath(fileName)
+			if b.apiState.openFiles == nil {
+				b.apiState.openFiles = make(map[tspath.Path]apiOpenedFile)
+			}
+			entry := b.apiState.openFiles[path]
+			entry.fileName = fileName
+			entry.refCount++
+			b.apiState.openFiles[path] = entry
+		}
+	}
+
+	for configPath := range b.apiState.openProjects {
 		if entry, ok := b.configuredProjects.Load(configPath); ok {
 			b.updateProgram(entry, logger)
 		} else {
@@ -185,7 +224,34 @@ func (b *ProjectCollectionBuilder) HandleAPIRequest(apiRequest *APISnapshotReque
 		}
 	}
 
+	// Ensure each API-opened file is placed like LSP's textDocument/didOpen: search
+	// up ancestor directories for a configured project that contains it, and only
+	// fall back to the inferred project if none is found. This also keeps already
+	// loaded configured projects up to date.
+	if apiRequest.OpenFiles != nil || apiRequest.CloseFiles != nil {
+		for path, file := range b.apiState.openFiles {
+			b.ensureAPIOpenedFilePlaced(file.fileName, path, logger)
+		}
+		b.updateInferredProjectRoots(b.collectInferredProjectRoots(), logger)
+		if b.inferredProject.Value() != nil {
+			b.updateProgram(b.inferredProject, logger)
+		}
+	}
+
 	return nil
+}
+
+// ensureAPIOpenedFilePlaced searches up the ancestor directories for a configured
+// project containing the file (loading it if necessary), mirroring the way LSP's
+// textDocument/didOpen resolves a project for an opened file. If no configured
+// project is found, the file is left for the inferred project, which is rebuilt
+// by the caller from collectInferredProjectRoots.
+func (b *ProjectCollectionBuilder) ensureAPIOpenedFilePlaced(fileName string, path tspath.Path, logger *logging.LogTree) {
+	if b.fs.isOpenFile(path) {
+		// Already an LSP overlay; its project membership is handled by DidChangeFiles.
+		return
+	}
+	b.ensureConfiguredProjectAndAncestorsForFile(fileName, path, logger)
 }
 
 func (b *ProjectCollectionBuilder) DidChangeFiles(summary FileChangeSummary, logger *logging.LogTree) {
@@ -327,12 +393,24 @@ func (b *ProjectCollectionBuilder) DidChangeFiles(summary FileChangeSummary, log
 				inferredProjectFiles = append(inferredProjectFiles, overlay.FileName())
 			}
 		}
+		// Treat API-opened files like open files: retain their configured project (so
+		// an LSP-driven open doesn't close it), or keep them as inferred project roots.
+		for path, file := range b.apiState.openFiles {
+			if b.fs.isOpenFile(path) {
+				continue
+			}
+			if p := b.findDefaultConfiguredProject(file.fileName, path); p != nil {
+				retainDefaultConfiguredProject(file.fileName, path, p.Value())
+			} else {
+				inferredProjectFiles = append(inferredProjectFiles, file.fileName)
+			}
+		}
 
 		for projectPath := range toRemoveProjects.Keys() {
 			if openFileResult.retain.Has(projectPath) {
 				continue
 			}
-			if _, ok := b.apiOpenedProjects[projectPath]; ok {
+			if _, ok := b.apiState.openProjects[projectPath]; ok {
 				continue
 			}
 			if p, ok := b.configuredProjects.Load(projectPath); ok {
@@ -353,26 +431,39 @@ func logChangeFileResult(result changeFileResult, logger *logging.LogTree) {
 	}
 }
 
-func (b *ProjectCollectionBuilder) cleanupInferredProject(logger *logging.LogTree) {
+func (b *ProjectCollectionBuilder) collectInferredProjectRoots() []string {
 	var inferredProjectFiles []string
 	for path, overlay := range b.fs.overlays {
 		if b.findDefaultConfiguredProject(overlay.FileName(), path) == nil {
 			inferredProjectFiles = append(inferredProjectFiles, overlay.FileName())
 		}
 	}
-	b.updateInferredProjectRoots(inferredProjectFiles, logger)
+	return b.appendAPIOpenedInferredRoots(inferredProjectFiles)
+}
+
+// appendAPIOpenedInferredRoots appends API-opened files that aren't open in an
+// overlay and have no configured project, so they're kept as inferred project
+// roots and persist across snapshots.
+func (b *ProjectCollectionBuilder) appendAPIOpenedInferredRoots(inferredProjectFiles []string) []string {
+	for path, file := range b.apiState.openFiles {
+		if b.fs.isOpenFile(path) {
+			continue
+		}
+		if b.findDefaultConfiguredProject(file.fileName, path) == nil {
+			inferredProjectFiles = append(inferredProjectFiles, file.fileName)
+		}
+	}
+	return inferredProjectFiles
+}
+
+func (b *ProjectCollectionBuilder) cleanupInferredProject(logger *logging.LogTree) {
+	b.updateInferredProjectRoots(b.collectInferredProjectRoots(), logger)
 }
 
 func (b *ProjectCollectionBuilder) ensureInferredProjectIncludesClosedFile(fileName string, logger *logging.LogTree) {
 	// Collect existing inferred project roots (open files not in configured projects)
 	// plus this closed file.
-	var inferredProjectFiles []string
-	for path, overlay := range b.fs.overlays {
-		if b.findDefaultConfiguredProject(overlay.FileName(), path) == nil {
-			inferredProjectFiles = append(inferredProjectFiles, overlay.FileName())
-		}
-	}
-	inferredProjectFiles = append(inferredProjectFiles, fileName)
+	inferredProjectFiles := append(b.collectInferredProjectRoots(), fileName)
 	b.updateInferredProjectRoots(inferredProjectFiles, logger)
 	if b.inferredProject.Value() != nil {
 		b.updateProgram(b.inferredProject, logger)

--- a/internal/project/projectcollectionbuilder.go
+++ b/internal/project/projectcollectionbuilder.go
@@ -227,31 +227,27 @@ func (b *ProjectCollectionBuilder) HandleAPIRequest(apiRequest *APISnapshotReque
 	// Ensure each API-opened file is placed like LSP's textDocument/didOpen: search
 	// up ancestor directories for a configured project that contains it, and only
 	// fall back to the inferred project if none is found. This also keeps already
-	// loaded configured projects up to date.
+	// loaded configured projects up to date. Then run the same cleanup the LSP open
+	// path uses, so configured projects auto-loaded for files that are no longer open
+	// are torn down instead of leaking.
 	if apiRequest.OpenFiles != nil || apiRequest.CloseFiles != nil {
+		var retain collections.Set[tspath.Path]
 		for path, file := range b.apiState.openFiles {
-			b.ensureAPIOpenedFilePlaced(file.fileName, path, logger)
+			if b.fs.isOpenFile(path) {
+				// Already an LSP overlay; its project membership is handled by the
+				// overlay pass in cleanupConfiguredProjects.
+				continue
+			}
+			result := b.ensureConfiguredProjectAndAncestorsForFile(file.fileName, path, logger)
+			retain.Union(&result.retain)
 		}
-		b.updateInferredProjectRoots(b.collectInferredProjectRoots(), logger)
+		b.cleanupConfiguredProjects(&retain, logger)
 		if b.inferredProject.Value() != nil {
 			b.updateProgram(b.inferredProject, logger)
 		}
 	}
 
 	return nil
-}
-
-// ensureAPIOpenedFilePlaced searches up the ancestor directories for a configured
-// project containing the file (loading it if necessary), mirroring the way LSP's
-// textDocument/didOpen resolves a project for an opened file. If no configured
-// project is found, the file is left for the inferred project, which is rebuilt
-// by the caller from collectInferredProjectRoots.
-func (b *ProjectCollectionBuilder) ensureAPIOpenedFilePlaced(fileName string, path tspath.Path, logger *logging.LogTree) {
-	if b.fs.isOpenFile(path) {
-		// Already an LSP overlay; its project membership is handled by DidChangeFiles.
-		return
-	}
-	b.ensureConfiguredProjectAndAncestorsForFile(fileName, path, logger)
 }
 
 func (b *ProjectCollectionBuilder) DidChangeFiles(summary FileChangeSummary, logger *logging.LogTree) {
@@ -325,101 +321,90 @@ func (b *ProjectCollectionBuilder) DidChangeFiles(summary FileChangeSummary, log
 
 	// Handle opened file
 	if summary.Opened != "" || summary.Reopened != "" {
-		var toRemoveProjects collections.Set[tspath.Path]
 		fileName := core.FirstNonZero(summary.Opened, summary.Reopened).FileName()
 		path := b.toPath(fileName)
 		openFileResult := b.ensureConfiguredProjectAndAncestorsForFile(fileName, path, logger)
-		b.configuredProjects.Range(func(entry *dirty.SyncMapEntry[tspath.Path, *Project]) bool {
-			toRemoveProjects.Add(entry.Key())
-			return true
-		})
-		var isReferencedBy func(project *Project, refPath tspath.Path, seenProjects *collections.Set[*Project]) bool
-		isReferencedBy = func(project *Project, refPath tspath.Path, seenProjects *collections.Set[*Project]) bool {
-			if !seenProjects.AddIfAbsent(project) {
-				return false
-			}
+		b.cleanupConfiguredProjects(&openFileResult.retain, logger)
+	}
+}
 
-			if project.potentialProjectReferences != nil {
-				for potentialRef := range project.potentialProjectReferences.Keys() {
-					if potentialRef == refPath {
-						return true
-					}
+// cleanupConfiguredProjects sweeps the loaded configured projects and unloads those
+// that are no longer needed. Starting from the set of all configured projects, it
+// retains any project that is the default project (along with its references and
+// ancestor configs) of an open overlay file or an API-opened file, any project
+// explicitly opened through the API, and any project in retain (e.g. the ancestor
+// solution tree built for a freshly opened overlay file). Every other configured
+// project is deleted, the inferred project roots are recomputed, and the config file
+// registry is cleaned up. This is the shared mechanism that keeps the set of loaded
+// projects minimal for both LSP file opens and API file opens/closes.
+func (b *ProjectCollectionBuilder) cleanupConfiguredProjects(retain *collections.Set[tspath.Path], logger *logging.LogTree) {
+	var toRemoveProjects collections.Set[tspath.Path]
+	b.configuredProjects.Range(func(entry *dirty.SyncMapEntry[tspath.Path, *Project]) bool {
+		toRemoveProjects.Add(entry.Key())
+		return true
+	})
+
+	retainProjectAndReferences := func(project *Project) {
+		// Retain project
+		toRemoveProjects.Delete(project.configFilePath)
+		if program := project.GetProgram(); program != nil {
+			program.RangeResolvedProjectReference(func(referencePath tspath.Path, _ *tsoptions.ParsedCommandLine, _ *tsoptions.ParsedCommandLine, _ int) bool {
+				if _, ok := b.configuredProjects.Load(referencePath); ok {
+					toRemoveProjects.Delete(referencePath)
 				}
-				for potentialRef := range project.potentialProjectReferences.Keys() {
-					if refProject, foundRef := b.configuredProjects.Load(potentialRef); foundRef && isReferencedBy(refProject.Value(), refPath, seenProjects) {
-						return true
-					}
-				}
-			} else if program := project.GetProgram(); program != nil && !program.RangeResolvedProjectReference(func(referencePath tspath.Path, _ *tsoptions.ParsedCommandLine, _ *tsoptions.ParsedCommandLine, _ int) bool {
-				return referencePath != refPath
-			}) {
 				return true
-			}
-			return false
-		}
-
-		retainProjectAndReferences := func(project *Project) {
-			// Retain project
-			toRemoveProjects.Delete(project.configFilePath)
-			if program := project.GetProgram(); program != nil {
-				program.RangeResolvedProjectReference(func(referencePath tspath.Path, _ *tsoptions.ParsedCommandLine, _ *tsoptions.ParsedCommandLine, _ int) bool {
-					if _, ok := b.configuredProjects.Load(referencePath); ok {
-						toRemoveProjects.Delete(referencePath)
-					}
-					return true
-				})
-			}
-		}
-
-		retainDefaultConfiguredProject := func(openFile string, openFilePath tspath.Path, project *Project) {
-			// Retain project and its references
-			retainProjectAndReferences(project)
-
-			// Retain all the ancestor projects
-			b.configFileRegistryBuilder.forEachConfigFileNameFor(openFilePath, func(configFileName string) {
-				if ancestor := b.findOrCreateProject(configFileName, b.toPath(configFileName), projectLoadKindFind, logger); ancestor != nil {
-					retainProjectAndReferences(ancestor.Value())
-				}
 			})
 		}
-
-		var inferredProjectFiles []string
-		for _, overlay := range b.fs.overlays {
-			openFile := overlay.FileName()
-			openFilePath := b.toPath(openFile)
-			if p := b.findDefaultConfiguredProject(openFile, openFilePath); p != nil {
-				retainDefaultConfiguredProject(openFile, openFilePath, p.Value())
-			} else {
-				inferredProjectFiles = append(inferredProjectFiles, overlay.FileName())
-			}
-		}
-		// Treat API-opened files like open files: retain their configured project (so
-		// an LSP-driven open doesn't close it), or keep them as inferred project roots.
-		for path, file := range b.apiState.openFiles {
-			if b.fs.isOpenFile(path) {
-				continue
-			}
-			if p := b.findDefaultConfiguredProject(file.fileName, path); p != nil {
-				retainDefaultConfiguredProject(file.fileName, path, p.Value())
-			} else {
-				inferredProjectFiles = append(inferredProjectFiles, file.fileName)
-			}
-		}
-
-		for projectPath := range toRemoveProjects.Keys() {
-			if openFileResult.retain.Has(projectPath) {
-				continue
-			}
-			if _, ok := b.apiState.openProjects[projectPath]; ok {
-				continue
-			}
-			if p, ok := b.configuredProjects.Load(projectPath); ok {
-				b.deleteConfiguredProject(p, logger)
-			}
-		}
-		b.updateInferredProjectRoots(inferredProjectFiles, logger)
-		b.configFileRegistryBuilder.Cleanup()
 	}
+
+	retainDefaultConfiguredProject := func(openFilePath tspath.Path, project *Project) {
+		// Retain project and its references
+		retainProjectAndReferences(project)
+
+		// Retain all the ancestor projects
+		b.configFileRegistryBuilder.forEachConfigFileNameFor(openFilePath, func(configFileName string) {
+			if ancestor := b.findOrCreateProject(configFileName, b.toPath(configFileName), projectLoadKindFind, logger); ancestor != nil {
+				retainProjectAndReferences(ancestor.Value())
+			}
+		})
+	}
+
+	var inferredProjectFiles []string
+	for _, overlay := range b.fs.overlays {
+		openFile := overlay.FileName()
+		openFilePath := b.toPath(openFile)
+		if p := b.findDefaultConfiguredProject(openFile, openFilePath); p != nil {
+			retainDefaultConfiguredProject(openFilePath, p.Value())
+		} else {
+			inferredProjectFiles = append(inferredProjectFiles, openFile)
+		}
+	}
+	// Treat API-opened files like open files: retain their configured project (so
+	// an LSP-driven open doesn't close it), or keep them as inferred project roots.
+	for path, file := range b.apiState.openFiles {
+		if b.fs.isOpenFile(path) {
+			continue
+		}
+		if p := b.findDefaultConfiguredProject(file.fileName, path); p != nil {
+			retainDefaultConfiguredProject(path, p.Value())
+		} else {
+			inferredProjectFiles = append(inferredProjectFiles, file.fileName)
+		}
+	}
+
+	for projectPath := range toRemoveProjects.Keys() {
+		if retain.Has(projectPath) {
+			continue
+		}
+		if _, ok := b.apiState.openProjects[projectPath]; ok {
+			continue
+		}
+		if p, ok := b.configuredProjects.Load(projectPath); ok {
+			b.deleteConfiguredProject(p, logger)
+		}
+	}
+	b.updateInferredProjectRoots(inferredProjectFiles, logger)
+	b.configFileRegistryBuilder.Cleanup()
 }
 
 func logChangeFileResult(result changeFileResult, logger *logging.LogTree) {

--- a/internal/project/snapshot.go
+++ b/internal/project/snapshot.go
@@ -159,6 +159,8 @@ func (s *Snapshot) ReadDirectory(currentDir string, path string, extensions []st
 type APISnapshotRequest struct {
 	OpenProjects  *collections.Set[string]
 	CloseProjects *collections.Set[tspath.Path]
+	OpenFiles     *collections.Set[lsproto.DocumentUri]
+	CloseFiles    *collections.Set[tspath.Path]
 }
 
 type ProjectTreeRequest struct {
@@ -327,7 +329,7 @@ func (s *Snapshot) Clone(ctx context.Context, change SnapshotChange, overlays ma
 		fs,
 		s.ProjectCollection,
 		s.ConfigFileRegistry,
-		s.ProjectCollection.apiOpenedProjects,
+		s.ProjectCollection.apiState,
 		compilerOptionsForInferredProjects,
 		s.sessionOptions,
 		customConfigFileName,


### PR DESCRIPTION
This allows the API client to include files to open/close in `updateSnapshot`, as well as adding the missing ability to close projects previously open. This means that the API can now use inferred projects to easily analyze files without a tsconfig.json, or automatically find a file’s tsconfig.json just by requesting to “open” the file.

Supersedes #4353 