### PR TITLE
Fix wildcard directories being dropped for "./"-prefixed includes with dot-directory excludes

### DIFF
--- a/internal/project/projectlifetime_test.go
+++ b/internal/project/projectlifetime_test.go
@@ -287,7 +287,6 @@ func TestProjectLifetime(t *testing.T) {
 	// The failure was independent of the order in which didOpen and the create
 	// watch event arrived, so both orderings are covered.
 	runNewFileScenario := func(t *testing.T, openBeforeCreateEvent bool) {
-		t.Parallel()
 		files := map[string]any{
 			"/home/projects/TS/monorepo/tsconfig.json": `{
 				"compilerOptions": {
@@ -345,10 +344,12 @@ func TestProjectLifetime(t *testing.T) {
 	}
 
 	t.Run("newly created file joins configured project with ./-prefixed includes (didOpen before create event)", func(t *testing.T) {
+		t.Parallel()
 		runNewFileScenario(t, true)
 	})
 
 	t.Run("newly created file joins configured project with ./-prefixed includes (create event before didOpen)", func(t *testing.T) {
+		t.Parallel()
 		runNewFileScenario(t, false)
 	})
 

--- a/internal/project/projectlifetime_test.go
+++ b/internal/project/projectlifetime_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/microsoft/typescript-go/internal/bundled"
+	"github.com/microsoft/typescript-go/internal/core"
 	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
 	"github.com/microsoft/typescript-go/internal/testutil/projecttestutil"
 	"github.com/microsoft/typescript-go/internal/tspath"
@@ -272,6 +273,83 @@ func TestProjectLifetime(t *testing.T) {
 		assert.Equal(t, len(snapshot.ProjectCollection.Projects()), 1)
 		assert.Assert(t, snapshot.ProjectCollection.InferredProject() == nil)
 		assert.Assert(t, snapshot.ProjectCollection.ConfiguredProject(tspath.Path("/home/projects/ts/p1/tsconfig.json")) != nil)
+	})
+
+	// Regression test for https://github.com/microsoft/typescript-go/issues/3733
+	//
+	// "./"-prefixed include specs combined with a dot-directory exclude ("**/.*/")
+	// used to drop all wildcard directories for the config, so a newly created file
+	// never triggered a root file reload. The stale nested config never claimed the
+	// file, and default-project resolution assigned it to the ancestor project
+	// (parsed fresh from disk, so it did contain the file) — or the inferred project
+	// when no ancestor config matched — until the session was restarted. The file
+	// then had the wrong compiler options (e.g. no Temporal from lib ESNext).
+	// The failure was independent of the order in which didOpen and the create
+	// watch event arrived, so both orderings are covered.
+	runNewFileScenario := func(t *testing.T, openBeforeCreateEvent bool) {
+		t.Parallel()
+		files := map[string]any{
+			"/home/projects/TS/monorepo/tsconfig.json": `{
+				"compilerOptions": {
+					"target": "ES2015",
+					"lib": ["DOM"]
+				},
+				"include": ["apps"]
+			}`,
+			"/home/projects/TS/monorepo/apps/web/tsconfig.json": `{
+				"compilerOptions": {
+					"target": "ESNext",
+					"lib": ["ESNext"]
+				},
+				"include": ["./app/**/*.ts"],
+				"exclude": ["**/.*/"]
+			}`,
+			"/home/projects/TS/monorepo/apps/web/app/existing.ts": `export const existing = 1;`,
+		}
+		session, utils := projecttestutil.Setup(files)
+
+		// Open an existing file so the nested configured project loads.
+		existingUri := lsproto.DocumentUri("file:///home/projects/TS/monorepo/apps/web/app/existing.ts")
+		session.DidOpenFile(context.Background(), existingUri, 1, files["/home/projects/TS/monorepo/apps/web/app/existing.ts"].(string), lsproto.LanguageKindTypeScript)
+		ls, err := session.GetLanguageService(context.Background(), existingUri)
+		assert.NilError(t, err)
+		assert.Equal(t, ls.GetProgram().Options().Target, core.ScriptTargetESNext)
+
+		// Create a new file on disk in a directory matched by the nested config's
+		// wildcard include, then simulate the editor events in the given order.
+		newFileContent := `export const newFile = 1;`
+		newFileUri := lsproto.DocumentUri("file:///home/projects/TS/monorepo/apps/web/app/subdir/new.ts")
+		assert.NilError(t, utils.FS().WriteFile("/home/projects/TS/monorepo/apps/web/app/subdir/new.ts", newFileContent))
+		openNewFile := func() {
+			session.DidOpenFile(context.Background(), newFileUri, 1, newFileContent, lsproto.LanguageKindTypeScript)
+		}
+		sendCreateEvent := func() {
+			session.DidChangeWatchedFiles(context.Background(), []*lsproto.FileEvent{
+				{Uri: newFileUri, Type: lsproto.FileChangeTypeCreated},
+			})
+		}
+		if openBeforeCreateEvent {
+			openNewFile()
+			sendCreateEvent()
+		} else {
+			sendCreateEvent()
+			openNewFile()
+		}
+
+		// The new file should be served by the nested configured project, not the
+		// root project (ES2015 target) or an inferred project.
+		ls, err = session.GetLanguageService(context.Background(), newFileUri)
+		assert.NilError(t, err)
+		assert.Equal(t, ls.GetProgram().Options().Target, core.ScriptTargetESNext)
+		assert.Assert(t, session.Snapshot().ProjectCollection.InferredProject() == nil)
+	}
+
+	t.Run("newly created file joins configured project with ./-prefixed includes (didOpen before create event)", func(t *testing.T) {
+		runNewFileScenario(t, true)
+	})
+
+	t.Run("newly created file joins configured project with ./-prefixed includes (create event before didOpen)", func(t *testing.T) {
+		runNewFileScenario(t, false)
 	})
 
 	t.Run("tsconfig move from subdirectory to parent via didChangeWatchedFiles", func(t *testing.T) {

--- a/internal/tsoptions/wildcarddirectories.go
+++ b/internal/tsoptions/wildcarddirectories.go
@@ -33,7 +33,7 @@ func getWildcardDirectories(include []string, exclude []string, comparePathsOpti
 	var recursiveKeys []string
 
 	for _, file := range include {
-		spec := tspath.NormalizeSlashes(tspath.CombinePaths(comparePathsOptions.CurrentDirectory, file))
+		spec := tspath.NormalizePath(tspath.CombinePaths(comparePathsOptions.CurrentDirectory, file))
 		if excludeMatcher != nil && excludeMatcher.MatchString(spec) {
 			continue
 		}

--- a/internal/tsoptions/wildcarddirectories_test.go
+++ b/internal/tsoptions/wildcarddirectories_test.go
@@ -4,7 +4,27 @@ import (
 	"testing"
 
 	"github.com/microsoft/typescript-go/internal/tspath"
+	"gotest.tools/v3/assert"
 )
+
+func TestGetWildcardDirectories_DotPrefixedIncludeWithDotDirExclude(t *testing.T) {
+	t.Parallel()
+
+	// https://github.com/microsoft/typescript-go/issues/3733
+	// "./"-prefixed include specs must be fully normalized before being tested
+	// against exclude patterns; otherwise the leftover literal "." path segment
+	// matches dot-directory excludes like "**/.*/", silently dropping every
+	// wildcard directory (and with them, root file watching for the config).
+	result := getWildcardDirectories(
+		[]string{"./app/**/*.ts", "./app/**/*.tsx"},
+		[]string{"**/node_modules", "**/.*/", "./build"},
+		tspath.ComparePathsOptions{
+			CurrentDirectory:          "/home/projects/monorepo/apps/web",
+			UseCaseSensitiveFileNames: true,
+		},
+	)
+	assert.DeepEqual(t, result, map[string]bool{"/home/projects/monorepo/apps/web/app": true})
+}
 
 func TestGetWildcardDirectories_NonASCIICharacters(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Fixes #3733 

Sorry it took me so long to get back to it. I employed Fable 5 to debug the issue. I came up with a hypothesis and i made it verify each claim it made so that it's not AI slop PR. If this is not the root cause, hopefully you'll find something to start from.

Here's the explanation (AI disclaimer):

Found the root cause — it's neither the 12k files nor the monorepo. The crux is the tsconfig: **`./`-prefixed `include` entries combined with a dot-directory `exclude` pattern (`"**/.*/"`)**. Two small tsconfigs and one source file reproduce it deterministically.

### Minimal repro

`tsconfig.json` (workspace root):

​```json
{
  "compilerOptions": { "target": "ES2015", "lib": ["DOM"], "noEmit": true },
  "include": ["apps"]
}
​```

`apps/web/tsconfig.json`:

​```json
{
  "compilerOptions": { "target": "ESNext", "lib": ["ESNext"], "noEmit": true },
  "include": ["./app/**/*.ts"],
  "exclude": ["**/.*/"]
}
​```

`apps/web/app/existing.ts`: any content.

Open `existing.ts` (loads the `apps/web` project), then create `apps/web/app/subdir/new_file.ts` containing `const b = Temporal.` → completions return 0 items and diagnostics show `Cannot find namespace 'Temporal'`. It never recovers (verified by polling completions for 10s after the `didChangeWatchedFiles` create event); restarting the server fixes it. The server log shows the misassignment directly:

​```
computeConfigFileName:: File: .../apps/web/app/subdir/new_file.ts:: Result: .../apps/web/tsconfig.json
Found default configured project for .../apps/web/app/subdir/new_file.ts: .../tsconfig.json   ← root project!
​```

It reproduces regardless of the ordering of `didOpen` vs. the file-create watch event, so it's not the open-before-watch race — created-file detection is simply dead for these configs.

### Root cause

In `getWildcardDirectories` (`internal/tsoptions/wildcarddirectories.go`), each include spec is made absolute with `tspath.NormalizeSlashes(tspath.CombinePaths(configDir, spec))`. Strada uses `normalizePath(combinePaths(...))` here, which collapses `./` segments; `NormalizeSlashes` does not. So `"./app/**/*.ts"` becomes `/…/apps/web/./app/**/*.ts` — with a literal `.` path segment left in.

Each include spec is then tested against the config's exclude matcher (excluded specs aren't watched). `"**/.*/"` means "any path with a segment starting with `.`" — and the leftover literal `.` segment matches it. Since every `./`-prefixed include spec matches, **the config ends up with zero wildcard directories**. (`"**/.*"` and `".*"` excludes trigger it identically; includes without the `./` prefix are unaffected.)

With no wildcard directories, `PossiblyMatchesFileName` has no globs, so when the *Created* watch event arrives, the config is never marked `PendingReloadFileNames` and its cached file list never learns the new file exists. When the file is opened, the nearest config (correctly computed) doesn't contain it, so default-project resolution walks up and the **root** project — parsed fresh from disk *after* the file was created — claims it. The file is then served with the root project's options (`lib: ["DOM"]`, `target: ES2015`, no `paths`): no `Temporal`, wrong globals, and degraded auto-imports since the file isn't in the project that knows the app's sources and path aliases. If no ancestor config covers the file at all, it lands in the *inferred* project instead (which matches the original screenshot where only node_modules packages were suggested). Only a restart (full re-parse) recovers.

The bug has been present since file watching was introduced (#806).

### Fix

One line: `NormalizeSlashes` → `NormalizePath` in `getWildcardDirectories`, matching strada. Verified: wildcard directories survive, the create event triggers a file-name reload, and the new file is assigned to the nested project immediately (both event orderings). Dot-directory exclusion semantics are unchanged (a file in `app/.hidden/` is still excluded from the program).

PR incoming with the fix plus regression tests (a unit test for `getWildcardDirectories` and a project-level test covering both event orderings).
