### PR TITLE
Handle unloaded projects in API snapshot responses

### DIFF
--- a/internal/api/proto.go
+++ b/internal/api/proto.go
@@ -494,12 +494,15 @@ type ProjectResponse struct {
 }
 
 func NewProjectResponse(p *project.Project) *ProjectResponse {
-	return &ProjectResponse{
-		Id:              ProjectHandle(p),
-		ConfigFileName:  p.Name(),
-		RootFiles:       p.CommandLine.FileNames(),
-		CompilerOptions: p.CommandLine.CompilerOptions(),
+	response := &ProjectResponse{
+		Id:             ProjectHandle(p),
+		ConfigFileName: p.Name(),
 	}
+	if p.CommandLine != nil {
+		response.RootFiles = p.CommandLine.FileNames()
+		response.CompilerOptions = p.CommandLine.CompilerOptions()
+	}
+	return response
 }
 
 type GetSymbolAtPositionParams struct {

--- a/internal/api/proto.go
+++ b/internal/api/proto.go
@@ -495,8 +495,10 @@ type ProjectResponse struct {
 
 func NewProjectResponse(p *project.Project) *ProjectResponse {
 	response := &ProjectResponse{
-		Id:             ProjectHandle(p),
-		ConfigFileName: p.Name(),
+		Id:              ProjectHandle(p),
+		ConfigFileName:  p.Name(),
+		RootFiles:       []string{},
+		CompilerOptions: &core.CompilerOptions{},
 	}
 	if p.CommandLine != nil {
 		response.RootFiles = p.CommandLine.FileNames()

--- a/internal/api/proto.go
+++ b/internal/api/proto.go
@@ -494,17 +494,15 @@ type ProjectResponse struct {
 }
 
 func NewProjectResponse(p *project.Project) *ProjectResponse {
-	response := &ProjectResponse{
+	if p == nil || p.CommandLine == nil {
+		panic("NewProjectResponse called with unloaded project")
+	}
+	return &ProjectResponse{
 		Id:              ProjectHandle(p),
 		ConfigFileName:  p.Name(),
-		RootFiles:       []string{},
-		CompilerOptions: &core.CompilerOptions{},
+		RootFiles:       p.CommandLine.FileNames(),
+		CompilerOptions: p.CommandLine.CompilerOptions(),
 	}
-	if p.CommandLine != nil {
-		response.RootFiles = p.CommandLine.FileNames()
-		response.CompilerOptions = p.CommandLine.CompilerOptions()
-	}
-	return response
 }
 
 type GetSymbolAtPositionParams struct {

--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -908,9 +908,12 @@ func (s *Session) handleUpdateSnapshot(ctx context.Context, params *UpdateSnapsh
 
 	// Build projects list
 	projects := snapshot.ProjectCollection.Projects()
-	projectResponses := make([]*ProjectResponse, len(projects))
-	for i, proj := range projects {
-		projectResponses[i] = NewProjectResponse(proj)
+	projectResponses := make([]*ProjectResponse, 0, len(projects))
+	for _, proj := range projects {
+		if proj.CommandLine == nil {
+			continue
+		}
+		projectResponses = append(projectResponses, NewProjectResponse(proj))
 	}
 
 	// Compute changes from the previous latest snapshot

--- a/internal/api/session_apistate_test.go
+++ b/internal/api/session_apistate_test.go
@@ -248,8 +248,9 @@ func TestUpdateSnapshotResponseHandlesUnloadedAncestorProject(t *testing.T) {
 			assert.Assert(t, project.CompilerOptions != nil)
 		case ancestorConfigFileName:
 			foundAncestorProject = true
-			assert.Assert(t, project.RootFiles == nil)
-			assert.Assert(t, project.CompilerOptions == nil)
+			assert.Assert(t, project.RootFiles != nil)
+			assert.Equal(t, len(project.RootFiles), 0)
+			assert.Assert(t, project.CompilerOptions != nil)
 		}
 	}
 	assert.Assert(t, foundNestedProject)

--- a/internal/api/session_apistate_test.go
+++ b/internal/api/session_apistate_test.go
@@ -194,12 +194,12 @@ func TestSessionTracksAndReleasesAPIRefs(t *testing.T) {
 	})
 }
 
-// TestUpdateSnapshotResponseHandlesUnloadedAncestorProject verifies that API
-// updateSnapshot can serialize a snapshot containing both a loaded nested
-// project and an unloaded ancestor project. This covers the case where opening a
-// file loads its nearest configured project while solution search discovers an
-// ancestor tsconfig placeholder whose command line is still nil.
-func TestUpdateSnapshotResponseHandlesUnloadedAncestorProject(t *testing.T) {
+// TestUpdateSnapshotResponseSkipsUnloadedAncestorProject verifies that API
+// updateSnapshot does not report unloaded ancestor project placeholders. This
+// covers the case where opening a file loads its nearest configured project
+// while solution search discovers an ancestor tsconfig placeholder whose command
+// line is still nil.
+func TestUpdateSnapshotResponseSkipsUnloadedAncestorProject(t *testing.T) {
 	t.Parallel()
 	if !bundled.Embedded {
 		t.Skip("bundled files are not embedded")
@@ -248,11 +248,8 @@ func TestUpdateSnapshotResponseHandlesUnloadedAncestorProject(t *testing.T) {
 			assert.Assert(t, project.CompilerOptions != nil)
 		case ancestorConfigFileName:
 			foundAncestorProject = true
-			assert.Assert(t, project.RootFiles != nil)
-			assert.Equal(t, len(project.RootFiles), 0)
-			assert.Assert(t, project.CompilerOptions != nil)
 		}
 	}
 	assert.Assert(t, foundNestedProject)
-	assert.Assert(t, foundAncestorProject)
+	assert.Assert(t, !foundAncestorProject)
 }

--- a/internal/api/session_apistate_test.go
+++ b/internal/api/session_apistate_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/microsoft/typescript-go/internal/bundled"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
 	"github.com/microsoft/typescript-go/internal/testutil/projecttestutil"
 	"github.com/microsoft/typescript-go/internal/tspath"
 	"gotest.tools/v3/assert"
@@ -191,4 +192,66 @@ func TestSessionTracksAndReleasesAPIRefs(t *testing.T) {
 			"configured project should be unloaded after closing the relatively-pathed file",
 		)
 	})
+}
+
+// TestUpdateSnapshotResponseHandlesUnloadedAncestorProject verifies that API
+// updateSnapshot can serialize a snapshot containing both a loaded nested
+// project and an unloaded ancestor project. This covers the case where opening a
+// file loads its nearest configured project while solution search discovers an
+// ancestor tsconfig placeholder whose command line is still nil.
+func TestUpdateSnapshotResponseHandlesUnloadedAncestorProject(t *testing.T) {
+	t.Parallel()
+	if !bundled.Embedded {
+		t.Skip("bundled files are not embedded")
+	}
+
+	const (
+		nestedConfigFileName   = "/repo/packages/app/tsconfig.json"
+		ancestorConfigFileName = "/repo/packages/tsconfig.json"
+		fileName               = "/repo/packages/app/src/index.ts"
+	)
+	files := map[string]any{
+		ancestorConfigFileName: `{ "files": [] }`,
+		nestedConfigFileName: `{
+			"compilerOptions": { "composite": true },
+			"include": ["**/*"]
+		}`,
+		fileName: `let s: string = 1234;`,
+	}
+	projectSession, _ := projecttestutil.Setup(files)
+	defer projectSession.Close()
+
+	projectSession.DidOpenFile(context.Background(), lsproto.DocumentUri("file://"+fileName), 1, files[fileName].(string), lsproto.LanguageKindTypeScript)
+	snapshot := projectSession.Snapshot()
+	nestedProject := snapshot.ProjectCollection.ConfiguredProject(tspath.Path(nestedConfigFileName))
+	assert.Assert(t, nestedProject != nil)
+	assert.Assert(t, nestedProject.CommandLine != nil)
+	ancestorProject := snapshot.ProjectCollection.ConfiguredProject(tspath.Path(ancestorConfigFileName))
+	assert.Assert(t, ancestorProject != nil)
+	assert.Assert(t, ancestorProject.CommandLine == nil)
+
+	session := NewSession(projectSession, nil)
+	defer session.Close()
+
+	response, err := session.handleUpdateSnapshot(context.Background(), &UpdateSnapshotParams{
+		OpenProjects: []DocumentIdentifier{{FileName: nestedConfigFileName}},
+	})
+	assert.NilError(t, err)
+
+	var foundNestedProject bool
+	var foundAncestorProject bool
+	for _, project := range response.Projects {
+		switch project.ConfigFileName {
+		case nestedConfigFileName:
+			foundNestedProject = true
+			assert.Assert(t, project.RootFiles != nil)
+			assert.Assert(t, project.CompilerOptions != nil)
+		case ancestorConfigFileName:
+			foundAncestorProject = true
+			assert.Assert(t, project.RootFiles == nil)
+			assert.Assert(t, project.CompilerOptions == nil)
+		}
+	}
+	assert.Assert(t, foundNestedProject)
+	assert.Assert(t, foundAncestorProject)
 }


### PR DESCRIPTION
Opening a file can load its nearest configured project while solution search discovers an ancestor tsconfig as an unloaded placeholder. API `updateSnapshot` previously serialized every project assuming `CommandLine` was non-nil, which couldp anic for that unloaded ancestor project.

```
Error: panic: runtime error: invalid memory address or nil pointer dereference
goroutine 932 [running]:
runtime/debug.Stack()
	runtime/debug/stack.go:26 +0x5e
github.com/microsoft/typescript-go/internal/api.(*AsyncConn).handleRequest.func1()
	github.com/microsoft/typescript-go/internal/api/conn_async.go:96 +0x58
panic({0xdd6c80?, 0x1b43150?})
	runtime/panic.go:860 +0x13a
github.com/microsoft/typescript-go/internal/tsoptions.(*ParsedCommandLine).FileNames(...)
	github.com/microsoft/typescript-go/internal/tsoptions/parsedcommandline.go:295
github.com/microsoft/typescript-go/internal/api.NewProjectResponse(...)
	github.com/microsoft/typescript-go/internal/api/proto.go:500
github.com/microsoft/typescript-go/internal/api.(*Session).handleUpdateSnapshot(0x18b1c3e22230, {0x11cec30, 0x18b1c3f85950}, 0x18b1bd2e5dc0)
	github.com/microsoft/typescript-go/internal/api/session.go:913 +0x1401
github.com/microsoft/typescript-go/internal/api.(*Session).HandleRequest(0x18b1c3e22230, {0x11cec30, 0x18b1c3f85950}, {0x18b1bc646902, 0xe}, {0x18b1b97a2980?, 0x18b1bbdca708?, 0x18b1c1549790?})
	github.com/microsoft/typescript-go/internal/api/session.go:521 +0xbe9
github.com/microsoft/typescript-go/internal/api.(*AsyncConn).handleRequest(0x18b1c3f859a0, {0x11cec30?, 0x18b1c3f85950?}, 0x18b1c35761e0)
	github.com/microsoft/typescript-go/internal/api/conn_async.go:112 +0xb4
created by github.com/microsoft/typescript-go/internal/api.(*AsyncConn).Run in goroutine 899
	github.com/microsoft/typescript-go/internal/api/conn_async.go:66 +0x105
```