### PR TITLE
Improve responsiveness of `tsc build` to interruption

### DIFF
--- a/cmd/tsgo/main.go
+++ b/cmd/tsgo/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/microsoft/typescript-go/internal/core"
 	"github.com/microsoft/typescript-go/internal/execute"
+	"github.com/microsoft/typescript-go/internal/execute/tsc"
 )
 
 func main() {
@@ -25,8 +26,38 @@ func runMain() int {
 			return runAPI(args[1:])
 		}
 	}
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer stop()
+
+	// Notify on our own channel rather than using signal.NotifyContext: we need the
+	// actual signal so a canceled run can exit with the conventional 128+signum code,
+	// matching the JS tsc (which installs no handler and lets node's default fire).
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var receivedSignal os.Signal
+	go func() {
+		select {
+		case receivedSignal = <-sigCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
 	result := execute.CommandLine(ctx, newSystem(), args, nil)
+
+	if result.Status == tsc.ExitStatusCanceled && receivedSignal != nil {
+		// A signal interrupted the run. Restore the default disposition and re-raise so
+		// the process terminates via the signal itself: this yields the conventional
+		// exit code (130 for SIGINT, 143 for SIGTERM) and lets the runtime reset the
+		// terminal, exactly as an unhandled signal would.
+		signal.Reset(receivedSignal)
+		if sig, ok := receivedSignal.(syscall.Signal); ok {
+			_ = syscall.Kill(os.Getpid(), sig)
+			// Block until the re-raised signal is delivered; do not fall through to a
+			// normal return, which would exit 6 and mask the signal.
+			select {}
+		}
+	}
 	return int(result.Status)
 }

--- a/cmd/tsgo/main.go
+++ b/cmd/tsgo/main.go
@@ -27,18 +27,21 @@ func runMain() int {
 		}
 	}
 
