### PR TITLE
Fix "Token end is child end" crash when range formatting is inside a JSDoc comment

### DIFF
--- a/internal/format/span.go
+++ b/internal/format/span.go
@@ -55,7 +55,8 @@ func getScanStartPosition(enclosingNode *ast.Node, originalRange core.TextRange,
 		return start
 	}
 
-	precedingToken := astnav.FindPrecedingToken(sourceFile, originalRange.Pos())
+	// exclude JSDoc so the scan never starts inside a JSDoc comment
+	precedingToken := astnav.FindPrecedingTokenEx(sourceFile, originalRange.Pos(), nil /*startNode*/, true /*excludeJSDoc*/)
 	if precedingToken == nil {
 		// no preceding token found - start from the beginning of enclosing node
 		return enclosingNode.Pos()

--- a/internal/fourslash/tests/rangeFormatInsideJSDocComment_test.go
+++ b/internal/fourslash/tests/rangeFormatInsideJSDocComment_test.go
@@ -1,0 +1,23 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestRangeFormatStartingInsideJSDocComment(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	content := "// @Filename: /a.ts\n" +
+		"/**\n" +
+		" * @a\n" +
+		" * `\n" +
+		"/*s*/ * @b\n" +
+		" */\n" +
+		"export function f() {}/*e*/"
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.FormatSelection(t, "s", "e")
+}


### PR DESCRIPTION
Fixes an issue uncovered in https://github.com/microsoft/typescript-go/issues/4459#issuecomment-4814129988 and https://github.com/microsoft/typescript-go/issues/4532#issuecomment-4879803554; `getScanStartPosition()` calls `astnav.FindPrecedingToken(originalRange.Pos())` to get the starting position for the scanner. However, if `Pos()` is inside of a JSDoc, the scanner never sees the `/**` opener, and mis-scans the backtick as an undetermined template literal running to the end of the file, which produces a token whose end doesn't match the child's end and triggers the crash.