### PR TITLE
Fix data race in `snapshotFSBuilder.GetAccessibleEntries()`

### DIFF
--- a/internal/project/snapshotfs.go
+++ b/internal/project/snapshotfs.go
@@ -326,8 +326,8 @@ func (s *snapshotFSBuilder) GetAccessibleEntries(path string) vfs.Entries {
 		return entries
 	}
 
-	entries.Files = slices.Clone(entries.Files)
-	entries.Directories = slices.Clone(entries.Directories)
+	entries.Files = slices.Clip(entries.Files)
+	entries.Directories = slices.Clip(entries.Directories)
 	readDirectoryIntoEntries(overlayDirectories, s.isOpenFile, &entries)
 	return entries
 }

--- a/internal/project/snapshotfs.go
+++ b/internal/project/snapshotfs.go
@@ -141,6 +141,7 @@ type snapshotFSBuilder struct {
 	diskDirectories            *dirty.Map[tspath.Path, dirty.CloneableMap[tspath.Path, string]]
 	nodeModulesRealpathAliases *dirty.SyncMap[tspath.Path, *realpathAliasSet]
 	toPath                     func(string) tspath.Path
+	accessibleEntries 			collections.SyncMap[tspath.Path, vfs.Entries]
 }
 
 func newSnapshotFSBuilder(
@@ -321,15 +322,23 @@ func (s *snapshotFSBuilder) GetFileByPath(fileName string, path tspath.Path) Fil
 
 func (s *snapshotFSBuilder) GetAccessibleEntries(path string) vfs.Entries {
 	entries := s.fs.GetAccessibleEntries(path)
-	overlayDirectories, ok := s.overlayDirectories[s.toPath(path)]
+	p := s.toPath(path)
+	overlayDirectories, ok := s.overlayDirectories[p]
 	if !ok {
 		return entries
 	}
 
-	entries.Files = slices.Clip(entries.Files)
-	entries.Directories = slices.Clip(entries.Directories)
-	readDirectoryIntoEntries(overlayDirectories, s.isOpenFile, &entries)
-	return entries
+	if merged, ok := s.accessibleEntries.Load(p); ok {
+		return merged
+	}
+	merged := vfs.Entries{
+		Files:       slices.Clone(entries.Files),
+		Directories: slices.Clone(entries.Directories),
+		Symlinks:    entries.Symlinks,
+	}
+	readDirectoryIntoEntries(overlayDirectories, s.isOpenFile, &merged)
+	merged, _ = s.accessibleEntries.LoadOrStore(p, merged)
+	return merged
 }
 
 func (s *snapshotFSBuilder) getDiskFile(fileName string, path tspath.Path, forceReload bool) FileHandle {

--- a/internal/project/snapshotfs.go
+++ b/internal/project/snapshotfs.go
@@ -141,7 +141,7 @@ type snapshotFSBuilder struct {
 	diskDirectories            *dirty.Map[tspath.Path, dirty.CloneableMap[tspath.Path, string]]
 	nodeModulesRealpathAliases *dirty.SyncMap[tspath.Path, *realpathAliasSet]
 	toPath                     func(string) tspath.Path
-	accessibleEntries          collections.SyncMap[tspath.Path, vfs.Entries]
+	accessibleEntries          collections.SyncMap[tspath.Path, *vfs.Entries]
 }
 
 func newSnapshotFSBuilder(
@@ -329,16 +329,16 @@ func (s *snapshotFSBuilder) GetAccessibleEntries(path string) vfs.Entries {
 	}
 
 	if merged, ok := s.accessibleEntries.Load(p); ok {
-		return merged
+		return *merged
 	}
-	merged := vfs.Entries{
-		Files:       slices.Clone(entries.Files),
-		Directories: slices.Clone(entries.Directories),
+	merged := &vfs.Entries{
+		Files:       slices.Clip(entries.Files),
+		Directories: slices.Clip(entries.Directories),
 		Symlinks:    entries.Symlinks,
 	}
-	readDirectoryIntoEntries(overlayDirectories, s.isOpenFile, &merged)
+	readDirectoryIntoEntries(overlayDirectories, s.isOpenFile, merged)
 	merged, _ = s.accessibleEntries.LoadOrStore(p, merged)
-	return merged
+	return *merged
 }
 
 func (s *snapshotFSBuilder) getDiskFile(fileName string, path tspath.Path, forceReload bool) FileHandle {

--- a/internal/project/snapshotfs.go
+++ b/internal/project/snapshotfs.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -325,6 +326,8 @@ func (s *snapshotFSBuilder) GetAccessibleEntries(path string) vfs.Entries {
 		return entries
 	}
 
+	entries.Files = slices.Clone(entries.Files)
+	entries.Directories = slices.Clone(entries.Directories)
 	readDirectoryIntoEntries(overlayDirectories, s.isOpenFile, &entries)
 	return entries
 }

--- a/internal/project/snapshotfs.go
+++ b/internal/project/snapshotfs.go
@@ -141,7 +141,7 @@ type snapshotFSBuilder struct {
 	diskDirectories            *dirty.Map[tspath.Path, dirty.CloneableMap[tspath.Path, string]]
 	nodeModulesRealpathAliases *dirty.SyncMap[tspath.Path, *realpathAliasSet]
 	toPath                     func(string) tspath.Path
-	accessibleEntries 			collections.SyncMap[tspath.Path, vfs.Entries]
+	accessibleEntries          collections.SyncMap[tspath.Path, vfs.Entries]
 }
 
 func newSnapshotFSBuilder(

--- a/internal/project/snapshotfs_test.go
+++ b/internal/project/snapshotfs_test.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"slices"
+	"sync"
 	"testing"
 
 	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
@@ -493,6 +494,49 @@ func TestSnapshotFSBuilder(t *testing.T) {
 
 		// Should contain both disk file and overlay file (both as basenames)
 		assert.Assert(t, slices.Contains(entries.Files, "disk.ts"), "should contain disk.ts")
+		assert.Assert(t, slices.Contains(entries.Files, "overlay.ts"), "should contain overlay.ts")
+	})
+
+	t.Run("GetAccessibleEntries is safe under concurrent calls", func(t *testing.T) {
+		t.Parallel()
+		testFS := vfstest.FromMap(map[string]string{
+			"/src/a.ts": "",
+			"/src/b.ts": "",
+			"/src/c.ts": "",
+			"/src/d.ts": "",
+			"/src/e.ts": "",
+		}, false /* useCaseSensitiveFileNames */)
+
+		overlays := map[tspath.Path]*Overlay{
+			tspath.Path("/src/overlay.ts"): {
+				fileBase: fileBase{fileName: "/src/overlay.ts", content: ""},
+			},
+		}
+
+		builder := newSnapshotFSBuilder(
+			testFS,
+			make(map[tspath.Path]*Overlay), // prevOverlays
+			overlays,
+			make(map[tspath.Path]*diskFile),
+			make(map[tspath.Path]dirty.CloneableMap[tspath.Path, string]),
+			nil, // nodeModulesRealpathAliases
+			lsproto.PositionEncodingKindUTF16,
+			toPath,
+		)
+
+		_ = builder.GetAccessibleEntries("/src")
+
+		var wg sync.WaitGroup
+		for range 50 {
+			wg.Go(func() {
+				// Must not mutate the shared cached entries in place.
+				_ = builder.GetAccessibleEntries("/src")
+			})
+		}
+		wg.Wait()
+
+		// Sanity: the overlay is still reported after all the concurrent calls.
+		entries := builder.GetAccessibleEntries("/src")
 		assert.Assert(t, slices.Contains(entries.Files, "overlay.ts"), "should contain overlay.ts")
 	})
 }

--- a/internal/project/snapshotfs_test.go
+++ b/internal/project/snapshotfs_test.go
@@ -524,15 +524,17 @@ func TestSnapshotFSBuilder(t *testing.T) {
 			toPath,
 		)
 
-		_ = builder.GetAccessibleEntries("/src")
+		_ = builder.fs.GetAccessibleEntries("/src")
 
+		start := make(chan struct{})
 		var wg sync.WaitGroup
 		for range 50 {
 			wg.Go(func() {
-				// Must not mutate the shared cached entries in place.
+				<-start
 				_ = builder.GetAccessibleEntries("/src")
 			})
 		}
+		close(start)
 		wg.Wait()
 
 		// Sanity: the overlay is still reported after all the concurrent calls.


### PR DESCRIPTION
Fixes a data race bug uncovered in https://github.com/microsoft/typescript-go/issues/4380#issuecomment-4755503460, where `entries.Files` or `entries.Directories` can cause a data race when the backing array has spare capacity and is written to by two different processes. The fix clones these properties to avoid mutating the cached backing arrays.