### PR TITLE
Fix panic in checker.Type.Types for non-union types via the API (#4426)

### DIFF
--- a/_packages/native-preview/test/async/api.test.ts
+++ b/_packages/native-preview/test/async/api.test.ts
@@ -2334,6 +2334,46 @@ describe("Checker - getTypeArguments", () => {
     });
 });
 
+describe("Type - getTypes", () => {
+    test("returns the constituents of a union type", async () => {
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/main.ts": `export const u: string | number = "";`,
+        });
+        try {
+            const snapshot = await api.updateSnapshot({ openProject: "/tsconfig.json" });
+            const project = snapshot.getProject("/tsconfig.json")!;
+            const symbol = await project.checker.getSymbolAtPosition("/src/main.ts", `export const `.length);
+            assert.ok(symbol);
+            const type = await project.checker.getTypeOfSymbol(symbol);
+            assert.ok(type);
+            assert.equal((await type.getTypes()).length, 2);
+        }
+        finally {
+            await api.close();
+        }
+    });
+
+    test("does not panic for a non-union type", async () => {
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/main.ts": `export const s: string = "";`,
+        });
+        try {
+            const snapshot = await api.updateSnapshot({ openProject: "/tsconfig.json" });
+            const project = snapshot.getProject("/tsconfig.json")!;
+            const symbol = await project.checker.getSymbolAtPosition("/src/main.ts", `export const `.length);
+            assert.ok(symbol);
+            const type = await project.checker.getTypeOfSymbol(symbol);
+            assert.ok(type);
+            assert.deepEqual(await type.getTypes(), []);
+        }
+        finally {
+            await api.close();
+        }
+    });
+});
+
 describe("TypeParameter - isThisType", () => {
     test("isThisType is true for the polymorphic 'this' type in a class method", async () => {
         const src = `\nexport class Builder {\n    setName(name: string): this { return this; }\n}\n`;

--- a/_packages/native-preview/test/sync/api.test.ts
+++ b/_packages/native-preview/test/sync/api.test.ts
@@ -2342,6 +2342,46 @@ describe("Checker - getTypeArguments", () => {
     });
 });
 
+describe("Type - getTypes", () => {
+    test("returns the constituents of a union type", () => {
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/main.ts": `export const u: string | number = "";`,
+        });
+        try {
+            const snapshot = api.updateSnapshot({ openProject: "/tsconfig.json" });
+            const project = snapshot.getProject("/tsconfig.json")!;
+            const symbol = project.checker.getSymbolAtPosition("/src/main.ts", `export const `.length);
+            assert.ok(symbol);
+            const type = project.checker.getTypeOfSymbol(symbol);
+            assert.ok(type);
+            assert.equal(type.getTypes().length, 2);
+        }
+        finally {
+            api.close();
+        }
+    });
+
+    test("does not panic for a non-union type", () => {
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/main.ts": `export const s: string = "";`,
+        });
+        try {
+            const snapshot = api.updateSnapshot({ openProject: "/tsconfig.json" });
+            const project = snapshot.getProject("/tsconfig.json")!;
+            const symbol = project.checker.getSymbolAtPosition("/src/main.ts", `export const `.length);
+            assert.ok(symbol);
+            const type = project.checker.getTypeOfSymbol(symbol);
+            assert.ok(type);
+            assert.deepEqual(type.getTypes(), []);
+        }
+        finally {
+            api.close();
+        }
+    });
+});
+
 describe("TypeParameter - isThisType", () => {
     test("isThisType is true for the polymorphic 'this' type in a class method", () => {
         const src = `\nexport class Builder {\n    setName(name: string): this { return this; }\n}\n`;

--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -1395,7 +1395,15 @@ func (s *Session) handleGetRegularTypeOfType(_ context.Context, params *GetTypeP
 }
 
 func (s *Session) handleGetTypesOfType(_ context.Context, params *GetTypePropertyParams) ([]*TypeResponse, error) {
-	return s.resolveTypeArrayPropertyOfType(params, (*checker.Type).Types)
+	// Type.Types panics on anything that isn't a union/intersection or template
+	// literal; a user can call getTypes() on any type, so guard the boundary and
+	// return no constituent types for the rest.
+	return s.resolveTypeArrayPropertyOfType(params, func(t *checker.Type) []*checker.Type {
+		if t.Flags()&(checker.TypeFlagsUnionOrIntersection|checker.TypeFlagsTemplateLiteral) == 0 {
+			return nil
+		}
+		return t.Types()
+	})
 }
 
 func (s *Session) handleGetTypeParametersOfType(_ context.Context, params *GetTypePropertyParams) ([]*TypeResponse, error) {


### PR DESCRIPTION
  Fixes #4426.

  Problem — The public getter getTypes() (Type.getTypes() → Session.handleGetTypesOfType → checker.Type.Types) forwards an arbitrary
  user type to Type.Types, an invariant accessor that only handles union/intersection and template-literal types and panic("Unhandled
  case in Type.Types")s on everything else. Calling getTypes() on e.g. the intrinsic string crashes the request. Unlike the
  getTypeParameters/getCheckType family (defended JS-side by ?? [] defaults and handle gates), getTypes() always reaches the server,
  so the panic is reachable directly through type.getTypes(). Same class as #4338 (getTypeArguments) and #4335/#4425 (getBaseTypes).

  Fix — Guard at the API boundary (internal/api/session.go); non-union types return []. The Type.Types accessor stays strict (meant
  to panic on misuse).

  Tests — New Type - getTypes block (sync + async): union returns 2 constituents; non-union returns [] (regression for #4426).

  Test plan — go build ✓, gofmt clean ✓, 4/4 new tests pass (non-union panics on main, passes here) ✓.

  Claude (Opus 4.8) helped investigate, reproduce, and test this fix.