-	// Notify on our own channel rather than using signal.NotifyContext: we need the
-	// actual signal so a canceled run can exit with the conventional 128+signum code,
-	// matching the JS tsc (which installs no handler and lets node's default fire).
+	// Use signal.Notify with our own channel rather than signal.NotifyContext: the
+	// latter's context can't tell us which signal fired, and we need it to exit like
+	// the JS tsc, which installs no handler and lets node terminate via the signal.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	defer signal.Stop(sigCh)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	var receivedSignal os.Signal
+	// canceledBy carries the interrupting signal (if any) to the code below. It is
+	// written before cancel() and thus before CommandLine can observe cancellation.
+	canceledBy := make(chan os.Signal, 1)
 	go func() {
 		select {
-		case receivedSignal = <-sigCh:
+		case sig := <-sigCh:
+			canceledBy <- sig
 			cancel()
 		case <-ctx.Done():
 		}
@@ -46,17 +49,18 @@ func runMain() int {
 
 	result := execute.CommandLine(ctx, newSystem(), args, nil)
 
-	if result.Status == tsc.ExitStatusCanceled && receivedSignal != nil {
-		// A signal interrupted the run. Restore the default disposition and re-raise so
-		// the process terminates via the signal itself: this yields the conventional
-		// exit code (130 for SIGINT, 143 for SIGTERM) and lets the runtime reset the
-		// terminal, exactly as an unhandled signal would.
-		signal.Reset(receivedSignal)
-		if sig, ok := receivedSignal.(syscall.Signal); ok {
-			_ = syscall.Kill(os.Getpid(), sig)
-			// Block until the re-raised signal is delivered; do not fall through to a
-			// normal return, which would exit 6 and mask the signal.
-			select {}
+	if result.Status == tsc.ExitStatusCanceled {
+		// A signal canceled the run. Re-raise it so we terminate via the signal itself,
+		// yielding the conventional exit code (130 for SIGINT, 143 for SIGTERM) and the
+		// terminal reset an unhandled signal would produce.
+		select {
+		case sig := <-canceledBy:
+			if s, ok := sig.(syscall.Signal); ok {
+				signal.Reset(s)
+				_ = syscall.Kill(os.Getpid(), s)
+				return 128 + int(s) // fallback in case the signal doesn't land promptly
+			}
+		default:
 		}
 	}
 	return int(result.Status)

--- a/cmd/tsgo/main.go
+++ b/cmd/tsgo/main.go
@@ -52,13 +52,13 @@ func runMain() int {
 	if result.Status == tsc.ExitStatusCanceled {
 		// A signal canceled the run. Re-raise it so we terminate via the signal itself,
 		// yielding the conventional exit code (130 for SIGINT, 143 for SIGTERM) and the
-		// terminal reset an unhandled signal would produce.
+		// terminal reset an unhandled signal would produce. On platforms that cannot
+		// re-deliver the signal (e.g. Windows), reRaiseSignal returns 0 and we exit with
+		// the numeric status instead.
 		select {
 		case sig := <-canceledBy:
-			if s, ok := sig.(syscall.Signal); ok {
-				signal.Reset(s)
-				_ = syscall.Kill(os.Getpid(), s)
-				return 128 + int(s) // fallback in case the signal doesn't land promptly
+			if signo := reRaiseSignal(sig); signo != 0 {
+				return 128 + signo // fallback in case the signal doesn't land promptly
 			}
 		default:
 		}

--- a/cmd/tsgo/reraisesignal_other.go
+++ b/cmd/tsgo/reraisesignal_other.go
@@ -1,0 +1,13 @@
+//go:build !unix
+
+package main
+
+import "os"
+
+// reRaiseSignal is a no-op on platforms that cannot re-deliver a termination
+// signal to the current process (notably Windows, where os.Process.Signal does
+// not implement Interrupt). It always returns 0 so the caller falls back to
+// exiting with a numeric status.
+func reRaiseSignal(sig os.Signal) int {
+	return 0
+}

--- a/cmd/tsgo/reraisesignal_unix.go
+++ b/cmd/tsgo/reraisesignal_unix.go
@@ -1,0 +1,27 @@
+//go:build unix
+
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// reRaiseSignal resets the default disposition for sig and re-delivers it to
+// this process, so we terminate via the signal itself (yielding the
+// conventional 128+signo exit code and the terminal reset an unhandled signal
+// produces). It returns the number of the signal that was re-raised, or 0 if
+// sig is not a signal this platform can re-deliver, in which case the caller
+// should fall back to exiting with a numeric status.
+func reRaiseSignal(sig os.Signal) int {
+	s, ok := sig.(syscall.Signal)
+	if !ok {
+		return 0
+	}
+	signal.Reset(s)
+	if proc, err := os.FindProcess(os.Getpid()); err == nil {
+		_ = proc.Signal(s)
+	}
+	return int(s)
+}

--- a/internal/compiler/checkerpool.go
+++ b/internal/compiler/checkerpool.go
@@ -156,20 +156,10 @@ func (p *checkerPool) forEachCheckerGroupDo(ctx context.Context, files []*ast.So
 			defer p.locks[checkerIdx].Unlock()
 			for i, file := range files {
 				checker := p.checkers[checkerIdx]
-				// Stop feeding this checker once cancellation is in play: ctx.Err()
-				// means nothing we produce will be used, and WasCanceled() means the
-				// checker is already poisoned so reusing it would panic in
-				// checkNotCanceled. The two coincide in the compile path today (one
-				// context, single-use pool), but WasCanceled() states the actual reuse
-				// precondition rather than a proxy for it, and guards against a checker
-				// canceled by some other context.
-				//
-				// This out-of-band check is only necessary because the diagnostics APIs
-				// return a bare []*ast.Diagnostic with no error channel: a canceled check
-				// yields an empty (incomplete) slice indistinguishable from a clean result,
-				// so cancellation is signaled via checker state rather than a returned error.
-				// If those APIs returned (diags, error), the caller would stop on the error
-				// and this guard would be unnecessary.
+				// A canceled checker panics on reuse (checkNotCanceled), so stop feeding
+				// it more files. This guard is needed because the diagnostics APIs return
+				// []*ast.Diagnostic with no error channel: a canceled check is signaled by
+				// checker state, not a returned error.
 				if ctx.Err() != nil || checker.WasCanceled() {
 					break
 				}

--- a/internal/compiler/checkerpool.go
+++ b/internal/compiler/checkerpool.go
@@ -155,19 +155,25 @@ func (p *checkerPool) forEachCheckerGroupDo(ctx context.Context, files []*ast.So
 			p.locks[checkerIdx].Lock()
 			defer p.locks[checkerIdx].Unlock()
 			for i, file := range files {
-				// Once the context is canceled, the checker enters a canceled state and
-				// reusing it for the next file would panic in checkNotCanceled. Stop early.
+				checker := p.checkers[checkerIdx]
+				// Stop feeding this checker once cancellation is in play: ctx.Err()
+				// means nothing we produce will be used, and WasCanceled() means the
+				// checker is already poisoned so reusing it would panic in
+				// checkNotCanceled. The two coincide in the compile path today (one
+				// context, single-use pool), but WasCanceled() states the actual reuse
+				// precondition rather than a proxy for it, and guards against a checker
+				// canceled by some other context.
 				//
-				// This guard is only necessary because the diagnostics APIs return a bare
-				// []*ast.Diagnostic with no error channel: a canceled check yields an empty
-				// (incomplete) slice that is indistinguishable from a clean result, so
-				// cancellation is signaled out-of-band via the checker's canceled state
-				// rather than a returned error. If those APIs returned (diags, error), the
-				// caller would stop on the error and this guard would be unnecessary.
-				if ctx.Err() != nil {
+				// This out-of-band check is only necessary because the diagnostics APIs
+				// return a bare []*ast.Diagnostic with no error channel: a canceled check
+				// yields an empty (incomplete) slice indistinguishable from a clean result,
+				// so cancellation is signaled via checker state rather than a returned error.
+				// If those APIs returned (diags, error), the caller would stop on the error
+				// and this guard would be unnecessary.
+				if ctx.Err() != nil || checker.WasCanceled() {
 					break
 				}
-				if checker := p.checkers[checkerIdx]; checker == p.fileAssociations[file] {
+				if checker == p.fileAssociations[file] {
 					cb(checker, i, file)
 				}
 			}

--- a/internal/compiler/checkerpool.go
+++ b/internal/compiler/checkerpool.go
@@ -155,6 +155,18 @@ func (p *checkerPool) forEachCheckerGroupDo(ctx context.Context, files []*ast.So
 			p.locks[checkerIdx].Lock()
 			defer p.locks[checkerIdx].Unlock()
 			for i, file := range files {
+				// Once the context is canceled, the checker enters a canceled state and
+				// reusing it for the next file would panic in checkNotCanceled. Stop early.
+				//
+				// This guard is only necessary because the diagnostics APIs return a bare
+				// []*ast.Diagnostic with no error channel: a canceled check yields an empty
+				// (incomplete) slice that is indistinguishable from a clean result, so
+				// cancellation is signaled out-of-band via the checker's canceled state
+				// rather than a returned error. If those APIs returned (diags, error), the
+				// caller would stop on the error and this guard would be unnecessary.
+				if ctx.Err() != nil {
+					break
+				}
 				if checker := p.checkers[checkerIdx]; checker == p.fileAssociations[file] {
 					cb(checker, i, file)
 				}

--- a/internal/compiler/checkerpool.go
+++ b/internal/compiler/checkerpool.go
@@ -160,12 +160,12 @@ func (p *checkerPool) forEachCheckerGroupDo(ctx context.Context, files []*ast.So
 			p.locks[checkerIdx].Lock()
 			defer p.locks[checkerIdx].Unlock()
 			for i, file := range files {
-				checker := p.checkers[checkerIdx]
-				// Check for cancellation
+				// Stop once canceled: feeding another file to a checker that already
+				// canceled mid-check would panic in checkNotCanceled.
 				if ctx.Err() != nil {
 					break
 				}
-				if checker == p.fileAssociations[file] {
+				if checker := p.checkers[checkerIdx]; checker == p.fileAssociations[file] {
 					cb(checker, i, file)
 				}
 			}

--- a/internal/compiler/checkerpool.go
+++ b/internal/compiler/checkerpool.go
@@ -137,6 +137,11 @@ func (p *checkerPool) GetGlobalDiagnostics() []*ast.Diagnostic {
 	p.createCheckers()
 	globalDiagnostics := make([][]*ast.Diagnostic, len(p.checkers))
 	p.forEachCheckerParallel(func(idx int, checker *checker.Checker) {
+		// A canceled checker panics if asked for diagnostics (checkNotCanceled), and
+		// its results are discarded once canceled anyway. Skip it.
+		if checker.WasCanceled() {
+			return
+		}
 		globalDiagnostics[idx] = checker.GetGlobalDiagnostics()
 	})
 	return SortAndDeduplicateDiagnostics(slices.Concat(globalDiagnostics...))
@@ -156,11 +161,8 @@ func (p *checkerPool) forEachCheckerGroupDo(ctx context.Context, files []*ast.So
 			defer p.locks[checkerIdx].Unlock()
 			for i, file := range files {
 				checker := p.checkers[checkerIdx]
-				// A canceled checker panics on reuse (checkNotCanceled), so stop feeding
-				// it more files. This guard is needed because the diagnostics APIs return
-				// []*ast.Diagnostic with no error channel: a canceled check is signaled by
-				// checker state, not a returned error.
-				if ctx.Err() != nil || checker.WasCanceled() {
+				// Check for cancellation
+				if ctx.Err() != nil {
 					break
 				}
 				if checker == p.fileAssociations[file] {

--- a/internal/compiler/checkerpool_test.go
+++ b/internal/compiler/checkerpool_test.go
@@ -1,0 +1,96 @@
+package compiler_test
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/bundled"
+	"github.com/microsoft/typescript-go/internal/compiler"
+	"github.com/microsoft/typescript-go/internal/core"
+	"github.com/microsoft/typescript-go/internal/tsoptions"
+	"github.com/microsoft/typescript-go/internal/vfs/vfstest"
+)
+
+// cancelAfterNPolls reports itself canceled only after Err has been polled
+// pollThreshold times while still uncanceled, so cancellation lands after checking
+// has begun rather than before it starts. Once tripped it stays canceled.
+type cancelAfterNPolls struct {
+	context.Context
+	pollThreshold int32
+	polls         atomic.Int32
+	tripped       atomic.Bool
+	done          chan struct{}
+}
+
+func newCancelAfterNPolls(pollThreshold int32) *cancelAfterNPolls {
+	return &cancelAfterNPolls{Context: context.Background(), pollThreshold: pollThreshold, done: make(chan struct{})}
+}
+
+func (c *cancelAfterNPolls) Err() error {
+	if c.tripped.Load() {
+		return context.Canceled
+	}
+	if c.polls.Add(1) > c.pollThreshold {
+		if c.tripped.CompareAndSwap(false, true) {
+			close(c.done)
+		}
+		return context.Canceled
+	}
+	return nil
+}
+
+func (c *cancelAfterNPolls) Done() <-chan struct{} { return c.done }
+
+// TestGetGlobalDiagnosticsAfterCancellation pins the checker-pool behavior that a
+// checker canceled mid-check is skipped by GetGlobalDiagnostics rather than reused
+// (which panics in checkNotCanceled). This is the source-level guard that protects
+// every GetGlobalDiagnostics caller, including emitBuildInfo's error-state probe,
+// which has no surrounding cancellation check.
+func TestGetGlobalDiagnosticsAfterCancellation(t *testing.T) {
+	t.Parallel()
+
+	if !bundled.Embedded {
+		t.Skip("bundled files are not embedded")
+	}
+
+	fs := bundled.WrapFS(vfstest.FromMap[any](nil, false /*useCaseSensitiveFileNames*/))
+
+	// Many statements with type errors across a few files: global diagnostics exist,
+	// and the checker polls often so cancellation lands mid-check.
+	var src strings.Builder
+	for i := range 50 {
+		src.WriteString("export const v")
+		src.WriteString(strings.Repeat("x", i+1))
+		src.WriteString(`: number = "not a number";` + "\n")
+	}
+	for _, name := range []string{"/src/a.ts", "/src/b.ts", "/src/c.ts"} {
+		_ = fs.WriteFile(name, src.String())
+	}
+
+	// One checker so a single mid-check cancellation marks the checker the subsequent
+	// GetGlobalDiagnostics will visit.
+	oneChecker := 1
+	program := compiler.NewProgram(compiler.ProgramOptions{
+		Config: &tsoptions.ParsedCommandLine{
+			ParsedConfig: &core.ParsedOptions{
+				FileNames:       []string{"/src/a.ts", "/src/b.ts", "/src/c.ts"},
+				CompilerOptions: &core.CompilerOptions{Strict: core.TSTrue, Checkers: &oneChecker},
+			},
+		},
+		Host: compiler.NewCompilerHost("/src", fs, bundled.LibPath(), nil, nil),
+	})
+
+	ctx := newCancelAfterNPolls(5)
+
+	// Drive checking under the canceling context to cancel the checker. Discard the
+	// (partial) result; we only care that the checker is now canceled.
+	_ = program.GetSemanticDiagnostics(ctx, nil)
+	if !ctx.tripped.Load() {
+		t.Fatal("expected cancellation to trip during checking, but it never did")
+	}
+
+	// The real assertion: this must not panic on the canceled checker.
+	_ = program.GetGlobalDiagnostics(ctx)
+}

--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -591,11 +591,6 @@ func (p *Program) collectCheckerDiagnosticsFromFiles(ctx context.Context, source
 				continue
 			}
 			wg.Queue(func() {
-				// Skip once canceled: a pooled checker may already be canceled from a
-				// prior file, and reusing it would panic in checkNotCanceled.
-				if ctx.Err() != nil {
-					return
-				}
 				c, done := p.checkerPool.GetChecker(ctx, file)
 				diagnostics[i] = collect(ctx, c, file)
 				done()
@@ -1783,13 +1778,8 @@ func GetDiagnosticsOfAnyProgram(
 
 			if len(allDiagnostics) == configFileParsingDiagnosticsLength {
 				allDiagnostics = append(allDiagnostics, getSemanticDiagnostics(ctx, file)...)
-				// Once canceled, the checker must not be reused (GetGlobalDiagnostics /
-				// GetDeclarationDiagnostics would panic in checkNotCanceled). The partial
-				// diagnostics are discarded by the caller. See forEachCheckerGroupDo.
-				if ctx.Err() != nil {
-					return allDiagnostics
-				}
 				// Ask for the global diagnostics again (they were empty above); we may have found new during checking, e.g. missing globals.
+				// Safe after cancellation: GetGlobalDiagnostics skips canceled checkers.
 				allDiagnostics = append(allDiagnostics, program.GetGlobalDiagnostics(ctx)...)
 			}
 

--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -591,8 +591,8 @@ func (p *Program) collectCheckerDiagnosticsFromFiles(ctx context.Context, source
 				continue
 			}
 			wg.Queue(func() {
-				// A checker obtained from the pool may already be in a canceled state from a
-				// prior file; reusing it would panic in checkNotCanceled. Skip once canceled.
+				// Skip once canceled: a pooled checker may already be canceled from a
+				// prior file, and reusing it would panic in checkNotCanceled.
 				if ctx.Err() != nil {
 					return
 				}
@@ -1783,11 +1783,9 @@ func GetDiagnosticsOfAnyProgram(
 
 			if len(allDiagnostics) == configFileParsingDiagnosticsLength {
 				allDiagnostics = append(allDiagnostics, getSemanticDiagnostics(ctx, file)...)
-				// If checking was canceled, the checker is now in a canceled state and must not
-				// be reused (GetGlobalDiagnostics/GetDeclarationDiagnostics would panic in
-				// checkNotCanceled). The diagnostics gathered so far are incomplete and will be
-				// discarded by the caller, so stop here. See checkerPool.forEachCheckerGroupDo
-				// for why this out-of-band check is needed (diagnostics APIs have no error channel).
+				// Once canceled, the checker must not be reused (GetGlobalDiagnostics /
+				// GetDeclarationDiagnostics would panic in checkNotCanceled). The partial
+				// diagnostics are discarded by the caller. See forEachCheckerGroupDo.
 				if ctx.Err() != nil {
 					return allDiagnostics
 				}

--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -1734,6 +1734,11 @@ func HandleNoEmitOnError(ctx context.Context, program ProgramLike, file *ast.Sou
 	if !program.Options().NoEmitOnError.IsTrue() {
 		return nil // No emit on error is not set, so we can proceed with emitting
 	}
+	if ctx.Err() != nil {
+		// Canceled: don't re-run diagnostics on checkers that may already be canceled
+		// (checkNotCanceled would panic). The emit is being abandoned regardless.
+		return nil
+	}
 
 	diagnostics := GetDiagnosticsOfAnyProgram(
 		ctx,
@@ -1778,8 +1783,13 @@ func GetDiagnosticsOfAnyProgram(
 
 			if len(allDiagnostics) == configFileParsingDiagnosticsLength {
 				allDiagnostics = append(allDiagnostics, getSemanticDiagnostics(ctx, file)...)
+				// Stop once canceled: the diagnostics are discarded anyway, and the calls
+				// below (GetGlobalDiagnostics, GetDeclarationDiagnostics) reuse the now
+				// canceled checkers, which panics in checkNotCanceled.
+				if ctx.Err() != nil {
+					return allDiagnostics
+				}
 				// Ask for the global diagnostics again (they were empty above); we may have found new during checking, e.g. missing globals.
-				// Safe after cancellation: GetGlobalDiagnostics skips canceled checkers.
 				allDiagnostics = append(allDiagnostics, program.GetGlobalDiagnostics(ctx)...)
 			}
 

--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -591,6 +591,11 @@ func (p *Program) collectCheckerDiagnosticsFromFiles(ctx context.Context, source
 				continue
 			}
 			wg.Queue(func() {
+				// A checker obtained from the pool may already be in a canceled state from a
+				// prior file; reusing it would panic in checkNotCanceled. Skip once canceled.
+				if ctx.Err() != nil {
+					return
+				}
 				c, done := p.checkerPool.GetChecker(ctx, file)
 				diagnostics[i] = collect(ctx, c, file)
 				done()
@@ -1778,6 +1783,14 @@ func GetDiagnosticsOfAnyProgram(
 
 			if len(allDiagnostics) == configFileParsingDiagnosticsLength {
 				allDiagnostics = append(allDiagnostics, getSemanticDiagnostics(ctx, file)...)
+				// If checking was canceled, the checker is now in a canceled state and must not
+				// be reused (GetGlobalDiagnostics/GetDeclarationDiagnostics would panic in
+				// checkNotCanceled). The diagnostics gathered so far are incomplete and will be
+				// discarded by the caller, so stop here. See checkerPool.forEachCheckerGroupDo
+				// for why this out-of-band check is needed (diagnostics APIs have no error channel).
+				if ctx.Err() != nil {
+					return allDiagnostics
+				}
 				// Ask for the global diagnostics again (they were empty above); we may have found new during checking, e.g. missing globals.
 				allDiagnostics = append(allDiagnostics, program.GetGlobalDiagnostics(ctx)...)
 			}

--- a/internal/execute/build/buildtask.go
+++ b/internal/execute/build/buildtask.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -216,7 +217,9 @@ func (t *BuildTask) compileAndEmit(orchestrator *Orchestrator, path tspath.Path)
 	t.result.program = incremental.NewProgram(program, oldProgram, orchestrator.host, orchestrator.opts.Testing != nil)
 	compileTimes.ChangesComputeTime = orchestrator.opts.Sys.Now().Sub(changesComputeStart)
 
-	result, statistics := tsc.EmitAndReportStatistics(tsc.EmitInput{
+	// The build orchestrator does not thread a per-task context today; cancellation
+	// for `tsc -b` is handled at the orchestrator level.
+	result, statistics := tsc.EmitAndReportStatistics(context.Background(), tsc.EmitInput{
 		Sys:                orchestrator.opts.Sys,
 		ProgramLike:        t.result.program,
 		Program:            program,

--- a/internal/execute/build/buildtask.go
+++ b/internal/execute/build/buildtask.go
@@ -254,11 +254,7 @@ func (t *BuildTask) compileAndEmit(ctx context.Context, orchestrator *Orchestrat
 	t.result.statistics = statistics
 	if result.Status == tsc.ExitStatusCanceled {
 		// Canceled: the result is incomplete (EmitResult is nil). Leave the task
-		// partial on purpose -- don't update timestamps, set buildKind, record
-		// packageJsons, or overwrite t.status -- so nothing partial is reported. The
-		// caller (buildProject) skips updateDownstream, and report() sees buildKind
-		// unset, so the project is not counted as built. Only ExitStatusCanceled
-		// propagates.
+		// partial on purpose. Only ExitStatusCanceled propagates.
 		return
 	}
 	t.packageJsons = t.result.program.PackageJsonLookupPaths()

--- a/internal/execute/build/buildtask.go
+++ b/internal/execute/build/buildtask.go
@@ -121,14 +121,14 @@ func (t *BuildTask) report(orchestrator *Orchestrator, configPath tspath.Path, b
 	close(t.reportDone)
 }
 
-func (t *BuildTask) buildProject(orchestrator *Orchestrator, path tspath.Path) {
+func (t *BuildTask) buildProject(ctx context.Context, orchestrator *Orchestrator, path tspath.Path) {
 	// Wait on upstream tasks to complete
 	t.waitOnUpstream()
 	if t.pending.Load() {
 		t.status = t.getUpToDateStatus(orchestrator, path)
 		t.reportUpToDateStatus(orchestrator)
 		if !t.handleStatusThatDoesntRequireBuild(orchestrator) {
-			t.compileAndEmit(orchestrator, path)
+			t.compileAndEmit(ctx, orchestrator, path)
 			t.updateDownstream(orchestrator, path)
 		} else {
 			if t.resolved != nil {
@@ -188,7 +188,7 @@ func (t *BuildTask) updateDownstream(orchestrator *Orchestrator, path tspath.Pat
 	}
 }
 
-func (t *BuildTask) compileAndEmit(orchestrator *Orchestrator, path tspath.Path) {
+func (t *BuildTask) compileAndEmit(ctx context.Context, orchestrator *Orchestrator, path tspath.Path) {
 	t.errors = nil
 	if orchestrator.opts.Command.BuildOptions.Verbose.IsTrue() {
 		t.result.reportStatus(ast.NewCompilerDiagnostic(diagnostics.Building_project_0, orchestrator.relativeFileName(t.config)))
@@ -217,9 +217,7 @@ func (t *BuildTask) compileAndEmit(orchestrator *Orchestrator, path tspath.Path)
 	t.result.program = incremental.NewProgram(program, oldProgram, orchestrator.host, orchestrator.opts.Testing != nil)
 	compileTimes.ChangesComputeTime = orchestrator.opts.Sys.Now().Sub(changesComputeStart)
 
-	// The build orchestrator does not thread a per-task context today; cancellation
-	// for `tsc -b` is handled at the orchestrator level.
-	result, statistics := tsc.EmitAndReportStatistics(context.Background(), tsc.EmitInput{
+	result, statistics := tsc.EmitAndReportStatistics(ctx, tsc.EmitInput{
 		Sys:                orchestrator.opts.Sys,
 		ProgramLike:        t.result.program,
 		Program:            program,
@@ -236,6 +234,14 @@ func (t *BuildTask) compileAndEmit(orchestrator *Orchestrator, path tspath.Path)
 	})
 	t.result.exitStatus = result.Status
 	t.result.statistics = statistics
+	if result.Status == tsc.ExitStatusCanceled {
+		// The compile was canceled (e.g. SIGINT). Its result is incomplete
+		// (result.EmitResult is nil), so do not update output timestamps or mark the
+		// project up-to-date, and leave buildKind as None so it is not counted as
+		// built. report() propagates the canceled exit status (it dominates via max),
+		// and rangeTask stops scheduling further projects.
+		return
+	}
 	t.packageJsons = t.result.program.PackageJsonLookupPaths()
 	if (!program.Options().NoEmitOnError.IsTrue() || len(result.Diagnostics) == 0) &&
 		(len(result.EmitResult.EmittedFiles) > 0 || t.status.kind != upToDateStatusTypeOutOfDateBuildInfoWithErrors) {

--- a/internal/execute/build/buildtask.go
+++ b/internal/execute/build/buildtask.go
@@ -165,9 +165,14 @@ func (t *BuildTask) buildProject(ctx context.Context, orchestrator *Orchestrator
 }
 
 func (t *BuildTask) updateDownstream(ctx context.Context, orchestrator *Orchestrator, path tspath.Path) {
-	// A canceled compile leaves t.status and t.result partial (no buildKind, stale
-	// up-to-date status). Don't propagate that to downstream tasks: on cancellation
-	// buildProject reports ExitStatusCanceled and nothing else.
+	// This seeds dependents' in-memory rebuild state (status, pending) from this
+	// project's result; it never touches emitted outputs. Skip it once canceled: the
+	// result may be from a compile that aborted mid-emit, and propagating its partial
+	// HasChangedDtsFile would corrupt downstream up-to-date decisions.
+	//
+	// Today this only fires in one-shot `tsc -b`, where downStream is empty and the
+	// body below is a no-op anyway. It becomes load-bearing once DoCycle threads a
+	// real (cancelable) context into watch rebuilds, where downStream is populated.
 	if ctx.Err() != nil {
 		return
 	}

--- a/internal/execute/build/buildtask.go
+++ b/internal/execute/build/buildtask.go
@@ -74,16 +74,18 @@ type BuildTask struct {
 	dirty              bool
 }
 
-func (t *BuildTask) waitOnUpstream(ctx context.Context) {
+// Returns true when upstream is done, false when cancelled
+func (t *BuildTask) waitOnUpstream(ctx context.Context) bool {
 	for _, upstream := range t.upStream {
 		select {
 		case <-upstream.task.done:
 		case <-ctx.Done():
 			// Canceled while waiting: stop blocking. buildProject observes the
 			// cancellation and completes this task without building.
-			return
+			return false
 		}
 	}
+	return true
 }
 
 func (t *BuildTask) unblockDownstream() {
@@ -129,12 +131,8 @@ func (t *BuildTask) report(orchestrator *Orchestrator, configPath tspath.Path, b
 
 func (t *BuildTask) buildProject(ctx context.Context, orchestrator *Orchestrator, path tspath.Path) {
 	// Wait on upstream tasks to complete
-	t.waitOnUpstream(ctx)
-	// Canceled before we started the compile: skip the expensive work but still fall
-	// through to unblockDownstream so downstream and report waiters don't deadlock. An
-	// in-flight compile aborts on its own (the checker polls ctx) and surfaces
-	// ExitStatusCanceled via compileAndEmit.
-	if ctx.Err() != nil {
+	if !t.waitOnUpstream(ctx) {
+		// We were cancelled while waiting, just set the status and unblockDownstream
 		t.result.exitStatus = tsc.ExitStatusCanceled
 	} else if t.pending.Load() {
 		t.status = t.getUpToDateStatus(orchestrator, path)
@@ -165,14 +163,12 @@ func (t *BuildTask) buildProject(ctx context.Context, orchestrator *Orchestrator
 }
 
 func (t *BuildTask) updateDownstream(ctx context.Context, orchestrator *Orchestrator, path tspath.Path) {
-	// This seeds dependents' in-memory rebuild state (status, pending) from this
-	// project's result; it never touches emitted outputs. Skip it once canceled: the
-	// result may be from a compile that aborted mid-emit, and propagating its partial
-	// HasChangedDtsFile would corrupt downstream up-to-date decisions.
+	// Skip notifying downstream if we are canceled. Canceled builds may have partial results
+	// which could be otherwise handled improperly by downstream tasks.
 	//
-	// Today this only fires in one-shot `tsc -b`, where downStream is empty and the
-	// body below is a no-op anyway. It becomes load-bearing once DoCycle threads a
-	// real (cancelable) context into watch rebuilds, where downStream is populated.
+	// In one-shot `tsc -b`, downStream is empty so the body below is a no-op.
+	// In watch mode, downStream is populated and this runs on subsequent rebuild cycles.
+	// Once DoCycle threads a cancelable context, the early-return here becomes load-bearing.
 	if ctx.Err() != nil {
 		return
 	}

--- a/internal/execute/build/buildtask.go
+++ b/internal/execute/build/buildtask.go
@@ -130,9 +130,13 @@ func (t *BuildTask) report(orchestrator *Orchestrator, configPath tspath.Path, b
 }
 
 func (t *BuildTask) buildProject(ctx context.Context, orchestrator *Orchestrator, path tspath.Path) {
-	// Wait on upstream tasks to complete
-	if !t.waitOnUpstream(ctx) {
-		// We were cancelled while waiting, just set the status and unblockDownstream
+	// Honor cancellation before doing any work. waitOnUpstream only observes the
+	// context while it has upstream tasks to wait on, so a task with no upstream
+	// (e.g. a root project that is already up to date) would otherwise take the
+	// no-build success path and swallow an interrupt that arrived before we started.
+	if ctx.Err() != nil || !t.waitOnUpstream(ctx) {
+		// Canceled before starting or while waiting on upstream: set the status and
+		// unblockDownstream without building.
 		t.result.exitStatus = tsc.ExitStatusCanceled
 	} else if t.pending.Load() {
 		t.status = t.getUpToDateStatus(orchestrator, path)
@@ -739,7 +743,7 @@ func (t *BuildTask) updateTimeStamps(orchestrator *Orchestrator, emittedFiles []
 	updateTimeStamp(t.resolved.GetBuildInfoFileName())
 }
 
-func (t *BuildTask) cleanProject(orchestrator *Orchestrator, path tspath.Path) {
+func (t *BuildTask) cleanProject(ctx context.Context, orchestrator *Orchestrator, path tspath.Path) {
 	if t.resolved == nil {
 		t.reportDiagnostic(ast.NewCompilerDiagnostic(diagnostics.File_0_not_found, t.config))
 		t.result.exitStatus = tsc.ExitStatusDiagnosticsPresent_OutputsSkipped
@@ -748,7 +752,17 @@ func (t *BuildTask) cleanProject(orchestrator *Orchestrator, path tspath.Path) {
 
 	inputs := collections.NewSetFromItems(core.Map(t.resolved.FileNames(), orchestrator.toPath)...)
 	for outputFile := range t.resolved.GetOutputFileNames() {
+		// Stop deleting outputs if we were canceled. Report cancellation so the CLI
+		// can re-raise the signal rather than exiting with success mid-clean.
+		if ctx.Err() != nil {
+			t.result.exitStatus = tsc.ExitStatusCanceled
+			return
+		}
 		t.cleanProjectOutput(orchestrator, outputFile, inputs)
+	}
+	if ctx.Err() != nil {
+		t.result.exitStatus = tsc.ExitStatusCanceled
+		return
 	}
 	t.cleanProjectOutput(orchestrator, t.resolved.GetBuildInfoFileName(), inputs)
 }

--- a/internal/execute/build/buildtask.go
+++ b/internal/execute/build/buildtask.go
@@ -74,9 +74,15 @@ type BuildTask struct {
 	dirty              bool
 }
 
-func (t *BuildTask) waitOnUpstream() {
+func (t *BuildTask) waitOnUpstream(ctx context.Context) {
 	for _, upstream := range t.upStream {
-		<-upstream.task.done
+		select {
+		case <-upstream.task.done:
+		case <-ctx.Done():
+			// Canceled while waiting: stop blocking. buildProject observes the
+			// cancellation and completes this task without building.
+			return
+		}
 	}
 }
 
@@ -123,13 +129,19 @@ func (t *BuildTask) report(orchestrator *Orchestrator, configPath tspath.Path, b
 
 func (t *BuildTask) buildProject(ctx context.Context, orchestrator *Orchestrator, path tspath.Path) {
 	// Wait on upstream tasks to complete
-	t.waitOnUpstream()
-	if t.pending.Load() {
+	t.waitOnUpstream(ctx)
+	// Canceled before we started the compile: skip the expensive work but still fall
+	// through to unblockDownstream so downstream and report waiters don't deadlock. An
+	// in-flight compile aborts on its own (the checker polls ctx) and surfaces
+	// ExitStatusCanceled via compileAndEmit.
+	if ctx.Err() != nil {
+		t.result.exitStatus = tsc.ExitStatusCanceled
+	} else if t.pending.Load() {
 		t.status = t.getUpToDateStatus(orchestrator, path)
 		t.reportUpToDateStatus(orchestrator)
 		if !t.handleStatusThatDoesntRequireBuild(orchestrator) {
 			t.compileAndEmit(ctx, orchestrator, path)
-			t.updateDownstream(orchestrator, path)
+			t.updateDownstream(ctx, orchestrator, path)
 		} else {
 			if t.resolved != nil {
 				for _, diagnostic := range t.resolved.GetConfigFileParsingDiagnostics() {
@@ -152,7 +164,13 @@ func (t *BuildTask) buildProject(ctx context.Context, orchestrator *Orchestrator
 	t.unblockDownstream()
 }
 
-func (t *BuildTask) updateDownstream(orchestrator *Orchestrator, path tspath.Path) {
+func (t *BuildTask) updateDownstream(ctx context.Context, orchestrator *Orchestrator, path tspath.Path) {
+	// A canceled compile leaves t.status and t.result partial (no buildKind, stale
+	// up-to-date status). Don't propagate that to downstream tasks: on cancellation
+	// buildProject reports ExitStatusCanceled and nothing else.
+	if ctx.Err() != nil {
+		return
+	}
 	if t.isInitialCycle {
 		return
 	}
@@ -235,9 +253,12 @@ func (t *BuildTask) compileAndEmit(ctx context.Context, orchestrator *Orchestrat
 	t.result.exitStatus = result.Status
 	t.result.statistics = statistics
 	if result.Status == tsc.ExitStatusCanceled {
-		// Canceled: the result is incomplete (EmitResult is nil). Don't update
-		// timestamps, mark the project up-to-date, or count it as built. report()
-		// still propagates the canceled status.
+		// Canceled: the result is incomplete (EmitResult is nil). Leave the task
+		// partial on purpose -- don't update timestamps, set buildKind, record
+		// packageJsons, or overwrite t.status -- so nothing partial is reported. The
+		// caller (buildProject) skips updateDownstream, and report() sees buildKind
+		// unset, so the project is not counted as built. Only ExitStatusCanceled
+		// propagates.
 		return
 	}
 	t.packageJsons = t.result.program.PackageJsonLookupPaths()

--- a/internal/execute/build/buildtask.go
+++ b/internal/execute/build/buildtask.go
@@ -235,11 +235,9 @@ func (t *BuildTask) compileAndEmit(ctx context.Context, orchestrator *Orchestrat
 	t.result.exitStatus = result.Status
 	t.result.statistics = statistics
 	if result.Status == tsc.ExitStatusCanceled {
-		// The compile was canceled (e.g. SIGINT). Its result is incomplete
-		// (result.EmitResult is nil), so do not update output timestamps or mark the
-		// project up-to-date, and leave buildKind as None so it is not counted as
-		// built. report() propagates the canceled exit status (it dominates via max),
-		// and rangeTask stops scheduling further projects.
+		// Canceled: the result is incomplete (EmitResult is nil). Don't update
+		// timestamps, mark the project up-to-date, or count it as built. report()
+		// still propagates the canceled status.
 		return
 	}
 	t.packageJsons = t.result.program.PackageJsonLookupPaths()

--- a/internal/execute/build/orchestrator.go
+++ b/internal/execute/build/orchestrator.go
@@ -229,16 +229,20 @@ func (o *Orchestrator) Start(ctx context.Context) tsc.CommandLineResult {
 		o.watchStatusReporter(ast.NewCompilerDiagnostic(diagnostics.Starting_compilation_in_watch_mode))
 	}
 	o.GenerateGraph(nil)
+	result := o.buildOrClean(ctx)
 	if o.opts.Command.CompilerOptions.Watch.IsTrue() {
-		// Watch mode: the initial build runs to completion; cancellation is observed
-		// at the RunLoop boundary (see the TODO in DoCycle).
-		result := o.buildOrClean(context.Background())
+		// If we were already cancelled return now, but treat it as success.
+		// in watch mode this is the only way to exit.
+		if result.Status == tsc.ExitStatusCanceled {
+			result.Status = tsc.ExitStatusSuccess
+			return result
+		}
 		o.Watch(ctx)
 		result.Watcher = o
 		return result
 	}
 	// Non-watch `tsc -b`: honor cancellation so a long build responds to SIGINT.
-	return o.buildOrClean(ctx)
+	return result
 }
 
 func (o *Orchestrator) Watch(ctx context.Context) {
@@ -609,11 +613,8 @@ func (o *Orchestrator) buildOrClean(ctx context.Context) tsc.CommandLineResult {
 		o.rangeTask(ctx, func(ctx context.Context, path tspath.Path, task *BuildTask) {
 			o.buildOrCleanProject(ctx, task, path, &buildResult)
 		})
-		if ctx.Err() != nil {
-			// Report the aborted status even if cancellation landed before any project
-			// produced one.
-			buildResult.result.Status = tsc.ExitStatusCanceled
-		}
+		// A canceled task surfaces ExitStatusCanceled through its own report(), so the
+		// aggregated status reflects cancellation without a separate override here.
 	} else {
 		// Circularity errors prevent any project from being built
 		buildResult.result.Status = tsc.ExitStatusProjectReferenceCycle_OutputsSkipped
@@ -648,11 +649,10 @@ func (o *Orchestrator) rangeTask(ctx context.Context, f func(ctx context.Context
 	}
 	runTask := func() {
 		for path, task, ok := getNextTask(); ok; path, task, ok = getNextTask() {
-			// Stop scheduling further projects once canceled; in-flight tasks finish
-			// (their compile is interruptible via ctx).
-			if ctx.Err() != nil {
-				return
-			}
+			// f is called for every task, even after cancellation: each task must
+			// complete its lifecycle (close its done/reportDone channels) or the
+			// upstream/report waiters of other tasks deadlock. Cancellation is observed
+			// inside buildProject, which skips the compile but still completes the task.
 			f(ctx, path, task)
 		}
 	}

--- a/internal/execute/build/orchestrator.go
+++ b/internal/execute/build/orchestrator.go
@@ -585,8 +585,7 @@ func (o *Orchestrator) DoCycle() {
 		o.GenerateGraphReusingOldTasks()
 	}
 
-	// TODO: thread the RunLoop context through DoCycle so a long rebuild is
-	// interruptible mid-cycle, not just between cycles (see the CLI watcher's TODO).
+	// TODO: propagate a proper context here and support cancellation with cycle
 	o.buildOrClean(context.Background())
 	o.updateWatch()
 	desiredDirs := o.computeDesiredWatches()

--- a/internal/execute/build/orchestrator.go
+++ b/internal/execute/build/orchestrator.go
@@ -229,12 +229,16 @@ func (o *Orchestrator) Start(ctx context.Context) tsc.CommandLineResult {
 		o.watchStatusReporter(ast.NewCompilerDiagnostic(diagnostics.Starting_compilation_in_watch_mode))
 	}
 	o.GenerateGraph(nil)
-	result := o.buildOrClean()
 	if o.opts.Command.CompilerOptions.Watch.IsTrue() {
+		// In watch mode the initial build, like each watch cycle, runs to completion;
+		// cancellation is observed at the RunLoop boundary (see the TODO in DoCycle).
+		result := o.buildOrClean(context.Background())
 		o.Watch(ctx)
 		result.Watcher = o
+		return result
 	}
-	return result
+	// Non-watch `tsc -b`: honor cancellation so a long build responds to SIGINT.
+	return o.buildOrClean(ctx)
 }
 
 func (o *Orchestrator) Watch(ctx context.Context) {
@@ -265,7 +269,7 @@ func (o *Orchestrator) Watch(ctx context.Context) {
 func (o *Orchestrator) updateWatch() {
 	oldCache := o.host.mTimes
 	o.host.mTimes = &collections.SyncMap[tspath.Path, time.Time]{}
-	o.rangeTask(func(path tspath.Path, task *BuildTask) {
+	o.rangeTask(context.Background(), func(_ context.Context, path tspath.Path, task *BuildTask) {
 		task.updateWatch(o, oldCache)
 	})
 }
@@ -390,7 +394,7 @@ func (o *Orchestrator) checkTasksForEventChanges(changedPaths map[string]fswatch
 		for eventPath := range changedPaths {
 			if o.host.FS().DirectoryExists(eventPath) {
 				if o.wm.IsPathUnderWatch(eventPath, opts) {
-					o.rangeTask(func(path tspath.Path, task *BuildTask) {
+					o.rangeTask(context.Background(), func(_ context.Context, path tspath.Path, task *BuildTask) {
 						task.resetStatus()
 						task.reportDone = make(chan struct{})
 						task.done = make(chan struct{})
@@ -554,7 +558,7 @@ func (o *Orchestrator) DoCycle() {
 
 	if overflow {
 		// Overflow: reset all tasks to force a full rebuild.
-		o.rangeTask(func(path tspath.Path, task *BuildTask) {
+		o.rangeTask(context.Background(), func(_ context.Context, path tspath.Path, task *BuildTask) {
 			task.resetConfig(o, path)
 			task.reportDone = make(chan struct{})
 			task.done = make(chan struct{})
@@ -577,7 +581,11 @@ func (o *Orchestrator) DoCycle() {
 		o.GenerateGraphReusingOldTasks()
 	}
 
-	o.buildOrClean()
+	// TODO: like the CLI watcher, a build watch cycle runs to completion; cancellation
+	// is only observed between cycles in WatchManager.RunLoop. Thread the RunLoop context
+	// through DoCycle to make a long rebuild interruptible (and handle ExitStatusCanceled
+	// by discarding the partial cycle).
+	o.buildOrClean(context.Background())
 	o.updateWatch()
 	desiredDirs := o.computeDesiredWatches()
 	if err := o.wm.ReconcileWatches(desiredDirs); err != nil {
@@ -588,7 +596,7 @@ func (o *Orchestrator) DoCycle() {
 	o.resetCaches()
 }
 
-func (o *Orchestrator) buildOrClean() tsc.CommandLineResult {
+func (o *Orchestrator) buildOrClean(ctx context.Context) tsc.CommandLineResult {
 	if !o.opts.Command.BuildOptions.Clean.IsTrue() && o.opts.Command.BuildOptions.Verbose.IsTrue() {
 		o.createBuilderStatusReporter(nil)(ast.NewCompilerDiagnostic(
 			diagnostics.Projects_in_this_build_Colon_0,
@@ -600,9 +608,15 @@ func (o *Orchestrator) buildOrClean() tsc.CommandLineResult {
 	var buildResult orchestratorResult
 	if len(o.errors) == 0 {
 		buildResult.statistics.Projects = len(o.Order())
-		o.rangeTask(func(path tspath.Path, task *BuildTask) {
-			o.buildOrCleanProject(task, path, &buildResult)
+		o.rangeTask(ctx, func(ctx context.Context, path tspath.Path, task *BuildTask) {
+			o.buildOrCleanProject(ctx, task, path, &buildResult)
 		})
+		if ctx.Err() != nil {
+			// The build was canceled (e.g. SIGINT). rangeTask stops scheduling further
+			// projects; report the aborted status even if cancellation landed before any
+			// project produced one.
+			buildResult.result.Status = tsc.ExitStatusCanceled
+		}
 	} else {
 		// Circularity errors prevent any project from being built
 		buildResult.result.Status = tsc.ExitStatusProjectReferenceCycle_OutputsSkipped
@@ -616,7 +630,7 @@ func (o *Orchestrator) buildOrClean() tsc.CommandLineResult {
 	return buildResult.result
 }
 
-func (o *Orchestrator) rangeTask(f func(path tspath.Path, task *BuildTask)) {
+func (o *Orchestrator) rangeTask(ctx context.Context, f func(ctx context.Context, path tspath.Path, task *BuildTask)) {
 	numRoutines := 4
 	if o.opts.Command.CompilerOptions.SingleThreaded.IsTrue() {
 		numRoutines = 1
@@ -637,7 +651,13 @@ func (o *Orchestrator) rangeTask(f func(path tspath.Path, task *BuildTask)) {
 	}
 	runTask := func() {
 		for path, task, ok := getNextTask(); ok; path, task, ok = getNextTask() {
-			f(path, task)
+			// Stop scheduling further projects once canceled (e.g. SIGINT). Tasks
+			// already in flight finish on their own; the compile they run is
+			// interruptible via the context threaded into compileAndEmit.
+			if ctx.Err() != nil {
+				return
+			}
+			f(ctx, path, task)
 		}
 	}
 
@@ -652,12 +672,12 @@ func (o *Orchestrator) rangeTask(f func(path tspath.Path, task *BuildTask)) {
 	}
 }
 
-func (o *Orchestrator) buildOrCleanProject(task *BuildTask, path tspath.Path, buildResult *orchestratorResult) {
+func (o *Orchestrator) buildOrCleanProject(ctx context.Context, task *BuildTask, path tspath.Path, buildResult *orchestratorResult) {
 	task.result = &taskResult{}
 	task.result.reportStatus = o.createBuilderStatusReporter(task)
 	task.result.diagnosticReporter = o.createDiagnosticReporter(task)
 	if !o.opts.Command.BuildOptions.Clean.IsTrue() {
-		task.buildProject(o, path)
+		task.buildProject(ctx, o, path)
 	} else {
 		task.cleanProject(o, path)
 	}

--- a/internal/execute/build/orchestrator.go
+++ b/internal/execute/build/orchestrator.go
@@ -255,7 +255,7 @@ func (o *Orchestrator) Watch(ctx context.Context) {
 		o.wm.EnsureDefaultBackend()
 	}
 
-	o.updateWatch()
+	o.updateWatch(ctx)
 	desiredDirs := o.computeDesiredWatches()
 	if err := o.wm.ReconcileWatches(desiredDirs); err != nil {
 		fmt.Fprintf(o.opts.Sys.Writer(), "%v\n", err)
@@ -270,10 +270,10 @@ func (o *Orchestrator) Watch(ctx context.Context) {
 	}
 }
 
-func (o *Orchestrator) updateWatch() {
+func (o *Orchestrator) updateWatch(ctx context.Context) {
 	oldCache := o.host.mTimes
 	o.host.mTimes = &collections.SyncMap[tspath.Path, time.Time]{}
-	o.rangeTask(context.Background(), func(_ context.Context, path tspath.Path, task *BuildTask) {
+	o.rangeTask(ctx, func(_ context.Context, path tspath.Path, task *BuildTask) {
 		task.updateWatch(o, oldCache)
 	})
 }
@@ -398,6 +398,7 @@ func (o *Orchestrator) checkTasksForEventChanges(changedPaths map[string]fswatch
 		for eventPath := range changedPaths {
 			if o.host.FS().DirectoryExists(eventPath) {
 				if o.wm.IsPathUnderWatch(eventPath, opts) {
+					// There is nothing interesting to cancel, just pass Background.
 					o.rangeTask(context.Background(), func(_ context.Context, path tspath.Path, task *BuildTask) {
 						task.resetStatus()
 						task.reportDone = make(chan struct{})
@@ -562,6 +563,7 @@ func (o *Orchestrator) DoCycle() {
 
 	if overflow {
 		// Overflow: reset all tasks to force a full rebuild.
+		// There is nothing interesting to cancel, just pass Background.
 		o.rangeTask(context.Background(), func(_ context.Context, path tspath.Path, task *BuildTask) {
 			task.resetConfig(o, path)
 			task.reportDone = make(chan struct{})
@@ -585,9 +587,10 @@ func (o *Orchestrator) DoCycle() {
 		o.GenerateGraphReusingOldTasks()
 	}
 
-	// TODO: propagate a proper context here and support cancellation with cycle
-	o.buildOrClean(context.Background())
-	o.updateWatch()
+	// TODO: propagate a proper context here and support cancellation within a cycle
+	ctx := context.Background()
+	o.buildOrClean(ctx)
+	o.updateWatch(ctx)
 	desiredDirs := o.computeDesiredWatches()
 	if err := o.wm.ReconcileWatches(desiredDirs); err != nil {
 		fmt.Fprintf(o.opts.Sys.Writer(), "%v\n", err)

--- a/internal/execute/build/orchestrator.go
+++ b/internal/execute/build/orchestrator.go
@@ -230,8 +230,8 @@ func (o *Orchestrator) Start(ctx context.Context) tsc.CommandLineResult {
 	}
 	o.GenerateGraph(nil)
 	if o.opts.Command.CompilerOptions.Watch.IsTrue() {
-		// In watch mode the initial build, like each watch cycle, runs to completion;
-		// cancellation is observed at the RunLoop boundary (see the TODO in DoCycle).
+		// Watch mode: the initial build runs to completion; cancellation is observed
+		// at the RunLoop boundary (see the TODO in DoCycle).
 		result := o.buildOrClean(context.Background())
 		o.Watch(ctx)
 		result.Watcher = o
@@ -581,10 +581,8 @@ func (o *Orchestrator) DoCycle() {
 		o.GenerateGraphReusingOldTasks()
 	}
 
-	// TODO: like the CLI watcher, a build watch cycle runs to completion; cancellation
-	// is only observed between cycles in WatchManager.RunLoop. Thread the RunLoop context
-	// through DoCycle to make a long rebuild interruptible (and handle ExitStatusCanceled
-	// by discarding the partial cycle).
+	// TODO: thread the RunLoop context through DoCycle so a long rebuild is
+	// interruptible mid-cycle, not just between cycles (see the CLI watcher's TODO).
 	o.buildOrClean(context.Background())
 	o.updateWatch()
 	desiredDirs := o.computeDesiredWatches()
@@ -612,9 +610,8 @@ func (o *Orchestrator) buildOrClean(ctx context.Context) tsc.CommandLineResult {
 			o.buildOrCleanProject(ctx, task, path, &buildResult)
 		})
 		if ctx.Err() != nil {
-			// The build was canceled (e.g. SIGINT). rangeTask stops scheduling further
-			// projects; report the aborted status even if cancellation landed before any
-			// project produced one.
+			// Report the aborted status even if cancellation landed before any project
+			// produced one.
 			buildResult.result.Status = tsc.ExitStatusCanceled
 		}
 	} else {
@@ -651,9 +648,8 @@ func (o *Orchestrator) rangeTask(ctx context.Context, f func(ctx context.Context
 	}
 	runTask := func() {
 		for path, task, ok := getNextTask(); ok; path, task, ok = getNextTask() {
-			// Stop scheduling further projects once canceled (e.g. SIGINT). Tasks
-			// already in flight finish on their own; the compile they run is
-			// interruptible via the context threaded into compileAndEmit.
+			// Stop scheduling further projects once canceled; in-flight tasks finish
+			// (their compile is interruptible via ctx).
 			if ctx.Err() != nil {
 				return
 			}

--- a/internal/execute/build/orchestrator.go
+++ b/internal/execute/build/orchestrator.go
@@ -231,8 +231,8 @@ func (o *Orchestrator) Start(ctx context.Context) tsc.CommandLineResult {
 	o.GenerateGraph(nil)
 	result := o.buildOrClean(ctx)
 	if o.opts.Command.CompilerOptions.Watch.IsTrue() {
-		// If we were already cancelled return now, but treat it as success.
-		// in watch mode this is the only way to exit.
+		// If we were already canceled return now, but treat it as success.
+		// In watch mode this is the only way to exit.
 		if result.Status == tsc.ExitStatusCanceled {
 			result.Status = tsc.ExitStatusSuccess
 			return result

--- a/internal/execute/build/orchestrator.go
+++ b/internal/execute/build/orchestrator.go
@@ -677,7 +677,7 @@ func (o *Orchestrator) buildOrCleanProject(ctx context.Context, task *BuildTask,
 	if !o.opts.Command.BuildOptions.Clean.IsTrue() {
 		task.buildProject(ctx, o, path)
 	} else {
-		task.cleanProject(o, path)
+		task.cleanProject(ctx, o, path)
 	}
 	task.report(o, path, buildResult)
 }

--- a/internal/execute/tsc.go
+++ b/internal/execute/tsc.go
@@ -243,6 +243,7 @@ func tscCompilation(ctx context.Context, sys tsc.System, commandLine *tsoptions.
 		return tsc.CommandLineResult{Status: tsc.ExitStatusSuccess, Watcher: watcher}
 	} else if configForCompilation.CompilerOptions().IsIncremental() {
 		return performIncrementalCompilation(
+			ctx,
 			sys,
 			configForCompilation,
 			reportDiagnostic,
@@ -253,6 +254,7 @@ func tscCompilation(ctx context.Context, sys tsc.System, commandLine *tsoptions.
 		)
 	}
 	return performCompilation(
+		ctx,
 		sys,
 		configForCompilation,
 		reportDiagnostic,
@@ -282,6 +284,7 @@ func getTraceFromSys(sys tsc.System, locale locale.Locale, testing tsc.CommandLi
 }
 
 func performIncrementalCompilation(
+	ctx context.Context,
 	sys tsc.System,
 	config *tsoptions.ParsedCommandLine,
 	reportDiagnostic tsc.DiagnosticReporter,
@@ -307,7 +310,7 @@ func performIncrementalCompilation(
 	changesComputeStart := sys.Now()
 	incrementalProgram := incremental.NewProgram(program, oldProgram, incremental.CreateHost(host), testing != nil)
 	compileTimes.ChangesComputeTime = sys.Now().Sub(changesComputeStart)
-	result, _ := tsc.EmitAndReportStatistics(tsc.EmitInput{
+	result, _ := tsc.EmitAndReportStatistics(ctx, tsc.EmitInput{
 		Sys:                sys,
 		ProgramLike:        incrementalProgram,
 		Program:            incrementalProgram.GetProgram(),
@@ -331,6 +334,7 @@ func performIncrementalCompilation(
 }
 
 func performCompilation(
+	ctx context.Context,
 	sys tsc.System,
 	config *tsoptions.ParsedCommandLine,
 	reportDiagnostic tsc.DiagnosticReporter,
@@ -350,7 +354,7 @@ func performCompilation(
 		Tracing: tr,
 	})
 	compileTimes.ParseTime = sys.Now().Sub(parseStart)
-	result, _ := tsc.EmitAndReportStatistics(tsc.EmitInput{
+	result, _ := tsc.EmitAndReportStatistics(ctx, tsc.EmitInput{
 		Sys:                sys,
 		ProgramLike:        program,
 		Program:            program,

--- a/internal/execute/tsc.go
+++ b/internal/execute/tsc.go
@@ -55,15 +55,15 @@ func CommandLine(ctx context.Context, sys tsc.System, commandLineArgs []string, 
 		case "-b", "--b", "-build", "--build":
 			return tscBuildCompilation(ctx, sys, tsoptions.ParseBuildCommandLine(commandLineArgs, sys), testing)
 			// case "-f":
-			// 	return fmtMain(sys, commandLineArgs[1], commandLineArgs[1])
+			// 	return fmtMain(ctx, sys, commandLineArgs[1], commandLineArgs[1])
 		}
 	}
 
 	return tscCompilation(ctx, sys, tsoptions.ParseCommandLine(commandLineArgs, sys), testing)
 }
 
-func fmtMain(sys tsc.System, input, output string) tsc.ExitStatus {
-	ctx := format.WithFormatCodeSettings(context.Background(), lsutil.GetDefaultFormatCodeSettings(), "\n")
+func fmtMain(ctx context.Context, sys tsc.System, input, output string) tsc.ExitStatus {
+	ctx = format.WithFormatCodeSettings(ctx, lsutil.GetDefaultFormatCodeSettings(), "\n")
 	input = string(tspath.ToPath(input, sys.GetCurrentDirectory(), sys.FS().UseCaseSensitiveFileNames()))
 	output = string(tspath.ToPath(output, sys.GetCurrentDirectory(), sys.FS().UseCaseSensitiveFileNames()))
 	fileContent, ok := sys.FS().ReadFile(input)

--- a/internal/execute/tsc/compile.go
+++ b/internal/execute/tsc/compile.go
@@ -36,6 +36,7 @@ const (
 	ExitStatusInvalidProject_OutputsSkipped        ExitStatus = 3
 	ExitStatusProjectReferenceCycle_OutputsSkipped ExitStatus = 4
 	ExitStatusNotImplemented                       ExitStatus = 5
+	ExitStatusCanceled                             ExitStatus = 6
 )
 
 type Watcher interface {

--- a/internal/execute/tsc/emit.go
+++ b/internal/execute/tsc/emit.go
@@ -45,8 +45,8 @@ type EmitInput struct {
 func EmitAndReportStatistics(ctx context.Context, input EmitInput) (CompileAndEmitResult, *Statistics) {
 	var statistics *Statistics
 	result := EmitFilesAndReportErrors(ctx, input)
-	if result.Status != ExitStatusSuccess {
-		// compile exited early
+	if result.Status != ExitStatusSuccess || result.EmitResult == nil {
+		// compile exited early (e.g. errors or cancellation); EmitResult may be nil
 		return result, nil
 	}
 	result.times.totalTime = input.Sys.SinceStart()
@@ -115,6 +115,13 @@ func EmitFilesAndReportErrors(ctx context.Context, input EmitInput) (result Comp
 			WriteFile: input.WriteFile,
 		})
 		result.times.emitTime = input.Sys.Now().Sub(emitStart)
+		// Emit returns nil if it was canceled partway through (e.g. cancellation
+		// during the internal no-emit-on-error recheck). Abort rather than report a
+		// nil result as success.
+		if ctx.Err() != nil {
+			result.Status = ExitStatusCanceled
+			return result
+		}
 	}
 	if emitResult != nil {
 		allDiagnostics = append(allDiagnostics, emitResult.Diagnostics...)

--- a/internal/execute/tsc/emit.go
+++ b/internal/execute/tsc/emit.go
@@ -42,9 +42,9 @@ type EmitInput struct {
 	Tracing            *tracing.Tracing
 }
 
-func EmitAndReportStatistics(input EmitInput) (CompileAndEmitResult, *Statistics) {
+func EmitAndReportStatistics(ctx context.Context, input EmitInput) (CompileAndEmitResult, *Statistics) {
 	var statistics *Statistics
-	result := EmitFilesAndReportErrors(input)
+	result := EmitFilesAndReportErrors(ctx, input)
 	if result.Status != ExitStatusSuccess {
 		// compile exited early
 		return result, nil
@@ -70,9 +70,8 @@ func EmitAndReportStatistics(input EmitInput) (CompileAndEmitResult, *Statistics
 	return result, statistics
 }
 
-func EmitFilesAndReportErrors(input EmitInput) (result CompileAndEmitResult) {
+func EmitFilesAndReportErrors(ctx context.Context, input EmitInput) (result CompileAndEmitResult) {
 	result.times = input.CompileTimes
-	ctx := context.Background()
 
 	allDiagnostics := compiler.GetDiagnosticsOfAnyProgram(
 		ctx,
@@ -101,6 +100,14 @@ func EmitFilesAndReportErrors(input EmitInput) (result CompileAndEmitResult) {
 			return diags
 		},
 	)
+
+	// If the compile was canceled (e.g. SIGINT), the checker stops early and the
+	// diagnostics above are incomplete. Do not emit or report them as a complete
+	// result; abort with a distinct status instead.
+	if ctx.Err() != nil {
+		result.Status = ExitStatusCanceled
+		return result
+	}
 
 	emitResult := &compiler.EmitResult{EmitSkipped: true, Diagnostics: []*ast.Diagnostic{}}
 	if !input.ProgramLike.Options().ListFilesOnly.IsTrue() {

--- a/internal/execute/tsc/emit.go
+++ b/internal/execute/tsc/emit.go
@@ -101,9 +101,8 @@ func EmitFilesAndReportErrors(ctx context.Context, input EmitInput) (result Comp
 		},
 	)
 
-	// If the compile was canceled (e.g. SIGINT), the checker stops early and the
-	// diagnostics above are incomplete. Do not emit or report them as a complete
-	// result; abort with a distinct status instead.
+	// On cancellation the diagnostics above are incomplete; abort rather than emit
+	// or report them as a complete result.
 	if ctx.Err() != nil {
 		result.Status = ExitStatusCanceled
 		return result

--- a/internal/execute/tsctests/runner.go
+++ b/internal/execute/tsctests/runner.go
@@ -57,6 +57,8 @@ func (test *tscInput) executeCommand(sys *TestSys, baselineBuilder *strings.Buil
 		baselineBuilder.WriteString("ExitStatus:: ProjectReferenceCycle_OutputsSkipped")
 	case tsc.ExitStatusNotImplemented:
 		baselineBuilder.WriteString("ExitStatus:: NotImplemented")
+	case tsc.ExitStatusCanceled:
+		baselineBuilder.WriteString("ExitStatus:: Canceled")
 	default:
 		panic(fmt.Sprintf("UnknownExitStatus %d", result.Status))
 	}

--- a/internal/execute/tsctests/tsccancel_test.go
+++ b/internal/execute/tsctests/tsccancel_test.go
@@ -9,20 +9,15 @@ import (
 	"github.com/microsoft/typescript-go/internal/execute/tsc"
 )
 
-// TestTscNoEmitCancellation verifies that interrupting a `--noEmit` compile via
-// the context passed to execute.CommandLine (which the CLI wires to SIGINT/SIGTERM
-// in cmd/tsgo/main.go) aborts the compile promptly rather than running it to
-// completion.
-//
-// A pre-canceled context deterministically exercises the same isCanceled() polling
-// the checker uses for a mid-flight SIGINT (see internal/checker/utilities.go), so
-// it covers both the "already canceled" and "canceled during check" cases.
+// TestTscNoEmitCancellation verifies that a canceled context (wired to SIGINT in
+// cmd/tsgo/main.go) aborts a compile instead of running it to completion. A
+// pre-canceled context deterministically hits the same checker cancellation polling
+// a mid-flight SIGINT would.
 func TestTscNoEmitCancellation(t *testing.T) {
 	t.Parallel()
 
-	// Each file contains a type error so we can prove whether the checker ran to
-	// completion: if it did, the diagnostic is reported; if the compile was
-	// abandoned on cancellation, it is not.
+	// A type error lets us tell whether the checker ran to completion: if it did,
+	// the diagnostic is reported; if aborted, it is not.
 	const badSource = `const x: number = "not a number";`
 
 	testCases := []struct {
@@ -31,8 +26,7 @@ func TestTscNoEmitCancellation(t *testing.T) {
 		files FileMap
 	}{
 		{
-			// Single file: exercises the top-level cancellation short-circuit in
-			// EmitFilesAndReportErrors / GetDiagnosticsOfAnyProgram.
+			// Top-level short-circuit in EmitFilesAndReportErrors.
 			name: "single file",
 			args: []string{"--noEmit"},
 			files: FileMap{
@@ -41,11 +35,9 @@ func TestTscNoEmitCancellation(t *testing.T) {
 			},
 		},
 		{
-			// Multiple files under --singleThreaded funnel through a single checker,
-			// so the per-file loop in checkerPool.forEachCheckerGroupDo reuses the
-			// same checker across files. Once the first file cancels it, reusing it
-			// for the next file would panic in checkNotCanceled without the guard
-			// there. This case pins that guard.
+			// --singleThreaded funnels all files through one checker, so
+			// forEachCheckerGroupDo reuses it across files. Pins the guard that stops
+			// reuse after cancellation (else checkNotCanceled panics on the 2nd file).
 			name: "multi file single checker",
 			args: []string{"--noEmit", "--singleThreaded"},
 			files: FileMap{
@@ -56,10 +48,7 @@ func TestTscNoEmitCancellation(t *testing.T) {
 			},
 		},
 		{
-			// Build mode (`tsc -b`): exercises the context threaded through the build
-			// orchestrator (Start -> buildOrClean -> rangeTask -> buildProject ->
-			// compileAndEmit). A canceled build must abort rather than run the project's
-			// compile to completion.
+			// `tsc -b`: exercises the context threaded through the build orchestrator.
 			name: "build mode",
 			args: []string{"-b"},
 			files: FileMap{
@@ -82,15 +71,12 @@ func TestTscNoEmitCancellation(t *testing.T) {
 
 			result := execute.CommandLine(ctx, sys, tc.args, sys)
 
-			// The compile should short-circuit with a distinct canceled status
-			// instead of running the checker to completion (and it must not panic
-			// reusing a canceled checker).
+			// Aborts with a distinct status (and must not panic reusing a canceled checker).
 			if result.Status != tsc.ExitStatusCanceled {
 				t.Errorf("status = %v, want ExitStatusCanceled (compile should abort on cancellation)", result.Status)
 			}
 
-			// Because the check was abandoned, its (incomplete) diagnostics must not
-			// be reported: the type errors should be absent from the output.
+			// Aborted checks must not report their incomplete diagnostics.
 			if out := sys.getOutput(true); strings.Contains(out, "error TS") {
 				t.Errorf("expected no diagnostics to be reported after cancellation; got output:\n%s", out)
 			}

--- a/internal/execute/tsctests/tsccancel_test.go
+++ b/internal/execute/tsctests/tsccancel_test.go
@@ -189,6 +189,85 @@ func runWithCancellation(t *testing.T, sys *TestSys, args []string, midCheck boo
 	}
 }
 
+// runPreCanceled runs the command line on an existing sys under a context that is
+// already canceled before the run starts, guarded by a timeout so a regression that
+// ignores cancellation fails loudly instead of hanging.
+func runPreCanceled(t *testing.T, sys *TestSys, args []string) tsc.CommandLineResult {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	resultCh := make(chan tsc.CommandLineResult, 1)
+	go func() {
+		resultCh <- execute.CommandLine(ctx, sys, args, sys)
+	}()
+	select {
+	case result := <-resultCh:
+		return result
+	case <-time.After(30 * time.Second):
+		t.Fatal("run did not abort after cancellation")
+		return tsc.CommandLineResult{}
+	}
+}
+
+// TestTscBuildCancellationUpToDate verifies that an interrupt is honored even when a
+// `tsc -b` build has nothing to do. A root project that is already up to date has no
+// upstream to wait on, so the no-build path must still observe a pre-canceled context
+// and report ExitStatusCanceled rather than swallowing the interrupt as success.
+func TestTscBuildCancellationUpToDate(t *testing.T) {
+	t.Parallel()
+	files := FileMap{
+		"/home/src/workspaces/project/tsconfig.json": `{ "compilerOptions": { "composite": true } }`,
+		"/home/src/workspaces/project/a.ts":          "export const a = 1;\n",
+	}
+	sys := newTestSys(&tscInput{
+		commandLineArgs: []string{"-b"},
+		files:           files,
+	}, false)
+
+	// First build to success so the project is up to date on the next run.
+	if result := execute.CommandLine(context.Background(), sys, []string{"-b"}, sys); result.Status != tsc.ExitStatusSuccess {
+		t.Fatalf("initial build status = %v, want ExitStatusSuccess", result.Status)
+	}
+
+	// A second, pre-canceled build has nothing to build; it must still report canceled.
+	result := runPreCanceled(t, sys, []string{"-b"})
+	if result.Status != tsc.ExitStatusCanceled {
+		t.Errorf("status = %v, want ExitStatusCanceled", result.Status)
+	}
+}
+
+// TestTscCleanCancellation verifies that `tsc -b --clean` interrupted before it runs
+// does not delete outputs and reports ExitStatusCanceled instead of success.
+func TestTscCleanCancellation(t *testing.T) {
+	t.Parallel()
+	const outFile = "/home/src/workspaces/project/a.js"
+	files := FileMap{
+		"/home/src/workspaces/project/tsconfig.json": `{ "compilerOptions": { "composite": true } }`,
+		"/home/src/workspaces/project/a.ts":          "export const a = 1;\n",
+	}
+	sys := newTestSys(&tscInput{
+		commandLineArgs: []string{"-b"},
+		files:           files,
+	}, false)
+
+	// Build first so there is an output for clean to (potentially) delete.
+	if result := execute.CommandLine(context.Background(), sys, []string{"-b"}, sys); result.Status != tsc.ExitStatusSuccess {
+		t.Fatalf("initial build status = %v, want ExitStatusSuccess", result.Status)
+	}
+	if !sys.FS().FileExists(outFile) {
+		t.Fatalf("expected %s to exist after build", outFile)
+	}
+
+	// A pre-canceled clean must abort before deleting outputs and report canceled.
+	result := runPreCanceled(t, sys, []string{"-b", "--clean"})
+	if result.Status != tsc.ExitStatusCanceled {
+		t.Errorf("status = %v, want ExitStatusCanceled", result.Status)
+	}
+	if !sys.FS().FileExists(outFile) {
+		t.Errorf("expected %s to survive a canceled clean", outFile)
+	}
+}
+
 // TestTscCancellationSweep steps the cancellation point across the whole compile by
 // increasing the poll threshold one step at a time, walking past the check phase and
 // into emit. This covers windows a single fixed threshold would miss -- the

--- a/internal/execute/tsctests/tsccancel_test.go
+++ b/internal/execute/tsctests/tsccancel_test.go
@@ -3,17 +3,18 @@ package tsctests
 import (
 	"context"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/microsoft/typescript-go/internal/execute"
 	"github.com/microsoft/typescript-go/internal/execute/tsc"
 )
 
-// TestTscNoEmitCancellation verifies that a canceled context (wired to SIGINT in
-// cmd/tsgo/main.go) aborts a compile instead of running it to completion. A
-// pre-canceled context deterministically hits the same checker cancellation polling
-// a mid-flight SIGINT would.
-func TestTscNoEmitCancellation(t *testing.T) {
+// TestTscPreCanceledCompilation verifies that a context canceled before the compile
+// starts aborts immediately with ExitStatusCanceled and reports no diagnostics,
+// without panicking on checker reuse.
+func TestTscPreCanceledCompilation(t *testing.T) {
 	t.Parallel()
 
 	// A type error lets us tell whether the checker ran to completion: if it did,
@@ -36,8 +37,7 @@ func TestTscNoEmitCancellation(t *testing.T) {
 		},
 		{
 			// --singleThreaded funnels all files through one checker, so
-			// forEachCheckerGroupDo reuses it across files. Pins the guard that stops
-			// reuse after cancellation (else checkNotCanceled panics on the 2nd file).
+			// forEachCheckerGroupDo reuses it across files.
 			name: "multi file single checker",
 			args: []string{"--noEmit", "--singleThreaded"},
 			files: FileMap{
@@ -67,7 +67,7 @@ func TestTscNoEmitCancellation(t *testing.T) {
 			}, false)
 
 			ctx, cancel := context.WithCancel(context.Background())
-			cancel() // simulate SIGINT delivered before/at the start of the compile
+			cancel() // simulate SIGINT delivered before the compile starts
 
 			result := execute.CommandLine(ctx, sys, tc.args, sys)
 
@@ -79,6 +79,127 @@ func TestTscNoEmitCancellation(t *testing.T) {
 			// Aborted checks must not report their incomplete diagnostics.
 			if out := sys.getOutput(true); strings.Contains(out, "error TS") {
 				t.Errorf("expected no diagnostics to be reported after cancellation; got output:\n%s", out)
+			}
+		})
+	}
+}
+
+// cancelAfterNPolls is a context that reports itself canceled only after Err has
+// been polled pollThreshold times while still uncanceled. The checker polls
+// ctx.Err() between top-level statements (checkSourceElements), so this lands the
+// cancellation *after* checking has begun rather than before it starts -- the case
+// a pre-canceled context cannot exercise. Once tripped it stays canceled.
+type cancelAfterNPolls struct {
+	context.Context
+	pollThreshold int32
+	polls         atomic.Int32
+	tripped       atomic.Bool
+	done          chan struct{}
+}
+
+func newCancelAfterNPolls(pollThreshold int32) *cancelAfterNPolls {
+	return &cancelAfterNPolls{
+		Context:       context.Background(),
+		pollThreshold: pollThreshold,
+		done:          make(chan struct{}),
+	}
+}
+
+func (c *cancelAfterNPolls) Err() error {
+	if c.tripped.Load() {
+		return context.Canceled
+	}
+	if c.polls.Add(1) > c.pollThreshold {
+		if c.tripped.CompareAndSwap(false, true) {
+			close(c.done)
+		}
+		return context.Canceled
+	}
+	return nil
+}
+
+func (c *cancelAfterNPolls) Done() <-chan struct{} {
+	return c.done
+}
+
+// TestTscMidCheckCancellation cancels the context after type-checking has already
+// begun (not before it starts). This exercises the paths a pre-canceled context
+// skips: a checker actually runs, sets wasCanceled, and would panic in
+// checkNotCanceled on the second GetGlobalDiagnostics / on reuse across files if
+// the cancellation guards were missing.
+func TestTscMidCheckCancellation(t *testing.T) {
+	t.Parallel()
+
+	// Enough top-level statements across multiple files that the checker polls
+	// ctx.Err() many times, so cancellation reliably lands mid-check.
+	var manyStatements strings.Builder
+	for i := range 50 {
+		manyStatements.WriteString("export const v")
+		manyStatements.WriteString(strings.Repeat("x", i+1))
+		manyStatements.WriteString(`: number = "not a number";` + "\n")
+	}
+	src := manyStatements.String()
+
+	testCases := []struct {
+		name string
+		args []string
+	}{
+		{
+			// Single checker reused across files: after it cancels on an early file,
+			// forEachCheckerGroupDo must stop feeding it later files.
+			name: "single checker",
+			args: []string{"--noEmit", "--singleThreaded"},
+		},
+		{
+			// tsc -b through the incremental program + orchestrator.
+			name: "build mode",
+			args: []string{"-b"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			files := FileMap{
+				"/home/src/workspaces/project/a.ts": src,
+				"/home/src/workspaces/project/b.ts": src,
+				"/home/src/workspaces/project/c.ts": src,
+			}
+			if tc.name == "build mode" {
+				files["/home/src/workspaces/project/tsconfig.json"] = `{ "compilerOptions": { "composite": true, "strict": true } }`
+			} else {
+				files["/home/src/workspaces/project/tsconfig.json"] = `{ "compilerOptions": { "noEmit": true, "strict": true } }`
+			}
+
+			sys := newTestSys(&tscInput{
+				commandLineArgs: tc.args,
+				files:           files,
+			}, false)
+
+			// Let checking start, then cancel. The threshold is small relative to the
+			// number of statements so cancellation lands well before checking finishes.
+			ctx := newCancelAfterNPolls(5)
+
+			resultCh := make(chan tsc.CommandLineResult, 1)
+			go func() {
+				resultCh <- execute.CommandLine(ctx, sys, tc.args, sys)
+			}()
+
+			select {
+			case result := <-resultCh:
+				// The run must abort (not run to completion) once canceled mid-check,
+				// and must not panic in checkNotCanceled.
+				if result.Status != tsc.ExitStatusCanceled {
+					t.Errorf("status = %v, want ExitStatusCanceled", result.Status)
+				}
+				// The cancellation must actually have landed mid-check, otherwise this
+				// test is not exercising what it claims.
+				if !ctx.tripped.Load() {
+					t.Error("expected cancellation to trip during checking, but it never did")
+				}
+			case <-time.After(30 * time.Second):
+				t.Fatal("compile did not abort after mid-check cancellation")
 			}
 		})
 	}

--- a/internal/execute/tsctests/tsccancel_test.go
+++ b/internal/execute/tsctests/tsccancel_test.go
@@ -11,84 +11,11 @@ import (
 	"github.com/microsoft/typescript-go/internal/execute/tsc"
 )
 
-// TestTscPreCanceledCompilation verifies that a context canceled before the compile
-// starts aborts immediately with ExitStatusCanceled and reports no diagnostics,
-// without panicking on checker reuse.
-func TestTscPreCanceledCompilation(t *testing.T) {
-	t.Parallel()
-
-	// A type error lets us tell whether the checker ran to completion: if it did,
-	// the diagnostic is reported; if aborted, it is not.
-	const badSource = `const x: number = "not a number";`
-
-	testCases := []struct {
-		name  string
-		args  []string
-		files FileMap
-	}{
-		{
-			// Top-level short-circuit in EmitFilesAndReportErrors.
-			name: "single file",
-			args: []string{"--noEmit"},
-			files: FileMap{
-				"/home/src/workspaces/project/tsconfig.json": `{ "compilerOptions": { "noEmit": true, "strict": true } }`,
-				"/home/src/workspaces/project/main.ts":       badSource,
-			},
-		},
-		{
-			// --singleThreaded funnels all files through one checker, so
-			// forEachCheckerGroupDo reuses it across files.
-			name: "multi file single checker",
-			args: []string{"--noEmit", "--singleThreaded"},
-			files: FileMap{
-				"/home/src/workspaces/project/tsconfig.json": `{ "compilerOptions": { "noEmit": true, "strict": true } }`,
-				"/home/src/workspaces/project/a.ts":          badSource,
-				"/home/src/workspaces/project/b.ts":          badSource,
-				"/home/src/workspaces/project/c.ts":          badSource,
-			},
-		},
-		{
-			// `tsc -b`: exercises the context threaded through the build orchestrator.
-			name: "build mode",
-			args: []string{"-b"},
-			files: FileMap{
-				"/home/src/workspaces/project/tsconfig.json": `{ "compilerOptions": { "composite": true, "strict": true } }`,
-				"/home/src/workspaces/project/main.ts":       badSource,
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			sys := newTestSys(&tscInput{
-				commandLineArgs: tc.args,
-				files:           tc.files,
-			}, false)
-
-			ctx, cancel := context.WithCancel(context.Background())
-			cancel() // simulate SIGINT delivered before the compile starts
-
-			result := execute.CommandLine(ctx, sys, tc.args, sys)
-
-			// Aborts with a distinct status (and must not panic reusing a canceled checker).
-			if result.Status != tsc.ExitStatusCanceled {
-				t.Errorf("status = %v, want ExitStatusCanceled (compile should abort on cancellation)", result.Status)
-			}
-
-			// Aborted checks must not report their incomplete diagnostics.
-			if out := sys.getOutput(true); strings.Contains(out, "error TS") {
-				t.Errorf("expected no diagnostics to be reported after cancellation; got output:\n%s", out)
-			}
-		})
-	}
-}
-
 // cancelAfterNPolls is a context that reports itself canceled only after Err has
 // been polled pollThreshold times while still uncanceled. The checker polls
-// ctx.Err() between top-level statements (checkSourceElements), so this lands the
-// cancellation *after* checking has begun rather than before it starts -- the case
-// a pre-canceled context cannot exercise. Once tripped it stays canceled.
+// ctx.Err() between top-level statements (checkSourceElements), so a small threshold
+// lands the cancellation *after* checking has begun rather than before it starts --
+// the case a pre-canceled context cannot exercise. Once tripped it stays canceled.
 type cancelAfterNPolls struct {
 	context.Context
 	pollThreshold int32
@@ -118,74 +45,83 @@ func (c *cancelAfterNPolls) Err() error {
 	return nil
 }
 
-func (c *cancelAfterNPolls) Done() <-chan struct{} {
-	return c.done
-}
+func (c *cancelAfterNPolls) Done() <-chan struct{} { return c.done }
 
-// TestTscMidCheckCancellation cancels the context after type-checking has already
-// begun (not before it starts). This exercises the paths a pre-canceled context
-// skips: a checker actually runs, sets wasCanceled, and would panic in
-// checkNotCanceled on the second GetGlobalDiagnostics / on reuse across files if
-// the cancellation guards were missing.
-func TestTscMidCheckCancellation(t *testing.T) {
+// TestTscCancellationAborts verifies that a canceled compile aborts with
+// ExitStatusCanceled and never reports its (incomplete) diagnostics -- both when the
+// signal arrives before the compile starts and when it lands mid-check, where a
+// checker actually runs and is marked canceled. The mid-check cases are what would
+// panic in checkNotCanceled if the reuse guards were missing (a canceled checker fed
+// more files, or asked for global/declaration diagnostics again).
+func TestTscCancellationAborts(t *testing.T) {
 	t.Parallel()
 
-	// Many top-level statements per file so the checker polls ctx.Err() often and
-	// cancellation reliably lands mid-check, across more than one file.
-	var badStatements strings.Builder
+	// Many statements per file so a mid-check cancellation reliably lands while
+	// checking, across more than one file. The type errors let us tell whether the
+	// checker ran to completion: if it did the diagnostics are reported, if aborted
+	// they are not. Distinct names per statement keep the checker busy.
+	var bad, inferred strings.Builder
 	for i := range 50 {
-		badStatements.WriteString("export const v")
-		badStatements.WriteString(strings.Repeat("x", i+1))
-		badStatements.WriteString(`: number = "not a number";` + "\n")
+		x := strings.Repeat("x", i+1)
+		bad.WriteString("export const v" + x + `: number = "not a number";` + "\n")
+		// Inferred return types force type serialization during declaration emit
+		// (SerializeReturnTypeForSignature -> node reuse -> checkNotCanceled), a
+		// distinct checker-reuse path from plain semantic checking.
+		inferred.WriteString("export function make" + x + "() { return { a: 1, b: 'x', deep: [1, 2, 3] as const }; }\n")
 	}
-	badSrc := badStatements.String()
-
-	// Inferred return types force the checker to serialize types during declaration
-	// emit (SerializeReturnTypeForSignature -> node reuse -> checkNotCanceled), a
-	// distinct reuse path from plain semantic checking.
-	var inferredSrc strings.Builder
-	for i := range 50 {
-		inferredSrc.WriteString("export function make")
-		inferredSrc.WriteString(strings.Repeat("x", i+1))
-		inferredSrc.WriteString("() { return { a: 1, b: 'x', deep: [1, 2, 3] as const }; }\n")
-	}
+	badSrc, inferredSrc := bad.String(), inferred.String()
 
 	testCases := []struct {
 		name     string
 		args     []string
 		tsconfig string
 		src      string
+		midCheck bool // cancel during checking rather than before the compile starts
 	}{
 		{
-			// Single checker reused across files: after it cancels on an early file,
-			// forEachCheckerGroupDo must stop feeding it later files.
-			name:     "single checker",
-			args:     []string{"--noEmit", "--singleThreaded"},
+			name:     "pre-canceled single file",
+			args:     []string{"--noEmit"},
 			tsconfig: `{ "compilerOptions": { "noEmit": true, "strict": true } }`,
 			src:      badSrc,
 		},
 		{
-			// tsc -b through the incremental program + orchestrator, which also reaches
-			// GetGlobalDiagnostics from emitBuildInfo -> ensureHasErrorsForState.
-			name:     "build mode",
+			name:     "pre-canceled build mode",
 			args:     []string{"-b"},
 			tsconfig: `{ "compilerOptions": { "composite": true, "strict": true } }`,
 			src:      badSrc,
 		},
 		{
-			// Declaration emit reuses checkers to serialize types; a canceled checker
-			// must not be handed to GetDeclarationDiagnostics.
-			name:     "declaration emit",
+			// --singleThreaded funnels all files through one checker, so after it
+			// cancels on an early file forEachCheckerGroupDo must stop feeding it later
+			// files.
+			name:     "mid-check single checker",
+			args:     []string{"--noEmit", "--singleThreaded"},
+			tsconfig: `{ "compilerOptions": { "noEmit": true, "strict": true } }`,
+			src:      badSrc,
+			midCheck: true,
+		},
+		{
+			// tsc -b through the incremental program + orchestrator, which also reaches
+			// GetGlobalDiagnostics from emitBuildInfo -> ensureHasErrorsForState.
+			name:     "mid-check build mode",
+			args:     []string{"-b"},
+			tsconfig: `{ "compilerOptions": { "composite": true, "strict": true } }`,
+			src:      badSrc,
+			midCheck: true,
+		},
+		{
+			// A canceled checker must not be handed to GetDeclarationDiagnostics.
+			name:     "mid-check declaration emit",
 			args:     []string{"--noEmit", "--declaration", "--singleThreaded"},
 			tsconfig: `{ "compilerOptions": { "noEmit": true, "declaration": true, "strict": true } }`,
-			src:      inferredSrc.String(),
+			src:      inferredSrc,
+			midCheck: true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-
 			sys := newTestSys(&tscInput{
 				commandLineArgs: tc.args,
 				files: FileMap{
@@ -196,40 +132,65 @@ func TestTscMidCheckCancellation(t *testing.T) {
 				},
 			}, false)
 
-			// Let checking start, then cancel. The threshold is small relative to the
-			// number of statements so cancellation lands well before checking finishes.
-			ctx := newCancelAfterNPolls(5)
+			result, midChecked := runWithCancellation(t, sys, tc.args, tc.midCheck)
 
-			resultCh := make(chan tsc.CommandLineResult, 1)
-			go func() {
-				resultCh <- execute.CommandLine(ctx, sys, tc.args, sys)
-			}()
-
-			select {
-			case result := <-resultCh:
-				// The run must abort (not run to completion) once canceled mid-check,
-				// and must not panic in checkNotCanceled.
-				if result.Status != tsc.ExitStatusCanceled {
-					t.Errorf("status = %v, want ExitStatusCanceled", result.Status)
-				}
-				// The cancellation must actually have landed mid-check, otherwise this
-				// test is not exercising what it claims.
-				if !ctx.tripped.Load() {
-					t.Error("expected cancellation to trip during checking, but it never did")
-				}
-			case <-time.After(30 * time.Second):
-				t.Fatal("compile did not abort after mid-check cancellation")
+			// Aborts with a distinct status (and must not panic reusing a canceled checker).
+			if result.Status != tsc.ExitStatusCanceled {
+				t.Errorf("status = %v, want ExitStatusCanceled", result.Status)
+			}
+			// Aborted checks must not report their incomplete diagnostics.
+			if out := sys.getOutput(true); strings.Contains(out, "error TS") {
+				t.Errorf("expected no diagnostics after cancellation; got output:\n%s", out)
+			}
+			// A mid-check case that never tripped during checking isn't testing what it claims.
+			if tc.midCheck && !midChecked {
+				t.Error("expected cancellation to trip during checking, but it never did")
 			}
 		})
 	}
 }
 
-// TestTscCancellationSweep cancels at every successive point in the compile by
-// increasing the poll threshold one step at a time. It walks cancellation past the
-// check phase and into emit, covering windows a single fixed threshold would miss:
-// the no-emit-on-error recheck that runs during emit, the emit-returns-nil path, and
-// declaration-emit type serialization. At no threshold may the run panic, and it
-// must always end Canceled or Success (if it finished before the trip).
+// runWithCancellation runs the command line under a canceled context and returns the
+// result. When midCheck is false the context is canceled before the run starts; when
+// true it is canceled after checking has begun, and the returned bool reports whether
+// that mid-check cancellation actually tripped. The run is guarded by a timeout so a
+// regression that ignores cancellation fails loudly instead of hanging.
+func runWithCancellation(t *testing.T, sys *TestSys, args []string, midCheck bool) (tsc.CommandLineResult, bool) {
+	t.Helper()
+	var (
+		ctx        context.Context
+		midChecked func() bool
+	)
+	if midCheck {
+		// Threshold small relative to the statement count so cancellation lands well
+		// before checking finishes.
+		c := newCancelAfterNPolls(5)
+		ctx, midChecked = c, c.tripped.Load
+	} else {
+		canceled, cancel := context.WithCancel(context.Background())
+		cancel()
+		ctx, midChecked = canceled, func() bool { return false }
+	}
+
+	resultCh := make(chan tsc.CommandLineResult, 1)
+	go func() {
+		resultCh <- execute.CommandLine(ctx, sys, args, sys)
+	}()
+	select {
+	case result := <-resultCh:
+		return result, midChecked()
+	case <-time.After(30 * time.Second):
+		t.Fatal("compile did not abort after cancellation")
+		return tsc.CommandLineResult{}, false
+	}
+}
+
+// TestTscCancellationSweep steps the cancellation point across the whole compile by
+// increasing the poll threshold one step at a time, walking past the check phase and
+// into emit. This covers windows a single fixed threshold would miss -- the
+// no-emit-on-error recheck that runs during emit, the emit-returns-nil path, and
+// declaration-emit type serialization -- and asserts that at no point does the run
+// panic or report a partial result as success.
 func TestTscCancellationSweep(t *testing.T) {
 	t.Parallel()
 

--- a/internal/execute/tsctests/tsccancel_test.go
+++ b/internal/execute/tsctests/tsccancel_test.go
@@ -55,6 +55,18 @@ func TestTscNoEmitCancellation(t *testing.T) {
 				"/home/src/workspaces/project/c.ts":          badSource,
 			},
 		},
+		{
+			// Build mode (`tsc -b`): exercises the context threaded through the build
+			// orchestrator (Start -> buildOrClean -> rangeTask -> buildProject ->
+			// compileAndEmit). A canceled build must abort rather than run the project's
+			// compile to completion.
+			name: "build mode",
+			args: []string{"-b"},
+			files: FileMap{
+				"/home/src/workspaces/project/tsconfig.json": `{ "compilerOptions": { "composite": true, "strict": true } }`,
+				"/home/src/workspaces/project/main.ts":       badSource,
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/execute/tsctests/tsccancel_test.go
+++ b/internal/execute/tsctests/tsccancel_test.go
@@ -130,30 +130,55 @@ func (c *cancelAfterNPolls) Done() <-chan struct{} {
 func TestTscMidCheckCancellation(t *testing.T) {
 	t.Parallel()
 
-	// Enough top-level statements across multiple files that the checker polls
-	// ctx.Err() many times, so cancellation reliably lands mid-check.
-	var manyStatements strings.Builder
+	// Many top-level statements per file so the checker polls ctx.Err() often and
+	// cancellation reliably lands mid-check, across more than one file.
+	var badStatements strings.Builder
 	for i := range 50 {
-		manyStatements.WriteString("export const v")
-		manyStatements.WriteString(strings.Repeat("x", i+1))
-		manyStatements.WriteString(`: number = "not a number";` + "\n")
+		badStatements.WriteString("export const v")
+		badStatements.WriteString(strings.Repeat("x", i+1))
+		badStatements.WriteString(`: number = "not a number";` + "\n")
 	}
-	src := manyStatements.String()
+	badSrc := badStatements.String()
+
+	// Inferred return types force the checker to serialize types during declaration
+	// emit (SerializeReturnTypeForSignature -> node reuse -> checkNotCanceled), a
+	// distinct reuse path from plain semantic checking.
+	var inferredSrc strings.Builder
+	for i := range 50 {
+		inferredSrc.WriteString("export function make")
+		inferredSrc.WriteString(strings.Repeat("x", i+1))
+		inferredSrc.WriteString("() { return { a: 1, b: 'x', deep: [1, 2, 3] as const }; }\n")
+	}
 
 	testCases := []struct {
-		name string
-		args []string
+		name     string
+		args     []string
+		tsconfig string
+		src      string
 	}{
 		{
 			// Single checker reused across files: after it cancels on an early file,
 			// forEachCheckerGroupDo must stop feeding it later files.
-			name: "single checker",
-			args: []string{"--noEmit", "--singleThreaded"},
+			name:     "single checker",
+			args:     []string{"--noEmit", "--singleThreaded"},
+			tsconfig: `{ "compilerOptions": { "noEmit": true, "strict": true } }`,
+			src:      badSrc,
 		},
 		{
-			// tsc -b through the incremental program + orchestrator.
-			name: "build mode",
-			args: []string{"-b"},
+			// tsc -b through the incremental program + orchestrator, which also reaches
+			// GetGlobalDiagnostics from emitBuildInfo -> ensureHasErrorsForState.
+			name:     "build mode",
+			args:     []string{"-b"},
+			tsconfig: `{ "compilerOptions": { "composite": true, "strict": true } }`,
+			src:      badSrc,
+		},
+		{
+			// Declaration emit reuses checkers to serialize types; a canceled checker
+			// must not be handed to GetDeclarationDiagnostics.
+			name:     "declaration emit",
+			args:     []string{"--noEmit", "--declaration", "--singleThreaded"},
+			tsconfig: `{ "compilerOptions": { "noEmit": true, "declaration": true, "strict": true } }`,
+			src:      inferredSrc.String(),
 		},
 	}
 
@@ -161,20 +186,14 @@ func TestTscMidCheckCancellation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			files := FileMap{
-				"/home/src/workspaces/project/a.ts": src,
-				"/home/src/workspaces/project/b.ts": src,
-				"/home/src/workspaces/project/c.ts": src,
-			}
-			if tc.name == "build mode" {
-				files["/home/src/workspaces/project/tsconfig.json"] = `{ "compilerOptions": { "composite": true, "strict": true } }`
-			} else {
-				files["/home/src/workspaces/project/tsconfig.json"] = `{ "compilerOptions": { "noEmit": true, "strict": true } }`
-			}
-
 			sys := newTestSys(&tscInput{
 				commandLineArgs: tc.args,
-				files:           files,
+				files: FileMap{
+					"/home/src/workspaces/project/tsconfig.json": tc.tsconfig,
+					"/home/src/workspaces/project/a.ts":          tc.src,
+					"/home/src/workspaces/project/b.ts":          tc.src,
+					"/home/src/workspaces/project/c.ts":          tc.src,
+				},
 			}, false)
 
 			// Let checking start, then cancel. The threshold is small relative to the
@@ -200,6 +219,76 @@ func TestTscMidCheckCancellation(t *testing.T) {
 				}
 			case <-time.After(30 * time.Second):
 				t.Fatal("compile did not abort after mid-check cancellation")
+			}
+		})
+	}
+}
+
+// TestTscCancellationSweep cancels at every successive point in the compile by
+// increasing the poll threshold one step at a time. It walks cancellation past the
+// check phase and into emit, covering windows a single fixed threshold would miss:
+// the no-emit-on-error recheck that runs during emit, the emit-returns-nil path, and
+// declaration-emit type serialization. At no threshold may the run panic, and it
+// must always end Canceled or Success (if it finished before the trip).
+func TestTscCancellationSweep(t *testing.T) {
+	t.Parallel()
+
+	configs := []struct {
+		name     string
+		tsconfig string
+	}{
+		{
+			// noEmitOnError + incremental: emit performs the internal no-emit-on-error
+			// recheck, the path where a mid-emit cancellation makes Emit return nil.
+			name:     "incremental noEmitOnError",
+			tsconfig: `{ "compilerOptions": { "outDir": "out", "incremental": true, "noEmitOnError": true, "strict": true } }`,
+		},
+		{
+			// declaration emit serializes inferred types via the checker during emit.
+			name:     "declaration",
+			tsconfig: `{ "compilerOptions": { "outDir": "out", "declaration": true, "noEmitOnError": true, "strict": true } }`,
+		},
+	}
+
+	for _, cfg := range configs {
+		t.Run(cfg.name, func(t *testing.T) {
+			t.Parallel()
+			files := FileMap{
+				"/home/src/workspaces/project/tsconfig.json": cfg.tsconfig,
+				"/home/src/workspaces/project/a.ts":          "export const a = 1;\nexport function f() { return { x: 1, y: 'z' }; }\n",
+				"/home/src/workspaces/project/b.ts":          "export const b = 2;\nexport function g() { return [1, 2, 3] as const; }\n",
+			}
+
+			// Upper bound comfortably exceeds a full clean run's poll count for this
+			// project, so the sweep covers check, the second global-diagnostics pass,
+			// and emit.
+			for threshold := int32(1); threshold <= 150; threshold++ {
+				sys := newTestSys(&tscInput{
+					commandLineArgs: []string{"--singleThreaded"},
+					files:           files,
+				}, false)
+				ctx := newCancelAfterNPolls(threshold)
+
+				var result tsc.CommandLineResult
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							t.Fatalf("threshold=%d: panicked (want clean abort): %v", threshold, r)
+						}
+					}()
+					result = execute.CommandLine(ctx, sys, []string{"--singleThreaded"}, sys)
+				}()
+
+				// Success only if cancellation never tripped (the build outran it);
+				// otherwise it must be a clean Canceled. Anything else means partial
+				// state leaked out.
+				if ctx.tripped.Load() {
+					if result.Status != tsc.ExitStatusCanceled {
+						t.Fatalf("threshold=%d: status = %v, want ExitStatusCanceled", threshold, result.Status)
+					}
+				} else if result.Status != tsc.ExitStatusSuccess {
+					t.Fatalf("threshold=%d: status = %v, want ExitStatusSuccess (cancellation never tripped)", threshold, result.Status)
+				}
 			}
 		})
 	}

--- a/internal/execute/tsctests/tsccancel_test.go
+++ b/internal/execute/tsctests/tsccancel_test.go
@@ -63,11 +63,15 @@ func TestTscCancellationAborts(t *testing.T) {
 	var bad, inferred strings.Builder
 	for i := range 50 {
 		x := strings.Repeat("x", i+1)
-		bad.WriteString("export const v" + x + `: number = "not a number";` + "\n")
+		bad.WriteString("export const v")
+		bad.WriteString(x)
+		bad.WriteString(`: number = "not a number";` + "\n")
 		// Inferred return types force type serialization during declaration emit
 		// (SerializeReturnTypeForSignature -> node reuse -> checkNotCanceled), a
 		// distinct checker-reuse path from plain semantic checking.
-		inferred.WriteString("export function make" + x + "() { return { a: 1, b: 'x', deep: [1, 2, 3] as const }; }\n")
+		inferred.WriteString("export function make")
+		inferred.WriteString(x)
+		inferred.WriteString("() { return { a: 1, b: 'x', deep: [1, 2, 3] as const }; }\n")
 	}
 	badSrc, inferredSrc := bad.String(), inferred.String()
 

--- a/internal/execute/tsctests/tsccancel_test.go
+++ b/internal/execute/tsctests/tsccancel_test.go
@@ -1,0 +1,87 @@
+package tsctests
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/execute"
+	"github.com/microsoft/typescript-go/internal/execute/tsc"
+)
+
+// TestTscNoEmitCancellation verifies that interrupting a `--noEmit` compile via
+// the context passed to execute.CommandLine (which the CLI wires to SIGINT/SIGTERM
+// in cmd/tsgo/main.go) aborts the compile promptly rather than running it to
+// completion.
+//
+// A pre-canceled context deterministically exercises the same isCanceled() polling
+// the checker uses for a mid-flight SIGINT (see internal/checker/utilities.go), so
+// it covers both the "already canceled" and "canceled during check" cases.
+func TestTscNoEmitCancellation(t *testing.T) {
+	t.Parallel()
+
+	// Each file contains a type error so we can prove whether the checker ran to
+	// completion: if it did, the diagnostic is reported; if the compile was
+	// abandoned on cancellation, it is not.
+	const badSource = `const x: number = "not a number";`
+
+	testCases := []struct {
+		name  string
+		args  []string
+		files FileMap
+	}{
+		{
+			// Single file: exercises the top-level cancellation short-circuit in
+			// EmitFilesAndReportErrors / GetDiagnosticsOfAnyProgram.
+			name: "single file",
+			args: []string{"--noEmit"},
+			files: FileMap{
+				"/home/src/workspaces/project/tsconfig.json": `{ "compilerOptions": { "noEmit": true, "strict": true } }`,
+				"/home/src/workspaces/project/main.ts":       badSource,
+			},
+		},
+		{
+			// Multiple files under --singleThreaded funnel through a single checker,
+			// so the per-file loop in checkerPool.forEachCheckerGroupDo reuses the
+			// same checker across files. Once the first file cancels it, reusing it
+			// for the next file would panic in checkNotCanceled without the guard
+			// there. This case pins that guard.
+			name: "multi file single checker",
+			args: []string{"--noEmit", "--singleThreaded"},
+			files: FileMap{
+				"/home/src/workspaces/project/tsconfig.json": `{ "compilerOptions": { "noEmit": true, "strict": true } }`,
+				"/home/src/workspaces/project/a.ts":          badSource,
+				"/home/src/workspaces/project/b.ts":          badSource,
+				"/home/src/workspaces/project/c.ts":          badSource,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			sys := newTestSys(&tscInput{
+				commandLineArgs: tc.args,
+				files:           tc.files,
+			}, false)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel() // simulate SIGINT delivered before/at the start of the compile
+
+			result := execute.CommandLine(ctx, sys, tc.args, sys)
+
+			// The compile should short-circuit with a distinct canceled status
+			// instead of running the checker to completion (and it must not panic
+			// reusing a canceled checker).
+			if result.Status != tsc.ExitStatusCanceled {
+				t.Errorf("status = %v, want ExitStatusCanceled (compile should abort on cancellation)", result.Status)
+			}
+
+			// Because the check was abandoned, its (incomplete) diagnostics must not
+			// be reported: the type errors should be absent from the output.
+			if out := sys.getOutput(true); strings.Contains(out, "error TS") {
+				t.Errorf("expected no diagnostics to be reported after cancellation; got output:\n%s", out)
+			}
+		})
+	}
+}

--- a/internal/execute/tsctests/watcher_race_test.go
+++ b/internal/execute/tsctests/watcher_race_test.go
@@ -284,8 +284,11 @@ func TestBuildWatchStopsWhenContextIsCancelled(t *testing.T) {
 
 	select {
 	case result := <-resultCh:
+		// Cancellation is honored during the initial build: it aborts promptly without
+		// establishing a watcher. But cancellation is the expected way to end a watch,
+		// so it still reports success -- Ctrl-C is not a build failure.
 		assert.Equal(t, result.Status, tsc.ExitStatusSuccess)
-		assert.Assert(t, result.Watcher != nil)
+		assert.Assert(t, result.Watcher == nil)
 	case <-time.After(2 * time.Second):
 		t.Fatal("build watch did not stop after context cancellation")
 	}

--- a/internal/execute/watcher.go
+++ b/internal/execute/watcher.go
@@ -368,15 +368,12 @@ func (w *Watcher) evictChangedSourceFiles(changedPaths map[string]fswatch.EventK
 }
 
 func (w *Watcher) compileAndEmit() tsc.CompileAndEmitResult {
-	// Watch-cycle cancellation is currently handled only at the RunLoop level (see
-	// WatchManager.RunLoop), which checks ctx.Done() between cycles; a compile already
-	// in flight runs to completion.
+	// Watch cancellation is only observed between cycles (WatchManager.RunLoop); a
+	// compile in flight runs to completion.
 	//
-	// TODO: thread the RunLoop context through DoCycle -> doBuild -> compileAndEmit and
-	// pass it here instead of context.Background(), so a long rebuild becomes
-	// interruptible at the checker's granularity. Doing so also requires handling an
-	// ExitStatusCanceled result (discard the partial cycle, keep the prior program)
-	// rather than reporting incomplete diagnostics.
+	// TODO: thread the RunLoop context through DoCycle -> doBuild -> compileAndEmit so
+	// a long rebuild is interruptible mid-cycle. That also means handling an
+	// ExitStatusCanceled result (discard the partial cycle, keep the prior program).
 	return tsc.EmitFilesAndReportErrors(context.Background(), tsc.EmitInput{
 		Sys:                w.sys,
 		ProgramLike:        w.program,

--- a/internal/execute/watcher.go
+++ b/internal/execute/watcher.go
@@ -368,8 +368,15 @@ func (w *Watcher) evictChangedSourceFiles(changedPaths map[string]fswatch.EventK
 }
 
 func (w *Watcher) compileAndEmit() tsc.CompileAndEmitResult {
-	// Watch-cycle cancellation is handled at the RunLoop level (see WatchManager.RunLoop),
-	// so the per-cycle compile runs to completion.
+	// Watch-cycle cancellation is currently handled only at the RunLoop level (see
+	// WatchManager.RunLoop), which checks ctx.Done() between cycles; a compile already
+	// in flight runs to completion.
+	//
+	// TODO: thread the RunLoop context through DoCycle -> doBuild -> compileAndEmit and
+	// pass it here instead of context.Background(), so a long rebuild becomes
+	// interruptible at the checker's granularity. Doing so also requires handling an
+	// ExitStatusCanceled result (discard the partial cycle, keep the prior program)
+	// rather than reporting incomplete diagnostics.
 	return tsc.EmitFilesAndReportErrors(context.Background(), tsc.EmitInput{
 		Sys:                w.sys,
 		ProgramLike:        w.program,

--- a/internal/execute/watcher.go
+++ b/internal/execute/watcher.go
@@ -368,7 +368,7 @@ func (w *Watcher) evictChangedSourceFiles(changedPaths map[string]fswatch.EventK
 }
 
 func (w *Watcher) compileAndEmit() tsc.CompileAndEmitResult {
-	// TODO: propagate a proper context here to better support cancelation
+	// TODO: propagate a proper context here to better support cancellation
 	return tsc.EmitFilesAndReportErrors(context.Background(), tsc.EmitInput{
 		Sys:                w.sys,
 		ProgramLike:        w.program,

--- a/internal/execute/watcher.go
+++ b/internal/execute/watcher.go
@@ -368,12 +368,7 @@ func (w *Watcher) evictChangedSourceFiles(changedPaths map[string]fswatch.EventK
 }
 
 func (w *Watcher) compileAndEmit() tsc.CompileAndEmitResult {
-	// Watch cancellation is only observed between cycles (WatchManager.RunLoop); a
-	// compile in flight runs to completion.
-	//
-	// TODO: thread the RunLoop context through DoCycle -> doBuild -> compileAndEmit so
-	// a long rebuild is interruptible mid-cycle. That also means handling an
-	// ExitStatusCanceled result (discard the partial cycle, keep the prior program).
+	// TODO: propagate a proper context here to better support cancelation
 	return tsc.EmitFilesAndReportErrors(context.Background(), tsc.EmitInput{
 		Sys:                w.sys,
 		ProgramLike:        w.program,

--- a/internal/execute/watcher.go
+++ b/internal/execute/watcher.go
@@ -368,7 +368,9 @@ func (w *Watcher) evictChangedSourceFiles(changedPaths map[string]fswatch.EventK
 }
 
 func (w *Watcher) compileAndEmit() tsc.CompileAndEmitResult {
-	return tsc.EmitFilesAndReportErrors(tsc.EmitInput{
+	// Watch-cycle cancellation is handled at the RunLoop level (see WatchManager.RunLoop),
+	// so the per-cycle compile runs to completion.
+	return tsc.EmitFilesAndReportErrors(context.Background(), tsc.EmitInput{
 		Sys:                w.sys,
 		ProgramLike:        w.program,
 		Program:            w.program.GetProgram(),


### PR DESCRIPTION
Improve responsiveness of `tsc` and `tsc build` to signal based interruption.

# Overview
When integrating typescript 7 into next.js we observed that `tsc`, launched as a subprocess, wouldn't exit on `SIGTERM`/`SIGINT` until the build finished. The CLI wired the signal to a context, but the compile and build paths never threaded it to the checker, so its cooperative cancellation never took effect.

This PR:

1. **Improved context threading.** The context now flows through the compile and `tsc -b` paths (`performCompilation`/`performIncrementalCompilation` → `EmitFilesAndReportErrors` → the build orchestrator), so the checker's existing cancellation polling takes effect.
2. **Node-compatible exit codes.** On interruption the process now re-raises the signal and exits with the conventional code (130 for `SIGINT`, 143 for `SIGTERM`), matching the JS `tsc`. (Watch mode instead reports success — `Ctrl-C` is the normal way to stop a watch.)
3. **Early returns for responsiveness and consistency.** Cancellation is checked at each stage of a compile so an aborted run stops promptly and never reports partial diagnostics, or reuses a canceled checker, as a complete result.
4. **Comprehensive tests.** Cancellation is exercised before the compile, mid-check, and swept across every point through emit, asserting the run always aborts cleanly and never panics or reports a partial result as success.

This PR was authored by a mix of me and Claude Opus.

# Known follow-up

Watch-mode rebuild cycles still run on `context.Background()`, so a long rebuild is only interruptible between cycles, not mid-cycle (marked with a TODO).

# Alternatives

Just don't install the signal handlers, or only install them in `watch` mode where they can interrupt the watch loop?

Fixes #4620