### PR TITLE
Add `program.getSourceFileNames`, `checker.getApparentType`, `checker.getImmediateAliasedSymbol`, `checker.getMemberInModuleExports`, and `Type` type guards

### DIFF
--- a/_packages/native-preview/src/api/async/api.ts
+++ b/_packages/native-preview/src/api/async/api.ts
@@ -584,6 +584,14 @@ export class Program {
         return this.sourceFileCache.set(path, sourceFile, parseOptionsKey, contentHash, this.snapshotId, this.projectId);
     }
 
+    async getSourceFileNames(): Promise<readonly string[]> {
+        const data = await this.client.apiRequest<string[] | null>("getSourceFileNames", {
+            snapshot: this.snapshotId,
+            project: this.projectId,
+        });
+        return data ?? [];
+    }
+
     /**
      * Get syntactic (parse) diagnostics for a specific file or all files.
      * @param file - Optional file to get diagnostics for. If omitted, returns diagnostics for all files.
@@ -1148,6 +1156,15 @@ export class Checker {
         return data ? data.map(d => this.objectRegistry.getOrCreateType(d)) : [];
     }
 
+    async getApparentType(type: Type): Promise<Type | undefined> {
+        const data = await this.client.apiRequest<TypeResponse | null>("getApparentType", {
+            snapshot: this.snapshotId,
+            project: this.projectId,
+            type: type.id,
+        });
+        return data ? this.objectRegistry.getOrCreateType(data) : undefined;
+    }
+
     async getPropertiesOfType(type: Type): Promise<readonly Symbol[]> {
         const data = await this.client.apiRequest<SymbolResponse[] | null>("getPropertiesOfType", {
             snapshot: this.snapshotId,
@@ -1236,6 +1253,15 @@ export class Checker {
         return data ? this.objectRegistry.getOrCreateSymbol(data) : undefined;
     }
 
+    async getImmediateAliasedSymbol(symbol: Symbol): Promise<Symbol | undefined> {
+        const data = await this.client.apiRequest<SymbolResponse | null>("getImmediateAliasedSymbol", {
+            snapshot: this.snapshotId,
+            project: this.projectId,
+            symbol: symbol.id,
+        });
+        return data ? this.objectRegistry.getOrCreateSymbol(data) : undefined;
+    }
+
     async getExportsOfModule(symbol: Symbol): Promise<readonly Symbol[]> {
         const data = await this.client.apiRequest<SymbolResponse[] | null>("getExportsOfModule", {
             snapshot: this.snapshotId,
@@ -1243,6 +1269,16 @@ export class Checker {
             symbol: symbol.id,
         });
         return data ? data.map(d => this.objectRegistry.getOrCreateSymbol(d)) : [];
+    }
+
+    async getMemberInModuleExports(symbol: Symbol, name: string): Promise<Symbol | undefined> {
+        const data = await this.client.apiRequest<SymbolResponse | null>("getMemberInModuleExports", {
+            snapshot: this.snapshotId,
+            project: this.projectId,
+            symbol: symbol.id,
+            name,
+        });
+        return data ? this.objectRegistry.getOrCreateSymbol(data) : undefined;
     }
 
     async getJsDocTagsOfSymbol(symbol: Symbol): Promise<readonly JSDocTagInfo[]> {
@@ -1516,6 +1552,150 @@ class TypeObject implements Type {
     async getConstraint(): Promise<Type> {
         return this.objectRegistry.fetchType(this, "getConstraintOfType", this.substConstraint);
     }
+
+    isUnionType(): this is UnionType {
+        return isUnionType(this);
+    }
+
+    isIntersectionType(): this is IntersectionType {
+        return isIntersectionType(this);
+    }
+
+    isObjectType(): this is ObjectType {
+        return isObjectType(this);
+    }
+
+    isIntrinsicType(): this is IntrinsicType {
+        return isIntrinsicType(this);
+    }
+
+    isLiteralType(): this is LiteralType {
+        return isLiteralType(this);
+    }
+
+    isStringLiteralType(): this is StringLiteralType {
+        return isStringLiteralType(this);
+    }
+
+    isNumberLiteralType(): this is NumberLiteralType {
+        return isNumberLiteralType(this);
+    }
+
+    isBigIntLiteralType(): this is BigIntLiteralType {
+        return isBigIntLiteralType(this);
+    }
+
+    isBooleanLiteralType(): this is BooleanLiteralType {
+        return isBooleanLiteralType(this);
+    }
+
+    isTypeReference(): this is TypeReference {
+        return isTypeReference(this);
+    }
+
+    isTupleType(): this is TupleType {
+        return isTupleType(this);
+    }
+
+    isIndexType(): this is IndexType {
+        return isIndexType(this);
+    }
+
+    isIndexedAccessType(): this is IndexedAccessType {
+        return isIndexedAccessType(this);
+    }
+
+    isConditionalType(): this is ConditionalType {
+        return isConditionalType(this);
+    }
+
+    isSubstitutionType(): this is SubstitutionType {
+        return isSubstitutionType(this);
+    }
+
+    isTemplateLiteralType(): this is TemplateLiteralType {
+        return isTemplateLiteralType(this);
+    }
+
+    isStringMappingType(): this is StringMappingType {
+        return isStringMappingType(this);
+    }
+
+    isTypeParameter(): this is TypeParameter {
+        return isTypeParameter(this);
+    }
+}
+
+export function isUnionType(type: Type): type is UnionType {
+    return (type.flags & TypeFlags.Union) !== 0;
+}
+
+export function isIntersectionType(type: Type): type is IntersectionType {
+    return (type.flags & TypeFlags.Intersection) !== 0;
+}
+
+export function isObjectType(type: Type): type is ObjectType {
+    return (type.flags & TypeFlags.Object) !== 0;
+}
+
+export function isIntrinsicType(type: Type): type is IntrinsicType {
+    return (type.flags & TypeFlags.Intrinsic) !== 0;
+}
+
+export function isLiteralType(type: Type): type is LiteralType {
+    return (type.flags & TypeFlags.Literal) !== 0;
+}
+
+export function isStringLiteralType(type: Type): type is StringLiteralType {
+    return (type.flags & TypeFlags.StringLiteral) !== 0;
+}
+
+export function isNumberLiteralType(type: Type): type is NumberLiteralType {
+    return (type.flags & TypeFlags.NumberLiteral) !== 0;
+}
+
+export function isBigIntLiteralType(type: Type): type is BigIntLiteralType {
+    return (type.flags & TypeFlags.BigIntLiteral) !== 0;
+}
+
+export function isBooleanLiteralType(type: Type): type is BooleanLiteralType {
+    return (type.flags & TypeFlags.BooleanLiteral) !== 0;
+}
+
+export function isTypeReference(type: Type): type is TypeReference {
+    return isObjectType(type) && (type.objectFlags & ObjectFlags.Reference) !== 0;
+}
+
+export function isTupleType(type: Type): type is TupleType {
+    return isObjectType(type) && (type.objectFlags & ObjectFlags.Tuple) !== 0;
+}
+
+export function isIndexType(type: Type): type is IndexType {
+    return (type.flags & TypeFlags.Index) !== 0;
+}
+
+export function isIndexedAccessType(type: Type): type is IndexedAccessType {
+    return (type.flags & TypeFlags.IndexedAccess) !== 0;
+}
+
+export function isConditionalType(type: Type): type is ConditionalType {
+    return (type.flags & TypeFlags.Conditional) !== 0;
+}
+
+export function isSubstitutionType(type: Type): type is SubstitutionType {
+    return (type.flags & TypeFlags.Substitution) !== 0;
+}
+
+export function isTemplateLiteralType(type: Type): type is TemplateLiteralType {
+    return (type.flags & TypeFlags.TemplateLiteral) !== 0;
+}
+
+export function isStringMappingType(type: Type): type is StringMappingType {
+    return (type.flags & TypeFlags.StringMapping) !== 0;
+}
+
+export function isTypeParameter(type: Type): type is TypeParameter {
+    return (type.flags & TypeFlags.TypeParameter) !== 0;
 }
 
 export class Signature {

--- a/_packages/native-preview/src/api/async/types.ts
+++ b/_packages/native-preview/src/api/async/types.ts
@@ -22,10 +22,11 @@ import type {
  * ```
  */
 export interface Type {
+    /** Type flags — use to determine the specific kind of type. */
+    readonly flags: TypeFlags;
+
     /** Unique identifier for this type */
     readonly id: number;
-    /** Type flags — use to determine the specific kind of type */
-    readonly flags: TypeFlags;
 
     /** Get the symbol associated with this type, if any */
     getSymbol(): Promise<Symbol | undefined>;
@@ -35,6 +36,43 @@ export interface Type {
 
     /** Get the symbol of the type alias this type was instantiated from, if any */
     getAliasSymbol(): Promise<Symbol | undefined>;
+
+    /** Whether this type is a union type */
+    isUnionType(): this is UnionType;
+    /** Whether this type is an intersection type */
+    isIntersectionType(): this is IntersectionType;
+    /** Whether this type is an object type */
+    isObjectType(): this is ObjectType;
+    /** Whether this type is an intrinsic primitive type */
+    isIntrinsicType(): this is IntrinsicType;
+    /** Whether this type is a literal type */
+    isLiteralType(): this is LiteralType;
+    /** Whether this type is a string literal type */
+    isStringLiteralType(): this is StringLiteralType;
+    /** Whether this type is a number literal type */
+    isNumberLiteralType(): this is NumberLiteralType;
+    /** Whether this type is a bigint literal type */
+    isBigIntLiteralType(): this is BigIntLiteralType;
+    /** Whether this type is a boolean literal type */
+    isBooleanLiteralType(): this is BooleanLiteralType;
+    /** Whether this type is a type reference */
+    isTypeReference(): this is TypeReference;
+    /** Whether this type is a tuple type */
+    isTupleType(): this is TupleType;
+    /** Whether this type is an index type (`keyof T`) */
+    isIndexType(): this is IndexType;
+    /** Whether this type is an indexed access type (`T[K]`) */
+    isIndexedAccessType(): this is IndexedAccessType;
+    /** Whether this type is a conditional type */
+    isConditionalType(): this is ConditionalType;
+    /** Whether this type is a substitution type */
+    isSubstitutionType(): this is SubstitutionType;
+    /** Whether this type is a template literal type */
+    isTemplateLiteralType(): this is TemplateLiteralType;
+    /** Whether this type is a string mapping type */
+    isStringMappingType(): this is StringMappingType;
+    /** Whether this type is a type parameter */
+    isTypeParameter(): this is TypeParameter;
 }
 
 /**
@@ -79,7 +117,7 @@ export interface BooleanLiteralType extends LiteralType {
 
 /** Object types (TypeFlags.Object) */
 export interface ObjectType extends Type {
-    /** Object flags — use to determine the specific kind of object type */
+    /** Object flags — use to determine the specific kind of object type. */
     readonly objectFlags: ObjectFlags;
 }
 

--- a/_packages/native-preview/src/api/sync/api.ts
+++ b/_packages/native-preview/src/api/sync/api.ts
@@ -592,6 +592,14 @@ export class Program {
         return this.sourceFileCache.set(path, sourceFile, parseOptionsKey, contentHash, this.snapshotId, this.projectId);
     }
 
+    getSourceFileNames(): readonly string[] {
+        const data = this.client.apiRequest<string[] | null>("getSourceFileNames", {
+            snapshot: this.snapshotId,
+            project: this.projectId,
+        });
+        return data ?? [];
+    }
+
     /**
      * Get syntactic (parse) diagnostics for a specific file or all files.
      * @param file - Optional file to get diagnostics for. If omitted, returns diagnostics for all files.
@@ -1156,6 +1164,15 @@ export class Checker {
         return data ? data.map(d => this.objectRegistry.getOrCreateType(d)) : [];
     }
 
+    getApparentType(type: Type): Type | undefined {
+        const data = this.client.apiRequest<TypeResponse | null>("getApparentType", {
+            snapshot: this.snapshotId,
+            project: this.projectId,
+            type: type.id,
+        });
+        return data ? this.objectRegistry.getOrCreateType(data) : undefined;
+    }
+
     getPropertiesOfType(type: Type): readonly Symbol[] {
         const data = this.client.apiRequest<SymbolResponse[] | null>("getPropertiesOfType", {
             snapshot: this.snapshotId,
@@ -1244,6 +1261,15 @@ export class Checker {
         return data ? this.objectRegistry.getOrCreateSymbol(data) : undefined;
     }
 
+    getImmediateAliasedSymbol(symbol: Symbol): Symbol | undefined {
+        const data = this.client.apiRequest<SymbolResponse | null>("getImmediateAliasedSymbol", {
+            snapshot: this.snapshotId,
+            project: this.projectId,
+            symbol: symbol.id,
+        });
+        return data ? this.objectRegistry.getOrCreateSymbol(data) : undefined;
+    }
+
     getExportsOfModule(symbol: Symbol): readonly Symbol[] {
         const data = this.client.apiRequest<SymbolResponse[] | null>("getExportsOfModule", {
             snapshot: this.snapshotId,
@@ -1251,6 +1277,16 @@ export class Checker {
             symbol: symbol.id,
         });
         return data ? data.map(d => this.objectRegistry.getOrCreateSymbol(d)) : [];
+    }
+
+    getMemberInModuleExports(symbol: Symbol, name: string): Symbol | undefined {
+        const data = this.client.apiRequest<SymbolResponse | null>("getMemberInModuleExports", {
+            snapshot: this.snapshotId,
+            project: this.projectId,
+            symbol: symbol.id,
+            name,
+        });
+        return data ? this.objectRegistry.getOrCreateSymbol(data) : undefined;
     }
 
     getJsDocTagsOfSymbol(symbol: Symbol): readonly JSDocTagInfo[] {
@@ -1524,6 +1560,150 @@ class TypeObject implements Type {
     getConstraint(): Type {
         return this.objectRegistry.fetchType(this, "getConstraintOfType", this.substConstraint);
     }
+
+    isUnionType(): this is UnionType {
+        return isUnionType(this);
+    }
+
+    isIntersectionType(): this is IntersectionType {
+        return isIntersectionType(this);
+    }
+
+    isObjectType(): this is ObjectType {
+        return isObjectType(this);
+    }
+
+    isIntrinsicType(): this is IntrinsicType {
+        return isIntrinsicType(this);
+    }
+
+    isLiteralType(): this is LiteralType {
+        return isLiteralType(this);
+    }
+
+    isStringLiteralType(): this is StringLiteralType {
+        return isStringLiteralType(this);
+    }
+
+    isNumberLiteralType(): this is NumberLiteralType {
+        return isNumberLiteralType(this);
+    }
+
+    isBigIntLiteralType(): this is BigIntLiteralType {
+        return isBigIntLiteralType(this);
+    }
+
+    isBooleanLiteralType(): this is BooleanLiteralType {
+        return isBooleanLiteralType(this);
+    }
+
+    isTypeReference(): this is TypeReference {
+        return isTypeReference(this);
+    }
+
+    isTupleType(): this is TupleType {
+        return isTupleType(this);
+    }
+
+    isIndexType(): this is IndexType {
+        return isIndexType(this);
+    }
+
+    isIndexedAccessType(): this is IndexedAccessType {
+        return isIndexedAccessType(this);
+    }
+
+    isConditionalType(): this is ConditionalType {
+        return isConditionalType(this);
+    }
+
+    isSubstitutionType(): this is SubstitutionType {
+        return isSubstitutionType(this);
+    }
+
+    isTemplateLiteralType(): this is TemplateLiteralType {
+        return isTemplateLiteralType(this);
+    }
+
+    isStringMappingType(): this is StringMappingType {
+        return isStringMappingType(this);
+    }
+
+    isTypeParameter(): this is TypeParameter {
+        return isTypeParameter(this);
+    }
+}
+
+export function isUnionType(type: Type): type is UnionType {
+    return (type.flags & TypeFlags.Union) !== 0;
+}
+
+export function isIntersectionType(type: Type): type is IntersectionType {
+    return (type.flags & TypeFlags.Intersection) !== 0;
+}
+
+export function isObjectType(type: Type): type is ObjectType {
+    return (type.flags & TypeFlags.Object) !== 0;
+}
+
+export function isIntrinsicType(type: Type): type is IntrinsicType {
+    return (type.flags & TypeFlags.Intrinsic) !== 0;
+}
+
+export function isLiteralType(type: Type): type is LiteralType {
+    return (type.flags & TypeFlags.Literal) !== 0;
+}
+
+export function isStringLiteralType(type: Type): type is StringLiteralType {
+    return (type.flags & TypeFlags.StringLiteral) !== 0;
+}
+
+export function isNumberLiteralType(type: Type): type is NumberLiteralType {
+    return (type.flags & TypeFlags.NumberLiteral) !== 0;
+}
+
+export function isBigIntLiteralType(type: Type): type is BigIntLiteralType {
+    return (type.flags & TypeFlags.BigIntLiteral) !== 0;
+}
+
+export function isBooleanLiteralType(type: Type): type is BooleanLiteralType {
+    return (type.flags & TypeFlags.BooleanLiteral) !== 0;
+}
+
+export function isTypeReference(type: Type): type is TypeReference {
+    return isObjectType(type) && (type.objectFlags & ObjectFlags.Reference) !== 0;
+}
+
+export function isTupleType(type: Type): type is TupleType {
+    return isObjectType(type) && (type.objectFlags & ObjectFlags.Tuple) !== 0;
+}
+
+export function isIndexType(type: Type): type is IndexType {
+    return (type.flags & TypeFlags.Index) !== 0;
+}
+
+export function isIndexedAccessType(type: Type): type is IndexedAccessType {
+    return (type.flags & TypeFlags.IndexedAccess) !== 0;
+}
+
+export function isConditionalType(type: Type): type is ConditionalType {
+    return (type.flags & TypeFlags.Conditional) !== 0;
+}
+
+export function isSubstitutionType(type: Type): type is SubstitutionType {
+    return (type.flags & TypeFlags.Substitution) !== 0;
+}
+
+export function isTemplateLiteralType(type: Type): type is TemplateLiteralType {
+    return (type.flags & TypeFlags.TemplateLiteral) !== 0;
+}
+
+export function isStringMappingType(type: Type): type is StringMappingType {
+    return (type.flags & TypeFlags.StringMapping) !== 0;
+}
+
+export function isTypeParameter(type: Type): type is TypeParameter {
+    return (type.flags & TypeFlags.TypeParameter) !== 0;
 }
 
 export class Signature {

--- a/_packages/native-preview/src/api/sync/types.ts
+++ b/_packages/native-preview/src/api/sync/types.ts
@@ -30,10 +30,11 @@ import type {
  * ```
  */
 export interface Type {
+    /** Type flags — use to determine the specific kind of type. */
+    readonly flags: TypeFlags;
+
     /** Unique identifier for this type */
     readonly id: number;
-    /** Type flags — use to determine the specific kind of type */
-    readonly flags: TypeFlags;
 
     /** Get the symbol associated with this type, if any */
     getSymbol(): Symbol | undefined;
@@ -43,6 +44,43 @@ export interface Type {
 
     /** Get the symbol of the type alias this type was instantiated from, if any */
     getAliasSymbol(): Symbol | undefined;
+
+    /** Whether this type is a union type */
+    isUnionType(): this is UnionType;
+    /** Whether this type is an intersection type */
+    isIntersectionType(): this is IntersectionType;
+    /** Whether this type is an object type */
+    isObjectType(): this is ObjectType;
+    /** Whether this type is an intrinsic primitive type */
+    isIntrinsicType(): this is IntrinsicType;
+    /** Whether this type is a literal type */
+    isLiteralType(): this is LiteralType;
+    /** Whether this type is a string literal type */
+    isStringLiteralType(): this is StringLiteralType;
+    /** Whether this type is a number literal type */
+    isNumberLiteralType(): this is NumberLiteralType;
+    /** Whether this type is a bigint literal type */
+    isBigIntLiteralType(): this is BigIntLiteralType;
+    /** Whether this type is a boolean literal type */
+    isBooleanLiteralType(): this is BooleanLiteralType;
+    /** Whether this type is a type reference */
+    isTypeReference(): this is TypeReference;
+    /** Whether this type is a tuple type */
+    isTupleType(): this is TupleType;
+    /** Whether this type is an index type (`keyof T`) */
+    isIndexType(): this is IndexType;
+    /** Whether this type is an indexed access type (`T[K]`) */
+    isIndexedAccessType(): this is IndexedAccessType;
+    /** Whether this type is a conditional type */
+    isConditionalType(): this is ConditionalType;
+    /** Whether this type is a substitution type */
+    isSubstitutionType(): this is SubstitutionType;
+    /** Whether this type is a template literal type */
+    isTemplateLiteralType(): this is TemplateLiteralType;
+    /** Whether this type is a string mapping type */
+    isStringMappingType(): this is StringMappingType;
+    /** Whether this type is a type parameter */
+    isTypeParameter(): this is TypeParameter;
 }
 
 /**
@@ -87,7 +125,7 @@ export interface BooleanLiteralType extends LiteralType {
 
 /** Object types (TypeFlags.Object) */
 export interface ObjectType extends Type {
-    /** Object flags — use to determine the specific kind of object type */
+    /** Object flags — use to determine the specific kind of object type. */
     readonly objectFlags: ObjectFlags;
 }
 

--- a/_packages/native-preview/test/async/api.test.ts
+++ b/_packages/native-preview/test/async/api.test.ts
@@ -86,6 +86,29 @@ describe("API", () => {
     });
 });
 
