### PR TITLE
Fix fswatch coalescing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
           - os: macos-latest
             coverage: true
             # There aren't enough macOS runners; skip in PRs and rely on main branch runs.
-            skip: ${{ github.event_name == 'merge_group' || github.event_name == 'pull_request' }}
+            skip: ${{ github.event_name == 'merge_group' }}
           - os: ubuntu-latest
             name: 'no submodules'
             no-submodules: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
           - os: macos-latest
             coverage: true
             # There aren't enough macOS runners; skip in PRs and rely on main branch runs.
-            skip: ${{ github.event_name == 'merge_group' }}
+            skip: ${{ github.event_name == 'merge_group' || github.event_name == 'pull_request' }}
           - os: ubuntu-latest
             name: 'no submodules'
             no-submodules: true

--- a/internal/fswatch/CHANGES.md
+++ b/internal/fswatch/CHANGES.md
@@ -143,7 +143,11 @@ fast path attempts one stream containing every active physical watch root; if
 that stream cannot be started, the backend retries with bounded path chunks.
 Events from shared streams are routed back to matching logical watches by path,
 so non-recursive and per-subscriber ignore semantics are preserved while using
-far fewer system-wide FSEvents stream slots.
+far fewer system-wide FSEvents stream slots. When many sibling watches are
+consolidated under one recursive parent watch, each callback still keeps its own
+logical root, physical root, event-ID cutoff, and termination state, so
+late-added watches don't receive older queued events and symlinked watch roots
+continue reporting caller-visible paths.
 
 ## New backends
 
@@ -164,12 +168,12 @@ configuration. The Go port is pure Go on all platforms:
   arm64), following the pattern from Go's `crypto/x509/internal/macos`. The
   FSEvents C callback runs on a libdispatch (GCD) thread, not a Go goroutine. An
   assembly shim, staying entirely in C calling convention, retains the CFArray
-  of paths, allocates a per-callback payload on the C heap, copies the flags
-  array into it, and writes the payload pointer to the stream's event pipe,
-  waking a dedicated Go event-loop goroutine that classifies the events and
-  frees the payload. The shim then returns immediately, so the dispatch thread
-  never enters Go ABI and does not wait for Go-side event classification. Each
-  FSEventStream has its own serial GCD dispatch queue and event pipe, so
+  of paths, allocates a per-callback payload on the C heap, copies the flags and
+  event ID arrays into it, and writes the payload pointer to the stream's event
+  pipe, waking a dedicated Go event-loop goroutine that classifies the events
+  and frees the payload. The shim then returns immediately, so the dispatch
+  thread never enters Go ABI and does not wait for Go-side event classification.
+  Each FSEventStream has its own serial GCD dispatch queue and event pipe, so
   callbacks for different streams run concurrently without contention: a stuck
   callback for one stream cannot back up callbacks for any other stream behind
   it. Teardown invalidates the stream and uses a `dispatch_sync_f` barrier on

