### PR TITLE
Generate isSourceFile, fix updateSourceFile/cloneNode/getSynthesizedDeepClone for SourceFiles

### DIFF
--- a/_packages/native-preview/src/api/node/node.ts
+++ b/_packages/native-preview/src/api/node/node.ts
@@ -46,6 +46,12 @@ export class RemoteSourceFile extends RemoteNode implements SourceFileInfo {
     readonly _offsetStructuredData: number;
     readonly _decoder: TextDecoder;
     private _cachedText: string | undefined;
+    private _cachedReferencedFiles: readonly FileReference[] | undefined;
+    private _cachedTypeReferenceDirectives: readonly FileReference[] | undefined;
+    private _cachedLibReferenceDirectives: readonly FileReference[] | undefined;
+    private _cachedImports: readonly Node[] | undefined;
+    private _cachedModuleAugmentations: readonly Node[] | undefined;
+    private _cachedAmbientModuleNames: readonly string[] | undefined;
 
     constructor(data: Uint8Array, decoder: TextDecoder) {
         const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
@@ -160,33 +166,51 @@ export class RemoteSourceFile extends RemoteNode implements SourceFileInfo {
     }
 
     get referencedFiles(): readonly FileReference[] {
+        if (this._cachedReferencedFiles !== undefined) return this._cachedReferencedFiles;
         const offset = this.view.getUint32(this.extendedDataOffset + 20, true);
-        return this.readFileReferences(offset);
+        const files = this.readFileReferences(offset);
+        this._cachedReferencedFiles = files;
+        return files;
     }
 
     get typeReferenceDirectives(): readonly FileReference[] {
+        if (this._cachedTypeReferenceDirectives !== undefined) return this._cachedTypeReferenceDirectives;
         const offset = this.view.getUint32(this.extendedDataOffset + 24, true);
-        return this.readFileReferences(offset);
+        const directives = this.readFileReferences(offset);
+        this._cachedTypeReferenceDirectives = directives;
+        return directives;
     }
 
     get libReferenceDirectives(): readonly FileReference[] {
+        if (this._cachedLibReferenceDirectives !== undefined) return this._cachedLibReferenceDirectives;
         const offset = this.view.getUint32(this.extendedDataOffset + 28, true);
-        return this.readFileReferences(offset);
+        const directives = this.readFileReferences(offset);
+        this._cachedLibReferenceDirectives = directives;
+        return directives;
     }
 
     get imports(): readonly Node[] {
+        if (this._cachedImports !== undefined) return this._cachedImports;
         const offset = this.view.getUint32(this.extendedDataOffset + 32, true);
-        return this.readNodeIndexArray(offset);
+        const imports = this.readNodeIndexArray(offset);
+        this._cachedImports = imports;
+        return imports;
     }
 
     get moduleAugmentations(): readonly Node[] {
+        if (this._cachedModuleAugmentations !== undefined) return this._cachedModuleAugmentations;
         const offset = this.view.getUint32(this.extendedDataOffset + 36, true);
-        return this.readNodeIndexArray(offset);
+        const moduleAugmentations = this.readNodeIndexArray(offset);
+        this._cachedModuleAugmentations = moduleAugmentations;
+        return moduleAugmentations;
     }
 
     get ambientModuleNames(): readonly string[] {
+        if (this._cachedAmbientModuleNames !== undefined) return this._cachedAmbientModuleNames;
         const offset = this.view.getUint32(this.extendedDataOffset + 40, true);
-        return this.readStringArray(offset);
+        const names = this.readStringArray(offset);
+        this._cachedAmbientModuleNames = names;
+        return names;
     }
 
     get externalModuleIndicator(): Node | true | undefined {

--- a/_packages/native-preview/src/ast/factory.generated.ts
+++ b/_packages/native-preview/src/ast/factory.generated.ts
@@ -258,6 +258,7 @@ import type {
     YieldExpression,
 } from "./ast.ts";
 import { getTokenPosOfNode } from "./astnav.ts";
+import { cloneSourceFileData } from "./utils.ts";
 import {
     forEachChildOfJSDocParameterTag,
     forEachChildOfJSDocPropertyTag,
@@ -1094,7 +1095,7 @@ function cloneNodeData(node: Node): any {
         case SyntaxKind.JSDocPropertyTag:
             return { tagName: n.tagName, name: n.name, isBracketed: n.isBracketed, typeExpression: n.typeExpression, isNameFirst: n.isNameFirst, comment: n.comment };
         case SyntaxKind.SourceFile:
-            return { statements: n.statements, endOfFileToken: n.endOfFileToken, text: n.text, fileName: n.fileName, path: n.path };
+            return cloneSourceFileData(n);
         default:
             return undefined;
     }
@@ -3793,8 +3794,16 @@ export function createSourceFile(statements: readonly Statement[], endOfFileToke
     }) as unknown as SourceFile;
 }
 
+function cloneSourceFileWithChanges(source: SourceFile, statements: readonly Statement[], endOfFileToken: EndOfFile): SourceFile {
+    return new NodeObject(SyntaxKind.SourceFile, {
+        ...cloneSourceFileData(source),
+        statements: createNodeArray(statements),
+        endOfFileToken,
+    }) as unknown as SourceFile;
+}
+
 export function updateSourceFile(node: SourceFile, statements: readonly Statement[], endOfFileToken: EndOfFile): SourceFile {
     return node.statements !== statements || node.endOfFileToken !== endOfFileToken
-        ? createSourceFile(statements, endOfFileToken, node.text, node.fileName, node.path)
+        ? cloneSourceFileWithChanges(node, statements, endOfFileToken)
         : node;
 }

--- a/_packages/native-preview/src/ast/is.generated.ts
+++ b/_packages/native-preview/src/ast/is.generated.ts
@@ -273,6 +273,7 @@ import type {
     ShiftOperatorOrHigher,
     ShorthandPropertyAssignment,
     SignatureDeclaration,
+    SourceFile,
     SpreadAssignment,
     SpreadElement,
     StaticKeyword,
@@ -1032,6 +1033,10 @@ export function isJSDocSignature(node: Node): node is JSDocSignature {
 
 export function isJSDocNameReference(node: Node): node is JSDocNameReference {
     return node.kind === SyntaxKind.JSDocNameReference;
+}
+
+export function isSourceFile(node: Node): node is SourceFile {
+    return node.kind === SyntaxKind.SourceFile;
 }
 
 export function isModuleDeclaration(node: Node): node is ModuleDeclaration {

--- a/_packages/native-preview/src/ast/utils.ts
+++ b/_packages/native-preview/src/ast/utils.ts
@@ -1,4 +1,5 @@
 import { SyntaxKind } from "#enums/syntaxKind";
+import type { SourceFile } from "./ast.ts";
 
 let syntaxKindNames: Map<number, string> | undefined;
 function getSyntaxKindNames(): Map<number, string> {
@@ -27,4 +28,25 @@ export function cast<TOut extends TIn, TIn = any>(value: TIn | undefined, test: 
     if (value !== undefined && test(value)) return value;
 
     throw new Error(`Invalid cast. The supplied value ${value} did not pass the test '${test.name}'.`);
+}
+
+export function cloneSourceFileData(sourceFile: SourceFile): Record<string, unknown> {
+    return {
+        statements: sourceFile.statements,
+        endOfFileToken: sourceFile.endOfFileToken,
+        text: sourceFile.text,
+        fileName: sourceFile.fileName,
+        path: sourceFile.path,
+        languageVariant: sourceFile.languageVariant,
+        scriptKind: sourceFile.scriptKind,
+        isDeclarationFile: sourceFile.isDeclarationFile,
+        referencedFiles: sourceFile.referencedFiles,
+        typeReferenceDirectives: sourceFile.typeReferenceDirectives,
+        libReferenceDirectives: sourceFile.libReferenceDirectives,
+        imports: sourceFile.imports,
+        moduleAugmentations: sourceFile.moduleAugmentations,
+        ambientModuleNames: sourceFile.ambientModuleNames,
+        externalModuleIndicator: sourceFile.externalModuleIndicator,
+        tokenCache: sourceFile.tokenCache,
+    };
 }

--- a/_packages/native-preview/src/ast/utils.ts
+++ b/_packages/native-preview/src/ast/utils.ts
@@ -47,6 +47,6 @@ export function cloneSourceFileData(sourceFile: SourceFile): Record<string, unkn
         moduleAugmentations: sourceFile.moduleAugmentations,
         ambientModuleNames: sourceFile.ambientModuleNames,
         externalModuleIndicator: sourceFile.externalModuleIndicator,
-        tokenCache: undefined,
+        tokenCache: undefined,
     };
 }

--- a/_packages/native-preview/src/ast/utils.ts
+++ b/_packages/native-preview/src/ast/utils.ts
@@ -47,6 +47,6 @@ export function cloneSourceFileData(sourceFile: SourceFile): Record<string, unkn
         moduleAugmentations: sourceFile.moduleAugmentations,
         ambientModuleNames: sourceFile.ambientModuleNames,
         externalModuleIndicator: sourceFile.externalModuleIndicator,
-        tokenCache: sourceFile.tokenCache,
+        tokenCache: undefined,
     };
 }

--- a/_packages/native-preview/test/sync/ast.test.ts
+++ b/_packages/native-preview/test/sync/ast.test.ts
@@ -26,6 +26,7 @@ import {
     createIfStatement,
     createNodeArray,
     createNumericLiteral,
+    createSourceFile,
     createStringLiteral,
     createToken,
     NodeObject,
@@ -530,6 +531,19 @@ describe("RemoteNode + cloneNode", () => {
             assert.notStrictEqual(clone, sf);
             assert.ok(clone instanceof NodeObject);
             assert.strictEqual(clone.statements, sf.statements);
+            assert.strictEqual(clone.text, sf.text);
+            assert.strictEqual(clone.fileName, sf.fileName);
+            assert.strictEqual(clone.path, sf.path);
+            assert.strictEqual(clone.scriptKind, sf.scriptKind);
+            assert.strictEqual(clone.languageVariant, sf.languageVariant);
+            assert.strictEqual(clone.isDeclarationFile, sf.isDeclarationFile);
+            assert.strictEqual(clone.referencedFiles, sf.referencedFiles);
+            assert.strictEqual(clone.typeReferenceDirectives, sf.typeReferenceDirectives);
+            assert.strictEqual(clone.libReferenceDirectives, sf.libReferenceDirectives);
+            assert.strictEqual(clone.imports, sf.imports);
+            assert.strictEqual(clone.moduleAugmentations, sf.moduleAugmentations);
+            assert.strictEqual(clone.ambientModuleNames, sf.ambientModuleNames);
+            assert.strictEqual(clone.externalModuleIndicator, sf.externalModuleIndicator);
 
             assert.strictEqual(clone.kind, sf.kind);
             assert.strictEqual(clone.pos, sf.pos);
@@ -658,6 +672,33 @@ describe("RemoteNode + getSynthesizedDeepClone", () => {
                 assert.ok(node instanceof NodeObject);
                 node.forEachChild(visit);
             });
+        }
+        finally {
+            api.close();
+        }
+    });
+
+    test("deep clone of remote SourceFile preserves top-level metadata references", () => {
+        const api = spawnAPI();
+        try {
+            const sf = getRemoteSourceFile(api, "/tsconfig.json", "/src/foo.ts");
+            const referencedFiles = sf.referencedFiles;
+            const typeReferenceDirectives = sf.typeReferenceDirectives;
+            const libReferenceDirectives = sf.libReferenceDirectives;
+            const imports = sf.imports;
+            const moduleAugmentations = sf.moduleAugmentations;
+            const ambientModuleNames = sf.ambientModuleNames;
+
+            const clone = getSynthesizedDeepClone(sf);
+
+            assert.notStrictEqual(clone, sf);
+            assert.strictEqual(clone.referencedFiles, referencedFiles);
+            assert.strictEqual(clone.typeReferenceDirectives, typeReferenceDirectives);
+            assert.strictEqual(clone.libReferenceDirectives, libReferenceDirectives);
+            assert.strictEqual(clone.imports, imports);
+            assert.strictEqual(clone.moduleAugmentations, moduleAugmentations);
+            assert.strictEqual(clone.ambientModuleNames, ambientModuleNames);
+            assert.strictEqual(clone.externalModuleIndicator, sf.externalModuleIndicator);
         }
         finally {
             api.close();

--- a/_scripts/generate-ts-ast.ts
+++ b/_scripts/generate-ts-ast.ts
@@ -499,6 +499,9 @@ function generateFactory(): string {
     for (const t of ["Node", "NodeArray", "KeywordTypeSyntaxKind", "Token", "SourceFile", "KeywordTypeNode", "EndOfFile", "ImportPhaseModifierSyntaxKind", "Path", "Statement"]) {
         importTypes.add(t);
     }
+    const handWrittenCloneHelpers = api.nodes()
+        .filter(node => node.handWritten && !isVariantNode(node))
+        .map(node => ({ node, helperName: `clone${node.name}Data` }));
     // Remove enum types that are imported separately
     importTypes.delete("NodeFlags");
     importTypes.delete("SyntaxKind");
@@ -518,6 +521,13 @@ function generateFactory(): string {
     }
     out.push(`} from "./ast.ts";`);
     out.push(`import { getTokenPosOfNode } from "./astnav.ts";`);
+    if (handWrittenCloneHelpers.length > 0) {
+        out.push(`import {`);
+        for (const helperName of [...new Set(handWrittenCloneHelpers.map(h => h.helperName))].sort((a, b) => a.localeCompare(b))) {
+            out.push(`    ${helperName},`);
+        }
+        out.push(`} from "./utils.ts";`);
+    }
 
     // Import hand-written forEachChild functions
     const handWrittenForEachChildImports: string[] = [];
@@ -660,9 +670,12 @@ function generateFactory(): string {
         out.push(`        case SyntaxKind.${v.syntaxKind}:`);
         out.push(`            return { ${propStr} };`);
     }
-    // SourceFile is handWritten so we add its case manually
-    out.push(`        case SyntaxKind.SourceFile:`);
-    out.push(`            return { statements: n.statements, endOfFileToken: n.endOfFileToken, text: n.text, fileName: n.fileName, path: n.path };`);
+    for (const { node, helperName } of handWrittenCloneHelpers) {
+        for (const sk of node.allKinds()) {
+            out.push(`        case ${sk.formatTypeScript()}:`);
+        }
+        out.push(`            return ${helperName}(n);`);
+    }
     out.push(`        default:`);
     out.push(`            return undefined;`);
     out.push(`    }`);
@@ -1029,10 +1042,19 @@ function generateFactory(): string {
     out.push(`}`);
     out.push(``);
 
+    out.push(`function cloneSourceFileWithChanges(source: SourceFile, statements: readonly Statement[], endOfFileToken: EndOfFile): SourceFile {`);
+    out.push(`    return new NodeObject(SyntaxKind.SourceFile, {`);
+    out.push(`        ...cloneSourceFileData(source),`);
+    out.push(`        statements: createNodeArray(statements),`);
+    out.push(`        endOfFileToken,`);
+    out.push(`    }) as unknown as SourceFile;`);
+    out.push(`}`);
+    out.push(``);
+
     // ── updateSourceFile (hand-written in schema) ──
     out.push(`export function updateSourceFile(node: SourceFile, statements: readonly Statement[], endOfFileToken: EndOfFile): SourceFile {`);
     out.push(`    return node.statements !== statements || node.endOfFileToken !== endOfFileToken`);
-    out.push(`        ? createSourceFile(statements, endOfFileToken, node.text, node.fileName, node.path)`);
+    out.push(`        ? cloneSourceFileWithChanges(node, statements, endOfFileToken)`);
     out.push(`        : node;`);
     out.push(`}`);
     out.push(``);
@@ -1058,7 +1080,6 @@ function generateIsGenerated(): string {
     const guards: { funcName: string; typeName: string; kindChecks: string[]; kindAliasConstraint?: string; }[] = [];
 
     for (const node of api.nodes()) {
-        if (node.handWritten) continue;
         if (isVariantNode(node)) continue;
 
         const typeName = node.name;


### PR DESCRIPTION
Also in testing this, noticed a bug that new array instances were being created for every access of a RemoteSourceFile's `sf.imports`, `sf.moduleAugmentations`, etc., so fixed that too.

Closes #4208