### PR TITLE
Use shared FSEvents streams

### DIFF
--- a/internal/execute/tsctests/mock_watch_backend.go
+++ b/internal/execute/tsctests/mock_watch_backend.go
@@ -55,14 +55,33 @@ func (w *MockWatch) Close() error {
 }
 
 func (m *MockWatchBackend) WatchDirectory(dir string, fn fswatch.WatchCallback, recursive bool, ignore func(string) bool) (io.Closer, error) {
+	closers, err := m.WatchDirectories([]watchmanager.WatchDirectoryRequest{{
+		Dir:       dir,
+		Callback:  fn,
+		Recursive: recursive,
+		Ignore:    ignore,
+	}})
+	if err != nil {
+		return nil, err
+	}
+	return closers[0], nil
+}
+
+func (m *MockWatchBackend) WatchDirectories(requests []watchmanager.WatchDirectoryRequest) ([]io.Closer, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if m.DirectoryExists != nil && !m.DirectoryExists(dir) {
-		return nil, fmt.Errorf("directory does not exist: %s", dir)
+	for _, request := range requests {
+		if m.DirectoryExists != nil && !m.DirectoryExists(request.Dir) {
+			return nil, fmt.Errorf("directory does not exist: %s", request.Dir)
+		}
 	}
-	w := &MockWatch{Path: dir, Callback: fn, Recursive: recursive, Ignore: ignore}
-	m.Dirs[dir] = w
-	return w, nil
+	closers := make([]io.Closer, len(requests))
+	for i, request := range requests {
+		w := &MockWatch{Path: request.Dir, Callback: request.Callback, Recursive: request.Recursive, Ignore: request.Ignore}
+		m.Dirs[request.Dir] = w
+		closers[i] = w
+	}
+	return closers, nil
 }
 
 // SendEvents routes events through the registered watch callbacks

--- a/internal/execute/watchmanager/watchbackend.go
+++ b/internal/execute/watchmanager/watchbackend.go
@@ -11,6 +11,14 @@ import (
 // WatchBackend abstracts fswatch.Watcher for testing
 type WatchBackend interface {
 	WatchDirectory(dir string, fn fswatch.WatchCallback, recursive bool, ignore func(string) bool) (io.Closer, error)
+	WatchDirectories(requests []WatchDirectoryRequest) ([]io.Closer, error)
+}
+
+type WatchDirectoryRequest struct {
+	Dir       string
+	Callback  fswatch.WatchCallback
+	Recursive bool
+	Ignore    func(string) bool
 }
 
 // CommandLineTestingWithWatchBackend is an optional extension of
@@ -22,14 +30,43 @@ type CommandLineTestingWithWatchBackend interface {
 type FSWatchBackend struct{ Inner fswatch.Watcher }
 
 func (b *FSWatchBackend) WatchDirectory(dir string, fn fswatch.WatchCallback, recursive bool, ignore func(string) bool) (io.Closer, error) {
-	var opts []fswatch.WatchOption
-	if recursive {
-		opts = append(opts, fswatch.WithRecursive())
+	closers, err := b.WatchDirectories([]WatchDirectoryRequest{{
+		Dir:       dir,
+		Callback:  fn,
+		Recursive: recursive,
+		Ignore:    ignore,
+	}})
+	if err != nil {
+		return nil, err
 	}
-	if ignore != nil {
-		opts = append(opts, fswatch.WithIgnore(ignore))
+	return closers[0], nil
+}
+
+func (b *FSWatchBackend) WatchDirectories(requests []WatchDirectoryRequest) ([]io.Closer, error) {
+	fswatchRequests := make([]fswatch.WatchDirectoryRequest, len(requests))
+	for i, request := range requests {
+		var opts []fswatch.WatchOption
+		if request.Recursive {
+			opts = append(opts, fswatch.WithRecursive())
+		}
+		if request.Ignore != nil {
+			opts = append(opts, fswatch.WithIgnore(request.Ignore))
+		}
+		fswatchRequests[i] = fswatch.WatchDirectoryRequest{
+			Dir:      request.Dir,
+			Callback: request.Callback,
+			Options:  opts,
+		}
 	}
-	return b.Inner.WatchDirectory(dir, fn, opts...)
+	watches, err := b.Inner.WatchDirectories(fswatchRequests)
+	if err != nil {
+		return nil, err
+	}
+	closers := make([]io.Closer, len(watches))
+	for i, watch := range watches {
+		closers[i] = watch
+	}
+	return closers, nil
 }
 
 func ShouldIgnoreWatchPath(path string) bool {

--- a/internal/execute/watchmanager/watchmanager.go
+++ b/internal/execute/watchmanager/watchmanager.go
@@ -17,6 +17,11 @@ type watchedDir struct {
 	recursive bool
 }
 
+type dirWatchUpdate struct {
+	dir       string
+	recursive bool
+}
+
 // WatchManager manages fswatch directory watches, event accumulation,
 // and DoCycle signaling. It is shared by the CLI watcher and the build
 // mode orchestrator.
@@ -174,14 +179,8 @@ func (wm *WatchManager) CloseAllWatches() {
 
 func (wm *WatchManager) createDirWatch(dir string, recursive bool) error {
 	entry := &watchedDir{recursive: recursive}
-	cb := func(events []fswatch.Event, err error) {
-		if err != nil && errors.Is(err, fswatch.ErrWatchTerminated) {
-			wm.handleWatchTerminated(dir, entry)
-			return
-		}
-		wm.onWatchEvents(events, err)
-	}
-	watch, err := wm.backend.WatchDirectory(dir, cb, recursive, ShouldIgnoreWatchPath)
+	request := wm.createDirWatchRequest(dir, entry)
+	watch, err := wm.backend.WatchDirectory(request.Dir, request.Callback, request.Recursive, request.Ignore)
 	if err != nil {
 		if wm.DebugLog != nil {
 			fmt.Fprintf(wm.DebugLog, "[watch] failed to watch directory %s: %v\n", dir, err)
@@ -191,6 +190,21 @@ func (wm *WatchManager) createDirWatch(dir string, recursive bool) error {
 	entry.closer = watch
 	wm.watchedDirs[dir] = entry
 	return nil
+}
+
+func (wm *WatchManager) createDirWatchRequest(dir string, entry *watchedDir) WatchDirectoryRequest {
+	return WatchDirectoryRequest{
+		Dir:       dir,
+		Recursive: entry.recursive,
+		Ignore:    ShouldIgnoreWatchPath,
+		Callback: func(events []fswatch.Event, err error) {
+			if err != nil && errors.Is(err, fswatch.ErrWatchTerminated) {
+				wm.handleWatchTerminated(dir, entry)
+				return
+			}
+			wm.onWatchEvents(events, err)
+		},
+	}
 }
 
 func (wm *WatchManager) ResolveDesiredDirs(desiredDirs map[string]bool) map[string]bool {
@@ -229,7 +243,9 @@ func (wm *WatchManager) ReconcileWatches(desiredDirs map[string]bool) error {
 		return nil
 	}
 
-	var watchErr error
+	var additions []dirWatchUpdate
+	var changes []dirWatchUpdate
+
 	core.DiffMapsFunc(
 		wm.watchedDirs,
 		desiredDirs,
@@ -238,9 +254,7 @@ func (wm *WatchManager) ReconcileWatches(desiredDirs map[string]bool) error {
 			if wm.DebugLog != nil {
 				fmt.Fprintf(wm.DebugLog, "[watch] watching directory %s (recursive=%v)\n", dir, recursive)
 			}
-			if err := wm.createDirWatch(dir, recursive); err != nil && watchErr == nil {
-				watchErr = err
-			}
+			additions = append(additions, dirWatchUpdate{dir: dir, recursive: recursive})
 		},
 		func(dir string, wd *watchedDir) {
 			if wm.DebugLog != nil {
@@ -255,12 +269,41 @@ func (wm *WatchManager) ReconcileWatches(desiredDirs map[string]bool) error {
 			}
 			wd.closer.Close()
 			delete(wm.watchedDirs, dir)
-			if err := wm.createDirWatch(dir, recursive); err != nil && watchErr == nil {
-				watchErr = err
-			}
+			changes = append(changes, dirWatchUpdate{dir: dir, recursive: recursive})
 		},
 	)
-	return watchErr
+	additions = append(additions, changes...)
+	return wm.createDirWatches(additions)
+}
+
+func (wm *WatchManager) createDirWatches(updates []dirWatchUpdate) error {
+	if len(updates) == 0 {
+		return nil
+	}
+	requests := make([]WatchDirectoryRequest, len(updates))
+	entries := make([]*watchedDir, len(updates))
+	for i, update := range updates {
+		entry := &watchedDir{recursive: update.recursive}
+		entries[i] = entry
+		requests[i] = wm.createDirWatchRequest(update.dir, entry)
+	}
+	closers, err := wm.backend.WatchDirectories(requests)
+	if err != nil {
+		for i, update := range updates {
+			if wm.DebugLog != nil {
+				fmt.Fprintf(wm.DebugLog, "[watch] failed to watch directory %s: %v\n", update.dir, err)
+			}
+			if i < len(closers) && closers[i] != nil {
+				closers[i].Close()
+			}
+		}
+		return err
+	}
+	for i, update := range updates {
+		entries[i].closer = closers[i]
+		wm.watchedDirs[update.dir] = entries[i]
+	}
+	return nil
 }
 
 func IsDirCoveredByWatch(dirs map[string]bool, dir string, opts tspath.ComparePathsOptions) bool {

--- a/internal/fswatch/CHANGES.md
+++ b/internal/fswatch/CHANGES.md
@@ -127,6 +127,16 @@ can't starve event delivery on any of the others. In practice most callers will
 only ever use one backend (`Default()`), so this mainly matters for processes
 that mix backends, but the cost of the split is essentially nothing.
 
+### Shared FSEvents streams
+
+Upstream opens one macOS FSEventStream per subscription. Go's FSEvents backend
+shares streams across all logical directory watches in a backend instance. The
+fast path attempts one stream containing every active physical watch root; if
+that stream cannot be started, the backend retries with bounded path chunks.
+Events from shared streams are routed back to matching logical watches by path,
+so non-recursive and per-subscriber ignore semantics are preserved while using
+far fewer system-wide FSEvents stream slots.
+
 ## New backends
 
 **fanotify** (Linux, kernel ≥ 5.13) is the default on Linux when available. It

--- a/internal/fswatch/CHANGES.md
+++ b/internal/fswatch/CHANGES.md
@@ -9,11 +9,12 @@ simplifications, new features, and bugfixes.
 
 ### Method naming
 
-| C++ / JS               | Go                                 |
-| ---------------------- | ---------------------------------- |
-| `subscribe(dir, fn)`   | `WatchDirectory(dir, fn, opts...)` |
-| —                      | `WatchFile(path, fn)`              |
-| `unsubscribe(dir, fn)` | `w.Close()`                        |
+| C++ / JS               | Go                                          |
+| ---------------------- | ------------------------------------------- |
+| `subscribe(dir, fn)`   | `WatchDirectory(dir, fn, opts...)`          |
+| —                      | `WatchDirectories([]WatchDirectoryRequest)` |
+| —                      | `WatchFile(path, fn)`                       |
+| `unsubscribe(dir, fn)` | `w.Close()`                                 |
 
 ### Recursion default
 
@@ -54,6 +55,13 @@ Go adds functional options not present in the C++ API:
 `WatchFile(path, fn)` watches a single file by watching its parent directory
 non-recursively and filtering events to the target path. Multiple file watches
 in the same directory share one OS watch. Not available in the C++ API.
+
+### Batch directory watching
+
+`WatchDirectories` registers multiple directory watches in one call. It has the
+same logical behavior as repeated `WatchDirectory` calls, but lets backends batch
+the underlying OS subscription work. On macOS this avoids rebuilding the shared
+FSEvents stream once per logical watch during large watch reconciliations.
 
 ### Error delivery
 

--- a/internal/fswatch/fsevents_darwin.go
+++ b/internal/fswatch/fsevents_darwin.go
@@ -494,8 +494,10 @@ func fsEventsCallback(cb *streamCallback, payload *fsEventsCallbackPayload) {
 				overflow = errFSEventsTooMany
 			}
 			for _, watch := range watches {
-				watch.w.events.setError(overflow)
-				touched[watch.w] = struct{}{}
+				if fseventsOverflowMatches(watch.w, path) {
+					watch.w.events.setError(overflow)
+					touched[watch.w] = struct{}{}
+				}
 			}
 		}
 
@@ -571,7 +573,7 @@ func (b *fsEventsBackend) activeWatchesSnapshot(paths []string) []fseventsWatchS
 	}
 	filtered := watches[:0]
 	for _, watch := range watches {
-		if slices.Contains(paths, watch.w.physicalDir) {
+		if _, ok := slices.BinarySearch(paths, watch.w.physicalDir); ok {
 			filtered = append(filtered, watch)
 		}
 	}
@@ -586,4 +588,11 @@ func fseventsDisplayPath(w *dirWatch, rawPath string) (string, bool) {
 		return rawPath, true
 	}
 	return "", false
+}
+
+func fseventsOverflowMatches(w *dirWatch, rawPath string) bool {
+	if isInDirectoryOrSelf(w.physicalDir, rawPath) || isInDirectoryOrSelf(rawPath, w.physicalDir) {
+		return true
+	}
+	return w.physicalDir != w.dir && (isInDirectoryOrSelf(w.dir, rawPath) || isInDirectoryOrSelf(rawPath, w.dir))
 }

--- a/internal/fswatch/fsevents_darwin.go
+++ b/internal/fswatch/fsevents_darwin.go
@@ -401,27 +401,40 @@ func stopFSEventsStream(state *fseventsStream) {
 
 // subscribe mirrors `fsEventsBackend::subscribe`.
 func (b *fsEventsBackend) subscribe(w *dirWatch) error {
-	if err := checkWatcher(w); err != nil {
-		return err
+	return b.subscribeMany([]*dirWatch{w})
+}
+
+func (b *fsEventsBackend) subscribeMany(watchesToAdd []*dirWatch) error {
+	if len(watchesToAdd) == 0 {
+		return nil
+	}
+	states := make(map[*dirWatch]*fseventsState, len(watchesToAdd))
+	for _, w := range watchesToAdd {
+		if err := checkWatcher(w); err != nil {
+			return err
+		}
+		states[w] = &fseventsState{}
 	}
 
-	state := &fseventsState{}
-	w.state = state
-
 	b.mu.Lock()
-	b.watches[w] = state
+	for w, state := range states {
+		w.state = state
+		b.watches[w] = state
+	}
 	watches := b.activeWatchesLocked()
 	b.mu.Unlock()
 
 	streams, err := b.startStreams(watches)
 	if err != nil {
 		b.mu.Lock()
-		if b.watches[w] == state {
-			delete(b.watches, w)
-			w.state = nil
+		for w, state := range states {
+			if b.watches[w] == state {
+				delete(b.watches, w)
+				w.state = nil
+			}
 		}
 		b.mu.Unlock()
-		return &dirWatchError{err: err, dirWatch: w}
+		return &dirWatchError{err: err, dirWatch: watchesToAdd[0]}
 	}
 
 	b.mu.Lock()

--- a/internal/fswatch/fsevents_darwin.go
+++ b/internal/fswatch/fsevents_darwin.go
@@ -209,8 +209,10 @@ func checkWatcher(w *dirWatch) error {
 }
 
 var (
-	errStreamCreateNull  = errors.New("FSEventStreamCreate returned NULL")
-	errStreamStartFailed = errors.New("error starting FSEvents stream")
+	errCFStringCreateNull = errors.New("CFStringCreate returned NULL")
+	errCFArrayCreateNull  = errors.New("CFArrayCreate returned NULL")
+	errStreamCreateNull   = errors.New("FSEventStreamCreate returned NULL")
+	errStreamStartFailed  = errors.New("error starting FSEvents stream")
 )
 
 var (
@@ -294,7 +296,7 @@ func (b *fsEventsBackend) startStream(paths []string) (*fseventsStream, error) {
 			for _, cfString := range cfStrings {
 				cfRelease(cfString)
 			}
-			return nil, errStreamCreateNull
+			return nil, errCFStringCreateNull
 		}
 		cfStrings = append(cfStrings, cfDir)
 	}
@@ -306,7 +308,7 @@ func (b *fsEventsBackend) startStream(paths []string) (*fseventsStream, error) {
 
 	pathsToWatch := cfArrayCreate(0, unsafe.Pointer(&cfStrings[0]), len(cfStrings), 0)
 	if pathsToWatch == 0 {
-		return nil, errStreamCreateNull
+		return nil, errCFArrayCreateNull
 	}
 	defer cfRelease(pathsToWatch)
 

--- a/internal/fswatch/fsevents_darwin.go
+++ b/internal/fswatch/fsevents_darwin.go
@@ -241,6 +241,10 @@ func (b *fsEventsBackend) activeWatchesLocked() []fseventsWatchSnapshot {
 }
 
 func (b *fsEventsBackend) startStreams(watches []fseventsWatchSnapshot) ([]*fseventsStream, error) {
+	return startFSEventsStreams(watches, b.startStream)
+}
+
+func startFSEventsStreams(watches []fseventsWatchSnapshot, startStream func([]string) (*fseventsStream, error)) ([]*fseventsStream, error) {
 	if len(watches) == 0 {
 		return nil, nil
 	}
@@ -256,16 +260,22 @@ func (b *fsEventsBackend) startStreams(watches []fseventsWatchSnapshot) ([]*fsev
 	}
 	sort.Strings(paths)
 
+	stream, err := startStream(paths)
+	if err == nil {
+		return []*fseventsStream{stream}, nil
+	}
+
 	streams := make([]*fseventsStream, 0, (len(paths)+fseventsPathsPerStream-1)/fseventsPathsPerStream)
-	for len(paths) > 0 {
-		chunkLen := min(len(paths), fseventsPathsPerStream)
-		stream, err := b.startStream(paths[:chunkLen])
+	remainingPaths := paths
+	for len(remainingPaths) > 0 {
+		chunkLen := min(len(remainingPaths), fseventsPathsPerStream)
+		stream, err := startStream(remainingPaths[:chunkLen])
 		if err != nil {
 			stopFSEventsStreams(streams)
 			return nil, err
 		}
 		streams = append(streams, stream)
-		paths = paths[chunkLen:]
+		remainingPaths = remainingPaths[chunkLen:]
 	}
 	return streams, nil
 }

--- a/internal/fswatch/fsevents_darwin.go
+++ b/internal/fswatch/fsevents_darwin.go
@@ -7,6 +7,10 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"slices"
+	"sort"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"unsafe"
@@ -31,13 +35,14 @@ import (
 //	│ fsEventsBackend                                           │
 //	│ (no event loop; start() just signals readiness)           │
 //	│                                                           │
-//	│ subscribe() per directory:                                │
+//	│ subscribe/closeWatch rebuild the shared stream set:       │
 //	│      │                                                    │
 //	│      ▼                                                    │
 //	│ ┌─────────────────────────────────────────────────────┐   │
-//	│ │ fseventsState                                       │   │
+//	│ │ fseventsStream[]                                    │   │
 //	│ │                                                     │   │
-//	│ │  FSEventStream ──► per-stream GCD dispatch queue    │   │
+//	│ │  each FSEventStream watches up to N paths ────────► │   │
+//	│ │  per-stream GCD dispatch queue                      │   │
 //	│ │  (UseCFTypes | FileEvents = 0x11)                   │   │
 //	│ │                                                     │   │
 //	│ │  callback fires on GCD thread:                      │   │
@@ -60,15 +65,14 @@ import (
 //     that GCD thread in the C calling convention. It never enters Go ABI.
 //     It retains/copies the callback payload and passes it to Go through
 //     eventPipe.
-//   - One Go goroutine per stream (eventLoop, in fsevents_darwin_ffi.go)
+//   - One Go goroutine per stream chunk (eventLoop, in fsevents_darwin_ffi.go)
 //     blocks on eventFile.Read(), integrated with Go's netpoll so it parks
-//     without consuming an OS thread. When woken by the asm callback, it
-//     calls fsEventsCallback() to classify events and post them to the
-//     dirWatch's eventList.
-//   - subscribe/closeWatch and stream lifecycle (startStream/stopStream)
-//     run on the caller's goroutine under watcherBase.mu. Stream teardown
-//     uses atomic.Swap on the stream pointer so that only one of
-//     (Close, callback's deleted-root path) performs cleanup.
+//     without consuming an OS thread. When woken by the asm callback, it calls
+//     fsEventsCallback() to classify events and route them to matching
+//     dirWatch event lists.
+//   - subscribe/closeWatch rebuild the stream chunks on the caller's goroutine
+//     under watcherBase.mu. Old streams are swapped out before teardown so a
+//     callback cannot deadlock against stream teardown while routing events.
 //
 // Callback delivery:
 //   dirWatch.notify() posts to the shared process-wide debouncer. After a
@@ -79,11 +83,11 @@ import (
 //   per-subscriber before delivery.
 //
 // WatchDirectory flow (caller goroutine):
-//   subscribe → startStream: create an FSEventStream with
-//   kFSEventStreamEventIdSinceNow and start it on its own serial GCD
-//   queue. No directory walk or tree is needed; FSEvents watches
-//   recursively via the kernel, and event classification uses only the
-//   flags.
+//   subscribe/closeWatch snapshots active dirWatches and creates one or more
+//   FSEventStreams with kFSEventStreamEventIdSinceNow. Each stream receives a
+//   chunk of physical watch roots. No directory walk or tree is needed;
+//   FSEvents watches recursively via the kernel, and event classification uses
+//   only the flags.
 //
 // Event classification (fsEventsCallback, on eventLoop goroutine):
 //   Each batch delivers arrays of paths, flags, and event IDs. The flags
@@ -154,12 +158,11 @@ type fsEventStreamContext struct {
 	copyDescription uintptr
 }
 
-// fseventsState.
-//
-// stream is claimed by Close with an atomic Swap. Root deletion is detected in
-// the callback, but teardown is deferred to Close because the assembly callback
-// is still waiting on the done pipe while fsEventsCallback runs.
 type fseventsState struct {
+	terminated atomic.Bool
+}
+
+type fseventsStream struct {
 	stream atomic.Uintptr
 	cb     *streamCallback
 	pinner runtime.Pinner
@@ -170,6 +173,10 @@ type fseventsState struct {
 // fsEventsBackend.
 type fsEventsBackend struct {
 	watcherBase
+
+	mu      sync.Mutex
+	watches map[*dirWatch]*fseventsState
+	streams []*fseventsStream
 }
 
 func init() {
@@ -177,7 +184,9 @@ func init() {
 }
 
 func newFSEventsBackend() *fsEventsBackend {
-	b := &fsEventsBackend{}
+	b := &fsEventsBackend{
+		watches: make(map[*dirWatch]*fseventsState),
+	}
 	b.watcherBase.init(b)
 	return b
 }
@@ -200,9 +209,8 @@ func checkWatcher(w *dirWatch) error {
 }
 
 var (
-	errMissingFSEventsState = errors.New("fsevents: missing state")
-	errStreamCreateNull     = errors.New("FSEventStreamCreate returned NULL")
-	errStreamStartFailed    = errors.New("error starting FSEvents stream")
+	errStreamCreateNull  = errors.New("FSEventStreamCreate returned NULL")
+	errStreamStartFailed = errors.New("error starting FSEvents stream")
 )
 
 var (
@@ -211,31 +219,93 @@ var (
 	errFSEventsTooMany       = fmt.Errorf("too many events: %w", ErrOverflow)
 )
 
-// startStream creates and starts an FSEventStream on its per-stream
-// serial dispatch queue.
-func (b *fsEventsBackend) startStream(w *dirWatch, since uint64) error {
-	if err := checkWatcher(w); err != nil {
-		return err
+const fseventsPathsPerStream = 512
+
+type fseventsWatchSnapshot struct {
+	w     *dirWatch
+	state *fseventsState
+}
+
+func (b *fsEventsBackend) activeWatchesLocked() []fseventsWatchSnapshot {
+	watches := make([]fseventsWatchSnapshot, 0, len(b.watches))
+	for w, state := range b.watches {
+		if state.terminated.Load() {
+			continue
+		}
+		watches = append(watches, fseventsWatchSnapshot{w: w, state: state})
+	}
+	slices.SortFunc(watches, func(a, b fseventsWatchSnapshot) int {
+		return strings.Compare(a.w.physicalDir, b.w.physicalDir)
+	})
+	return watches
+}
+
+func (b *fsEventsBackend) startStreams(watches []fseventsWatchSnapshot) ([]*fseventsStream, error) {
+	if len(watches) == 0 {
+		return nil, nil
+	}
+	seen := make(map[string]struct{}, len(watches))
+	paths := make([]string, 0, len(watches))
+	for _, watch := range watches {
+		path := watch.w.physicalDir
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	streams := make([]*fseventsStream, 0, (len(paths)+fseventsPathsPerStream-1)/fseventsPathsPerStream)
+	for len(paths) > 0 {
+		chunkLen := min(len(paths), fseventsPathsPerStream)
+		stream, err := b.startStream(paths[:chunkLen])
+		if err != nil {
+			stopFSEventsStreams(streams)
+			return nil, err
+		}
+		streams = append(streams, stream)
+		paths = paths[chunkLen:]
+	}
+	return streams, nil
+}
+
+// startStream creates and starts one FSEventStream watching all supplied paths.
+func (b *fsEventsBackend) startStream(paths []string) (*fseventsStream, error) {
+	if len(paths) == 0 {
+		return nil, nil
 	}
 
-	state, _ := w.state.(*fseventsState)
-	if state == nil {
-		return errMissingFSEventsState
+	cfStrings := make([]uintptr, 0, len(paths))
+	for _, path := range paths {
+		dirCStr := append([]byte(path), 0)
+		cfDir := cfStringCreate(0, unsafe.Pointer(&dirCStr[0]), cfStringEncodingUTF8)
+		if cfDir == 0 {
+			for _, cfString := range cfStrings {
+				cfRelease(cfString)
+			}
+			return nil, errStreamCreateNull
+		}
+		cfStrings = append(cfStrings, cfDir)
 	}
+	defer func() {
+		for _, cfString := range cfStrings {
+			cfRelease(cfString)
+		}
+	}()
 
-	dirCStr := append([]byte(w.physicalDir), 0)
-	cfDir := cfStringCreate(0, unsafe.Pointer(&dirCStr[0]), cfStringEncodingUTF8)
-	defer cfRelease(cfDir)
-
-	pathsToWatch := cfArrayCreate(0, unsafe.Pointer(&cfDir), 1, 0)
+	pathsToWatch := cfArrayCreate(0, unsafe.Pointer(&cfStrings[0]), len(cfStrings), 0)
+	if pathsToWatch == 0 {
+		return nil, errStreamCreateNull
+	}
 	defer cfRelease(pathsToWatch)
 
-	cb, err := newStreamCallback(w)
+	cb, err := newStreamCallback(b)
 	if err != nil {
-		return &dirWatchError{err: err, dirWatch: w}
+		return nil, err
 	}
+	state := &fseventsStream{cb: cb}
 	state.pinner.Pin(cb)
-	state.cb = cb
 
 	ctx := fsEventStreamContext{info: uintptr(unsafe.Pointer(cb))}
 
@@ -244,14 +314,14 @@ func (b *fsEventsBackend) startStream(w *dirWatch, since uint64) error {
 		fsEventsCallbackAsmAddr,
 		unsafe.Pointer(&ctx),
 		pathsToWatch,
-		since,
+		eventIDSinceNow,
 		0.001,
 	)
 	if stream == 0 {
 		cb.close()
 		state.cb = nil
 		state.pinner.Unpin()
-		return &dirWatchError{err: errStreamCreateNull, dirWatch: w}
+		return nil, errStreamCreateNull
 	}
 
 	fsEventStreamSetDispatchQueue(stream, cb.queue)
@@ -261,11 +331,11 @@ func (b *fsEventsBackend) startStream(w *dirWatch, since uint64) error {
 		cb.close()
 		state.cb = nil
 		state.pinner.Unpin()
-		return &dirWatchError{err: errStreamStartFailed, dirWatch: w}
+		return nil, errStreamStartFailed
 	}
 	fsEventStreamFlushSync(stream)
 	state.stream.Store(stream)
-	return nil
+	return state, nil
 }
 
 // teardownStream performs the full FSEventStream cleanup. Stop and Invalidate
@@ -284,10 +354,15 @@ func teardownStream(stream uintptr, cb *streamCallback) {
 	fsEventStreamRelease(stream)
 }
 
-// stopStream tears down a stream if WatchDirectory successfully started one.
 // The atomic Swap gates teardown so concurrent or repeated calls are safe:
 // only the goroutine that observes a non-zero stream performs the cleanup.
-func (b *fsEventsBackend) stopStream(state *fseventsState) {
+func stopFSEventsStreams(streams []*fseventsStream) {
+	for _, stream := range streams {
+		stopFSEventsStream(stream)
+	}
+}
+
+func stopFSEventsStream(state *fseventsStream) {
 	if state == nil {
 		return
 	}
@@ -303,9 +378,35 @@ func (b *fsEventsBackend) stopStream(state *fseventsState) {
 
 // subscribe mirrors `fsEventsBackend::subscribe`.
 func (b *fsEventsBackend) subscribe(w *dirWatch) error {
+	if err := checkWatcher(w); err != nil {
+		return err
+	}
+
 	state := &fseventsState{}
 	w.state = state
-	return b.startStream(w, eventIDSinceNow)
+
+	b.mu.Lock()
+	b.watches[w] = state
+	watches := b.activeWatchesLocked()
+	b.mu.Unlock()
+
+	streams, err := b.startStreams(watches)
+	if err != nil {
+		b.mu.Lock()
+		if b.watches[w] == state {
+			delete(b.watches, w)
+			w.state = nil
+		}
+		b.mu.Unlock()
+		return &dirWatchError{err: err, dirWatch: w}
+	}
+
+	b.mu.Lock()
+	oldStreams := b.streams
+	b.streams = streams
+	b.mu.Unlock()
+	stopFSEventsStreams(oldStreams)
+	return nil
 }
 
 // closeWatch mirrors `fsEventsBackend::closeWatch`.
@@ -315,7 +416,23 @@ func (b *fsEventsBackend) closeWatch(w *dirWatch) error {
 	if state == nil {
 		return nil
 	}
-	b.stopStream(state)
+	state.terminated.Store(true)
+
+	b.mu.Lock()
+	delete(b.watches, w)
+	watches := b.activeWatchesLocked()
+	b.mu.Unlock()
+
+	streams, err := b.startStreams(watches)
+	if err != nil {
+		return err
+	}
+
+	b.mu.Lock()
+	oldStreams := b.streams
+	b.streams = streams
+	b.mu.Unlock()
+	stopFSEventsStreams(oldStreams)
 	return nil
 }
 
@@ -344,8 +461,8 @@ func fsEventsCallback(cb *streamCallback, payload *fsEventsCallbackPayload) {
 	paths := payload.paths
 	flags := payload.flags
 
-	w := cb.dirWatch
-	deletedRoot := false
+	watches := cb.backend.activeWatchesSnapshot()
+	touched := map[*dirWatch]struct{}{}
 
 	for i := range numEvents {
 		flag := *(*uint32)(unsafe.Add(nil, flags+i*flagSize))
@@ -361,18 +478,22 @@ func fsEventsCallback(cb *streamCallback, payload *fsEventsCallbackPayload) {
 		isDone := flag&flagHistoryDone != 0
 
 		if flag&flagMustScanSubDirs != 0 {
+			var overflow error
 			switch {
 			case flag&flagUserDropped != 0:
-				w.events.setError(errFSEventsUserDropped)
+				overflow = errFSEventsUserDropped
 			case flag&flagKernelDropped != 0:
-				w.events.setError(errFSEventsKernelDropped)
+				overflow = errFSEventsKernelDropped
 			default:
-				w.events.setError(errFSEventsTooMany)
+				overflow = errFSEventsTooMany
+			}
+			for _, watch := range watches {
+				watch.w.events.setError(overflow)
+				touched[watch.w] = struct{}{}
 			}
 		}
 
 		if isDone {
-			w.notify()
 			break
 		}
 
@@ -380,58 +501,73 @@ func fsEventsCallback(cb *streamCallback, payload *fsEventsCallbackPayload) {
 			continue
 		}
 
-		// Skip events for the watched directory itself unless it's been
-		// removed. fseventsd reports a change on the watched dir when a
-		// child is added or removed; subscribers observe changes *within*
-		// the directory, not the dir's own metadata churn.
-		// (A removal of the dir is still propagated because Watcher
-		// relies on it to tear down the stream.)
 		rawPath := path
-		path = w.displayPath(path)
+		pathExists := false
+		pathExistsKnown := false
 
-		if path == w.dir && !isRemoved && !isRenamed {
-			continue
-		}
-
-		switch {
-		case isRemoved && !isCreated:
-			// Pure remove, or remove+rename: file is gone.
-			w.events.remove(path)
-			if path == w.dir {
-				deletedRoot = true
+		for _, watch := range watches {
+			w := watch.w
+			displayPath, ok := fseventsDisplayPath(w, rawPath)
+			if !ok {
+				continue
 			}
-		case isRenamed || (isRemoved && isCreated):
-			// Ambiguous: rename could mean moved away (delete) or
-			// moved in (update); remove+create could mean replaced.
-			// Stat to check existence.
-			var st unix.Stat_t
-			if unix.Lstat(rawPath, &st) != nil {
-				w.events.remove(path)
-				if path == w.dir {
-					deletedRoot = true
+
+			// Skip events for the watched directory itself unless it's been
+			// removed. fseventsd reports a change on the watched dir when a
+			// child is added or removed; subscribers observe changes *within*
+			// the directory, not the dir's own metadata churn.
+			// (A removal of the dir is still propagated because Watcher
+			// relies on it to tear down the stream.)
+			if displayPath == w.dir && !isRemoved && !isRenamed {
+				continue
+			}
+
+			switch {
+			case isRemoved && !isCreated:
+				w.events.remove(displayPath)
+				if displayPath == w.dir {
+					watch.state.terminated.Store(true)
+					w.events.setError(fmt.Errorf("%w: watched directory removed", ErrWatchTerminated))
 				}
-			} else {
-				w.events.update(path)
+			case isRenamed || (isRemoved && isCreated):
+				if !pathExistsKnown {
+					var st unix.Stat_t
+					pathExists = unix.Lstat(rawPath, &st) == nil
+					pathExistsKnown = true
+				}
+				if pathExists {
+					w.events.update(displayPath)
+				} else {
+					w.events.remove(displayPath)
+					if displayPath == w.dir {
+						watch.state.terminated.Store(true)
+						w.events.setError(fmt.Errorf("%w: watched directory removed", ErrWatchTerminated))
+					}
+				}
+			default:
+				w.events.update(displayPath)
 			}
-		default:
-			// Create, modify, or any other flag combo.
-			w.events.update(path)
+			touched[w] = struct{}{}
 		}
 	}
 
-	if deletedRoot {
-		// Surface ErrWatchTerminated alongside the delete event so the
-		// caller knows no further events will arrive. Stream teardown is
-		// still deferred to Close.
-		w.events.setError(fmt.Errorf("%w: watched directory removed", ErrWatchTerminated))
+	for w := range touched {
+		w.notify()
 	}
+}
 
-	w.notify()
+func (b *fsEventsBackend) activeWatchesSnapshot() []fseventsWatchSnapshot {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.activeWatchesLocked()
+}
 
-	if deletedRoot {
-		// The watched root was deleted. Mark the callback as closed so
-		// future callbacks are no-ops. Stream teardown and pipe cleanup
-		// are deferred to Close.
-		cb.closed.Store(true)
+func fseventsDisplayPath(w *dirWatch, rawPath string) (string, bool) {
+	if isInDirectoryOrSelf(w.physicalDir, rawPath) {
+		return w.displayPath(rawPath), true
 	}
+	if w.physicalDir != w.dir && isInDirectoryOrSelf(w.dir, rawPath) {
+		return rawPath, true
+	}
+	return "", false
 }

--- a/internal/fswatch/fsevents_darwin.go
+++ b/internal/fswatch/fsevents_darwin.go
@@ -9,7 +9,6 @@ import (
 	"runtime"
 	"slices"
 	"sort"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -101,8 +100,9 @@ import (
 //   flagMustScanSubDirs → ErrOverflow with detail (user/kernel/too-many).
 //
 // Root deletion:
-//   Detected in the callback; cb.closed is set so future callbacks are
-//   no-ops. Stream teardown is deferred to Close.
+//   Detected in the callback; the logical watch is marked terminated and
+//   receives ErrWatchTerminated. The shared stream remains active for other
+//   watches until the owner closes or reconciles the terminated watch.
 // ---------------------------------------------------------------------------
 
 // ----- FSEvents flag bits (from FSEvents.h) ------------------------------
@@ -166,6 +166,7 @@ type fseventsStream struct {
 	stream atomic.Uintptr
 	cb     *streamCallback
 	pinner runtime.Pinner
+	paths  []string
 }
 
 // ----- the watcherImpl -------------------------------------------------------
@@ -236,9 +237,6 @@ func (b *fsEventsBackend) activeWatchesLocked() []fseventsWatchSnapshot {
 		}
 		watches = append(watches, fseventsWatchSnapshot{w: w, state: state})
 	}
-	slices.SortFunc(watches, func(a, b fseventsWatchSnapshot) int {
-		return strings.Compare(a.w.physicalDir, b.w.physicalDir)
-	})
 	return watches
 }
 
@@ -312,11 +310,11 @@ func (b *fsEventsBackend) startStream(paths []string) (*fseventsStream, error) {
 	}
 	defer cfRelease(pathsToWatch)
 
-	cb, err := newStreamCallback(b)
+	cb, err := newStreamCallback(b, paths)
 	if err != nil {
 		return nil, err
 	}
-	state := &fseventsStream{cb: cb}
+	state := &fseventsStream{cb: cb, paths: slices.Clone(paths)}
 	state.pinner.Pin(cb)
 
 	ctx := fsEventStreamContext{info: uintptr(unsafe.Pointer(cb))}
@@ -457,10 +455,6 @@ func (b *fsEventsBackend) closeWatch(w *dirWatch) error {
 func fsEventsCallback(cb *streamCallback, payload *fsEventsCallbackPayload) {
 	defer payload.close()
 
-	if cb.closed.Load() {
-		return
-	}
-
 	const (
 		flagSize = unsafe.Sizeof(uint32(0))
 	)
@@ -473,7 +467,7 @@ func fsEventsCallback(cb *streamCallback, payload *fsEventsCallbackPayload) {
 	paths := payload.paths
 	flags := payload.flags
 
-	watches := cb.backend.activeWatchesSnapshot()
+	watches := cb.backend.activeWatchesSnapshot(cb.paths)
 	touched := map[*dirWatch]struct{}{}
 
 	for i := range numEvents {
@@ -568,10 +562,20 @@ func fsEventsCallback(cb *streamCallback, payload *fsEventsCallbackPayload) {
 	}
 }
 
-func (b *fsEventsBackend) activeWatchesSnapshot() []fseventsWatchSnapshot {
+func (b *fsEventsBackend) activeWatchesSnapshot(paths []string) []fseventsWatchSnapshot {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	return b.activeWatchesLocked()
+	watches := b.activeWatchesLocked()
+	if len(paths) == 0 {
+		return watches
+	}
+	filtered := watches[:0]
+	for _, watch := range watches {
+		if slices.Contains(paths, watch.w.physicalDir) {
+			filtered = append(filtered, watch)
+		}
+	}
+	return filtered
 }
 
 func fseventsDisplayPath(w *dirWatch, rawPath string) (string, bool) {

--- a/internal/fswatch/fsevents_darwin.go
+++ b/internal/fswatch/fsevents_darwin.go
@@ -166,7 +166,6 @@ type fseventsStream struct {
 	stream atomic.Uintptr
 	cb     *streamCallback
 	pinner runtime.Pinner
-	paths  []string
 }
 
 // ----- the watcherImpl -------------------------------------------------------
@@ -244,7 +243,7 @@ func (b *fsEventsBackend) startStreams(watches []fseventsWatchSnapshot) ([]*fsev
 	return startFSEventsStreams(watches, b.startStream)
 }
 
-func startFSEventsStreams(watches []fseventsWatchSnapshot, startStream func([]string) (*fseventsStream, error)) ([]*fseventsStream, error) {
+func startFSEventsStreams(watches []fseventsWatchSnapshot, startStream func([]string, []fseventsWatchSnapshot) (*fseventsStream, error)) ([]*fseventsStream, error) {
 	if len(watches) == 0 {
 		return nil, nil
 	}
@@ -260,7 +259,7 @@ func startFSEventsStreams(watches []fseventsWatchSnapshot, startStream func([]st
 	}
 	sort.Strings(paths)
 
-	stream, err := startStream(paths)
+	stream, err := startStream(paths, watches)
 	if err == nil {
 		return []*fseventsStream{stream}, nil
 	}
@@ -269,7 +268,8 @@ func startFSEventsStreams(watches []fseventsWatchSnapshot, startStream func([]st
 	remainingPaths := paths
 	for len(remainingPaths) > 0 {
 		chunkLen := min(len(remainingPaths), fseventsPathsPerStream)
-		stream, err := startStream(remainingPaths[:chunkLen])
+		chunkPaths := remainingPaths[:chunkLen]
+		stream, err := startStream(chunkPaths, watchesForFSEventsPaths(watches, chunkPaths))
 		if err != nil {
 			stopFSEventsStreams(streams)
 			return nil, err
@@ -280,8 +280,21 @@ func startFSEventsStreams(watches []fseventsWatchSnapshot, startStream func([]st
 	return streams, nil
 }
 
+func watchesForFSEventsPaths(watches []fseventsWatchSnapshot, paths []string) []fseventsWatchSnapshot {
+	if len(paths) == 0 {
+		return nil
+	}
+	filtered := make([]fseventsWatchSnapshot, 0, len(watches))
+	for _, watch := range watches {
+		if _, ok := slices.BinarySearch(paths, watch.w.physicalDir); ok {
+			filtered = append(filtered, watch)
+		}
+	}
+	return filtered
+}
+
 // startStream creates and starts one FSEventStream watching all supplied paths.
-func (b *fsEventsBackend) startStream(paths []string) (*fseventsStream, error) {
+func (b *fsEventsBackend) startStream(paths []string, watches []fseventsWatchSnapshot) (*fseventsStream, error) {
 	if len(paths) == 0 {
 		return nil, nil
 	}
@@ -310,11 +323,11 @@ func (b *fsEventsBackend) startStream(paths []string) (*fseventsStream, error) {
 	}
 	defer cfRelease(pathsToWatch)
 
-	cb, err := newStreamCallback(b, paths)
+	cb, err := newStreamCallback(watches)
 	if err != nil {
 		return nil, err
 	}
-	state := &fseventsStream{cb: cb, paths: slices.Clone(paths)}
+	state := &fseventsStream{cb: cb}
 	state.pinner.Pin(cb)
 
 	ctx := fsEventStreamContext{info: uintptr(unsafe.Pointer(cb))}
@@ -467,7 +480,7 @@ func fsEventsCallback(cb *streamCallback, payload *fsEventsCallbackPayload) {
 	paths := payload.paths
 	flags := payload.flags
 
-	watches := cb.backend.activeWatchesSnapshot(cb.paths)
+	watches := cb.watches
 	touched := map[*dirWatch]struct{}{}
 
 	for i := range numEvents {
@@ -494,6 +507,9 @@ func fsEventsCallback(cb *streamCallback, payload *fsEventsCallbackPayload) {
 				overflow = errFSEventsTooMany
 			}
 			for _, watch := range watches {
+				if watch.state.terminated.Load() {
+					continue
+				}
 				if fseventsOverflowMatches(watch.w, path) {
 					watch.w.events.setError(overflow)
 					touched[watch.w] = struct{}{}
@@ -514,6 +530,9 @@ func fsEventsCallback(cb *streamCallback, payload *fsEventsCallbackPayload) {
 		pathExistsKnown := false
 
 		for _, watch := range watches {
+			if watch.state.terminated.Load() {
+				continue
+			}
 			w := watch.w
 			displayPath, ok := fseventsDisplayPath(w, rawPath)
 			if !ok {
@@ -562,22 +581,6 @@ func fsEventsCallback(cb *streamCallback, payload *fsEventsCallbackPayload) {
 	for w := range touched {
 		w.notify()
 	}
-}
-
-func (b *fsEventsBackend) activeWatchesSnapshot(paths []string) []fseventsWatchSnapshot {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	watches := b.activeWatchesLocked()
-	if len(paths) == 0 {
-		return watches
-	}
-	filtered := watches[:0]
-	for _, watch := range watches {
-		if _, ok := slices.BinarySearch(paths, watch.w.physicalDir); ok {
-			filtered = append(filtered, watch)
-		}
-	}
-	return filtered
 }
 
 func fseventsDisplayPath(w *dirWatch, rawPath string) (string, bool) {

--- a/internal/fswatch/fsevents_darwin_ffi.go
+++ b/internal/fswatch/fsevents_darwin_ffi.go
@@ -452,8 +452,7 @@ type streamCallback struct {
 	eventFile *os.File
 	queue     uintptr // per-stream serial dispatch queue
 	done      chan struct{}
-	backend   *fsEventsBackend
-	paths     []string
+	watches   []fseventsWatchSnapshot
 }
 
 type fsEventsCallbackPayload struct {
@@ -478,7 +477,7 @@ func (p *fsEventsCallbackPayload) close() {
 // callbacks. The per-stream serial queue serializes this stream's callbacks
 // and prevents cross-stream head-of-line blocking that a process-wide serial
 // queue would cause.
-func newStreamCallback(backend *fsEventsBackend, paths []string) (*streamCallback, error) {
+func newStreamCallback(watches []fseventsWatchSnapshot) (*streamCallback, error) {
 	var eventPipe [2]int
 	if err := unix.Pipe(eventPipe[:]); err != nil {
 		return nil, err
@@ -500,8 +499,7 @@ func newStreamCallback(backend *fsEventsBackend, paths []string) (*streamCallbac
 		eventFile:      os.NewFile(uintptr(eventPipe[0]), "fsevents-event"),
 		queue:          queue,
 		done:           make(chan struct{}),
-		backend:        backend,
-		paths:          slices.Clone(paths),
+		watches:        slices.Clone(watches),
 	}
 	go cb.eventLoop()
 	return cb, nil

--- a/internal/fswatch/fsevents_darwin_ffi.go
+++ b/internal/fswatch/fsevents_darwin_ffi.go
@@ -7,7 +7,7 @@ import (
 	"math"
 	"os"
 	"runtime"
-	"sync/atomic"
+	"slices"
 	"syscall"
 	"unsafe"
 
@@ -453,7 +453,7 @@ type streamCallback struct {
 	queue     uintptr // per-stream serial dispatch queue
 	done      chan struct{}
 	backend   *fsEventsBackend
-	closed    atomic.Bool
+	paths     []string
 }
 
 type fsEventsCallbackPayload struct {
@@ -478,7 +478,7 @@ func (p *fsEventsCallbackPayload) close() {
 // callbacks. The per-stream serial queue serializes this stream's callbacks
 // and prevents cross-stream head-of-line blocking that a process-wide serial
 // queue would cause.
-func newStreamCallback(backend *fsEventsBackend) (*streamCallback, error) {
+func newStreamCallback(backend *fsEventsBackend, paths []string) (*streamCallback, error) {
 	var eventPipe [2]int
 	if err := unix.Pipe(eventPipe[:]); err != nil {
 		return nil, err
@@ -501,6 +501,7 @@ func newStreamCallback(backend *fsEventsBackend) (*streamCallback, error) {
 		queue:          queue,
 		done:           make(chan struct{}),
 		backend:        backend,
+		paths:          slices.Clone(paths),
 	}
 	go cb.eventLoop()
 	return cb, nil

--- a/internal/fswatch/fsevents_darwin_ffi.go
+++ b/internal/fswatch/fsevents_darwin_ffi.go
@@ -75,7 +75,7 @@ import (
 //	  asm: return to FSEvents          fsEventsCallback(cb, payload)
 //	                                   classifies events,
 //	                                   frees payload,
-//	                                   posts to dirWatch.events
+//	                                   routes to matching dirWatch events
 //
 // The assembly callback never enters Go ABI; it stays entirely in C
 // context. One pipe per stream hands retained/copied callback payloads from
@@ -452,7 +452,7 @@ type streamCallback struct {
 	eventFile *os.File
 	queue     uintptr // per-stream serial dispatch queue
 	done      chan struct{}
-	dirWatch  *dirWatch
+	backend   *fsEventsBackend
 	closed    atomic.Bool
 }
 
@@ -478,7 +478,7 @@ func (p *fsEventsCallbackPayload) close() {
 // callbacks. The per-stream serial queue serializes this stream's callbacks
 // and prevents cross-stream head-of-line blocking that a process-wide serial
 // queue would cause.
-func newStreamCallback(w *dirWatch) (*streamCallback, error) {
+func newStreamCallback(backend *fsEventsBackend) (*streamCallback, error) {
 	var eventPipe [2]int
 	if err := unix.Pipe(eventPipe[:]); err != nil {
 		return nil, err
@@ -500,7 +500,7 @@ func newStreamCallback(w *dirWatch) (*streamCallback, error) {
 		eventFile:      os.NewFile(uintptr(eventPipe[0]), "fsevents-event"),
 		queue:          queue,
 		done:           make(chan struct{}),
-		dirWatch:       w,
+		backend:        backend,
 	}
 	go cb.eventLoop()
 	return cb, nil

--- a/internal/fswatch/fsevents_darwin_shared_test.go
+++ b/internal/fswatch/fsevents_darwin_shared_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 )
@@ -103,4 +104,36 @@ func TestFSEventsSharedStreamRoutesEvents(t *testing.T) {
 	}
 	expectContains(t, recB, EventUpdate, fileB)
 	assertNoEventsForPath(t, recA.drainQuiet(500*time.Millisecond), fileB, "sibling watch saw event")
+}
+
+func TestFSEventsSharedStreamFallsBackToChunks(t *testing.T) {
+	t.Parallel()
+
+	const count = fseventsPathsPerStream*2 + 1
+	watches := make([]fseventsWatchSnapshot, 0, count)
+	for i := range count {
+		watches = append(watches, fseventsWatchSnapshot{
+			w:     &dirWatch{physicalDir: fmt.Sprintf("/watch/dir%04d", i)},
+			state: &fseventsState{},
+		})
+	}
+
+	var calls []int
+	streams, err := startFSEventsStreams(watches, func(paths []string) (*fseventsStream, error) {
+		calls = append(calls, len(paths))
+		if len(calls) == 1 {
+			return nil, errStreamStartFailed
+		}
+		return &fseventsStream{}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(streams) != 3 {
+		t.Fatalf("expected 3 chunked streams, got %d", len(streams))
+	}
+	wantCalls := []int{count, fseventsPathsPerStream, fseventsPathsPerStream, 1}
+	if !slices.Equal(calls, wantCalls) {
+		t.Fatalf("startStream calls = %v, want %v", calls, wantCalls)
+	}
 }

--- a/internal/fswatch/fsevents_darwin_shared_test.go
+++ b/internal/fswatch/fsevents_darwin_shared_test.go
@@ -1,0 +1,106 @@
+//go:build darwin && (amd64 || arm64)
+
+package fswatch
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func newTestFSEventsWatcher(impl **fsEventsBackend) Watcher {
+	return &watcher{
+		name: "fsevents",
+		factory: func() watcherImpl {
+			*impl = newFSEventsBackend()
+			return *impl
+		},
+	}
+}
+
+func TestFSEventsSharedStreamAcrossWatches(t *testing.T) {
+	t.Parallel()
+
+	var impl *fsEventsBackend
+	watcherImpl := newTestFSEventsWatcher(&impl)
+	root := newTmpDir(t)
+
+	var subs []Watch
+	for i := range 5 {
+		dir := filepath.Join(root, fmt.Sprintf("dir%d", i))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		sub, err := watcherImpl.WatchDirectory(dir, func([]Event, error) {})
+		if err != nil {
+			t.Fatal(err)
+		}
+		subs = append(subs, sub)
+	}
+	t.Cleanup(func() {
+		for _, sub := range subs {
+			_ = sub.Close()
+		}
+	})
+
+	impl.mu.Lock()
+	streamCount := len(impl.streams)
+	watchCount := len(impl.watches)
+	impl.mu.Unlock()
+	if streamCount != 1 {
+		t.Fatalf("expected one shared FSEvents stream, got %d", streamCount)
+	}
+	if watchCount != len(subs) {
+		t.Fatalf("expected %d logical watches, got %d", len(subs), watchCount)
+	}
+}
+
+func TestFSEventsSharedStreamRoutesEvents(t *testing.T) {
+	t.Parallel()
+
+	var impl *fsEventsBackend
+	watcherImpl := newTestFSEventsWatcher(&impl)
+	root := newTmpDir(t)
+	dirA := filepath.Join(root, "a")
+	dirB := filepath.Join(root, "b")
+	if err := os.MkdirAll(dirA, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dirB, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(preSubscribeSleep(watcherImpl))
+	recA := newRecorder(t)
+	recA.watcher = watcherImpl
+	subA, err := watcherImpl.WatchDirectory(dirA, recA.callback)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = subA.Close() })
+
+	recB := newRecorder(t)
+	recB.watcher = watcherImpl
+	subB, err := watcherImpl.WatchDirectory(dirB, recB.callback)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = subB.Close() })
+	time.Sleep(settleSleep(watcherImpl))
+
+	fileA := filepath.Join(dirA, "file.ts")
+	if err := os.WriteFile(fileA, []byte("export {}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	expectContains(t, recA, EventUpdate, fileA)
+	assertNoEventsForPath(t, recB.drainQuiet(500*time.Millisecond), fileA, "sibling watch saw event")
+
+	fileB := filepath.Join(dirB, "file.ts")
+	if err := os.WriteFile(fileB, []byte("export {}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	expectContains(t, recB, EventUpdate, fileB)
+	assertNoEventsForPath(t, recA.drainQuiet(500*time.Millisecond), fileB, "sibling watch saw event")
+}

--- a/internal/fswatch/fsevents_darwin_shared_test.go
+++ b/internal/fswatch/fsevents_darwin_shared_test.go
@@ -137,3 +137,27 @@ func TestFSEventsSharedStreamFallsBackToChunks(t *testing.T) {
 		t.Fatalf("startStream calls = %v, want %v", calls, wantCalls)
 	}
 }
+
+func TestFSEventsActiveWatchesSnapshotFiltersToStreamPaths(t *testing.T) {
+	t.Parallel()
+
+	b := newFSEventsBackend()
+	watchA := &dirWatch{physicalDir: "/watch/a"}
+	watchB := &dirWatch{physicalDir: "/watch/b"}
+	watchC := &dirWatch{physicalDir: "/watch/c"}
+	b.watches[watchA] = &fseventsState{}
+	b.watches[watchB] = &fseventsState{}
+	b.watches[watchC] = &fseventsState{}
+
+	got := b.activeWatchesSnapshot([]string{"/watch/a", "/watch/c"})
+	gotPaths := make([]string, 0, len(got))
+	for _, watch := range got {
+		gotPaths = append(gotPaths, watch.w.physicalDir)
+	}
+	slices.Sort(gotPaths)
+
+	want := []string{"/watch/a", "/watch/c"}
+	if !slices.Equal(gotPaths, want) {
+		t.Fatalf("activeWatchesSnapshot paths = %v, want %v", gotPaths, want)
+	}
+}

--- a/internal/fswatch/fsevents_darwin_shared_test.go
+++ b/internal/fswatch/fsevents_darwin_shared_test.go
@@ -161,3 +161,34 @@ func TestFSEventsActiveWatchesSnapshotFiltersToStreamPaths(t *testing.T) {
 		t.Fatalf("activeWatchesSnapshot paths = %v, want %v", gotPaths, want)
 	}
 }
+
+func TestFSEventsOverflowMatchesWatch(t *testing.T) {
+	t.Parallel()
+
+	w := &dirWatch{
+		dir:         "/logical/root",
+		physicalDir: "/physical/root",
+	}
+	cases := []struct {
+		name    string
+		rawPath string
+		want    bool
+	}{
+		{name: "physical root", rawPath: "/physical/root", want: true},
+		{name: "physical descendant", rawPath: "/physical/root/sub", want: true},
+		{name: "physical ancestor", rawPath: "/physical", want: true},
+		{name: "logical root", rawPath: "/logical/root", want: true},
+		{name: "logical descendant", rawPath: "/logical/root/sub", want: true},
+		{name: "logical ancestor", rawPath: "/logical", want: true},
+		{name: "unrelated", rawPath: "/other/root", want: false},
+		{name: "sibling prefix", rawPath: "/physical/root2", want: false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if got := fseventsOverflowMatches(w, c.rawPath); got != c.want {
+				t.Fatalf("fseventsOverflowMatches(%q) = %v, want %v", c.rawPath, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/fswatch/fsevents_darwin_shared_test.go
+++ b/internal/fswatch/fsevents_darwin_shared_test.go
@@ -119,8 +119,10 @@ func TestFSEventsSharedStreamFallsBackToChunks(t *testing.T) {
 	}
 
 	var calls []int
-	streams, err := startFSEventsStreams(watches, func(paths []string) (*fseventsStream, error) {
+	var watchCalls []int
+	streams, err := startFSEventsStreams(watches, func(paths []string, streamWatches []fseventsWatchSnapshot) (*fseventsStream, error) {
 		calls = append(calls, len(paths))
+		watchCalls = append(watchCalls, len(streamWatches))
 		if len(calls) == 1 {
 			return nil, errStreamStartFailed
 		}
@@ -136,20 +138,24 @@ func TestFSEventsSharedStreamFallsBackToChunks(t *testing.T) {
 	if !slices.Equal(calls, wantCalls) {
 		t.Fatalf("startStream calls = %v, want %v", calls, wantCalls)
 	}
+	if !slices.Equal(watchCalls, wantCalls) {
+		t.Fatalf("startStream watch calls = %v, want %v", watchCalls, wantCalls)
+	}
 }
 
-func TestFSEventsActiveWatchesSnapshotFiltersToStreamPaths(t *testing.T) {
+func TestWatchesForFSEventsPaths(t *testing.T) {
 	t.Parallel()
 
-	b := newFSEventsBackend()
 	watchA := &dirWatch{physicalDir: "/watch/a"}
 	watchB := &dirWatch{physicalDir: "/watch/b"}
 	watchC := &dirWatch{physicalDir: "/watch/c"}
-	b.watches[watchA] = &fseventsState{}
-	b.watches[watchB] = &fseventsState{}
-	b.watches[watchC] = &fseventsState{}
+	watches := []fseventsWatchSnapshot{
+		{w: watchA, state: &fseventsState{}},
+		{w: watchB, state: &fseventsState{}},
+		{w: watchC, state: &fseventsState{}},
+	}
 
-	got := b.activeWatchesSnapshot([]string{"/watch/a", "/watch/c"})
+	got := watchesForFSEventsPaths(watches, []string{"/watch/a", "/watch/c"})
 	gotPaths := make([]string, 0, len(got))
 	for _, watch := range got {
 		gotPaths = append(gotPaths, watch.w.physicalDir)
@@ -158,7 +164,7 @@ func TestFSEventsActiveWatchesSnapshotFiltersToStreamPaths(t *testing.T) {
 
 	want := []string{"/watch/a", "/watch/c"}
 	if !slices.Equal(gotPaths, want) {
-		t.Fatalf("activeWatchesSnapshot paths = %v, want %v", gotPaths, want)
+		t.Fatalf("watchesForFSEventsPaths = %v, want %v", gotPaths, want)
 	}
 }
 

--- a/internal/fswatch/watcher.go
+++ b/internal/fswatch/watcher.go
@@ -67,6 +67,11 @@ type Watcher interface {
 	// Returns [ErrUnavailable] if the watcher is not supported on
 	// the current platform.
 	WatchDirectory(dir string, fn WatchCallback, opts ...WatchOption) (Watch, error)
+	// WatchDirectories watches multiple directories as a batch. It has the
+	// same semantics as calling [Watcher.WatchDirectory] for each request, but
+	// lets backends arm the underlying OS watches once for the whole batch.
+	// Returned watches are in the same order as requests.
+	WatchDirectories(requests []WatchDirectoryRequest) ([]Watch, error)
 	// WatchFile watches a single file for changes, calling fn with
 	// batched events. path must be an absolute path. The file does not
 	// need to exist at subscribe time; its creation will be reported.
@@ -91,6 +96,14 @@ type Watcher interface {
 // WatchOption configures a watch.
 type WatchOption interface {
 	applyWatchOption(opts *watchOptions)
+}
+
+// WatchDirectoryRequest describes one directory subscription in a
+// [Watcher.WatchDirectories] batch.
+type WatchDirectoryRequest struct {
+	Dir      string
+	Callback WatchCallback
+	Options  []WatchOption
 }
 
 type watchOptions struct {
@@ -361,39 +374,86 @@ func (w *watcher) removeDirWatch(dw *dirWatch) {
 }
 
 func (w *watcher) WatchDirectory(dir string, fn WatchCallback, opts ...WatchOption) (Watch, error) {
-	if fn == nil {
-		return nil, errNilCallback
+	watches, err := w.WatchDirectories([]WatchDirectoryRequest{{
+		Dir:      dir,
+		Callback: fn,
+		Options:  opts,
+	}})
+	if err != nil {
+		return nil, err
 	}
+	return watches[0], nil
+}
+
+func (w *watcher) WatchDirectories(requests []WatchDirectoryRequest) ([]Watch, error) {
 	if !w.Available() {
 		return nil, ErrUnavailable
 	}
-	dir = filepath.Clean(dir)
-	if !filepath.IsAbs(dir) {
-		return nil, errNotAbsolute
-	}
-	dir = canonicalizePath(dir)
-	physicalDir := physicalDirFor(dir)
-
-	var sopts watchOptions
-	for _, o := range opts {
-		o.applyWatchOption(&sopts)
+	if len(requests) == 0 {
+		return nil, nil
 	}
 
-	dw := w.getOrCreateDirWatch(dir, physicalDir, sopts.recursive)
-	id, _ := dw.watch(dir, sopts.recursive, fn, sopts.ignore)
+	type preparedWatch struct {
+		dw        *dirWatch
+		id        uint64
+		recursive bool
+		dir       string
+	}
+	prepared := make([]preparedWatch, 0, len(requests))
+	uniqueDirWatches := make([]*dirWatch, 0, len(requests))
+	seenDirWatches := make(map[*dirWatch]struct{}, len(requests))
+	rollback := func() {
+		for i := len(prepared) - 1; i >= 0; i-- {
+			p := prepared[i]
+			p.dw.unwatch(p.id)
+			p.dw.unref(w)
+		}
+	}
+
+	for _, request := range requests {
+		dir := request.Dir
+		fn := request.Callback
+		if fn == nil {
+			rollback()
+			return nil, errNilCallback
+		}
+		dir = filepath.Clean(dir)
+		if !filepath.IsAbs(dir) {
+			rollback()
+			return nil, errNotAbsolute
+		}
+		dir = canonicalizePath(dir)
+		physicalDir := physicalDirFor(dir)
+
+		var sopts watchOptions
+		for _, o := range request.Options {
+			o.applyWatchOption(&sopts)
+		}
+
+		dw := w.getOrCreateDirWatch(dir, physicalDir, sopts.recursive)
+		id, _ := dw.watch(dir, sopts.recursive, fn, sopts.ignore)
+		prepared = append(prepared, preparedWatch{dw: dw, id: id, recursive: sopts.recursive, dir: dir})
+		if _, ok := seenDirWatches[dw]; !ok {
+			seenDirWatches[dw] = struct{}{}
+			uniqueDirWatches = append(uniqueDirWatches, dw)
+		}
+	}
 
 	impl, err := w.getImpl()
 	if err != nil {
-		dw.unwatch(id)
-		dw.unref(w)
+		rollback()
 		return nil, err
 	}
-	if err := impl.watchAdd(dw); err != nil {
-		dw.unwatch(id)
-		dw.unref(w)
+	if err := impl.watchAddMany(uniqueDirWatches); err != nil {
+		rollback()
 		return nil, err
 	}
-	return &watch{w: w, dw: dw, impl: impl, id: id}, nil
+
+	watches := make([]Watch, len(prepared))
+	for i, p := range prepared {
+		watches[i] = &watch{w: w, dw: p.dw, impl: impl, id: p.id}
+	}
+	return watches, nil
 }
 
 func (w *watcher) WatchFile(path string, fn WatchCallback) (Watch, error) {
@@ -467,6 +527,7 @@ type watcherImpl interface {
 	shutdown()
 
 	watchAdd(w *dirWatch) error
+	watchAddMany(watches []*dirWatch) error
 	watchRemove(w *dirWatch)
 	handleWatcherError(err *dirWatchError)
 
@@ -538,16 +599,50 @@ func (b *watcherBase) handleStartError(err error) {
 }
 
 func (b *watcherBase) watchAdd(w *dirWatch) error {
+	return b.watchAddMany([]*dirWatch{w})
+}
+
+func (b *watcherBase) watchAddMany(watches []*dirWatch) error {
 	b.mu.Lock()
-	if _, ok := b.subscriptions[w]; ok {
+	toAdd := make([]*dirWatch, 0, len(watches))
+	for _, w := range watches {
+		if _, ok := b.subscriptions[w]; ok {
+			continue
+		}
+		toAdd = append(toAdd, w)
+	}
+	if len(toAdd) == 0 {
 		b.mu.Unlock()
 		return nil
 	}
-	if err := b.self.subscribe(w); err != nil {
+
+	if subscriber, ok := b.self.(interface {
+		subscribeMany(watches []*dirWatch) error
+	}); ok {
+		if err := subscriber.subscribeMany(toAdd); err != nil {
+			b.mu.Unlock()
+			return err
+		}
+		for _, w := range toAdd {
+			b.subscriptions[w] = struct{}{}
+		}
 		b.mu.Unlock()
-		return err
+		return nil
 	}
-	b.subscriptions[w] = struct{}{}
+
+	added := make([]*dirWatch, 0, len(toAdd))
+	for _, w := range toAdd {
+		if err := b.self.subscribe(w); err != nil {
+			for _, addedWatch := range added {
+				delete(b.subscriptions, addedWatch)
+				_ = b.self.closeWatch(addedWatch)
+			}
+			b.mu.Unlock()
+			return err
+		}
+		b.subscriptions[w] = struct{}{}
+		added = append(added, w)
+	}
 	b.mu.Unlock()
 	return nil
 }

--- a/internal/fswatch/watcher_test.go
+++ b/internal/fswatch/watcher_test.go
@@ -1366,6 +1366,43 @@ func TestSubscribeMultipleDifferentDirs(t *testing.T) {
 	})
 }
 
+func TestWatchDirectoriesBatch(t *testing.T) {
+	t.Parallel()
+	runForEachWatcher(t, func(t testingT, watcherImpl Watcher) {
+		dir1 := newTmpDir(t)
+		dir2 := newTmpDir(t)
+		r1 := newRecorder(t)
+		r1.watcher = watcherImpl
+		r2 := newRecorder(t)
+		r2.watcher = watcherImpl
+
+		watches, err := watcherImpl.WatchDirectories([]WatchDirectoryRequest{
+			{Dir: dir1, Callback: r1.callback, Options: []WatchOption{WithRecursive()}},
+			{Dir: dir2, Callback: r2.callback, Options: []WatchOption{WithRecursive()}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			for _, watch := range watches {
+				_ = watch.Close()
+			}
+		})
+		time.Sleep(settleSleep(watcherImpl))
+
+		f1 := subPath(dir1)
+		f2 := subPath(dir2)
+		if err := os.WriteFile(f1, []byte("a"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(f2, []byte("b"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		assertEventSequence(t, r1.next(r1.deadline()), []wantEvent{{EventUpdate, f1}})
+		assertEventSequence(t, r2.next(r2.deadline()), []wantEvent{{EventUpdate, f2}})
+	})
+}
+
 type countingWatcherImpl struct {
 	watcherBase
 	subscribed []*dirWatch


### PR DESCRIPTION
Fixes #4441

Parcel's watcher would create a single fsevents stream. But, there's a max stream count per process and per system. Since our watch code is a port of it, we inherited that problem.

VS Code had been working around this by registering parent dir streams. This is what #4379 does up to a point.

libuv, what we used via Node previously, avoids this problem by only ever making one fsevents stream _per event loop_. That makes it much harder to hit the global max.

The problem with reusing streams for more than one watch is that you have to provide the list of dirs to watch at create time. Adding another one means you have to create a whole new stream.

This PR tries to take a hybrid approach, instead chunking fsevents streams so we still have more than one, but way fewer, so can avoid the limit quite a bit more.