### PR TITLE
[api] Use stable order for symbol tables

### DIFF
--- a/_packages/native-preview/src/api/async/api.ts
+++ b/_packages/native-preview/src/api/async/api.ts
@@ -383,7 +383,7 @@ class SnapshotObjectRegistry {
 class ProjectObjectRegistry {
     private client: Client;
     private snapshotId: number;
-    private projectId: Path;
+    private project: Project;
     private snapshotRegistry: SnapshotObjectRegistry;
     private types: Map<number, TypeObject> = new Map();
     private signatures: Map<number, Signature> = new Map();
@@ -391,12 +391,12 @@ class ProjectObjectRegistry {
     constructor(
         client: Client,
         snapshotId: number,
-        projectId: Path,
+        project: Project,
         snapshotRegistry: SnapshotObjectRegistry,
     ) {
         this.client = client;
         this.snapshotId = snapshotId;
-        this.projectId = projectId;
+        this.project = project;
         this.snapshotRegistry = snapshotRegistry;
     }
 
@@ -406,15 +406,6 @@ class ProjectObjectRegistry {
 
     getSymbol(id: number): Symbol | undefined {
         return this.snapshotRegistry.getSymbol(id);
-    }
-
-    /** The Project this registry belongs to, used as the canonical project for handles it produces. */
-    getOwnProject(): Project {
-        const project = this.snapshotRegistry.getProject(this.projectId);
-        if (!project) {
-            throw new Error(`ProjectObjectRegistry references unknown project '${this.projectId}'`);
-        }
-        return project;
     }
 
     getOrCreateType(data: TypeResponse): TypeObject {
@@ -433,7 +424,7 @@ class ProjectObjectRegistry {
     getOrCreateSignature(data: SignatureResponse): Signature {
         let sig = this.signatures.get(data.id);
         if (!sig) {
-            sig = new Signature(data, this);
+            sig = new Signature(data, this.project, this);
             this.signatures.set(data.id, sig);
         }
         return sig;
@@ -457,7 +448,7 @@ class ProjectObjectRegistry {
 
         const data = await this.client.apiRequest<TypeResponse | null>(method, {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             objectId: source.id,
         });
         if (!data) throw new Error(`${method} returned null type for ${source.constructor.name} ${source.id}`);
@@ -465,7 +456,7 @@ class ProjectObjectRegistry {
     }
 
     async fetchSymbol(source: Symbol | Signature | Type, method: string, handle: number | undefined): Promise<Symbol> {
-        return this.snapshotRegistry.fetchSymbol(source, method, handle, this.projectId);
+        return this.snapshotRegistry.fetchSymbol(source, method, handle, this.project.id);
     }
 
     async fetchSignature(source: Symbol | Signature | Type, method: string, handle: number | undefined): Promise<Signature> {
@@ -475,7 +466,7 @@ class ProjectObjectRegistry {
 
         const data = await this.client.apiRequest<SignatureResponse | null>(method, {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             objectId: source.id,
         });
         if (!data) throw new Error(`${method} returned null signature for ${source.constructor.name} ${source.id}`);
@@ -498,7 +489,7 @@ class ProjectObjectRegistry {
         }
         const typesData = await this.client.apiRequest<TypeResponse[] | null>(method, {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             objectId: source.id,
         });
         if (typesData == null) return [];
@@ -506,7 +497,7 @@ class ProjectObjectRegistry {
     }
 
     async fetchSymbols(source: Symbol | Signature | Type, method: string, handles?: readonly number[]): Promise<readonly Symbol[]> {
-        return this.snapshotRegistry.fetchSymbols(source, method, handles, this.projectId);
+        return this.snapshotRegistry.fetchSymbols(source, method, handles, this.project.id);
     }
 
     // getBaseTypes is a checker-level endpoint keyed by `type` (not `objectId`),
@@ -514,7 +505,7 @@ class ProjectObjectRegistry {
     async fetchBaseTypes(source: Type): Promise<readonly Type[]> {
         const typesData = await this.client.apiRequest<TypeResponse[] | null>("getBaseTypes", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: source.id,
         });
         if (typesData == null) return [];
@@ -553,10 +544,10 @@ export class Project {
             sourceFileCache,
             toPath,
         );
-        const objectRegistry = new ProjectObjectRegistry(client, snapshotId, this.id, snapshotRegistry);
+        const objectRegistry = new ProjectObjectRegistry(client, snapshotId, this, snapshotRegistry);
         this.checker = new Checker(
             snapshotId,
-            this.id,
+            this,
             client,
             objectRegistry,
         );
@@ -782,19 +773,19 @@ export class Program {
 
 export class Checker {
     private snapshotId: number;
-    private projectId: Path;
+    private project: Project;
     private client: Client;
     private objectRegistry: ProjectObjectRegistry;
     private wellKnownSymbols: Promise<{ unknown: number; undefined: number; arguments: number; }> | undefined;
 
     constructor(
         snapshotId: number,
-        projectId: Path,
+        project: Project,
         client: Client,
         objectRegistry: ProjectObjectRegistry,
     ) {
         this.snapshotId = snapshotId;
-        this.projectId = projectId;
+        this.project = project;
         this.client = client;
         this.objectRegistry = objectRegistry;
     }
@@ -809,14 +800,14 @@ export class Checker {
         if (Array.isArray(nodeOrNodes)) {
             const data = await this.client.apiRequest<(SymbolResponse | null)[]>("getSymbolsAtLocations", {
                 snapshot: this.snapshotId,
-                project: this.projectId,
+                project: this.project.id,
                 locations: nodeOrNodes.map(node => getNodeId(node)),
             });
             return data.map(d => d ? this.objectRegistry.getOrCreateSymbol(d) : undefined);
         }
         const data = await this.client.apiRequest<SymbolResponse | null>("getSymbolAtLocation", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             location: getNodeId(nodeOrNodes as Node),
         });
         return data ? this.objectRegistry.getOrCreateSymbol(data) : undefined;
@@ -828,7 +819,7 @@ export class Checker {
         if (typeof positionOrPositions === "number") {
             const data = await this.client.apiRequest<SymbolResponse | null>("getSymbolAtPosition", {
                 snapshot: this.snapshotId,
-                project: this.projectId,
+                project: this.project.id,
                 file,
                 position: positionOrPositions,
             });
@@ -836,7 +827,7 @@ export class Checker {
         }
         const data = await this.client.apiRequest<(SymbolResponse | null)[]>("getSymbolsAtPositions", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             file,
             positions: positionOrPositions,
         });
@@ -849,14 +840,14 @@ export class Checker {
         if (Array.isArray(symbolOrSymbols)) {
             const data = await this.client.apiRequest<(TypeResponse | null)[]>("getTypesOfSymbols", {
                 snapshot: this.snapshotId,
-                project: this.projectId,
+                project: this.project.id,
                 symbols: symbolOrSymbols.map(s => s.id),
             });
             return data.map(d => d ? this.objectRegistry.getOrCreateType(d) : undefined);
         }
         const data = await this.client.apiRequest<TypeResponse | null>("getTypeOfSymbol", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             symbol: (symbolOrSymbols as Symbol).id,
         });
         return data ? this.objectRegistry.getOrCreateType(data) : undefined;
@@ -870,7 +861,7 @@ export class Checker {
     async getDeclaredTypeOfSymbol(symbol: Symbol): Promise<Type> {
         const data = await this.client.apiRequest<TypeResponse | null>("getDeclaredTypeOfSymbol", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             symbol: symbol.id,
         });
         if (!data) throw new Error(`getDeclaredTypeOfSymbol returned no type for symbol ${symbol.id}`);
@@ -880,45 +871,43 @@ export class Checker {
     async getReferencesToSymbolInFile(file: DocumentIdentifier, symbol: Symbol): Promise<NodeHandle[]> {
         const data = await this.client.apiRequest<string[] | null>("getReferencesToSymbolInFile", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             file,
             symbol: symbol.id,
         });
-        return (data ?? []).map(h => new NodeHandle(h, this.objectRegistry.getOwnProject()));
+        return (data ?? []).map(h => new NodeHandle(h, this.project));
     }
 
     async getReferencedSymbolsForNode(node: Node, position: number): Promise<ReferencedSymbolEntry[]> {
         const data = await this.client.apiRequest<{ definition: string; symbol?: SymbolResponse; references: string[]; }[] | null>("getReferencedSymbolsForNode", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             node: getNodeId(node),
             position,
         });
-        const canonicalProject = this.objectRegistry.getOwnProject();
         return (data ?? []).map(entry => ({
-            definition: new NodeHandle(entry.definition, canonicalProject),
+            definition: new NodeHandle(entry.definition, this.project),
             symbol: entry.symbol ? this.objectRegistry.getOrCreateSymbol(entry.symbol) : undefined,
-            references: (entry.references ?? []).map(h => new NodeHandle(h, canonicalProject)),
+            references: (entry.references ?? []).map(h => new NodeHandle(h, this.project)),
         }));
     }
 
     async getSignatureUsage(signatureDecl: Node): Promise<SignatureUsage[]> {
         const data = await this.client.apiRequest<{ name: string; call?: string; }[] | null>("getSignatureUsages", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             signatureDecl: getNodeId(signatureDecl),
         });
-        const canonicalProject = this.objectRegistry.getOwnProject();
         return (data ?? []).map(entry => ({
-            name: new NodeHandle(entry.name, canonicalProject),
-            call: entry.call ? new NodeHandle(entry.call, canonicalProject) : undefined,
+            name: new NodeHandle(entry.name, this.project),
+            call: entry.call ? new NodeHandle(entry.call, this.project) : undefined,
         }));
     }
 
     async getCompletionsAtPosition(document: string, position: number, options?: CompletionOptions): Promise<CompletionInfo | undefined> {
         const data = await this.client.apiRequest<CompletionInfoResponse | null>("getCompletionsAtPosition", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             file: document,
             position,
             triggerCharacter: options?.triggerCharacter,
@@ -940,14 +929,14 @@ export class Checker {
         if (Array.isArray(nodeOrNodes)) {
             const data = await this.client.apiRequest<(TypeResponse | null)[]>("getTypeAtLocations", {
                 snapshot: this.snapshotId,
-                project: this.projectId,
+                project: this.project.id,
                 locations: nodeOrNodes.map(node => getNodeId(node)),
             });
             return data.map(d => d ? this.objectRegistry.getOrCreateType(d) : undefined);
         }
         const data = await this.client.apiRequest<TypeResponse | null>("getTypeAtLocation", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             location: getNodeId(nodeOrNodes as Node),
         });
         return data ? this.objectRegistry.getOrCreateType(data) : undefined;
@@ -956,7 +945,7 @@ export class Checker {
     async getSignaturesOfType(type: Type, kind: SignatureKind): Promise<readonly Signature[]> {
         const data = await this.client.apiRequest<SignatureResponse[]>("getSignaturesOfType", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
             kind,
         });
@@ -966,7 +955,7 @@ export class Checker {
     async getResolvedSignature(node: Node): Promise<Signature | undefined> {
         const data = await this.client.apiRequest<SignatureResponse | null>("getResolvedSignature", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             location: getNodeId(node),
         });
         return data ? this.objectRegistry.getOrCreateSignature(data) : undefined;
@@ -978,7 +967,7 @@ export class Checker {
         if (typeof positionOrPositions === "number") {
             const data = await this.client.apiRequest<TypeResponse | null>("getTypeAtPosition", {
                 snapshot: this.snapshotId,
-                project: this.projectId,
+                project: this.project.id,
                 file,
                 position: positionOrPositions,
             });
@@ -986,7 +975,7 @@ export class Checker {
         }
         const data = await this.client.apiRequest<(TypeResponse | null)[]>("getTypesAtPositions", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             file,
             positions: positionOrPositions,
         });
@@ -1003,7 +992,7 @@ export class Checker {
         const isNode = location && "kind" in location;
         const data = await this.client.apiRequest<SymbolResponse | null>("resolveName", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             name,
             meaning,
             location: isNode ? getNodeId(location as Node) : undefined,
@@ -1023,7 +1012,7 @@ export class Checker {
     async getContextualType(node: Expression): Promise<Type | undefined> {
         const data = await this.client.apiRequest<TypeResponse | null>("getContextualType", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             location: getNodeId(node),
         });
         return data ? this.objectRegistry.getOrCreateType(data) : undefined;
@@ -1032,7 +1021,7 @@ export class Checker {
     async getBaseTypeOfLiteralType(type: Type): Promise<Type | undefined> {
         const data = await this.client.apiRequest<TypeResponse | null>("getBaseTypeOfLiteralType", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
         });
         return data ? this.objectRegistry.getOrCreateType(data) : undefined;
@@ -1041,7 +1030,7 @@ export class Checker {
     async getNonNullableType(type: Type): Promise<Type | undefined> {
         const data = await this.client.apiRequest<TypeResponse | null>("getNonNullableType", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
         });
         return data ? this.objectRegistry.getOrCreateType(data) : undefined;
@@ -1050,7 +1039,7 @@ export class Checker {
     async getTypeFromTypeNode(node: TypeNode): Promise<Type | undefined> {
         const data = await this.client.apiRequest<TypeResponse | null>("getTypeFromTypeNode", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             location: getNodeId(node),
         });
         return data ? this.objectRegistry.getOrCreateType(data) : undefined;
@@ -1059,7 +1048,7 @@ export class Checker {
     async getWidenedType(type: Type): Promise<Type | undefined> {
         const data = await this.client.apiRequest<TypeResponse | null>("getWidenedType", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
         });
         return data ? this.objectRegistry.getOrCreateType(data) : undefined;
@@ -1068,7 +1057,7 @@ export class Checker {
     async getParameterType(signature: Signature, index: number): Promise<Type | undefined> {
         const data = await this.client.apiRequest<TypeResponse | null>("getParameterType", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             signature: signature.id,
             index,
         });
@@ -1078,7 +1067,7 @@ export class Checker {
     async isArrayLikeType(type: Type): Promise<boolean> {
         return this.client.apiRequest<boolean>("isArrayLikeType", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
         });
     }
@@ -1086,7 +1075,7 @@ export class Checker {
     async isTypeAssignableTo(source: Type, target: Type): Promise<boolean> {
         return this.client.apiRequest<boolean>("isTypeAssignableTo", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             source: source.id,
             target: target.id,
         });
@@ -1095,7 +1084,7 @@ export class Checker {
     async getShorthandAssignmentValueSymbol(node: Node): Promise<Symbol | undefined> {
         const data = await this.client.apiRequest<SymbolResponse | null>("getShorthandAssignmentValueSymbol", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             location: getNodeId(node),
         });
         return data ? this.objectRegistry.getOrCreateSymbol(data) : undefined;
@@ -1109,7 +1098,7 @@ export class Checker {
     async getTypeOfSymbolAtLocation(symbol: Symbol, location: Node): Promise<Type> {
         const data = await this.client.apiRequest<TypeResponse | null>("getTypeOfSymbolAtLocation", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             symbol: symbol.id,
             location: getNodeId(location),
         });
@@ -1120,7 +1109,7 @@ export class Checker {
     private async getIntrinsicType(method: string): Promise<Type> {
         const data = await this.client.apiRequest<TypeResponse>(method, {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
         });
         return this.objectRegistry.getOrCreateType(data);
     }
@@ -1162,7 +1151,7 @@ export class Checker {
     async typeToTypeNode(type: Type, enclosingDeclaration?: Node, flags?: number): Promise<TypeNode | undefined> {
         const binaryData = await this.client.apiRequestBinary("typeToTypeNode", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
             location: enclosingDeclaration ? getNodeId(enclosingDeclaration) : undefined,
             flags,
@@ -1174,7 +1163,7 @@ export class Checker {
     async signatureToSignatureDeclaration(signature: Signature, kind: SyntaxKind, enclosingDeclaration?: Node, flags?: NodeBuilderFlags): Promise<Node | undefined> {
         const binaryData = await this.client.apiRequestBinary("signatureToSignatureDeclaration", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             signature: signature.id,
             kind,
             location: enclosingDeclaration ? getNodeId(enclosingDeclaration) : undefined,
@@ -1187,7 +1176,7 @@ export class Checker {
     async typeToString(type: Type, enclosingDeclaration?: Node, flags?: number): Promise<string> {
         return this.client.apiRequest<string>("typeToString", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
             location: enclosingDeclaration ? getNodeId(enclosingDeclaration) : undefined,
             flags,
@@ -1197,7 +1186,7 @@ export class Checker {
     async isContextSensitive(node: Node): Promise<boolean> {
         return this.client.apiRequest<boolean>("isContextSensitive", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             location: getNodeId(node),
         });
     }
@@ -1205,7 +1194,7 @@ export class Checker {
     async isArrayType(type: Type): Promise<boolean> {
         return this.client.apiRequest<boolean>("isArrayType", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
         });
     }
@@ -1213,7 +1202,7 @@ export class Checker {
     async isTupleType(type: Type): Promise<boolean> {
         return this.client.apiRequest<boolean>("isTupleType", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
         });
     }
@@ -1221,7 +1210,7 @@ export class Checker {
     async getReturnTypeOfSignature(signature: Signature): Promise<Type | undefined> {
         const data = await this.client.apiRequest<TypeResponse | null>("getReturnTypeOfSignature", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             signature: signature.id,
         });
         return data ? this.objectRegistry.getOrCreateType(data) : undefined;
@@ -1230,7 +1219,7 @@ export class Checker {
     async getRestTypeOfSignature(signature: Signature): Promise<Type | undefined> {
         const data = await this.client.apiRequest<TypeResponse | null>("getRestTypeOfSignature", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             signature: signature.id,
         });
         return data ? this.objectRegistry.getOrCreateType(data) : undefined;
@@ -1239,7 +1228,7 @@ export class Checker {
     async getTypePredicateOfSignature(signature: Signature): Promise<TypePredicate | undefined> {
         const data = await this.client.apiRequest<TypePredicateResponse | null>("getTypePredicateOfSignature", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             signature: signature.id,
         });
         if (!data) return undefined;
@@ -1258,7 +1247,7 @@ export class Checker {
     async getBaseTypes(type: InterfaceType): Promise<readonly Type[]> {
         const data = await this.client.apiRequest<TypeResponse[] | null>("getBaseTypes", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
         });
         return data ? data.map(d => this.objectRegistry.getOrCreateType(d)) : [];
@@ -1267,7 +1256,7 @@ export class Checker {
     async getApparentType(type: Type): Promise<Type | undefined> {
         const data = await this.client.apiRequest<TypeResponse | null>("getApparentType", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
         });
         return data ? this.objectRegistry.getOrCreateType(data) : undefined;
@@ -1276,7 +1265,7 @@ export class Checker {
     async getPropertiesOfType(type: Type): Promise<readonly Symbol[]> {
         const data = await this.client.apiRequest<SymbolResponse[] | null>("getPropertiesOfType", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
         });
         return data ? data.map(d => this.objectRegistry.getOrCreateSymbol(d)) : [];
@@ -1285,7 +1274,7 @@ export class Checker {
     async getIndexInfosOfType(type: Type): Promise<readonly IndexInfo[]> {
         const data = await this.client.apiRequest<IndexInfoResponse[] | null>("getIndexInfosOfType", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
         });
         if (!data) return [];
@@ -1293,7 +1282,7 @@ export class Checker {
             keyType: this.objectRegistry.getOrCreateType(d.keyType),
             valueType: this.objectRegistry.getOrCreateType(d.valueType),
             isReadonly: d.isReadonly ?? false,
-            declaration: d.declaration ? new NodeHandle(d.declaration, this.objectRegistry.getOwnProject()) : undefined,
+            declaration: d.declaration ? new NodeHandle(d.declaration, this.project) : undefined,
         }));
     }
 
@@ -1304,7 +1293,7 @@ export class Checker {
     async getConstraintOfTypeParameter(type: TypeParameter): Promise<Type | undefined> {
         const data = await this.client.apiRequest<TypeResponse | null>("getConstraintOfTypeParameter", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
         });
         return data ? this.objectRegistry.getOrCreateType(data) : undefined;
@@ -1313,7 +1302,7 @@ export class Checker {
     async getBaseConstraintOfType(type: Type): Promise<Type | undefined> {
         const data = await this.client.apiRequest<TypeResponse | null>("getBaseConstraintOfType", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
         });
         return data ? this.objectRegistry.getOrCreateType(data) : undefined;
@@ -1322,7 +1311,7 @@ export class Checker {
     async getPropertyOfType(type: Type, name: string): Promise<Symbol | undefined> {
         const data = await this.client.apiRequest<SymbolResponse | null>("getPropertyOfType", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
             name,
         });
@@ -1332,7 +1321,7 @@ export class Checker {
     async getConstantValue(node: Node): Promise<string | number | undefined> {
         const data = await this.client.apiRequest<string | number | null>("getConstantValue", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             location: getNodeId(node),
         });
         return data ?? undefined;
@@ -1341,7 +1330,7 @@ export class Checker {
     async getSignatureFromDeclaration(node: Node): Promise<Signature | undefined> {
         const data = await this.client.apiRequest<SignatureResponse | null>("getSignatureFromDeclaration", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             location: getNodeId(node),
         });
         return data ? this.objectRegistry.getOrCreateSignature(data) : undefined;
@@ -1350,7 +1339,7 @@ export class Checker {
     async getExportSpecifierLocalTargetSymbol(node: Node): Promise<Symbol | undefined> {
         const data = await this.client.apiRequest<SymbolResponse | null>("getExportSpecifierLocalTargetSymbol", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             location: getNodeId(node),
         });
         return data ? this.objectRegistry.getOrCreateSymbol(data) : undefined;
@@ -1364,7 +1353,7 @@ export class Checker {
     async getAliasedSymbol(symbol: Symbol): Promise<Symbol> {
         const data = await this.client.apiRequest<SymbolResponse | null>("getAliasedSymbol", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             symbol: symbol.id,
         });
         if (!data) throw new Error(`getAliasedSymbol returned no symbol for symbol ${symbol.id}`);
@@ -1374,7 +1363,7 @@ export class Checker {
     async getImmediateAliasedSymbol(symbol: Symbol): Promise<Symbol | undefined> {
         const data = await this.client.apiRequest<SymbolResponse | null>("getImmediateAliasedSymbol", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             symbol: symbol.id,
         });
         return data ? this.objectRegistry.getOrCreateSymbol(data) : undefined;
@@ -1389,7 +1378,7 @@ export class Checker {
     private getWellKnownSymbols(): Promise<{ unknown: number; undefined: number; arguments: number; }> {
         return this.wellKnownSymbols ??= this.client.apiRequest<{ unknown: number; undefined: number; arguments: number; }>("getWellKnownSymbols", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
         });
     }
 
@@ -1418,7 +1407,7 @@ export class Checker {
     async getExportsOfModule(symbol: Symbol): Promise<readonly Symbol[]> {
         const data = await this.client.apiRequest<SymbolResponse[] | null>("getExportsOfModule", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             symbol: symbol.id,
         });
         return data ? data.map(d => this.objectRegistry.getOrCreateSymbol(d)) : [];
@@ -1427,7 +1416,7 @@ export class Checker {
     async getMemberInModuleExports(symbol: Symbol, name: string): Promise<Symbol | undefined> {
         const data = await this.client.apiRequest<SymbolResponse | null>("getMemberInModuleExports", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             symbol: symbol.id,
             name,
         });
@@ -1437,7 +1426,7 @@ export class Checker {
     async getJsDocTagsOfSymbol(symbol: Symbol): Promise<readonly JSDocTagInfo[]> {
         const data = await this.client.apiRequest<JSDocTagInfo[] | null>("getJsDocTags", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             symbol: symbol.id,
         });
         return data ?? [];
@@ -1446,7 +1435,7 @@ export class Checker {
     async getDocumentationCommentOfSymbol(symbol: Symbol): Promise<string> {
         return this.client.apiRequest<string>("getDocumentationComment", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             symbol: symbol.id,
         });
     }
@@ -1457,7 +1446,7 @@ export class Checker {
     async getTypeArguments(type: TypeReference): Promise<readonly Type[]> {
         const data = await this.client.apiRequest<TypeResponse[] | null>("getTypeArguments", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
         });
         return data ? data.map(d => this.objectRegistry.getOrCreateType(d)) : [];
@@ -1964,11 +1953,11 @@ export class Signature {
     readonly thisParameter?: number | undefined;
     readonly target?: number | undefined;
 
-    constructor(data: SignatureResponse, objectRegistry: ProjectObjectRegistry) {
+    constructor(data: SignatureResponse, project: Project, objectRegistry: ProjectObjectRegistry) {
         this.id = data.id;
         this.flags = data.flags;
         this.objectRegistry = objectRegistry;
-        this.declaration = data.declaration ? new NodeHandle(data.declaration, objectRegistry.getOwnProject()) : undefined;
+        this.declaration = data.declaration ? new NodeHandle(data.declaration, project) : undefined;
         this.typeParameters = data.typeParameters ?? [];
         this.parameters = data.parameters ?? [];
         this.thisParameter = data.thisParameter;

--- a/_packages/native-preview/src/api/async/api.ts
+++ b/_packages/native-preview/src/api/async/api.ts
@@ -252,9 +252,9 @@ export class Snapshot {
         this.client = client;
         this.toPath = toPath;
         this.onDispose = onDispose;
-        this.snapshotRegistry = new SnapshotObjectRegistry(client, this.id);
-
         this.projectMap = new Map();
+        this.snapshotRegistry = new SnapshotObjectRegistry(client, this.id, projectId => this.projectMap.get(projectId));
+
         for (const projData of data.projects) {
             const project = new Project(projData, this.id, client, sourceFileCache, toPath, this.snapshotRegistry);
             this.projectMap.set(toPath(projData.configFileName), project);
@@ -312,10 +312,17 @@ class SnapshotObjectRegistry {
     private readonly symbols: Map<number, Symbol> = new Map();
     private readonly client: Client;
     private readonly snapshotId: number;
+    private readonly resolveProject: (projectId: Path) => Project | undefined;
 
-    constructor(client: Client, snapshotId: number) {
+    constructor(client: Client, snapshotId: number, resolveProject: (projectId: Path) => Project | undefined) {
         this.client = client;
         this.snapshotId = snapshotId;
+        this.resolveProject = resolveProject;
+    }
+
+    /** Resolve a project id (a config file path) to its Project within this snapshot. */
+    getProject(projectId: Path): Project | undefined {
+        return this.resolveProject(projectId);
     }
 
     getOrCreateSymbol(data: SymbolResponse): Symbol {
@@ -335,7 +342,7 @@ class SnapshotObjectRegistry {
         this.symbols.clear();
     }
 
-    async fetchSymbol(source: Symbol | Signature | Type, method: string, handle: number | undefined, projectId?: string): Promise<Symbol> {
+    async fetchSymbol(source: Symbol | Signature | Type, method: string, handle: number | undefined, projectId?: Path): Promise<Symbol> {
         if (!handle) return undefined as unknown as Symbol;
         const cached = this.getSymbol(handle);
         if (cached) return cached;
@@ -349,7 +356,7 @@ class SnapshotObjectRegistry {
         return this.getOrCreateSymbol(data);
     }
 
-    async fetchSymbols(source: Symbol | Signature | Type, method: string, handles?: readonly number[], projectId?: string): Promise<readonly Symbol[]> {
+    async fetchSymbols(source: Symbol | Signature | Type, method: string, handles?: readonly number[], projectId?: Path): Promise<readonly Symbol[]> {
         if (handles) {
             const result = new Array<Symbol>(handles.length);
             let allCached = true;
@@ -376,7 +383,7 @@ class SnapshotObjectRegistry {
 class ProjectObjectRegistry {
     private client: Client;
     private snapshotId: number;
-    private projectId: string;
+    private projectId: Path;
     private snapshotRegistry: SnapshotObjectRegistry;
     private types: Map<number, TypeObject> = new Map();
     private signatures: Map<number, Signature> = new Map();
@@ -384,7 +391,7 @@ class ProjectObjectRegistry {
     constructor(
         client: Client,
         snapshotId: number,
-        projectId: string,
+        projectId: Path,
         snapshotRegistry: SnapshotObjectRegistry,
     ) {
         this.client = client;
@@ -399,6 +406,15 @@ class ProjectObjectRegistry {
 
     getSymbol(id: number): Symbol | undefined {
         return this.snapshotRegistry.getSymbol(id);
+    }
+
+    /** The Project this registry belongs to, used as the canonical project for handles it produces. */
+    getOwnProject(): Project {
+        const project = this.snapshotRegistry.getProject(this.projectId);
+        if (!project) {
+            throw new Error(`ProjectObjectRegistry references unknown project '${this.projectId}'`);
+        }
+        return project;
     }
 
     getOrCreateType(data: TypeResponse): TypeObject {
@@ -507,7 +523,7 @@ class ProjectObjectRegistry {
 }
 
 export class Project {
-    readonly id: string;
+    readonly id: Path;
     readonly configFileName: string;
     readonly compilerOptions: Record<string, unknown>;
     readonly rootFiles: readonly string[];
@@ -554,7 +570,7 @@ export class Project {
 
 export class Program {
     private snapshotId: number;
-    private projectId: string;
+    private projectId: Path;
     private client: Client;
     private sourceFileCache: SourceFileCache;
     private toPath: (fileName: string) => Path;
@@ -563,7 +579,7 @@ export class Program {
 
     constructor(
         snapshotId: number,
-        projectId: string,
+        projectId: Path,
         client: Client,
         sourceFileCache: SourceFileCache,
         toPath: (fileName: string) => Path,
@@ -766,14 +782,14 @@ export class Program {
 
 export class Checker {
     private snapshotId: number;
-    private projectId: string;
+    private projectId: Path;
     private client: Client;
     private objectRegistry: ProjectObjectRegistry;
     private wellKnownSymbols: Promise<{ unknown: number; undefined: number; arguments: number; }> | undefined;
 
     constructor(
         snapshotId: number,
-        projectId: string,
+        projectId: Path,
         client: Client,
         objectRegistry: ProjectObjectRegistry,
     ) {
@@ -868,7 +884,7 @@ export class Checker {
             file,
             symbol: symbol.id,
         });
-        return (data ?? []).map(h => new NodeHandle(h));
+        return (data ?? []).map(h => new NodeHandle(h, this.objectRegistry.getOwnProject()));
     }
 
     async getReferencedSymbolsForNode(node: Node, position: number): Promise<ReferencedSymbolEntry[]> {
@@ -878,10 +894,11 @@ export class Checker {
             node: getNodeId(node),
             position,
         });
+        const canonicalProject = this.objectRegistry.getOwnProject();
         return (data ?? []).map(entry => ({
-            definition: new NodeHandle(entry.definition),
+            definition: new NodeHandle(entry.definition, canonicalProject),
             symbol: entry.symbol ? this.objectRegistry.getOrCreateSymbol(entry.symbol) : undefined,
-            references: (entry.references ?? []).map(h => new NodeHandle(h)),
+            references: (entry.references ?? []).map(h => new NodeHandle(h, canonicalProject)),
         }));
     }
 
@@ -891,9 +908,10 @@ export class Checker {
             project: this.projectId,
             signatureDecl: getNodeId(signatureDecl),
         });
+        const canonicalProject = this.objectRegistry.getOwnProject();
         return (data ?? []).map(entry => ({
-            name: new NodeHandle(entry.name),
-            call: entry.call ? new NodeHandle(entry.call) : undefined,
+            name: new NodeHandle(entry.name, canonicalProject),
+            call: entry.call ? new NodeHandle(entry.call, canonicalProject) : undefined,
         }));
     }
 
@@ -1275,7 +1293,7 @@ export class Checker {
             keyType: this.objectRegistry.getOrCreateType(d.keyType),
             valueType: this.objectRegistry.getOrCreateType(d.valueType),
             isReadonly: d.isReadonly ?? false,
-            declaration: d.declaration ? new NodeHandle(d.declaration) : undefined,
+            declaration: d.declaration ? new NodeHandle(d.declaration, this.objectRegistry.getOwnProject()) : undefined,
         }));
     }
 
@@ -1470,22 +1488,30 @@ export class Emitter {
 }
 
 export class NodeHandle {
+    /**
+     * The project this handle was produced in, used as the default for {@link resolve}.
+     * Node handles are only meaningful within a project's program, so the producing project
+     * is remembered so callers don't have to pass it explicitly.
+     */
+    private readonly canonicalProject: Project;
     readonly index: number;
     readonly kind: SyntaxKind;
     readonly path: Path;
 
-    constructor(handle: string) {
+    constructor(handle: string, canonicalProject: Project) {
         const parsed = parseNodeHandle(handle);
         this.index = parsed.index;
         this.kind = parsed.kind;
         this.path = parsed.path;
+        this.canonicalProject = canonicalProject;
     }
 
     /**
-     * Resolve this handle to the actual AST node by fetching the source file
-     * from the given project and looking up the node by index.
+     * Resolve this handle to the actual AST node by fetching the source file from a project
+     * and looking up the node by index. If no project is passed, the project that produced
+     * the handle is used.
      */
-    async resolve(project: Project): Promise<Node | undefined> {
+    async resolve(project: Project = this.canonicalProject): Promise<Node | undefined> {
         const sourceFile = await project.program.getSourceFile(this.path);
         if (!sourceFile) {
             return undefined;
@@ -1514,6 +1540,12 @@ export interface SignatureUsage {
 
 export class Symbol {
     private objectRegistry: SnapshotObjectRegistry;
+    /**
+     * The project this symbol was first observed in, used as the default project for
+     * lookups that need a project context (members/exports/parent). Symbols are shared
+     * snapshot-wide, so these lookups can otherwise be ambiguous about which project to use.
+     */
+    private readonly canonicalProject: Project;
 
     readonly id: number;
     /** The escaped (`__String`) name, used as the key in member/export tables. */
@@ -1537,15 +1569,20 @@ export class Symbol {
         this.name = unescapeLeadingUnderscores(data.name);
         this.flags = data.flags;
         this.checkFlags = data.checkFlags;
-        this.declarations = (data.declarations ?? []).map(d => new NodeHandle(d));
-        this.valueDeclaration = data.valueDeclaration ? new NodeHandle(data.valueDeclaration) : undefined;
+        const canonicalProject = objectRegistry.getProject(data.project);
+        if (!canonicalProject) {
+            throw new Error(`Symbol ${data.id} references unknown canonical project '${data.project}'`);
+        }
+        this.canonicalProject = canonicalProject;
+        this.declarations = (data.declarations ?? []).map(d => new NodeHandle(d, canonicalProject));
+        this.valueDeclaration = data.valueDeclaration ? new NodeHandle(data.valueDeclaration, canonicalProject) : undefined;
 
         if (data.parent !== undefined) this.parent = data.parent;
         if (data.exportSymbol !== undefined) this.exportSymbol = data.exportSymbol;
     }
 
     async getParent(): Promise<Symbol | undefined> {
-        return this.objectRegistry.fetchSymbol(this, "getParentOfSymbol", this.parent);
+        return this.objectRegistry.fetchSymbol(this, "getParentOfSymbol", this.parent, this.canonicalProject.id);
     }
 
     /**
@@ -1565,7 +1602,7 @@ export class Symbol {
     }
 
     private async fetchSymbolTable(method: string): Promise<ReadonlyMap<__String, Symbol>> {
-        const symbols = await this.objectRegistry.fetchSymbols(this, method);
+        const symbols = await this.objectRegistry.fetchSymbols(this, method, undefined, this.canonicalProject.id);
         const table = new Map<__String, Symbol>();
         for (const symbol of symbols) {
             table.set(symbol.escapedName, symbol);
@@ -1575,7 +1612,7 @@ export class Symbol {
 
     async getExportSymbol(): Promise<Symbol> {
         if (!this.exportSymbol) return this;
-        return this.objectRegistry.fetchSymbol(this, "getExportSymbolOfSymbol", this.exportSymbol);
+        return this.objectRegistry.fetchSymbol(this, "getExportSymbolOfSymbol", this.exportSymbol, this.canonicalProject.id);
     }
 
     async getJsDocTags(checker: Checker): Promise<readonly JSDocTagInfo[]> {
@@ -1931,7 +1968,7 @@ export class Signature {
         this.id = data.id;
         this.flags = data.flags;
         this.objectRegistry = objectRegistry;
-        this.declaration = data.declaration ? new NodeHandle(data.declaration) : undefined;
+        this.declaration = data.declaration ? new NodeHandle(data.declaration, objectRegistry.getOwnProject()) : undefined;
         this.typeParameters = data.typeParameters ?? [];
         this.parameters = data.parameters ?? [];
         this.thisParameter = data.thisParameter;

--- a/_packages/native-preview/src/api/proto.ts
+++ b/_packages/native-preview/src/api/proto.ts
@@ -1,6 +1,9 @@
 import type { CompletionItemKind } from "#enums/completionItemKind";
 import type { ModuleKind } from "#enums/moduleKind";
-import type { __String, Path } from "../ast/index.ts";
+import type {
+    __String,
+    Path,
+} from "../ast/index.ts";
 import {
     documentURIToFileName,
     fileNameToDocumentURI,

--- a/_packages/native-preview/src/api/proto.ts
+++ b/_packages/native-preview/src/api/proto.ts
@@ -1,6 +1,6 @@
 import type { CompletionItemKind } from "#enums/completionItemKind";
 import type { ModuleKind } from "#enums/moduleKind";
-import type { __String } from "../ast/index.ts";
+import type { __String, Path } from "../ast/index.ts";
 import {
     documentURIToFileName,
     fileNameToDocumentURI,
@@ -163,7 +163,7 @@ export interface UpdateSnapshotResponse {
 }
 
 export interface ProjectResponse {
-    id: string;
+    id: Path;
     configFileName: string;
     compilerOptions: Record<string, unknown>;
     rootFiles: string[];
@@ -184,6 +184,12 @@ export interface SourceFileMetadata {
 
 export interface SymbolResponse {
     id: number;
+    /**
+     * The project the symbol was first observed in. Used as the default project for
+     * follow-up lookups that need a project context (e.g. members/exports), since symbols
+     * are shared snapshot-wide and such lookups can vary by project.
+     */
+    project: Path;
     name: __String;
     flags: number;
     checkFlags: number;

--- a/_packages/native-preview/src/api/sync/api.ts
+++ b/_packages/native-preview/src/api/sync/api.ts
@@ -260,9 +260,9 @@ export class Snapshot {
         this.client = client;
         this.toPath = toPath;
         this.onDispose = onDispose;
-        this.snapshotRegistry = new SnapshotObjectRegistry(client, this.id);
-
         this.projectMap = new Map();
+        this.snapshotRegistry = new SnapshotObjectRegistry(client, this.id, projectId => this.projectMap.get(projectId));
+
         for (const projData of data.projects) {
             const project = new Project(projData, this.id, client, sourceFileCache, toPath, this.snapshotRegistry);
             this.projectMap.set(toPath(projData.configFileName), project);
@@ -320,10 +320,17 @@ class SnapshotObjectRegistry {
     private readonly symbols: Map<number, Symbol> = new Map();
     private readonly client: Client;
     private readonly snapshotId: number;
+    private readonly resolveProject: (projectId: Path) => Project | undefined;
 
-    constructor(client: Client, snapshotId: number) {
+    constructor(client: Client, snapshotId: number, resolveProject: (projectId: Path) => Project | undefined) {
         this.client = client;
         this.snapshotId = snapshotId;
+        this.resolveProject = resolveProject;
+    }
+
+    /** Resolve a project id (a config file path) to its Project within this snapshot. */
+    getProject(projectId: Path): Project | undefined {
+        return this.resolveProject(projectId);
     }
 
     getOrCreateSymbol(data: SymbolResponse): Symbol {
@@ -343,7 +350,7 @@ class SnapshotObjectRegistry {
         this.symbols.clear();
     }
 
-    fetchSymbol(source: Symbol | Signature | Type, method: string, handle: number | undefined, projectId?: string): Symbol {
+    fetchSymbol(source: Symbol | Signature | Type, method: string, handle: number | undefined, projectId?: Path): Symbol {
         if (!handle) return undefined as unknown as Symbol;
         const cached = this.getSymbol(handle);
         if (cached) return cached;
@@ -357,7 +364,7 @@ class SnapshotObjectRegistry {
         return this.getOrCreateSymbol(data);
     }
 
-    fetchSymbols(source: Symbol | Signature | Type, method: string, handles?: readonly number[], projectId?: string): readonly Symbol[] {
+    fetchSymbols(source: Symbol | Signature | Type, method: string, handles?: readonly number[], projectId?: Path): readonly Symbol[] {
         if (handles) {
             const result = new Array<Symbol>(handles.length);
             let allCached = true;
@@ -384,7 +391,7 @@ class SnapshotObjectRegistry {
 class ProjectObjectRegistry {
     private client: Client;
     private snapshotId: number;
-    private projectId: string;
+    private projectId: Path;
     private snapshotRegistry: SnapshotObjectRegistry;
     private types: Map<number, TypeObject> = new Map();
     private signatures: Map<number, Signature> = new Map();
@@ -392,7 +399,7 @@ class ProjectObjectRegistry {
     constructor(
         client: Client,
         snapshotId: number,
-        projectId: string,
+        projectId: Path,
         snapshotRegistry: SnapshotObjectRegistry,
     ) {
         this.client = client;
@@ -407,6 +414,15 @@ class ProjectObjectRegistry {
 
     getSymbol(id: number): Symbol | undefined {
         return this.snapshotRegistry.getSymbol(id);
+    }
+
+    /** The Project this registry belongs to, used as the canonical project for handles it produces. */
+    getOwnProject(): Project {
+        const project = this.snapshotRegistry.getProject(this.projectId);
+        if (!project) {
+            throw new Error(`ProjectObjectRegistry references unknown project '${this.projectId}'`);
+        }
+        return project;
     }
 
     getOrCreateType(data: TypeResponse): TypeObject {
@@ -515,7 +531,7 @@ class ProjectObjectRegistry {
 }
 
 export class Project {
-    readonly id: string;
+    readonly id: Path;
     readonly configFileName: string;
     readonly compilerOptions: Record<string, unknown>;
     readonly rootFiles: readonly string[];
@@ -562,7 +578,7 @@ export class Project {
 
 export class Program {
     private snapshotId: number;
-    private projectId: string;
+    private projectId: Path;
     private client: Client;
     private sourceFileCache: SourceFileCache;
     private toPath: (fileName: string) => Path;
@@ -571,7 +587,7 @@ export class Program {
 
     constructor(
         snapshotId: number,
-        projectId: string,
+        projectId: Path,
         client: Client,
         sourceFileCache: SourceFileCache,
         toPath: (fileName: string) => Path,
@@ -774,14 +790,14 @@ export class Program {
 
 export class Checker {
     private snapshotId: number;
-    private projectId: string;
+    private projectId: Path;
     private client: Client;
     private objectRegistry: ProjectObjectRegistry;
     private wellKnownSymbols: { unknown: number; undefined: number; arguments: number; } | undefined;
 
     constructor(
         snapshotId: number,
-        projectId: string,
+        projectId: Path,
         client: Client,
         objectRegistry: ProjectObjectRegistry,
     ) {
@@ -876,7 +892,7 @@ export class Checker {
             file,
             symbol: symbol.id,
         });
-        return (data ?? []).map(h => new NodeHandle(h));
+        return (data ?? []).map(h => new NodeHandle(h, this.objectRegistry.getOwnProject()));
     }
 
     getReferencedSymbolsForNode(node: Node, position: number): ReferencedSymbolEntry[] {
@@ -886,10 +902,11 @@ export class Checker {
             node: getNodeId(node),
             position,
         });
+        const canonicalProject = this.objectRegistry.getOwnProject();
         return (data ?? []).map(entry => ({
-            definition: new NodeHandle(entry.definition),
+            definition: new NodeHandle(entry.definition, canonicalProject),
             symbol: entry.symbol ? this.objectRegistry.getOrCreateSymbol(entry.symbol) : undefined,
-            references: (entry.references ?? []).map(h => new NodeHandle(h)),
+            references: (entry.references ?? []).map(h => new NodeHandle(h, canonicalProject)),
         }));
     }
 
@@ -899,9 +916,10 @@ export class Checker {
             project: this.projectId,
             signatureDecl: getNodeId(signatureDecl),
         });
+        const canonicalProject = this.objectRegistry.getOwnProject();
         return (data ?? []).map(entry => ({
-            name: new NodeHandle(entry.name),
-            call: entry.call ? new NodeHandle(entry.call) : undefined,
+            name: new NodeHandle(entry.name, canonicalProject),
+            call: entry.call ? new NodeHandle(entry.call, canonicalProject) : undefined,
         }));
     }
 
@@ -1283,7 +1301,7 @@ export class Checker {
             keyType: this.objectRegistry.getOrCreateType(d.keyType),
             valueType: this.objectRegistry.getOrCreateType(d.valueType),
             isReadonly: d.isReadonly ?? false,
-            declaration: d.declaration ? new NodeHandle(d.declaration) : undefined,
+            declaration: d.declaration ? new NodeHandle(d.declaration, this.objectRegistry.getOwnProject()) : undefined,
         }));
     }
 
@@ -1478,22 +1496,30 @@ export class Emitter {
 }
 
 export class NodeHandle {
+    /**
+     * The project this handle was produced in, used as the default for {@link resolve}.
+     * Node handles are only meaningful within a project's program, so the producing project
+     * is remembered so callers don't have to pass it explicitly.
+     */
+    private readonly canonicalProject: Project;
     readonly index: number;
     readonly kind: SyntaxKind;
     readonly path: Path;
 
-    constructor(handle: string) {
+    constructor(handle: string, canonicalProject: Project) {
         const parsed = parseNodeHandle(handle);
         this.index = parsed.index;
         this.kind = parsed.kind;
         this.path = parsed.path;
+        this.canonicalProject = canonicalProject;
     }
 
     /**
-     * Resolve this handle to the actual AST node by fetching the source file
-     * from the given project and looking up the node by index.
+     * Resolve this handle to the actual AST node by fetching the source file from a project
+     * and looking up the node by index. If no project is passed, the project that produced
+     * the handle is used.
      */
-    resolve(project: Project): Node | undefined {
+    resolve(project: Project = this.canonicalProject): Node | undefined {
         const sourceFile = project.program.getSourceFile(this.path);
         if (!sourceFile) {
             return undefined;
@@ -1522,6 +1548,12 @@ export interface SignatureUsage {
 
 export class Symbol {
     private objectRegistry: SnapshotObjectRegistry;
+    /**
+     * The project this symbol was first observed in, used as the default project for
+     * lookups that need a project context (members/exports/parent). Symbols are shared
+     * snapshot-wide, so these lookups can otherwise be ambiguous about which project to use.
+     */
+    private readonly canonicalProject: Project;
 
     readonly id: number;
     /** The escaped (`__String`) name, used as the key in member/export tables. */
@@ -1545,15 +1577,20 @@ export class Symbol {
         this.name = unescapeLeadingUnderscores(data.name);
         this.flags = data.flags;
         this.checkFlags = data.checkFlags;
-        this.declarations = (data.declarations ?? []).map(d => new NodeHandle(d));
-        this.valueDeclaration = data.valueDeclaration ? new NodeHandle(data.valueDeclaration) : undefined;
+        const canonicalProject = objectRegistry.getProject(data.project);
+        if (!canonicalProject) {
+            throw new Error(`Symbol ${data.id} references unknown canonical project '${data.project}'`);
+        }
+        this.canonicalProject = canonicalProject;
+        this.declarations = (data.declarations ?? []).map(d => new NodeHandle(d, canonicalProject));
+        this.valueDeclaration = data.valueDeclaration ? new NodeHandle(data.valueDeclaration, canonicalProject) : undefined;
 
         if (data.parent !== undefined) this.parent = data.parent;
         if (data.exportSymbol !== undefined) this.exportSymbol = data.exportSymbol;
     }
 
     getParent(): Symbol | undefined {
-        return this.objectRegistry.fetchSymbol(this, "getParentOfSymbol", this.parent);
+        return this.objectRegistry.fetchSymbol(this, "getParentOfSymbol", this.parent, this.canonicalProject.id);
     }
 
     /**
@@ -1573,7 +1610,7 @@ export class Symbol {
     }
 
     private fetchSymbolTable(method: string): ReadonlyMap<__String, Symbol> {
-        const symbols = this.objectRegistry.fetchSymbols(this, method);
+        const symbols = this.objectRegistry.fetchSymbols(this, method, undefined, this.canonicalProject.id);
         const table = new Map<__String, Symbol>();
         for (const symbol of symbols) {
             table.set(symbol.escapedName, symbol);
@@ -1583,7 +1620,7 @@ export class Symbol {
 
     getExportSymbol(): Symbol {
         if (!this.exportSymbol) return this;
-        return this.objectRegistry.fetchSymbol(this, "getExportSymbolOfSymbol", this.exportSymbol);
+        return this.objectRegistry.fetchSymbol(this, "getExportSymbolOfSymbol", this.exportSymbol, this.canonicalProject.id);
     }
 
     getJsDocTags(checker: Checker): readonly JSDocTagInfo[] {
@@ -1939,7 +1976,7 @@ export class Signature {
         this.id = data.id;
         this.flags = data.flags;
         this.objectRegistry = objectRegistry;
-        this.declaration = data.declaration ? new NodeHandle(data.declaration) : undefined;
+        this.declaration = data.declaration ? new NodeHandle(data.declaration, objectRegistry.getOwnProject()) : undefined;
         this.typeParameters = data.typeParameters ?? [];
         this.parameters = data.parameters ?? [];
         this.thisParameter = data.thisParameter;

--- a/_packages/native-preview/src/api/sync/api.ts
+++ b/_packages/native-preview/src/api/sync/api.ts
@@ -391,7 +391,7 @@ class SnapshotObjectRegistry {
 class ProjectObjectRegistry {
     private client: Client;
     private snapshotId: number;
-    private projectId: Path;
+    private project: Project;
     private snapshotRegistry: SnapshotObjectRegistry;
     private types: Map<number, TypeObject> = new Map();
     private signatures: Map<number, Signature> = new Map();
@@ -399,12 +399,12 @@ class ProjectObjectRegistry {
     constructor(
         client: Client,
         snapshotId: number,
-        projectId: Path,
+        project: Project,
         snapshotRegistry: SnapshotObjectRegistry,
     ) {
         this.client = client;
         this.snapshotId = snapshotId;
-        this.projectId = projectId;
+        this.project = project;
         this.snapshotRegistry = snapshotRegistry;
     }
 
@@ -414,15 +414,6 @@ class ProjectObjectRegistry {
 
     getSymbol(id: number): Symbol | undefined {
         return this.snapshotRegistry.getSymbol(id);
-    }
-
-    /** The Project this registry belongs to, used as the canonical project for handles it produces. */
-    getOwnProject(): Project {
-        const project = this.snapshotRegistry.getProject(this.projectId);
-        if (!project) {
-            throw new Error(`ProjectObjectRegistry references unknown project '${this.projectId}'`);
-        }
-        return project;
     }
 
     getOrCreateType(data: TypeResponse): TypeObject {
@@ -441,7 +432,7 @@ class ProjectObjectRegistry {
     getOrCreateSignature(data: SignatureResponse): Signature {
         let sig = this.signatures.get(data.id);
         if (!sig) {
-            sig = new Signature(data, this);
+            sig = new Signature(data, this.project, this);
             this.signatures.set(data.id, sig);
         }
         return sig;
@@ -465,7 +456,7 @@ class ProjectObjectRegistry {
 
         const data = this.client.apiRequest<TypeResponse | null>(method, {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             objectId: source.id,
         });
         if (!data) throw new Error(`${method} returned null type for ${source.constructor.name} ${source.id}`);
@@ -473,7 +464,7 @@ class ProjectObjectRegistry {
     }
 
     fetchSymbol(source: Symbol | Signature | Type, method: string, handle: number | undefined): Symbol {
-        return this.snapshotRegistry.fetchSymbol(source, method, handle, this.projectId);
+        return this.snapshotRegistry.fetchSymbol(source, method, handle, this.project.id);
     }
 
     fetchSignature(source: Symbol | Signature | Type, method: string, handle: number | undefined): Signature {
@@ -483,7 +474,7 @@ class ProjectObjectRegistry {
 
         const data = this.client.apiRequest<SignatureResponse | null>(method, {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             objectId: source.id,
         });
         if (!data) throw new Error(`${method} returned null signature for ${source.constructor.name} ${source.id}`);
@@ -506,7 +497,7 @@ class ProjectObjectRegistry {
         }
         const typesData = this.client.apiRequest<TypeResponse[] | null>(method, {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             objectId: source.id,
         });
         if (typesData == null) return [];
@@ -514,7 +505,7 @@ class ProjectObjectRegistry {
     }
 
     fetchSymbols(source: Symbol | Signature | Type, method: string, handles?: readonly number[]): readonly Symbol[] {
-        return this.snapshotRegistry.fetchSymbols(source, method, handles, this.projectId);
+        return this.snapshotRegistry.fetchSymbols(source, method, handles, this.project.id);
     }
 
     // getBaseTypes is a checker-level endpoint keyed by `type` (not `objectId`),
@@ -522,7 +513,7 @@ class ProjectObjectRegistry {
     fetchBaseTypes(source: Type): readonly Type[] {
         const typesData = this.client.apiRequest<TypeResponse[] | null>("getBaseTypes", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: source.id,
         });
         if (typesData == null) return [];
@@ -561,10 +552,10 @@ export class Project {
             sourceFileCache,
             toPath,
         );
-        const objectRegistry = new ProjectObjectRegistry(client, snapshotId, this.id, snapshotRegistry);
+        const objectRegistry = new ProjectObjectRegistry(client, snapshotId, this, snapshotRegistry);
         this.checker = new Checker(
             snapshotId,
-            this.id,
+            this,
             client,
             objectRegistry,
         );
@@ -790,19 +781,19 @@ export class Program {
 
 export class Checker {
     private snapshotId: number;
-    private projectId: Path;
+    private project: Project;
     private client: Client;
     private objectRegistry: ProjectObjectRegistry;
     private wellKnownSymbols: { unknown: number; undefined: number; arguments: number; } | undefined;
 
     constructor(
         snapshotId: number,
-        projectId: Path,
+        project: Project,
         client: Client,
         objectRegistry: ProjectObjectRegistry,
     ) {
         this.snapshotId = snapshotId;
-        this.projectId = projectId;
+        this.project = project;
         this.client = client;
         this.objectRegistry = objectRegistry;
     }
@@ -817,14 +808,14 @@ export class Checker {
         if (Array.isArray(nodeOrNodes)) {
             const data = this.client.apiRequest<(SymbolResponse | null)[]>("getSymbolsAtLocations", {
                 snapshot: this.snapshotId,
-                project: this.projectId,
+                project: this.project.id,
                 locations: nodeOrNodes.map(node => getNodeId(node)),
             });
             return data.map(d => d ? this.objectRegistry.getOrCreateSymbol(d) : undefined);
         }
         const data = this.client.apiRequest<SymbolResponse | null>("getSymbolAtLocation", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             location: getNodeId(nodeOrNodes as Node),
         });
         return data ? this.objectRegistry.getOrCreateSymbol(data) : undefined;
@@ -836,7 +827,7 @@ export class Checker {
         if (typeof positionOrPositions === "number") {
             const data = this.client.apiRequest<SymbolResponse | null>("getSymbolAtPosition", {
                 snapshot: this.snapshotId,
-                project: this.projectId,
+                project: this.project.id,
                 file,
                 position: positionOrPositions,
             });
@@ -844,7 +835,7 @@ export class Checker {
         }
         const data = this.client.apiRequest<(SymbolResponse | null)[]>("getSymbolsAtPositions", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             file,
             positions: positionOrPositions,
         });
@@ -857,14 +848,14 @@ export class Checker {
         if (Array.isArray(symbolOrSymbols)) {
             const data = this.client.apiRequest<(TypeResponse | null)[]>("getTypesOfSymbols", {
                 snapshot: this.snapshotId,
-                project: this.projectId,
+                project: this.project.id,
                 symbols: symbolOrSymbols.map(s => s.id),
             });
             return data.map(d => d ? this.objectRegistry.getOrCreateType(d) : undefined);
         }
         const data = this.client.apiRequest<TypeResponse | null>("getTypeOfSymbol", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             symbol: (symbolOrSymbols as Symbol).id,
         });
         return data ? this.objectRegistry.getOrCreateType(data) : undefined;
@@ -878,7 +869,7 @@ export class Checker {
     getDeclaredTypeOfSymbol(symbol: Symbol): Type {
         const data = this.client.apiRequest<TypeResponse | null>("getDeclaredTypeOfSymbol", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             symbol: symbol.id,
         });
         if (!data) throw new Error(`getDeclaredTypeOfSymbol returned no type for symbol ${symbol.id}`);
@@ -888,45 +879,43 @@ export class Checker {
     getReferencesToSymbolInFile(file: DocumentIdentifier, symbol: Symbol): NodeHandle[] {
         const data = this.client.apiRequest<string[] | null>("getReferencesToSymbolInFile", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             file,
             symbol: symbol.id,
         });
-        return (data ?? []).map(h => new NodeHandle(h, this.objectRegistry.getOwnProject()));
+        return (data ?? []).map(h => new NodeHandle(h, this.project));
     }
 
     getReferencedSymbolsForNode(node: Node, position: number): ReferencedSymbolEntry[] {
         const data = this.client.apiRequest<{ definition: string; symbol?: SymbolResponse; references: string[]; }[] | null>("getReferencedSymbolsForNode", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             node: getNodeId(node),
             position,
         });
-        const canonicalProject = this.objectRegistry.getOwnProject();
         return (data ?? []).map(entry => ({
-            definition: new NodeHandle(entry.definition, canonicalProject),
+            definition: new NodeHandle(entry.definition, this.project),
             symbol: entry.symbol ? this.objectRegistry.getOrCreateSymbol(entry.symbol) : undefined,
-            references: (entry.references ?? []).map(h => new NodeHandle(h, canonicalProject)),
+            references: (entry.references ?? []).map(h => new NodeHandle(h, this.project)),
         }));
     }
 
     getSignatureUsage(signatureDecl: Node): SignatureUsage[] {
         const data = this.client.apiRequest<{ name: string; call?: string; }[] | null>("getSignatureUsages", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             signatureDecl: getNodeId(signatureDecl),
         });
-        const canonicalProject = this.objectRegistry.getOwnProject();
         return (data ?? []).map(entry => ({
-            name: new NodeHandle(entry.name, canonicalProject),
-            call: entry.call ? new NodeHandle(entry.call, canonicalProject) : undefined,
+            name: new NodeHandle(entry.name, this.project),
+            call: entry.call ? new NodeHandle(entry.call, this.project) : undefined,
         }));
     }
 
     getCompletionsAtPosition(document: string, position: number, options?: CompletionOptions): CompletionInfo | undefined {
         const data = this.client.apiRequest<CompletionInfoResponse | null>("getCompletionsAtPosition", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             file: document,
             position,
             triggerCharacter: options?.triggerCharacter,
@@ -948,14 +937,14 @@ export class Checker {
         if (Array.isArray(nodeOrNodes)) {
             const data = this.client.apiRequest<(TypeResponse | null)[]>("getTypeAtLocations", {
                 snapshot: this.snapshotId,
-                project: this.projectId,
+                project: this.project.id,
                 locations: nodeOrNodes.map(node => getNodeId(node)),
             });
             return data.map(d => d ? this.objectRegistry.getOrCreateType(d) : undefined);
         }
         const data = this.client.apiRequest<TypeResponse | null>("getTypeAtLocation", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             location: getNodeId(nodeOrNodes as Node),
         });
         return data ? this.objectRegistry.getOrCreateType(data) : undefined;
@@ -964,7 +953,7 @@ export class Checker {
     getSignaturesOfType(type: Type, kind: SignatureKind): readonly Signature[] {
         const data = this.client.apiRequest<SignatureResponse[]>("getSignaturesOfType", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
             kind,
         });
@@ -974,7 +963,7 @@ export class Checker {
     getResolvedSignature(node: Node): Signature | undefined {
         const data = this.client.apiRequest<SignatureResponse | null>("getResolvedSignature", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             location: getNodeId(node),
         });
         return data ? this.objectRegistry.getOrCreateSignature(data) : undefined;
@@ -986,7 +975,7 @@ export class Checker {
         if (typeof positionOrPositions === "number") {
             const data = this.client.apiRequest<TypeResponse | null>("getTypeAtPosition", {
                 snapshot: this.snapshotId,
-                project: this.projectId,
+                project: this.project.id,
                 file,
                 position: positionOrPositions,
             });
@@ -994,7 +983,7 @@ export class Checker {
         }
         const data = this.client.apiRequest<(TypeResponse | null)[]>("getTypesAtPositions", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             file,
             positions: positionOrPositions,
         });
@@ -1011,7 +1000,7 @@ export class Checker {
         const isNode = location && "kind" in location;
         const data = this.client.apiRequest<SymbolResponse | null>("resolveName", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             name,
             meaning,
             location: isNode ? getNodeId(location as Node) : undefined,
@@ -1031,7 +1020,7 @@ export class Checker {
     getContextualType(node: Expression): Type | undefined {
         const data = this.client.apiRequest<TypeResponse | null>("getContextualType", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             location: getNodeId(node),
         });
         return data ? this.objectRegistry.getOrCreateType(data) : undefined;
@@ -1040,7 +1029,7 @@ export class Checker {
     getBaseTypeOfLiteralType(type: Type): Type | undefined {
         const data = this.client.apiRequest<TypeResponse | null>("getBaseTypeOfLiteralType", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
         });
         return data ? this.objectRegistry.getOrCreateType(data) : undefined;
@@ -1049,7 +1038,7 @@ export class Checker {
     getNonNullableType(type: Type): Type | undefined {
         const data = this.client.apiRequest<TypeResponse | null>("getNonNullableType", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
         });
         return data ? this.objectRegistry.getOrCreateType(data) : undefined;
@@ -1058,7 +1047,7 @@ export class Checker {
     getTypeFromTypeNode(node: TypeNode): Type | undefined {
         const data = this.client.apiRequest<TypeResponse | null>("getTypeFromTypeNode", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             location: getNodeId(node),
         });
         return data ? this.objectRegistry.getOrCreateType(data) : undefined;
@@ -1067,7 +1056,7 @@ export class Checker {
     getWidenedType(type: Type): Type | undefined {
         const data = this.client.apiRequest<TypeResponse | null>("getWidenedType", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
         });
         return data ? this.objectRegistry.getOrCreateType(data) : undefined;
@@ -1076,7 +1065,7 @@ export class Checker {
     getParameterType(signature: Signature, index: number): Type | undefined {
         const data = this.client.apiRequest<TypeResponse | null>("getParameterType", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             signature: signature.id,
             index,
         });
@@ -1086,7 +1075,7 @@ export class Checker {
     isArrayLikeType(type: Type): boolean {
         return this.client.apiRequest<boolean>("isArrayLikeType", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
         });
     }
@@ -1094,7 +1083,7 @@ export class Checker {
     isTypeAssignableTo(source: Type, target: Type): boolean {
         return this.client.apiRequest<boolean>("isTypeAssignableTo", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             source: source.id,
             target: target.id,
         });
@@ -1103,7 +1092,7 @@ export class Checker {
     getShorthandAssignmentValueSymbol(node: Node): Symbol | undefined {
         const data = this.client.apiRequest<SymbolResponse | null>("getShorthandAssignmentValueSymbol", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             location: getNodeId(node),
         });
         return data ? this.objectRegistry.getOrCreateSymbol(data) : undefined;
@@ -1117,7 +1106,7 @@ export class Checker {
     getTypeOfSymbolAtLocation(symbol: Symbol, location: Node): Type {
         const data = this.client.apiRequest<TypeResponse | null>("getTypeOfSymbolAtLocation", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             symbol: symbol.id,
             location: getNodeId(location),
         });
@@ -1128,7 +1117,7 @@ export class Checker {
     private getIntrinsicType(method: string): Type {
         const data = this.client.apiRequest<TypeResponse>(method, {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
         });
         return this.objectRegistry.getOrCreateType(data);
     }
@@ -1170,7 +1159,7 @@ export class Checker {
     typeToTypeNode(type: Type, enclosingDeclaration?: Node, flags?: number): TypeNode | undefined {
         const binaryData = this.client.apiRequestBinary("typeToTypeNode", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
             location: enclosingDeclaration ? getNodeId(enclosingDeclaration) : undefined,
             flags,
@@ -1182,7 +1171,7 @@ export class Checker {
     signatureToSignatureDeclaration(signature: Signature, kind: SyntaxKind, enclosingDeclaration?: Node, flags?: NodeBuilderFlags): Node | undefined {
         const binaryData = this.client.apiRequestBinary("signatureToSignatureDeclaration", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             signature: signature.id,
             kind,
             location: enclosingDeclaration ? getNodeId(enclosingDeclaration) : undefined,
@@ -1195,7 +1184,7 @@ export class Checker {
     typeToString(type: Type, enclosingDeclaration?: Node, flags?: number): string {
         return this.client.apiRequest<string>("typeToString", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
             location: enclosingDeclaration ? getNodeId(enclosingDeclaration) : undefined,
             flags,
@@ -1205,7 +1194,7 @@ export class Checker {
     isContextSensitive(node: Node): boolean {
         return this.client.apiRequest<boolean>("isContextSensitive", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             location: getNodeId(node),
         });
     }
@@ -1213,7 +1202,7 @@ export class Checker {
     isArrayType(type: Type): boolean {
         return this.client.apiRequest<boolean>("isArrayType", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
         });
     }
@@ -1221,7 +1210,7 @@ export class Checker {
     isTupleType(type: Type): boolean {
         return this.client.apiRequest<boolean>("isTupleType", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
         });
     }
@@ -1229,7 +1218,7 @@ export class Checker {
     getReturnTypeOfSignature(signature: Signature): Type | undefined {
         const data = this.client.apiRequest<TypeResponse | null>("getReturnTypeOfSignature", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             signature: signature.id,
         });
         return data ? this.objectRegistry.getOrCreateType(data) : undefined;
@@ -1238,7 +1227,7 @@ export class Checker {
     getRestTypeOfSignature(signature: Signature): Type | undefined {
         const data = this.client.apiRequest<TypeResponse | null>("getRestTypeOfSignature", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             signature: signature.id,
         });
         return data ? this.objectRegistry.getOrCreateType(data) : undefined;
@@ -1247,7 +1236,7 @@ export class Checker {
     getTypePredicateOfSignature(signature: Signature): TypePredicate | undefined {
         const data = this.client.apiRequest<TypePredicateResponse | null>("getTypePredicateOfSignature", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             signature: signature.id,
         });
         if (!data) return undefined;
@@ -1266,7 +1255,7 @@ export class Checker {
     getBaseTypes(type: InterfaceType): readonly Type[] {
         const data = this.client.apiRequest<TypeResponse[] | null>("getBaseTypes", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
         });
         return data ? data.map(d => this.objectRegistry.getOrCreateType(d)) : [];
@@ -1275,7 +1264,7 @@ export class Checker {
     getApparentType(type: Type): Type | undefined {
         const data = this.client.apiRequest<TypeResponse | null>("getApparentType", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
         });
         return data ? this.objectRegistry.getOrCreateType(data) : undefined;
@@ -1284,7 +1273,7 @@ export class Checker {
     getPropertiesOfType(type: Type): readonly Symbol[] {
         const data = this.client.apiRequest<SymbolResponse[] | null>("getPropertiesOfType", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
         });
         return data ? data.map(d => this.objectRegistry.getOrCreateSymbol(d)) : [];
@@ -1293,7 +1282,7 @@ export class Checker {
     getIndexInfosOfType(type: Type): readonly IndexInfo[] {
         const data = this.client.apiRequest<IndexInfoResponse[] | null>("getIndexInfosOfType", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
         });
         if (!data) return [];
@@ -1301,7 +1290,7 @@ export class Checker {
             keyType: this.objectRegistry.getOrCreateType(d.keyType),
             valueType: this.objectRegistry.getOrCreateType(d.valueType),
             isReadonly: d.isReadonly ?? false,
-            declaration: d.declaration ? new NodeHandle(d.declaration, this.objectRegistry.getOwnProject()) : undefined,
+            declaration: d.declaration ? new NodeHandle(d.declaration, this.project) : undefined,
         }));
     }
 
@@ -1312,7 +1301,7 @@ export class Checker {
     getConstraintOfTypeParameter(type: TypeParameter): Type | undefined {
         const data = this.client.apiRequest<TypeResponse | null>("getConstraintOfTypeParameter", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
         });
         return data ? this.objectRegistry.getOrCreateType(data) : undefined;
@@ -1321,7 +1310,7 @@ export class Checker {
     getBaseConstraintOfType(type: Type): Type | undefined {
         const data = this.client.apiRequest<TypeResponse | null>("getBaseConstraintOfType", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
         });
         return data ? this.objectRegistry.getOrCreateType(data) : undefined;
@@ -1330,7 +1319,7 @@ export class Checker {
     getPropertyOfType(type: Type, name: string): Symbol | undefined {
         const data = this.client.apiRequest<SymbolResponse | null>("getPropertyOfType", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
             name,
         });
@@ -1340,7 +1329,7 @@ export class Checker {
     getConstantValue(node: Node): string | number | undefined {
         const data = this.client.apiRequest<string | number | null>("getConstantValue", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             location: getNodeId(node),
         });
         return data ?? undefined;
@@ -1349,7 +1338,7 @@ export class Checker {
     getSignatureFromDeclaration(node: Node): Signature | undefined {
         const data = this.client.apiRequest<SignatureResponse | null>("getSignatureFromDeclaration", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             location: getNodeId(node),
         });
         return data ? this.objectRegistry.getOrCreateSignature(data) : undefined;
@@ -1358,7 +1347,7 @@ export class Checker {
     getExportSpecifierLocalTargetSymbol(node: Node): Symbol | undefined {
         const data = this.client.apiRequest<SymbolResponse | null>("getExportSpecifierLocalTargetSymbol", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             location: getNodeId(node),
         });
         return data ? this.objectRegistry.getOrCreateSymbol(data) : undefined;
@@ -1372,7 +1361,7 @@ export class Checker {
     getAliasedSymbol(symbol: Symbol): Symbol {
         const data = this.client.apiRequest<SymbolResponse | null>("getAliasedSymbol", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             symbol: symbol.id,
         });
         if (!data) throw new Error(`getAliasedSymbol returned no symbol for symbol ${symbol.id}`);
@@ -1382,7 +1371,7 @@ export class Checker {
     getImmediateAliasedSymbol(symbol: Symbol): Symbol | undefined {
         const data = this.client.apiRequest<SymbolResponse | null>("getImmediateAliasedSymbol", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             symbol: symbol.id,
         });
         return data ? this.objectRegistry.getOrCreateSymbol(data) : undefined;
@@ -1397,7 +1386,7 @@ export class Checker {
     private getWellKnownSymbols(): { unknown: number; undefined: number; arguments: number; } {
         return this.wellKnownSymbols ??= this.client.apiRequest<{ unknown: number; undefined: number; arguments: number; }>("getWellKnownSymbols", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
         });
     }
 
@@ -1426,7 +1415,7 @@ export class Checker {
     getExportsOfModule(symbol: Symbol): readonly Symbol[] {
         const data = this.client.apiRequest<SymbolResponse[] | null>("getExportsOfModule", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             symbol: symbol.id,
         });
         return data ? data.map(d => this.objectRegistry.getOrCreateSymbol(d)) : [];
@@ -1435,7 +1424,7 @@ export class Checker {
     getMemberInModuleExports(symbol: Symbol, name: string): Symbol | undefined {
         const data = this.client.apiRequest<SymbolResponse | null>("getMemberInModuleExports", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             symbol: symbol.id,
             name,
         });
@@ -1445,7 +1434,7 @@ export class Checker {
     getJsDocTagsOfSymbol(symbol: Symbol): readonly JSDocTagInfo[] {
         const data = this.client.apiRequest<JSDocTagInfo[] | null>("getJsDocTags", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             symbol: symbol.id,
         });
         return data ?? [];
@@ -1454,7 +1443,7 @@ export class Checker {
     getDocumentationCommentOfSymbol(symbol: Symbol): string {
         return this.client.apiRequest<string>("getDocumentationComment", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             symbol: symbol.id,
         });
     }
@@ -1465,7 +1454,7 @@ export class Checker {
     getTypeArguments(type: TypeReference): readonly Type[] {
         const data = this.client.apiRequest<TypeResponse[] | null>("getTypeArguments", {
             snapshot: this.snapshotId,
-            project: this.projectId,
+            project: this.project.id,
             type: type.id,
         });
         return data ? data.map(d => this.objectRegistry.getOrCreateType(d)) : [];
@@ -1972,11 +1961,11 @@ export class Signature {
     readonly thisParameter?: number | undefined;
     readonly target?: number | undefined;
 
-    constructor(data: SignatureResponse, objectRegistry: ProjectObjectRegistry) {
+    constructor(data: SignatureResponse, project: Project, objectRegistry: ProjectObjectRegistry) {
         this.id = data.id;
         this.flags = data.flags;
         this.objectRegistry = objectRegistry;
-        this.declaration = data.declaration ? new NodeHandle(data.declaration, objectRegistry.getOwnProject()) : undefined;
+        this.declaration = data.declaration ? new NodeHandle(data.declaration, project) : undefined;
         this.typeParameters = data.typeParameters ?? [];
         this.parameters = data.parameters ?? [];
         this.thisParameter = data.thisParameter;

--- a/_packages/native-preview/test/async/api.test.ts
+++ b/_packages/native-preview/test/async/api.test.ts
@@ -1237,6 +1237,10 @@ export class Cache {
             assert.ok(sig.declaration);
             const node = await sig.declaration.resolve(project);
             assert.ok(node);
+            // The handle remembers its canonical project, so resolve() works without an argument.
+            const nodeFromCanonical = await sig.declaration.resolve();
+            assert.ok(nodeFromCanonical);
+            assert.strictEqual(nodeFromCanonical.kind, node.kind);
 
             const methodPos = src.indexOf("getValue");
             const methodSymbol = await project.checker.getSymbolAtPosition("/src/main.ts", methodPos);
@@ -1246,6 +1250,10 @@ export class Cache {
             assert.ok(methodNode);
             assert.strictEqual(methodNode.parent.kind, SyntaxKind.ClassDeclaration);
             assert.strictEqual(methodNode.parent.parent.kind, SyntaxKind.SourceFile);
+            // A symbol's declaration handles default to the symbol's canonical project.
+            const methodNodeFromCanonical = await methodSymbol.valueDeclaration.resolve();
+            assert.ok(methodNodeFromCanonical);
+            assert.strictEqual(methodNodeFromCanonical.kind, methodNode.kind);
         }
         finally {
             await api.close();

--- a/_packages/native-preview/test/sync/api.test.ts
+++ b/_packages/native-preview/test/sync/api.test.ts
@@ -1245,6 +1245,10 @@ export class Cache {
             assert.ok(sig.declaration);
             const node = sig.declaration.resolve(project);
             assert.ok(node);
+            // The handle remembers its canonical project, so resolve() works without an argument.
+            const nodeFromCanonical = sig.declaration.resolve();
+            assert.ok(nodeFromCanonical);
+            assert.strictEqual(nodeFromCanonical.kind, node.kind);
 
             const methodPos = src.indexOf("getValue");
             const methodSymbol = project.checker.getSymbolAtPosition("/src/main.ts", methodPos);
@@ -1254,6 +1258,10 @@ export class Cache {
             assert.ok(methodNode);
             assert.strictEqual(methodNode.parent.kind, SyntaxKind.ClassDeclaration);
             assert.strictEqual(methodNode.parent.parent.kind, SyntaxKind.SourceFile);
+            // A symbol's declaration handles default to the symbol's canonical project.
+            const methodNodeFromCanonical = methodSymbol.valueDeclaration.resolve();
+            assert.ok(methodNodeFromCanonical);
+            assert.strictEqual(methodNodeFromCanonical.kind, methodNode.kind);
         }
         finally {
             api.close();

--- a/internal/api/proto.go
+++ b/internal/api/proto.go
@@ -536,6 +536,7 @@ type GetSymbolsAtLocationsParams struct {
 
 type SymbolResponse struct {
 	Id               SymbolID     `json:"id"`
+	Project          ProjectID    `json:"project"`
 	Name             string       `json:"name"`
 	Flags            uint32       `json:"flags"`
 	CheckFlags       uint32       `json:"checkFlags"`
@@ -787,6 +788,7 @@ type GetTypePropertyParams struct {
 // GetSymbolPropertyParams is used for all symbol sub-property endpoints.
 type GetSymbolPropertyParams struct {
 	Snapshot SnapshotID `json:"snapshot"`
+	Project  ProjectID  `json:"project"`
 	Symbol   SymbolID   `json:"objectId"`
 }
 

--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -43,6 +44,14 @@ type snapshotData struct {
 	// querying the same symbol from two different projects returns the same handle.
 	symbolRegistry   map[SymbolID]*ast.Symbol
 	symbolRegistryMu sync.RWMutex
+
+	// symbolCanonicalProjects records, for each registered symbol, the project it was
+	// first observed in. Because symbols are shared snapshot-wide (binder symbols are
+	// attached to source files, which can be shared across projects), lookups that need
+	// a project context (e.g. member/export ordering, node handle resolution) but don't
+	// receive one from the caller default to this canonical project. First-writer wins so
+	// the choice is stable. Guarded by symbolRegistryMu.
+	symbolCanonicalProjects map[SymbolID]ProjectID
 
 	projectRegistries   map[ProjectID]*projectRegistryData
 	projectRegistriesMu sync.RWMutex
@@ -120,13 +129,18 @@ func (sd *snapshotData) getOrCreateProjectRegistry(projectID ProjectID) *project
 }
 
 // newSymbolResponse registers a symbol in the snapshot's registry and returns the response.
-func (sd *snapshotData) newSymbolResponse(symbol *ast.Symbol) *SymbolResponse {
+// canonicalProject is the project the symbol was observed in and must be non-empty; it is recorded
+// as the symbol's canonical project (first writer wins) and returned to the client so it can default
+// project-scoped follow-up lookups (members/exports, node resolution) to it.
+func (sd *snapshotData) newSymbolResponse(symbol *ast.Symbol, canonicalProject ProjectID) *SymbolResponse {
 	if symbol == nil {
 		return nil
 	}
 
+	id, project := sd.registerSymbol(symbol, canonicalProject)
 	resp := &SymbolResponse{
-		Id:         sd.registerSymbol(symbol),
+		Id:         id,
+		Project:    project,
 		Name:       ast.EscapeSymbolName(symbol.Name),
 		Flags:      uint32(symbol.Flags),
 		CheckFlags: uint32(symbol.CheckFlags),
@@ -154,9 +168,17 @@ func (sd *snapshotData) newSymbolResponse(symbol *ast.Symbol) *SymbolResponse {
 	return resp
 }
 
-func (sd *snapshotData) registerSymbol(symbol *ast.Symbol) SymbolID {
+// registerSymbol registers a symbol in the snapshot's registry and returns its handle along with
+// its canonical project. The canonical project is the project the symbol was first observed in
+// (first writer wins for stability) and is always non-empty: every symbol handed to a client must
+// carry a project so that project-scoped follow-up lookups (members/exports, parent, node
+// resolution) have a default context. Callers must supply a non-empty project.
+func (sd *snapshotData) registerSymbol(symbol *ast.Symbol, canonicalProject ProjectID) (SymbolID, ProjectID) {
 	if symbol == nil {
-		return 0
+		return 0, ""
+	}
+	if canonicalProject == "" {
+		panic("registerSymbol requires a non-empty canonical project")
 	}
 	id := SymbolHandle(symbol)
 	sd.symbolRegistryMu.Lock()
@@ -166,10 +188,15 @@ func (sd *snapshotData) registerSymbol(symbol *ast.Symbol) SymbolID {
 		if existing != symbol {
 			panic("duplicate symbol")
 		}
-		return id
+	} else {
+		sd.symbolRegistry[id] = symbol
 	}
-	sd.symbolRegistry[id] = symbol
-	return id
+	project, ok := sd.symbolCanonicalProjects[id]
+	if !ok {
+		sd.symbolCanonicalProjects[id] = canonicalProject
+		project = canonicalProject
+	}
+	return id, project
 }
 
 // newTypeResponse registers a type in the project's registry and returns the response.
@@ -439,7 +466,7 @@ func (setup checkerSetup) newTypeResponse(t *checker.Type) *TypeResponse {
 }
 
 func (setup checkerSetup) newSymbolResponse(sym *ast.Symbol) *SymbolResponse {
-	return setup.sd.newSymbolResponse(sym)
+	return setup.sd.newSymbolResponse(sym, setup.projectID)
 }
 
 func (setup checkerSetup) newSignatureResponse(sig *checker.Signature) *SignatureResponse {
@@ -907,10 +934,11 @@ func (s *Session) handleUpdateSnapshot(ctx context.Context, params *UpdateSnapsh
 		sd.refCount++
 	} else {
 		sd = &snapshotData{
-			snapshot:          snapshot,
-			refCount:          1,
-			symbolRegistry:    make(map[SymbolID]*ast.Symbol),
-			projectRegistries: make(map[ProjectID]*projectRegistryData),
+			snapshot:                snapshot,
+			refCount:                1,
+			symbolRegistry:          make(map[SymbolID]*ast.Symbol),
+			symbolCanonicalProjects: make(map[SymbolID]ProjectID),
+			projectRegistries:       make(map[ProjectID]*projectRegistryData),
 		}
 		s.snapshots[handle] = sd
 	}
@@ -1456,14 +1484,14 @@ func (s *Session) handleGetParentOfSymbol(_ context.Context, params *GetSymbolPr
 	return s.resolveSymbolPropertyOfSymbol(params, func(sym *ast.Symbol) *ast.Symbol { return sym.Parent })
 }
 
-func (s *Session) handleGetMembersOfSymbol(_ context.Context, params *GetSymbolPropertyParams) ([]*SymbolResponse, error) {
-	return s.resolveSymbolTablePropertyOfSymbol(params, func(symbol *ast.Symbol) ast.SymbolTable {
+func (s *Session) handleGetMembersOfSymbol(ctx context.Context, params *GetSymbolPropertyParams) ([]*SymbolResponse, error) {
+	return s.resolveSymbolTablePropertyOfSymbol(ctx, params, func(symbol *ast.Symbol) ast.SymbolTable {
 		return symbol.Members
 	})
 }
 
-func (s *Session) handleGetExportsOfSymbol(_ context.Context, params *GetSymbolPropertyParams) ([]*SymbolResponse, error) {
-	return s.resolveSymbolTablePropertyOfSymbol(params, func(symbol *ast.Symbol) ast.SymbolTable {
+func (s *Session) handleGetExportsOfSymbol(ctx context.Context, params *GetSymbolPropertyParams) ([]*SymbolResponse, error) {
+	return s.resolveSymbolTablePropertyOfSymbol(ctx, params, func(symbol *ast.Symbol) ast.SymbolTable {
 		return symbol.Exports
 	})
 }
@@ -1622,7 +1650,7 @@ func (s *Session) resolveSymbolPropertyOfType(params *GetTypePropertyParams, get
 	if result == nil {
 		return nil, nil
 	}
-	return sd.newSymbolResponse(result), nil
+	return sd.newSymbolResponse(result, params.Project), nil
 }
 
 // resolveSymbolTablePropertyOfSymbol resolves a symbol property of type `Symbol` and returns a symbol response.
@@ -1641,29 +1669,38 @@ func (s *Session) resolveSymbolPropertyOfSymbol(params *GetSymbolPropertyParams,
 	if result == nil {
 		return nil, nil
 	}
-	return sd.newSymbolResponse(result), nil
+	return sd.newSymbolResponse(result, params.Project), nil
 }
 
 // resolveSymbolTablePropertyOfSymbol resolves a symbol property of type `SymbolTable` and returns an array of symbol responses.
-func (s *Session) resolveSymbolTablePropertyOfSymbol(params *GetSymbolPropertyParams, getter func(*ast.Symbol) ast.SymbolTable) ([]*SymbolResponse, error) {
-	sd, err := s.getSnapshotData(params.Snapshot)
+// Results are sorted using the checker's canonical symbol ordering so that API consumers receive
+// a stable, deterministic order instead of Go's randomized map iteration order.
+func (s *Session) resolveSymbolTablePropertyOfSymbol(ctx context.Context, params *GetSymbolPropertyParams, getter func(*ast.Symbol) ast.SymbolTable) ([]*SymbolResponse, error) {
+	setup, err := s.setupChecker(ctx, params.Snapshot, params.Project)
 	if err != nil {
 		return nil, err
 	}
+	defer setup.done()
 
-	symbol, err := sd.resolveSymbolHandle(params.Symbol)
+	symbol, err := setup.resolveSymbolHandle(params.Symbol)
 	if err != nil {
 		return nil, err
 	}
 
 	symbolTable := getter(symbol)
-	if symbolTable == nil || len(symbolTable) == 0 {
+	if len(symbolTable) == 0 {
 		return nil, nil
 	}
 
-	results := make([]*SymbolResponse, 0, len(symbolTable))
+	symbols := make([]*ast.Symbol, 0, len(symbolTable))
 	for _, sub := range symbolTable {
-		results = append(results, sd.newSymbolResponse(sub))
+		symbols = append(symbols, sub)
+	}
+	slices.SortFunc(symbols, setup.checker.CompareSymbols)
+
+	results := make([]*SymbolResponse, len(symbols))
+	for i, sub := range symbols {
+		results[i] = setup.newSymbolResponse(sub)
 	}
 	return results, nil
 }
@@ -1687,7 +1724,7 @@ func (s *Session) resolveSymbolArrayPropertyOfSignature(params *GetSignatureProp
 
 	results := make([]*SymbolResponse, len(symbols))
 	for i, sym := range symbols {
-		results[i] = sd.newSymbolResponse(sym)
+		results[i] = sd.newSymbolResponse(sym, params.Project)
 	}
 	return results, nil
 }
@@ -1708,7 +1745,7 @@ func (s *Session) resolveSymbolPropertyOfSignature(params *GetSignaturePropertyP
 	if result == nil {
 		return nil, nil
 	}
-	return sd.newSymbolResponse(result), nil
+	return sd.newSymbolResponse(result, params.Project), nil
 }
 
 func (s *Session) resolveTypeArrayPropertyOfSignature(params *GetSignaturePropertyParams, getter func(signature *checker.Signature) []*checker.Type) ([]*TypeResponse, error) {
@@ -2129,10 +2166,13 @@ func (s *Session) handleGetWellKnownSymbols(ctx context.Context, params *GetIntr
 	}
 	defer setup.done()
 
+	unknown, _ := setup.sd.registerSymbol(setup.checker.GetUnknownSymbol(), setup.projectID)
+	undefined, _ := setup.sd.registerSymbol(setup.checker.GetUndefinedSymbol(), setup.projectID)
+	arguments, _ := setup.sd.registerSymbol(setup.checker.GetArgumentsSymbol(), setup.projectID)
 	return &WellKnownSymbolsResponse{
-		Unknown:   setup.sd.registerSymbol(setup.checker.GetUnknownSymbol()),
-		Undefined: setup.sd.registerSymbol(setup.checker.GetUndefinedSymbol()),
-		Arguments: setup.sd.registerSymbol(setup.checker.GetArgumentsSymbol()),
+		Unknown:   unknown,
+		Undefined: undefined,
+		Arguments: arguments,
 	}, nil
 }
 
@@ -2564,6 +2604,7 @@ func (s *Session) handleGetExportsOfModule(ctx context.Context, params *CheckerS
 	if len(exports) == 0 {
 		return nil, nil
 	}
+	slices.SortFunc(exports, setup.checker.CompareSymbols)
 
 	results := make([]*SymbolResponse, len(exports))
 	for i, exp := range exports {
@@ -3180,7 +3221,7 @@ func (s *Session) handleGetCompletionsAtPosition(ctx context.Context, params *Ge
 			}
 		}
 		if item.Symbol != nil {
-			entry.Symbol = sd.newSymbolResponse(item.Symbol)
+			entry.Symbol = sd.newSymbolResponse(item.Symbol, params.Project)
 		}
 		entries = append(entries, entry)
 	}
@@ -3237,7 +3278,7 @@ func (s *Session) handleGetReferencedSymbolsForNode(ctx context.Context, params 
 			References: refs,
 		}
 		if sym := entry.DefinitionSymbol(); sym != nil {
-			re.Symbol = sd.newSymbolResponse(sym)
+			re.Symbol = sd.newSymbolResponse(sym, params.Project)
 		}
 		result = append(result, re)
 	}

--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -1676,13 +1676,12 @@ func (s *Session) resolveSymbolPropertyOfSymbol(params *GetSymbolPropertyParams,
 // Results are sorted using the checker's canonical symbol ordering so that API consumers receive
 // a stable, deterministic order instead of Go's randomized map iteration order.
 func (s *Session) resolveSymbolTablePropertyOfSymbol(ctx context.Context, params *GetSymbolPropertyParams, getter func(*ast.Symbol) ast.SymbolTable) ([]*SymbolResponse, error) {
-	setup, err := s.setupChecker(ctx, params.Snapshot, params.Project)
+	sd, err := s.getSnapshotData(params.Snapshot)
 	if err != nil {
 		return nil, err
 	}
-	defer setup.done()
 
-	symbol, err := setup.resolveSymbolHandle(params.Symbol)
+	symbol, err := sd.resolveSymbolHandle(params.Symbol)
 	if err != nil {
 		return nil, err
 	}
@@ -1691,6 +1690,18 @@ func (s *Session) resolveSymbolTablePropertyOfSymbol(ctx context.Context, params
 	if len(symbolTable) == 0 {
 		return nil, nil
 	}
+	if len(symbolTable) == 1 {
+		for _, sub := range symbolTable {
+			return []*SymbolResponse{sd.newSymbolResponse(sub, params.Project)}, nil
+		}
+	}
+
+	// More than one symbol, need a checker to sort
+	setup, err := s.setupChecker(ctx, params.Snapshot, params.Project)
+	if err != nil {
+		return nil, err
+	}
+	defer setup.done()
 
 	symbols := make([]*ast.Symbol, 0, len(symbolTable))
 	for _, sub := range symbolTable {

--- a/internal/checker/exports.go
+++ b/internal/checker/exports.go
@@ -349,3 +349,7 @@ func (c *Checker) RemoveMissingOrUndefinedType(t *Type) *Type {
 func (c *Checker) GetWidenedType(t *Type) *Type {
 	return c.getWidenedType(t)
 }
+
+func (c *Checker) CompareSymbols(s1, s2 *ast.Symbol) int {
+	return c.compareSymbols(s1, s2)
+}

--- a/internal/checker/utilities.go
+++ b/internal/checker/utilities.go
@@ -340,6 +340,13 @@ func (c *Checker) sortSymbols(symbols []*ast.Symbol) {
 	slices.SortFunc(symbols, c.compareSymbols)
 }
 
+// CompareSymbols compares two symbols to produce a stable, deterministic ordering.
+// It orders by the containing file's index in the program and then by declaration
+// position, falling back to name and symbol id.
+func (c *Checker) CompareSymbols(s1, s2 *ast.Symbol) int {
+	return c.compareSymbols(s1, s2)
+}
+
 func (c *Checker) compareSymbolsWorker(s1, s2 *ast.Symbol) int {
 	if s1 == s2 {
 		return 0

--- a/internal/checker/utilities.go
+++ b/internal/checker/utilities.go
@@ -340,13 +340,6 @@ func (c *Checker) sortSymbols(symbols []*ast.Symbol) {
 	slices.SortFunc(symbols, c.compareSymbols)
 }
 
-// CompareSymbols compares two symbols to produce a stable, deterministic ordering.
-// It orders by the containing file's index in the program and then by declaration
-// position, falling back to name and symbol id.
-func (c *Checker) CompareSymbols(s1, s2 *ast.Symbol) int {
-	return c.compareSymbols(s1, s2)
-}
-
 func (c *Checker) compareSymbolsWorker(s1, s2 *ast.Symbol) int {
 	if s1 == s2 {
 		return 0


### PR DESCRIPTION
`symbol.getExports()` and `symbol.getMembers()` go from a Go map to a slice to a JSON array over the wire and then back to a JS map, which means clients were seeing random iteration order; the conversion forgot to do any sorting when converting from a Go map.

However, this brought up an issue: sorting symbols requires a type checker, because one input to the sort algorithm is the checker's file order. But binder-produced symbols are attached to SourceFiles, which can be shared by multiple projects and therefore processed by multiple checkers. The API client stores Symbol objects independently of projects/checkers so a query against two different checkers that returns the same symbol will yield the same reference-equal client-side object. But this makes it inconvenient to simply ask for a Symbol's members—you would need to provide a Checker just to get the ordering, and if that Symbol was legitimately a part of two different programs, the order you get back would depend on which Checker you provide.

The overwhelmingly common case is dealing with only one project for any given Symbol—whichever project you arrived at that Symbol reference by. So, Symbols now store a reference to that project, while still maintaining reference equality across the projects that contain them. This gives them a default Checker to use for sorting their members and exports.

I also extended this convenience to `NodeHandle`. For similar reasons, you had to provide a Project to `symbol.valueDeclaration.resolve(project)`, because different projects with different compiler options could actually parse the SourceFile referenced by `valueDeclaration` differently. Now, the `project` parameter is optional, and defaults to the canonical project of the Symbol.