### PR TITLE
Fix handle get completions at position

### DIFF
--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -1,0 +1,365 @@
+# MODIFIED IN THIS FORK: 2025-10-02 Aleksei Berezkin f30777cda3c5b4a77cc5b46ad97604f4e16e3a4d Revert "WEB-74070 amd64 -> x64"
+# MODIFIED IN THIS FORK: 2025-10-02 Aleksei Berezkin 176bf7c9614b2d6e33d6a7fc14e743d2bf07528f WEB-74070 amd64 -> x64
+# MODIFIED IN THIS FORK: 2025-09-25 Vladislav Minaev ea2f806510b3c2736f219c9bb96f678715038667 Add executable permission to assembled binary
+# MODIFIED IN THIS FORK: 2025-09-25 Vladislav Minaev 15feabc9a5a69274a97a24361fc79b396e217290 add assemble workflow
+name: Assemble and Release
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to use if not running on a tag (e.g. 1.2.3). Will be prefixed with v.'
+        default: ''
+        required: false
+        type: string
+      prerelease:
+        description: 'Mark the release as a prerelease'
+        default: false
+        required: true
+        type: boolean
+      make_release:
+        description: 'Create a GitHub Release and upload assets'
+        default: true
+        required: true
+        type: boolean
+
+permissions:
+  contents: write
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build-binaries:
+    name: Build ${{ matrix.name }}
+    if: github.ref_name == 'main' || github.ref_name == 'api-dev' || github.ref_name == 'api-dev-release'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-amd64
+            os: ubuntu-latest
+            goos: linux
+            goarch: amd64
+          - name: linux-arm64
+            os: ubuntu-latest
+            goos: linux
+            goarch: arm64
+          - name: windows-amd64
+            os: windows-latest
+            goos: windows
+            goarch: amd64
+          - name: windows-arm64
+            os: ubuntu-latest
+            goos: windows
+            goarch: arm64
+          - name: darwin-arm64
+            os: macos-latest
+            goos: darwin
+            goarch: arm64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 'lts/*'
+      - uses: dtolnay/rust-toolchain@fcf085fcb4b4b8f63f96906cd713eb52181b5ea4 # stable
+      - uses: ./.github/actions/setup-go
+
+      - name: Disable PR annotations
+        run: |
+          echo "::remove-matcher owner=eslint-compact::"
+          echo "::remove-matcher owner=eslint-stylish::"
+          echo "::remove-matcher owner=tsc::"
+          echo "::remove-matcher owner=go::"
+
+      - run: npm ci
+      - run: npx hereby build
+
+      - name: Include LICENSE and NOTICE.txt
+        run: |
+          set -euo pipefail
+          cp -f LICENSE NOTICE.txt built/local/
+          ls -lah built/local
+
+      - name: Upload platform binary artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: tsgo-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: built/local/*
+          retention-days: 1
+
+  pack-npm:
+    name: Pack npm packages
+    if: github.ref_name == 'main' || github.ref_name == 'api-dev' || github.ref_name == 'api-dev-release'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 'lts/*'
+      - uses: ./.github/actions/setup-go
+
+      - name: Disable PR annotations
+        run: |
+          echo "::remove-matcher owner=eslint-compact::"
+          echo "::remove-matcher owner=eslint-stylish::"
+          echo "::remove-matcher owner=tsc::"
+          echo "::remove-matcher owner=go::"
+
+      - run: npm ci
+
+      # --forRelease requires --setPrerelease. Derive the prerelease suffix from the version
+      # requested for this run (the workflow_dispatch version, or the tag name) so the npm
+      # package version matches the release tag. getVersion() in the Herebyfile builds the
+      # version as <base-from-internal/core/version.go>-<suffix>, e.g. suffix "dev.3" yields
+      # 7.0.0-dev.3 for a requested version of 7.0.0-dev.3.
+      - name: Compute prerelease suffix
+        id: ver
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$REF_TYPE" == "tag" && -n "$REF_NAME" ]]; then
+            VERSION="${REF_NAME#v}"
+          elif [[ -n "${INPUT_VERSION:-}" ]]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION="0.0.0-dev-${SHA:0:8}"
+          fi
+          if [[ "$VERSION" == *-* ]]; then
+            SUFFIX="${VERSION#*-}"
+          else
+            # No prerelease component in the requested version, but --forRelease requires one.
+            SUFFIX="dev"
+          fi
+          echo "Requested version: $VERSION -> setPrerelease: $SUFFIX"
+          echo "SUFFIX=$SUFFIX" >> "$GITHUB_OUTPUT"
+
+      # Build and pack the @typescript/native-preview meta package plus all per-platform
+      # packages. --forRelease enables cross-compilation of every supported platform (the
+      # Go binary is built with CGO_ENABLED=0, so this works from a single Linux runner).
+      # Signing is intentionally not invoked (it lives only in native-preview:release).
+      - name: Build and pack npm packages
+        env:
+          SUFFIX: ${{ steps.ver.outputs.SUFFIX }}
+        run: |
+          set -euo pipefail
+          npx hereby native-preview:build-packages --forRelease --setPrerelease="$SUFFIX"
+          npx hereby native-preview:pack-packages --forRelease --setPrerelease="$SUFFIX"
+
+      - run: ls -lah built/npm
+
+      - name: Upload npm package artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: native-preview-npm
+          path: |
+            built/npm/*.tgz
+            built/npm/publish-order.json
+
+  assemble:
+    name: Assemble per-platform archives
+    needs: build-binaries
+    runs-on: ubuntu-latest
+    if: github.ref_name == 'main' || github.ref_name == 'api-dev' || github.ref_name == 'api-dev-release'
+    outputs:
+      TAG_NAME: ${{ steps.meta.outputs.TAG_NAME }}
+      DO_RELEASE: ${{ steps.meta.outputs.DO_RELEASE }}
+      PRERELEASE: ${{ steps.meta.outputs.PRERELEASE }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Compute metadata
+        id: meta
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_PRERELEASE: ${{ inputs.prerelease }}
+          INPUT_MAKE_RELEASE: ${{ inputs.make_release }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$REF_TYPE" == "tag" && -n "$REF_NAME" ]]; then
+            TAG_NAME="$REF_NAME"
+          elif [[ -n "${INPUT_VERSION:-}" ]]; then
+            TAG_NAME="v$INPUT_VERSION"
+          else
+            TAG_NAME="v0.0.0-dev-${SHA:0:8}"
+          fi
+          if [[ "$REF_TYPE" == "tag" ]]; then
+            DO_RELEASE="true"
+          else
+            DO_RELEASE="${INPUT_MAKE_RELEASE:-true}"
+          fi
+          PRERELEASE="${INPUT_PRERELEASE:-false}"
+          echo "TAG_NAME=$TAG_NAME" >> "$GITHUB_OUTPUT"
+          echo "DO_RELEASE=$DO_RELEASE" >> "$GITHUB_OUTPUT"
+          echo "PRERELEASE=$PRERELEASE" >> "$GITHUB_OUTPUT"
+
+      - name: Download all platform binaries
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          pattern: tsgo-*
+          path: dist
+          merge-multiple: false
+
+      - name: Package per-platform archives
+        env:
+          TAG_NAME: ${{ steps.meta.outputs.TAG_NAME }}
+        run: |
+          set -euo pipefail
+          mkdir -p release
+          shopt -s nullglob
+          for dir in dist/tsgo-*; do
+            base="$(basename "$dir")"        # e.g., tsgo-linux-amd64
+            suffix="${base#tsgo-}"           # linux-amd64
+            GOOS="${suffix%-*}"              # linux
+            GOARCH="${suffix#*-}"            # amd64
+            PLATFORM_NAME="$GOOS"
+            ARCH_NAME="$GOARCH"
+            [[ "$GOARCH" == "amd64" ]] && ARCH_NAME="x64"
+            [[ "$GOOS" == "windows" ]] && PLATFORM_NAME="win32"
+            ARCHIVE="tsgo-${TAG_NAME}-${PLATFORM_NAME}-${ARCH_NAME}.zip"
+            echo "Packaging $dir -> release/$ARCHIVE"
+            (
+              cd "$dir"
+              chmod +x tsgo* 2>/dev/null || true
+              zip -9X "../../release/${ARCHIVE}" tsgo* *.d.ts LICENSE NOTICE.txt
+            )
+            sha256sum "release/${ARCHIVE}" | tee "release/${ARCHIVE}.sha256"
+          done
+          ls -lah release
+
+      - name: Upload assembled archives
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: tsgo-archives
+          path: |
+            release/*.zip
+            release/*.sha256
+
+
+  release:
+    name: Create GitHub Release
+    needs: [assemble, pack-npm]
+    if: ${{ needs.assemble.outputs.DO_RELEASE == 'true' && (github.ref_name == 'main' || github.ref_name == 'api-dev' || github.ref_name == 'api-dev-release') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download assembled archives
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: tsgo-archives
+          path: .
+
+      - name: Download npm packages
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: native-preview-npm
+          path: npm-dist
+
+      - name: Create or update release and upload assets
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          TAG_NAME: ${{ needs.assemble.outputs.TAG_NAME }}
+          PRERELEASE: ${{ needs.assemble.outputs.PRERELEASE }}
+        with:
+          script: |
+            const fs = require('fs');
+            const tagName = process.env.TAG_NAME;
+            const prerelease = process.env.PRERELEASE === 'true';
+            
+            // Fetch an existing release by tag. If it doesn't exist (404), create it. This makes the workflow idempotent.
+            let release;
+            try {
+              release = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: tagName,
+              });
+            } catch (e) {
+              if (e.status === 404) {
+                release = await github.rest.repos.createRelease({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  tag_name: tagName,
+                  name: `tsgo ${tagName}`,
+                  body: `Release ${tagName}`,
+                  draft: false,
+                  prerelease,
+                  generate_release_notes: true,
+                });
+              } else {
+                // Any other error is unexpected and should fail the workflow.
+                throw e;
+              }
+            }
+            
+            const uploadUrl = (release.data?.upload_url) || (release.upload_url);
+            
+            // Upload the per-platform archives and matching checksums produced by the assemble job.
+            for (const entry of fs.readdirSync('.')) {
+              if (entry.endsWith('.zip')) {
+                console.log(`Uploading asset: ${entry}`);
+                await github.rest.repos.uploadReleaseAsset({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  url: uploadUrl,
+                  headers: { "content-type": "application/zip" },
+                  name: entry,
+                  data: fs.readFileSync(entry),
+                });
+            
+                const sum = `${entry}.sha256`;
+                if (fs.existsSync(sum)) {
+                  console.log(`Uploading checksum: ${sum}`);
+                  await github.rest.repos.uploadReleaseAsset({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    url: uploadUrl,
+                    headers: { "content-type": "text/plain" },
+                    name: sum,
+                    data: fs.readFileSync(sum),
+                  });
+                }
+              }
+            }
+
+            // Upload the npm package tarballs (and publish manifest) produced by the pack-npm job.
+            const npmDir = 'npm-dist';
+            if (fs.existsSync(npmDir)) {
+              for (const entry of fs.readdirSync(npmDir)) {
+                const filePath = `${npmDir}/${entry}`;
+                if (entry.endsWith('.tgz')) {
+                  console.log(`Uploading npm package: ${entry}`);
+                  await github.rest.repos.uploadReleaseAsset({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    url: uploadUrl,
+                    headers: { "content-type": "application/gzip" },
+                    name: entry,
+                    data: fs.readFileSync(filePath),
+                  });
+                } else if (entry === 'publish-order.json') {
+                  console.log(`Uploading npm manifest: ${entry}`);
+                  await github.rest.repos.uploadReleaseAsset({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    url: uploadUrl,
+                    headers: { "content-type": "application/json" },
+                    name: entry,
+                    data: fs.readFileSync(filePath),
+                  });
+                }
+              }
+            }

--- a/_packages/native-preview/src/api/async/api.ts
+++ b/_packages/native-preview/src/api/async/api.ts
@@ -1419,15 +1419,15 @@ class TypeObject implements Type {
         return this.objectRegistry.fetchType(this, "getConstraintOfType", this.substConstraint);
     }
 
-    async getTrueType(): Promise<Type | undefined> {
+    async getTrueType(): Promise<Type> {
         const result = await this.objectRegistry.fetchType(this, "getTrueTypeOfConditionalType", this.trueType);
-        this.trueType = result?.id;
+        this.trueType = result.id;
         return result;
     }
 
-    async getFalseType(): Promise<Type | undefined> {
+    async getFalseType(): Promise<Type> {
         const result = await this.objectRegistry.fetchType(this, "getFalseTypeOfConditionalType", this.falseType);
-        this.falseType = result?.id;
+        this.falseType = result.id;
         return result;
     }
 }

--- a/_packages/native-preview/src/api/async/api.ts
+++ b/_packages/native-preview/src/api/async/api.ts
@@ -426,10 +426,12 @@ class ProjectObjectRegistry {
         this.signatures.clear();
     }
 
-    async fetchType<T extends Type>(source: Symbol | Signature | Type, method: string, handle: number | undefined): Promise<T> {
-        if (!handle) return undefined as unknown as T;
-        const cached = this.getType(handle);
-        if (cached) return cached as unknown as T;
+    async fetchType<T extends Type>(source: Symbol | Signature | Type, method: string, handle: number | false | undefined): Promise<T> {
+        if (handle !== false) {
+            if (!handle) return undefined as unknown as T;
+            const cached = this.getType(handle);
+            if (cached) return cached as unknown as T;
+        }
 
         const data = await this.client.apiRequest<TypeResponse | null>(method, {
             snapshot: this.snapshotId,
@@ -1313,6 +1315,9 @@ class TypeObject implements Type {
     readonly baseType!: number;
     readonly substConstraint!: number;
 
+    private trueType: number | false; // false if not yet loaded
+    private falseType: number | false; // false if not yet loaded
+
     constructor(data: TypeResponse, objectRegistry: ProjectObjectRegistry) {
         this.objectRegistry = objectRegistry;
 
@@ -1345,6 +1350,9 @@ class TypeObject implements Type {
         if (data.extendsType !== undefined) this.extendsType = data.extendsType;
         if (data.baseType !== undefined) this.baseType = data.baseType;
         if (data.substConstraint !== undefined) this.substConstraint = data.substConstraint;
+
+        this.trueType = false;
+        this.falseType = false;
     }
 
     async getSymbol(): Promise<Symbol | undefined> {
@@ -1409,6 +1417,18 @@ class TypeObject implements Type {
 
     async getConstraint(): Promise<Type> {
         return this.objectRegistry.fetchType(this, "getConstraintOfType", this.substConstraint);
+    }
+
+    async getTrueType(): Promise<Type | undefined> {
+        const result = await this.objectRegistry.fetchType(this, "getTrueTypeOfConditionalType", this.trueType);
+        this.trueType = result?.id;
+        return result;
+    }
+
+    async getFalseType(): Promise<Type | undefined> {
+        const result = await this.objectRegistry.fetchType(this, "getFalseTypeOfConditionalType", this.falseType);
+        this.falseType = result?.id;
+        return result;
     }
 }
 

--- a/_packages/native-preview/src/api/async/types.ts
+++ b/_packages/native-preview/src/api/async/types.ts
@@ -149,6 +149,10 @@ export interface ConditionalType extends Type {
     getCheckType(): Promise<Type>;
     /** Get the extends type U in `T extends U ? X : Y` */
     getExtendsType(): Promise<Type>;
