### PR TITLE
Fix stack overflow in inherited JSDoc resolution

### DIFF
--- a/internal/fourslash/tests/hoverCircularInheritedDocumentation_test.go
+++ b/internal/fourslash/tests/hoverCircularInheritedDocumentation_test.go
@@ -1,0 +1,41 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+// Regression test for a stack overflow in getJSDocOrTag (issue #4380).
+//
+// This is a minimized reproduction of nuxt's schema types, which crashed the language
+// server on hover / completionItem/resolve. A "bridge" module re-exports a base module
+// (`export * from "./base"`) and, via an aliased import, augments the re-exported
+// interface to extend itself: `interface Options extends _Options { hooks: {} }` where
+// `_Options` is the same (re-exported) `Options`. The alias + module boundary evades the
+// checker's heritage-cycle detection, so `Options` legally has itself as a base type.
+//
+// When resolving inherited JSDoc for `hooks`, getJSDocOrTag walks base-type members: the
+// base (`Options` itself) exposes the same `hooks` declaration node, so the walk recursed
+// on that one node until the goroutine stack overflowed (a fatal runtime error that could
+// not be recovered). Hovering must terminate and produce quick info without overflowing.
+func TestHoverCircularInheritedDocumentation(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+
+	const content = `// @filename: base.ts
+export interface Options {}
+// @filename: bridge.ts
+import type { Options as _Options } from "./base";
+export * from "./base";
+declare module "./bridge" {
+    interface Options extends _Options { hooks: {} }
+}
+declare const v: Options;
+v.hooks/*1*/;`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+
+	f.VerifyQuickInfoAt(t, "1", "(property) Options.hooks: {}", "")
+}

--- a/internal/ls/hover.go
+++ b/internal/ls/hover.go
@@ -158,7 +158,7 @@ func (l *LanguageService) getDocumentationFromDeclaration(c *checker.Checker, sy
 	}
 	isMarkdown := contentFormat == lsproto.MarkupKindMarkdown
 	var b strings.Builder
