### PR TITLE
Call IsDirCoveredByWatch less often to improve performance

### DIFF
--- a/internal/execute/watcher.go
+++ b/internal/execute/watcher.go
@@ -185,15 +185,21 @@ func (w *Watcher) computeDesiredWatches(seenFilePaths []string) map[string]bool 
 	resolvedDirs := w.wm.ResolveDesiredDirs(desiredDirs)
 
 	opts := w.comparePathsOptions()
-	toAddDirs := make(map[string]bool) // dir → should add
+	toAddDirs := make(map[tspath.Path]string) // canonicalized dir → original dir
 	for _, filePath := range seenFilePaths {
 		dir := tspath.GetDirectoryPath(filePath)
-		if _, has := toAddDirs[dir]; !has {
-			toAddDirs[dir] = !watchmanager.IsDirCoveredByWatch(resolvedDirs, dir, opts) && watchmanager.CanWatchDirectory(dir)
+		canonicalDir := tspath.ToPath(dir, cwd, opts.UseCaseSensitiveFileNames)
+		if _, has := toAddDirs[canonicalDir]; !has {
+			if !watchmanager.IsDirCoveredByWatch(resolvedDirs, dir, opts) && watchmanager.CanWatchDirectory(dir) {
+				toAddDirs[canonicalDir] = dir
+			} else {
+				// Cache the IsDirCoveredByWatch call, but don't add the dir
+				toAddDirs[canonicalDir] = ""
+			}
 		}
 	}
-	for dir, shouldAdd := range toAddDirs {
-		if shouldAdd {
+	for _, dir := range toAddDirs {
+		if dir != "" {
 			resolvedDirs[dir] = false
 		}
 	}

--- a/internal/execute/watcher.go
+++ b/internal/execute/watcher.go
@@ -185,12 +185,16 @@ func (w *Watcher) computeDesiredWatches(seenFilePaths []string) map[string]bool 
 	resolvedDirs := w.wm.ResolveDesiredDirs(desiredDirs)
 
 	opts := w.comparePathsOptions()
+	toAddDirs := make(map[string]bool) // dir → should add
 	for _, filePath := range seenFilePaths {
 		dir := tspath.GetDirectoryPath(filePath)
-		if !watchmanager.IsDirCoveredByWatch(resolvedDirs, dir, opts) {
-			if watchmanager.CanWatchDirectory(dir) {
-				resolvedDirs[dir] = false
-			}
+		if _, has := toAddDirs[dir]; !has {
+			toAddDirs[dir] = !watchmanager.IsDirCoveredByWatch(resolvedDirs, dir, opts) && watchmanager.CanWatchDirectory(dir)
+		}
+	}
+	for dir, shouldAdd := range toAddDirs {
+		if shouldAdd {
+			resolvedDirs[dir] = false
 		}
 	}
 


### PR DESCRIPTION
I'm experiencing a significant performance penalty when using `tsc --watch`. I'm seeing `tsc` complete in ~2 seconds while `tsc --watch` will hang for ~15 seconds after reporting the first build status.

Profiling shows a large amount of time being spent doing string manipulation as a result of calls to `watchmanager.IsDirCoveredByWatch`. I noticed a couple of pieces of low hanging optimization fruit.
1. `watchmanager.IsDirCoveredByWatch` was being called once for each path in `seenFilePaths`, even if two paths were in the same directory. For my project `seenFilePaths` had a length of around 40k files, but only 2k directories. This is where I was the most improvement for my project, reducing time spent in this part of the code from ~15s to ~200ms.
2. The `resolvedDirs` map was (potentially) having new directories added to it each iteration of the loop. Since `IsDirCoveredByWatch` iterates over that map to check if a directory is covered, this led to some accidentally quadratic time complexity. Since all directories being added to it are _not_ recursive, they don't affect behavior and can be added after doing all the checks. This improved time spent in this part of the code from ~200ms to ~20ms.

I can't easily share the project I'm testing with, so I also checked the performance difference when checking https://github.com/grafana/grafana

Before, using `@typescript/native-preview@7.0.0-dev.20260707.2` (~30 seconds)

```
$ tsgo --version
Version 7.0.0-dev.20260707.2

$ tsgo --noemit --watch --preserveWatchOutput
[12:07:01 AM] Starting compilation in watch mode...

[12:07:31 AM] Found 0 errors. Watching for file changes.
```

After, with this PR (~1 second):

```
$ ~/code/typescript-go/built/local/tsgo --noemit --watch --preserveWatchOutput
[12:06:55 AM] Starting compilation in watch mode...

[12:06:56 AM] Found 0 errors. Watching for file changes.
```

AI Assistance: I used Github Coilot Completions, and asked Claude Code to give the commit + PR description a sanity check.