### PR TITLE
fix(checker): avoid computed enum member stack overflow

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -23787,7 +23787,7 @@ func (c *Checker) getDeclaredTypeOfEnum(symbol *ast.Symbol) *Type {
 		for _, declaration := range symbol.Declarations {
 			if declaration.Kind == ast.KindEnumDeclaration {
 				for _, member := range declaration.Members() {
-					if c.hasBindableName(member) {
+					if !ast.HasDynamicName(member) {
 						memberSymbol := c.getSymbolOfDeclaration(member)
 						value := c.getEnumMemberValue(member).Value
 						var memberType *Type

--- a/testdata/baselines/reference/compiler/computedEnumMemberKeyNoCrash1.errors.txt
+++ b/testdata/baselines/reference/compiler/computedEnumMemberKeyNoCrash1.errors.txt
@@ -1,0 +1,15 @@
+computedEnumMemberKeyNoCrash1.ts(4,5): error TS1164: Computed property names are not allowed in enums.
+
+
+==== computedEnumMemberKeyNoCrash1.ts (1 errors) ====
+    // https://github.com/microsoft/TypeScript/issues/63173
+    
+    declare const enum E {
+        [foo] = 1,
+        ~~~~~
+!!! error TS1164: Computed property names are not allowed in enums.
+        A,
+        foo = 10,
+    }
+    E.A.toString();
+    

--- a/testdata/baselines/reference/compiler/computedEnumMemberKeyNoCrash1.symbols
+++ b/testdata/baselines/reference/compiler/computedEnumMemberKeyNoCrash1.symbols
@@ -1,0 +1,25 @@
+//// [tests/cases/compiler/computedEnumMemberKeyNoCrash1.ts] ////
+
+=== computedEnumMemberKeyNoCrash1.ts ===
+// https://github.com/microsoft/TypeScript/issues/63173
+
+declare const enum E {
+>E : Symbol(E, Decl(computedEnumMemberKeyNoCrash1.ts, 0, 0))
+
+    [foo] = 1,
+>[foo] : Symbol(E[foo], Decl(computedEnumMemberKeyNoCrash1.ts, 2, 22))
+>foo : Symbol(E.foo, Decl(computedEnumMemberKeyNoCrash1.ts, 4, 6))
+
+    A,
+>A : Symbol(E.A, Decl(computedEnumMemberKeyNoCrash1.ts, 3, 14))
+
+    foo = 10,
+>foo : Symbol(E.foo, Decl(computedEnumMemberKeyNoCrash1.ts, 4, 6))
+}
+E.A.toString();
+>E.A.toString : Symbol(Number.toString, Decl(lib.es5.d.ts, --, --))
+>E.A : Symbol(E.A, Decl(computedEnumMemberKeyNoCrash1.ts, 3, 14))
+>E : Symbol(E, Decl(computedEnumMemberKeyNoCrash1.ts, 0, 0))
+>A : Symbol(E.A, Decl(computedEnumMemberKeyNoCrash1.ts, 3, 14))
+>toString : Symbol(Number.toString, Decl(lib.es5.d.ts, --, --))
+

--- a/testdata/baselines/reference/compiler/computedEnumMemberKeyNoCrash1.types
+++ b/testdata/baselines/reference/compiler/computedEnumMemberKeyNoCrash1.types
@@ -1,0 +1,28 @@
+//// [tests/cases/compiler/computedEnumMemberKeyNoCrash1.ts] ////
+
+=== computedEnumMemberKeyNoCrash1.ts ===
+// https://github.com/microsoft/TypeScript/issues/63173
+
+declare const enum E {
+>E : E
+
+    [foo] = 1,
+>[foo] : E
+>foo : E.foo
+>1 : 1
+
+    A,
+>A : E.A
+
+    foo = 10,
+>foo : E.foo
+>10 : 10
+}
+E.A.toString();
+>E.A.toString() : string
+>E.A.toString : (radix?: number) => string
+>E.A : E.A
+>E : typeof E
+>A : E.A
+>toString : (radix?: number) => string
+

--- a/testdata/tests/cases/compiler/computedEnumMemberKeyNoCrash1.ts
+++ b/testdata/tests/cases/compiler/computedEnumMemberKeyNoCrash1.ts
@@ -1,0 +1,11 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/63173
+
+declare const enum E {
+    [foo] = 1,
+    A,
+    foo = 10,
+}
+E.A.toString();


### PR DESCRIPTION
## Summary

- skip dynamic enum member names while constructing an enum's declared type
- preserve the existing TS1164 diagnostic for invalid computed enum names
- add compiler regression coverage and generated type, symbol, and error baselines

## Root cause

`getDeclaredTypeOfEnum` called `hasBindableName` for a dynamic computed member name. Determining whether that name was late-bindable checked the computed expression, which resolved an enum member type and re-entered `getDeclaredTypeOfEnum` for the same enum until the goroutine stack overflowed.

Enums do not permit dynamic computed member names, so excluding them from declared-type construction breaks the cycle without changing valid enum behavior. This ports the approach and regression coverage from microsoft/TypeScript#63182 to the Go implementation.

## Validation

- `go test ./internal/testrunner -run 'TestLocal/computedEnumMemberKeyNoCrash1' -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- verified the original repro now reports TS1164 instead of a fatal stack overflow

## AI assistance

AI assistance was used to investigate and implement this change. The resulting diff and validation output were reviewed before submission.

Fixes microsoft/TypeScript#63173
