### PR TITLE
Fix continueOnError casing in pipeline YAML and The indentation

### DIFF
--- a/_build/azure-pipelines.compliance.yml
+++ b/_build/azure-pipelines.compliance.yml
@@ -45,5 +45,6 @@ extends:
                 retryCountOnTaskFailure: 3
 
               - task: ComponentGovernanceComponentDetection@0
+                displayName: Run Component Governance Detection
                 condition: succeededOrFailed()
-                continueOnError: True
+                continueOnError: true


### PR DESCRIPTION
## Summary

Updated the Component Governance task display name and YAML formatting.

## Changes

- Improved task display name.
- Changed `continueOnError` to `true`.

## Testing

No functional changes. YAML formatting only.


AI assistance was used for wording and YAML formatting review.