### PR TITLE
Fix concurrent extractionCache read/write

### DIFF
--- a/internal/ls/autoimport/registry.go
+++ b/internal/ls/autoimport/registry.go
@@ -974,7 +974,10 @@ func (b *registryBuilder) updateIndexes(ctx context.Context, change RegistryChan
 
 	// For packages whose main extraction yielded nothing, fall back to @types.
 	for _, pkg := range typesFallbackCandidates {
-		if extractionCache[pkg.realpath] != nil || seen[pkg.typesRealpath] {
+		extractionMu.Lock()
+		mainExtracted := extractionCache[pkg.realpath] != nil
+		extractionMu.Unlock()
+		if mainExtracted || seen[pkg.typesRealpath] {
 			continue
 		}
 		seen[pkg.typesRealpath] = true

--- a/internal/ls/autoimport/registry_test.go
+++ b/internal/ls/autoimport/registry_test.go
@@ -1008,6 +1008,41 @@ const (
 	monorepoProjectRoot  = "/home/src/autoimport-monorepo"
 )
 
+func TestUpdateIndexesConcurrentMapSafety(t *testing.T) {
+	t.Parallel()
+	const projectRoot = "/home/src/autoimport-fallback-race"
+	const packageCount = 40
+
+	files := map[string]any{
+		projectRoot + "/tsconfig.json": `{
+			"compilerOptions": { "module": "esnext", "target": "esnext", "strict": true }
+		}`,
+		projectRoot + "/index.ts": "export {};\n",
+	}
+	for i := range packageCount {
+		pkgDir := fmt.Sprintf("%s/node_modules/pkg%d", projectRoot, i)
+		files[pkgDir+"/package.json"] = fmt.Sprintf(`{"name":"pkg%d","version":"1.0.0","main":"index.js"}`, i)
+		files[pkgDir+"/index.js"] = "module.exports = {};\n"
+		typesDir := fmt.Sprintf("%s/node_modules/@types/pkg%d", projectRoot, i)
+		files[typesDir+"/package.json"] = fmt.Sprintf(`{"name":"@types/pkg%d","version":"1.0.0","types":"index.d.ts"}`, i)
+		files[typesDir+"/index.d.ts"] = fmt.Sprintf("export declare const foo%d: number;\n", i)
+	}
+
+	session, _ := projecttestutil.Setup(files)
+	t.Cleanup(session.Close)
+
+	ctx := context.Background()
+	indexURI := lsproto.DocumentUri("file://" + projectRoot + "/index.ts")
+	session.DidOpenFile(ctx, indexURI, 1, "export {};\n", lsproto.LanguageKindTypeScript)
+
+	_, err := session.GetCurrentLanguageServiceWithAutoImports(ctx, indexURI)
+	assert.NilError(t, err)
+
+	stats := autoImportStats(t, session)
+	nodeModulesBucket := singleBucket(t, stats.NodeModulesBuckets)
+	assert.Equal(t, nodeModulesBucket.ExportCount, packageCount)
+}
+
 func autoImportStats(t *testing.T, session *project.Session) *autoimport.CacheStats {
 	t.Helper()
 	snapshot := session.Snapshot()


### PR DESCRIPTION
Fixes an issue uncovered in https://github.com/microsoft/typescript-go/issues/4380#issuecomment-4755503508, https://github.com/microsoft/typescript-go/issues/4380#issuecomment-4755503431, and https://github.com/microsoft/typescript-go/issues/4380#issuecomment-4755503486 (cypress); building the auto-import index in `registryBuilder.updateIndexes` spawns workers that populate the shared `extractionCache` map. However, reading this map in the `@types` fallback loop is unprotected by the lock and can cause a read/write data race.