### PR TITLE
Fix stack overflow in `checkTypeExpandability()`

### DIFF
--- a/internal/checker/nodebuilderimpl.go
+++ b/internal/checker/nodebuilderimpl.go
@@ -236,13 +236,19 @@ func (b *NodeBuilderImpl) checkTypeExpandability(t *Type) {
 	}
 	// Push t onto the type stack so shouldExpandType's cycle detection works correctly.
 	b.ctx.typeStack = append(b.ctx.typeStack, t)
+	defer func() {
+		b.ctx.typeStack = b.ctx.typeStack[:len(b.ctx.typeStack)-1]
+	}()
+	// If t is an ancestor in the current expansion, return early to avoid unbounded recursion.
+	if b.isTypeOnStack(t) {
+		return
+	}
 	if t.alias != nil {
 		b.shouldExpandType(t, true)
 	}
 	if !b.ctx.canIncreaseExpansionDepth {
 		b.shouldExpandType(t, false)
 	}
-	b.ctx.typeStack = b.ctx.typeStack[:len(b.ctx.typeStack)-1]
 	if b.ctx.canIncreaseExpansionDepth {
 		return
 	}

--- a/internal/fourslash/tests/quickinfoVerbositySelfReferentialTypeArg_test.go
+++ b/internal/fourslash/tests/quickinfoVerbositySelfReferentialTypeArg_test.go
@@ -1,0 +1,36 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+// Regression test for a stack overflow in checkTypeExpandability (issue #4380).
+//
+// This is a minimized reproduction of pixijs's Container type, which crashed the language
+// server on hover. `Container` defaults its own type parameter to the alias `ContainerChild`,
+// and `type ContainerChild = Container` closes the loop, so `Container` is `Container<Container<...>>`
+// — a reference type whose type argument is itself. During verbosity expansion the node builder
+// probes the reused `Container` annotation, and checkTypeExpandability recursed into that
+// self-referential type argument forever (a fatal runtime error, so it could not be recovered).
+//
+// The alias indirection is essential: `Container<C = Container>` directly is broken by the
+// checker's cycle detection, but the `ContainerChild` alias defeats it — matching the real code.
+// Hovering must terminate and produce quick info at every verbosity level without overflowing.
+func TestQuickinfoVerbositySelfReferentialTypeArg(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+
+	const content = `type ContainerChild = Container;
+interface Container<C = ContainerChild> {
+    parent: Container;
+}
+declare const x: Container;
+x/*1*/;`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+
+	f.VerifyBaselineHoverWithVerbosity(t, map[string][]int{"1": {3}})
+}

--- a/testdata/baselines/reference/fourslash/quickInfo/quickinfoVerbositySelfReferentialTypeArg.baseline
+++ b/testdata/baselines/reference/fourslash/quickInfo/quickinfoVerbositySelfReferentialTypeArg.baseline
@@ -1,0 +1,52 @@
+// === QuickInfo ===
+=== /quickinfoVerbositySelfReferentialTypeArg.ts ===
+// type ContainerChild = Container;
+// interface Container<C = ContainerChild> {
+//     parent: Container;
+// }
+// declare const x: Container;
+// x;
+// ^
+// | ----------------------------------------------------------------------
+// | ```typescript
+// | const x: {
+// |     parent: Container<{
+// |         parent: Container;
+// |     }>;
+// | }
+// | ```
+// | 
+// | (verbosity level: 3)
+// | ----------------------------------------------------------------------
+[
+  {
+    "marker": {
+      "Position": 129,
+      "LSPosition": {
+        "line": 5,
+        "character": 1
+      },
+      "Name": "1",
+      "Data": {}
+    },
+    "item": {
+      "hover": {
+        "contents": {
+          "kind": "markdown",
+          "value": "```typescript\nconst x: {\n    parent: Container<{\n        parent: Container;\n    }>;\n}\n```\n"
+        },
+        "range": {
+          "start": {
+            "line": 5,
+            "character": 0
+          },
+          "end": {
+            "line": 5,
+            "character": 1
+          }
+        }
+      },
+      "verbosityLevel": 3
+    }
+  }
+]


### PR DESCRIPTION
Fixes an issue uncovered in https://github.com/microsoft/typescript-go/issues/4380#issuecomment-4755503486 (pixijs); `checkTypeExpandibility()` recurses into a reference type's type arguments, but it only stored the type on the `typeStack` around the `shouldExpandType()` calls. This means that self-referential types were never detected as already in-progress and could lead to a stack overflow error.