### PR TITLE
Match Strada's behavior to allow satisfying recursive indexed access

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -57,7 +57,7 @@ const (
 	TypeSystemPropertyNameResolvedBaseConstructorType
 	TypeSystemPropertyNameDeclaredType
 	TypeSystemPropertyNameResolvedReturnType
-	TypeSystemPropertyNameResolvedBaseConstraint
+	TypeSystemPropertyNameImmediateBaseConstraint
 	TypeSystemPropertyNameResolvedTypeArguments
 	TypeSystemPropertyNameResolvedBaseTypes
 	TypeSystemPropertyNameWriteType
@@ -16971,7 +16971,7 @@ func (c *Checker) getConstraintOfTypeParameter(typeParameter *Type) *Type {
 }
 
 func (c *Checker) hasNonCircularBaseConstraint(t *Type) bool {
-	return c.getResolvedBaseConstraint(t, nil) != c.circularConstraintType
+	return c.getResolvedBaseConstraint(t) != c.circularConstraintType
 }
 
 // This is a worker function. Use getConstraintOfTypeParameter which guards against circular constraints
@@ -18706,8 +18706,8 @@ func (c *Checker) typeResolutionHasProperty(r *TypeResolution) bool {
 		return r.target.(*Type).AsInterfaceType().resolvedBaseConstructorType != nil
 	case TypeSystemPropertyNameResolvedReturnType:
 		return r.target.(*Signature).resolvedReturnType != nil
-	case TypeSystemPropertyNameResolvedBaseConstraint:
-		return r.target.(*Type).AsConstrainedType().resolvedBaseConstraint != nil
+	case TypeSystemPropertyNameImmediateBaseConstraint:
+		return r.target.(*Type).AsConstrainedType().immediateBaseConstraint != nil
 	case TypeSystemPropertyNameInitializerIsUndefined:
 		return c.nodeLinks.Get(r.target.(*ast.Node)).flags&NodeCheckFlagsInitializerIsUndefinedComputed != 0
 	case TypeSystemPropertyNameWriteType:
@@ -22452,7 +22452,7 @@ func (c *Checker) instantiateMappedType(t *Type, m *TypeMapper, alias *TypeAlias
 			return s
 		}
 		if d.declaration.NameType == nil {
-			if c.isArrayType(s) || s.flags&TypeFlagsAny != 0 && c.findResolutionCycleStartIndex(typeVariable, TypeSystemPropertyNameResolvedBaseConstraint) < 0 && c.hasArrayOrTypeTypeConstraint(typeVariable) {
+			if c.isArrayType(s) || s.flags&TypeFlagsAny != 0 && c.findResolutionCycleStartIndex(typeVariable, TypeSystemPropertyNameImmediateBaseConstraint) < 0 && c.hasArrayOrTypeTypeConstraint(typeVariable) {
 				return c.instantiateMappedArrayType(s, t, prependTypeMapping(typeVariable, s, m))
 			}
 			if isTupleType(s) {
@@ -27295,7 +27295,7 @@ func (c *Checker) getBaseConstraintOrType(t *Type) *Type {
 
 func (c *Checker) getBaseConstraintOfType(t *Type) *Type {
 	if t.flags&(TypeFlagsInstantiableNonPrimitive|TypeFlagsUnionOrIntersection|TypeFlagsTemplateLiteral|TypeFlagsStringMapping|TypeFlagsIndex) != 0 || c.isGenericTupleType(t) {
-		constraint := c.getResolvedBaseConstraint(t, nil)
+		constraint := c.getResolvedBaseConstraint(t)
 		if constraint != c.noConstraintType && constraint != c.circularConstraintType {
 			return constraint
 		}
@@ -27304,7 +27304,7 @@ func (c *Checker) getBaseConstraintOfType(t *Type) *Type {
 	return nil
 }
 
-func (c *Checker) getResolvedBaseConstraint(t *Type, stack []RecursionId) *Type {
+func (c *Checker) getResolvedBaseConstraint(t *Type) *Type {
 	constrained := t.AsConstrainedType()
 	if constrained == nil {
 		return t
@@ -27312,55 +27312,81 @@ func (c *Checker) getResolvedBaseConstraint(t *Type, stack []RecursionId) *Type 
 	if constrained.resolvedBaseConstraint != nil {
 		return constrained.resolvedBaseConstraint
 	}
-	if !c.pushTypeResolution(t, TypeSystemPropertyNameResolvedBaseConstraint) {
-		return c.circularConstraintType
-	}
-	var constraint *Type
-	// We always explore at least 10 levels of nested constraints. Thereafter, we continue to explore
-	// up to 50 levels of nested constraints provided there are no "deeply nested" types on the stack
-	// (i.e. no types for which five instantiations have been recorded on the stack). If we reach 50
-	// levels of nesting, we are presumably exploring a repeating pattern with a long cycle that hasn't
-	// yet triggered the deeply nested limiter. We have no test cases that actually get to 50 levels of
-	// nesting, so it is effectively just a safety stop.
-	identity := getRecursionIdentity(t)
-	if len(stack) < 10 || len(stack) < 50 && !slices.Contains(stack, identity) {
-		constraint = c.computeBaseConstraint(c.getSimplifiedType(t /*writing*/, false), append(stack, identity))
-	}
-	if !c.popTypeResolution() {
-		if t.flags&TypeFlagsTypeParameter != 0 {
-			errorNode := c.getConstraintDeclaration(t)
-			if errorNode != nil {
-				diagnostic := c.error(errorNode, diagnostics.Type_parameter_0_has_a_circular_constraint, c.TypeToString(t))
-				if c.currentNode != nil && !isNodeDescendantOf(errorNode, c.currentNode) && !isNodeDescendantOf(c.currentNode, errorNode) {
-					diagnostic.AddRelatedInfo(NewDiagnosticForNode(c.currentNode, diagnostics.Circularity_originates_in_type_at_this_location))
+
+	var stack []RecursionId
+	var getImmediateBaseConstraint func(*Type) *Type
+	var getBaseConstraint func(*Type) *Type
+
+	getImmediateBaseConstraint = func(t *Type) *Type {
+		immediateConstrained := t.AsConstrainedType()
+		if immediateConstrained == nil {
+			return t
+		}
+		if immediateConstrained.immediateBaseConstraint == nil {
+			if !c.pushTypeResolution(t, TypeSystemPropertyNameImmediateBaseConstraint) {
+				return c.circularConstraintType
+			}
+			var result *Type
+			// We always explore at least 10 levels of nested constraints. Thereafter, we continue to explore
+			// up to 50 levels of nested constraints provided there are no "deeply nested" types on the stack
+			// (i.e. no types for which five instantiations have been recorded on the stack). If we reach 50
+			// levels of nesting, we are presumably exploring a repeating pattern with a long cycle that hasn't
+			// yet triggered the deeply nested limiter. We have no test cases that actually get to 50 levels of
+			// nesting, so it is effectively just a safety stop.
+			identity := getRecursionIdentity(t)
+			if len(stack) < 10 || len(stack) < 50 && !slices.Contains(stack, identity) {
+				stack = append(stack, identity)
+				result = c.computeBaseConstraint(c.getSimplifiedType(t /*writing*/, false), getBaseConstraint)
+				stack = stack[:len(stack)-1]
+			}
+			if !c.popTypeResolution() {
+				if t.flags&TypeFlagsTypeParameter != 0 {
+					errorNode := c.getConstraintDeclaration(t)
+					if errorNode != nil {
+						diagnostic := c.error(errorNode, diagnostics.Type_parameter_0_has_a_circular_constraint, c.TypeToString(t))
+						if c.currentNode != nil && !isNodeDescendantOf(errorNode, c.currentNode) && !isNodeDescendantOf(c.currentNode, errorNode) {
+							diagnostic.AddRelatedInfo(NewDiagnosticForNode(c.currentNode, diagnostics.Circularity_originates_in_type_at_this_location))
+						}
+					}
 				}
+				result = c.circularConstraintType
+			}
+			if immediateConstrained.immediateBaseConstraint == nil {
+				immediateConstrained.immediateBaseConstraint = core.OrElse(result, c.noConstraintType)
 			}
 		}
-		constraint = c.circularConstraintType
+		return immediateConstrained.immediateBaseConstraint
 	}
-	if constraint == nil {
-		constraint = c.noConstraintType
+
+	getBaseConstraint = func(t *Type) *Type {
+		if t == nil {
+			return nil
+		}
+		constraint := getImmediateBaseConstraint(t)
+		if constraint != c.noConstraintType && constraint != c.circularConstraintType {
+			return constraint
+		}
+		return nil
 	}
-	if constrained.resolvedBaseConstraint == nil {
-		constrained.resolvedBaseConstraint = constraint
-	}
-	return constraint
+
+	constrained.resolvedBaseConstraint = getImmediateBaseConstraint(t)
+	return constrained.resolvedBaseConstraint
 }
 
-func (c *Checker) computeBaseConstraint(t *Type, stack []RecursionId) *Type {
+func (c *Checker) computeBaseConstraint(t *Type, getBaseConstraint func(*Type) *Type) *Type {
 	switch {
 	case t.flags&TypeFlagsTypeParameter != 0:
 		constraint := c.getConstraintFromTypeParameter(t)
 		if t.AsTypeParameter().isThisType {
 			return constraint
 		}
-		return c.getNextBaseConstraint(constraint, stack)
+		return getBaseConstraint(constraint)
 	case t.flags&TypeFlagsUnionOrIntersection != 0:
 		types := t.Types()
 		constraints := make([]*Type, 0, len(types))
 		different := false
 		for _, s := range types {
-			constraint := c.getNextBaseConstraint(s, stack)
+			constraint := getBaseConstraint(s)
 			if constraint != nil {
 				if constraint != s {
 					different = true
@@ -27384,7 +27410,7 @@ func (c *Checker) computeBaseConstraint(t *Type, stack []RecursionId) *Type {
 		if c.isGenericMappedType(t.AsIndexType().target) {
 			mappedType := t.AsIndexType().target
 			if c.getNameTypeFromMappedType(mappedType) != nil && !c.isMappedTypeWithKeyofConstraintDeclaration(mappedType) {
-				return c.getNextBaseConstraint(c.getIndexTypeForMappedType(mappedType, IndexFlagsNone), stack)
+				return getBaseConstraint(c.getIndexTypeForMappedType(mappedType, IndexFlagsNone))
 			}
 		}
 		return c.stringNumberSymbolType
@@ -27392,7 +27418,7 @@ func (c *Checker) computeBaseConstraint(t *Type, stack []RecursionId) *Type {
 		types := t.Types()
 		constraints := make([]*Type, 0, len(types))
 		for _, s := range types {
-			constraint := c.getNextBaseConstraint(s, stack)
+			constraint := getBaseConstraint(s)
 			if constraint != nil {
 				constraints = append(constraints, constraint)
 			}
@@ -27402,7 +27428,7 @@ func (c *Checker) computeBaseConstraint(t *Type, stack []RecursionId) *Type {
 		}
 		return c.stringType
 	case t.flags&TypeFlagsStringMapping != 0:
-		constraint := c.getNextBaseConstraint(t.Target(), stack)
+		constraint := getBaseConstraint(t.Target())
 		if constraint != nil && constraint != t.Target() {
 			return c.getStringMappingType(t.symbol, constraint)
 		}
@@ -27411,31 +27437,38 @@ func (c *Checker) computeBaseConstraint(t *Type, stack []RecursionId) *Type {
 		if c.isMappedTypeGenericIndexedAccess(t) {
 			// For indexed access types of the form { [P in K]: E }[X], where K is non-generic and X is generic,
 			// we substitute an instantiation of E where P is replaced with X.
-			return c.getNextBaseConstraint(c.substituteIndexedMappedType(t.AsIndexedAccessType().objectType, t.AsIndexedAccessType().indexType), stack)
+			return getBaseConstraint(c.substituteIndexedMappedType(t.AsIndexedAccessType().objectType, t.AsIndexedAccessType().indexType))
 		}
-		baseObjectType := c.getNextBaseConstraint(t.AsIndexedAccessType().objectType, stack)
-		baseIndexType := c.getNextBaseConstraint(t.AsIndexedAccessType().indexType, stack)
-		if baseObjectType == nil || baseIndexType == nil {
-			return nil
+		baseObjectType := getBaseConstraint(t.AsIndexedAccessType().objectType)
+		baseIndexType := getBaseConstraint(t.AsIndexedAccessType().indexType)
+		if baseObjectType != nil && baseIndexType != nil {
+			baseIndexedAccess := c.getIndexedAccessTypeOrUndefined(baseObjectType, baseIndexType, t.AsIndexedAccessType().accessFlags, nil, nil)
+			if baseIndexedAccess != nil {
+				return getBaseConstraint(baseIndexedAccess)
+			}
 		}
-		return c.getNextBaseConstraint(c.getIndexedAccessTypeOrUndefined(baseObjectType, baseIndexType, t.AsIndexedAccessType().accessFlags, nil, nil), stack)
+		return nil
 	case t.flags&TypeFlagsConditional != 0:
 		d := t.AsConditionalType()
 		if d.root.isDistributive && c.cachedTypes[CachedTypeKey{kind: CachedTypeKindRestrictiveInstantiation, typeId: t.id}] != t {
 			constraint := c.getSimplifiedType(d.checkType, false /*writing*/)
 			if constraint == d.checkType {
-				constraint = c.getNextBaseConstraint(constraint, stack)
+				if constraint.flags&TypeFlagsIndexedAccess != 0 && constraint.AsIndexedAccessType().indexType.flags&TypeFlagsConditional == 0 {
+					constraint = c.getConstraintOfType(constraint)
+				} else {
+					constraint = getBaseConstraint(constraint)
+				}
 			}
 			if constraint != nil && constraint != d.checkType {
 				instantiated := c.getConditionalTypeInstantiation(t, prependTypeMapping(d.root.checkType, constraint, d.mapper), true /*forConstraint*/, nil)
 				if instantiated.flags&TypeFlagsNever == 0 {
-					return c.getNextBaseConstraint(instantiated, stack)
+					return getBaseConstraint(instantiated)
 				}
 			}
 		}
-		return c.getNextBaseConstraint(c.getDefaultConstraintOfConditionalType(t), stack)
+		return getBaseConstraint(c.getDefaultConstraintOfConditionalType(t))
 	case t.flags&TypeFlagsSubstitution != 0:
-		return c.getNextBaseConstraint(c.getSubstitutionIntersection(t), stack)
+		return getBaseConstraint(c.getSubstitutionIntersection(t))
 	case c.isGenericTupleType(t):
 		// We substitute constraints for variadic elements only when the constraints are array types or
 		// non-variadic tuple types as we want to avoid further (possibly unbounded) recursion.
@@ -27445,7 +27478,7 @@ func (c *Checker) computeBaseConstraint(t *Type, stack []RecursionId) *Type {
 		for i, v := range elementTypes {
 			newElement := v
 			if v.flags&TypeFlagsTypeParameter != 0 && elementInfos[i].flags&ElementFlagsVariadic != 0 {
-				constraint := c.getNextBaseConstraint(v, stack)
+				constraint := getBaseConstraint(v)
 				if constraint != nil && constraint != v && everyType(constraint, func(n *Type) bool { return c.isArrayOrTupleType(n) && !c.isGenericTupleType(n) }) {
 					newElement = constraint
 				}
@@ -27455,17 +27488,6 @@ func (c *Checker) computeBaseConstraint(t *Type, stack []RecursionId) *Type {
 		return c.createTupleTypeEx(newElements, elementInfos, t.TargetTupleType().readonly)
 	}
 	return t
-}
-
-func (c *Checker) getNextBaseConstraint(t *Type, stack []RecursionId) *Type {
-	if t == nil {
-		return nil
-	}
-	constraint := c.getResolvedBaseConstraint(t, stack)
-	if constraint == c.noConstraintType || constraint == c.circularConstraintType {
-		return nil
-	}
-	return constraint
 }
 
 // Return true if type might be of the given kind. A union or intersection type might be of a given

--- a/internal/checker/types.go
+++ b/internal/checker/types.go
@@ -907,7 +907,8 @@ type UniqueESSymbolType struct {
 
 type ConstrainedType struct {
 	TypeBase
-	resolvedBaseConstraint *Type
+	immediateBaseConstraint *Type
+	resolvedBaseConstraint  *Type
 }
 
 func (t *ConstrainedType) AsConstrainedType() *ConstrainedType { return t }

--- a/internal/checker/utilities.go
+++ b/internal/checker/utilities.go
@@ -1742,7 +1742,7 @@ func (c *Checker) isJSLiteralType(t *Type) bool {
 		return core.Some(t.AsIntersectionType().types, c.isJSLiteralType)
 	}
 	if t.flags&TypeFlagsInstantiable != 0 {
-		constraint := c.getResolvedBaseConstraint(t, nil)
+		constraint := c.getResolvedBaseConstraint(t)
 		return constraint != t && c.isJSLiteralType(constraint)
 	}
 	return false

--- a/testdata/baselines/reference/compiler/recursiveMappedTypeDefaultConstraint.js
+++ b/testdata/baselines/reference/compiler/recursiveMappedTypeDefaultConstraint.js
@@ -1,0 +1,21 @@
+//// [tests/cases/compiler/recursiveMappedTypeDefaultConstraint.ts] ////
+
+//// [recursiveMappedTypeDefaultConstraint.ts]
+type Type = { values: string };
+
+type Wrapped<T extends Type> = { values: T["values"] };
+
+type FromObject<
+    Context extends Record<string, Type>,
+    Props extends Context,
+    Shape extends Record<keyof Props, Type> = {
+        [Key in keyof Props]: Wrapped<FromSchema<Context, Props[Key]>>;
+    },
+> = Shape;
+
+type FromSchema<Context extends Record<string, Type>, S> =
+    S extends Type ? FromSchema<Context, Context[keyof Context]> : never;
+
+
+//// [recursiveMappedTypeDefaultConstraint.js]
+"use strict";

--- a/testdata/baselines/reference/compiler/recursiveMappedTypeDefaultConstraint.symbols
+++ b/testdata/baselines/reference/compiler/recursiveMappedTypeDefaultConstraint.symbols
@@ -1,0 +1,60 @@
+//// [tests/cases/compiler/recursiveMappedTypeDefaultConstraint.ts] ////
+
+=== recursiveMappedTypeDefaultConstraint.ts ===
+type Type = { values: string };
+>Type : Symbol(Type, Decl(recursiveMappedTypeDefaultConstraint.ts, 0, 0))
+>values : Symbol(values, Decl(recursiveMappedTypeDefaultConstraint.ts, 0, 13))
+
+type Wrapped<T extends Type> = { values: T["values"] };
+>Wrapped : Symbol(Wrapped, Decl(recursiveMappedTypeDefaultConstraint.ts, 0, 31))
+>T : Symbol(T, Decl(recursiveMappedTypeDefaultConstraint.ts, 2, 13))
+>Type : Symbol(Type, Decl(recursiveMappedTypeDefaultConstraint.ts, 0, 0))
+>values : Symbol(values, Decl(recursiveMappedTypeDefaultConstraint.ts, 2, 32))
+>T : Symbol(T, Decl(recursiveMappedTypeDefaultConstraint.ts, 2, 13))
+
+type FromObject<
+>FromObject : Symbol(FromObject, Decl(recursiveMappedTypeDefaultConstraint.ts, 2, 55))
+
+    Context extends Record<string, Type>,
+>Context : Symbol(Context, Decl(recursiveMappedTypeDefaultConstraint.ts, 4, 16))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>Type : Symbol(Type, Decl(recursiveMappedTypeDefaultConstraint.ts, 0, 0))
+
+    Props extends Context,
+>Props : Symbol(Props, Decl(recursiveMappedTypeDefaultConstraint.ts, 5, 41))
+>Context : Symbol(Context, Decl(recursiveMappedTypeDefaultConstraint.ts, 4, 16))
+
+    Shape extends Record<keyof Props, Type> = {
+>Shape : Symbol(Shape, Decl(recursiveMappedTypeDefaultConstraint.ts, 6, 26))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>Props : Symbol(Props, Decl(recursiveMappedTypeDefaultConstraint.ts, 5, 41))
+>Type : Symbol(Type, Decl(recursiveMappedTypeDefaultConstraint.ts, 0, 0))
+
+        [Key in keyof Props]: Wrapped<FromSchema<Context, Props[Key]>>;
+>Key : Symbol(Key, Decl(recursiveMappedTypeDefaultConstraint.ts, 8, 9))
+>Props : Symbol(Props, Decl(recursiveMappedTypeDefaultConstraint.ts, 5, 41))
+>Wrapped : Symbol(Wrapped, Decl(recursiveMappedTypeDefaultConstraint.ts, 0, 31))
+>FromSchema : Symbol(FromSchema, Decl(recursiveMappedTypeDefaultConstraint.ts, 10, 10))
+>Context : Symbol(Context, Decl(recursiveMappedTypeDefaultConstraint.ts, 4, 16))
+>Props : Symbol(Props, Decl(recursiveMappedTypeDefaultConstraint.ts, 5, 41))
+>Key : Symbol(Key, Decl(recursiveMappedTypeDefaultConstraint.ts, 8, 9))
+
+    },
+> = Shape;
+>Shape : Symbol(Shape, Decl(recursiveMappedTypeDefaultConstraint.ts, 6, 26))
+
+type FromSchema<Context extends Record<string, Type>, S> =
+>FromSchema : Symbol(FromSchema, Decl(recursiveMappedTypeDefaultConstraint.ts, 10, 10))
+>Context : Symbol(Context, Decl(recursiveMappedTypeDefaultConstraint.ts, 12, 16))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>Type : Symbol(Type, Decl(recursiveMappedTypeDefaultConstraint.ts, 0, 0))
+>S : Symbol(S, Decl(recursiveMappedTypeDefaultConstraint.ts, 12, 53))
+
+    S extends Type ? FromSchema<Context, Context[keyof Context]> : never;
+>S : Symbol(S, Decl(recursiveMappedTypeDefaultConstraint.ts, 12, 53))
+>Type : Symbol(Type, Decl(recursiveMappedTypeDefaultConstraint.ts, 0, 0))
+>FromSchema : Symbol(FromSchema, Decl(recursiveMappedTypeDefaultConstraint.ts, 10, 10))
+>Context : Symbol(Context, Decl(recursiveMappedTypeDefaultConstraint.ts, 12, 16))
+>Context : Symbol(Context, Decl(recursiveMappedTypeDefaultConstraint.ts, 12, 16))
+>Context : Symbol(Context, Decl(recursiveMappedTypeDefaultConstraint.ts, 12, 16))
+

--- a/testdata/baselines/reference/compiler/recursiveMappedTypeDefaultConstraint.types
+++ b/testdata/baselines/reference/compiler/recursiveMappedTypeDefaultConstraint.types
@@ -1,0 +1,26 @@
+//// [tests/cases/compiler/recursiveMappedTypeDefaultConstraint.ts] ////
+
+=== recursiveMappedTypeDefaultConstraint.ts ===
+type Type = { values: string };
+>Type : Type
+>values : string
+
+type Wrapped<T extends Type> = { values: T["values"] };
+>Wrapped : Wrapped<T>
+>values : T["values"]
+
+type FromObject<
+>FromObject : Shape
+
+    Context extends Record<string, Type>,
+    Props extends Context,
+    Shape extends Record<keyof Props, Type> = {
+        [Key in keyof Props]: Wrapped<FromSchema<Context, Props[Key]>>;
+    },
+> = Shape;
+
+type FromSchema<Context extends Record<string, Type>, S> =
+>FromSchema : FromSchema<Context, S>
+
+    S extends Type ? FromSchema<Context, Context[keyof Context]> : never;
+

--- a/testdata/baselines/reference/submodule/compiler/infiniteConstraints.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/infiniteConstraints.errors.txt
@@ -1,4 +1,3 @@
-infiniteConstraints.ts(3,37): error TS2321: Excessive stack depth comparing types '"val"' and 'keyof Extract<B[Exclude<keyof B, K>], { val: string; }>'.
 infiniteConstraints.ts(3,37): error TS2536: Type '"val"' cannot be used to index type 'Extract<B[Exclude<keyof B, K>], { val: string; }>'.
 infiniteConstraints.ts(4,37): error TS2536: Type '"val"' cannot be used to index type 'B[Exclude<keyof B, K>]'.
 infiniteConstraints.ts(31,43): error TS2322: Type 'Value<"dup">' is not assignable to type 'never'.
@@ -6,12 +5,10 @@ infiniteConstraints.ts(31,63): error TS2322: Type 'Value<"dup">' is not assignab
 infiniteConstraints.ts(36,71): error TS2536: Type '"foo"' cannot be used to index type 'T[keyof T]'.
 
 
-==== infiniteConstraints.ts (6 errors) ====
+==== infiniteConstraints.ts (5 errors) ====
     // Both of the following types trigger the recursion limiter in getImmediateBaseConstraint
     
     type T1<B extends { [K in keyof B]: Extract<B[Exclude<keyof B, K>], { val: string }>["val"] }> = B;
-                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2321: Excessive stack depth comparing types '"val"' and 'keyof Extract<B[Exclude<keyof B, K>], { val: string; }>'.
                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2536: Type '"val"' cannot be used to index type 'Extract<B[Exclude<keyof B, K>], { val: string; }>'.
     type T2<B extends { [K in keyof B]: B[Exclude<keyof B, K>]["val"] }> = B;

--- a/testdata/baselines/reference/submodule/compiler/infiniteConstraints.errors.txt.diff
+++ b/testdata/baselines/reference/submodule/compiler/infiniteConstraints.errors.txt.diff
@@ -1,7 +1,6 @@
 --- old.infiniteConstraints.errors.txt
 +++ new.infiniteConstraints.errors.txt
 @@= skipped -0, +0 lines =@@
-+infiniteConstraints.ts(3,37): error TS2321: Excessive stack depth comparing types '"val"' and 'keyof Extract<B[Exclude<keyof B, K>], { val: string; }>'.
 +infiniteConstraints.ts(3,37): error TS2536: Type '"val"' cannot be used to index type 'Extract<B[Exclude<keyof B, K>], { val: string; }>'.
  infiniteConstraints.ts(4,37): error TS2536: Type '"val"' cannot be used to index type 'B[Exclude<keyof B, K>]'.
  infiniteConstraints.ts(31,43): error TS2322: Type 'Value<"dup">' is not assignable to type 'never'.
@@ -10,12 +9,10 @@
 
 
 -==== infiniteConstraints.ts (4 errors) ====
-+==== infiniteConstraints.ts (6 errors) ====
++==== infiniteConstraints.ts (5 errors) ====
      // Both of the following types trigger the recursion limiter in getImmediateBaseConstraint
      
      type T1<B extends { [K in keyof B]: Extract<B[Exclude<keyof B, K>], { val: string }>["val"] }> = B;
-+                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-+!!! error TS2321: Excessive stack depth comparing types '"val"' and 'keyof Extract<B[Exclude<keyof B, K>], { val: string; }>'.
 +                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 +!!! error TS2536: Type '"val"' cannot be used to index type 'Extract<B[Exclude<keyof B, K>], { val: string; }>'.
      type T2<B extends { [K in keyof B]: B[Exclude<keyof B, K>]["val"] }> = B;

--- a/testdata/tests/cases/compiler/recursiveMappedTypeDefaultConstraint.ts
+++ b/testdata/tests/cases/compiler/recursiveMappedTypeDefaultConstraint.ts
@@ -1,0 +1,14 @@
+type Type = { values: string };
+
+type Wrapped<T extends Type> = { values: T["values"] };
+
+type FromObject<
+    Context extends Record<string, Type>,
+    Props extends Context,
+    Shape extends Record<keyof Props, Type> = {
+        [Key in keyof Props]: Wrapped<FromSchema<Context, Props[Key]>>;
+    },
+> = Shape;
+
+type FromSchema<Context extends Record<string, Type>, S> =
+    S extends Type ? FromSchema<Context, Context[keyof Context]> : never;


### PR DESCRIPTION
Authored by copilot
---

Fixes microsoft/TypeScript#63568

## Analysis

The regression came from Corsa not matching Strada’s base-constraint cache model.

In Strada, base-constraint resolution has two distinct caches:

- [`immediateBaseConstraint`](./_submodules/TypeScript/src/compiler/types.ts#L6452), cached on every `Type`
- [`resolvedBaseConstraint`](./_submodules/TypeScript/src/compiler/types.ts#L6855), cached on instantiable/union/intersection types

The key Strada implementation is [`getResolvedBaseConstraint`](./_submodules/TypeScript/src/compiler/checker.ts#L15322-L15430). It computes `resolvedBaseConstraint` by calling an inner `getImmediateBaseConstraint`, and recursive base-constraint walks go through an inner `getBaseConstraint` helper. Circularity tracking is also keyed to [`TypeSystemPropertyName.ImmediateBaseConstraint`](./_submodules/TypeScript/src/compiler/checker.ts#L1331), and `resolutionTargetHasProperty` checks `immediateBaseConstraint` at [`checker.ts#L11525-L11526`](./_submodules/TypeScript/src/compiler/checker.ts#L11525-L11526).

Corsa had collapsed this into a single `resolvedBaseConstraint` cache and passed an explicit recursion stack through `getResolvedBaseConstraint(t, stack)`. That made conditional/indexed-access constraint recovery diverge in recursive cases like:

```ts
FromSchema<Context, Context[keyof Context]>["values"]
```

In the reduced repro, the checker needs to keep advancing the conditional/indexed-access constraint chain far enough to see the `values: string` shape. The old Corsa model treated one of those recursive conditional constraints as circular too early, so `Wrapped<FromSchema<...>>` failed the `Type` constraint even though Strada accepts the type parameter default.

## Fix

This ports Corsa’s base-constraint machinery closer to Strada

The main changes are:

1. Added `immediateBaseConstraint` to Corsa’s `ConstrainedType`, matching Strada’s separate immediate/resolved cache split:
   - Strada: [`types.ts#L6452`](./_submodules/TypeScript/src/compiler/[types.ts#L6452](https://github.com/microsoft/typescript-go/compare/main...RyanCavanaugh:fix63568?expand=1#))
   - Corsa: [`[internal/checker/types.go](https://github.com/microsoft/typescript-go/compare/main...RyanCavanaugh:fix63568?expand=1#)`](./internal/checker/types.go)

2. Renamed the type-resolution property from resolved-base-constraint tracking to immediate-base-constraint tracking:
   - Strada enum/property check: [`[checker.ts#L1331](https://github.com/microsoft/typescript-go/compare/main...RyanCavanaugh:fix63568?expand=1#)`](./_submodules/TypeScript/src/compiler/checker.ts#L1331), [`[checker.ts#L11525-L11526](https://github.com/microsoft/typescript-go/compare/main...RyanCavanaugh:fix63568?expand=1#)`](./_submodules/TypeScript/src/compiler/checker.ts#L11525-L11526)
   - Corsa equivalent: [`[internal/checker/checker.go](https://github.com/microsoft/typescript-go/compare/main...RyanCavanaugh:fix63568?expand=1#)`](./internal/checker/checker.go)

3. Refactored Corsa’s `getResolvedBaseConstraint` to mirror Strada’s structure:
   - inner `getImmediateBaseConstraint`
   - inner `getBaseConstraint`
   - `resolvedBaseConstraint = getImmediateBaseConstraint(t)`
   - Strada reference: [`[checker.ts#L15322-L15367](https://github.com/microsoft/typescript-go/compare/main...RyanCavanaugh:fix63568?expand=1#)`](./_submodules/TypeScript/src/compiler/checker.ts#L15322-L15367)
   - Corsa implementation: [`[internal/checker/checker.go](https://github.com/microsoft/typescript-go/compare/main...RyanCavanaugh:fix63568?expand=1#)`](./internal/checker/checker.go)

4. Updated `computeBaseConstraint` to use the inner `getBaseConstraint` helper, matching the Strada flow through type parameters, unions/intersections, index types, indexed accesses, substitutions, and tuples:
   - Strada reference: [`[checker.ts#L15369-L15440](https://github.com/microsoft/typescript-go/compare/main...RyanCavanaugh:fix63568?expand=1#)`](./_submodules/TypeScript/src/compiler/checker.ts#L15369-L15440)
   - Corsa implementation: [`[internal/checker/checker.go](https://github.com/microsoft/typescript-go/compare/main...RyanCavanaugh:fix63568?expand=1#)`](./internal/checker/checker.go)

5. Kept Corsa’s existing safeguard for pathological recursive conditional constraints, but adjusted indexed-access check types to use the regular constraint path when appropriate. This preserves the existing infinite-constraint behavior while allowing the #63568 recursive mapped/default constraint case to resolve like Strada.

6. Added a regression test:
   - [`[testdata/tests/cases/compiler/recursiveMappedTypeDefaultConstraint.ts](https://github.com/microsoft/typescript-go/compare/main...RyanCavanaugh:fix63568?expand=1#)`](./testdata/tests/cases/compiler/recursiveMappedTypeDefaultConstraint.ts)

The baseline update also improves the existing `infiniteConstraints` submodule output by removing one excessive-stack-depth diagnostic while retaining the intended indexing error.