### PR TITLE
Fix "Token end is child end" crash on grammar error

### DIFF
--- a/internal/format/span.go
+++ b/internal/format/span.go
@@ -350,7 +350,7 @@ func (w *formatSpanWorker) processChildNode(
 		return inheritedIndentation
 	}
 	if isGrammarError(parent, child) {
-		if w.originalRange.Overlaps(child.Loc) {
+		if w.originalRange.Overlaps(child.Loc) || child.End() < w.originalRange.Pos() {
 			w.formattingScanner.skipToEndOf(&child.Loc)
 		}
 		return inheritedIndentation

--- a/internal/format/span.go
+++ b/internal/format/span.go
@@ -346,7 +346,13 @@ func (w *formatSpanWorker) processChildNode(
 ) int {
 	debug.Assert(!ast.NodeIsSynthesized(child))
 
-	if ast.NodeIsMissing(child) || isGrammarError(parent, child) || child.Flags&ast.NodeFlagsReparsed != 0 {
+	if ast.NodeIsMissing(child) || child.Flags&ast.NodeFlagsReparsed != 0 {
+		return inheritedIndentation
+	}
+	if isGrammarError(parent, child) {
+		if w.originalRange.Overlaps(child.Loc) {
+			w.formattingScanner.skipToEndOf(&child.Loc)
+		}
 		return inheritedIndentation
 	}
 

--- a/internal/fourslash/tests/formatDocumentGrammarErrorInitializer_test.go
+++ b/internal/fourslash/tests/formatDocumentGrammarErrorInitializer_test.go
@@ -1,0 +1,32 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+// A malformed intersection type with an unclosed object type (`x as A & { a: { b: C }`) makes
+// the parser swallow the following statements into the still-open type literal as recovered
+// members. One becomes a PropertySignature whose (grammar-error) initializer is an array literal
+// containing a template literal. isGrammarError skips that initializer, so the formatting scanner
+// must be advanced past it; otherwise it stays parked on the template backtick and mis-scans it,
+// failing the "token end is child end" span invariant on a later sibling.
+func TestFormatDocumentGrammarErrorInitializer(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	content := "// @Filename: /a.ts\n" +
+		"const f = () => {\n" +
+		"  const v = x as A & {\n" +
+		"    a: { b: C\n" +
+		"  }\n" +
+		"  const m: T[] = [\n" +
+		"    { g: () => { nav(`${z}`) } },\n" +
+		"  ]\n" +
+		"  const n: T[] =\n" +
+		"}\n"
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.FormatDocument(t, "/a.ts")
+}

--- a/internal/fourslash/tests/formatDocumentGrammarErrorInitializer_test.go
+++ b/internal/fourslash/tests/formatDocumentGrammarErrorInitializer_test.go
@@ -16,16 +16,17 @@ import (
 func TestFormatDocumentGrammarErrorInitializer(t *testing.T) {
 	t.Parallel()
 	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
-	content := "// @Filename: /a.ts\n" +
-		"const f = () => {\n" +
-		"  const v = x as A & {\n" +
-		"    a: { b: C\n" +
-		"  }\n" +
-		"  const m: T[] = [\n" +
-		"    { g: () => { nav(`${z}`) } },\n" +
-		"  ]\n" +
-		"  const n: T[] =\n" +
-		"}\n"
+	content := `// @Filename: /a.ts
+const f = () => {
+  const v = x as A & {
+    a: { b: C
+  }
+  const m: T[] = [
+    { g: () => { nav(` + "`${z}`" + `) } },
+  ]
+  const n: T[] =
+}
+`
 	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
 	defer done()
 	f.FormatDocument(t, "/a.ts")


### PR DESCRIPTION
Fixes an issue uncovered in https://github.com/microsoft/typescript-go/issues/4459#issuecomment-4814129956 and https://github.com/microsoft/typescript-go/issues/4459#issuecomment-4814130022; `processChildNode()` skips children with grammar errors with an early return but doesn't advance the scanner. This results in the backtick being scanned as an undetermined template literal, and the resulting token's end no longer matches its AST child's end, resulting in the formatter crash.