### PR TITLE
Prepare main for 7.1 nightly builds

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -1595,7 +1595,8 @@ function nodeToGOARCH(arch, os) {
 }
 
 const getPlatforms = memoize(() => {
-    let supportedPlatforms = publishAsTypescript
+    const publishTag = getPublishTag();
+    let supportedPlatforms = publishAsTypescript && publishTag !== "next"
         ? platforms
         : platforms.filter(({ vsix }) => vsix);
 

--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -84,18 +84,14 @@ const { values: rawOptions } = parseArgs({
  */
 const options = /** @type {Options} */ (rawOptions);
 
-// Native release branches can edit these constants to publish a different
-// package flavor. Main's defaults publish @typescript/native-preview.
-const nativePreviewReleaseProfile = /** @type {"native-preview" | "typescript"} */ ("native-preview");
+// Native release branches can edit these constants to publish a fixed stable version.
+// Main publishes prerelease builds of the TypeScript package.
+const nativePreviewReleaseProfile = /** @type {"native-preview" | "typescript"} */ ("typescript");
 const nativePreviewReleaseVersion = /** @type {string | undefined} */ (undefined);
 const produceNativePreviewVsix = /** @type {boolean} */ (false);
 const produceTypeScriptNightlyVsix = /** @type {boolean} */ (true);
 const produceAnyVsix = produceNativePreviewVsix || produceTypeScriptNightlyVsix;
 const publishAsTypescript = nativePreviewReleaseProfile === "typescript";
-
-if (publishAsTypescript && !nativePreviewReleaseVersion) {
-    throw new Error("Publishing as 'typescript' requires hardcoding nativePreviewReleaseVersion.");
-}
 
 if (options.forRelease && !options.setPrerelease && (!nativePreviewReleaseVersion || produceAnyVsix)) {
     throw new Error("forRelease requires setPrerelease unless nativePreviewReleaseVersion is hardcoded and VSIX production is disabled");

--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -88,8 +88,8 @@ const options = /** @type {Options} */ (rawOptions);
 // package flavor. Main's defaults publish @typescript/native-preview.
 const nativePreviewReleaseProfile = /** @type {"native-preview" | "typescript"} */ ("native-preview");
 const nativePreviewReleaseVersion = /** @type {string | undefined} */ (undefined);
-const produceNativePreviewVsix = /** @type {boolean} */ (true);
-const produceTypeScriptNightlyVsix = /** @type {boolean} */ (false);
+const produceNativePreviewVsix = /** @type {boolean} */ (false);
+const produceTypeScriptNightlyVsix = /** @type {boolean} */ (true);
 const produceAnyVsix = produceNativePreviewVsix || produceTypeScriptNightlyVsix;
 const publishAsTypescript = nativePreviewReleaseProfile === "typescript";
 

--- a/_extension/l10n/bundle.l10n.json
+++ b/_extension/l10n/bundle.l10n.json
@@ -1,8 +1,7 @@
 {
   "Could not find a TypeScript executable in the extension package.": "Could not find a TypeScript executable in the extension package.",
   "TypeScript 7": "TypeScript 7",
-  "$(beaker) {0} {1}": "$(beaker) {0} {1}",
-  "{0} {1}": "{0} {1}",
+  "$(beaker) {0}": "$(beaker) {0}",
   "TypeScript Language Server": "TypeScript Language Server",
   "Show Menu": "Show Menu",
   "Language server is not running.": "Language server is not running.",

--- a/_extension/src/statusBar.ts
+++ b/_extension/src/statusBar.ts
@@ -7,7 +7,7 @@ import {
 export function setupStatusBar(exe: ExeInfo): vscode.Disposable {
     const statusItem = vscode.languages.createLanguageStatusItem("typescript.native-preview.status", jsTsLanguageModes);
     statusItem.name = vscode.l10n.t("TypeScript 7");
-    statusItem.text = exe.isLocal ? vscode.l10n.t("$(beaker) {0} {1}", exe.name, exe.version) : vscode.l10n.t("{0} {1}", exe.name, exe.version);
+    statusItem.text = exe.isLocal ? vscode.l10n.t("$(beaker) {0}", exe.version) : exe.version;
     statusItem.detail = vscode.l10n.t("TypeScript Language Server");
     statusItem.command = {
         title: vscode.l10n.t("Show Menu"),

--- a/_extension/src/util.ts
+++ b/_extension/src/util.ts
@@ -55,7 +55,7 @@ export async function getBuiltinExePath(context: vscode.ExtensionContext): Promi
         }
         catch {}
     }
-    return getPackagedExePath(context.extension.extensionUri, context.extension.packageJSON.version);
+    return getPackagedExePath(context.extension.extensionUri, getBundledTypeScriptVersion(context.extension.packageJSON));
 }
 
 export async function getNightlyExePath(): Promise<ExeInfo | undefined> {
@@ -64,7 +64,7 @@ export async function getNightlyExePath(): Promise<ExeInfo | undefined> {
         return undefined;
     }
 
-    return tryGetPackagedExePath(extension.extensionUri, extension.packageJSON?.version);
+    return tryGetPackagedExePath(extension.extensionUri, getBundledTypeScriptVersion(extension.packageJSON));
 }
 
 export async function getDefaultExePath(context: vscode.ExtensionContext): Promise<ExeInfo> {
@@ -83,6 +83,16 @@ async function getPackagedExePath(extensionUri: vscode.Uri, version: unknown): P
         return exe;
     }
     throw new Error(vscode.l10n.t("Could not find a TypeScript executable in the extension package."));
+}
+
+function getBundledTypeScriptVersion(packageJSON: unknown): string {
+    if (packageJSON && typeof packageJSON === "object" && "bundledTypeScriptVersion" in packageJSON) {
+        const version = packageJSON.bundledTypeScriptVersion;
+        if (typeof version === "string") {
+            return version;
+        }
+    }
+    return "unknown";
 }
 
 async function tryGetPackagedExePath(extensionUri: vscode.Uri, version: unknown): Promise<ExeInfo | undefined> {

--- a/internal/core/version.go
+++ b/internal/core/version.go
@@ -5,7 +5,7 @@ import (
 )
 
 // This is a var so it can be overridden by ldflags.
-var version = "7.0.0-dev"
+var version = "7.1.0-dev"
 
 func Version() string {
 	return version


### PR DESCRIPTION
Now publishing `typescript@next` with `typescript@7.1.0-dev.20260707.1` etc, plus `vscode-typescript-nightly`. The release branch now is doing `typescript@latest` and the main VS Code ext. `@typescript/native-preview` is no longer published.