+describe("Checker - getImmediateAliasedSymbol", () => {
+    test("resolves one level of alias indirection", async () => {
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/foo.ts": `export const foo = 42;`,
+            "/src/main.ts": `import { foo } from "./foo";\nexport const usage = foo;`,
+        });
+        try {
+            const snapshot = await api.updateSnapshot({ openProject: "/tsconfig.json" });
+            const project = snapshot.getProject("/tsconfig.json")!;
+            const pos = `import { foo } from "./foo";`.indexOf("foo }");
+            const aliasSymbol = await project.checker.getSymbolAtPosition("/src/main.ts", pos);
+            assert.ok(aliasSymbol);
+            const aliased = await project.checker.getImmediateAliasedSymbol(aliasSymbol);
+            assert.ok(aliased, "Should resolve the immediate aliased symbol");
+            assert.equal(aliased.name, "foo");
+        }
+        finally {
+            await api.close();
+        }
+    });
+});
+
 describe("Snapshot", () => {
     test("updateSnapshot returns snapshot with projects", async () => {
         const api = spawnAPI();
@@ -155,7 +178,87 @@ describe("Snapshot", () => {
     });
 });
 
+describe("Checker - getApparentType", () => {
+    test("returns the apparent type of a literal type", async () => {
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/main.ts": `export const x = "hello" as const;`,
+        });
+        try {
+            const snapshot = await api.updateSnapshot({ openProject: "/tsconfig.json" });
+            const project = snapshot.getProject("/tsconfig.json")!;
+            const pos = `export const x = "hello" as const;`.indexOf("x =");
+            const symbol = await project.checker.getSymbolAtPosition("/src/main.ts", pos);
+            assert.ok(symbol);
+            const type = await project.checker.getTypeOfSymbol(symbol);
+            assert.ok(type);
+            assert.equal(type.isLiteralType(), true);
+            assert.equal(type.isStringLiteralType(), true);
+            assert.equal(type.isIntrinsicType(), false);
+            const apparent = await project.checker.getApparentType(type);
+            assert.ok(apparent);
+            assert.ok(apparent.id > 0);
+        }
+        finally {
+            await api.close();
+        }
+    });
+});
+
+describe("Checker - getMemberInModuleExports", () => {
+    test("returns a named export when present", async () => {
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/index.ts": `export const direct = 1;`,
+        });
+        try {
+            const snapshot = await api.updateSnapshot({ openProject: "/tsconfig.json" });
+            const project = snapshot.getProject("/tsconfig.json")!;
+            const sourceFile = await project.program.getSourceFile("/src/index.ts");
+            assert.ok(sourceFile);
+            const moduleSymbol = await project.checker.getSymbolAtLocation(sourceFile);
+            assert.ok(moduleSymbol);
+            const found = await project.checker.getMemberInModuleExports(moduleSymbol, "direct");
+            assert.ok(found);
+            assert.equal(found.name, "direct");
+            const missing = await project.checker.getMemberInModuleExports(moduleSymbol, "missing");
+            assert.equal(missing, undefined);
+        }
+        finally {
+            await api.close();
+        }
+    });
+});
+
 describe("SourceFile", () => {
+    test("getSourceFileNames returns all program files, not just root files", async () => {
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({
+                compilerOptions: {
+                    moduleResolution: "node10",
+                    noLib: true,
+                },
+            }),
+            "/src/index.ts": `import { foo } from "./foo";\nimport { bar } from "my-lib";\nexport const result = foo + bar;`,
+            "/src/foo.ts": `export const foo = 42;`,
+            "/node_modules/my-lib/package.json": JSON.stringify({ name: "my-lib", types: "./index.d.ts" }),
+            "/node_modules/my-lib/index.d.ts": `export declare const bar: number;`,
+        });
+        try {
+            const snapshot = await api.updateSnapshot({ openProject: "/tsconfig.json" });
+            const project = snapshot.getProject("/tsconfig.json")!;
+            const fileNames = await project.program.getSourceFileNames();
+            assert.deepEqual(fileNames, [
+                "/src/foo.ts",
+                "/node_modules/my-lib/index.d.ts",
+                "/src/index.ts",
+            ]);
+        }
+        finally {
+            await api.close();
+        }
+    });
+
     test("file properties", async () => {
         const api = spawnAPI();
         try {
@@ -1279,6 +1382,9 @@ export const tuple: readonly [number, string?, ...boolean[]] = [1];
             assert.ok(type.flags & TypeFlags.Object);
             const ref = type as TypeReference;
             assert.ok(ref.objectFlags & ObjectFlags.Reference);
+            assert.equal(type.isObjectType(), true);
+            assert.equal(type.isTypeReference(), true);
+            assert.equal(type.isLiteralType(), false);
             const target = await ref.getTarget();
             assert.ok(target);
             assert.ok(target.flags & TypeFlags.Object);
@@ -1295,6 +1401,8 @@ export const tuple: readonly [number, string?, ...boolean[]] = [1];
             const union = type as UnionOrIntersectionType;
             const types = await union.getTypes();
             assert.ok(types.length >= 2);
+            assert.equal(type.isUnionType(), true);
+            assert.equal(type.isIntersectionType(), false);
         }
         finally {
             await api.close();
@@ -1345,6 +1453,7 @@ export const tuple: readonly [number, string?, ...boolean[]] = [1];
             assert.ok(type);
             assert.ok(type.flags & TypeFlags.IndexedAccess, `Expected IndexedAccessType, got flags ${type.flags}`);
             const ia = type as IndexedAccessType;
+            assert.equal(type.isIndexedAccessType(), true);
             const objectType = await ia.getObjectType();
             assert.ok(objectType);
             const indexType = await ia.getIndexType();
@@ -1366,6 +1475,7 @@ export const tuple: readonly [number, string?, ...boolean[]] = [1];
             assert.ok(type);
             assert.ok(type.flags & TypeFlags.Conditional, `Expected ConditionalType, got flags ${type.flags}`);
             const cond = type as ConditionalType;
+            assert.equal(type.isConditionalType(), true);
             const checkType = await cond.getCheckType();
             assert.ok(checkType);
             const extendsType = await cond.getExtendsType();

--- a/_packages/native-preview/test/sync/api.test.ts
+++ b/_packages/native-preview/test/sync/api.test.ts
@@ -94,6 +94,29 @@ describe("API", () => {
     });
 });
 
+describe("Checker - getImmediateAliasedSymbol", () => {
+    test("resolves one level of alias indirection", () => {
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/foo.ts": `export const foo = 42;`,
+            "/src/main.ts": `import { foo } from "./foo";\nexport const usage = foo;`,
+        });
+        try {
+            const snapshot = api.updateSnapshot({ openProject: "/tsconfig.json" });
+            const project = snapshot.getProject("/tsconfig.json")!;
+            const pos = `import { foo } from "./foo";`.indexOf("foo }");
+            const aliasSymbol = project.checker.getSymbolAtPosition("/src/main.ts", pos);
+            assert.ok(aliasSymbol);
+            const aliased = project.checker.getImmediateAliasedSymbol(aliasSymbol);
+            assert.ok(aliased, "Should resolve the immediate aliased symbol");
+            assert.equal(aliased.name, "foo");
+        }
+        finally {
+            api.close();
+        }
+    });
+});
+
 describe("Snapshot", () => {
     test("updateSnapshot returns snapshot with projects", () => {
         const api = spawnAPI();
@@ -163,7 +186,87 @@ describe("Snapshot", () => {
     });
 });
 
+describe("Checker - getApparentType", () => {
+    test("returns the apparent type of a literal type", () => {
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/main.ts": `export const x = "hello" as const;`,
+        });
+        try {
+            const snapshot = api.updateSnapshot({ openProject: "/tsconfig.json" });
+            const project = snapshot.getProject("/tsconfig.json")!;
+            const pos = `export const x = "hello" as const;`.indexOf("x =");
+            const symbol = project.checker.getSymbolAtPosition("/src/main.ts", pos);
+            assert.ok(symbol);
+            const type = project.checker.getTypeOfSymbol(symbol);
+            assert.ok(type);
+            assert.equal(type.isLiteralType(), true);
+            assert.equal(type.isStringLiteralType(), true);
+            assert.equal(type.isIntrinsicType(), false);
+            const apparent = project.checker.getApparentType(type);
+            assert.ok(apparent);
+            assert.ok(apparent.id > 0);
+        }
+        finally {
+            api.close();
+        }
+    });
+});
+
+describe("Checker - getMemberInModuleExports", () => {
+    test("returns a named export when present", () => {
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/index.ts": `export const direct = 1;`,
+        });
+        try {
+            const snapshot = api.updateSnapshot({ openProject: "/tsconfig.json" });
+            const project = snapshot.getProject("/tsconfig.json")!;
+            const sourceFile = project.program.getSourceFile("/src/index.ts");
+            assert.ok(sourceFile);
+            const moduleSymbol = project.checker.getSymbolAtLocation(sourceFile);
+            assert.ok(moduleSymbol);
+            const found = project.checker.getMemberInModuleExports(moduleSymbol, "direct");
+            assert.ok(found);
+            assert.equal(found.name, "direct");
+            const missing = project.checker.getMemberInModuleExports(moduleSymbol, "missing");
+            assert.equal(missing, undefined);
+        }
+        finally {
+            api.close();
+        }
+    });
+});
+
 describe("SourceFile", () => {
+    test("getSourceFileNames returns all program files, not just root files", () => {
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({
+                compilerOptions: {
+                    moduleResolution: "node10",
+                    noLib: true,
+                },
+            }),
+            "/src/index.ts": `import { foo } from "./foo";\nimport { bar } from "my-lib";\nexport const result = foo + bar;`,
+            "/src/foo.ts": `export const foo = 42;`,
+            "/node_modules/my-lib/package.json": JSON.stringify({ name: "my-lib", types: "./index.d.ts" }),
+            "/node_modules/my-lib/index.d.ts": `export declare const bar: number;`,
+        });
+        try {
+            const snapshot = api.updateSnapshot({ openProject: "/tsconfig.json" });
+            const project = snapshot.getProject("/tsconfig.json")!;
+            const fileNames = project.program.getSourceFileNames();
+            assert.deepEqual(fileNames, [
+                "/src/foo.ts",
+                "/node_modules/my-lib/index.d.ts",
+                "/src/index.ts",
+            ]);
+        }
+        finally {
+            api.close();
+        }
+    });
+
     test("file properties", () => {
         const api = spawnAPI();
         try {
@@ -1287,6 +1390,9 @@ export const tuple: readonly [number, string?, ...boolean[]] = [1];
             assert.ok(type.flags & TypeFlags.Object);
             const ref = type as TypeReference;
             assert.ok(ref.objectFlags & ObjectFlags.Reference);
+            assert.equal(type.isObjectType(), true);
+            assert.equal(type.isTypeReference(), true);
+            assert.equal(type.isLiteralType(), false);
             const target = ref.getTarget();
             assert.ok(target);
             assert.ok(target.flags & TypeFlags.Object);
@@ -1303,6 +1409,8 @@ export const tuple: readonly [number, string?, ...boolean[]] = [1];
             const union = type as UnionOrIntersectionType;
             const types = union.getTypes();
             assert.ok(types.length >= 2);
+            assert.equal(type.isUnionType(), true);
+            assert.equal(type.isIntersectionType(), false);
         }
         finally {
             api.close();
@@ -1353,6 +1461,7 @@ export const tuple: readonly [number, string?, ...boolean[]] = [1];
             assert.ok(type);
             assert.ok(type.flags & TypeFlags.IndexedAccess, `Expected IndexedAccessType, got flags ${type.flags}`);
             const ia = type as IndexedAccessType;
+            assert.equal(type.isIndexedAccessType(), true);
             const objectType = ia.getObjectType();
             assert.ok(objectType);
             const indexType = ia.getIndexType();
@@ -1374,6 +1483,7 @@ export const tuple: readonly [number, string?, ...boolean[]] = [1];
             assert.ok(type);
             assert.ok(type.flags & TypeFlags.Conditional, `Expected ConditionalType, got flags ${type.flags}`);
             const cond = type as ConditionalType;
+            assert.equal(type.isConditionalType(), true);
             const checkType = cond.getCheckType();
             assert.ok(checkType);
             const extendsType = cond.getExtendsType();

--- a/internal/api/proto.go
+++ b/internal/api/proto.go
@@ -68,6 +68,7 @@ const (
 	MethodGetTypesOfSymbols        Method = "getTypesOfSymbols"
 	MethodGetDeclaredTypeOfSymbol  Method = "getDeclaredTypeOfSymbol"
 	MethodGetSourceFile            Method = "getSourceFile"
+	MethodGetSourceFileNames       Method = "getSourceFileNames"
 	MethodResolveName              Method = "resolveName"
 	MethodGetSignaturesOfType      Method = "getSignaturesOfType"
 	MethodGetResolvedSignature     Method = "getResolvedSignature"
@@ -126,6 +127,7 @@ const (
 	MethodGetTypePredicateOfSignature       Method = "getTypePredicateOfSignature"
 	MethodGetBaseTypes                      Method = "getBaseTypes"
 	MethodGetPropertiesOfType               Method = "getPropertiesOfType"
+	MethodGetApparentType                   Method = "getApparentType"
 	MethodGetPropertyOfType                 Method = "getPropertyOfType"
 	MethodGetIndexInfosOfType               Method = "getIndexInfosOfType"
 	MethodGetConstraintOfTypeParameter      Method = "getConstraintOfTypeParameter"
@@ -135,7 +137,9 @@ const (
 	MethodGetSignatureFromDeclaration       Method = "getSignatureFromDeclaration"
 	MethodGetExportSpecifierLocalTarget     Method = "getExportSpecifierLocalTargetSymbol"
 	MethodGetAliasedSymbol                  Method = "getAliasedSymbol"
+	MethodGetImmediateAliasedSymbol         Method = "getImmediateAliasedSymbol"
 	MethodGetExportsOfModule                Method = "getExportsOfModule"
+	MethodGetMemberInModuleExports          Method = "getMemberInModuleExports"
 	MethodGetJSDocTags                      Method = "getJsDocTags"
 	MethodGetDocumentationComment           Method = "getDocumentationComment"
 	MethodIsArrayType                       Method = "isArrayType"
@@ -343,6 +347,7 @@ var unmarshalers = map[Method]func([]byte) (any, error){
 	MethodParseConfigFile:          unmarshallerFor[ParseConfigFileParams],
 	MethodGetDefaultProjectForFile: unmarshallerFor[GetDefaultProjectForFileParams],
 	MethodGetSourceFile:            unmarshallerFor[GetSourceFileParams],
+	MethodGetSourceFileNames:       unmarshallerFor[GetSourceFileNamesParams],
 	MethodGetSymbolAtPosition:      unmarshallerFor[GetSymbolAtPositionParams],
 	MethodGetSymbolsAtPositions:    unmarshallerFor[GetSymbolsAtPositionsParams],
 	MethodGetSymbolAtLocation:      unmarshallerFor[GetSymbolAtLocationParams],
@@ -404,6 +409,7 @@ var unmarshalers = map[Method]func([]byte) (any, error){
 	MethodGetTypePredicateOfSignature:       unmarshallerFor[CheckerSignatureParams],
 	MethodGetBaseTypes:                      unmarshallerFor[CheckerTypeParams],
 	MethodGetPropertiesOfType:               unmarshallerFor[CheckerTypeParams],
+	MethodGetApparentType:                   unmarshallerFor[CheckerTypeParams],
 	MethodGetPropertyOfType:                 unmarshallerFor[GetPropertyOfTypeParams],
 	MethodGetIndexInfosOfType:               unmarshallerFor[CheckerTypeParams],
 	MethodGetConstraintOfTypeParameter:      unmarshallerFor[CheckerTypeParams],
@@ -413,7 +419,9 @@ var unmarshalers = map[Method]func([]byte) (any, error){
 	MethodGetSignatureFromDeclaration:       unmarshallerFor[CheckerNodeParams],
 	MethodGetExportSpecifierLocalTarget:     unmarshallerFor[CheckerNodeParams],
 	MethodGetAliasedSymbol:                  unmarshallerFor[CheckerSymbolParams],
+	MethodGetImmediateAliasedSymbol:         unmarshallerFor[CheckerSymbolParams],
 	MethodGetExportsOfModule:                unmarshallerFor[CheckerSymbolParams],
+	MethodGetMemberInModuleExports:          unmarshallerFor[GetMemberInModuleExportsParams],
 	MethodGetJSDocTags:                      unmarshallerFor[CheckerSymbolParams],
 	MethodGetDocumentationComment:           unmarshallerFor[CheckerSymbolParams],
 	MethodIsArrayType:                       unmarshallerFor[CheckerTypeParams],
@@ -734,6 +742,11 @@ type GetSourceFileParams struct {
 	File     DocumentIdentifier `json:"file"`
 }
 
+type GetSourceFileNamesParams struct {
+	Snapshot SnapshotID `json:"snapshot"`
+	Project  ProjectID  `json:"project"`
+}
+
 type ResolveNameParams struct {
 	Snapshot       SnapshotID          `json:"snapshot"`
 	Project        ProjectID           `json:"project"`
@@ -985,6 +998,14 @@ type GetPropertyOfTypeParams struct {
 	Snapshot SnapshotID `json:"snapshot"`
 	Project  ProjectID  `json:"project"`
 	Type     TypeID     `json:"type"`
+	Name     string     `json:"name"`
+}
+
+// GetMemberInModuleExportsParams are parameters for getMemberInModuleExports.
+type GetMemberInModuleExportsParams struct {
+	Snapshot SnapshotID `json:"snapshot"`
+	Project  ProjectID  `json:"project"`
+	Symbol   SymbolID   `json:"symbol"`
 	Name     string     `json:"name"`
 }
 

--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -525,6 +525,8 @@ func (s *Session) HandleRequest(ctx context.Context, method string, params json.
 		return s.handleGetDefaultProjectForFile(ctx, parsed.(*GetDefaultProjectForFileParams))
 	case string(MethodGetSourceFile):
 		return s.handleGetSourceFile(ctx, parsed.(*GetSourceFileParams))
+	case string(MethodGetSourceFileNames):
+		return s.handleGetSourceFileNames(ctx, parsed.(*GetSourceFileNamesParams))
 	case string(MethodGetSymbolAtPosition):
 		return s.handleGetSymbolAtPosition(ctx, parsed.(*GetSymbolAtPositionParams))
 	case string(MethodGetSymbolsAtPositions):
@@ -641,6 +643,8 @@ func (s *Session) HandleRequest(ctx context.Context, method string, params json.
 		return s.handleGetBaseTypes(ctx, parsed.(*CheckerTypeParams))
 	case string(MethodGetPropertiesOfType):
 		return s.handleGetPropertiesOfType(ctx, parsed.(*CheckerTypeParams))
+	case string(MethodGetApparentType):
+		return s.handleGetApparentType(ctx, parsed.(*CheckerTypeParams))
 	case string(MethodGetPropertyOfType):
 		return s.handleGetPropertyOfType(ctx, parsed.(*GetPropertyOfTypeParams))
 	case string(MethodGetIndexInfosOfType):
@@ -659,8 +663,12 @@ func (s *Session) HandleRequest(ctx context.Context, method string, params json.
 		return s.handleGetExportSpecifierLocalTargetSymbol(ctx, parsed.(*CheckerNodeParams))
 	case string(MethodGetAliasedSymbol):
 		return s.handleGetAliasedSymbol(ctx, parsed.(*CheckerSymbolParams))
+	case string(MethodGetImmediateAliasedSymbol):
+		return s.handleGetImmediateAliasedSymbol(ctx, parsed.(*CheckerSymbolParams))
 	case string(MethodGetExportsOfModule):
 		return s.handleGetExportsOfModule(ctx, parsed.(*CheckerSymbolParams))
+	case string(MethodGetMemberInModuleExports):
+		return s.handleGetMemberInModuleExports(ctx, parsed.(*GetMemberInModuleExportsParams))
 	case string(MethodGetJSDocTags):
 		return s.handleGetJSDocTags(ctx, parsed.(*CheckerSymbolParams))
 	case string(MethodGetDocumentationComment):
@@ -1019,6 +1027,26 @@ func (s *Session) handleGetSourceFile(ctx context.Context, params *GetSourceFile
 	return &SourceFileResponse{
 		Data: base64.StdEncoding.EncodeToString(data),
 	}, nil
+}
+
+// handleGetSourceFileNames returns file names of all source files in a project.
+func (s *Session) handleGetSourceFileNames(ctx context.Context, params *GetSourceFileNamesParams) ([]string, error) {
+	sd, err := s.getSnapshotData(params.Snapshot)
+	if err != nil {
+		return nil, err
+	}
+
+	program, err := sd.getProgram(params.Project)
+	if err != nil {
+		return nil, err
+	}
+
+	sourceFiles := program.GetSourceFiles()
+	result := make([]string, len(sourceFiles))
+	for i, sourceFile := range sourceFiles {
+		result[i] = sourceFile.FileName()
+	}
+	return result, nil
 }
 
 // handleGetSymbolAtPosition returns the symbol at a position in a file.
@@ -2223,6 +2251,27 @@ func (s *Session) handleGetPropertiesOfType(ctx context.Context, params *Checker
 	return results, nil
 }
 
+// handleGetApparentType returns the apparent type of a type.
+func (s *Session) handleGetApparentType(ctx context.Context, params *CheckerTypeParams) (*TypeResponse, error) {
+	setup, err := s.setupChecker(ctx, params.Snapshot, params.Project)
+	if err != nil {
+		return nil, err
+	}
+	defer setup.done()
+
+	t, err := setup.resolveTypeHandle(params.Type)
+	if err != nil {
+		return nil, err
+	}
+
+	apparent := setup.checker.GetApparentType(t)
+	if apparent == nil {
+		return nil, nil
+	}
+
+	return setup.newTypeResponse(apparent), nil
+}
+
 // handleGetIndexInfosOfType returns the index infos of a type.
 func (s *Session) handleGetIndexInfosOfType(ctx context.Context, params *CheckerTypeParams) ([]*IndexInfoResponse, error) {
 	setup, err := s.setupChecker(ctx, params.Snapshot, params.Project)
@@ -2410,6 +2459,30 @@ func (s *Session) handleGetAliasedSymbol(ctx context.Context, params *CheckerSym
 	return setup.newSymbolResponse(aliased), nil
 }
 
+// handleGetImmediateAliasedSymbol resolves one level of alias indirection.
+func (s *Session) handleGetImmediateAliasedSymbol(ctx context.Context, params *CheckerSymbolParams) (*SymbolResponse, error) {
+	setup, err := s.setupChecker(ctx, params.Snapshot, params.Project)
+	if err != nil {
+		return nil, err
+	}
+	defer setup.done()
+
+	symbol, err := setup.resolveSymbolHandle(params.Symbol)
+	if err != nil {
+		return nil, err
+	}
+	if symbol == nil {
+		return nil, nil
+	}
+
+	aliased := setup.checker.GetImmediateAliasedSymbol(symbol)
+	if aliased == nil {
+		return nil, nil
+	}
+
+	return setup.newSymbolResponse(aliased), nil
+}
+
 // handleGetExportsOfModule returns the resolved exports of a module symbol,
 // including those introduced by `export *` and re-exports.
 func (s *Session) handleGetExportsOfModule(ctx context.Context, params *CheckerSymbolParams) ([]*SymbolResponse, error) {
@@ -2438,6 +2511,30 @@ func (s *Session) handleGetExportsOfModule(ctx context.Context, params *CheckerS
 	}
 
 	return results, nil
+}
+
+// handleGetMemberInModuleExports returns an export by name from a module symbol.
+func (s *Session) handleGetMemberInModuleExports(ctx context.Context, params *GetMemberInModuleExportsParams) (*SymbolResponse, error) {
+	setup, err := s.setupChecker(ctx, params.Snapshot, params.Project)
+	if err != nil {
+		return nil, err
+	}
+	defer setup.done()
+
+	symbol, err := setup.resolveSymbolHandle(params.Symbol)
+	if err != nil {
+		return nil, err
+	}
+	if symbol == nil {
+		return nil, nil
+	}
+
+	member := setup.checker.TryGetMemberInModuleExports(params.Name, symbol)
+	if member == nil {
+		return nil, nil
+	}
+
+	return setup.newSymbolResponse(member), nil
 }
 
 // handleGetJSDocTags returns the JSDoc tags of a symbol as structured name/text pairs.


### PR DESCRIPTION
This, along with #4434 and #4431, finishes out the current list of things people have specifically asked for that are also trivially easy.