### PR TITLE
[api] Tighten client-side type safety of Type subtypes

### DIFF
--- a/_packages/native-preview/src/api/async/api.ts
+++ b/_packages/native-preview/src/api/async/api.ts
@@ -1139,7 +1139,11 @@ export class Checker {
         } as TypePredicate;
     }
 
-    async getBaseTypes(type: Type): Promise<readonly Type[]> {
+    /**
+     * Get the base types of a class or interface type. A type with no base types
+     * yields an empty array.
+     */
+    async getBaseTypes(type: InterfaceType): Promise<readonly Type[]> {
         const data = await this.client.apiRequest<TypeResponse[] | null>("getBaseTypes", {
             snapshot: this.snapshotId,
             project: this.projectId,
@@ -1172,7 +1176,11 @@ export class Checker {
         }));
     }
 
-    async getConstraintOfTypeParameter(type: Type): Promise<Type | undefined> {
+    /**
+     * Get the constraint of a type parameter (the `T` in `<U extends T>`), or
+     * undefined if it has none.
+     */
+    async getConstraintOfTypeParameter(type: TypeParameter): Promise<Type | undefined> {
         const data = await this.client.apiRequest<TypeResponse | null>("getConstraintOfTypeParameter", {
             snapshot: this.snapshotId,
             project: this.projectId,
@@ -1262,7 +1270,10 @@ export class Checker {
         });
     }
 
-    async getTypeArguments(type: Type): Promise<readonly Type[]> {
+    /**
+     * Get the type arguments of a type reference (e.g. the `string` in `Array<string>`).
+     */
+    async getTypeArguments(type: TypeReference): Promise<readonly Type[]> {
         const data = await this.client.apiRequest<TypeResponse[] | null>("getTypeArguments", {
             snapshot: this.snapshotId,
             project: this.projectId,
@@ -1473,20 +1484,26 @@ class TypeObject implements Type {
         return this.objectRegistry.fetchType(this, "getRegularTypeOfType", this.regularType);
     }
 
-    async getTypes(): Promise<readonly Type[]> {
+    async getTypes(): Promise<readonly Type[] | undefined> {
+        // Only union, intersection, and template literal types have constituent
+        // types; any other kind has none, so return undefined rather than sending
+        // a request the server cannot satisfy.
+        if (!(this.flags & (TypeFlags.UnionOrIntersection | TypeFlags.TemplateLiteral))) {
+            return undefined;
+        }
         return this.objectRegistry.fetchTypes(this, "getTypesOfType");
     }
 
-    async getTypeParameters(): Promise<readonly Type[]> {
-        return this.objectRegistry.fetchTypes(this, "getTypeParametersOfType", this.typeParameters);
+    async getTypeParameters(): Promise<readonly TypeParameter[]> {
+        return this.objectRegistry.fetchTypes(this, "getTypeParametersOfType", this.typeParameters) as Promise<readonly TypeParameter[]>;
     }
 
-    async getOuterTypeParameters(): Promise<readonly Type[]> {
-        return this.objectRegistry.fetchTypes(this, "getOuterTypeParametersOfType", this.outerTypeParameters);
+    async getOuterTypeParameters(): Promise<readonly TypeParameter[]> {
+        return this.objectRegistry.fetchTypes(this, "getOuterTypeParametersOfType", this.outerTypeParameters) as Promise<readonly TypeParameter[]>;
     }
 
-    async getLocalTypeParameters(): Promise<readonly Type[]> {
-        return this.objectRegistry.fetchTypes(this, "getLocalTypeParametersOfType", this.localTypeParameters);
+    async getLocalTypeParameters(): Promise<readonly TypeParameter[]> {
+        return this.objectRegistry.fetchTypes(this, "getLocalTypeParametersOfType", this.localTypeParameters) as Promise<readonly TypeParameter[]>;
     }
 
     async getAliasTypeArguments(): Promise<readonly Type[]> {
@@ -1540,8 +1557,8 @@ export class Signature {
         this.target = data.target;
     }
 
-    async getTypeParameters(): Promise<readonly Type[]> {
-        return this.objectRegistry.fetchTypes(this, "getTypeParametersOfSignature", this.typeParameters);
+    async getTypeParameters(): Promise<readonly TypeParameter[]> {
+        return this.objectRegistry.fetchTypes(this, "getTypeParametersOfSignature", this.typeParameters) as Promise<readonly TypeParameter[]>;
     }
 
     async getParameters(): Promise<readonly Symbol[]> {

--- a/_packages/native-preview/src/api/async/types.ts
+++ b/_packages/native-preview/src/api/async/types.ts
@@ -92,11 +92,11 @@ export interface TypeReference extends ObjectType {
 /** Interface types — classes and interfaces (ObjectFlags.ClassOrInterface) */
 export interface InterfaceType extends TypeReference {
     /** Get all type parameters (outer + local, excluding thisType) */
-    getTypeParameters(): Promise<readonly Type[]>;
+    getTypeParameters(): Promise<readonly TypeParameter[]>;
     /** Get outer type parameters from enclosing declarations */
-    getOuterTypeParameters(): Promise<readonly Type[]>;
+    getOuterTypeParameters(): Promise<readonly TypeParameter[]>;
     /** Get local type parameters declared on this interface/class */
-    getLocalTypeParameters(): Promise<readonly Type[]>;
+    getLocalTypeParameters(): Promise<readonly TypeParameter[]>;
 }
 
 /** Tuple types (ObjectFlags.Tuple) */

--- a/_packages/native-preview/src/api/sync/api.ts
+++ b/_packages/native-preview/src/api/sync/api.ts
@@ -1147,7 +1147,11 @@ export class Checker {
         } as TypePredicate;
     }
 
-    getBaseTypes(type: Type): readonly Type[] {
+    /**
+     * Get the base types of a class or interface type. A type with no base types
+     * yields an empty array.
+     */
+    getBaseTypes(type: InterfaceType): readonly Type[] {
         const data = this.client.apiRequest<TypeResponse[] | null>("getBaseTypes", {
             snapshot: this.snapshotId,
             project: this.projectId,
@@ -1180,7 +1184,11 @@ export class Checker {
         }));
     }
 
-    getConstraintOfTypeParameter(type: Type): Type | undefined {
+    /**
+     * Get the constraint of a type parameter (the `T` in `<U extends T>`), or
+     * undefined if it has none.
+     */
+    getConstraintOfTypeParameter(type: TypeParameter): Type | undefined {
         const data = this.client.apiRequest<TypeResponse | null>("getConstraintOfTypeParameter", {
             snapshot: this.snapshotId,
             project: this.projectId,
@@ -1270,7 +1278,10 @@ export class Checker {
         });
     }
 
-    getTypeArguments(type: Type): readonly Type[] {
+    /**
+     * Get the type arguments of a type reference (e.g. the `string` in `Array<string>`).
+     */
+    getTypeArguments(type: TypeReference): readonly Type[] {
         const data = this.client.apiRequest<TypeResponse[] | null>("getTypeArguments", {
             snapshot: this.snapshotId,
             project: this.projectId,
@@ -1481,20 +1492,26 @@ class TypeObject implements Type {
         return this.objectRegistry.fetchType(this, "getRegularTypeOfType", this.regularType);
     }
 
-    getTypes(): readonly Type[] {
+    getTypes(): readonly Type[] | undefined {
+        // Only union, intersection, and template literal types have constituent
+        // types; any other kind has none, so return undefined rather than sending
+        // a request the server cannot satisfy.
+        if (!(this.flags & (TypeFlags.UnionOrIntersection | TypeFlags.TemplateLiteral))) {
+            return undefined;
+        }
         return this.objectRegistry.fetchTypes(this, "getTypesOfType");
     }
 
-    getTypeParameters(): readonly Type[] {
-        return this.objectRegistry.fetchTypes(this, "getTypeParametersOfType", this.typeParameters);
+    getTypeParameters(): readonly TypeParameter[] {
+        return this.objectRegistry.fetchTypes(this, "getTypeParametersOfType", this.typeParameters) as readonly TypeParameter[];
     }
 
-    getOuterTypeParameters(): readonly Type[] {
-        return this.objectRegistry.fetchTypes(this, "getOuterTypeParametersOfType", this.outerTypeParameters);
+    getOuterTypeParameters(): readonly TypeParameter[] {
+        return this.objectRegistry.fetchTypes(this, "getOuterTypeParametersOfType", this.outerTypeParameters) as readonly TypeParameter[];
     }
 
-    getLocalTypeParameters(): readonly Type[] {
-        return this.objectRegistry.fetchTypes(this, "getLocalTypeParametersOfType", this.localTypeParameters);
+    getLocalTypeParameters(): readonly TypeParameter[] {
+        return this.objectRegistry.fetchTypes(this, "getLocalTypeParametersOfType", this.localTypeParameters) as readonly TypeParameter[];
     }
 
     getAliasTypeArguments(): readonly Type[] {
@@ -1548,8 +1565,8 @@ export class Signature {
         this.target = data.target;
     }
 
-    getTypeParameters(): readonly Type[] {
-        return this.objectRegistry.fetchTypes(this, "getTypeParametersOfSignature", this.typeParameters);
+    getTypeParameters(): readonly TypeParameter[] {
+        return this.objectRegistry.fetchTypes(this, "getTypeParametersOfSignature", this.typeParameters) as readonly TypeParameter[];
     }
 
     getParameters(): readonly Symbol[] {

--- a/_packages/native-preview/src/api/sync/types.ts
+++ b/_packages/native-preview/src/api/sync/types.ts
@@ -100,11 +100,11 @@ export interface TypeReference extends ObjectType {
 /** Interface types — classes and interfaces (ObjectFlags.ClassOrInterface) */
 export interface InterfaceType extends TypeReference {
     /** Get all type parameters (outer + local, excluding thisType) */
-    getTypeParameters(): readonly Type[];
+    getTypeParameters(): readonly TypeParameter[];
     /** Get outer type parameters from enclosing declarations */
-    getOuterTypeParameters(): readonly Type[];
+    getOuterTypeParameters(): readonly TypeParameter[];
     /** Get local type parameters declared on this interface/class */
-    getLocalTypeParameters(): readonly Type[];
+    getLocalTypeParameters(): readonly TypeParameter[];
 }
 
 /** Tuple types (ObjectFlags.Tuple) */

--- a/_packages/native-preview/test/async/api.test.ts
+++ b/_packages/native-preview/test/async/api.test.ts
@@ -40,6 +40,7 @@ import {
     type FreshableType,
     type IndexedAccessType,
     type IndexType,
+    type InterfaceType,
     type IntrinsicType,
     type LiteralType,
     ModifierFlags,
@@ -1314,6 +1315,37 @@ export const tuple: readonly [number, string?, ...boolean[]] = [1];
         }
     });
 
+    test("UnionOrIntersectionType.getTypes() on a wrongly-cast type returns undefined without hitting the server", async () => {
+        const src = `export const s: string = ""; export const u: string | number = "";`;
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/main.ts": src,
+        });
+        try {
+            const snapshot = await api.updateSnapshot({ openProject: "/tsconfig.json" });
+            const project = snapshot.getProject("/tsconfig.json")!;
+
+            // `string` is neither a union/intersection nor a template literal type,
+            // so it has no constituent types. The client guards on the type's flags
+            // and returns undefined without ever sending a request the server cannot satisfy.
+            const sSymbol = await project.checker.getSymbolAtPosition("/src/main.ts", src.indexOf("s:"));
+            assert.ok(sSymbol);
+            const sType = await project.checker.getTypeOfSymbol(sSymbol);
+            assert.ok(sType);
+            assert.equal(await (sType as unknown as UnionOrIntersectionType).getTypes(), undefined);
+
+            // A real union still returns its constituents.
+            const uSymbol = await project.checker.getSymbolAtPosition("/src/main.ts", src.indexOf("u:"));
+            assert.ok(uSymbol);
+            const uType = await project.checker.getTypeOfSymbol(uSymbol);
+            assert.ok(uType);
+            assert.equal((await (uType as UnionOrIntersectionType).getTypes()).length, 2);
+        }
+        finally {
+            await api.close();
+        }
+    });
+
     test("IndexType.getTarget() returns the target type", async () => {
         const api = spawnAPI(typeFiles);
         try {
@@ -2273,7 +2305,7 @@ export class Derived extends Base {
             assert.ok(symbol);
             const type = await project.checker.getDeclaredTypeOfSymbol(symbol);
             assert.ok(type);
-            const baseTypes = await project.checker.getBaseTypes(type);
+            const baseTypes = await project.checker.getBaseTypes(type as InterfaceType);
             assert.ok(baseTypes.length > 0, "Should have at least one base type");
             const baseSymbol = await baseTypes[0].getSymbol();
             assert.ok(baseSymbol);
@@ -2305,7 +2337,7 @@ export interface Dog extends Animal {
             assert.ok(symbol);
             const type = await project.checker.getDeclaredTypeOfSymbol(symbol);
             assert.ok(type);
-            const baseTypes = await project.checker.getBaseTypes(type);
+            const baseTypes = await project.checker.getBaseTypes(type as InterfaceType);
             assert.ok(baseTypes.length > 0, "Should have at least one base type");
             const baseSymbol = await baseTypes[0].getSymbol();
             assert.ok(baseSymbol);
@@ -2335,7 +2367,9 @@ export type BoxOfString = Box<string>;
             assert.ok(typeAlias);
             const type = await project.checker.getTypeAtLocation(typeAlias);
             assert.ok(type);
-            const baseTypes = await project.checker.getBaseTypes(type);
+            // A generic interface instantiation produces a type reference, not an
+            // interface type, so it has no base types and yields [].
+            const baseTypes = await project.checker.getBaseTypes(type as InterfaceType);
             assert.deepEqual(baseTypes, []);
         }
         finally {
@@ -2486,9 +2520,41 @@ describe("Checker - getTypeArguments", () => {
             assert.ok(symbol);
             const type = await project.checker.getTypeOfSymbol(symbol);
             assert.ok(type);
-            const typeArgs = await project.checker.getTypeArguments(type);
+            const typeArgs = await project.checker.getTypeArguments(type as TypeReference);
             assert.ok(typeArgs.length > 0, "Should have type arguments");
             assert.ok(typeArgs[0].flags & TypeFlags.Number, `Expected number type argument, got flags ${typeArgs[0].flags}`);
+        }
+        finally {
+            await api.close();
+        }
+    });
+
+    test("a wrongly-typed call throws on the client without taking down the server", async () => {
+        const src = `export const s: string = ""; export const arr: Array<number> = [1];`;
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/main.ts": src,
+        });
+        try {
+            const snapshot = await api.updateSnapshot({ openProject: "/tsconfig.json" });
+            const project = snapshot.getProject("/tsconfig.json")!;
+
+            // `string` is not a type reference. When getTypeArguments is reached
+            // with one, the server panics, but the per-request panic recovery
+            // converts that into an error response rather than crashing the process.
+            const sSymbol = await project.checker.getSymbolAtPosition("/src/main.ts", src.indexOf("s:"));
+            assert.ok(sSymbol);
+            const sType = await project.checker.getTypeOfSymbol(sSymbol);
+            assert.ok(sType);
+            await assert.rejects(() => project.checker.getTypeArguments(sType as unknown as TypeReference)); // @sync: assert.throws(() => project.checker.getTypeArguments(sType as unknown as TypeReference));
+
+            // The server survived: a subsequent valid request still succeeds.
+            const arrSymbol = await project.checker.getSymbolAtPosition("/src/main.ts", src.indexOf("arr:"));
+            assert.ok(arrSymbol);
+            const arrType = await project.checker.getTypeOfSymbol(arrSymbol);
+            assert.ok(arrType);
+            const typeArgs = await project.checker.getTypeArguments(arrType as TypeReference);
+            assert.ok(typeArgs.length > 0, "Server should still serve valid requests");
         }
         finally {
             await api.close();

--- a/_packages/native-preview/test/sync/api.test.ts
+++ b/_packages/native-preview/test/sync/api.test.ts
@@ -50,6 +50,7 @@ import {
     type FreshableType,
     type IndexedAccessType,
     type IndexType,
+    type InterfaceType,
     type IntrinsicType,
     type LiteralType,
     ModifierFlags,
@@ -1322,6 +1323,37 @@ export const tuple: readonly [number, string?, ...boolean[]] = [1];
         }
     });
 
+    test("UnionOrIntersectionType.getTypes() on a wrongly-cast type returns undefined without hitting the server", () => {
+        const src = `export const s: string = ""; export const u: string | number = "";`;
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/main.ts": src,
+        });
+        try {
+            const snapshot = api.updateSnapshot({ openProject: "/tsconfig.json" });
+            const project = snapshot.getProject("/tsconfig.json")!;
+
+            // `string` is neither a union/intersection nor a template literal type,
+            // so it has no constituent types. The client guards on the type's flags
+            // and returns undefined without ever sending a request the server cannot satisfy.
+            const sSymbol = project.checker.getSymbolAtPosition("/src/main.ts", src.indexOf("s:"));
+            assert.ok(sSymbol);
+            const sType = project.checker.getTypeOfSymbol(sSymbol);
+            assert.ok(sType);
+            assert.equal((sType as unknown as UnionOrIntersectionType).getTypes(), undefined);
+
+            // A real union still returns its constituents.
+            const uSymbol = project.checker.getSymbolAtPosition("/src/main.ts", src.indexOf("u:"));
+            assert.ok(uSymbol);
+            const uType = project.checker.getTypeOfSymbol(uSymbol);
+            assert.ok(uType);
+            assert.equal(((uType as UnionOrIntersectionType).getTypes()).length, 2);
+        }
+        finally {
+            api.close();
+        }
+    });
+
     test("IndexType.getTarget() returns the target type", () => {
         const api = spawnAPI(typeFiles);
         try {
@@ -2281,7 +2313,7 @@ export class Derived extends Base {
             assert.ok(symbol);
             const type = project.checker.getDeclaredTypeOfSymbol(symbol);
             assert.ok(type);
-            const baseTypes = project.checker.getBaseTypes(type);
+            const baseTypes = project.checker.getBaseTypes(type as InterfaceType);
             assert.ok(baseTypes.length > 0, "Should have at least one base type");
             const baseSymbol = baseTypes[0].getSymbol();
             assert.ok(baseSymbol);
@@ -2313,7 +2345,7 @@ export interface Dog extends Animal {
             assert.ok(symbol);
             const type = project.checker.getDeclaredTypeOfSymbol(symbol);
             assert.ok(type);
-            const baseTypes = project.checker.getBaseTypes(type);
+            const baseTypes = project.checker.getBaseTypes(type as InterfaceType);
             assert.ok(baseTypes.length > 0, "Should have at least one base type");
             const baseSymbol = baseTypes[0].getSymbol();
             assert.ok(baseSymbol);
@@ -2343,7 +2375,9 @@ export type BoxOfString = Box<string>;
             assert.ok(typeAlias);
             const type = project.checker.getTypeAtLocation(typeAlias);
             assert.ok(type);
-            const baseTypes = project.checker.getBaseTypes(type);
+            // A generic interface instantiation produces a type reference, not an
+            // interface type, so it has no base types and yields [].
+            const baseTypes = project.checker.getBaseTypes(type as InterfaceType);
             assert.deepEqual(baseTypes, []);
         }
         finally {
@@ -2494,9 +2528,41 @@ describe("Checker - getTypeArguments", () => {
             assert.ok(symbol);
             const type = project.checker.getTypeOfSymbol(symbol);
             assert.ok(type);
-            const typeArgs = project.checker.getTypeArguments(type);
+            const typeArgs = project.checker.getTypeArguments(type as TypeReference);
             assert.ok(typeArgs.length > 0, "Should have type arguments");
             assert.ok(typeArgs[0].flags & TypeFlags.Number, `Expected number type argument, got flags ${typeArgs[0].flags}`);
+        }
+        finally {
+            api.close();
+        }
+    });
+
+    test("a wrongly-typed call throws on the client without taking down the server", () => {
+        const src = `export const s: string = ""; export const arr: Array<number> = [1];`;
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/main.ts": src,
+        });
+        try {
+            const snapshot = api.updateSnapshot({ openProject: "/tsconfig.json" });
+            const project = snapshot.getProject("/tsconfig.json")!;
+
+            // `string` is not a type reference. When getTypeArguments is reached
+            // with one, the server panics, but the per-request panic recovery
+            // converts that into an error response rather than crashing the process.
+            const sSymbol = project.checker.getSymbolAtPosition("/src/main.ts", src.indexOf("s:"));
+            assert.ok(sSymbol);
+            const sType = project.checker.getTypeOfSymbol(sSymbol);
+            assert.ok(sType);
+            assert.throws(() => project.checker.getTypeArguments(sType as unknown as TypeReference));
+
+            // The server survived: a subsequent valid request still succeeds.
+            const arrSymbol = project.checker.getSymbolAtPosition("/src/main.ts", src.indexOf("arr:"));
+            assert.ok(arrSymbol);
+            const arrType = project.checker.getTypeOfSymbol(arrSymbol);
+            assert.ok(arrType);
+            const typeArgs = project.checker.getTypeArguments(arrType as TypeReference);
+            assert.ok(typeArgs.length > 0, "Server should still serve valid requests");
         }
         finally {
             api.close();


### PR DESCRIPTION
- Methods like `unionType.getTypes()` which in Strada were plain property accesses like `unionType.types` now return `undefined` instead of throwing if you access them on an unsafe cast, like `(notReallyAUnionType as UnionType).getTypes()` - fixes #4426 
- Otherwise, it's expected that methods may throw (server may panic, recover, and return an error thrown by the client) if you pass an incorrectly typed argument. The API layer doesn't do any extra guards before calling Checker methods. This is in line with Strada's behavior. Some Checker methods may be tolerant of bad inputs and return `nil` or an empty slice or whatever, but the decision of whether to do that or assert things about its inputs is left up to the Checker itself.
- Those inputs are guarded by client-side types, some of which were too wide and fixed in this PR - fixes #4338 