### PR TITLE
Fix nondeterministic Realpath on darwin for hardlinked files

### DIFF
--- a/internal/nativepath/realpath_darwin.go
+++ b/internal/nativepath/realpath_darwin.go
@@ -1,6 +1,7 @@
 package nativepath
 
 import (
+	"os"
 	"path/filepath"
 	"sync"
 	"unsafe"
@@ -19,6 +20,12 @@ import (
 //     references the vnode. O_NONBLOCK prevents blocking on FIFOs.
 //   - fcntl(fd, F_GETPATH, buf) asks the kernel for the canonical path of the
 //     open file descriptor, written into a MAXPATHLEN buffer.
+//
+// F_GETPATH answers from the vnode name cache, so for a regular file with
+// nlink > 1 it may return any hardlink sibling's name — nondeterministically
+// under concurrency (pnpm and Nix stores hardlink-dedupe identical files).
+// For that case we resolve the parent directory instead (directories cannot
+// be hardlinked) and re-attach the final component.
 //
 // unix.FcntlInt takes an int arg, so call it through a uintptr-escaping wrapper
 // to keep the buffer pointer valid until fcntl returns.
@@ -46,21 +53,67 @@ func fcntlGetPathPtr(fd uintptr, buf uintptr) (int, error) {
 	return unix.FcntlInt(fd, unix.F_GETPATH, int(buf))
 }
 
+// maxSymlinkDepth mirrors the kernel's symlink loop limit (MAXSYMLINKS).
+const maxSymlinkDepth = 40
+
 func Realpath(path string) (string, error) {
 	if !hasFGetPath() {
 		return filepath.EvalSymlinks(path)
 	}
+	return realpathFast(path, 0)
+}
 
+func realpathFast(path string, depth int) (string, error) {
 	fd, err := unix.Open(path, unix.O_EVTONLY|unix.O_NONBLOCK|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return "", err
 	}
-	defer unix.Close(fd)
 
-	var buf [unix.PathMax]byte
-	if _, err := fcntlGetPath(fd, &buf); err != nil {
+	var st unix.Stat_t
+	if _, err := ignoringEINTR(func() (struct{}, error) {
+		return struct{}{}, unix.Fstat(fd, &st)
+	}); err != nil {
+		unix.Close(fd)
 		return "", err
 	}
 
-	return unix.ByteSliceToString(buf[:]), nil
+	if st.Mode&unix.S_IFMT == unix.S_IFDIR || st.Nlink == 1 {
+		defer unix.Close(fd)
+		var buf [unix.PathMax]byte
+		if _, err := fcntlGetPath(fd, &buf); err != nil {
+			return "", err
+		}
+		return unix.ByteSliceToString(buf[:]), nil
+	}
+	unix.Close(fd)
+
+	// hardlinked regular file: F_GETPATH may name any of its links (see above)
+	if depth > maxSymlinkDepth {
+		return "", unix.ELOOP
+	}
+	dir, base := filepath.Dir(path), filepath.Base(path)
+	if dir == path || base == "." || base == ".." || base == string(filepath.Separator) {
+		// Cannot split the path further; defer to the stdlib resolver.
+		return filepath.EvalSymlinks(path)
+	}
+	resolvedDir, err := realpathFast(dir, depth)
+	if err != nil {
+		return "", err
+	}
+	joined := filepath.Join(resolvedDir, base)
+	fi, err := os.Lstat(joined)
+	if err != nil {
+		return "", err
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		return joined, nil
+	}
+	target, err := os.Readlink(joined)
+	if err != nil {
+		return "", err
+	}
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(resolvedDir, target)
+	}
+	return realpathFast(target, depth+1)
 }

--- a/internal/nativepath/realpath_darwin_test.go
+++ b/internal/nativepath/realpath_darwin_test.go
@@ -1,0 +1,100 @@
+package nativepath
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// F_GETPATH can return any hardlink sibling's name for an nlink > 1 file;
+// Realpath must return the canonical path of the name it was asked about.
+func TestRealpathHardlinkedFile(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+
+	// expected values resolve /var -> /private/var etc. the same way
+	// Realpath's result does
+	canonical := func(path string) string {
+		resolved, err := filepath.EvalSymlinks(path)
+		assert.NilError(t, err)
+		return resolved
+	}
+
+	// prime the kernel name cache for the inode under a specific name
+	prime := func(path string) {
+		f, err := os.Open(path)
+		assert.NilError(t, err)
+		assert.NilError(t, f.Close())
+	}
+
+	t.Run("returns the queried hardlink, not a cached sibling", func(t *testing.T) {
+		t.Parallel()
+		real := filepath.Join(tmp, "real.d.ts")
+		alias := filepath.Join(tmp, "alias.d.ts")
+		assert.NilError(t, os.WriteFile(real, []byte("export * from './lib';\n"), 0o666))
+		assert.NilError(t, os.Link(real, alias))
+
+		// v_name follows the latest lookup: the bug needs a concurrent
+		// sibling open between Realpath's open() and F_GETPATH
+		stop := make(chan struct{})
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					prime(real)
+				}
+			}
+		}()
+		defer func() { close(stop); <-done }()
+
+		// measured unpatched first-failure max is 15 iterations; 200 = >10x margin
+		want := canonical(alias)
+		for range 200 {
+			got, err := Realpath(alias)
+			assert.NilError(t, err)
+			assert.Equal(t, got, want)
+		}
+	})
+
+	t.Run("symlink to a hardlinked file resolves to the link target", func(t *testing.T) {
+		t.Parallel()
+		real := filepath.Join(tmp, "sym-real.d.ts")
+		alias := filepath.Join(tmp, "sym-alias.d.ts")
+		link := filepath.Join(tmp, "sym-link.d.ts")
+		assert.NilError(t, os.WriteFile(real, []byte("export {};\n"), 0o666))
+		assert.NilError(t, os.Link(real, alias))
+		assert.NilError(t, os.Symlink(alias, link))
+
+		prime(real)
+		got, err := Realpath(link)
+		assert.NilError(t, err)
+		assert.Equal(t, got, canonical(alias))
+	})
+
+	t.Run("nlink == 1 file keeps the fast path result", func(t *testing.T) {
+		t.Parallel()
+		single := filepath.Join(tmp, "single.d.ts")
+		assert.NilError(t, os.WriteFile(single, []byte("export {};\n"), 0o666))
+
+		got, err := Realpath(single)
+		assert.NilError(t, err)
+		assert.Equal(t, got, canonical(single))
+	})
+
+	t.Run("directory keeps the fast path result", func(t *testing.T) {
+		t.Parallel()
+		dir := filepath.Join(tmp, "some-dir")
+		assert.NilError(t, os.MkdirAll(dir, 0o777))
+
+		got, err := Realpath(dir)
+		assert.NilError(t, err)
+		assert.Equal(t, got, canonical(dir))
+	})
+}