+    /** Get the true type X in `T extends U ? X : Y` */
+    getTrueType(): Promise<Type | undefined>;
+    /** Get the false type Y in `T extends U ? X : Y` */
+    getFalseType(): Promise<Type | undefined>;
 }
 
 /** Substitution types (TypeFlags.Substitution) */

--- a/_packages/native-preview/src/api/async/types.ts
+++ b/_packages/native-preview/src/api/async/types.ts
@@ -150,9 +150,9 @@ export interface ConditionalType extends Type {
     /** Get the extends type U in `T extends U ? X : Y` */
     getExtendsType(): Promise<Type>;
     /** Get the true type X in `T extends U ? X : Y` */
-    getTrueType(): Promise<Type | undefined>;
+    getTrueType(): Promise<Type>;
     /** Get the false type Y in `T extends U ? X : Y` */
-    getFalseType(): Promise<Type | undefined>;
+    getFalseType(): Promise<Type>;
 }
 
 /** Substitution types (TypeFlags.Substitution) */

--- a/_packages/native-preview/src/api/sync/api.ts
+++ b/_packages/native-preview/src/api/sync/api.ts
@@ -434,10 +434,12 @@ class ProjectObjectRegistry {
         this.signatures.clear();
     }
 
-    fetchType<T extends Type>(source: Symbol | Signature | Type, method: string, handle: number | undefined): T {
-        if (!handle) return undefined as unknown as T;
-        const cached = this.getType(handle);
-        if (cached) return cached as unknown as T;
+    fetchType<T extends Type>(source: Symbol | Signature | Type, method: string, handle: number | false | undefined): T {
+        if (handle !== false) {
+            if (!handle) return undefined as unknown as T;
+            const cached = this.getType(handle);
+            if (cached) return cached as unknown as T;
+        }
 
         const data = this.client.apiRequest<TypeResponse | null>(method, {
             snapshot: this.snapshotId,
@@ -1321,6 +1323,9 @@ class TypeObject implements Type {
     readonly baseType!: number;
     readonly substConstraint!: number;
 
+    private trueType: number | false; // false if not yet loaded
+    private falseType: number | false; // false if not yet loaded
+
     constructor(data: TypeResponse, objectRegistry: ProjectObjectRegistry) {
         this.objectRegistry = objectRegistry;
 
@@ -1353,6 +1358,9 @@ class TypeObject implements Type {
         if (data.extendsType !== undefined) this.extendsType = data.extendsType;
         if (data.baseType !== undefined) this.baseType = data.baseType;
         if (data.substConstraint !== undefined) this.substConstraint = data.substConstraint;
+
+        this.trueType = false;
+        this.falseType = false;
     }
 
     getSymbol(): Symbol | undefined {
@@ -1417,6 +1425,18 @@ class TypeObject implements Type {
 
     getConstraint(): Type {
         return this.objectRegistry.fetchType(this, "getConstraintOfType", this.substConstraint);
+    }
+
+    getTrueType(): Type | undefined {
+        const result = this.objectRegistry.fetchType(this, "getTrueTypeOfConditionalType", this.trueType);
+        this.trueType = result?.id;
+        return result;
+    }
+
+    getFalseType(): Type | undefined {
+        const result = this.objectRegistry.fetchType(this, "getFalseTypeOfConditionalType", this.falseType);
+        this.falseType = result?.id;
+        return result;
     }
 }
 

--- a/_packages/native-preview/src/api/sync/api.ts
+++ b/_packages/native-preview/src/api/sync/api.ts
@@ -1427,15 +1427,15 @@ class TypeObject implements Type {
         return this.objectRegistry.fetchType(this, "getConstraintOfType", this.substConstraint);
     }
 
-    getTrueType(): Type | undefined {
+    getTrueType(): Type {
         const result = this.objectRegistry.fetchType(this, "getTrueTypeOfConditionalType", this.trueType);
-        this.trueType = result?.id;
+        this.trueType = result.id;
         return result;
     }
 
-    getFalseType(): Type | undefined {
+    getFalseType(): Type {
         const result = this.objectRegistry.fetchType(this, "getFalseTypeOfConditionalType", this.falseType);
-        this.falseType = result?.id;
+        this.falseType = result.id;
         return result;
     }
 }

--- a/_packages/native-preview/src/api/sync/types.ts
+++ b/_packages/native-preview/src/api/sync/types.ts
@@ -158,9 +158,9 @@ export interface ConditionalType extends Type {
     /** Get the extends type U in `T extends U ? X : Y` */
     getExtendsType(): Type;
     /** Get the true type X in `T extends U ? X : Y` */
-    getTrueType(): Type | undefined;
+    getTrueType(): Type;
     /** Get the false type Y in `T extends U ? X : Y` */
-    getFalseType(): Type | undefined;
+    getFalseType(): Type;
 }
 
 /** Substitution types (TypeFlags.Substitution) */

--- a/_packages/native-preview/src/api/sync/types.ts
+++ b/_packages/native-preview/src/api/sync/types.ts
@@ -157,6 +157,10 @@ export interface ConditionalType extends Type {
     getCheckType(): Type;
     /** Get the extends type U in `T extends U ? X : Y` */
     getExtendsType(): Type;
+    /** Get the true type X in `T extends U ? X : Y` */
+    getTrueType(): Type | undefined;
+    /** Get the false type Y in `T extends U ? X : Y` */
+    getFalseType(): Type | undefined;
 }
 
 /** Substitution types (TypeFlags.Substitution) */

--- a/_packages/native-preview/test/async/api.test.ts
+++ b/_packages/native-preview/test/async/api.test.ts
@@ -1375,6 +1375,32 @@ export const tuple: readonly [number, string?, ...boolean[]] = [1];
         }
     });
 
+    test("ConditionalType.getTrueType() and getFalseType()", async () => {
+        const api = spawnAPI(typeFiles);
+        try {
+            const snapshot = await api.updateSnapshot({ openProject: "/tsconfig.json" });
+            const project = snapshot.getProject("/tsconfig.json")!;
+            const symbol = await project.checker.resolveName("Cond", SymbolFlags.TypeAlias, { document: "/src/types.ts", position: 0 });
+            assert.ok(symbol);
+            const type = await project.checker.getDeclaredTypeOfSymbol(symbol);
+            assert.ok(type);
+            assert.ok(type.flags & TypeFlags.Conditional, `Expected ConditionalType, got flags ${type.flags}`);
+
+            const trueType = await (type as ConditionalType).getTrueType();
+            assert.ok(trueType, "should return the true-branch type");
+            assert.ok(trueType.flags & TypeFlags.StringLiteral, `Expected StringLiteral for true branch, got flags ${trueType.flags}`);
+            assert.equal((trueType as LiteralType).value, "yes");
+
+            const falseType = await (type as ConditionalType).getFalseType();
+            assert.ok(falseType, "should return the false-branch type");
+            assert.ok(falseType.flags & TypeFlags.StringLiteral, `Expected StringLiteral for false branch, got flags ${falseType.flags}`);
+            assert.equal((falseType as LiteralType).value, "no");
+        }
+        finally {
+            await api.close();
+        }
+    });
+
     test("TemplateLiteralType.texts and getTypes()", async () => {
         const { type, api } = await getTypeAtName(spawnAPI(typeFiles), "tpl:");
         try {

--- a/_packages/native-preview/test/sync/api.test.ts
+++ b/_packages/native-preview/test/sync/api.test.ts
@@ -1383,6 +1383,32 @@ export const tuple: readonly [number, string?, ...boolean[]] = [1];
         }
     });
 
+    test("ConditionalType.getTrueType() and getFalseType()", () => {
+        const api = spawnAPI(typeFiles);
+        try {
+            const snapshot = api.updateSnapshot({ openProject: "/tsconfig.json" });
+            const project = snapshot.getProject("/tsconfig.json")!;
+            const symbol = project.checker.resolveName("Cond", SymbolFlags.TypeAlias, { document: "/src/types.ts", position: 0 });
+            assert.ok(symbol);
+            const type = project.checker.getDeclaredTypeOfSymbol(symbol);
+            assert.ok(type);
+            assert.ok(type.flags & TypeFlags.Conditional, `Expected ConditionalType, got flags ${type.flags}`);
+
+            const trueType = (type as ConditionalType).getTrueType();
+            assert.ok(trueType, "should return the true-branch type");
+            assert.ok(trueType.flags & TypeFlags.StringLiteral, `Expected StringLiteral for true branch, got flags ${trueType.flags}`);
+            assert.equal((trueType as LiteralType).value, "yes");
+
+            const falseType = (type as ConditionalType).getFalseType();
+            assert.ok(falseType, "should return the false-branch type");
+            assert.ok(falseType.flags & TypeFlags.StringLiteral, `Expected StringLiteral for false branch, got flags ${falseType.flags}`);
+            assert.equal((falseType as LiteralType).value, "no");
+        }
+        finally {
+            api.close();
+        }
+    });
+
     test("TemplateLiteralType.texts and getTypes()", () => {
         const { type, api } = getTypeAtName(spawnAPI(typeFiles), "tpl:");
         try {

--- a/internal/api/proto.go
+++ b/internal/api/proto.go
@@ -129,6 +129,8 @@ const (
 	MethodGetIndexInfosOfType               Method = "getIndexInfosOfType"
 	MethodGetConstraintOfTypeParameter      Method = "getConstraintOfTypeParameter"
 	MethodGetTypeArguments                  Method = "getTypeArguments"
+	MethodGetTrueTypeOfConditionalType      Method = "getTrueTypeOfConditionalType"
+	MethodGetFalseTypeOfConditionalType     Method = "getFalseTypeOfConditionalType"
 
 	// Reference methods
 	MethodGetReferencesToSymbolInFile Method = "getReferencesToSymbolInFile"
@@ -352,22 +354,24 @@ var unmarshalers = map[Method]func([]byte) (any, error){
 	MethodGetExportsOfSymbol:      unmarshallerFor[GetSymbolPropertyParams],
 	MethodGetExportSymbolOfSymbol: unmarshallerFor[GetSymbolPropertyParams],
 
-	MethodGetSymbolOfType:              unmarshallerFor[GetTypePropertyParams],
-	MethodGetTargetOfType:              unmarshallerFor[GetTypePropertyParams],
-	MethodGetFreshTypeOfType:           unmarshallerFor[GetTypePropertyParams],
-	MethodGetRegularTypeOfType:         unmarshallerFor[GetTypePropertyParams],
-	MethodGetTypesOfType:               unmarshallerFor[GetTypePropertyParams],
-	MethodGetTypeParametersOfType:      unmarshallerFor[GetTypePropertyParams],
-	MethodGetOuterTypeParametersOfType: unmarshallerFor[GetTypePropertyParams],
-	MethodGetLocalTypeParametersOfType: unmarshallerFor[GetTypePropertyParams],
-	MethodGetAliasTypeArgumentsOfType:  unmarshallerFor[GetTypePropertyParams],
-	MethodGetAliasSymbolOfType:         unmarshallerFor[GetTypePropertyParams],
-	MethodGetObjectTypeOfType:          unmarshallerFor[GetTypePropertyParams],
-	MethodGetIndexTypeOfType:           unmarshallerFor[GetTypePropertyParams],
-	MethodGetCheckTypeOfType:           unmarshallerFor[GetTypePropertyParams],
-	MethodGetExtendsTypeOfType:         unmarshallerFor[GetTypePropertyParams],
-	MethodGetBaseTypeOfType:            unmarshallerFor[GetTypePropertyParams],
-	MethodGetConstraintOfType:          unmarshallerFor[GetTypePropertyParams],
+	MethodGetSymbolOfType:               unmarshallerFor[GetTypePropertyParams],
+	MethodGetTargetOfType:               unmarshallerFor[GetTypePropertyParams],
+	MethodGetFreshTypeOfType:            unmarshallerFor[GetTypePropertyParams],
+	MethodGetRegularTypeOfType:          unmarshallerFor[GetTypePropertyParams],
+	MethodGetTypesOfType:                unmarshallerFor[GetTypePropertyParams],
+	MethodGetTypeParametersOfType:       unmarshallerFor[GetTypePropertyParams],
+	MethodGetOuterTypeParametersOfType:  unmarshallerFor[GetTypePropertyParams],
+	MethodGetLocalTypeParametersOfType:  unmarshallerFor[GetTypePropertyParams],
+	MethodGetAliasTypeArgumentsOfType:   unmarshallerFor[GetTypePropertyParams],
+	MethodGetAliasSymbolOfType:          unmarshallerFor[GetTypePropertyParams],
+	MethodGetObjectTypeOfType:           unmarshallerFor[GetTypePropertyParams],
+	MethodGetIndexTypeOfType:            unmarshallerFor[GetTypePropertyParams],
+	MethodGetCheckTypeOfType:            unmarshallerFor[GetTypePropertyParams],
+	MethodGetExtendsTypeOfType:          unmarshallerFor[GetTypePropertyParams],
+	MethodGetBaseTypeOfType:             unmarshallerFor[GetTypePropertyParams],
+	MethodGetConstraintOfType:           unmarshallerFor[GetTypePropertyParams],
+	MethodGetTrueTypeOfConditionalType:  unmarshallerFor[GetTypePropertyParams],
+	MethodGetFalseTypeOfConditionalType: unmarshallerFor[GetTypePropertyParams],
 
 	MethodGetTypeParametersOfSignature: unmarshallerFor[GetSignaturePropertyParams],
 	MethodGetParametersOfSignature:     unmarshallerFor[GetSignaturePropertyParams],

--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -593,6 +593,10 @@ func (s *Session) HandleRequest(ctx context.Context, method string, params json.
 		return s.handleGetBaseTypeOfType(ctx, parsed.(*GetTypePropertyParams))
 	case string(MethodGetConstraintOfType):
 		return s.handleGetConstraintOfType(ctx, parsed.(*GetTypePropertyParams))
+	case string(MethodGetTrueTypeOfConditionalType):
+		return s.handleGetTrueTypeOfConditionalType(ctx, parsed.(*GetTypePropertyParams))
+	case string(MethodGetFalseTypeOfConditionalType):
+		return s.handleGetFalseTypeOfConditionalType(ctx, parsed.(*GetTypePropertyParams))
 	case string(MethodGetTypeParametersOfSignature):
 		return s.handleGetTypeParametersOfSignature(ctx, parsed.(*GetSignaturePropertyParams))
 	case string(MethodGetParametersOfSignature):
@@ -2247,6 +2251,36 @@ func (s *Session) handleGetTypeArguments(ctx context.Context, params *CheckerTyp
 	}
 
 	return results, nil
+}
+
+func (s *Session) handleGetTrueTypeOfConditionalType(ctx context.Context, params *GetTypePropertyParams) (*TypeResponse, error) {
+	setup, err := s.setupChecker(ctx, params.Snapshot, params.Project)
+	if err != nil {
+		return nil, err
+	}
+	defer setup.done()
+
+	t, err := setup.sd.resolveTypeHandle(params.Project, params.Type)
+	if err != nil {
+		return nil, err
+	}
+
+	return setup.sd.newTypeResponse(params.Project, setup.checker.GetTrueTypeOfConditionalType(t)), nil
+}
+
+func (s *Session) handleGetFalseTypeOfConditionalType(ctx context.Context, params *GetTypePropertyParams) (*TypeResponse, error) {
+	setup, err := s.setupChecker(ctx, params.Snapshot, params.Project)
+	if err != nil {
+		return nil, err
+	}
+	defer setup.done()
+
+	t, err := setup.sd.resolveTypeHandle(params.Project, params.Type)
+	if err != nil {
+		return nil, err
+	}
+
+	return setup.sd.newTypeResponse(params.Project, setup.checker.GetFalseTypeOfConditionalType(t)), nil
 }
 
 func (sd *snapshotData) resolveNodeHandle(program *compiler.Program, handle NodeHandle) (*ast.Node, error) {

--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -484,6 +484,14 @@ func (s *Session) setupChecker(ctx context.Context, snapshot SnapshotID, project
 // setupLanguageService creates a LanguageService for the given snapshot/project.
 // Unlike setupChecker, this does NOT acquire a checker from the pool, so callers that
 // only need an LS (and not a Checker) can avoid blocking on / holding a pooled checker.
+//
+// The LS acquires its own checker internally (keyed by the ctx's checker lifetime).
+// If a handler returns symbol/type/signature handles the client may later re-query
+// on the API checker (e.g. completion with IncludeSymbol -> GetTypeOfSymbol), wrap
+// ctx with core.WithCheckerLifetime(ctx, core.CheckerLifetimeAPI) so those handles
+// are produced on the persistent API checker and stay resolvable. Only safe when the
+// LS operation acquires a checker exactly once; nested acquisitions (e.g. find-all-
+// references) would deadlock on the single-slot persistent checker.
 func (s *Session) setupLanguageService(sd *snapshotData, program *compiler.Program, projectHandle ProjectID, activeFile string) (*ls.LanguageService, error) {
 	projectName := parseProjectHandle(projectHandle)
 	proj := sd.snapshot.ProjectCollection.GetProjectByPath(projectName)
@@ -2710,6 +2718,9 @@ func (s *Session) handleGetSignatureUsages(ctx context.Context, params *GetSigna
 
 // handleGetCompletionsAtPosition returns completions at a position in a document.
 func (s *Session) handleGetCompletionsAtPosition(ctx context.Context, params *GetCompletionsAtPositionParams) (*CompletionInfoResponse, error) {
+	if params.IncludeSymbol {
+		ctx = core.WithCheckerLifetime(ctx, core.CheckerLifetimeAPI)
+	}
 	sd, err := s.getSnapshotData(params.Snapshot)
 	if err != nil {
 		return nil, err

--- a/internal/api/session_completion_test.go
+++ b/internal/api/session_completion_test.go
@@ -1,0 +1,89 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/bundled"
+	"github.com/microsoft/typescript-go/internal/testutil/projecttestutil"
+	"gotest.tools/v3/assert"
+)
+
+// TestCompletionSymbolTypeIsResolvable reproduces a crash where requesting the
+// type of a completion-provided symbol panicked with a nil pointer dereference.
+//
+// Completion ran on an ephemeral query checker (default lifetime), so members of
+// a generic type such as `string[]` (= Array<string>) were returned as
+// *instantiated* symbols whose per-checker instantiation links live only on that
+// query checker. GetTypeOfSymbol runs on the persistent API checker — a
+// different instance — where those links are absent, so getTypeOfInstantiatedSymbol
+// dereferenced a nil target and brought down the connection.
+//
+// The fix pins symbol-producing completion to the API checker, so the returned
+// handles resolve on the same checker the client re-queries.
+func TestCompletionSymbolTypeIsResolvable(t *testing.T) {
+	t.Parallel()
+	if !bundled.Embedded {
+		t.Skip("bundled files are not embedded")
+	}
+
+	const fileName = "/home/projects/p/src/index.ts"
+	// The caret sits right after `people.`, requesting members of `string[]`.
+	const content = "declare const people: string[];\npeople."
+
+	files := map[string]any{
+		"/home/projects/p/tsconfig.json": `{ "compilerOptions": { "strict": true } }`,
+		fileName:                         content,
+	}
+	projectSession, _ := projecttestutil.Setup(files)
+	defer projectSession.Close()
+	session := NewSession(projectSession, nil)
+	defer session.Close()
+
+	ctx := context.Background()
+
+	snapshotResp, err := session.handleUpdateSnapshot(ctx, &UpdateSnapshotParams{
+		OpenFiles: []DocumentIdentifier{{FileName: fileName}},
+	})
+	assert.NilError(t, err)
+
+	proj, err := session.handleGetDefaultProjectForFile(ctx, &GetDefaultProjectForFileParams{
+		Snapshot: snapshotResp.Snapshot,
+		File:     DocumentIdentifier{FileName: fileName},
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, proj != nil, "file should resolve to a default project")
+
+	// content is pure ASCII, so the UTF-16 caret offset equals the byte length.
+	completions, err := session.handleGetCompletionsAtPosition(ctx, &GetCompletionsAtPositionParams{
+		Snapshot:      snapshotResp.Snapshot,
+		Project:       proj.Id,
+		File:          DocumentIdentifier{FileName: fileName},
+		Position:      uint32(len(content)),
+		IncludeSymbol: true,
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, completions != nil, "expected a completion list for array members")
+
+	// Resolving the type of every completion symbol must not panic, and known
+	// members like `push` must produce a concrete type.
+	var sawSymbol, sawPush bool
+	for _, entry := range completions.Entries {
+		if entry.Symbol == nil {
+			continue
+		}
+		sawSymbol = true
+		typeResp, err := session.handleGetTypeOfSymbol(ctx, &GetTypeOfSymbolParams{
+			Snapshot: snapshotResp.Snapshot,
+			Project:  proj.Id,
+			Symbol:   entry.Symbol.Id,
+		})
+		assert.NilError(t, err)
+		assert.Assert(t, typeResp != nil, "type of completion symbol %q should resolve", entry.Name)
+		if entry.Name == "push" {
+			sawPush = true
+		}
+	}
+	assert.Assert(t, sawSymbol, "completion entries should include resolvable symbols")
+	assert.Assert(t, sawPush, "array member completions should include `push`")
+}

--- a/internal/checker/exports.go
+++ b/internal/checker/exports.go
@@ -169,6 +169,14 @@ func (c *Checker) GetConstraintOfTypeParameter(typeParameter *Type) *Type {
 	return c.getConstraintOfTypeParameter(typeParameter)
 }
 
+func (c *Checker) GetTrueTypeOfConditionalType(t *Type) *Type {
+	return c.getTrueTypeFromConditionalType(t)
+}
+
+func (c *Checker) GetFalseTypeOfConditionalType(t *Type) *Type {
+	return c.getFalseTypeFromConditionalType(t)
+}
+
 func (c *Checker) GetDefaultFromTypeParameter(typeParameter *Type) *Type {
 	return c.getDefaultFromTypeParameter(typeParameter)
 }


### PR DESCRIPTION
Set CheckerLifetimeAPI in handleGetCompletionsAtPosition so completion symbols resolve on the same checker GetTypeOfSymbol uses, fixing a nil-pointer panic (e.g. `people.` where `people: string[]`). Document the rule on setupLanguageService and add a regression test