### PR TITLE
Move dprint plugins to npm

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -58,9 +58,9 @@
     // Note: if adding new languages, make sure settings.template.json is updated too.
     // Also, if updating typescript, update the one in package.json.
     "plugins": [
-        "https://plugins.dprint.dev/typescript-0.96.1.wasm",
-        "https://plugins.dprint.dev/json-0.22.0.wasm",
-        "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.6.0.wasm",
-        "https://plugins.dprint.dev/jakebailey/gofumpt-v0.0.12.wasm"
+        "npm:@dprint/typescript@0.96.1",
+        "npm:@dprint/json@0.22.0",
+        "npm:dprint-plugin-yaml@0.6.0",
+        "npm:@jakebailey/dprint-plugin-gofumpt@0.0.13"
     ]
 }

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -36,5 +36,3 @@ jobs:
       - run: npm i -g @playwright/mcp@0.0.28
       - run: go install golang.org/x/tools/gopls@latest
       - run: npm ci
-      # pull dprint caches before network access is blocked
-      - run: npx hereby check:format || true

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "@unicode/unicode-15.1.0": "^1.6.17",
                 "adm-zip": "^0.5.17",
                 "chokidar": "^5.0.0",
-                "dprint": "^0.54.0",
+                "dprint": "^0.55.1",
                 "execa": "^9.6.1",
                 "glob": "^13.0.6",
                 "hereby": "^1.15.1",
@@ -287,10 +287,38 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@dprint/android-arm64": {
+            "version": "0.55.1",
+            "resolved": "https://registry.npmjs.org/@dprint/android-arm64/-/android-arm64-0.55.1.tgz",
+            "integrity": "sha512-H1UQIcBJEo1dA8AVrkPnw5AYMMGHNe4w0lq9rEDSY3Lds0VUKACu2MK3JLNARpjljh3WKeO109J26Wpq8PTuGQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@dprint/android-x64": {
+            "version": "0.55.1",
+            "resolved": "https://registry.npmjs.org/@dprint/android-x64/-/android-x64-0.55.1.tgz",
+            "integrity": "sha512-8dPiGpEo4S4cQhnLaoHtNm4HiqR9DIPr/81z3gWb5qTmJp8bKj+3DO4mAmmldMRBicmpXCss0xudniNTxnWOMg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
         "node_modules/@dprint/darwin-arm64": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@dprint/darwin-arm64/-/darwin-arm64-0.54.0.tgz",
-            "integrity": "sha512-yqRI4enH+BDp+4+ZsPVdZM5h873JK1lN7li9l9A5u4C4cvh1oEsiBWAzEPccRkJ2ctF8LgaizBSxO38sqEVYbw==",
+            "version": "0.55.1",
+            "resolved": "https://registry.npmjs.org/@dprint/darwin-arm64/-/darwin-arm64-0.55.1.tgz",
+            "integrity": "sha512-c65u8f63R/etCKP0CZ/RkbMCRC99wgZDt/vhwjY2QdO0k23dMKXKEV6+ruUEwV2toh+QIRT02dRL7BtxjA0V7w==",
             "cpu": [
                 "arm64"
             ],
@@ -302,9 +330,9 @@
             ]
         },
         "node_modules/@dprint/darwin-x64": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@dprint/darwin-x64/-/darwin-x64-0.54.0.tgz",
-            "integrity": "sha512-W9BARpgHypcQwatg5mnHaCpX6pLX5dBxxiv+tZKruhOmq8MKYOrAYDXlceMuHSowmWREfUF5yL4SRgXDGI6WQw==",
+            "version": "0.55.1",
+            "resolved": "https://registry.npmjs.org/@dprint/darwin-x64/-/darwin-x64-0.55.1.tgz",
+            "integrity": "sha512-AsET9+4rMk7ZFEMq3HYl/hYNBMBrR/juiSzclEU0oUCf3koxFbVKL8Srad8Vhyv8jEnOaMn78TCnahmHhp1SCQ==",
             "cpu": [
                 "x64"
             ],
@@ -316,9 +344,9 @@
             ]
         },
         "node_modules/@dprint/linux-arm64-glibc": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@dprint/linux-arm64-glibc/-/linux-arm64-glibc-0.54.0.tgz",