### PR DESCRIPTION
Fixes #4262

`Realpath` on darwin resolves paths with `open()` + `fcntl(F_GETPATH)`. F_GETPATH answers from the kernel vnode name cache, and a regular file with `nlink > 1` has several equally valid names, if a concurrent `open()` of a hardlink sibling lands between our `open()` and the `fcntl()`, the kernel returns the sibling's path.

Content addressed package stores (e.g. pnpm) hardlink deduplicate identical files. One of our dependencies, for example, ships hundreds of byte-identical `index.d.ts` files (`export * from './lib';`), which a content addressed store collapses to one inode with `nlink=325`. Under parallel file loading, resolution then intermittently returns a different submodule's path. From a failing `--traceResolution` run:

```
Resolving real path for '.../library/assertions/index.d.ts',
  result '.../library/shared/index.d.ts'
```

That produces TS2305 errors naming the wrong module, and occasionally drops whole import subtrees (This explains the varying `Files:` counts in the issue).

The fix: after opening, `fstat` the fd. Directories and `nlink == 1` files keep the O(1) F_GETPATH path. Hardlinked regular files resolve their parent directory via F_GETPATH instead (directories cannot be hardlinked, so that answer is unambiguous) and re-attach the final component, resolving it manually if it's a symlink (bounded at MAXSYMLINKS=40; unsplittable paths fall back to `filepath.EvalSymlinks`).

The regression test needs concurrency: the vnode's cached name follows the most recent lookup, so a sequential two-hardlink check will pass since `Realpath`'s own `open()` touches the cache. The test instead churns opens of the sibling from a goroutine while asserting 200 `Realpath` calls on the other link.

Validation on the monorepo where we found this: a build of one affected package failed 17-18/20 runs unpatched, 0/140 patched across load conditions. Emitted output is byte-identical to stock tsc, and there's no measurable perf change (0.458s vs 0.460s on the repro build). `go test ./internal/nativepath/... ./internal/vfs/...` pass with and without `-race`; the new test fails 10/10 on unpatched main.

Disclosure per CONTRIBUTING.md: this was investigated and authored with substantial AI assistance, operated and reviewed by me. I chose this issue, I've read and understand the patch, and I'll respond to review feedback myself.
