### PR TITLE
Test and fix nonlocal callable variance cycles

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -734,6 +734,7 @@ type Checker struct {
 	uniqueLiteralType                           *Type
 	uniqueLiteralMapper                         *TypeMapper
 	reliabilityFlags                            RelationComparisonResult
+	varianceStack                               []*ast.Symbol
 	reportUnreliableMapper                      *TypeMapper
 	reportUnmeasurableMapper                    *TypeMapper
 	restrictiveMapper                           *TypeMapper

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -61,6 +61,58 @@ foo.bar;`
 	}
 }
 
+func TestNonlocalCallableVarianceCycleDoesNotInferIndependence(t *testing.T) {
+	t.Parallel()
+
+	content := `
+interface ActionArgs<T> {
+  context: T;
+}
+type ActionFunction<T> = {
+  (args: ActionArgs<T>): void;
+};`
+	fs := vfstest.FromMap(map[string]string{
+		"/variance.ts": content,
+		"/tsconfig.json": `
+				{
+					"compilerOptions": {
+						"strict": true
+					},
+					"files": ["variance.ts"]
+				}
+			`,
+	}, false /*useCaseSensitiveFileNames*/)
+	fs = bundled.WrapFS(fs)
+
+	cd := "/"
+	host := compiler.NewCompilerHost(cd, fs, bundled.LibPath(), nil, nil)
+
+	parsed, errors := tsoptions.GetParsedCommandLineOfConfigFile("/tsconfig.json", &core.CompilerOptions{}, nil, host, nil)
+	assert.Equal(t, len(errors), 0, "Expected no errors in parsed command line")
+
+	p := compiler.NewProgram(compiler.ProgramOptions{
+		Config: parsed,
+		Host:   host,
+	})
+	p.BindSourceFiles()
+	c, done := p.GetTypeChecker(t.Context())
+	defer done()
+
+	file := p.GetSourceFile("/variance.ts")
+	actionArgsSymbol := c.GetSymbolAtLocation(file.Statements.Nodes[0].Name())
+	actionFunctionSymbol := c.GetSymbolAtLocation(file.Statements.Nodes[1].Name())
+	c.GetDeclaredTypeOfSymbol(actionArgsSymbol)
+	c.GetDeclaredTypeOfSymbol(actionFunctionSymbol)
+
+	restore := c.MarkVarianceInProgressForTesting(actionArgsSymbol)
+	defer restore()
+
+	variances := c.GetAliasVariancesForTesting(actionFunctionSymbol)
+	assert.Equal(t, len(variances), 1)
+	assert.Equal(t, variances[0]&checker.VarianceFlagsVarianceMask, checker.VarianceFlagsInvariant)
+	assert.Assert(t, variances[0]&checker.VarianceFlagsUnreliable != 0)
+}
+
 func BenchmarkNewChecker(b *testing.B) {
 	repo.SkipIfNoTypeScriptSubmodule(b)
 	fs := osvfs.FS()

--- a/internal/checker/export_test.go
+++ b/internal/checker/export_test.go
@@ -1,0 +1,46 @@
+package checker
+
+import (
+	"reflect"
+	"unsafe"
+
+	"github.com/microsoft/typescript-go/internal/ast"
+)
+
+func (c *Checker) GetAliasVariancesForTesting(symbol *ast.Symbol) []VarianceFlags {
+	return c.getAliasVariances(symbol)
+}
+
+func (c *Checker) MarkVarianceInProgressForTesting(symbol *ast.Symbol) func() {
+	links := c.varianceLinks.Get(symbol)
+	oldVariances := links.variances
+	oldInVarianceComputation := c.inVarianceComputation
+
+	links.variances = []VarianceFlags{}
+	c.inVarianceComputation = true
+
+	var oldVarianceStack reflect.Value
+	var varianceStack reflect.Value
+	if stack, ok := varianceStackForTesting(c); ok {
+		varianceStack = stack
+		oldVarianceStack = reflect.MakeSlice(stack.Type(), stack.Len(), stack.Len())
+		reflect.Copy(oldVarianceStack, stack)
+		stack.Set(reflect.Append(stack, reflect.ValueOf(symbol)))
+	}
+
+	return func() {
+		links.variances = oldVariances
+		c.inVarianceComputation = oldInVarianceComputation
+		if varianceStack.IsValid() {
+			varianceStack.Set(oldVarianceStack)
+		}
+	}
+}
+
+func varianceStackForTesting(c *Checker) (reflect.Value, bool) {
+	field := reflect.ValueOf(c).Elem().FieldByName("varianceStack")
+	if !field.IsValid() {
+		return reflect.Value{}, false
+	}
+	return reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem(), true
+}

--- a/internal/checker/relater.go
+++ b/internal/checker/relater.go
@@ -1360,6 +1360,10 @@ func (c *Checker) getVariancesWorker(symbol *ast.Symbol, typeParameters []*Type)
 			c.inVarianceComputation = true
 			c.resolutionStart = len(c.typeResolutions)
 		}
+		c.varianceStack = append(c.varianceStack, symbol)
+		defer func() {
+			c.varianceStack = c.varianceStack[:len(c.varianceStack)-1]
+		}()
 		links.variances = []VarianceFlags{}
 		variances := make([]VarianceFlags, len(typeParameters))
 		for i, tp := range typeParameters {
@@ -1389,7 +1393,11 @@ func (c *Checker) getVariancesWorker(symbol *ast.Symbol, typeParameters []*Type)
 				// type). To determine this we compare instantiations where the type parameter is
 				// replaced with marker types that are known to be unrelated.
 				if variance == VarianceFlagsBivariant && c.isTypeAssignableTo(c.createMarkerType(symbol, tp, c.markerOtherType), typeWithSuper) {
-					variance = VarianceFlagsIndependent
+					if c.reliabilityFlags&(RelationComparisonResultReportsUnmeasurable|RelationComparisonResultReportsUnreliable) == 0 {
+						variance = VarianceFlagsIndependent
+					} else {
+						variance = VarianceFlagsInvariant
+					}
 				}
 				if c.reliabilityFlags&RelationComparisonResultReportsUnmeasurable != 0 {
 					variance |= VarianceFlagsUnmeasurable
@@ -1428,6 +1436,21 @@ func (c *Checker) createMarkerType(symbol *ast.Symbol, source *Type, target *Typ
 
 func (c *Checker) isMarkerType(t *Type) bool {
 	return c.markerTypes.Has(t)
+}
+
+func (c *Checker) reportUnreliableNonlocalVarianceCycle(symbol *ast.Symbol, source *Type, target *Type) {
+	if !c.inVarianceComputation || len(c.varianceStack) == 0 || c.varianceStack[len(c.varianceStack)-1] == symbol {
+		return
+	}
+	if !slices.Contains(c.varianceStack[:len(c.varianceStack)-1], symbol) {
+		return
+	}
+	declaredType := c.getDeclaredTypeOfSymbol(c.varianceStack[len(c.varianceStack)-1])
+	if declaredType.flags&TypeFlagsStructuredType == 0 || len(c.getSignaturesOfType(declaredType, SignatureKindCall)) == 0 && len(c.getSignaturesOfType(declaredType, SignatureKindConstruct)) == 0 {
+		return
+	}
+	c.instantiateType(source, c.reportUnreliableMapper)
+	c.instantiateType(target, c.reportUnreliableMapper)
 }
 
 func (c *Checker) getTypeParameterModifiers(tp *Type) ast.ModifierFlags {
@@ -3832,6 +3855,7 @@ func (r *Relater) structuredTypeRelatedToWorker(source *Type, target *Type, repo
 			// effectively means we measure variance only from type parameter occurrences that aren't nested in
 			// recursive instantiations of the generic type.
 			if len(variances) == 0 {
+				r.c.reportUnreliableNonlocalVarianceCycle(source.Target().symbol, source, target)
 				return TernaryUnknown
 			}
 			varianceResult, ok := relateVariances(r.c.getTypeArguments(source), r.c.getTypeArguments(target), variances, intersectionState)


### PR DESCRIPTION
This is what xstate hit in #4313. It's really hard to test because it depends on a very specific checker association and ordering.

Maybe @ahejlsberg can reason about this?