-            "integrity": "sha512-VhM7p70VFuNqxZMdiv1e+nMboPj/hMFlTIBWrRaX7+6VThs9mJr9+94wrUeXgfnfsyaEKSbRFa/dru1PINoSNw==",
+            "version": "0.55.1",
+            "resolved": "https://registry.npmjs.org/@dprint/linux-arm64-glibc/-/linux-arm64-glibc-0.55.1.tgz",
+            "integrity": "sha512-vt7w+aL2MjtD3RRfnUTDuK/b7xg1/feBe3WoV0S2rGNmPEJI+K7wwBXkOl/I77V9w3PP2zvN/aRY5dMOZrkbSg==",
             "cpu": [
                 "arm64"
             ],
@@ -333,9 +361,9 @@
             ]
         },
         "node_modules/@dprint/linux-arm64-musl": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@dprint/linux-arm64-musl/-/linux-arm64-musl-0.54.0.tgz",
-            "integrity": "sha512-QS1A74Lv60/L9oemHCzbHgOLbV2smSJG5IxS5fjf8ZWetyUt918WDzIHBilz/+uiB+OlW2UVTsm952UG0YOrLw==",
+            "version": "0.55.1",
+            "resolved": "https://registry.npmjs.org/@dprint/linux-arm64-musl/-/linux-arm64-musl-0.55.1.tgz",
+            "integrity": "sha512-7shUIOvJcTn4IYEPlb/Up4KLt5kbDuCTdc3DN68i88XT+nRBFQatD7Qok+6Ysra34KJMxF88QVHiimjH1ABy4A==",
             "cpu": [
                 "arm64"
             ],
@@ -350,9 +378,9 @@
             ]
         },
         "node_modules/@dprint/linux-loong64-glibc": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@dprint/linux-loong64-glibc/-/linux-loong64-glibc-0.54.0.tgz",
-            "integrity": "sha512-8Myka2/0KbhuZnEKL6jagPXTgDKVpd/tfXDRa0oibUBgaqOSku6iRMzHGa/PhqHL+s14Gcp+/cIHz0zU3Tkgug==",
+            "version": "0.55.1",
+            "resolved": "https://registry.npmjs.org/@dprint/linux-loong64-glibc/-/linux-loong64-glibc-0.55.1.tgz",
+            "integrity": "sha512-G2mXiOGpkeC3LP8huSnImxU7hMvRY6rHIW+yBuw1vDDm5r6+H9CVhcXr3TMOk3poZ7IlWwQnDmP0/RuGQUEpYw==",
             "cpu": [
                 "loong64"
             ],
@@ -367,9 +395,9 @@
             ]
         },
         "node_modules/@dprint/linux-loong64-musl": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@dprint/linux-loong64-musl/-/linux-loong64-musl-0.54.0.tgz",
-            "integrity": "sha512-/AN3xCuMhC4PK7Pbj7/4zBuhFGr4m0OHV/5uGTfzpkKX/3+AXoyKl7PbT2VlNMGXAK0kuRThfjtx23gIwlWk7Q==",
+            "version": "0.55.1",
+            "resolved": "https://registry.npmjs.org/@dprint/linux-loong64-musl/-/linux-loong64-musl-0.55.1.tgz",
+            "integrity": "sha512-uO2r4QPYawDfQUyATr0opqfMkG2hVpz3yScRKs5ve9PWzqx2f5kJaaLuLVoXwSbWqDkozMGPcldAVSpOwGJ24Q==",
             "cpu": [
                 "loong64"
             ],
@@ -383,10 +411,44 @@
                 "linux"
             ]
         },
