### PR TITLE
Run symbol-returning completion on the API checker

### DIFF
--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -484,6 +484,14 @@ func (s *Session) setupChecker(ctx context.Context, snapshot SnapshotID, project
 // setupLanguageService creates a LanguageService for the given snapshot/project.
 // Unlike setupChecker, this does NOT acquire a checker from the pool, so callers that
 // only need an LS (and not a Checker) can avoid blocking on / holding a pooled checker.
+//
+// The LS acquires its own checker internally (keyed by the ctx's checker lifetime).
+// If a handler returns symbol/type/signature handles the client may later re-query
+// on the API checker (e.g. completion with IncludeSymbol -> GetTypeOfSymbol), wrap
+// ctx with core.WithCheckerLifetime(ctx, core.CheckerLifetimeAPI) so those handles
+// are produced on the persistent API checker and stay resolvable. Only safe when the
+// LS operation acquires a checker exactly once; nested acquisitions (e.g. find-all-
+// references) would deadlock on the single-slot persistent checker.
 func (s *Session) setupLanguageService(sd *snapshotData, program *compiler.Program, projectHandle ProjectID, activeFile string) (*ls.LanguageService, error) {
 	projectName := parseProjectHandle(projectHandle)
 	proj := sd.snapshot.ProjectCollection.GetProjectByPath(projectName)
@@ -3080,6 +3088,9 @@ func (s *Session) handleGetSignatureUsages(ctx context.Context, params *GetSigna
 
 // handleGetCompletionsAtPosition returns completions at a position in a document.
 func (s *Session) handleGetCompletionsAtPosition(ctx context.Context, params *GetCompletionsAtPositionParams) (*CompletionInfoResponse, error) {
+	if params.IncludeSymbol {
+		ctx = core.WithCheckerLifetime(ctx, core.CheckerLifetimeAPI)
+	}
 	sd, err := s.getSnapshotData(params.Snapshot)
 	if err != nil {
 		return nil, err

--- a/internal/api/session_completion_test.go
+++ b/internal/api/session_completion_test.go
@@ -1,0 +1,89 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/bundled"
+	"github.com/microsoft/typescript-go/internal/testutil/projecttestutil"
+	"gotest.tools/v3/assert"
+)
+
+// TestCompletionSymbolTypeIsResolvable reproduces a crash where requesting the
+// type of a completion-provided symbol panicked with a nil pointer dereference.
+//
+// Completion ran on an ephemeral query checker (default lifetime), so members of
+// a generic type such as `string[]` (= Array<string>) were returned as
+// *instantiated* symbols whose per-checker instantiation links live only on that
+// query checker. GetTypeOfSymbol runs on the persistent API checker — a
+// different instance — where those links are absent, so getTypeOfInstantiatedSymbol
+// dereferenced a nil target and brought down the connection.
+//
+// The fix pins symbol-producing completion to the API checker, so the returned
+// handles resolve on the same checker the client re-queries.
+func TestCompletionSymbolTypeIsResolvable(t *testing.T) {
+	t.Parallel()
+	if !bundled.Embedded {
+		t.Skip("bundled files are not embedded")
+	}
+
+	const fileName = "/home/projects/p/src/index.ts"
+	// The caret sits right after `people.`, requesting members of `string[]`.
+	const content = "declare const people: string[];\npeople."
+
+	files := map[string]any{
+		"/home/projects/p/tsconfig.json": `{ "compilerOptions": { "strict": true } }`,
+		fileName:                         content,
+	}
+	projectSession, _ := projecttestutil.Setup(files)
+	defer projectSession.Close()
+	session := NewSession(projectSession, nil)
+	defer session.Close()
+
+	ctx := context.Background()
+
+	snapshotResp, err := session.handleUpdateSnapshot(ctx, &UpdateSnapshotParams{
+		OpenFiles: []DocumentIdentifier{{FileName: fileName}},
+	})
+	assert.NilError(t, err)
+
+	proj, err := session.handleGetDefaultProjectForFile(ctx, &GetDefaultProjectForFileParams{
+		Snapshot: snapshotResp.Snapshot,
+		File:     DocumentIdentifier{FileName: fileName},
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, proj != nil, "file should resolve to a default project")
+
+	// content is pure ASCII, so the UTF-16 caret offset equals the byte length.
+	completions, err := session.handleGetCompletionsAtPosition(ctx, &GetCompletionsAtPositionParams{
+		Snapshot:      snapshotResp.Snapshot,
+		Project:       proj.Id,
+		File:          DocumentIdentifier{FileName: fileName},
+		Position:      uint32(len(content)),
+		IncludeSymbol: true,
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, completions != nil, "expected a completion list for array members")
+
+	// Resolving the type of every completion symbol must not panic, and known
+	// members like `push` must produce a concrete type.
+	var sawSymbol, sawPush bool
+	for _, entry := range completions.Entries {
+		if entry.Symbol == nil {
+			continue
+		}
+		sawSymbol = true
+		typeResp, err := session.handleGetTypeOfSymbol(ctx, &GetTypeOfSymbolParams{
+			Snapshot: snapshotResp.Snapshot,
+			Project:  proj.Id,
+			Symbol:   entry.Symbol.Id,
+		})
+		assert.NilError(t, err)
+		assert.Assert(t, typeResp != nil, "type of completion symbol %q should resolve", entry.Name)
+		if entry.Name == "push" {
+			sawPush = true
+		}
+	}
+	assert.Assert(t, sawSymbol, "completion entries should include resolvable symbols")
+	assert.Assert(t, sawPush, "array member completions should include `push`")
+}


### PR DESCRIPTION
Set CheckerLifetimeAPI in handleGetCompletionsAtPosition so completion symbols resolve on the same checker GetTypeOfSymbol uses, fixing a nil-pointer panic (e.g. `people.` where `people: string[]`). Document the rule on setupLanguageService and add a regression test