### PR TITLE
Big string union optimizations

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -27138,11 +27138,9 @@ func (c *Checker) getSuggestionForNonexistentIndexSignature(objectType *Type, ex
 	return suggestion + "." + suggestedMethod
 }
 
-const maxStringLiteralSuggestionCandidates = 10_000
-
 func (c *Checker) getSuggestedTypeForNonexistentStringLiteralType(source *Type, target *Type) *Type {
 	candidates := core.FilterSeq(target.Types(), func(t *Type) bool { return t.flags&TypeFlagsStringLiteral != 0 })
-	return core.GetSpellingSuggestionWithMaxCandidateCount(getStringLiteralValue(source), candidates, getStringLiteralValue, CompareTypes, maxStringLiteralSuggestionCandidates)
+	return core.GetSpellingSuggestionWithMaxCandidateCount(getStringLiteralValue(source), candidates, getStringLiteralValue, CompareTypes, 1000)
 }
 
 func getIndexNodeForAccessExpression(accessNode *ast.Node) *ast.Node {

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -25554,7 +25554,10 @@ func (c *Checker) getUnionTypeEx(types []*Type, unionReduction UnionReduction, a
 }
 
 func (c *Checker) getUnionTypeWorker(types []*Type, unionReduction UnionReduction, alias *TypeAlias, origin *Type) *Type {
-	typeSet, includes := c.addTypesToUnion(make([]*Type, 0, len(types)), 0, types)
+	typeSet, includes, needsSort := c.addTypesToUnion(make([]*Type, 0, len(types)), 0, types, false /*needsSort*/)
+	if needsSort {
+		typeSet = sortAndDeduplicateTypes(typeSet)
+	}
 	if unionReduction != UnionReductionNone {
 		if includes&TypeFlagsAnyOrUnknown != 0 {
 			if includes&TypeFlagsAny != 0 {
@@ -25661,7 +25664,7 @@ func (c *Checker) UnionTypes() iter.Seq[*Type] {
 	return maps.Values(c.unionTypes)
 }
 
-func (c *Checker) addTypesToUnion(typeSet []*Type, includes TypeFlags, types []*Type) ([]*Type, TypeFlags) {
+func (c *Checker) addTypesToUnion(typeSet []*Type, includes TypeFlags, types []*Type, needsSort bool) ([]*Type, TypeFlags, bool) {
 	var lastType *Type
 	for _, t := range types {
 		if t != lastType {
@@ -25670,17 +25673,20 @@ func (c *Checker) addTypesToUnion(typeSet []*Type, includes TypeFlags, types []*
 				if t.alias != nil || u.origin != nil {
 					includes |= TypeFlagsUnion
 				}
-				typeSet, includes = c.addTypesToUnion(typeSet, includes, u.types)
+				typeSet = slices.Grow(typeSet, len(u.types))
+				typeSet, includes, needsSort = c.addTypesToUnion(typeSet, includes, u.types, needsSort)
 			} else {
-				typeSet, includes = c.addTypeToUnion(typeSet, includes, t)
+				typeSet, includes, needsSort = c.addTypeToUnion(typeSet, includes, t, needsSort)
 			}
 			lastType = t
 		}
 	}
-	return typeSet, includes
+	return typeSet, includes, needsSort
 }
 
-func (c *Checker) addTypeToUnion(typeSet []*Type, includes TypeFlags, t *Type) ([]*Type, TypeFlags) {
+const deferredUnionSortThreshold = 1_000
+
+func (c *Checker) addTypeToUnion(typeSet []*Type, includes TypeFlags, t *Type, needsSort bool) ([]*Type, TypeFlags, bool) {
 	flags := t.flags
 	// We ignore 'never' types in unions
 	if flags&TypeFlagsNever == 0 {
@@ -25702,12 +25708,31 @@ func (c *Checker) addTypeToUnion(typeSet []*Type, includes TypeFlags, t *Type) (
 				includes |= TypeFlagsIncludesNonWideningType
 			}
 		} else {
-			if index, ok := slices.BinarySearchFunc(typeSet, t, CompareTypes); !ok {
+			if needsSort || flags&TypeFlagsStringLiteral != 0 && len(typeSet) >= deferredUnionSortThreshold {
+				typeSet = append(typeSet, t)
+				needsSort = true
+			} else if index, ok := slices.BinarySearchFunc(typeSet, t, CompareTypes); !ok {
 				typeSet = slices.Insert(typeSet, index, t)
 			}
 		}
 	}
-	return typeSet, includes
+	return typeSet, includes, needsSort
+}
+
+func sortAndDeduplicateTypes(types []*Type) []*Type {
+	if len(types) < 2 {
+		return types
+	}
+	slices.SortStableFunc(types, CompareTypes)
+	unique := 1
+	for _, t := range types[1:] {
+		if CompareTypes(types[unique-1], t) != 0 {
+			types[unique] = t
+			unique++
+		}
+	}
+	clear(types[unique:])
+	return types[:unique]
 }
 
 func (c *Checker) addNamedUnions(namedUnions []*Type, types []*Type) []*Type {
@@ -27110,8 +27135,20 @@ func (c *Checker) getSuggestionForNonexistentIndexSignature(objectType *Type, ex
 	return suggestion + "." + suggestedMethod
 }
 
+const maxStringLiteralSuggestionCandidates = 10_000
+
 func (c *Checker) getSuggestedTypeForNonexistentStringLiteralType(source *Type, target *Type) *Type {
-	candidates := core.FilterSeq(target.Types(), func(t *Type) bool { return t.flags&TypeFlagsStringLiteral != 0 })
+	types := target.Types()
+	candidateCount := 0
+	for _, t := range types {
+		if t.flags&TypeFlagsStringLiteral != 0 {
+			candidateCount++
+			if candidateCount > maxStringLiteralSuggestionCandidates {
+				return nil
+			}
+		}
+	}
+	candidates := core.FilterSeq(types, func(t *Type) bool { return t.flags&TypeFlagsStringLiteral != 0 })
 	return core.GetSpellingSuggestion(getStringLiteralValue(source), candidates, getStringLiteralValue, CompareTypes)
 }
 

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -25665,6 +25665,10 @@ func (c *Checker) UnionTypes() iter.Seq[*Type] {
 }
 
 func (c *Checker) addTypesToUnion(typeSet []*Type, includes TypeFlags, types []*Type, needsSort bool) ([]*Type, TypeFlags, bool) {
+	if !needsSort && len(typeSet)+len(types) >= deferredUnionSortThreshold && (includes&TypeFlagsStringLiteral != 0 || core.Some(types, func(t *Type) bool { return t.flags&TypeFlagsStringLiteral != 0 })) {
+		needsSort = true
+		typeSet = slices.Grow(typeSet, len(types))
+	}
 	var lastType *Type
 	for _, t := range types {
 		if t != lastType {
@@ -25708,9 +25712,8 @@ func (c *Checker) addTypeToUnion(typeSet []*Type, includes TypeFlags, t *Type, n
 				includes |= TypeFlagsIncludesNonWideningType
 			}
 		} else {
-			if needsSort || flags&TypeFlagsStringLiteral != 0 && len(typeSet) >= deferredUnionSortThreshold {
+			if needsSort {
 				typeSet = append(typeSet, t)
-				needsSort = true
 			} else if index, ok := slices.BinarySearchFunc(typeSet, t, CompareTypes); !ok {
 				typeSet = slices.Insert(typeSet, index, t)
 			}
@@ -27138,18 +27141,8 @@ func (c *Checker) getSuggestionForNonexistentIndexSignature(objectType *Type, ex
 const maxStringLiteralSuggestionCandidates = 10_000
 
 func (c *Checker) getSuggestedTypeForNonexistentStringLiteralType(source *Type, target *Type) *Type {
-	types := target.Types()
-	candidateCount := 0
-	for _, t := range types {
-		if t.flags&TypeFlagsStringLiteral != 0 {
-			candidateCount++
-			if candidateCount > maxStringLiteralSuggestionCandidates {
-				return nil
-			}
-		}
-	}
-	candidates := core.FilterSeq(types, func(t *Type) bool { return t.flags&TypeFlagsStringLiteral != 0 })
-	return core.GetSpellingSuggestion(getStringLiteralValue(source), candidates, getStringLiteralValue, CompareTypes)
+	candidates := core.FilterSeq(target.Types(), func(t *Type) bool { return t.flags&TypeFlagsStringLiteral != 0 })
+	return core.GetSpellingSuggestionWithMaxCandidateCount(getStringLiteralValue(source), candidates, getStringLiteralValue, CompareTypes, maxStringLiteralSuggestionCandidates)
 }
 
 func getIndexNodeForAccessExpression(accessNode *ast.Node) *ast.Node {

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -557,6 +557,14 @@ func GetScriptKindFromFileName(fileName string) ScriptKind {
 //
 // @internal
 func GetSpellingSuggestion[T any](name string, candidates iter.Seq[T], getName func(T) string, compare func(T, T) int) T {
+	return getSpellingSuggestion(name, candidates, getName, compare, 0 /*maxCandidates*/)
+}
+
+func GetSpellingSuggestionWithMaxCandidateCount[T any](name string, candidates iter.Seq[T], getName func(T) string, compare func(T, T) int, maxCandidates int) T {
+	return getSpellingSuggestion(name, candidates, getName, compare, maxCandidates)
+}
+
+func getSpellingSuggestion[T any](name string, candidates iter.Seq[T], getName func(T) string, compare func(T, T) int, maxCandidates int) T {
 	runeName := []rune(name)
 	maximumLengthDifference := max(2, int(float64(len(runeName))*0.34))
 	bestDistance := math.Floor(float64(len(runeName))*0.4) + 0.9 // If the best result is worse than this, don't bother.
@@ -564,6 +572,7 @@ func GetSpellingSuggestion[T any](name string, candidates iter.Seq[T], getName f
 	defer levenshteinBuffersPool.Put(buffers)
 	var bestCandidate T
 	hasBest := false
+	checkedCandidates := 0
 	for candidate := range candidates {
 		candidateName := getName(candidate)
 		maxLen := max(len(candidateName), len(runeName))
@@ -576,6 +585,11 @@ func GetSpellingSuggestion[T any](name string, candidates iter.Seq[T], getName f
 			// Otherwise, don't bother, since a user would usually notice differences of a 2-character name.
 			if len(candidateName) < 3 && !strings.EqualFold(candidateName, name) {
 				continue
+			}
+			checkedCandidates++
+			if maxCandidates > 0 && checkedCandidates > maxCandidates {
+				var zero T
+				return zero
 			}
 			distance := levenshteinWithMax(buffers, runeName, []rune(candidateName), bestDistance)
 			if distance < 0 {

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -574,6 +574,11 @@ func getSpellingSuggestion[T any](name string, candidates iter.Seq[T], getName f
 	hasBest := false
 	checkedCandidates := 0
 	for candidate := range candidates {
+		checkedCandidates++
+		if maxCandidates > 0 && checkedCandidates > maxCandidates {
+			var zero T
+			return zero
+		}
 		candidateName := getName(candidate)
 		maxLen := max(len(candidateName), len(runeName))
 		minLen := min(len(candidateName), len(runeName))
@@ -585,11 +590,6 @@ func getSpellingSuggestion[T any](name string, candidates iter.Seq[T], getName f
 			// Otherwise, don't bother, since a user would usually notice differences of a 2-character name.
 			if len(candidateName) < 3 && !strings.EqualFold(candidateName, name) {
 				continue
-			}
-			checkedCandidates++
-			if maxCandidates > 0 && checkedCandidates > maxCandidates {
-				var zero T
-				return zero
 			}
 			distance := levenshteinWithMax(buffers, runeName, []rune(candidateName), bestDistance)
 			if distance < 0 {

--- a/testdata/baselines/reference/compiler/largeStringLiteralUnionSuggestion.errors.txt
+++ b/testdata/baselines/reference/compiler/largeStringLiteralUnionSuggestion.errors.txt
@@ -1,0 +1,13 @@
+largeStringLiteralUnionSuggestion.ts(6,7): error TS2322: Type '"zzzz"' is not assignable to type '"a000" | "a001" | "a002" | "a003" | "a004" | "a005" | "a006" | "a007" | "a008" | "a009" | "a010" | "a011" | "a012" | "a013" | "a014" | "a015" | "a016" | "a017" | "a018" | "a019" | "a020" | ... 10978 more ... | "k999"'.
+
+
+==== largeStringLiteralUnionSuggestion.ts (1 errors) ====
+    type Prefix = "a" | "b" | "c" | "d" | "e" | "f" | "g" | "h" | "i" | "j" | "k";
+    type Digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9";
+    type LargeStringLiteralUnion = `${Prefix}${Digit}${Digit}${Digit}`;
+    
+    const ok: LargeStringLiteralUnion = "a000";
+    const bad: LargeStringLiteralUnion = "zzzz";
+          ~~~
+!!! error TS2322: Type '"zzzz"' is not assignable to type '"a000" | "a001" | "a002" | "a003" | "a004" | "a005" | "a006" | "a007" | "a008" | "a009" | "a010" | "a011" | "a012" | "a013" | "a014" | "a015" | "a016" | "a017" | "a018" | "a019" | "a020" | ... 10978 more ... | "k999"'.
+    

--- a/testdata/tests/cases/compiler/largeStringLiteralUnionSuggestion.ts
+++ b/testdata/tests/cases/compiler/largeStringLiteralUnionSuggestion.ts
@@ -1,0 +1,11 @@
+// @strict: true
+// @noEmit: true
+// @noErrorTruncation: false
+// @noTypesAndSymbols: true
+
+type Prefix = "a" | "b" | "c" | "d" | "e" | "f" | "g" | "h" | "i" | "j" | "k";
+type Digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9";
+type LargeStringLiteralUnion = `${Prefix}${Digit}${Digit}${Digit}`;
+
+const ok: LargeStringLiteralUnion = "a000";
+const bad: LargeStringLiteralUnion = "zzzz";


### PR DESCRIPTION
Inspired by this thread: https://bsky.app/profile/kurtextrem.de/post/3mpgzqxsafc2d

https://gist.github.com/fabiospampinato/d5a08c346c481fc2ac68e1e5de06ae90

| Case | tsc check time | tsgo before | tsgo after | Improvement |
|---|---:|---:|---:|---:|
| Full gist repro | 4.625s ± 0.046s | ~5.2s | 1.232s ± 0.027s | ~4.2x faster |
| Type only | 0.712s ± 0.039s | 2.44s | 0.492s ± 0.016s | ~5.0x faster |
| Valid assignments only | 0.676s ± 0.008s | 2.38s | 0.481s ± 0.013s | ~4.9x faster |
| Invalid assignments only | 2.973s ± 0.034s | 3.45s | 1.103s ± 0.025s | ~3.1x faster |
| Mixed first block | 2.984s ± 0.025s | 3.38s | 1.076s ± 0.006s | ~3.1x faster |


This:

- Defers sorting in union construction for string unions, up to a point
- Stops offering "did you mean" suggestions in large unions