+        "node_modules/@dprint/linux-ppc64-glibc": {
+            "version": "0.55.1",
+            "resolved": "https://registry.npmjs.org/@dprint/linux-ppc64-glibc/-/linux-ppc64-glibc-0.55.1.tgz",
+            "integrity": "sha512-NVR+BN4kTQd/vJ91YOGSkBotAM2f1hFD+HD5zq5Oc1djxjl1U2Zvc667UWKamxaXdv/ssZxkLuj0lbvbx9E3/A==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@dprint/linux-ppc64-musl": {
+            "version": "0.55.1",
+            "resolved": "https://registry.npmjs.org/@dprint/linux-ppc64-musl/-/linux-ppc64-musl-0.55.1.tgz",
+            "integrity": "sha512-34Db83XGoKbwmvIY52sokywIMCmmIZM1vzw4ILlOkKugG51TltBOzLCssT9Rkfxz/TjR9dgwtBHEQJZjftuQ6Q==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
         "node_modules/@dprint/linux-riscv64-glibc": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@dprint/linux-riscv64-glibc/-/linux-riscv64-glibc-0.54.0.tgz",
-            "integrity": "sha512-Aw2vXzzwFDpPbXh6ajsSabVCkCc66C3hCyMKprR/IxYvFtjYX80nh1ox0c7iaw6c4HacHMRLGw7FUSXvomPaEQ==",
+            "version": "0.55.1",
+            "resolved": "https://registry.npmjs.org/@dprint/linux-riscv64-glibc/-/linux-riscv64-glibc-0.55.1.tgz",
+            "integrity": "sha512-MVeYH48GhR3QkfhMhhYbXl9x+iO2sK1nNpr2ByJ4IKogHIlvlFff0eeukqAZZAod+rhAzJnLMBGgIDbIUHWK1g==",
             "cpu": [
                 "riscv64"
             ],
@@ -401,9 +463,9 @@
             ]
         },
         "node_modules/@dprint/linux-x64-glibc": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@dprint/linux-x64-glibc/-/linux-x64-glibc-0.54.0.tgz",
-            "integrity": "sha512-zZqj3wQELOX8n6QfT2uuWoMf64Wv0lMXNyam3btm+PKkg0P6a54TPL09Bs9XsViOdxgTcamsiQ7HlErt/LEjIA==",
+            "version": "0.55.1",
+            "resolved": "https://registry.npmjs.org/@dprint/linux-x64-glibc/-/linux-x64-glibc-0.55.1.tgz",
+            "integrity": "sha512-ILHgXOIIXeZDjt51egaC4kmu744UuNfaauUM1El+dG9QGan4Vv4f0RRDDbQMKN95zTpacECuNKEhuUtS8euNWA==",
             "cpu": [
                 "x64"
             ],
@@ -418,9 +480,9 @@
             ]
         },
         "node_modules/@dprint/linux-x64-musl": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@dprint/linux-x64-musl/-/linux-x64-musl-0.54.0.tgz",
-            "integrity": "sha512-it6Qdt06dyW2adbAXpOCb7/KQLxlm4i1UphUAWqWsZk4t3EYetyAza9J0g3Vu9itIWSEIo9MnccgANckQJ6+qw==",
+            "version": "0.55.1",
+            "resolved": "https://registry.npmjs.org/@dprint/linux-x64-musl/-/linux-x64-musl-0.55.1.tgz",
+            "integrity": "sha512-SwWxWd313VkeH63fR4IlQCDfJNJ+mSw50BidP0PQInCNbUHYOIeWTcyzAaVa8GQdLvmhiNcJ0pmTDOL0F98QIQ==",
             "cpu": [
                 "x64"
             ],
@@ -435,9 +497,9 @@
             ]
         },
         "node_modules/@dprint/win32-arm64": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@dprint/win32-arm64/-/win32-arm64-0.54.0.tgz",
-            "integrity": "sha512-F5kjV/6I9YtNOTDWHUpTqM2HHHS510BPL7z4NJuU0nDnaVeks7GwNEltGr56CcsG8XQYhkiAsqZytPu6AhA2hQ==",
+            "version": "0.55.1",
+            "resolved": "https://registry.npmjs.org/@dprint/win32-arm64/-/win32-arm64-0.55.1.tgz",
+            "integrity": "sha512-9jiZWZ2AkaaXIkaOpOoiP6v0XxuBFp1Hyi3kUMUAY4NVCmvlSEDQhr+UZgnDhozYygDbAV13iNMLERDeoUa0nA==",
             "cpu": [
                 "arm64"
             ],