--- a/internal/fswatch/event.go
+++ b/internal/fswatch/event.go
@@ -23,16 +23,17 @@ func (k EventKind) String() string {
 
 // Event describes a single filesystem change.
 type Event struct {
-	Kind EventKind
-	Path string
+	Kind              EventKind
+	Path              string
+	includedWatchRoot bool
 }
 
 // eventEntry tracks coalescing state during a debounce batch.
-// The two booleans are independent: a file can be created then deleted
-// in the same batch, which cancels out (filtered by getEvents).
 type eventEntry struct {
-	isCreated bool
-	isDeleted bool
+	createdSeq        uint64
+	updatedSeq        uint64
+	deletedSeq        uint64
+	includedWatchRoot bool
 }
 
 // eventList coalesces filesystem events by path within a debounce window.
@@ -42,6 +43,7 @@ type eventList struct {
 	mu      sync.Mutex
 	entries map[string]*eventEntry
 	err     error
+	seq     uint64
 }
 
 // create records a new-file event for path. Both create and update
@@ -50,15 +52,28 @@ type eventList struct {
 func (el *eventList) create(path string) {
 	el.mu.Lock()
 	defer el.mu.Unlock()
+	seq := el.nextSeqLocked()
+	el.createLocked(path, seq)
+}
+
+func (el *eventList) createAt(path string, seq uint64) {
+	el.mu.Lock()
+	defer el.mu.Unlock()
+	el.advanceSeqLocked(seq)
+	el.createLocked(path, seq)
+}
+
+func (el *eventList) createLocked(path string, seq uint64) {
 	entry := el.getOrCreate(path)
-	if entry.isDeleted {
+	if entry.isDeleted() {
 		// Rapid delete+recreate: clear both flags so the entry
 		// emits EventUpdate (the default for non-deleted entries).
 		// https://github.com/parcel-bundler/watcher/issues/72
-		entry.isDeleted = false
-		entry.isCreated = false
+		entry.deletedSeq = 0
+		entry.createdSeq = 0
+		entry.updatedSeq = seq
 	} else {
-		entry.isCreated = true
+		entry.createdSeq = seq
 	}
 }
 
@@ -66,15 +81,55 @@ func (el *eventList) create(path string) {
 func (el *eventList) update(path string) {
 	el.mu.Lock()
 	defer el.mu.Unlock()
-	el.getOrCreate(path)
+	seq := el.nextSeqLocked()
+	el.updateLocked(path, seq)
+}
+
+func (el *eventList) updateAt(path string, seq uint64) {
+	el.mu.Lock()
+	defer el.mu.Unlock()
+	el.advanceSeqLocked(seq)
+	el.updateLocked(path, seq)
+}
+
+func (el *eventList) updateWatchRootAt(path string, seq uint64) {
+	el.mu.Lock()
+	defer el.mu.Unlock()
+	el.advanceSeqLocked(seq)
+	el.updateLocked(path, seq)
+	el.getOrCreate(path).includedWatchRoot = true
+}
+
+func (el *eventList) updateLocked(path string, seq uint64) {
+	el.getOrCreate(path).updatedSeq = seq
 }
 
 // remove records a delete event for path.
 func (el *eventList) remove(path string) {
 	el.mu.Lock()
 	defer el.mu.Unlock()
+	seq := el.nextSeqLocked()
+	el.removeLocked(path, seq)
+}
+
+func (el *eventList) removeAt(path string, seq uint64) {
+	el.mu.Lock()
+	defer el.mu.Unlock()
+	el.advanceSeqLocked(seq)
+	el.removeLocked(path, seq)
+}
+
+func (el *eventList) removeWatchRootAt(path string, seq uint64) {
+	el.mu.Lock()
+	defer el.mu.Unlock()
+	el.advanceSeqLocked(seq)
+	el.removeLocked(path, seq)
+	el.getOrCreate(path).includedWatchRoot = true
+}
+
+func (el *eventList) removeLocked(path string, seq uint64) {
 	entry := el.getOrCreate(path)
-	entry.isDeleted = true
+	entry.deletedSeq = seq
 }
 
 // size returns the number of tracked entries (including ones that may
@@ -88,16 +143,17 @@ func (el *eventList) size() int {
 // snapshotLocked returns the current set of pending events with
 // create+delete pairs filtered out. Caller must hold el.mu.
 func (el *eventList) snapshotLocked() []Event {
+	return el.snapshotSinceLocked(0)
+}
+
+func (el *eventList) snapshotSinceLocked(startSeq uint64) []Event {
 	out := make([]Event, 0, len(el.entries))
 	for path, e := range el.entries {
-		if e.isCreated && e.isDeleted {
+		kind, ok := e.kindSince(startSeq)
+		if !ok {
 			continue
 		}
-		kind := EventUpdate
-		if e.isDeleted {
-			kind = EventDelete
-		}
-		out = append(out, Event{Kind: kind, Path: path})
+		out = append(out, Event{Kind: kind, Path: path, includedWatchRoot: e.includedWatchRoot})
 	}
 	return out
 }
@@ -117,6 +173,19 @@ func (el *eventList) drain() ([]Event, error) {
 	el.mu.Lock()
 	defer el.mu.Unlock()
 	out := el.snapshotLocked()
+	err := el.err
+	el.entries = nil
+	el.err = nil
+	return out, err
+}
+
+func (el *eventList) drainForSequences(startSeqs []uint64) ([][]Event, error) {
+	el.mu.Lock()
+	defer el.mu.Unlock()
+	out := make([][]Event, len(startSeqs))
+	for i, startSeq := range startSeqs {
+		out[i] = el.snapshotSinceLocked(startSeq)
+	}
 	err := el.err
 	el.entries = nil
 	el.err = nil
@@ -156,4 +225,39 @@ func (el *eventList) getOrCreate(path string) *eventEntry {
 	e := &eventEntry{}
 	el.entries[path] = e
 	return e
+}
+
+func (el *eventList) sequence() uint64 {
+	el.mu.Lock()
+	defer el.mu.Unlock()
+	return el.seq
+}
+
+func (el *eventList) nextSeqLocked() uint64 {
+	el.seq++
+	return el.seq
+}
+
+func (el *eventList) advanceSeqLocked(seq uint64) {
+	if seq > el.seq {
+		el.seq = seq
+	}
+}
+
+func (e *eventEntry) isDeleted() bool {
+	return e.deletedSeq > e.createdSeq && e.deletedSeq > e.updatedSeq
+}
+
+func (e *eventEntry) kindSince(startSeq uint64) (EventKind, bool) {
+	if e.deletedSeq > startSeq {
+		if e.createdSeq > startSeq && e.createdSeq < e.deletedSeq && e.updatedSeq < e.deletedSeq {
+			return 0, false
+		}
+		return EventDelete, true
+	}
+	seq := max(e.createdSeq, e.updatedSeq)
+	if seq > startSeq {
+		return EventUpdate, true
+	}
+	return 0, false
 }

--- a/internal/fswatch/event.go
+++ b/internal/fswatch/event.go
@@ -112,6 +112,14 @@ func (el *eventList) remove(path string) {
 	el.removeLocked(path, seq)
 }
 
+func (el *eventList) removeAndGetSequence(path string) uint64 {
+	el.mu.Lock()
+	defer el.mu.Unlock()
+	seq := el.nextSeqLocked()
+	el.removeLocked(path, seq)
+	return seq
+}
+
 func (el *eventList) removeAt(path string, seq uint64) {
 	el.mu.Lock()
 	defer el.mu.Unlock()

--- a/internal/fswatch/event.go
+++ b/internal/fswatch/event.go
@@ -47,8 +47,8 @@ type eventList struct {
 }
 
 // create records a new-file event for path. Both create and update
-// produce EventUpdate externally; isCreated is tracked only for
-// coalescing (create+delete within a batch cancels out).
+// produce EventUpdate externally; sequence state tracks coalescing
+// (create+delete within a batch cancels out).
 func (el *eventList) create(path string) {
 	el.mu.Lock()
 	defer el.mu.Unlock()

--- a/internal/fswatch/eventlist_test.go
+++ b/internal/fswatch/eventlist_test.go
@@ -123,3 +123,25 @@ func TestEventListDrainReturnsErrorWithEvents(t *testing.T) {
 		t.Fatalf("expected 1 event alongside error, got %d", len(events))
 	}
 }
+
+func TestEventListDrainForSequences(t *testing.T) {
+	t.Parallel()
+	var el eventList
+	el.create("file.txt")
+	startAfterCreate := el.sequence()
+	el.remove("file.txt")
+
+	eventsByCallback, err := el.drainForSequences([]uint64{0, startAfterCreate})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(eventsByCallback[0]) != 0 {
+		t.Fatalf("create+delete should cancel for original callback, got %v", eventsByCallback[0])
+	}
+	if len(eventsByCallback[1]) != 1 {
+		t.Fatalf("expected delete for later callback, got %v", eventsByCallback[1])
+	}
+	if got := eventsByCallback[1][0]; got.Kind != EventDelete || got.Path != "file.txt" {
+		t.Fatalf("expected delete for file.txt, got %v", got)
+	}
+}

--- a/internal/fswatch/fsevents_darwin.go
+++ b/internal/fswatch/fsevents_darwin.go
@@ -181,6 +181,7 @@ type fsEventsBackend struct {
 
 func init() {
 	fseventsWatcher.factory = func() watcherImpl { return newFSEventsBackend() }
+	fseventsWatcher.sequence = fsEventsGetCurrentEventID
 }
 
 func newFSEventsBackend() *fsEventsBackend {
@@ -483,21 +484,24 @@ func fsEventsCallback(cb *streamCallback, payload *fsEventsCallbackPayload) {
 
 	const (
 		flagSize = unsafe.Sizeof(uint32(0))
+		idSize   = unsafe.Sizeof(uint64(0))
 	)
 
-	if payload == nil || payload.paths == 0 || payload.flags == 0 {
+	if payload == nil || payload.paths == 0 || payload.flags == 0 || payload.ids == 0 {
 		return
 	}
 
 	numEvents := payload.numEvents
 	paths := payload.paths
 	flags := payload.flags
+	ids := payload.ids
 
 	watches := cb.watches
 	touched := map[*dirWatch]struct{}{}
 
 	for i := range numEvents {
 		flag := *(*uint32)(unsafe.Add(nil, flags+i*flagSize))
+		eventID := *(*uint64)(unsafe.Add(nil, ids+i*idSize))
 		pathRef := cfArrayGetValueAtIndex(paths, int(i))
 		path := cfStringToNFC(pathRef)
 		if path == "" {
@@ -564,7 +568,14 @@ func fsEventsCallback(cb *streamCallback, payload *fsEventsCallbackPayload) {
 
 			switch {
 			case isRemoved && !isCreated:
-				w.events.remove(displayPath)
+				if displayPath == w.dir {
+					w.events.removeWatchRootAt(displayPath, eventID)
+				} else {
+					w.events.removeAt(displayPath, eventID)
+				}
+				if w.terminateCallbacksForDeletedRoot(displayPath, eventID, fmt.Errorf("%w: watched directory removed", ErrWatchTerminated)) {
+					touched[w] = struct{}{}
+				}
 				if displayPath == w.dir {
 					watch.state.terminated.Store(true)
 					w.events.setError(fmt.Errorf("%w: watched directory removed", ErrWatchTerminated))
@@ -576,16 +587,31 @@ func fsEventsCallback(cb *streamCallback, payload *fsEventsCallbackPayload) {
 					pathExistsKnown = true
 				}
 				if pathExists {
-					w.events.update(displayPath)
+					if displayPath == w.dir {
+						w.events.updateWatchRootAt(displayPath, eventID)
+					} else {
+						w.events.updateAt(displayPath, eventID)
+					}
 				} else {
-					w.events.remove(displayPath)
+					if displayPath == w.dir {
+						w.events.removeWatchRootAt(displayPath, eventID)
+					} else {
+						w.events.removeAt(displayPath, eventID)
+					}
+					if w.terminateCallbacksForDeletedRoot(displayPath, eventID, fmt.Errorf("%w: watched directory removed", ErrWatchTerminated)) {
+						touched[w] = struct{}{}
+					}
 					if displayPath == w.dir {
 						watch.state.terminated.Store(true)
 						w.events.setError(fmt.Errorf("%w: watched directory removed", ErrWatchTerminated))
 					}
 				}
 			default:
-				w.events.update(displayPath)
+				if displayPath == w.dir {
+					w.events.updateWatchRootAt(displayPath, eventID)
+				} else {
+					w.events.updateAt(displayPath, eventID)
+				}
 			}
 			touched[w] = struct{}{}
 		}

--- a/internal/fswatch/fsevents_darwin_ffi.go
+++ b/internal/fswatch/fsevents_darwin_ffi.go
@@ -375,6 +375,15 @@ func fsEventStreamFlushSync(stream uintptr) {
 	_, _, _ = syscall_syscall6(fse_FSEventStreamFlushSync_trampoline_addr, stream, 0, 0, 0, 0, 0)
 }
 
+//go:cgo_import_dynamic fse_FSEventsGetCurrentEventId FSEventsGetCurrentEventId "/System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices"
+
+var fse_FSEventsGetCurrentEventId_trampoline_addr uintptr
+
+func fsEventsGetCurrentEventID() uint64 {
+	r1, _, _ := syscall_syscall6(fse_FSEventsGetCurrentEventId_trampoline_addr, 0, 0, 0, 0, 0, 0)
+	return uint64(r1)
+}
+
 //go:cgo_import_dynamic fse_FSEventStreamStop FSEventStreamStop "/System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices"
 
 var fse_FSEventStreamStop_trampoline_addr uintptr
@@ -459,6 +468,7 @@ type fsEventsCallbackPayload struct {
 	numEvents uintptr
 	paths     uintptr
 	flags     uintptr
+	ids       uintptr
 }
 
 func (p *fsEventsCallbackPayload) close() {
@@ -469,6 +479,7 @@ func (p *fsEventsCallbackPayload) close() {
 		cfRelease(p.paths)
 	}
 	libcFree(p.flags)
+	libcFree(p.ids)
 	libcFree(uintptr(unsafe.Pointer(p)))
 }
 

--- a/internal/fswatch/fsevents_darwin_ffi.s
+++ b/internal/fswatch/fsevents_darwin_ffi.s
@@ -127,6 +127,12 @@ TEXT fse_FSEventStreamFlushSync_trampoline<>(SB), NOSPLIT, $0-0
 GLOBL ·fse_FSEventStreamFlushSync_trampoline_addr(SB), RODATA, $8
 DATA ·fse_FSEventStreamFlushSync_trampoline_addr(SB)/8, $fse_FSEventStreamFlushSync_trampoline<>(SB)
 
+TEXT fse_FSEventsGetCurrentEventId_trampoline<>(SB), NOSPLIT, $0-0
+	JMP fse_FSEventsGetCurrentEventId(SB)
+
+GLOBL ·fse_FSEventsGetCurrentEventId_trampoline_addr(SB), RODATA, $8
+DATA ·fse_FSEventsGetCurrentEventId_trampoline_addr(SB)/8, $fse_FSEventsGetCurrentEventId_trampoline<>(SB)
+
 TEXT fse_FSEventStreamStop_trampoline<>(SB), NOSPLIT, $0-0
 	JMP fse_FSEventStreamStop(SB)
 

--- a/internal/fswatch/fsevents_darwin_ffi_amd64.s
+++ b/internal/fswatch/fsevents_darwin_ffi_amd64.s
@@ -62,6 +62,8 @@ DATA ·fse_FSEventStreamCreate_trampoline_addr(SB)/8, $fse_FSEventStreamCreate_t
 //   RSP+24: saved original flags pointer
 //   RSP+32: retained CFArray paths
 //   RSP+40: copied flags pointer
+//   RSP+48: saved original IDs pointer
+//   RSP+56: copied IDs pointer
 //   RSP+80: saved RBP  ← BP points here (C frame chain)
 //   RSP+88: return address (pushed by C's CALL)
 // ---------------------------------------------------------------------------
@@ -74,6 +76,7 @@ TEXT fsEventsCallbackASM<>(SB), NOSPLIT|NOFRAME, $0
 	MOVQ SI, 8(SP)  // info
 	MOVQ DX, 16(SP) // numEvents
 	MOVQ R8, 24(SP) // original flags
+	MOVQ R9, 48(SP) // original IDs
 
 	// Retain the CFArray paths because FSEvents owns the callback argument.
 	MOVQ  CX, DI
@@ -99,12 +102,28 @@ TEXT fsEventsCallbackASM<>(SB), NOSPLIT|NOFRAME, $0
 	XORL AX, AX
 	CALL fse_memcpy(SB)
 
-	// Allocate and populate fsEventsCallbackPayload.
-	MOVQ  $24, DI
+	// Copy the event ID array into C heap memory owned by the Go event loop.
+	MOVQ  16(SP), DI
+	SHLQ  $3, DI
 	XORL  AX, AX
 	CALL  fse_malloc(SB)
 	TESTQ AX, AX
 	JEQ   freeFlags
+	MOVQ  AX, 56(SP)
+
+	MOVQ AX, DI
+	MOVQ 48(SP), SI
+	MOVQ 16(SP), DX
+	SHLQ $3, DX
+	XORL AX, AX
+	CALL fse_memcpy(SB)
+
+	// Allocate and populate fsEventsCallbackPayload.
+	MOVQ  $32, DI
+	XORL  AX, AX
+	CALL  fse_malloc(SB)
+	TESTQ AX, AX
+	JEQ   freeIDs
 	MOVQ  AX, 0(SP)
 
 	MOVQ 16(SP), CX
@@ -113,6 +132,8 @@ TEXT fsEventsCallbackASM<>(SB), NOSPLIT|NOFRAME, $0
 	MOVQ CX, (1*8)(AX)
 	MOVQ 40(SP), CX
 	MOVQ CX, (2*8)(AX)
+	MOVQ 56(SP), CX
+	MOVQ CX, (3*8)(AX)
 
 	// write(info->eventPipeWrite, &payload, sizeof(payload)).
 writeAgain:
@@ -135,6 +156,11 @@ writeAgain:
 
 freePayload:
 	MOVQ 0(SP), DI
+	XORL AX, AX
+	CALL fse_free(SB)
+
+freeIDs:
+	MOVQ 56(SP), DI
 	XORL AX, AX
 	CALL fse_free(SB)
 

--- a/internal/fswatch/fsevents_darwin_ffi_arm64.s
+++ b/internal/fswatch/fsevents_darwin_ffi_arm64.s
@@ -59,6 +59,8 @@ DATA ·fse_FSEventStreamCreate_trampoline_addr(SB)/8, $fse_FSEventStreamCreate_t
 //   RSP+40: saved original flags pointer
 //   RSP+48: retained CFArray paths
 //   RSP+56: copied flags pointer
+//   RSP+64: saved original IDs pointer
+//   RSP+72: copied IDs pointer
 // ---------------------------------------------------------------------------
 
 TEXT fsEventsCallbackASM<>(SB), NOSPLIT|NOFRAME, $0
@@ -70,6 +72,7 @@ TEXT fsEventsCallbackASM<>(SB), NOSPLIT|NOFRAME, $0
 	MOVD R1, 24(RSP) // info
 	MOVD R2, 32(RSP) // numEvents
 	MOVD R4, 40(RSP) // original flags
+	MOVD R5, 64(RSP) // original IDs
 
 	// Retain the CFArray paths because FSEvents owns the callback argument.
 	MOVD R3, R0
@@ -90,10 +93,23 @@ TEXT fsEventsCallbackASM<>(SB), NOSPLIT|NOFRAME, $0
 	LSL  $2, R2, R2
 	BL   fse_memcpy(SB)
 
-	// Allocate and populate fsEventsCallbackPayload.
-	MOVD $24, R0
+	// Copy the event ID array into C heap memory owned by the Go event loop.
+	MOVD 32(RSP), R0
+	LSL  $3, R0, R0
 	BL   fse_malloc(SB)
 	CBZ  R0, freeFlags
+	MOVD R0, 72(RSP)
+
+	MOVD R0, R0
+	MOVD 64(RSP), R1
+	MOVD 32(RSP), R2
+	LSL  $3, R2, R2
+	BL   fse_memcpy(SB)
+
+	// Allocate and populate fsEventsCallbackPayload.
+	MOVD $32, R0
+	BL   fse_malloc(SB)
+	CBZ  R0, freeIDs
 	MOVD R0, 16(RSP)
 
 	MOVD 32(RSP), R6
@@ -102,6 +118,8 @@ TEXT fsEventsCallbackASM<>(SB), NOSPLIT|NOFRAME, $0
 	MOVD R6, (1*8)(R0)
 	MOVD 56(RSP), R6
 	MOVD R6, (2*8)(R0)
+	MOVD 72(RSP), R6
+	MOVD R6, (3*8)(R0)
 
 	// write(info->eventPipeWrite, &payload, sizeof(payload)).
 writeAgain:
@@ -122,6 +140,10 @@ writeAgain:
 
 freePayload:
 	MOVD 16(RSP), R0
+	BL   fse_free(SB)
+
+freeIDs:
+	MOVD 72(RSP), R0
 	BL   fse_free(SB)
 
 freeFlags:

--- a/internal/fswatch/fsevents_darwin_shared_test.go
+++ b/internal/fswatch/fsevents_darwin_shared_test.go
@@ -3,6 +3,7 @@
 package fswatch
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,7 +14,8 @@ import (
 
 func newTestFSEventsWatcher(impl **fsEventsBackend) Watcher {
 	return &watcher{
-		name: "fsevents",
+		name:     "fsevents",
+		sequence: fsEventsGetCurrentEventID,
 		factory: func() watcherImpl {
 			*impl = newFSEventsBackend()
 			return *impl
@@ -104,6 +106,96 @@ func TestFSEventsSharedStreamRoutesEvents(t *testing.T) {
 	}
 	expectContains(t, recB, EventUpdate, fileB)
 	assertNoEventsForPath(t, recA.drainQuiet(500*time.Millisecond), fileB, "sibling watch saw event")
+}
+
+func setupFSEventsConsolidatedParent(t *testing.T) (Watcher, string) {
+	t.Helper()
+
+	var impl *fsEventsBackend
+	watcherImpl := newTestFSEventsWatcher(&impl)
+	parent := filepath.Join(newTmpDir(t), "parent")
+
+	var subs []Watch
+	for i := range recursiveConsolidateThreshold {
+		dir := filepath.Join(parent, fmt.Sprintf("pkg%d", i))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		sub, err := watcherImpl.WatchDirectory(dir, func([]Event, error) {})
+		if err != nil {
+			t.Fatal(err)
+		}
+		subs = append(subs, sub)
+	}
+	t.Cleanup(func() {
+		for _, sub := range subs {
+			_ = sub.Close()
+		}
+	})
+
+	return watcherImpl, parent
+}
+
+func TestFSEventsConsolidatedWatchValidatesLogicalRoot(t *testing.T) {
+	t.Parallel()
+
+	watcherImpl, parent := setupFSEventsConsolidatedParent(t)
+
+	if sub, err := watcherImpl.WatchDirectory(filepath.Join(parent, "missing"), func([]Event, error) {}); err == nil {
+		_ = sub.Close()
+		t.Fatal("expected error subscribing to missing consolidated child")
+	}
+
+	file := filepath.Join(parent, "file")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if sub, err := watcherImpl.WatchDirectory(file, func([]Event, error) {}); err == nil {
+		_ = sub.Close()
+		t.Fatal("expected error subscribing to file consolidated child")
+	}
+}
+
+func TestFSEventsConsolidatedWatchTerminatesLogicalRoot(t *testing.T) {
+	t.Parallel()
+
+	watcherImpl, parent := setupFSEventsConsolidatedParent(t)
+
+	watched := filepath.Join(parent, "watched")
+	if err := os.MkdirAll(watched, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	r := newRecorder(t)
+	r.watcher = watcherImpl
+	sub, err := watcherImpl.WatchDirectory(watched, r.callback, WithRecursive())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = sub.Close() })
+	time.Sleep(settleSleep(watcherImpl))
+
+	if err := os.RemoveAll(watched); err != nil {
+		t.Fatal(err)
+	}
+	expectEventSequence(t, r, []wantEvent{{EventDelete, watched}})
+
+	deadline := time.Now().Add(r.deadline())
+	for time.Now().Before(deadline) {
+		r.mu.Lock()
+		n := len(r.errs)
+		r.mu.Unlock()
+		if n > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	r.mu.Lock()
+	errs := slices.Clone(r.errs)
+	r.errs = nil
+	r.mu.Unlock()
+	if !slices.ContainsFunc(errs, func(err error) bool { return errors.Is(err, ErrWatchTerminated) }) {
+		t.Fatalf("expected ErrWatchTerminated after watched dir delete, got errs=%v", errs)
+	}
 }
 
 func TestFSEventsSharedStreamFallsBackToChunks(t *testing.T) {

--- a/internal/fswatch/watcher.go
+++ b/internal/fswatch/watcher.go
@@ -294,10 +294,10 @@ func (w *watcher) keyForDirWatch(dir string, recursive bool) string {
 	return dir
 }
 
-func (w *watcher) findCoveringRecursiveWatchLocked(dir string) *dirWatch {
+func (w *watcher) findCoveringRecursiveWatchLocked(dir string, physicalDir string) *dirWatch {
 	var best *dirWatch
 	for _, dw := range w.dirWatches {
-		if !dw.recursive || !isInDirectoryOrSelf(dw.dir, dir) {
+		if !dw.recursive || !isInDirectoryOrSelf(dw.dir, dir) || !isInDirectoryOrSelf(dw.physicalDir, physicalDir) {
 			continue
 		}
 		if best == nil || len(dw.dir) > len(best.dir) {
@@ -307,7 +307,7 @@ func (w *watcher) findCoveringRecursiveWatchLocked(dir string) *dirWatch {
 	return best
 }
 
-func (w *watcher) findConsolidationDirLocked(dir string) string {
+func (w *watcher) findConsolidationDirLocked(dir string, physicalDir string) string {
 	if !w.canShareRecursiveDirWatches() {
 		return ""
 	}
@@ -316,9 +316,13 @@ func (w *watcher) findConsolidationDirLocked(dir string) string {
 		if filepath.Dir(parent) == parent {
 			break
 		}
+		physicalParent := physicalDirFor(parent)
+		if !isInDirectoryOrSelf(physicalParent, physicalDir) {
+			return ""
+		}
 		count := 1
 		for _, dw := range w.dirWatches {
-			if isInDirectoryOrSelf(parent, dw.dir) {
+			if isInDirectoryOrSelf(parent, dw.dir) && isInDirectoryOrSelf(physicalParent, dw.physicalDir) {
 				count++
 				if count >= recursiveConsolidateThreshold {
 					return parent
@@ -346,14 +350,14 @@ func (w *watcher) getOrCreateDirWatch(dir string, physicalDir string, recursive 
 	}
 
 	if w.canShareRecursiveDirWatches() {
-		if dw := w.findCoveringRecursiveWatchLocked(dir); dw != nil {
+		if dw := w.findCoveringRecursiveWatchLocked(dir, physicalDir); dw != nil {
 			return dw
 		}
-		if consolidationDir := w.findConsolidationDirLocked(dir); consolidationDir != "" {
+		if consolidationDir := w.findConsolidationDirLocked(dir, physicalDir); consolidationDir != "" {
 			dir = consolidationDir
 			physicalDir = physicalDirFor(dir)
 			recursive = true
-			if dw := w.findCoveringRecursiveWatchLocked(dir); dw != nil {
+			if dw := w.findCoveringRecursiveWatchLocked(dir, physicalDir); dw != nil {
 				return dw
 			}
 		}
@@ -690,15 +694,17 @@ func (b *watcherBase) handleWatcherError(werr *dirWatchError) {
 // ----- dirWatch: per-directory watch state -------------------------
 
 type callback struct {
-	id          uint64
-	dir         string
-	physicalDir string
-	recursive   bool
-	fn          WatchCallback
-	ignore      func(path string) bool
-	sinceSeq    uint64
-	terminal    error
-	delivered   bool
+	id               uint64
+	dir              string
+	physicalDir      string
+	watchDir         string
+	watchPhysicalDir string
+	recursive        bool
+	fn               WatchCallback
+	ignore           func(path string) bool
+	sinceSeq         uint64
+	terminal         error
+	delivered        bool
 }
 
 // dirWatchError associates an error with a specific directory watch.
@@ -919,10 +925,20 @@ func (dw *dirWatch) triggerCallbacks() {
 }
 
 func (cb callback) mapEvent(e Event) Event {
-	if cb.physicalDir != "" && cb.physicalDir != cb.dir && isInDirectoryOrSelf(cb.physicalDir, e.Path) {
-		e.Path = rebasePath(e.Path, cb.physicalDir, cb.dir)
+	if cb.physicalDir != "" && cb.physicalDir != cb.dir {
+		physicalPath := cb.eventPhysicalPath(e.Path)
+		if isInDirectoryOrSelf(cb.physicalDir, physicalPath) {
+			e.Path = rebasePath(physicalPath, cb.physicalDir, cb.dir)
+		}
 	}
 	return e
+}
+
+func (cb callback) eventPhysicalPath(path string) string {
+	if cb.watchPhysicalDir != "" && cb.watchDir != "" && cb.watchPhysicalDir != cb.watchDir && isInDirectoryOrSelf(cb.watchDir, path) {
+		return rebasePath(path, cb.watchDir, cb.watchPhysicalDir)
+	}
+	return path
 }
 
 func (dw *dirWatch) terminateCallbacksForDeletedRoot(path string, seq uint64, err error) bool {
@@ -934,7 +950,8 @@ func (dw *dirWatch) terminateCallbacksForDeletedRoot(path string, seq uint64, er
 		if cb.delivered || cb.terminal != nil || cb.sinceSeq >= seq {
 			continue
 		}
-		if isInDirectoryOrSelf(path, cb.dir) || (cb.physicalDir != cb.dir && isInDirectoryOrSelf(path, cb.physicalDir)) {
+		physicalPath := cb.eventPhysicalPath(path)
+		if isInDirectoryOrSelf(path, cb.dir) || (cb.physicalDir != cb.dir && isInDirectoryOrSelf(physicalPath, cb.physicalDir)) {
 			cb.terminal = err
 			changed = true
 		}
@@ -988,7 +1005,7 @@ func (dw *dirWatch) watch(dir string, physicalDir string, recursive bool, fn Wat
 	if dw.sequence != nil {
 		sinceSeq = dw.sequence()
 	}
-	dw.callbacks = append(dw.callbacks, callback{id: id, dir: dir, physicalDir: physicalDir, recursive: recursive, fn: fn, ignore: ignore, sinceSeq: sinceSeq})
+	dw.callbacks = append(dw.callbacks, callback{id: id, dir: dir, physicalDir: physicalDir, watchDir: dw.dir, watchPhysicalDir: dw.physicalDir, recursive: recursive, fn: fn, ignore: ignore, sinceSeq: sinceSeq})
 	return id, true
 }
 

--- a/internal/fswatch/watcher.go
+++ b/internal/fswatch/watcher.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"syscall"
 
 	"github.com/microsoft/typescript-go/internal/nativepath"
 )
@@ -232,6 +233,7 @@ type watcher struct {
 	factory    func() watcherImpl // nil if not available on this platform
 	dirWatches map[string]*dirWatch
 	debounce   *debounce // lazily created in getOrCreateDirWatch
+	sequence   func() uint64
 }
 
 const recursiveConsolidateThreshold = 10
@@ -362,6 +364,7 @@ func (w *watcher) getOrCreateDirWatch(dir string, physicalDir string, recursive 
 		return dw
 	}
 	dw := newDirWatch(dir, physicalDir, w.debounce)
+	dw.sequence = w.sequence
 	dw.recursive = recursive
 	w.dirWatches[key] = dw
 	return dw
@@ -427,6 +430,12 @@ func (w *watcher) WatchDirectories(requests []WatchDirectoryRequest) ([]Watch, e
 			return nil, errNotAbsolute
 		}
 		dir = canonicalizePath(dir)
+		if w.canShareRecursiveDirWatches() {
+			if err := validateWatchDirectory(dir); err != nil {
+				rollback()
+				return nil, err
+			}
+		}
 		physicalDir := physicalDirFor(dir)
 
 		var sopts watchOptions
@@ -435,7 +444,7 @@ func (w *watcher) WatchDirectories(requests []WatchDirectoryRequest) ([]Watch, e
 		}
 
 		dw := w.getOrCreateDirWatch(dir, physicalDir, sopts.recursive)
-		id, _ := dw.watch(dir, sopts.recursive, fn, sopts.ignore)
+		id, _ := dw.watch(dir, physicalDir, sopts.recursive, fn, sopts.ignore)
 		prepared = append(prepared, preparedWatch{dw: dw, id: id, recursive: sopts.recursive, dir: dir})
 		if _, ok := seenDirWatches[dw]; !ok {
 			seenDirWatches[dw] = struct{}{}
@@ -458,6 +467,17 @@ func (w *watcher) WatchDirectories(requests []WatchDirectoryRequest) ([]Watch, e
 		watches[i] = &watch{w: w, dw: p.dw, impl: impl, id: p.id}
 	}
 	return watches, nil
+}
+
+func validateWatchDirectory(dir string) error {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return syscall.ENOTDIR
+	}
+	return nil
 }
 
 func (w *watcher) WatchFile(path string, fn WatchCallback) (Watch, error) {
@@ -670,11 +690,15 @@ func (b *watcherBase) handleWatcherError(werr *dirWatchError) {
 // ----- dirWatch: per-directory watch state -------------------------
 
 type callback struct {
-	id        uint64
-	dir       string
-	recursive bool
-	fn        WatchCallback
-	ignore    func(path string) bool
+	id          uint64
+	dir         string
+	physicalDir string
+	recursive   bool
+	fn          WatchCallback
+	ignore      func(path string) bool
+	sinceSeq    uint64
+	terminal    error
+	delivered   bool
 }
 
 // dirWatchError associates an error with a specific directory watch.
@@ -699,6 +723,8 @@ type dirWatch struct {
 
 	// state stores per-directory platform-specific bookkeeping (fsevents, windows).
 	state any
+	// sequence returns a backend event sequence cutoff for new logical callbacks.
+	sequence func() uint64
 
 	mu        sync.Mutex
 	callbacks []callback
@@ -789,13 +815,18 @@ func (dw *dirWatch) destroyDebounce() {
 
 func (dw *dirWatch) notify() {
 	dw.mu.Lock()
-	hasCBs := len(dw.callbacks) > 0
+	hasPendingCBs := slices.ContainsFunc(dw.callbacks, func(cb callback) bool {
+		return !cb.delivered
+	})
+	hasTerminal := slices.ContainsFunc(dw.callbacks, func(cb callback) bool {
+		return cb.terminal != nil && !cb.delivered
+	})
 	hasEvents := dw.events.size() > 0
 	hasError := dw.events.hasError()
 	db := dw.debounce
 	dw.mu.Unlock()
 
-	if hasCBs && (hasEvents || hasError) && db != nil {
+	if hasPendingCBs && (hasEvents || hasError || hasTerminal) && db != nil {
 		db.trigger()
 	}
 }
@@ -814,20 +845,56 @@ func (dw *dirWatch) triggerCallbacks() {
 	dw.mu.Lock()
 	hasError := dw.events.hasError()
 	hasEvents := dw.events.size() > 0
-	if len(dw.callbacks) == 0 || (!hasEvents && !hasError) {
+	cbs := make([]callback, 0, len(dw.callbacks))
+	hasTerminal := false
+	for _, cb := range dw.callbacks {
+		if cb.delivered {
+			continue
+		}
+		if cb.terminal != nil {
+			hasTerminal = true
+		}
+		cbs = append(cbs, cb)
+	}
+	if len(cbs) == 0 {
+		if hasEvents || hasError {
+			_, _ = dw.events.drain()
+		}
 		dw.mu.Unlock()
 		return
 	}
-	events, err := dw.events.drain()
-	cbs := slices.Clone(dw.callbacks)
+	if !hasEvents && !hasError && !hasTerminal {
+		dw.mu.Unlock()
+		return
+	}
+	startSeqs := make([]uint64, len(cbs))
+	for i, cb := range cbs {
+		startSeqs[i] = cb.sinceSeq
+	}
+	eventsByCallback, err := dw.events.drainForSequences(startSeqs)
+	for _, cb := range cbs {
+		if cb.terminal == nil {
+			continue
+		}
+		for i := range dw.callbacks {
+			if dw.callbacks[i].id == cb.id {
+				dw.callbacks[i].delivered = true
+				break
+			}
+		}
+	}
 	dw.mu.Unlock()
 
-	for _, cb := range cbs {
-		cbEvents := events
+	for i, cb := range cbs {
+		cbEvents := eventsByCallback[i]
 		if cb.ignore != nil || !cb.recursive || cb.dir != dw.dir {
-			filtered := make([]Event, 0, len(events))
-			for _, e := range events {
+			filtered := make([]Event, 0, len(cbEvents))
+			for _, e := range cbEvents {
+				e = cb.mapEvent(e)
 				if cb.ignore != nil && cb.ignore(e.Path) {
+					continue
+				}
+				if cb.dir != dw.dir && !e.includedWatchRoot && e.Path == cb.dir && e.Kind == EventUpdate {
 					continue
 				}
 				if cb.recursive {
@@ -841,10 +908,38 @@ func (dw *dirWatch) triggerCallbacks() {
 			}
 			cbEvents = filtered
 		}
-		if len(cbEvents) > 0 || err != nil {
-			cb.fn(cbEvents, err)
+		cbErr := err
+		if cb.terminal != nil {
+			cbErr = cb.terminal
+		}
+		if len(cbEvents) > 0 || cbErr != nil {
+			cb.fn(cbEvents, cbErr)
 		}
 	}
+}
+
+func (cb callback) mapEvent(e Event) Event {
+	if cb.physicalDir != "" && cb.physicalDir != cb.dir && isInDirectoryOrSelf(cb.physicalDir, e.Path) {
+		e.Path = rebasePath(e.Path, cb.physicalDir, cb.dir)
+	}
+	return e
+}
+
+func (dw *dirWatch) terminateCallbacksForDeletedRoot(path string, seq uint64, err error) bool {
+	dw.mu.Lock()
+	defer dw.mu.Unlock()
+	changed := false
+	for i := range dw.callbacks {
+		cb := &dw.callbacks[i]
+		if cb.delivered || cb.terminal != nil || cb.sinceSeq >= seq {
+			continue
+		}
+		if isInDirectoryOrSelf(path, cb.dir) || (cb.physicalDir != cb.dir && isInDirectoryOrSelf(path, cb.physicalDir)) {
+			cb.terminal = err
+			changed = true
+		}
+	}
+	return changed
 }
 
 func isInDirectoryOrSelf(dir, path string) bool {
@@ -884,12 +979,16 @@ func isDirectChild(dir, path string) bool {
 	return len(rest) > 0 && !strings.ContainsRune(rest, '/') && !strings.ContainsRune(rest, filepath.Separator)
 }
 
-func (dw *dirWatch) watch(dir string, recursive bool, fn WatchCallback, ignore func(path string) bool) (uint64, bool) {
+func (dw *dirWatch) watch(dir string, physicalDir string, recursive bool, fn WatchCallback, ignore func(path string) bool) (uint64, bool) {
 	dw.mu.Lock()
 	defer dw.mu.Unlock()
 	dw.nextCBID++
 	id := dw.nextCBID
-	dw.callbacks = append(dw.callbacks, callback{id: id, dir: dir, recursive: recursive, fn: fn, ignore: ignore})
+	sinceSeq := dw.events.sequence()
+	if dw.sequence != nil {
+		sinceSeq = dw.sequence()
+	}
+	dw.callbacks = append(dw.callbacks, callback{id: id, dir: dir, physicalDir: physicalDir, recursive: recursive, fn: fn, ignore: ignore, sinceSeq: sinceSeq})
 	return id, true
 }
 

--- a/internal/fswatch/watcher.go
+++ b/internal/fswatch/watcher.go
@@ -254,6 +254,8 @@ func (w *watcher) HasFastRecursiveBackend() bool {
 }
 
 func (w *watcher) canShareRecursiveDirWatches() bool {
+	// TODO: Re-enable this for Windows once coalesced recursive watches have
+	// more real-world bake time.
 	return w.name == "fsevents"
 }
 

--- a/internal/fswatch/watcher_test.go
+++ b/internal/fswatch/watcher_test.go
@@ -1482,6 +1482,125 @@ func TestFastRecursiveWatcherConsolidatesSiblingDirectories(t *testing.T) {
 	}
 }
 
+func TestFastRecursiveWatcherDoesNotConsolidateSymlinkOutsideRoot(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	parent := filepath.Join(root, "node_modules", ".bun")
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var impl *countingWatcherImpl
+	watcherImpl := &watcher{
+		name: "fsevents",
+		factory: func() watcherImpl {
+			impl = newCountingWatcherImpl()
+			return impl
+		},
+	}
+
+	var subs []Watch
+	for i := range recursiveConsolidateThreshold {
+		dir := filepath.Join(parent, fmt.Sprintf("pkg%d", i))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		sub, err := watcherImpl.WatchDirectory(dir, func([]Event, error) {})
+		if err != nil {
+			t.Fatal(err)
+		}
+		subs = append(subs, sub)
+	}
+	t.Cleanup(func() {
+		for _, sub := range subs {
+			_ = sub.Close()
+		}
+	})
+
+	consolidated := impl.subscribed[len(impl.subscribed)-1]
+	if consolidated.dir != parent || !consolidated.recursive {
+		t.Fatalf("expected consolidated recursive watch on %s, got dir=%s recursive=%v", parent, consolidated.dir, consolidated.recursive)
+	}
+
+	target := filepath.Join(root, "outside")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(parent, "linked")
+	makeDirSymlink(t, target, link)
+
+	sub, err := watcherImpl.WatchDirectory(link, func([]Event, error) {})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = sub.Close() })
+
+	watch := sub.(*watch)
+	if watch.dw == consolidated {
+		t.Fatal("symlink outside consolidated physical root should keep its own watch")
+	}
+	if watch.dw.dir != link || watch.dw.physicalDir != physicalDirFor(link) {
+		t.Fatalf("expected watch on symlink root %s (%s), got %s (%s)", link, physicalDirFor(link), watch.dw.dir, watch.dw.physicalDir)
+	}
+}
+
+func TestConsolidatedSymlinkChildMapsSharedLogicalPath(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	physicalParent := filepath.Join(root, "physical-parent")
+	if err := os.MkdirAll(filepath.Join(physicalParent, "target"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logicalParent := filepath.Join(root, "logical-parent")
+	makeDirSymlink(t, physicalParent, logicalParent)
+	link := filepath.Join(logicalParent, "link")
+	makeDirSymlink(t, filepath.Join(physicalParent, "target"), link)
+
+	cb := callback{
+		dir:              link,
+		physicalDir:      physicalDirFor(link),
+		watchDir:         logicalParent,
+		watchPhysicalDir: physicalDirFor(logicalParent),
+	}
+	event := Event{Kind: EventUpdate, Path: filepath.Join(logicalParent, "target", "file.ts")}
+	got := cb.mapEvent(event)
+	want := filepath.Join(link, "file.ts")
+	if got.Path != want {
+		t.Fatalf("mapEvent path = %q, want %q", got.Path, want)
+	}
+}
+
+func TestConsolidatedSymlinkChildTerminatesFromSharedLogicalPath(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	physicalParent := filepath.Join(root, "physical-parent")
+	if err := os.MkdirAll(filepath.Join(physicalParent, "target"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logicalParent := filepath.Join(root, "logical-parent")
+	makeDirSymlink(t, physicalParent, logicalParent)
+	link := filepath.Join(logicalParent, "link")
+	makeDirSymlink(t, filepath.Join(physicalParent, "target"), link)
+
+	dw := newDirectWatcher(t, logicalParent)
+	dw.physicalDir = physicalDirFor(logicalParent)
+	id, _ := dw.watch(link, physicalDirFor(link), true, func([]Event, error) {}, nil)
+	err := errors.New("terminated")
+	if !dw.terminateCallbacksForDeletedRoot(filepath.Join(logicalParent, "target"), 1, err) {
+		t.Fatal("expected symlink child callback to terminate")
+	}
+	dw.mu.Lock()
+	defer dw.mu.Unlock()
+	for _, cb := range dw.callbacks {
+		if cb.id == id && !errors.Is(cb.terminal, err) {
+			t.Fatalf("terminal error = %v, want %v", cb.terminal, err)
+		}
+	}
+}
+
 func TestConsolidatedChildWatchFiltersAgainstRequestedDir(t *testing.T) {
 	t.Parallel()
 

--- a/internal/fswatch/watcher_test.go
+++ b/internal/fswatch/watcher_test.go
@@ -503,7 +503,7 @@ type wantEvent struct {
 func toWantEvents(events []Event) []wantEvent {
 	out := make([]wantEvent, len(events))
 	for i, e := range events {
-		out[i] = wantEvent(e)
+		out[i] = wantEvent{Kind: e.Kind, Path: e.Path}
 	}
 	return out
 }
@@ -1491,13 +1491,13 @@ func TestConsolidatedChildWatchFiltersAgainstRequestedDir(t *testing.T) {
 	dw := newDirectWatcher(t, parent)
 
 	var got []Event
-	dw.watch(child, false, func(events []Event, err error) {
+	dw.watch(child, child, false, func(events []Event, err error) {
 		if err != nil {
 			t.Fatal(err)
 		}
 		got = append(got, events...)
 	}, nil)
-	dw.events.update(child)
+	dw.events.updateWatchRootAt(child, 1)
 	dw.events.update(filepath.Join(child, "file.ts"))
 	dw.events.update(filepath.Join(child, "nested", "file.ts"))
 	dw.events.update(filepath.Join(sibling, "file.ts"))
@@ -1521,6 +1521,27 @@ func TestConsolidatedChildWatchFiltersAgainstRequestedDir(t *testing.T) {
 	}
 }
 
+func TestConsolidatedChildWatchIgnoresEventsBeforeSubscribe(t *testing.T) {
+	t.Parallel()
+
+	parent := filepath.Join(t.TempDir(), "parent")
+	child := filepath.Join(parent, "child")
+	dw := newDirectWatcher(t, parent)
+
+	dw.events.update(child)
+	var got []Event
+	dw.watch(child, child, true, func(events []Event, err error) {
+		if err != nil {
+			t.Fatal(err)
+		}
+		got = append(got, events...)
+	}, nil)
+	dw.events.remove(child)
+	dw.triggerCallbacks()
+
+	assertEventSequence(t, got, []wantEvent{{EventDelete, child}})
+}
+
 func TestRecursiveWatchWithIgnoreDoesNotFilterByLogicalRoot(t *testing.T) {
 	t.Parallel()
 
@@ -1529,7 +1550,7 @@ func TestRecursiveWatchWithIgnoreDoesNotFilterByLogicalRoot(t *testing.T) {
 
 	var got []Event
 	outsidePath := filepath.Join(t.TempDir(), "outside", "pkg", "index.ts")
-	dw.watch(dir, true, func(events []Event, err error) {
+	dw.watch(dir, dir, true, func(events []Event, err error) {
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/fswatch/windows.go
+++ b/internal/fswatch/windows.go
@@ -393,7 +393,10 @@ func (s *windowsSubscription) processOne(action uint32, name string) {
 			}
 		}
 	case windows.FILE_ACTION_REMOVED, windows.FILE_ACTION_RENAMED_OLD_NAME:
-		s.dirWatch.events.remove(path)
+		seq := s.dirWatch.events.removeAndGetSequence(path)
+		if s.dirWatch.terminateCallbacksForDeletedRoot(path, seq, fmt.Errorf("%w: watched directory removed", ErrWatchTerminated)) {
+			s.dirWatch.notify()
+		}
 	}
 }
 


### PR DESCRIPTION
The coalescing I added a while back was not functional over heavy contention. It takes a lot of junk to make it work regarding event sequencing across multiple watches.

This actually unbreaks Windows, which saw much more consistent errors. macOS was broken but we didn't load it enough.

I've opted to not enable this for Windows for now, it doesn't seem to have the resource limits that macOS does with fsevents, so not really worth it.

This is of course mostly copilot stuff though a lot of trial and error on my macbook.