### PR TITLE
Fix panic in RefCountCache.Ref during concurrent snapshot disposal

### DIFF
--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -373,12 +373,15 @@ func (p *Project) CreateProgram() CreateProgramResult {
 				// Use pointer identity: dirtyFile is the exact instance UpdateProgram acquired,
 				// and it is the only file whose refcount is already accounted for.
 				if file != dirtyFile {
-					// UpdateProgram acquired the changed file only, so we need to ref everything else
-					p.host.builder.parseCache.Ref(NewParseCacheKey(file.ParseOptions(), file.Hash, file.ScriptKind))
+					// UpdateProgram acquired the changed file only, so we need to ref everything else.
+					// Use RefOrStore because a concurrent snapshot disposal may have Deref'd the
+					// entry to zero and removed it between when UpdateProgram cloned the program
+					// and when we increment the refcount here.
+					p.host.builder.parseCache.RefOrStore(NewParseCacheKey(file.ParseOptions(), file.Hash, file.ScriptKind), file)
 				}
 			}
 			for _, file := range newProgram.DuplicateSourceFiles() {
-				p.host.builder.parseCache.Ref(NewParseCacheKey(file.ParseOptions, file.Hash, file.ScriptKind))
+				p.host.builder.parseCache.RefOrStore(NewParseCacheKey(file.ParseOptions, file.Hash, file.ScriptKind), nil)
 			}
 		} else if dirtyFile != nil {
 			// UpdateProgram always acquires the dirty file before deciding whether it can

--- a/internal/project/refcountcache.go
+++ b/internal/project/refcountcache.go
@@ -76,6 +76,35 @@ func (c *RefCountCache[K, V, AcquireArgs]) Ref(identity K) {
 	entry.refCount++
 }
 
+// RefOrStore increments the reference count for an existing entry,
+// or stores the given value as a new entry with refcount 1 if no entry exists.
+// This is safe to use when a concurrent Deref may have removed the entry
+// between the time the caller obtained the value and the time it calls RefOrStore.
+func (c *RefCountCache[K, V, AcquireArgs]) RefOrStore(identity K, value V) {
+	entry, ok := c.entries.Load(identity)
+	if !ok {
+		// Entry was concurrently deleted. Re-create it.
+		newEntry, loaded := c.loadOrStoreNewLockedEntry(identity)
+		defer newEntry.mu.Unlock()
+		if !loaded {
+			newEntry.value = value
+		}
+		return
+	}
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	if entry.refCount <= 0 && !c.Options.DisableDeletion {
+		// Entry was deleted while we were acquiring the lock
+		newEntry, loaded := c.loadOrStoreNewLockedEntry(identity)
+		defer newEntry.mu.Unlock()
+		if !loaded {
+			newEntry.value = value
+		}
+		return
+	}
+	entry.refCount++
+}
+
 // Deref decrements the reference count for an entry.
 // When the refcount reaches zero, the entry is removed from the cache
 // (unless DisableDeletion is set).

--- a/internal/project/refcountcache_test.go
+++ b/internal/project/refcountcache_test.go
@@ -321,3 +321,40 @@ func TestRefCountingCaches(t *testing.T) {
 		})
 	})
 }
+
+func TestRefOrStore_ConcurrentDeletion(t *testing.T) {
+	t.Parallel()
+
+	// RefOrStore should not panic when an entry was concurrently deleted.
+	// This simulates the scenario where a snapshot disposal Derefs an entry to zero
+	// (deleting it) while CreateProgram is trying to Ref the same entry for a cloned program.
+	cache := NewRefCountCache(
+		RefCountCacheOptions{},
+		func(key string, _ int) string {
+			return "parsed:" + key
+		},
+	)
+
+	// Acquire an entry (refcount = 1)
+	value := cache.Acquire("fileA", 0)
+	assert.Equal(t, value, "parsed:fileA")
+
+	// Deref it to 0, which deletes it from the cache
+	cache.Deref("fileA")
+	assert.Assert(t, !cache.Has("fileA"), "entry should be deleted after Deref to 0")
+
+	// RefOrStore should not panic; it should re-create the entry with the provided value
+	cache.RefOrStore("fileA", "existing-value")
+	assert.Assert(t, cache.Has("fileA"), "entry should exist after RefOrStore")
+
+	// Verify the re-created entry has the correct value
+	entry, ok := cache.entries.Load("fileA")
+	assert.Assert(t, ok)
+	assert.Equal(t, entry.value, "existing-value")
+	assert.Equal(t, entry.refCount, 1)
+
+	// Deref to clean up
+	cache.Deref("fileA")
+	assert.Assert(t, !cache.Has("fileA"))
+}
+


### PR DESCRIPTION
When UpdateProgram clones a program (single dirty file optimization), it shares source file pointers with the old program. If a concurrent snapshot disposal Derefs those shared files to refcount 0, the entries are deleted from the SyncMap. Then when the clone path calls Ref to increment refcounts for the new program, it panics because the entries no longer exist.

Add RefOrStore method that safely handles this race: if the entry exists, increment its refcount; if it was concurrently deleted, re-create it with the provided value (refcount 1). Use RefOrStore in the CreateProgram clone path where the caller already has the source file value.

Fixes the later repro provided in #4392