@@ -449,9 +511,9 @@
             ]
         },
         "node_modules/@dprint/win32-x64": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@dprint/win32-x64/-/win32-x64-0.54.0.tgz",
-            "integrity": "sha512-AAr2ye/DtgYXDplRoPS+5U++x7T6W4a3I9FvTFWFxziFmUptvAg5G2c4FcXoAduSruhYZJvjDZrLseR2c3IwXg==",
+            "version": "0.55.1",
+            "resolved": "https://registry.npmjs.org/@dprint/win32-x64/-/win32-x64-0.55.1.tgz",
+            "integrity": "sha512-+RmeJL8zzlEWTcrvyFN51rz0S98tV43Socs7xeVGE2S/EH5dG2fG2/fBe6RB3kuyZSfGqByApYeicIdshYIAgw==",
             "cpu": [
                 "x64"
             ],
@@ -2426,9 +2488,9 @@
             }
         },
         "node_modules/dprint": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/dprint/-/dprint-0.54.0.tgz",
-            "integrity": "sha512-sIy25poR2gRP/tWPTgP0MPeJoJcpv0xzYDcsboapvthbEt1Qw3Al252CA0xFyIh2cYEGGKyBJtKokryv4ERlJw==",
+            "version": "0.55.1",
+            "resolved": "https://registry.npmjs.org/dprint/-/dprint-0.55.1.tgz",
+            "integrity": "sha512-tgUCT9gAM7veMvLX5NmRoYVLnKGKrIYRXpNpJDJj5U7/YIIJef5rLJhPZaJXwB7ad2Vo0Kv//nQM1xkrn5j8kQ==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -2436,17 +2498,21 @@
                 "dprint": "bin.cjs"
             },
             "optionalDependencies": {
-                "@dprint/darwin-arm64": "0.54.0",
-                "@dprint/darwin-x64": "0.54.0",
-                "@dprint/linux-arm64-glibc": "0.54.0",
-                "@dprint/linux-arm64-musl": "0.54.0",
-                "@dprint/linux-loong64-glibc": "0.54.0",
-                "@dprint/linux-loong64-musl": "0.54.0",
-                "@dprint/linux-riscv64-glibc": "0.54.0",
-                "@dprint/linux-x64-glibc": "0.54.0",
-                "@dprint/linux-x64-musl": "0.54.0",
-                "@dprint/win32-arm64": "0.54.0",
-                "@dprint/win32-x64": "0.54.0"
+                "@dprint/android-arm64": "0.55.1",
+                "@dprint/android-x64": "0.55.1",
+                "@dprint/darwin-arm64": "0.55.1",
+                "@dprint/darwin-x64": "0.55.1",
+                "@dprint/linux-arm64-glibc": "0.55.1",
+                "@dprint/linux-arm64-musl": "0.55.1",
+                "@dprint/linux-loong64-glibc": "0.55.1",
+                "@dprint/linux-loong64-musl": "0.55.1",
+                "@dprint/linux-ppc64-glibc": "0.55.1",
+                "@dprint/linux-ppc64-musl": "0.55.1",
+                "@dprint/linux-riscv64-glibc": "0.55.1",
+                "@dprint/linux-x64-glibc": "0.55.1",
+                "@dprint/linux-x64-musl": "0.55.1",
+                "@dprint/win32-arm64": "0.55.1",
+                "@dprint/win32-x64": "0.55.1"
             }
         },
         "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "@unicode/unicode-15.1.0": "^1.6.17",
         "adm-zip": "^0.5.17",
         "chokidar": "^5.0.0",
-        "dprint": "^0.54.0",
+        "dprint": "^0.55.1",
         "execa": "^9.6.1",
         "glob": "^13.0.6",
         "hereby": "^1.15.1",
@@ -51,7 +51,7 @@
         "npm": "11.17.0"
     },
     "allowScripts": {
-        "dprint@0.54.0": true,
+        "dprint@0.55.1": true,
         "esbuild@0.28.1": true,
         "@vscode/vsce-sign@2.0.9": true,
         "keytar@7.9.0": true


### PR DESCRIPTION
This will make the firewall less mad, and means we don't need to preseed the plugins in the copilot agent setup steps.