### PR TITLE
Use workspace/diagnostics for global diagnostics

### DIFF
--- a/_extension/src/client.ts
+++ b/_extension/src/client.ts
@@ -80,6 +80,7 @@ export class Client implements vscode.Disposable {
                 codeLensShowLocationsCommandName,
                 enableTelemetry: true,
                 logVerbosity: this.outputChannel.logLevel,
+                useWorkspaceDiagnostics: true,
             },
             errorHandler: this.errorHandler,
             middleware: {

--- a/internal/lsp/lsproto/_generate/generate.mts
+++ b/internal/lsp/lsproto/_generate/generate.mts
@@ -45,6 +45,12 @@ const customStructures: Structure[] = [
                 documentation: "DisablePushDiagnostics disables automatic pushing of diagnostics to the client.",
             },
             {
+                name: "useWorkspaceDiagnostics",
+                type: { kind: "base", name: "boolean" },
+                optional: true,
+                documentation: "UseWorkspaceDiagnostics enables reporting program diagnostics through workspace/diagnostic.",
+            },
+            {
                 name: "codeLensShowLocationsCommandName",
                 type: { kind: "base", name: "string" },
                 optional: true,

--- a/internal/lsp/lsproto/lsp_generated.go
+++ b/internal/lsp/lsproto/lsp_generated.go
@@ -28053,6 +28053,9 @@ type InitializationOptions struct {
 	// DisablePushDiagnostics disables automatic pushing of diagnostics to the client.
 	DisablePushDiagnostics *bool `json:"disablePushDiagnostics,omitzero"`
 
+	// UseWorkspaceDiagnostics enables reporting program diagnostics through workspace/diagnostic.
+	UseWorkspaceDiagnostics *bool `json:"useWorkspaceDiagnostics,omitzero"`
+
 	// The client-side command name that resolved references/implementations `CodeLens` should trigger. Arguments passed will be `(DocumentUri, Position, Location[])`.
 	CodeLensShowLocationsCommandName *string `json:"codeLensShowLocationsCommandName,omitzero"`
 
@@ -28087,6 +28090,13 @@ func (s *InitializationOptions) UnmarshalJSONFrom(dec *json.Decoder) error {
 				return errNull("disablePushDiagnostics")
 			}
 			if err := json.UnmarshalDecode(dec, &s.DisablePushDiagnostics); err != nil {
+				return err
+			}
+		case `"useWorkspaceDiagnostics"`:
+			if dec.PeekKind() == 'n' {
+				return errNull("useWorkspaceDiagnostics")
+			}
+			if err := json.UnmarshalDecode(dec, &s.UseWorkspaceDiagnostics); err != nil {
 				return err
 			}
 		case `"codeLensShowLocationsCommandName"`:

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -348,6 +348,10 @@ func (s *Server) RefreshCodeLens(ctx context.Context) error {
 	return nil
 }
 
+func useWorkspaceDiagnostics(options *lsproto.InitializationOptions) bool {
+	return options != nil && options.UseWorkspaceDiagnostics != nil && *options.UseWorkspaceDiagnostics
+}
+
 // ProgressStart implements project.Client.
 func (s *Server) ProgressStart(message *diagnostics.Message, args ...any) {
 	if s.projectProgress != nil {
@@ -779,6 +783,7 @@ var handlers = sync.OnceValue(func() handlerMap {
 
 	registerLanguageServiceDocumentRequestHandler(handlers, lsproto.TextDocumentVSOnAutoInsertInfo, (*Server).handleVSOnAutoInsert)
 
+	registerRequestHandler(handlers, lsproto.WorkspaceDiagnosticInfo, (*Server).handleWorkspaceDiagnostic)
 	registerMultiProjectReferenceRequestHandler(handlers, lsproto.TextDocumentReferencesInfo, (*ls.LanguageService).ProvideReferences)
 	registerMultiProjectReferenceRequestHandler(handlers, lsproto.TextDocumentVSReferencesInfo, (*ls.LanguageService).ProvideVSReferences)
 	registerRequestHandler(handlers, lsproto.TextDocumentRenameInfo, (*Server).handleRename)
@@ -1093,6 +1098,7 @@ func (s *Server) handleInitialize(ctx context.Context, params *lsproto.Initializ
 				Options: &lsproto.DiagnosticOptions{
 					Identifier:            new("typescript"),
 					InterFileDependencies: true,
+					WorkspaceDiagnostics:  useWorkspaceDiagnostics(s.initializationOptions),
 				},
 			},
 			CompletionProvider: &lsproto.CompletionOptions{
@@ -1192,10 +1198,11 @@ func (s *Server) handleInitialize(ctx context.Context, params *lsproto.Initializ
 }
 
 func (s *Server) handleInitialized(ctx context.Context, params *lsproto.InitializedParams) error {
-	var disablePushDiagnostics bool
+	workspaceDiagnosticsEnabled := useWorkspaceDiagnostics(s.initializationOptions)
+	disablePushDiagnostics := workspaceDiagnosticsEnabled
 	var enableTelemetry bool
 	if s.initializationOptions.DisablePushDiagnostics != nil {
-		disablePushDiagnostics = *s.initializationOptions.DisablePushDiagnostics
+		disablePushDiagnostics = disablePushDiagnostics || *s.initializationOptions.DisablePushDiagnostics
 	}
 	if s.initializationOptions.EnableTelemetry != nil {
 		enableTelemetry = *s.initializationOptions.EnableTelemetry
@@ -1241,16 +1248,17 @@ func (s *Server) handleInitialized(ctx context.Context, params *lsproto.Initiali
 	s.session = project.NewSession(&project.SessionInit{
 		BackgroundCtx: lsproto.WithClientCapabilities(s.backgroundCtx, &s.clientCapabilities),
 		Options: &project.SessionOptions{
-			CurrentDirectory:       cwd,
-			DefaultLibraryPath:     s.defaultLibraryPath,
-			TypingsLocation:        s.typingsLocation,
-			PositionEncoding:       s.positionEncoding,
-			WatchEnabled:           s.watchEnabled,
-			LoggingEnabled:         true,
-			TelemetryEnabled:       enableTelemetry,
-			DebounceDelay:          500 * time.Millisecond,
-			PushDiagnosticsEnabled: !disablePushDiagnostics,
-			Locale:                 s.locale,
+			CurrentDirectory:            cwd,
+			DefaultLibraryPath:          s.defaultLibraryPath,
+			TypingsLocation:             s.typingsLocation,
+			PositionEncoding:            s.positionEncoding,
+			WatchEnabled:                s.watchEnabled,
+			LoggingEnabled:              true,
+			TelemetryEnabled:            enableTelemetry,
+			DebounceDelay:               500 * time.Millisecond,
+			PushDiagnosticsEnabled:      !disablePushDiagnostics,
+			WorkspaceDiagnosticsEnabled: workspaceDiagnosticsEnabled,
+			Locale:                      s.locale,
 		},
 		FS:          s.fs,
 		Logger:      s.logger,
@@ -1360,6 +1368,11 @@ func (s *Server) handleSetLogVerbosity(_ context.Context, params *lsproto.SetLog
 func (s *Server) handleDocumentDiagnostic(ctx context.Context, ls *ls.LanguageService, params *lsproto.DocumentDiagnosticParams) (lsproto.DocumentDiagnosticResponse, error) {
 	ctx = core.WithCheckerLifetime(ctx, core.CheckerLifetimeDiagnostics)
 	return ls.ProvideDiagnostics(ctx, params.TextDocument.Uri)
+}
+
+func (s *Server) handleWorkspaceDiagnostic(ctx context.Context, _ *lsproto.WorkspaceDiagnosticParams, _ *lsproto.RequestMessage) (lsproto.WorkspaceDiagnosticResponse, error) {
+	ctx = core.WithCheckerLifetime(ctx, core.CheckerLifetimeDiagnostics)
+	return s.session.ProvideWorkspaceDiagnostics(ctx), nil
 }
 
 func (s *Server) handleHover(ctx context.Context, ls *ls.LanguageService, params *lsproto.HoverParams) (lsproto.HoverResponse, error) {

--- a/internal/lsp/server_diagnostics_test.go
+++ b/internal/lsp/server_diagnostics_test.go
@@ -1,0 +1,137 @@
+package lsp_test
+
+import (
+	"context"
+	"io"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/bundled"
+	"github.com/microsoft/typescript-go/internal/lsp"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
+	"github.com/microsoft/typescript-go/internal/testutil/lsptestutil"
+	"github.com/microsoft/typescript-go/internal/vfs/vfstest"
+	"gotest.tools/v3/assert"
+)
+
+func initDiagnosticClient(t *testing.T, workspaceDiagnosticsCap bool, workspaceDiagnosticsOption bool) (*lsptestutil.LSPClient, lsproto.InitializeResponse, *atomic.Int32, *atomic.Int32) {
+	t.Helper()
+
+	fs := bundled.WrapFS(vfstest.FromMap(map[string]string{
+		"/home/projects/tsconfig.json": `{"compilerOptions": {"target": "nope"}}`,
+		"/home/projects/index.ts":      "export const x = 1;",
+	}, false))
+
+	var publishNotifications atomic.Int32
+	var refreshRequests atomic.Int32
+	onServerRequest := func(_ context.Context, req *lsproto.RequestMessage) *lsproto.ResponseMessage {
+		switch req.Method {
+		case lsproto.MethodWorkspaceDiagnosticRefresh:
+			refreshRequests.Add(1)
+			return &lsproto.ResponseMessage{
+				ID:      req.ID,
+				JSONRPC: req.JSONRPC,
+				Result:  lsproto.Null{},
+			}
+		case lsproto.MethodClientRegisterCapability, lsproto.MethodClientUnregisterCapability, lsproto.MethodWindowWorkDoneProgressCreate:
+			return &lsproto.ResponseMessage{
+				ID:      req.ID,
+				JSONRPC: req.JSONRPC,
+				Result:  lsproto.Null{},
+			}
+		default:
+			return nil
+		}
+	}
+
+	client, closeClient := lsptestutil.NewLSPClient(t, lsp.ServerOptions{
+		Err:                io.Discard,
+		Cwd:                "/home/projects",
+		FS:                 fs,
+		DefaultLibraryPath: bundled.LibPath(),
+	}, onServerRequest)
+	t.Cleanup(func() { _ = closeClient() })
+	client.OnServerNotification = func(_ context.Context, req *lsproto.RequestMessage) {
+		if req.Method == lsproto.MethodTextDocumentPublishDiagnostics {
+			publishNotifications.Add(1)
+		}
+	}
+
+	capabilities := &lsproto.ClientCapabilities{}
+	if workspaceDiagnosticsCap {
+		capabilities.Workspace = &lsproto.WorkspaceClientCapabilities{
+			Diagnostics: &lsproto.DiagnosticWorkspaceClientCapabilities{
+				RefreshSupport: new(true),
+			},
+		}
+	}
+	initializationOptions := &lsproto.InitializationOptions{
+		UseWorkspaceDiagnostics: &workspaceDiagnosticsOption,
+	}
+	initMsg, initResp, ok := lsptestutil.SendRequest(t, client, lsproto.InitializeInfo, &lsproto.InitializeParams{
+		Capabilities: capabilities,
+		InitializationOptions: &lsproto.InitializationOptionsOrNull{
+			InitializationOptions: initializationOptions,
+		},
+	})
+	assert.Assert(t, ok && initMsg.AsResponse().Error == nil, "Initialize failed")
+	lsptestutil.SendNotification(t, client, lsproto.InitializedInfo, &lsproto.InitializedParams{})
+	<-client.Server.InitComplete()
+
+	return client, initResp, &publishNotifications, &refreshRequests
+}
+
+func TestWorkspaceDiagnosticsCapabilityControlsProgramDiagnosticMode(t *testing.T) {
+	t.Parallel()
+	if !bundled.Embedded {
+		t.Skip("bundled files are not embedded")
+	}
+
+	t.Run("workspace diagnostics client pulls tsconfig diagnostics", func(t *testing.T) {
+		t.Parallel()
+		client, initResp, publishNotifications, refreshRequests := initDiagnosticClient(t, true, true)
+		diagnosticProvider := initResp.Capabilities.DiagnosticProvider
+		assert.Assert(t, diagnosticProvider != nil && diagnosticProvider.Options != nil, "expected diagnostic provider options")
+		assert.Equal(t, diagnosticProvider.Options.WorkspaceDiagnostics, true)
+
+		uri := lsproto.DocumentUri("file:///home/projects/index.ts")
+		lsptestutil.SendNotification(t, client, lsproto.TextDocumentDidOpenInfo, &lsproto.DidOpenTextDocumentParams{
+			TextDocument: &lsproto.TextDocumentItem{Uri: uri, LanguageId: "typescript", Text: "export const x = 1;"},
+		})
+		docMsg, _, ok := lsptestutil.SendRequest(t, client, lsproto.TextDocumentDiagnosticInfo, &lsproto.DocumentDiagnosticParams{
+			TextDocument: lsproto.TextDocumentIdentifier{Uri: uri},
+		})
+		assert.Assert(t, ok && docMsg.AsResponse().Error == nil, "textDocument/diagnostic failed")
+		client.Server.Session().WaitForBackgroundTasks()
+		msg, report, ok := lsptestutil.SendRequest(t, client, lsproto.WorkspaceDiagnosticInfo, &lsproto.WorkspaceDiagnosticParams{
+			PreviousResultIds: []lsproto.PreviousResultId{},
+		})
+		assert.Assert(t, ok && msg.AsResponse().Error == nil, "workspace/diagnostic failed")
+
+		assert.Equal(t, publishNotifications.Load(), int32(0), "expected no publish diagnostics notifications")
+		assert.Assert(t, refreshRequests.Load() > 0, "expected workspace diagnostic refresh request")
+		assert.Assert(t, len(report.Items) == 1, "expected one workspace diagnostic item, got: %v", report.Items)
+		item := report.Items[0].FullDocumentDiagnosticReport
+		assert.Assert(t, item != nil, "expected full workspace diagnostic report")
+		assert.Equal(t, item.Uri, lsproto.DocumentUri("file:///home/projects/tsconfig.json"))
+		assert.Assert(t, len(item.Items) > 0, "expected tsconfig diagnostics")
+		assert.Assert(t, strings.Contains(item.Items[0].Message.AsString(), "Argument for '--target' option must be:"), "unexpected diagnostic: %v", item.Items[0])
+	})
+
+	t.Run("legacy client does not advertise workspace diagnostics", func(t *testing.T) {
+		t.Parallel()
+		_, initResp, _, _ := initDiagnosticClient(t, false, false)
+		diagnosticProvider := initResp.Capabilities.DiagnosticProvider
+		assert.Assert(t, diagnosticProvider != nil && diagnosticProvider.Options != nil, "expected diagnostic provider options")
+		assert.Equal(t, diagnosticProvider.Options.WorkspaceDiagnostics, false)
+	})
+
+	t.Run("workspace capability alone does not enable workspace diagnostics", func(t *testing.T) {
+		t.Parallel()
+		_, initResp, _, _ := initDiagnosticClient(t, true, false)
+		diagnosticProvider := initResp.Capabilities.DiagnosticProvider
+		assert.Assert(t, diagnosticProvider != nil && diagnosticProvider.Options != nil, "expected diagnostic provider options")
+		assert.Equal(t, diagnosticProvider.Options.WorkspaceDiagnostics, false)
+	})
+}

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -32,6 +32,15 @@ func filterDiagnosticsByURI(calls []publishDiagnosticsCall, uri lsproto.Document
 	return result
 }
 
+func findWorkspaceDiagnostic(report *lsproto.WorkspaceDiagnosticReport, uri lsproto.DocumentUri) *lsproto.WorkspaceFullDocumentDiagnosticReport {
+	for i := range report.Items {
+		if item := report.Items[i].FullDocumentDiagnosticReport; item != nil && item.Uri == uri {
+			return item
+		}
+	}
+	return nil
+}
+
 // These tests explicitly verify ProgramUpdateKind using subtests with shared helpers.
 func TestProjectProgramUpdateKind(t *testing.T) {
 	t.Parallel()
@@ -522,6 +531,84 @@ func TestPushDiagnostics(t *testing.T) {
 		assert.Assert(t, len(reopenedCalls) > 0, "expected PublishDiagnostics call for tsconfig.json after reopening file")
 		lastReopenedCall := reopenedCalls[len(reopenedCalls)-1]
 		assert.Equal(t, len(lastReopenedCall.Params.Diagnostics), 1, "expected one diagnostic on tsconfig.json after reopening file")
+	})
+}
+
+func TestWorkspaceDiagnostics(t *testing.T) {
+	t.Parallel()
+	if !bundled.Embedded {
+		t.Skip("bundled files are not embedded")
+	}
+
+	setup := func(files map[string]any) (*project.Session, *projecttestutil.SessionUtils) {
+		return projecttestutil.SetupWithOptions(files, &project.SessionOptions{
+			CurrentDirectory:            "/",
+			DefaultLibraryPath:          bundled.LibPath(),
+			TypingsLocation:             projecttestutil.TestTypingsLocation,
+			PositionEncoding:            lsproto.PositionEncodingKindUTF8,
+			WatchEnabled:                true,
+			LoggingEnabled:              true,
+			WorkspaceDiagnosticsEnabled: true,
+			PushDiagnosticsEnabled:      false,
+		})
+	}
+
+	t.Run("returns current tsconfig diagnostics without publish", func(t *testing.T) {
+		t.Parallel()
+		files := map[string]any{
+			"/src/tsconfig.json": `{
+				"compilerOptions": {
+					"target": "nope"
+				}
+			}`,
+			"/src/index.ts": "export const x = 1;",
+		}
+		session, utils := setup(files)
+		session.DidOpenFile(context.Background(), "file:///src/index.ts", 1, files["/src/index.ts"].(string), lsproto.LanguageKindTypeScript)
+		_, err := session.GetLanguageService(context.Background(), lsproto.DocumentUri("file:///src/index.ts"))
+		assert.NilError(t, err)
+		session.WaitForBackgroundTasks()
+
+		assert.Equal(t, len(utils.Client().PublishDiagnosticsCalls()), 0, "expected no PublishDiagnostics calls")
+		report := session.ProvideWorkspaceDiagnostics(context.Background())
+		item := findWorkspaceDiagnostic(report, "file:///src/tsconfig.json")
+		assert.Assert(t, item != nil, "expected workspace diagnostic item for tsconfig.json")
+		assert.Assert(t, slices.ContainsFunc(item.Items, func(diag *lsproto.Diagnostic) bool {
+			return strings.Contains(diag.Message.AsString(), "Argument for '--target' option must be:")
+		}), "expected invalid target diagnostic on tsconfig.json, got: %v", item.Items)
+	})
+
+	t.Run("includes global diagnostics after checking without publish", func(t *testing.T) {
+		t.Parallel()
+		files := map[string]any{
+			"/src/tsconfig.json": `{
+				"compilerOptions": {
+					"target": "es2020"
+				}
+			}`,
+			"/src/index.ts": `export function f() {
+				using x = { [Symbol.dispose]() {} };
+			}`,
+		}
+		session, utils := setup(files)
+		session.DidOpenFile(context.Background(), "file:///src/index.ts", 1, files["/src/index.ts"].(string), lsproto.LanguageKindTypeScript)
+		ls, err := session.GetLanguageService(projecttestutil.WithRequestID(context.Background()), lsproto.DocumentUri("file:///src/index.ts"))
+		assert.NilError(t, err)
+		session.WaitForBackgroundTasks()
+
+		_, err = ls.ProvideDiagnostics(projecttestutil.WithRequestID(context.Background()), lsproto.DocumentUri("file:///src/index.ts"))
+		assert.NilError(t, err)
+		session.EnqueuePublishGlobalDiagnostics()
+		session.WaitForBackgroundTasks()
+
+		assert.Equal(t, len(utils.Client().PublishDiagnosticsCalls()), 0, "expected no PublishDiagnostics calls")
+		assert.Assert(t, len(utils.Client().RefreshDiagnosticsCalls()) > 0, "expected diagnostics refresh after new global diagnostics")
+		report := session.ProvideWorkspaceDiagnostics(context.Background())
+		item := findWorkspaceDiagnostic(report, "file:///src/tsconfig.json")
+		assert.Assert(t, item != nil, "expected workspace diagnostic item for tsconfig.json")
+		assert.Assert(t, slices.ContainsFunc(item.Items, func(diag *lsproto.Diagnostic) bool {
+			return strings.Contains(diag.Message.AsString(), "Cannot find global")
+		}), "expected a 'Cannot find global' diagnostic on tsconfig.json, got: %v", item.Items)
 	})
 }
 

--- a/internal/project/session.go
+++ b/internal/project/session.go
@@ -53,17 +53,18 @@ const watchRequestTimeout = time.Second
 // SessionOptions are the immutable initialization options for a session.
 // Snapshots may reference them as a pointer since they never change.
 type SessionOptions struct {
-	CurrentDirectory       string
-	DefaultLibraryPath     string
-	TypingsLocation        string
-	PositionEncoding       lsproto.PositionEncodingKind
-	WatchEnabled           bool
-	LoggingEnabled         bool
-	TelemetryEnabled       bool
-	PushDiagnosticsEnabled bool
-	DebounceDelay          time.Duration
-	Locale                 locale.Locale
-	CheckerPoolOptions     CheckerPoolOptions
+	CurrentDirectory            string
+	DefaultLibraryPath          string
+	TypingsLocation             string
+	PositionEncoding            lsproto.PositionEncodingKind
+	WatchEnabled                bool
+	LoggingEnabled              bool
+	TelemetryEnabled            bool
+	PushDiagnosticsEnabled      bool
+	WorkspaceDiagnosticsEnabled bool
+	DebounceDelay               time.Duration
+	Locale                      locale.Locale
+	CheckerPoolOptions          CheckerPoolOptions
 }
 
 type SessionInit struct {
@@ -1617,11 +1618,12 @@ func (s *Session) refreshATAIfNeeded(oldPrefs lsutil.UserPreferences, newPrefs l
 }
 
 func (s *Session) publishProgramDiagnostics(oldSnapshot *Snapshot, newSnapshot *Snapshot) {
-	if !s.options.PushDiagnosticsEnabled {
+	if !s.options.PushDiagnosticsEnabled && !s.options.WorkspaceDiagnosticsEnabled {
 		return
 	}
 
 	ctx := s.backgroundCtx
+	var changed bool
 	oldProjects := oldSnapshot.ProjectCollection.ProjectsByPath()
 	newProjects := newSnapshot.ProjectCollection.ProjectsByPath()
 	oldOpenProjects := oldSnapshot.ProjectCollection.GetOpenConfiguredProjects()
@@ -1633,19 +1635,28 @@ func (s *Session) publishProgramDiagnostics(oldSnapshot *Snapshot, newSnapshot *
 			if !shouldPublishProgramDiagnostics(addedProject, newSnapshot.ID()) || !newOpenProjects.Has(configFilePath) {
 				return
 			}
-			s.publishProjectDiagnostics(ctx, string(configFilePath), addedProject.GetProjectDiagnostics(ctx), newSnapshot.converters)
+			changed = true
+			if s.options.PushDiagnosticsEnabled {
+				s.publishProjectDiagnostics(ctx, string(configFilePath), addedProject.GetProjectDiagnostics(ctx), newSnapshot.converters)
+			}
 		},
 		func(configFilePath tspath.Path, removedProject *Project) {
 			if removedProject.Kind != KindConfigured {
 				return
 			}
-			s.publishProjectDiagnostics(ctx, string(configFilePath), nil, oldSnapshot.converters)
+			changed = true
+			if s.options.PushDiagnosticsEnabled {
+				s.publishProjectDiagnostics(ctx, string(configFilePath), nil, oldSnapshot.converters)
+			}
 		},
 		func(configFilePath tspath.Path, oldProject, newProject *Project) {
 			if !shouldPublishProgramDiagnostics(newProject, newSnapshot.ID()) || !newOpenProjects.Has(configFilePath) {
 				return
 			}
-			s.publishProjectDiagnostics(ctx, string(configFilePath), newProject.GetProjectDiagnostics(ctx), newSnapshot.converters)
+			changed = true
+			if s.options.PushDiagnosticsEnabled {
+				s.publishProjectDiagnostics(ctx, string(configFilePath), newProject.GetProjectDiagnostics(ctx), newSnapshot.converters)
+			}
 		},
 	)
 	// Sync diagnostics for projects whose open-file state changed without a program update.
@@ -1662,11 +1673,20 @@ func (s *Session) publishProgramDiagnostics(oldSnapshot *Snapshot, newSnapshot *
 		if newHasOpenFiles && !oldHasOpenFiles &&
 			(newProject == oldProject || !shouldPublishProgramDiagnostics(newProject, newSnapshot.ID())) {
 			// Project reopened without a program update
-			s.publishProjectDiagnostics(ctx, string(configFilePath), newProject.GetProjectDiagnostics(ctx), newSnapshot.converters)
+			changed = true
+			if s.options.PushDiagnosticsEnabled {
+				s.publishProjectDiagnostics(ctx, string(configFilePath), newProject.GetProjectDiagnostics(ctx), newSnapshot.converters)
+			}
 		} else if !newHasOpenFiles && oldHasOpenFiles {
 			// Project closed
-			s.publishProjectDiagnostics(ctx, string(configFilePath), nil, newSnapshot.converters)
+			changed = true
+			if s.options.PushDiagnosticsEnabled {
+				s.publishProjectDiagnostics(ctx, string(configFilePath), nil, newSnapshot.converters)
+			}
 		}
+	}
+	if changed && s.options.WorkspaceDiagnosticsEnabled && !s.options.PushDiagnosticsEnabled {
+		s.refreshDiagnostics(ctx)
 	}
 }
 
@@ -1691,11 +1711,17 @@ func (s *Session) publishProjectDiagnostics(ctx context.Context, configFilePath 
 	}
 }
 
+func (s *Session) refreshDiagnostics(ctx context.Context) {
+	if err := s.client.RefreshDiagnostics(ctx); err != nil && s.options.LoggingEnabled {
+		s.logger.Logf("Error refreshing diagnostics: %v", err)
+	}
+}
+
 // EnqueuePublishGlobalDiagnostics schedules a background check for new accumulated
 // global diagnostics from checker pools, re-publishing tsconfig diagnostics if changed.
 // Multiple calls are coalesced into a single background task.
 func (s *Session) EnqueuePublishGlobalDiagnostics() {
-	if !s.options.PushDiagnosticsEnabled {
+	if !s.options.PushDiagnosticsEnabled && !s.options.WorkspaceDiagnosticsEnabled {
 		return
 	}
 	if s.globalDiagPublishPending.CompareAndSwap(false, true) {
@@ -1717,9 +1743,44 @@ func (s *Session) publishGlobalDiagnostics(ctx context.Context) {
 			continue
 		}
 		if project.checkerPool.TakeNewGlobalDiagnostics() {
-			s.publishProjectDiagnostics(ctx, string(project.configFilePath), project.GetProjectDiagnostics(ctx), snapshot.converters)
+			if s.options.PushDiagnosticsEnabled {
+				s.publishProjectDiagnostics(ctx, string(project.configFilePath), project.GetProjectDiagnostics(ctx), snapshot.converters)
+			} else if s.options.WorkspaceDiagnosticsEnabled {
+				s.refreshDiagnostics(ctx)
+			}
 		}
 	}
+}
+
+func (s *Session) ProvideWorkspaceDiagnostics(ctx context.Context) *lsproto.WorkspaceDiagnosticReport {
+	s.snapshotMu.RLock()
+	snapshot := s.snapshot
+	snapshot.ref()
+	s.snapshotMu.RUnlock()
+	defer snapshot.Deref(s)
+
+	openProjects := snapshot.ProjectCollection.GetOpenConfiguredProjects()
+	projects := snapshot.ProjectCollection.ProjectsByPath()
+	items := make([]lsproto.WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport, 0, openProjects.Len())
+	for configFilePath, project := range projects.Entries() {
+		if project.Kind != KindConfigured || project.Program == nil || !openProjects.Has(configFilePath) {
+			continue
+		}
+		diagnostics := project.GetProjectDiagnostics(ctx)
+		lspDiagnostics := make([]*lsproto.Diagnostic, 0, len(diagnostics))
+		for _, diag := range diagnostics {
+			lspDiagnostics = append(lspDiagnostics, lsconv.DiagnosticToLSPPull(ctx, snapshot.converters, diag, snapshot.UserPreferences().ReportStyleChecksAsWarnings.IsTrue()))
+		}
+		items = append(items, lsproto.WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport{
+			FullDocumentDiagnosticReport: &lsproto.WorkspaceFullDocumentDiagnosticReport{
+				Kind:    lsproto.StringLiteralFull{},
+				Items:   lspDiagnostics,
+				Uri:     lsconv.FileNameToDocumentURI(string(configFilePath)),
+				Version: lsproto.IntegerOrNull{},
+			},
+		})
+	}
+	return &lsproto.WorkspaceDiagnosticReport{Items: items}
 }
 
 func (s *Session) triggerATAForUpdatedProjects(newSnapshot *Snapshot) {


### PR DESCRIPTION
To work around client-side diagnostic collection naming problems in VS Code. @dbaeumer

Unfortunately, this leads to some serious spam from the fact that the client just loops every few seconds and asks:

<img width="681" height="478" alt="image" src="https://github.com/user-attachments/assets/e3f7d025-1078-4262-8501-622d12d9f6cb" />
