### PR TITLE
Fix more return types that can’t actually be undefined

### DIFF
--- a/_packages/native-preview/src/api/async/api.ts
+++ b/_packages/native-preview/src/api/async/api.ts
@@ -806,6 +806,7 @@ export class Checker {
     private client: Client;
     private objectRegistry: ProjectObjectRegistry;
     private wellKnownSymbols: Promise<{ unknown: number; undefined: number; arguments: number; }> | undefined;
+    private wellKnownSignatures: Promise<{ unknown: number; }> | undefined;
 
     constructor(
         snapshotId: number,
@@ -863,23 +864,28 @@ export class Checker {
         return data.map(d => d ? this.objectRegistry.getOrCreateSymbol(d) : undefined);
     }
 
-    getTypeOfSymbol(symbol: Symbol): Promise<Type | undefined>;
-    getTypeOfSymbol(symbols: readonly Symbol[]): Promise<(Type | undefined)[]>;
-    async getTypeOfSymbol(symbolOrSymbols: Symbol | readonly Symbol[]): Promise<Type | (Type | undefined)[] | undefined> {
+    /**
+     * Get the type of a symbol. Always returns a type; for symbols whose type
+     * cannot be determined the checker yields the error type (use
+     * {@link Type.isErrorType} to detect it).
+     */
+    getTypeOfSymbol(symbol: Symbol): Promise<Type>;
+    getTypeOfSymbol(symbols: readonly Symbol[]): Promise<Type[]>;
+    async getTypeOfSymbol(symbolOrSymbols: Symbol | readonly Symbol[]): Promise<Type | Type[]> {
         if (Array.isArray(symbolOrSymbols)) {
-            const data = await this.client.apiRequest<(TypeResponse | null)[]>("getTypesOfSymbols", {
+            const data = await this.client.apiRequest<TypeResponse[]>("getTypesOfSymbols", {
                 snapshot: this.snapshotId,
                 project: this.project.id,
                 symbols: symbolOrSymbols.map(s => s.id),
             });
-            return data.map(d => d ? this.objectRegistry.getOrCreateType(d) : undefined);
+            return data.map(d => this.objectRegistry.getOrCreateType(d));
         }
-        const data = await this.client.apiRequest<TypeResponse | null>("getTypeOfSymbol", {
+        const data = await this.client.apiRequest<TypeResponse>("getTypeOfSymbol", {
             snapshot: this.snapshotId,
             project: this.project.id,
             symbol: (symbolOrSymbols as Symbol).id,
         });
-        return data ? this.objectRegistry.getOrCreateType(data) : undefined;
+        return this.objectRegistry.getOrCreateType(data);
     }
 
     /**
@@ -888,12 +894,11 @@ export class Checker {
      * {@link Type.isErrorType} to detect it).
      */
     async getDeclaredTypeOfSymbol(symbol: Symbol): Promise<Type> {
-        const data = await this.client.apiRequest<TypeResponse | null>("getDeclaredTypeOfSymbol", {
+        const data = await this.client.apiRequest<TypeResponse>("getDeclaredTypeOfSymbol", {
             snapshot: this.snapshotId,
             project: this.project.id,
             symbol: symbol.id,
         });
-        if (!data) throw new Error(`getDeclaredTypeOfSymbol returned no type for symbol ${symbol.id}`);
         return this.objectRegistry.getOrCreateType(data);
     }
 
@@ -952,23 +957,28 @@ export class Checker {
         };
     }
 
-    getTypeAtLocation(node: Node): Promise<Type | undefined>;
-    getTypeAtLocation(nodes: readonly Node[]): Promise<(Type | undefined)[]>;
-    async getTypeAtLocation(nodeOrNodes: Node | readonly Node[]): Promise<Type | (Type | undefined)[] | undefined> {
+    /**
+     * Get the type at a node location. Always returns a type; for nodes whose
+     * type cannot be determined the checker yields the error type (use
+     * {@link Type.isErrorType} to detect it).
+     */
+    getTypeAtLocation(node: Node): Promise<Type>;
+    getTypeAtLocation(nodes: readonly Node[]): Promise<Type[]>;
+    async getTypeAtLocation(nodeOrNodes: Node | readonly Node[]): Promise<Type | Type[]> {
         if (Array.isArray(nodeOrNodes)) {
-            const data = await this.client.apiRequest<(TypeResponse | null)[]>("getTypeAtLocations", {
+            const data = await this.client.apiRequest<TypeResponse[]>("getTypeAtLocations", {
                 snapshot: this.snapshotId,
                 project: this.project.id,
                 locations: nodeOrNodes.map(node => getNodeId(node)),
             });
-            return data.map(d => d ? this.objectRegistry.getOrCreateType(d) : undefined);
+            return data.map(d => this.objectRegistry.getOrCreateType(d));
         }
-        const data = await this.client.apiRequest<TypeResponse | null>("getTypeAtLocation", {
+        const data = await this.client.apiRequest<TypeResponse>("getTypeAtLocation", {
             snapshot: this.snapshotId,
             project: this.project.id,
             location: getNodeId(nodeOrNodes as Node),
         });
-        return data ? this.objectRegistry.getOrCreateType(data) : undefined;
+        return this.objectRegistry.getOrCreateType(data);
     }
 
     async getSignaturesOfType(type: Type, kind: SignatureKind): Promise<readonly Signature[]> {
@@ -981,13 +991,18 @@ export class Checker {
         return data.map(d => this.objectRegistry.getOrCreateSignature(d));
     }
 
-    async getResolvedSignature(node: Node): Promise<Signature | undefined> {
-        const data = await this.client.apiRequest<SignatureResponse | null>("getResolvedSignature", {
+    /**
+     * Get the resolved signature of a call-like expression. Always returns a
+     * signature; when a call cannot be resolved the checker yields the unknown
+     * signature (use {@link Checker.isUnknownSignature} to detect it).
+     */
+    async getResolvedSignature(node: Node): Promise<Signature> {
+        const data = await this.client.apiRequest<SignatureResponse>("getResolvedSignature", {
             snapshot: this.snapshotId,
             project: this.project.id,
             location: getNodeId(node),
         });
-        return data ? this.objectRegistry.getOrCreateSignature(data) : undefined;
+        return this.objectRegistry.getOrCreateSignature(data);
     }
 
     getTypeAtPosition(file: DocumentIdentifier, position: number): Promise<Type | undefined>;
@@ -1047,50 +1062,62 @@ export class Checker {
         return data ? this.objectRegistry.getOrCreateType(data) : undefined;
     }
 
-    async getBaseTypeOfLiteralType(type: Type): Promise<Type | undefined> {
-        const data = await this.client.apiRequest<TypeResponse | null>("getBaseTypeOfLiteralType", {
+    /** Get the base type of a literal type (e.g. `number` for `42`). Always returns a type. */
+    async getBaseTypeOfLiteralType(type: Type): Promise<Type> {
+        const data = await this.client.apiRequest<TypeResponse>("getBaseTypeOfLiteralType", {
             snapshot: this.snapshotId,
             project: this.project.id,
             type: type.id,
         });
-        return data ? this.objectRegistry.getOrCreateType(data) : undefined;
+        return this.objectRegistry.getOrCreateType(data);
     }
 
-    async getNonNullableType(type: Type): Promise<Type | undefined> {
-        const data = await this.client.apiRequest<TypeResponse | null>("getNonNullableType", {
+    /** Get the type with `null` and `undefined` removed. Always returns a type. */
+    async getNonNullableType(type: Type): Promise<Type> {
+        const data = await this.client.apiRequest<TypeResponse>("getNonNullableType", {
             snapshot: this.snapshotId,
             project: this.project.id,
             type: type.id,
         });
-        return data ? this.objectRegistry.getOrCreateType(data) : undefined;
+        return this.objectRegistry.getOrCreateType(data);
     }
 
-    async getTypeFromTypeNode(node: TypeNode): Promise<Type | undefined> {
-        const data = await this.client.apiRequest<TypeResponse | null>("getTypeFromTypeNode", {
+    /**
+     * Get the type for a type node. Always returns a type; for type nodes whose
+     * type cannot be determined the checker yields the error type (use
+     * {@link Type.isErrorType} to detect it).
+     */
+    async getTypeFromTypeNode(node: TypeNode): Promise<Type> {
+        const data = await this.client.apiRequest<TypeResponse>("getTypeFromTypeNode", {
             snapshot: this.snapshotId,
             project: this.project.id,
             location: getNodeId(node),
         });
-        return data ? this.objectRegistry.getOrCreateType(data) : undefined;
+        return this.objectRegistry.getOrCreateType(data);
     }
 
-    async getWidenedType(type: Type): Promise<Type | undefined> {
-        const data = await this.client.apiRequest<TypeResponse | null>("getWidenedType", {
+    /** Get the widened type. Always returns a type. */
+    async getWidenedType(type: Type): Promise<Type> {
+        const data = await this.client.apiRequest<TypeResponse>("getWidenedType", {
             snapshot: this.snapshotId,
             project: this.project.id,
             type: type.id,
         });
-        return data ? this.objectRegistry.getOrCreateType(data) : undefined;
+        return this.objectRegistry.getOrCreateType(data);
     }
 
-    async getParameterType(signature: Signature, index: number): Promise<Type | undefined> {
-        const data = await this.client.apiRequest<TypeResponse | null>("getParameterType", {
+    /**
+     * Get the type of the parameter at the given index in a signature. Always
+     * returns a type; an out-of-range index yields the `any` type.
+     */
+    async getParameterType(signature: Signature, index: number): Promise<Type> {
+        const data = await this.client.apiRequest<TypeResponse>("getParameterType", {
             snapshot: this.snapshotId,
             project: this.project.id,
             signature: signature.id,
             index,
         });
-        return data ? this.objectRegistry.getOrCreateType(data) : undefined;
+        return this.objectRegistry.getOrCreateType(data);
     }
 
     async isArrayLikeType(type: Type): Promise<boolean> {
@@ -1125,13 +1152,12 @@ export class Checker {
      * error type (use {@link Type.isErrorType} to detect it).
      */
     async getTypeOfSymbolAtLocation(symbol: Symbol, location: Node): Promise<Type> {
-        const data = await this.client.apiRequest<TypeResponse | null>("getTypeOfSymbolAtLocation", {
+        const data = await this.client.apiRequest<TypeResponse>("getTypeOfSymbolAtLocation", {
             snapshot: this.snapshotId,
             project: this.project.id,
             symbol: symbol.id,
             location: getNodeId(location),
         });
-        if (!data) throw new Error(`getTypeOfSymbolAtLocation returned no type for symbol ${symbol.id}`);
         return this.objectRegistry.getOrCreateType(data);
     }
 
@@ -1236,22 +1262,27 @@ export class Checker {
         });
     }
 
-    async getReturnTypeOfSignature(signature: Signature): Promise<Type | undefined> {
-        const data = await this.client.apiRequest<TypeResponse | null>("getReturnTypeOfSignature", {
+    /** Get the return type of a signature. Always returns a type. */
+    async getReturnTypeOfSignature(signature: Signature): Promise<Type> {
+        const data = await this.client.apiRequest<TypeResponse>("getReturnTypeOfSignature", {
             snapshot: this.snapshotId,
             project: this.project.id,
             signature: signature.id,
         });
-        return data ? this.objectRegistry.getOrCreateType(data) : undefined;
+        return this.objectRegistry.getOrCreateType(data);
     }
 
-    async getRestTypeOfSignature(signature: Signature): Promise<Type | undefined> {
-        const data = await this.client.apiRequest<TypeResponse | null>("getRestTypeOfSignature", {
+    /**
+     * Get the rest type of a signature. Always returns a type; a signature with
+     * no rest parameter yields the `any` type.
+     */
+    async getRestTypeOfSignature(signature: Signature): Promise<Type> {
+        const data = await this.client.apiRequest<TypeResponse>("getRestTypeOfSignature", {
             snapshot: this.snapshotId,
             project: this.project.id,
             signature: signature.id,
         });
-        return data ? this.objectRegistry.getOrCreateType(data) : undefined;
+        return this.objectRegistry.getOrCreateType(data);
     }
 
     async getTypePredicateOfSignature(signature: Signature): Promise<TypePredicate | undefined> {
@@ -1282,13 +1313,14 @@ export class Checker {
         return data ? data.map(d => this.objectRegistry.getOrCreateType(d)) : [];
     }
 
-    async getApparentType(type: Type): Promise<Type | undefined> {
-        const data = await this.client.apiRequest<TypeResponse | null>("getApparentType", {
+    /** Get the apparent type of a type. Always returns a type. */
+    async getApparentType(type: Type): Promise<Type> {
+        const data = await this.client.apiRequest<TypeResponse>("getApparentType", {
             snapshot: this.snapshotId,
             project: this.project.id,
             type: type.id,
         });
-        return data ? this.objectRegistry.getOrCreateType(data) : undefined;
+        return this.objectRegistry.getOrCreateType(data);
     }
 
     async getPropertiesOfType(type: Type): Promise<readonly Symbol[]> {
@@ -1356,13 +1388,14 @@ export class Checker {
         return data ?? undefined;
     }
 
-    async getSignatureFromDeclaration(node: Node): Promise<Signature | undefined> {
-        const data = await this.client.apiRequest<SignatureResponse | null>("getSignatureFromDeclaration", {
+    /** Get the signature of a function-like declaration. Always returns a signature. */
+    async getSignatureFromDeclaration(node: Node): Promise<Signature> {
+        const data = await this.client.apiRequest<SignatureResponse>("getSignatureFromDeclaration", {
             snapshot: this.snapshotId,
             project: this.project.id,
             location: getNodeId(node),
         });
-        return data ? this.objectRegistry.getOrCreateSignature(data) : undefined;
+        return this.objectRegistry.getOrCreateSignature(data);
     }
 
     async getExportSpecifierLocalTargetSymbol(node: Node): Promise<Symbol | undefined> {
@@ -1380,12 +1413,11 @@ export class Checker {
      * {@link Checker.isUnknownSymbol} to detect it).
      */
     async getAliasedSymbol(symbol: Symbol): Promise<Symbol> {
-        const data = await this.client.apiRequest<SymbolResponse | null>("getAliasedSymbol", {
+        const data = await this.client.apiRequest<SymbolResponse>("getAliasedSymbol", {
             snapshot: this.snapshotId,
             project: this.project.id,
             symbol: symbol.id,
         });
-        if (!data) throw new Error(`getAliasedSymbol returned no symbol for symbol ${symbol.id}`);
         return this.objectRegistry.getOrCreateSymbol(data);
     }
 
@@ -1431,6 +1463,27 @@ export class Checker {
      */
     async isArgumentsSymbol(symbol: Symbol): Promise<boolean> {
         return symbol.id === (await this.getWellKnownSymbols()).arguments;
+    }
+
+    /**
+     * Fetch (once, then cache) the handle id of the per-checker unknown
+     * signature. This id is stable for the life of the project's checker, so
+     * identity checks against it are local after the first call.
+     */
+    private getWellKnownSignatures(): Promise<{ unknown: number; }> {
+        return this.wellKnownSignatures ??= this.client.apiRequest<{ unknown: number; }>("getWellKnownSignatures", {
+            snapshot: this.snapshotId,
+            project: this.project.id,
+        });
+    }
+
+    /**
+     * Returns `true` if the signature is the checker's "unknown" signature (e.g.
+     * the result of {@link Checker.getResolvedSignature} on a call that cannot be
+     * resolved).
+     */
+    async isUnknownSignature(signature: Signature): Promise<boolean> {
+        return signature.id === (await this.getWellKnownSignatures()).unknown;
     }
 
     async getExportsOfModule(symbol: Symbol): Promise<readonly Symbol[]> {

--- a/_packages/native-preview/src/api/sync/api.ts
+++ b/_packages/native-preview/src/api/sync/api.ts
@@ -814,6 +814,7 @@ export class Checker {
     private client: Client;
     private objectRegistry: ProjectObjectRegistry;
     private wellKnownSymbols: { unknown: number; undefined: number; arguments: number; } | undefined;
+    private wellKnownSignatures: { unknown: number; } | undefined;
 
     constructor(
         snapshotId: number,
@@ -871,23 +872,28 @@ export class Checker {
         return data.map(d => d ? this.objectRegistry.getOrCreateSymbol(d) : undefined);
     }
 
-    getTypeOfSymbol(symbol: Symbol): Type | undefined;
-    getTypeOfSymbol(symbols: readonly Symbol[]): (Type | undefined)[];
-    getTypeOfSymbol(symbolOrSymbols: Symbol | readonly Symbol[]): Type | (Type | undefined)[] | undefined {
+    /**
+     * Get the type of a symbol. Always returns a type; for symbols whose type
+     * cannot be determined the checker yields the error type (use
+     * {@link Type.isErrorType} to detect it).
+     */
+    getTypeOfSymbol(symbol: Symbol): Type;
+    getTypeOfSymbol(symbols: readonly Symbol[]): Type[];
+    getTypeOfSymbol(symbolOrSymbols: Symbol | readonly Symbol[]): Type | Type[] {
         if (Array.isArray(symbolOrSymbols)) {
-            const data = this.client.apiRequest<(TypeResponse | null)[]>("getTypesOfSymbols", {
+            const data = this.client.apiRequest<TypeResponse[]>("getTypesOfSymbols", {
                 snapshot: this.snapshotId,
                 project: this.project.id,
                 symbols: symbolOrSymbols.map(s => s.id),
             });
-            return data.map(d => d ? this.objectRegistry.getOrCreateType(d) : undefined);
+            return data.map(d => this.objectRegistry.getOrCreateType(d));
         }
-        const data = this.client.apiRequest<TypeResponse | null>("getTypeOfSymbol", {
+        const data = this.client.apiRequest<TypeResponse>("getTypeOfSymbol", {
             snapshot: this.snapshotId,
             project: this.project.id,
             symbol: (symbolOrSymbols as Symbol).id,
         });
-        return data ? this.objectRegistry.getOrCreateType(data) : undefined;
+        return this.objectRegistry.getOrCreateType(data);
     }
 
     /**
@@ -896,12 +902,11 @@ export class Checker {
      * {@link Type.isErrorType} to detect it).
      */
     getDeclaredTypeOfSymbol(symbol: Symbol): Type {
-        const data = this.client.apiRequest<TypeResponse | null>("getDeclaredTypeOfSymbol", {
+        const data = this.client.apiRequest<TypeResponse>("getDeclaredTypeOfSymbol", {
             snapshot: this.snapshotId,
             project: this.project.id,
             symbol: symbol.id,
         });
-        if (!data) throw new Error(`getDeclaredTypeOfSymbol returned no type for symbol ${symbol.id}`);
         return this.objectRegistry.getOrCreateType(data);
     }
 
@@ -960,23 +965,28 @@ export class Checker {
         };
     }
 
-    getTypeAtLocation(node: Node): Type | undefined;
-    getTypeAtLocation(nodes: readonly Node[]): (Type | undefined)[];
-    getTypeAtLocation(nodeOrNodes: Node | readonly Node[]): Type | (Type | undefined)[] | undefined {
+    /**
+     * Get the type at a node location. Always returns a type; for nodes whose
+     * type cannot be determined the checker yields the error type (use
+     * {@link Type.isErrorType} to detect it).
+     */
+    getTypeAtLocation(node: Node): Type;
+    getTypeAtLocation(nodes: readonly Node[]): Type[];
+    getTypeAtLocation(nodeOrNodes: Node | readonly Node[]): Type | Type[] {
         if (Array.isArray(nodeOrNodes)) {
-            const data = this.client.apiRequest<(TypeResponse | null)[]>("getTypeAtLocations", {
+            const data = this.client.apiRequest<TypeResponse[]>("getTypeAtLocations", {
                 snapshot: this.snapshotId,
                 project: this.project.id,
                 locations: nodeOrNodes.map(node => getNodeId(node)),
             });
-            return data.map(d => d ? this.objectRegistry.getOrCreateType(d) : undefined);
+            return data.map(d => this.objectRegistry.getOrCreateType(d));
         }
-        const data = this.client.apiRequest<TypeResponse | null>("getTypeAtLocation", {
+        const data = this.client.apiRequest<TypeResponse>("getTypeAtLocation", {
             snapshot: this.snapshotId,
             project: this.project.id,
             location: getNodeId(nodeOrNodes as Node),
         });
-        return data ? this.objectRegistry.getOrCreateType(data) : undefined;
+        return this.objectRegistry.getOrCreateType(data);
     }
 
     getSignaturesOfType(type: Type, kind: SignatureKind): readonly Signature[] {
@@ -989,13 +999,18 @@ export class Checker {
         return data.map(d => this.objectRegistry.getOrCreateSignature(d));
     }
 
-    getResolvedSignature(node: Node): Signature | undefined {
-        const data = this.client.apiRequest<SignatureResponse | null>("getResolvedSignature", {
+    /**
+     * Get the resolved signature of a call-like expression. Always returns a
+     * signature; when a call cannot be resolved the checker yields the unknown
+     * signature (use {@link Checker.isUnknownSignature} to detect it).
+     */
+    getResolvedSignature(node: Node): Signature {
+        const data = this.client.apiRequest<SignatureResponse>("getResolvedSignature", {
             snapshot: this.snapshotId,
             project: this.project.id,
             location: getNodeId(node),
         });
-        return data ? this.objectRegistry.getOrCreateSignature(data) : undefined;
+        return this.objectRegistry.getOrCreateSignature(data);
     }
 
     getTypeAtPosition(file: DocumentIdentifier, position: number): Type | undefined;
@@ -1055,50 +1070,62 @@ export class Checker {
         return data ? this.objectRegistry.getOrCreateType(data) : undefined;
     }
 
-    getBaseTypeOfLiteralType(type: Type): Type | undefined {
-        const data = this.client.apiRequest<TypeResponse | null>("getBaseTypeOfLiteralType", {
+    /** Get the base type of a literal type (e.g. `number` for `42`). Always returns a type. */
+    getBaseTypeOfLiteralType(type: Type): Type {
+        const data = this.client.apiRequest<TypeResponse>("getBaseTypeOfLiteralType", {
             snapshot: this.snapshotId,
             project: this.project.id,
             type: type.id,
         });
-        return data ? this.objectRegistry.getOrCreateType(data) : undefined;
+        return this.objectRegistry.getOrCreateType(data);
     }
 
-    getNonNullableType(type: Type): Type | undefined {
-        const data = this.client.apiRequest<TypeResponse | null>("getNonNullableType", {
+    /** Get the type with `null` and `undefined` removed. Always returns a type. */
+    getNonNullableType(type: Type): Type {
+        const data = this.client.apiRequest<TypeResponse>("getNonNullableType", {
             snapshot: this.snapshotId,
             project: this.project.id,
             type: type.id,
         });
-        return data ? this.objectRegistry.getOrCreateType(data) : undefined;
+        return this.objectRegistry.getOrCreateType(data);
     }
 
-    getTypeFromTypeNode(node: TypeNode): Type | undefined {
-        const data = this.client.apiRequest<TypeResponse | null>("getTypeFromTypeNode", {
+    /**
+     * Get the type for a type node. Always returns a type; for type nodes whose
+     * type cannot be determined the checker yields the error type (use
+     * {@link Type.isErrorType} to detect it).
+     */
+    getTypeFromTypeNode(node: TypeNode): Type {
+        const data = this.client.apiRequest<TypeResponse>("getTypeFromTypeNode", {
             snapshot: this.snapshotId,
             project: this.project.id,
             location: getNodeId(node),
         });
-        return data ? this.objectRegistry.getOrCreateType(data) : undefined;
+        return this.objectRegistry.getOrCreateType(data);
     }
 
-    getWidenedType(type: Type): Type | undefined {
-        const data = this.client.apiRequest<TypeResponse | null>("getWidenedType", {
+    /** Get the widened type. Always returns a type. */
+    getWidenedType(type: Type): Type {
+        const data = this.client.apiRequest<TypeResponse>("getWidenedType", {
             snapshot: this.snapshotId,
             project: this.project.id,
             type: type.id,
         });
-        return data ? this.objectRegistry.getOrCreateType(data) : undefined;
+        return this.objectRegistry.getOrCreateType(data);
     }
 
-    getParameterType(signature: Signature, index: number): Type | undefined {
-        const data = this.client.apiRequest<TypeResponse | null>("getParameterType", {
+    /**
+     * Get the type of the parameter at the given index in a signature. Always
+     * returns a type; an out-of-range index yields the `any` type.
+     */
+    getParameterType(signature: Signature, index: number): Type {
+        const data = this.client.apiRequest<TypeResponse>("getParameterType", {
             snapshot: this.snapshotId,
             project: this.project.id,
             signature: signature.id,
             index,
         });
-        return data ? this.objectRegistry.getOrCreateType(data) : undefined;
+        return this.objectRegistry.getOrCreateType(data);
     }
 
     isArrayLikeType(type: Type): boolean {
@@ -1133,13 +1160,12 @@ export class Checker {
      * error type (use {@link Type.isErrorType} to detect it).
      */
     getTypeOfSymbolAtLocation(symbol: Symbol, location: Node): Type {
-        const data = this.client.apiRequest<TypeResponse | null>("getTypeOfSymbolAtLocation", {
+        const data = this.client.apiRequest<TypeResponse>("getTypeOfSymbolAtLocation", {
             snapshot: this.snapshotId,
             project: this.project.id,
             symbol: symbol.id,
             location: getNodeId(location),
         });
-        if (!data) throw new Error(`getTypeOfSymbolAtLocation returned no type for symbol ${symbol.id}`);
         return this.objectRegistry.getOrCreateType(data);
     }
 
@@ -1244,22 +1270,27 @@ export class Checker {
         });
     }
 
-    getReturnTypeOfSignature(signature: Signature): Type | undefined {
-        const data = this.client.apiRequest<TypeResponse | null>("getReturnTypeOfSignature", {
+    /** Get the return type of a signature. Always returns a type. */
+    getReturnTypeOfSignature(signature: Signature): Type {
+        const data = this.client.apiRequest<TypeResponse>("getReturnTypeOfSignature", {
             snapshot: this.snapshotId,
             project: this.project.id,
             signature: signature.id,
         });
-        return data ? this.objectRegistry.getOrCreateType(data) : undefined;
+        return this.objectRegistry.getOrCreateType(data);
     }
 
-    getRestTypeOfSignature(signature: Signature): Type | undefined {
-        const data = this.client.apiRequest<TypeResponse | null>("getRestTypeOfSignature", {
+    /**
+     * Get the rest type of a signature. Always returns a type; a signature with
+     * no rest parameter yields the `any` type.
+     */
+    getRestTypeOfSignature(signature: Signature): Type {
+        const data = this.client.apiRequest<TypeResponse>("getRestTypeOfSignature", {
             snapshot: this.snapshotId,
             project: this.project.id,
             signature: signature.id,
         });
-        return data ? this.objectRegistry.getOrCreateType(data) : undefined;
+        return this.objectRegistry.getOrCreateType(data);
     }
 
     getTypePredicateOfSignature(signature: Signature): TypePredicate | undefined {
@@ -1290,13 +1321,14 @@ export class Checker {
         return data ? data.map(d => this.objectRegistry.getOrCreateType(d)) : [];
     }
 
-    getApparentType(type: Type): Type | undefined {
-        const data = this.client.apiRequest<TypeResponse | null>("getApparentType", {
+    /** Get the apparent type of a type. Always returns a type. */
+    getApparentType(type: Type): Type {
+        const data = this.client.apiRequest<TypeResponse>("getApparentType", {
             snapshot: this.snapshotId,
             project: this.project.id,
             type: type.id,
         });
-        return data ? this.objectRegistry.getOrCreateType(data) : undefined;
+        return this.objectRegistry.getOrCreateType(data);
     }
 
     getPropertiesOfType(type: Type): readonly Symbol[] {
@@ -1364,13 +1396,14 @@ export class Checker {
         return data ?? undefined;
     }
 
-    getSignatureFromDeclaration(node: Node): Signature | undefined {
-        const data = this.client.apiRequest<SignatureResponse | null>("getSignatureFromDeclaration", {
+    /** Get the signature of a function-like declaration. Always returns a signature. */
+    getSignatureFromDeclaration(node: Node): Signature {
+        const data = this.client.apiRequest<SignatureResponse>("getSignatureFromDeclaration", {
             snapshot: this.snapshotId,
             project: this.project.id,
             location: getNodeId(node),
         });
-        return data ? this.objectRegistry.getOrCreateSignature(data) : undefined;
+        return this.objectRegistry.getOrCreateSignature(data);
     }
 
     getExportSpecifierLocalTargetSymbol(node: Node): Symbol | undefined {
@@ -1388,12 +1421,11 @@ export class Checker {
      * {@link Checker.isUnknownSymbol} to detect it).
      */
     getAliasedSymbol(symbol: Symbol): Symbol {
-        const data = this.client.apiRequest<SymbolResponse | null>("getAliasedSymbol", {
+        const data = this.client.apiRequest<SymbolResponse>("getAliasedSymbol", {
             snapshot: this.snapshotId,
             project: this.project.id,
             symbol: symbol.id,
         });
-        if (!data) throw new Error(`getAliasedSymbol returned no symbol for symbol ${symbol.id}`);
         return this.objectRegistry.getOrCreateSymbol(data);
     }
 
@@ -1439,6 +1471,27 @@ export class Checker {
      */
     isArgumentsSymbol(symbol: Symbol): boolean {
         return symbol.id === (this.getWellKnownSymbols()).arguments;
+    }
+
+    /**
+     * Fetch (once, then cache) the handle id of the per-checker unknown
+     * signature. This id is stable for the life of the project's checker, so
+     * identity checks against it are local after the first call.
+     */
+    private getWellKnownSignatures(): { unknown: number; } {
+        return this.wellKnownSignatures ??= this.client.apiRequest<{ unknown: number; }>("getWellKnownSignatures", {
+            snapshot: this.snapshotId,
+            project: this.project.id,
+        });
+    }
+
+    /**
+     * Returns `true` if the signature is the checker's "unknown" signature (e.g.
+     * the result of {@link Checker.getResolvedSignature} on a call that cannot be
+     * resolved).
+     */
+    isUnknownSignature(signature: Signature): boolean {
+        return signature.id === (this.getWellKnownSignatures()).unknown;
     }
 
     getExportsOfModule(symbol: Symbol): readonly Symbol[] {

--- a/_packages/native-preview/test/async/api.test.ts
+++ b/_packages/native-preview/test/async/api.test.ts
@@ -2789,6 +2789,44 @@ export type Alias = typeof value;
     });
 });
 
+describe("Checker - well-known signatures", () => {
+    test("isUnknownSignature identifies an unresolvable call", async () => {
+        const src = `
+const ok = (x: number) => x;
+ok(1);
+const notCallable = 1;
+notCallable();
+`;
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/main.ts": src,
+        });
+        try {
+            const snapshot = await api.updateSnapshot({ openProject: "/tsconfig.json" });
+            const project = snapshot.getProject("/tsconfig.json")!;
+            const sourceFile = await project.program.getSourceFile("/src/main.ts");
+            assert.ok(sourceFile);
+            const calls: Node[] = [];
+            sourceFile.forEachChild(function visit(node) {
+                if (isCallExpression(node)) calls.push(node);
+                node.forEachChild(visit);
+            });
+            assert.equal(calls.length, 2, "should find two call expressions");
+
+            // The valid call resolves to a real signature, not the unknown signature.
+            const okSig = await project.checker.getResolvedSignature(calls[0]);
+            assert.equal(await project.checker.isUnknownSignature(okSig), false);
+
+            // The call to a non-callable value yields the unknown signature.
+            const badSig = await project.checker.getResolvedSignature(calls[1]);
+            assert.equal(await project.checker.isUnknownSignature(badSig), true);
+        }
+        finally {
+            await api.close();
+        }
+    });
+});
+
 describe("Symbol - escaped names and tables", () => {
     test("getExports/getMembers return a cached Map keyed by escaped name", async () => {
         const api = spawnAPI({

--- a/_packages/native-preview/test/sync/api.test.ts
+++ b/_packages/native-preview/test/sync/api.test.ts
@@ -2797,6 +2797,44 @@ export type Alias = typeof value;
     });
 });
 
+describe("Checker - well-known signatures", () => {
+    test("isUnknownSignature identifies an unresolvable call", () => {
+        const src = `
+const ok = (x: number) => x;
+ok(1);
+const notCallable = 1;
+notCallable();
+`;
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/main.ts": src,
+        });
+        try {
+            const snapshot = api.updateSnapshot({ openProject: "/tsconfig.json" });
+            const project = snapshot.getProject("/tsconfig.json")!;
+            const sourceFile = project.program.getSourceFile("/src/main.ts");
+            assert.ok(sourceFile);
+            const calls: Node[] = [];
+            sourceFile.forEachChild(function visit(node) {
+                if (isCallExpression(node)) calls.push(node);
+                node.forEachChild(visit);
+            });
+            assert.equal(calls.length, 2, "should find two call expressions");
+
+            // The valid call resolves to a real signature, not the unknown signature.
+            const okSig = project.checker.getResolvedSignature(calls[0]);
+            assert.equal(project.checker.isUnknownSignature(okSig), false);
+
+            // The call to a non-callable value yields the unknown signature.
+            const badSig = project.checker.getResolvedSignature(calls[1]);
+            assert.equal(project.checker.isUnknownSignature(badSig), true);
+        }
+        finally {
+            api.close();
+        }
+    });
+});
+
 describe("Symbol - escaped names and tables", () => {
     test("getExports/getMembers return a cached Map keyed by escaped name", () => {
         const api = spawnAPI({

--- a/internal/api/proto.go
+++ b/internal/api/proto.go
@@ -196,6 +196,9 @@ const (
 	// Well-known per-checker symbols
 	MethodGetWellKnownSymbols Method = "getWellKnownSymbols"
 
+	// Well-known per-checker signatures
+	MethodGetWellKnownSignatures Method = "getWellKnownSignatures"
+
 	// Profiling methods
 	MethodStartCPUProfile Method = "startCPUProfile"
 	MethodStopCPUProfile  Method = "stopCPUProfile"
@@ -463,6 +466,7 @@ var unmarshalers = map[Method]func([]byte) (any, error){
 	MethodGetBigIntType:                     unmarshallerFor[GetIntrinsicTypeParams],
 	MethodGetESSymbolType:                   unmarshallerFor[GetIntrinsicTypeParams],
 	MethodGetWellKnownSymbols:               unmarshallerFor[GetIntrinsicTypeParams],
+	MethodGetWellKnownSignatures:            unmarshallerFor[GetIntrinsicTypeParams],
 	MethodGetSyntacticDiagnostics:           unmarshallerFor[GetDiagnosticsParams],
 	MethodGetBindDiagnostics:                unmarshallerFor[GetDiagnosticsParams],
 	MethodGetSemanticDiagnostics:            unmarshallerFor[GetDiagnosticsParams],
@@ -911,6 +915,13 @@ type WellKnownSymbolsResponse struct {
 	Unknown   SymbolID `json:"unknown"`
 	Undefined SymbolID `json:"undefined"`
 	Arguments SymbolID `json:"arguments"`
+}
+
+// WellKnownSignaturesResponse carries the handle id of the per-checker singleton
+// unknown signature (the signature the checker yields when a call cannot be
+// resolved) so the client can identify it by id without a round-trip on every check.
+type WellKnownSignaturesResponse struct {
+	Unknown SignatureID `json:"unknown"`
 }
 
 // GetBaseTypeOfLiteralTypeParams returns the base type of a literal type.

--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -742,6 +742,8 @@ func (s *Session) HandleRequest(ctx context.Context, method string, params json.
 		return s.handleGetIntrinsicType(ctx, parsed.(*GetIntrinsicTypeParams), (*checker.Checker).GetESSymbolType)
 	case string(MethodGetWellKnownSymbols):
 		return s.handleGetWellKnownSymbols(ctx, parsed.(*GetIntrinsicTypeParams))
+	case string(MethodGetWellKnownSignatures):
+		return s.handleGetWellKnownSignatures(ctx, parsed.(*GetIntrinsicTypeParams))
 	case string(MethodGetSyntacticDiagnostics):
 		return s.handleGetSyntacticDiagnostics(ctx, parsed.(*GetDiagnosticsParams))
 	case string(MethodGetBindDiagnostics):
@@ -1242,16 +1244,8 @@ func (s *Session) handleGetTypeOfSymbol(ctx context.Context, params *GetTypeOfSy
 	if err != nil {
 		return nil, err
 	}
-	if symbol == nil {
-		return nil, nil
-	}
 
-	t := setup.checker.GetTypeOfSymbol(symbol)
-	if t == nil {
-		return nil, nil
-	}
-
-	return setup.newTypeResponse(t), nil
+	return setup.newTypeResponse(setup.checker.GetTypeOfSymbol(symbol)), nil
 }
 
 // handleGetTypesOfSymbols returns the types of multiple symbols.
@@ -1268,13 +1262,9 @@ func (s *Session) handleGetTypesOfSymbols(ctx context.Context, params *GetTypesO
 		if err != nil {
 			return nil, err
 		}
-		if symbol == nil {
-			continue
-		}
-		t := setup.checker.GetTypeOfSymbol(symbol)
-		if t != nil {
-			results[i] = setup.newTypeResponse(t)
-		}
+		// resolveSymbolHandle errors on an unresolvable handle and GetTypeOfSymbol
+		// never returns nil, so every element resolves to a type (error type at worst).
+		results[i] = setup.newTypeResponse(setup.checker.GetTypeOfSymbol(symbol))
 	}
 
 	return results, nil
@@ -1292,16 +1282,8 @@ func (s *Session) handleGetDeclaredTypeOfSymbol(ctx context.Context, params *Get
 	if err != nil {
 		return nil, err
 	}
-	if symbol == nil {
-		return nil, nil
-	}
 
-	t := setup.checker.GetDeclaredTypeOfSymbol(symbol)
-	if t == nil {
-		return nil, nil
-	}
-
-	return setup.newTypeResponse(t), nil
+	return setup.newTypeResponse(setup.checker.GetDeclaredTypeOfSymbol(symbol)), nil
 }
 
 // handleResolveName resolves a name to a symbol at a given location.
@@ -1369,12 +1351,8 @@ func (s *Session) handleGetResolvedSignature(ctx context.Context, params *GetRes
 	if err != nil {
 		return nil, err
 	}
-	if node == nil {
-		return nil, nil
-	}
 
-	sig := setup.checker.GetResolvedSignature(node)
-	return setup.newSignatureResponse(sig), nil
+	return setup.newSignatureResponse(setup.checker.GetResolvedSignature(node)), nil
 }
 
 // handleGetTypeAtLocation returns the type at a node location.
@@ -1389,16 +1367,8 @@ func (s *Session) handleGetTypeAtLocation(ctx context.Context, params *GetTypeAt
 	if err != nil {
 		return nil, err
 	}
-	if node == nil {
-		return nil, nil
-	}
 
-	t := setup.checker.GetTypeAtLocation(node)
-	if t == nil {
-		return nil, nil
-	}
-
-	return setup.newTypeResponse(t), nil
+	return setup.newTypeResponse(setup.checker.GetTypeAtLocation(node)), nil
 }
 
 // handleGetTypeAtLocations returns types at multiple node locations.
@@ -1415,13 +1385,9 @@ func (s *Session) handleGetTypeAtLocations(ctx context.Context, params *GetTypeA
 		if err != nil {
 			return nil, err
 		}
-		if node == nil {
-			continue
-		}
-		t := setup.checker.GetTypeAtLocation(node)
-		if t != nil {
-			results[i] = setup.newTypeResponse(t)
-		}
+		// resolveNodeHandle errors on an unresolvable handle and GetTypeAtLocation
+		// never returns nil, so every element resolves to a type (error type at worst).
+		results[i] = setup.newTypeResponse(setup.checker.GetTypeAtLocation(node))
 	}
 
 	return results, nil
@@ -1840,12 +1806,7 @@ func (s *Session) handleGetBaseTypeOfLiteralType(ctx context.Context, params *Ge
 		return nil, err
 	}
 
-	result := setup.checker.GetBaseTypeOfLiteralType(t)
-	if result == nil {
-		return nil, nil
-	}
-
-	return setup.newTypeResponse(result), nil
+	return setup.newTypeResponse(setup.checker.GetBaseTypeOfLiteralType(t)), nil
 }
 
 // handleGetNonNullableType returns the type with null and undefined removed.
@@ -1861,12 +1822,7 @@ func (s *Session) handleGetNonNullableType(ctx context.Context, params *GetNonNu
 		return nil, err
 	}
 
-	result := setup.checker.GetNonNullableType(t)
-	if result == nil {
-		return nil, nil
-	}
-
-	return setup.newTypeResponse(result), nil
+	return setup.newTypeResponse(setup.checker.GetNonNullableType(t)), nil
 }
 
 // handleGetTypeFromTypeNode returns the type for a type node.
@@ -1881,16 +1837,8 @@ func (s *Session) handleGetTypeFromTypeNode(ctx context.Context, params *GetType
 	if err != nil {
 		return nil, err
 	}
-	if node == nil {
-		return nil, nil
-	}
 
-	t := setup.checker.GetTypeFromTypeNode(node)
-	if t == nil {
-		return nil, nil
-	}
-
-	return setup.newTypeResponse(t), nil
+	return setup.newTypeResponse(setup.checker.GetTypeFromTypeNode(node)), nil
 }
 
 // handleGetWidenedType returns the widened type.
@@ -1906,12 +1854,7 @@ func (s *Session) handleGetWidenedType(ctx context.Context, params *GetWidenedTy
 		return nil, err
 	}
 
-	result := setup.checker.GetWidenedType(t)
-	if result == nil {
-		return nil, nil
-	}
-
-	return setup.newTypeResponse(result), nil
+	return setup.newTypeResponse(setup.checker.GetWidenedType(t)), nil
 }
 
 // handleGetParameterType returns the type of a parameter at a given index in a signature.
@@ -1931,12 +1874,7 @@ func (s *Session) handleGetParameterType(ctx context.Context, params *GetParamet
 		return nil, fmt.Errorf("%w: invalid parameter index", ErrClientError)
 	}
 
-	t := setup.checker.GetTypeAtPosition(sig, int(params.Index))
-	if t == nil {
-		return nil, nil
-	}
-
-	return setup.newTypeResponse(t), nil
+	return setup.newTypeResponse(setup.checker.GetTypeAtPosition(sig, int(params.Index))), nil
 }
 
 // handleIsArrayLikeType returns whether a type is array-like.
@@ -2011,24 +1949,13 @@ func (s *Session) handleGetTypeOfSymbolAtLocation(ctx context.Context, params *G
 	if err != nil {
 		return nil, err
 	}
-	if symbol == nil {
-		return nil, nil
-	}
 
 	node, err := setup.sd.resolveNodeHandle(setup.program, params.Location)
 	if err != nil {
 		return nil, err
 	}
-	if node == nil {
-		return nil, nil
-	}
 
-	t := setup.checker.GetTypeOfSymbolAtLocation(symbol, node)
-	if t == nil {
-		return nil, nil
-	}
-
-	return setup.newTypeResponse(t), nil
+	return setup.newTypeResponse(setup.checker.GetTypeOfSymbolAtLocation(symbol, node)), nil
 }
 
 // handleTypeToTypeNode converts a Type to a TypeNode AST and returns it as binary-encoded data.
@@ -2190,6 +2117,20 @@ func (s *Session) handleGetWellKnownSymbols(ctx context.Context, params *GetIntr
 	}, nil
 }
 
+// handleGetWellKnownSignatures returns the handle id of the per-checker unknown
+// signature so the client can identify it by id.
+func (s *Session) handleGetWellKnownSignatures(ctx context.Context, params *GetIntrinsicTypeParams) (*WellKnownSignaturesResponse, error) {
+	setup, err := s.setupChecker(ctx, params.Snapshot, params.Project)
+	if err != nil {
+		return nil, err
+	}
+	defer setup.done()
+
+	return &WellKnownSignaturesResponse{
+		Unknown: setup.sd.registerSignature(setup.projectID, setup.checker.GetUnknownSignature()),
+	}, nil
+}
+
 // handleIsContextSensitive returns whether a node is context-sensitive.
 func (s *Session) handleIsContextSensitive(ctx context.Context, params *GetContextualTypeParams) (bool, error) {
 	setup, err := s.setupChecker(ctx, params.Snapshot, params.Project)
@@ -2222,12 +2163,7 @@ func (s *Session) handleGetReturnTypeOfSignature(ctx context.Context, params *Ch
 		return nil, err
 	}
 
-	t := setup.checker.GetReturnTypeOfSignature(sig)
-	if t == nil {
-		return nil, nil
-	}
-
-	return setup.newTypeResponse(t), nil
+	return setup.newTypeResponse(setup.checker.GetReturnTypeOfSignature(sig)), nil
 }
 
 // handleGetRestTypeOfSignature returns the rest type of a signature.
@@ -2243,12 +2179,7 @@ func (s *Session) handleGetRestTypeOfSignature(ctx context.Context, params *Chec
 		return nil, err
 	}
 
-	t := setup.checker.GetRestTypeOfSignature(sig)
-	if t == nil {
-		return nil, nil
-	}
-
-	return setup.newTypeResponse(t), nil
+	return setup.newTypeResponse(setup.checker.GetRestTypeOfSignature(sig)), nil
 }
 
 // handleGetTypePredicateOfSignature returns the type predicate of a signature.
@@ -2378,12 +2309,7 @@ func (s *Session) handleGetApparentType(ctx context.Context, params *CheckerType
 		return nil, err
 	}
 
-	apparent := setup.checker.GetApparentType(t)
-	if apparent == nil {
-		return nil, nil
-	}
-
-	return setup.newTypeResponse(apparent), nil
+	return setup.newTypeResponse(setup.checker.GetApparentType(t)), nil
 }
 
 // handleGetIndexInfosOfType returns the index infos of a type.
@@ -2513,16 +2439,8 @@ func (s *Session) handleGetSignatureFromDeclaration(ctx context.Context, params 
 	if err != nil {
 		return nil, err
 	}
-	if node == nil {
-		return nil, nil
-	}
 
-	sig := setup.checker.GetSignatureFromDeclaration(node)
-	if sig == nil {
-		return nil, nil
-	}
-
-	return setup.newSignatureResponse(sig), nil
+	return setup.newSignatureResponse(setup.checker.GetSignatureFromDeclaration(node)), nil
 }
 
 // handleGetExportSpecifierLocalTargetSymbol returns the local target symbol of an export specifier.
@@ -2561,16 +2479,8 @@ func (s *Session) handleGetAliasedSymbol(ctx context.Context, params *CheckerSym
 	if err != nil {
 		return nil, err
 	}
-	if symbol == nil {
-		return nil, nil
-	}
 
-	aliased := setup.checker.GetAliasedSymbol(symbol)
-	if aliased == nil {
-		return nil, nil
-	}
-
-	return setup.newSymbolResponse(aliased), nil
+	return setup.newSymbolResponse(setup.checker.GetAliasedSymbol(symbol)), nil
 }
 
 // handleGetImmediateAliasedSymbol resolves one level of alias indirection.

--- a/internal/checker/exports.go
+++ b/internal/checker/exports.go
@@ -70,6 +70,10 @@ func (c *Checker) GetArgumentsSymbol() *ast.Symbol {
 	return c.argumentsSymbol
 }
 
+func (c *Checker) GetUnknownSignature() *Signature {
+	return c.unknownSignature
+}
+
 func (c *Checker) GetUnionType(types []*Type) *Type {
 	return c.getUnionType(types)
 }


### PR DESCRIPTION
I missed removing `undefined` from the client-defined return types of a few methods in https://github.com/microsoft/typescript-go/pull/4493