-	if jsdoc := getJSDocOrTag(c, declaration); jsdoc != nil && !(declaration.Flags&ast.NodeFlagsReparsed == 0 && containsTypedefTag(jsdoc)) {
+	if jsdoc := getJSDocOrTag(c, declaration, &collections.Set[*ast.Symbol]{}); jsdoc != nil && !(declaration.Flags&ast.NodeFlagsReparsed == 0 && containsTypedefTag(jsdoc)) {
 		l.writeComments(&b, c, jsdoc.Comments(), isMarkdown)
 		if jsdoc.Kind == ast.KindJSDoc && !commentOnly {
 			if tags := jsdoc.AsJSDoc().Tags; tags != nil {
@@ -850,7 +850,10 @@ func getJSDoc(node *ast.Node) *ast.Node {
 	return core.LastOrNil(node.JSDoc(nil))
 }
 
-func getJSDocOrTag(c *checker.Checker, node *ast.Node) *ast.Node {
+func getJSDocOrTag(c *checker.Checker, node *ast.Node, seenSymbols *collections.Set[*ast.Symbol]) *ast.Node {
+	if node == nil {
+		return nil
+	}
 	if jsdoc := getJSDoc(node); jsdoc != nil {
 		return jsdoc
 	}
@@ -861,14 +864,14 @@ func getJSDocOrTag(c *checker.Checker, node *ast.Node) *ast.Node {
 			// For binding patterns, match JSDoc @param tags by position rather than by name
 			return getJSDocParameterTagByPosition(c, node)
 		}
-		return getMatchingJSDocTag(c, node.Parent, name.Text(), isMatchingParameterTag)
+		return getMatchingJSDocTag(c, node.Parent, name.Text(), isMatchingParameterTag, seenSymbols)
 	case ast.IsTypeParameterDeclaration(node):
-		return getMatchingJSDocTag(c, node.Parent, node.Name().Text(), isMatchingTemplateTag)
+		return getMatchingJSDocTag(c, node.Parent, node.Name().Text(), isMatchingTemplateTag, seenSymbols)
 	case ast.IsVariableDeclaration(node) && ast.IsVariableDeclarationList(node.Parent) && core.FirstOrNil(node.Parent.AsVariableDeclarationList().Declarations.Nodes) == node:
-		return getJSDocOrTag(c, node.Parent.Parent)
+		return getJSDocOrTag(c, node.Parent.Parent, seenSymbols)
 	case (ast.IsFunctionExpressionOrArrowFunction(node) || ast.IsClassExpression(node)) &&
 		(ast.IsVariableDeclaration(node.Parent) || ast.IsPropertyDeclaration(node.Parent) || ast.IsPropertyAssignment(node.Parent)) && node.Parent.Initializer() == node:
-		return getJSDocOrTag(c, node.Parent)
+		return getJSDocOrTag(c, node.Parent, seenSymbols)
 	case ast.IsBindingElement(node) && ast.IsObjectBindingPattern(node.Parent):
 		if name := node.PropertyNameOrName(); ast.IsIdentifier(name) {
 			if objectType := c.GetTypeAtLocation(node.Parent); objectType != nil {
@@ -886,7 +889,7 @@ func getJSDocOrTag(c *checker.Checker, node *ast.Node) *ast.Node {
 		if ast.IsFunctionDeclaration(node) || ast.IsMethodDeclaration(node) || ast.IsMethodSignatureDeclaration(node) || ast.IsConstructorDeclaration(node) || ast.IsConstructSignatureDeclaration(node) {
 			firstSignature := core.Find(symbol.Declarations, ast.IsFunctionLike)
 			if firstSignature != nil && node != firstSignature {
-				if jsDoc := getJSDocOrTag(c, firstSignature); jsDoc != nil {
+				if jsDoc := getJSDocOrTag(c, firstSignature, seenSymbols); jsDoc != nil {
 					return jsDoc
 				}
 			}
@@ -899,15 +902,15 @@ func getJSDocOrTag(c *checker.Checker, node *ast.Node) *ast.Node {
 				// This correctly handles intersection constructor types from mixins
 				// (e.g., typeof MixinClass & T) by preserving the full intersection.
 				staticBaseType := c.GetApparentType(c.GetBaseConstructorTypeOfClass(classType))
-				if prop := c.GetPropertyOfType(staticBaseType, symbol.Name); prop != nil && prop.ValueDeclaration != nil {
-					if jsDoc := getJSDocOrTag(c, prop.ValueDeclaration); jsDoc != nil {
+				if prop := c.GetPropertyOfType(staticBaseType, symbol.Name); prop != nil && prop.ValueDeclaration != nil && seenSymbols.AddIfAbsent(prop) {
+					if jsDoc := getJSDocOrTag(c, prop.ValueDeclaration, seenSymbols); jsDoc != nil {
 						return jsDoc
 					}
 				}
 			} else {
 				for _, baseType := range c.GetBaseTypes(classType) {
-					if prop := c.GetPropertyOfType(baseType, symbol.Name); prop != nil && prop.ValueDeclaration != nil {
-						if jsDoc := getJSDocOrTag(c, prop.ValueDeclaration); jsDoc != nil {
+					if prop := c.GetPropertyOfType(baseType, symbol.Name); prop != nil && prop.ValueDeclaration != nil && seenSymbols.AddIfAbsent(prop) {
+						if jsDoc := getJSDocOrTag(c, prop.ValueDeclaration, seenSymbols); jsDoc != nil {
 							return jsDoc
 						}
 					}
@@ -918,8 +921,8 @@ func getJSDocOrTag(c *checker.Checker, node *ast.Node) *ast.Node {
 	return nil
 }
 
-func getMatchingJSDocTag(c *checker.Checker, node *ast.Node, name string, match func(*ast.Node, string) bool) *ast.Node {
-	if jsdoc := getJSDocOrTag(c, node); jsdoc != nil && jsdoc.Kind == ast.KindJSDoc {
+func getMatchingJSDocTag(c *checker.Checker, node *ast.Node, name string, match func(*ast.Node, string) bool, seenSymbols *collections.Set[*ast.Symbol]) *ast.Node {
+	if jsdoc := getJSDocOrTag(c, node, seenSymbols); jsdoc != nil && jsdoc.Kind == ast.KindJSDoc {
 		if tags := jsdoc.AsJSDoc().Tags; tags != nil {
 			for _, tag := range tags.Nodes {
 				if match(tag, name) {
@@ -953,7 +956,7 @@ func getJSDocParameterTagByPosition(c *checker.Checker, param *ast.Node) *ast.No
 	}
 
 	// Get the JSDoc for the parent function/method
-	jsdoc := getJSDocOrTag(c, parent)
+	jsdoc := getJSDocOrTag(c, parent, &collections.Set[*ast.Symbol]{})
 	if jsdoc == nil || jsdoc.Kind != ast.KindJSDoc {
 		return nil
 	}


### PR DESCRIPTION
Fixes and issue uncovered in https://github.com/microsoft/typescript-go/issues/4380#issuecomment-4755503486 (nuxt); `getJSDocOrTag()` resolves an inherited JSDoc by recursing with no visited guard. This means that a circular or mutually referential class could recurse indefinitely and cause a stack overflow error.