### PR TITLE
Preserve pseudotype when serializing autoType declarations

### DIFF
--- a/internal/checker/nodebuilderimpl.go
+++ b/internal/checker/nodebuilderimpl.go
@@ -2221,7 +2221,10 @@ func (b *NodeBuilderImpl) serializeTypeForDeclaration(declaration *ast.Declarati
 			}
 		}
 		reportErrors := !b.ctx.suppressReportInferenceFallback
-		if b.pseudoTypeEquivalentToType(pt, t, !requiresAddingUndefined && (ast.IsParameterDeclaration(declaration) || ast.IsPropertySignatureDeclaration(declaration) || ast.IsPropertyDeclaration(declaration)) && isOptionalDeclaration(declaration), reportErrors) {
+		if ast.IsVariableDeclaration(declaration) && !ast.IsVarConstLike(declaration) && ast.HasInitializer(declaration) && t == b.ch.autoType {
+			// In the case of an autoType variable declaration (let v = null), we should still prefer the pseudotype derived from the AST for the .d.ts purposes.
+			result = b.pseudoTypeToNode(pt)
+		} else if b.pseudoTypeEquivalentToType(pt, t, !requiresAddingUndefined && (ast.IsParameterDeclaration(declaration) || ast.IsPropertySignatureDeclaration(declaration) || ast.IsPropertyDeclaration(declaration)) && isOptionalDeclaration(declaration), reportErrors) {
 			// !!! TODO: If annotated type node is a reference with insufficient type arguments, we should still fall back to type serialization
 			// see: canReuseTypeNodeAnnotation in strada for context
 			ptt := b.pseudoTypeToType(pt)

--- a/testdata/baselines/reference/submodule/compiler/letDeclarations.js
+++ b/testdata/baselines/reference/submodule/compiler/letDeclarations.js
@@ -32,4 +32,4 @@ declare let l2: number;
 declare let l3: any, l4: any, l5: string, l6: any;
 declare let l7: boolean;
 declare let l8: number;
-declare let l9: number, l10: string, l11: any;
+declare let l9: number, l10: string, l11: null;

--- a/testdata/baselines/reference/submoduleAccepted/compiler/letDeclarations.js.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/letDeclarations.js.diff
@@ -1,8 +1,0 @@
---- old.letDeclarations.js
-+++ new.letDeclarations.js
-@@= skipped -31, +31 lines =@@
- declare let l3: any, l4: any, l5: string, l6: any;
- declare let l7: boolean;
- declare let l8: number;
--declare let l9: number, l10: string, l11: null;
-+declare let l9: number, l10: string, l11: any;


### PR DESCRIPTION
This PR fixes declaration generation for variables with inferred `autoType` initialized with `null` or `undefined`.

Previously, declaration serialization preferred the inferred checker type over the pseudotype derived from the declaration syntax. This affects cases like

```ts
let x = null;
let y = undefined;
```

where the inferred type is `autoType`, while the pseudotype preserves the original `null`/`undefined` initializer. As a result, the declaration transform always emitted `any` instead of respecting the Strada's `strictNullChecks` behavior.
