### PR TITLE
VS enhanced hover: symbol icon + colorized text

### DIFF
--- a/internal/fourslash/baselineutil.go
+++ b/internal/fourslash/baselineutil.go
@@ -34,6 +34,7 @@ const (
 	inlayHintsCmd               baselineCommand = "Inlay Hints"
 	nonSuggestionDiagnosticsCmd baselineCommand = "Syntax and Semantic Diagnostics"
 	quickInfoCmd                baselineCommand = "QuickInfo"
+	vsQuickInfoCmd              baselineCommand = "VSQuickInfo"
 	linkedEditingCmd            baselineCommand = "linkedEditing"
 	renameCmd                   baselineCommand = "findRenameLocations"
 	signatureHelpCmd            baselineCommand = "SignatureHelp"
@@ -79,7 +80,7 @@ func getBaselineFileName(t *testing.T, command baselineCommand) string {
 
 func getBaselineExtension(command baselineCommand) string {
 	switch command {
-	case quickInfoCmd, signatureHelpCmd, smartSelectionCmd, inlayHintsCmd, nonSuggestionDiagnosticsCmd, documentSymbolsCmd, closingTagCmd, vsFindAllReferencesCmd:
+	case quickInfoCmd, vsQuickInfoCmd, signatureHelpCmd, smartSelectionCmd, inlayHintsCmd, nonSuggestionDiagnosticsCmd, documentSymbolsCmd, closingTagCmd, vsFindAllReferencesCmd:
 		return "baseline"
 	case callHierarchyCmd:
 		return "callHierarchy.txt"

--- a/internal/fourslash/fourslash.go
+++ b/internal/fourslash/fourslash.go
@@ -2857,6 +2857,75 @@ func (f *FourslashTest) VerifyBaselineHover(t *testing.T) {
 	}
 }
 
+// VerifyBaselineVSHover is like VerifyBaselineHover, but asserts on the VS-specific rich hover
+// content (Hover.VSRawContent / the "_vs_rawContent" wire field) that the LSP server emits for
+// clients advertising the VSSupportsVisualStudioExtensions capability.
+func (f *FourslashTest) VerifyBaselineVSHover(t *testing.T) {
+	markersAndItems := core.MapFiltered(f.Markers(), func(marker *Marker) (markerAndItem[*lsproto.Hover], bool) {
+		if marker.Name == nil {
+			return markerAndItem[*lsproto.Hover]{}, false
+		}
+
+		params := &lsproto.HoverParams{
+			TextDocument: lsproto.TextDocumentIdentifier{
+				Uri: lsconv.FileNameToDocumentURI(marker.fileName),
+			},
+			Position: marker.LSPosition,
+		}
+
+		result := sendRequest(t, f, lsproto.TextDocumentHoverInfo, params)
+		return markerAndItem[*lsproto.Hover]{Marker: marker, Item: result.Hover}, true
+	})
+
+	getRange := func(item *lsproto.Hover) *lsproto.Range {
+		if item == nil || item.Range == nil {
+			return nil
+		}
+		return item.Range
+	}
+
+	getTooltipLines := func(item, _prev *lsproto.Hover) []string {
+		if item == nil {
+			return nil
+		}
+		if item.VSRawContent == nil {
+			return []string{"(no _vs_rawContent; is VSSupportsVisualStudioExtensions set on the test's ClientCapabilities?)"}
+		}
+		return renderVSContainerElement(item.VSRawContent, "")
+	}
+
+	f.addResultToBaseline(t, vsQuickInfoCmd, annotateContentWithTooltips(t, f, markersAndItems, "vsquickinfo", getRange, getTooltipLines))
+	if jsonStr, err := core.StringifyJson(markersAndItems, "", "  "); err == nil {
+		f.writeToBaseline(vsQuickInfoCmd, jsonStr)
+	} else {
+		t.Fatalf("Failed to stringify markers and items for baseline: %v", err)
+	}
+}
+
+// renderVSContainerElement renders a VS rich-content container element (icon + colorized runs,
+// possibly nested for the stacked display-line/documentation shape) into readable baseline lines.
+func renderVSContainerElement(el *lsproto.VSContainerElement, indent string) []string {
+	lines := []string{fmt.Sprintf("%sContainerElement (Style=%s)", indent, el.Style)}
+	childIndent := indent + "  "
+	for _, child := range el.Elements {
+		switch {
+		case child.ImageElement != nil:
+			imageId := child.ImageElement.ImageId
+			lines = append(lines, fmt.Sprintf("%sImageElement { Guid: %s, Id: 0x%X }", childIndent, imageId.Guid, imageId.Id))
+		case child.ClassifiedTextElement != nil:
+			lines = append(lines, fmt.Sprintf("%sClassifiedTextElement", childIndent))
+			for _, run := range child.ClassifiedTextElement.Runs {
+				lines = append(lines, fmt.Sprintf("%s  [%s] %q", childIndent, run.ClassificationTypeName, run.Text))
+			}
+		case child.ContainerElement != nil:
+			lines = append(lines, renderVSContainerElement(child.ContainerElement, childIndent)...)
+		default:
+			lines = append(lines, fmt.Sprintf("%s<empty union element>", childIndent))
+		}
+	}
+	return lines
+}
+
 func appendLinesForMarkedStringWithLanguage(result []string, ms *lsproto.MarkedStringWithLanguage) []string {
 	result = append(result, "```"+ms.Language)
 	result = append(result, ms.Value)

--- a/internal/fourslash/fourslash.go
+++ b/internal/fourslash/fourslash.go
@@ -2913,14 +2913,14 @@ func renderVSContainerElement(el *lsproto.VSContainerElement, indent string) []s
 			imageId := child.ImageElement.ImageId
 			lines = append(lines, fmt.Sprintf("%sImageElement { Guid: %s, Id: 0x%X }", childIndent, imageId.Guid, imageId.Id))
 		case child.ClassifiedTextElement != nil:
-			lines = append(lines, fmt.Sprintf("%sClassifiedTextElement", childIndent))
+			lines = append(lines, childIndent+"ClassifiedTextElement")
 			for _, run := range child.ClassifiedTextElement.Runs {
 				lines = append(lines, fmt.Sprintf("%s  [%s] %q", childIndent, run.ClassificationTypeName, run.Text))
 			}
 		case child.ContainerElement != nil:
 			lines = append(lines, renderVSContainerElement(child.ContainerElement, childIndent)...)
 		default:
-			lines = append(lines, fmt.Sprintf("%s<empty union element>", childIndent))
+			lines = append(lines, childIndent+"<empty union element>")
 		}
 	}
 	return lines

--- a/internal/fourslash/tests/quickInfoAliasVS_test.go
+++ b/internal/fourslash/tests/quickInfoAliasVS_test.go
@@ -1,0 +1,39 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestQuickInfoAliasVS(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `// @Filename: /a.ts
+/**
+ * Doc
+ * @tag Tag text
+ */
+export const x = 0;
+// @Filename: /b.ts
+import { x } from "./a";
+x/*b*/;
+// @Filename: /c.ts
+/**
+ * Doc 2
+ * @tag Tag text 2
+ */
+import {
+    /**
+     * Doc 3
+     * @tag Tag text 3
+     */
+    x
+} from "./a";
+x/*c*/;`
+	f, done := fourslash.NewFourslash(t, &lsproto.ClientCapabilities{VSSupportsVisualStudioExtensions: new(true)}, content)
+	defer done()
+	f.VerifyBaselineVSHover(t)
+}

--- a/internal/fourslash/tests/quickInfoCommentsFunctionDeclarationVS_test.go
+++ b/internal/fourslash/tests/quickInfoCommentsFunctionDeclarationVS_test.go
@@ -1,0 +1,34 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestQuickInfoCommentsFunctionDeclarationVS(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `/** This comment should appear for foo*/
+function f/*1*/oo() {
+}
+f/*2*/oo();
+/** This is comment for function signature*/
+function fo/*5*/oWithParameters(/** this is comment about a*/a: string,
+    /** this is comment for b*/
+    b: number) {
+    var /*6*/d = a;
+}
+fooWithParam/*8*/eters("a",10);
+/**
+* Does something
+* @param a a string
+*/
+declare function fn(a: string);
+fn("hello");`
+	f, done := fourslash.NewFourslash(t, &lsproto.ClientCapabilities{VSSupportsVisualStudioExtensions: new(true)}, content)
+	defer done()
+	f.VerifyBaselineVSHover(t)
+}

--- a/internal/fourslash/tests/quickInfoDisplayPartsClassMethodVS_test.go
+++ b/internal/fourslash/tests/quickInfoDisplayPartsClassMethodVS_test.go
@@ -1,0 +1,36 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestQuickInfoDisplayPartsClassMethodVS(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `class c {
+    public /*1*/publicMethod() { }
+    private /*2*/privateMethod() { }
+    protected /*21*/protectedMethod() { }
+    static /*3*/staticMethod() { }
+    private static /*4*/privateStaticMethod() { }
+    protected static /*41*/protectedStaticMethod() { }
+    method() {
+        this./*5*/publicMethod();
+        this./*6*/privateMethod();
+        this./*61*/protectedMethod();
+        c./*7*/staticMethod();
+        c./*8*/privateStaticMethod();
+        c./*81*/protectedStaticMethod();
+    }
+}
+var cInstance = new c();
+/*9*/cInstance./*10*/publicMethod();
+/*11*/c./*12*/staticMethod();`
+	f, done := fourslash.NewFourslash(t, &lsproto.ClientCapabilities{VSSupportsVisualStudioExtensions: new(true)}, content)
+	defer done()
+	f.VerifyBaselineVSHover(t)
+}

--- a/internal/fourslash/tests/quickInfoDisplayPartsClassPropertyVS_test.go
+++ b/internal/fourslash/tests/quickInfoDisplayPartsClassPropertyVS_test.go
@@ -1,0 +1,36 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestQuickInfoDisplayPartsClassPropertyVS(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `class c {
+    public /*1*/publicProperty: string;
+    private /*2*/privateProperty: string;
+    protected /*21*/protectedProperty: string;
+    static /*3*/staticProperty: string;
+    private static /*4*/privateStaticProperty: string;
+    protected static /*41*/protectedStaticProperty: string;
+    method() {
+        this./*5*/publicProperty;
+        this./*6*/privateProperty;
+        this./*61*/protectedProperty;
+        c./*7*/staticProperty;
+        c./*8*/privateStaticProperty;
+        c./*81*/protectedStaticProperty;
+    }
+}
+var cInstance = new c();
+/*9*/cInstance./*10*/publicProperty;
+/*11*/c./*12*/staticProperty;`
+	f, done := fourslash.NewFourslash(t, &lsproto.ClientCapabilities{VSSupportsVisualStudioExtensions: new(true)}, content)
+	defer done()
+	f.VerifyBaselineVSHover(t)
+}

--- a/internal/fourslash/tests/quickInfoDisplayPartsFunctionVS_test.go
+++ b/internal/fourslash/tests/quickInfoDisplayPartsFunctionVS_test.go
@@ -1,0 +1,36 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestQuickInfoDisplayPartsFunctionVS(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `function /*1*/foo(param: string, optionalParam?: string, paramWithInitializer = "hello", ...restParam: string[]) {
+}
+function /*2*/foowithoverload(a: string): string;
+function /*3*/foowithoverload(a: number): number;
+function /*4*/foowithoverload(a: any): any {
+    return a;
+}
+function /*5*/foowith3overload(a: string): string;
+function /*6*/foowith3overload(a: number): number;
+function /*7*/foowith3overload(a: boolean): boolean;
+function /*8*/foowith3overload(a: any): any {
+    return a;
+}
+/*9*/foo("hello");
+/*10*/foowithoverload("hello");
+/*11*/foowithoverload(10);
+/*12*/foowith3overload("hello");
+/*13*/foowith3overload(10);
+/*14*/foowith3overload(true);`
+	f, done := fourslash.NewFourslash(t, &lsproto.ClientCapabilities{VSSupportsVisualStudioExtensions: new(true)}, content)
+	defer done()
+	f.VerifyBaselineVSHover(t)
+}

--- a/internal/ls/completions.go
+++ b/internal/ls/completions.go
@@ -5125,7 +5125,7 @@ func (l *LanguageService) createCompletionDetailsForSymbol(
 	position int,
 	docFormat lsproto.MarkupKind,
 ) *lsproto.CompletionItem {
-	quickInfo, documentation, _ := l.getQuickInfoAndDocumentationForSymbol(checker, symbol, location, docFormat, nil, false /*vsCapability*/)
+	quickInfo, documentation, _, _ := l.getQuickInfoAndDocumentationForSymbol(checker, symbol, location, docFormat, nil, false /*vsCapability*/)
 	return createCompletionDetails(item, quickInfo, documentation, docFormat)
 }
 

--- a/internal/ls/completions.go
+++ b/internal/ls/completions.go
@@ -5125,7 +5125,7 @@ func (l *LanguageService) createCompletionDetailsForSymbol(
 	position int,
 	docFormat lsproto.MarkupKind,
 ) *lsproto.CompletionItem {
-	quickInfo, documentation := l.getQuickInfoAndDocumentationForSymbol(checker, symbol, location, docFormat, nil)
+	quickInfo, documentation, _ := l.getQuickInfoAndDocumentationForSymbol(checker, symbol, location, docFormat, nil, false /*vsCapability*/)
 	return createCompletionDetails(item, quickInfo, documentation, docFormat)
 }
 

--- a/internal/ls/hover.go
+++ b/internal/ls/hover.go
@@ -11,6 +11,7 @@ import (
 	"github.com/microsoft/typescript-go/internal/checker"
 	"github.com/microsoft/typescript-go/internal/collections"
 	"github.com/microsoft/typescript-go/internal/core"
+	"github.com/microsoft/typescript-go/internal/ls/lsutil"
 	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
 	"github.com/microsoft/typescript-go/internal/nodebuilder"
 	"github.com/microsoft/typescript-go/internal/printer"
@@ -55,7 +56,8 @@ func (l *LanguageService) ProvideHover(ctx context.Context, params *lsproto.Hove
 		MaxTruncationLength: maxTruncLen,
 	}
 
-	quickInfo, documentation := l.getQuickInfoAndDocumentationForSymbol(c, symbol, rangeNode, contentFormat, vc)
+	vsCapability := caps.VSSupportsVisualStudioExtensions
+	quickInfo, documentation, quickInfoRuns := l.getQuickInfoAndDocumentationForSymbol(c, symbol, rangeNode, contentFormat, vc, vsCapability)
 	if quickInfo == "" {
 		return lsproto.HoverOrNull{}, nil
 	}
@@ -82,27 +84,55 @@ func (l *LanguageService) ProvideHover(ctx context.Context, params *lsproto.Hove
 		hover.CanIncreaseVerbosity = vc.CanIncreaseVerbosity && !vc.Truncated
 	}
 
+	// Clients that support Visual Studio extensions (e.g. VS itself, when Corsa/Native TS Preview is
+	// enabled) render `_vs_rawContent` in place of `contents`. Without it, VS shows plain markdown
+	// with no symbol icon and no syntax coloring, unlike the legacy TSServer-backed hover path.
+	if vsCapability && len(quickInfoRuns) > 0 {
+		kind := lsutil.ScriptElementKindKeyword
+		var modifiers lsutil.ScriptElementKindModifier
+		if symbol != nil {
+			// Resolve aliases to their target before computing the icon kind, so e.g. `import { x }`
+			// shows the icon for whatever `x` actually is (const, function, ...) rather than a
+			// generic alias icon. GetSymbolModifiers already accounts for the alias target itself.
+			iconSymbol := symbol
+			if symbol.Flags&ast.SymbolFlagsAlias != 0 {
+				if resolved := c.GetAliasedSymbol(symbol); resolved != nil && resolved != symbol {
+					iconSymbol = resolved
+				}
+			}
+			kind = lsutil.GetSymbolKind(c, iconSymbol, rangeNode)
+			modifiers = lsutil.GetSymbolModifiers(c, symbol)
+		}
+		imageId := getVSHoverImageId(kind, modifiers)
+		var documentationRuns []*lsproto.VSClassifiedTextRun
+		if documentation != "" {
+			documentationRuns = []*lsproto.VSClassifiedTextRun{{ClassificationTypeName: string(lsproto.ClassificationTypeNameText), Text: documentation}}
+		}
+		hover.VSRawContent = buildVSHoverRawContent(imageId, quickInfoRuns, documentationRuns)
+	}
+
 	return lsproto.HoverOrNull{Hover: hover}, nil
 }
 
-func (l *LanguageService) getQuickInfoAndDocumentationForSymbol(c *checker.Checker, symbol *ast.Symbol, node *ast.Node, contentFormat lsproto.MarkupKind, vc *checker.VerbosityContext) (string, string) {
-	info := getQuickInfoAndDeclarationAtLocation(c, symbol, node, vc, false /*vsCapability*/, getMeaningFromLocation(node))
+func (l *LanguageService) getQuickInfoAndDocumentationForSymbol(c *checker.Checker, symbol *ast.Symbol, node *ast.Node, contentFormat lsproto.MarkupKind, vc *checker.VerbosityContext, vsCapability bool) (string, string, []*lsproto.VSClassifiedTextRun) {
+	info := getQuickInfoAndDeclarationAtLocation(c, symbol, node, vc, vsCapability, getMeaningFromLocation(node))
 	quickInfo := info.displayParts.String()
 	if quickInfo == "" {
-		return "", ""
+		return "", "", nil
 	}
+	quickInfoRuns := info.displayParts.GetRuns()
 
 	documentation := l.documentationFromSignature(c, symbol, getCallOrNewExpression(node), node, contentFormat, false /*commentOnly*/)
 	if documentation != "" {
-		return quickInfo, documentation
+		return quickInfo, documentation, quickInfoRuns
 	}
 
 	documentation = l.getDocumentationFromDeclaration(c, symbol, info.declaration, node, contentFormat, false /*commentOnly*/)
 	if documentation != "" {
-		return quickInfo, documentation
+		return quickInfo, documentation, quickInfoRuns
 	}
 
-	return quickInfo, l.documentationFromAlias(c, symbol, node, contentFormat)
+	return quickInfo, l.documentationFromAlias(c, symbol, node, contentFormat), quickInfoRuns
 }
 
 func (l *LanguageService) documentationFromSignature(c *checker.Checker, symbol *ast.Symbol, node *ast.Node, location *ast.Node, contentFormat lsproto.MarkupKind, commentOnly bool) string {

--- a/internal/ls/hover.go
+++ b/internal/ls/hover.go
@@ -57,7 +57,7 @@ func (l *LanguageService) ProvideHover(ctx context.Context, params *lsproto.Hove
 	}
 
 	vsCapability := caps.VSSupportsVisualStudioExtensions
-	quickInfo, documentation, quickInfoRuns := l.getQuickInfoAndDocumentationForSymbol(c, symbol, rangeNode, contentFormat, vc, vsCapability)
+	quickInfo, documentation, vsDocumentation, quickInfoRuns := l.getQuickInfoAndDocumentationForSymbol(c, symbol, rangeNode, contentFormat, vc, vsCapability)
 	if quickInfo == "" {
 		return lsproto.HoverOrNull{}, nil
 	}
@@ -105,8 +105,8 @@ func (l *LanguageService) ProvideHover(ctx context.Context, params *lsproto.Hove
 		}
 		imageId := getVSHoverImageId(kind, modifiers)
 		var documentationRuns []*lsproto.VSClassifiedTextRun
-		if documentation != "" {
-			documentationRuns = []*lsproto.VSClassifiedTextRun{{ClassificationTypeName: string(lsproto.ClassificationTypeNameText), Text: documentation}}
+		if docText := strings.TrimLeft(vsDocumentation, "\n"); docText != "" {
+			documentationRuns = []*lsproto.VSClassifiedTextRun{{ClassificationTypeName: string(lsproto.ClassificationTypeNameText), Text: docText}}
 		}
 		hover.VSRawContent = buildVSHoverRawContent(imageId, quickInfoRuns, documentationRuns)
 	}
@@ -114,25 +114,47 @@ func (l *LanguageService) ProvideHover(ctx context.Context, params *lsproto.Hove
 	return lsproto.HoverOrNull{Hover: hover}, nil
 }
 
-func (l *LanguageService) getQuickInfoAndDocumentationForSymbol(c *checker.Checker, symbol *ast.Symbol, node *ast.Node, contentFormat lsproto.MarkupKind, vc *checker.VerbosityContext, vsCapability bool) (string, string, []*lsproto.VSClassifiedTextRun) {
+func (l *LanguageService) getQuickInfoAndDocumentationForSymbol(c *checker.Checker, symbol *ast.Symbol, node *ast.Node, contentFormat lsproto.MarkupKind, vc *checker.VerbosityContext, vsCapability bool) (string, string, string, []*lsproto.VSClassifiedTextRun) {
 	info := getQuickInfoAndDeclarationAtLocation(c, symbol, node, vc, vsCapability, getMeaningFromLocation(node))
 	quickInfo := info.displayParts.String()
 	if quickInfo == "" {
-		return "", "", nil
+		return "", "", "", nil
 	}
 	quickInfoRuns := info.displayParts.GetRuns()
 
-	documentation := l.documentationFromSignature(c, symbol, getCallOrNewExpression(node), node, contentFormat, false /*commentOnly*/)
-	if documentation != "" {
-		return quickInfo, documentation, quickInfoRuns
+	documentation := l.getDocumentationForSymbol(c, symbol, node, info.declaration, contentFormat, false /*commentOnly*/)
+
+	// VS's rich hover (_vs_rawContent) renders documentation as plain colorized text with no Markdown
+	// parser, so it can't use the tag section (@param/@returns/@example/@see, etc.) that
+	// getDocumentationFromDeclaration renders with '*@tag*' bolding and ```-fenced @example blocks --
+	// those would show up as literal asterisks/backticks. This also matches the legacy TSServer-backed
+	// VS hover (TypeScript-VS's HoverService.cs), which only ever surfaced the JSDoc summary
+	// (TSServer's quickinfo `documentation`) and never included the tag section at all (TSServer
+	// exposes tags via a separate `tags` field that legacy VS hover never read). So request
+	// comment-only, plain-text documentation for the VS path instead of reusing `documentation`.
+	var vsDocumentation string
+	if vsCapability {
+		vsDocumentation = l.getDocumentationForSymbol(c, symbol, node, info.declaration, lsproto.MarkupKindPlainText, true /*commentOnly*/)
 	}
 
-	documentation = l.getDocumentationFromDeclaration(c, symbol, info.declaration, node, contentFormat, false /*commentOnly*/)
+	return quickInfo, documentation, vsDocumentation, quickInfoRuns
+}
+
+// getDocumentationForSymbol tries each documentation source in turn (call-signature documentation,
+// declaration JSDoc, alias target JSDoc) and returns the first non-empty result, formatted for
+// contentFormat. commentOnly restricts the result to the JSDoc summary, excluding the @tag section.
+func (l *LanguageService) getDocumentationForSymbol(c *checker.Checker, symbol *ast.Symbol, node *ast.Node, declaration *ast.Node, contentFormat lsproto.MarkupKind, commentOnly bool) string {
+	documentation := l.documentationFromSignature(c, symbol, getCallOrNewExpression(node), node, contentFormat, commentOnly)
 	if documentation != "" {
-		return quickInfo, documentation, quickInfoRuns
+		return documentation
 	}
 
-	return quickInfo, l.documentationFromAlias(c, symbol, node, contentFormat), quickInfoRuns
+	documentation = l.getDocumentationFromDeclaration(c, symbol, declaration, node, contentFormat, commentOnly)
+	if documentation != "" {
+		return documentation
+	}
+
+	return l.documentationFromAlias(c, symbol, node, contentFormat, commentOnly)
 }
 
 func (l *LanguageService) documentationFromSignature(c *checker.Checker, symbol *ast.Symbol, node *ast.Node, location *ast.Node, contentFormat lsproto.MarkupKind, commentOnly bool) string {
@@ -153,7 +175,7 @@ func (l *LanguageService) documentationFromSignature(c *checker.Checker, symbol 
 	return ""
 }
 
-func (l *LanguageService) documentationFromAlias(c *checker.Checker, symbol *ast.Symbol, node *ast.Node, contentFormat lsproto.MarkupKind) string {
+func (l *LanguageService) documentationFromAlias(c *checker.Checker, symbol *ast.Symbol, node *ast.Node, contentFormat lsproto.MarkupKind, commentOnly bool) string {
 	if symbol == nil || symbol.Flags&ast.SymbolFlagsAlias == 0 {
 		return ""
 	}
@@ -174,7 +196,7 @@ func (l *LanguageService) documentationFromAlias(c *checker.Checker, symbol *ast
 			continue
 		}
 
-		if documentation := l.getDocumentationFromDeclaration(c, candidate, aliasedDeclaration, node, contentFormat, false /*commentOnly*/); documentation != "" {
+		if documentation := l.getDocumentationFromDeclaration(c, candidate, aliasedDeclaration, node, contentFormat, commentOnly); documentation != "" {
 			return documentation
 		}
 	}

--- a/internal/ls/hovericon.go
+++ b/internal/ls/hovericon.go
@@ -135,7 +135,7 @@ func buildVSHoverRawContent(imageId *lsproto.VSImageId, quickInfoRuns []*lsproto
 	}
 
 	displayLine := &lsproto.VSContainerElement{
-		ElementStyle: lsproto.VSContainerElementStyleWrapped,
+		Style: lsproto.VSContainerElementStyleWrapped,
 		Elements: []lsproto.VSImageElementOrClassifiedTextElementOrContainerElement{
 			{ImageElement: &lsproto.VSImageElement{ImageId: imageId}},
 			{ClassifiedTextElement: &lsproto.VSClassifiedTextElement{Runs: quickInfoRuns}},
@@ -147,7 +147,7 @@ func buildVSHoverRawContent(imageId *lsproto.VSImageId, quickInfoRuns []*lsproto
 	}
 
 	return &lsproto.VSContainerElement{
-		ElementStyle: lsproto.VSContainerElementStyleStacked,
+		Style: lsproto.VSContainerElementStyleStacked,
 		Elements: []lsproto.VSImageElementOrClassifiedTextElementOrContainerElement{
 			{ContainerElement: displayLine},
 			{ClassifiedTextElement: &lsproto.VSClassifiedTextElement{Runs: documentationRuns}},

--- a/internal/ls/hovericon.go
+++ b/internal/ls/hovericon.go
@@ -14,35 +14,35 @@ const vsImageCatalogGuid = "ae27a6b0-e345-4288-96df-5eaf394ee369"
 // consumed by TypeScript-VS's ImageIdMapping.cs for hover tooltips. Corsa (this LSP server) has no
 // TSServer/Roslyn dependency to reuse that mapping from, so the values are duplicated here.
 const (
-	imageIdWarning         int32 = 0x00000637
-	imageIdKeyword         int32 = 0x00000635
-	imageIdModulePrivate   int32 = 0x0000077D
-	imageIdModuleProtected int32 = 0x0000077E
-	imageIdModulePublic    int32 = 0x0000077F
-	imageIdType            int32 = 0x00000CA1
-	imageIdNamespace       int32 = 0x0000079F
-	imageIdClassPrivate    int32 = 0x000001D7
-	imageIdClassProtected  int32 = 0x000001D8
-	imageIdClassPublic     int32 = 0x000001D9
+	imageIdWarning            int32 = 0x00000637
+	imageIdKeyword            int32 = 0x00000635
+	imageIdModulePrivate      int32 = 0x0000077D
+	imageIdModuleProtected    int32 = 0x0000077E
+	imageIdModulePublic       int32 = 0x0000077F
+	imageIdType               int32 = 0x00000CA1
+	imageIdNamespace          int32 = 0x0000079F
+	imageIdClassPrivate       int32 = 0x000001D7
+	imageIdClassProtected     int32 = 0x000001D8
+	imageIdClassPublic        int32 = 0x000001D9
 	imageIdInterfacePrivate   int32 = 0x00000646
 	imageIdInterfaceProtected int32 = 0x00000647
 	imageIdInterfacePublic    int32 = 0x00000648
-	imageIdEnumPrivate     int32 = 0x00000469
-	imageIdEnumProtected   int32 = 0x0000046A
-	imageIdEnumPublic      int32 = 0x0000046B
-	imageIdEnumMember      int32 = 0x00000465
-	imageIdLocalVariable   int32 = 0x000006D3
-	imageIdPropertyPrivate   int32 = 0x00000982
-	imageIdPropertyProtected int32 = 0x00000983
-	imageIdPropertyPublic    int32 = 0x00000984
-	imageIdMethodPrivate   int32 = 0x00000756
-	imageIdMethodProtected int32 = 0x00000757
-	imageIdMethodPublic    int32 = 0x00000758
-	imageIdLabel           int32 = 0x0000067D
-	imageIdAssembly        int32 = 0x000000C4
-	imageIdConstantPrivate   int32 = 0x0000026A
-	imageIdConstantProtected int32 = 0x0000026B
-	imageIdConstantPublic    int32 = 0x0000026C
+	imageIdEnumPrivate        int32 = 0x00000469
+	imageIdEnumProtected      int32 = 0x0000046A
+	imageIdEnumPublic         int32 = 0x0000046B
+	imageIdEnumMember         int32 = 0x00000465
+	imageIdLocalVariable      int32 = 0x000006D3
+	imageIdPropertyPrivate    int32 = 0x00000982
+	imageIdPropertyProtected  int32 = 0x00000983
+	imageIdPropertyPublic     int32 = 0x00000984
+	imageIdMethodPrivate      int32 = 0x00000756
+	imageIdMethodProtected    int32 = 0x00000757
+	imageIdMethodPublic       int32 = 0x00000758
+	imageIdLabel              int32 = 0x0000067D
+	imageIdAssembly           int32 = 0x000000C4
+	imageIdConstantPrivate    int32 = 0x0000026A
+	imageIdConstantProtected  int32 = 0x0000026B
+	imageIdConstantPublic     int32 = 0x0000026C
 )
 
 func newVSImageId(id int32) *lsproto.VSImageId {

--- a/internal/ls/hovericon.go
+++ b/internal/ls/hovericon.go
@@ -1,0 +1,156 @@
+package ls
+
+import (
+	"github.com/microsoft/typescript-go/internal/ls/lsutil"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
+)
+
+// vsImageCatalogGuid is the GUID of the shared VS image catalog (see
+// Microsoft.VisualStudio.Imaging.KnownImageIds), mirroring the constant duplicated in
+// TypeScript-VS's ImageIdMapping.cs (which avoids taking an assembly reference just for this GUID).
+const vsImageCatalogGuid = "ae27a6b0-e345-4288-96df-5eaf394ee369"
+
+// Known image IDs from Microsoft.VisualStudio.Imaging.KnownImageIds, restricted to the subset
+// consumed by TypeScript-VS's ImageIdMapping.cs for hover tooltips. Corsa (this LSP server) has no
+// TSServer/Roslyn dependency to reuse that mapping from, so the values are duplicated here.
+const (
+	imageIdWarning         int32 = 0x00000637
+	imageIdKeyword         int32 = 0x00000635
+	imageIdModulePrivate   int32 = 0x0000077D
+	imageIdModuleProtected int32 = 0x0000077E
+	imageIdModulePublic    int32 = 0x0000077F
+	imageIdType            int32 = 0x00000CA1
+	imageIdNamespace       int32 = 0x0000079F
+	imageIdClassPrivate    int32 = 0x000001D7
+	imageIdClassProtected  int32 = 0x000001D8
+	imageIdClassPublic     int32 = 0x000001D9
+	imageIdInterfacePrivate   int32 = 0x00000646
+	imageIdInterfaceProtected int32 = 0x00000647
+	imageIdInterfacePublic    int32 = 0x00000648
+	imageIdEnumPrivate     int32 = 0x00000469
+	imageIdEnumProtected   int32 = 0x0000046A
+	imageIdEnumPublic      int32 = 0x0000046B
+	imageIdEnumMember      int32 = 0x00000465
+	imageIdLocalVariable   int32 = 0x000006D3
+	imageIdPropertyPrivate   int32 = 0x00000982
+	imageIdPropertyProtected int32 = 0x00000983
+	imageIdPropertyPublic    int32 = 0x00000984
+	imageIdMethodPrivate   int32 = 0x00000756
+	imageIdMethodProtected int32 = 0x00000757
+	imageIdMethodPublic    int32 = 0x00000758
+	imageIdLabel           int32 = 0x0000067D
+	imageIdAssembly        int32 = 0x000000C4
+	imageIdConstantPrivate   int32 = 0x0000026A
+	imageIdConstantProtected int32 = 0x0000026B
+	imageIdConstantPublic    int32 = 0x0000026C
+)
+
+func newVSImageId(id int32) *lsproto.VSImageId {
+	return &lsproto.VSImageId{Guid: vsImageCatalogGuid, Id: id}
+}
+
+// getVSHoverImageId maps a symbol's ScriptElementKind/modifiers to the VS image shown next to the
+// symbol name in hover tooltips. This mirrors TypeScript-VS's ImageIdMapping.GetImageId, which the
+// legacy (TSServer-backed) hover path uses; Corsa has no TSServer to source that mapping from, so
+// the LSP hover response must carry the equivalent icon directly.
+func getVSHoverImageId(kind lsutil.ScriptElementKind, modifiers lsutil.ScriptElementKindModifier) *lsproto.VSImageId {
+	isPrivate := modifiers&lsutil.ScriptElementKindModifierPrivate != 0
+	isProtected := modifiers&lsutil.ScriptElementKindModifierProtected != 0
+
+	// No internal/exported arm: the *Internal VS icons carry a chevron overlay that conveys
+	// C# assembly-scoped visibility, a concept that doesn't apply to TypeScript.
+	pick := func(private, protected, public int32) *lsproto.VSImageId {
+		switch {
+		case isPrivate:
+			return newVSImageId(private)
+		case isProtected:
+			return newVSImageId(protected)
+		default:
+			return newVSImageId(public)
+		}
+	}
+
+	switch kind {
+	case lsutil.ScriptElementKindWarning:
+		return newVSImageId(imageIdWarning)
+	case lsutil.ScriptElementKindKeyword:
+		return newVSImageId(imageIdKeyword)
+	case lsutil.ScriptElementKindScriptElement:
+		return pick(imageIdModulePrivate, imageIdModuleProtected, imageIdModulePublic)
+	case lsutil.ScriptElementKindPrimitiveType:
+		return newVSImageId(imageIdType)
+	case lsutil.ScriptElementKindModuleElement:
+		return newVSImageId(imageIdNamespace)
+	case lsutil.ScriptElementKindConstructorImplementationElement,
+		lsutil.ScriptElementKindClassElement,
+		lsutil.ScriptElementKindLocalClassElement,
+		lsutil.ScriptElementKindTypeElement:
+		return pick(imageIdClassPrivate, imageIdClassProtected, imageIdClassPublic)
+	case lsutil.ScriptElementKindInterfaceElement:
+		return pick(imageIdInterfacePrivate, imageIdInterfaceProtected, imageIdInterfacePublic)
+	case lsutil.ScriptElementKindEnumElement:
+		return pick(imageIdEnumPrivate, imageIdEnumProtected, imageIdEnumPublic)
+	case lsutil.ScriptElementKindEnumMemberElement:
+		return newVSImageId(imageIdEnumMember)
+	case lsutil.ScriptElementKindParameterElement,
+		lsutil.ScriptElementKindVariableElement,
+		lsutil.ScriptElementKindLocalVariableElement,
+		lsutil.ScriptElementKindVariableUsingElement,
+		lsutil.ScriptElementKindVariableAwaitUsingElement,
+		lsutil.ScriptElementKindLetElement,
+		lsutil.ScriptElementKindString:
+		return newVSImageId(imageIdLocalVariable)
+	case lsutil.ScriptElementKindConstElement:
+		return pick(imageIdConstantPrivate, imageIdConstantProtected, imageIdConstantPublic)
+	case lsutil.ScriptElementKindMemberGetAccessorElement,
+		lsutil.ScriptElementKindMemberSetAccessorElement,
+		lsutil.ScriptElementKindMemberVariableElement,
+		lsutil.ScriptElementKindMemberAccessorVariableElement:
+		return pick(imageIdPropertyPrivate, imageIdPropertyProtected, imageIdPropertyPublic)
+	case lsutil.ScriptElementKindFunctionElement,
+		lsutil.ScriptElementKindLocalFunctionElement,
+		lsutil.ScriptElementKindMemberFunctionElement,
+		lsutil.ScriptElementKindCallSignatureElement,
+		lsutil.ScriptElementKindIndexSignatureElement,
+		lsutil.ScriptElementKindConstructSignatureElement:
+		return pick(imageIdMethodPrivate, imageIdMethodProtected, imageIdMethodPublic)
+	case lsutil.ScriptElementKindTypeParameterElement:
+		return newVSImageId(imageIdType)
+	case lsutil.ScriptElementKindLabel:
+		return newVSImageId(imageIdLabel)
+	case lsutil.ScriptElementKindAlias:
+		return newVSImageId(imageIdModulePublic)
+	default:
+		return newVSImageId(imageIdAssembly)
+	}
+}
+
+// buildVSHoverRawContent assembles the VS-specific rich hover content (symbol icon + colorized
+// declaration line, plus an optional colorized documentation block) matching the shape that
+// TypeScript-VS's legacy HoverService.cs builds from TSServer's quickinfo-full response
+// (ImageElement + ClassifiedTextElement wrapped in a ContainerElement).
+func buildVSHoverRawContent(imageId *lsproto.VSImageId, quickInfoRuns []*lsproto.VSClassifiedTextRun, documentationRuns []*lsproto.VSClassifiedTextRun) *lsproto.VSContainerElement {
+	if len(quickInfoRuns) == 0 {
+		return nil
+	}
+
+	displayLine := &lsproto.VSContainerElement{
+		ElementStyle: lsproto.VSContainerElementStyleWrapped,
+		Elements: []lsproto.VSImageElementOrClassifiedTextElementOrContainerElement{
+			{ImageElement: &lsproto.VSImageElement{ImageId: imageId}},
+			{ClassifiedTextElement: &lsproto.VSClassifiedTextElement{Runs: quickInfoRuns}},
+		},
+	}
+
+	if len(documentationRuns) == 0 {
+		return displayLine
+	}
+
+	return &lsproto.VSContainerElement{
+		ElementStyle: lsproto.VSContainerElementStyleStacked,
+		Elements: []lsproto.VSImageElementOrClassifiedTextElementOrContainerElement{
+			{ContainerElement: displayLine},
+			{ClassifiedTextElement: &lsproto.VSClassifiedTextElement{Runs: documentationRuns}},
+		},
+	}
+}

--- a/internal/lsp/lsproto/_generate/generate.mts
+++ b/internal/lsp/lsproto/_generate/generate.mts
@@ -648,7 +648,7 @@ const customStructures: Structure[] = [
         name: "VSContainerElement",
         properties: [
             {
-                name: "ElementStyle",
+                name: "Style",
                 type: { kind: "reference", name: "VSContainerElementStyle" },
                 documentation: "Layout style for the child elements.",
             },

--- a/internal/lsp/lsproto/_generate/generate.mts
+++ b/internal/lsp/lsproto/_generate/generate.mts
@@ -607,9 +607,86 @@ const customStructures: Structure[] = [
         ],
         documentation: "A classified text element containing an array of classified text runs, used for colorized labels in VS.",
     },
+    {
+        name: "VSImageId",
+        properties: [
+            {
+                name: "Guid",
+                type: { kind: "base", name: "string" },
+                documentation: "The GUID of the image catalog containing this image.",
+            },
+            {
+                name: "Id",
+                type: { kind: "base", name: "integer" },
+                documentation: "The numeric identifier of the image within its catalog.",
+            },
+            {
+                name: "_vs_type",
+                type: { kind: "stringLiteral", value: "ImageId" },
+                documentation: "VS type discriminator required by ObjectContentConverter for deserialization.",
+            },
+        ],
+        documentation: "Identifies an image in a VS image catalog. Used to render symbol-kind icons (e.g. in hover tooltips).",
+    },
+    {
+        name: "VSImageElement",
+        properties: [
+            {
+                name: "ImageId",
+                type: { kind: "reference", name: "VSImageId" },
+                documentation: "The image to display.",
+            },
+            {
+                name: "_vs_type",
+                type: { kind: "stringLiteral", value: "ImageElement" },
+                documentation: "VS type discriminator required by ObjectContentConverter for deserialization.",
+            },
+        ],
+        documentation: "An image element (e.g. a symbol-kind icon) for use in VS rich content such as hover tooltips.",
+    },
+    {
+        name: "VSContainerElement",
+        properties: [
+            {
+                name: "ElementStyle",
+                type: { kind: "reference", name: "VSContainerElementStyle" },
+                documentation: "Layout style for the child elements.",
+            },
+            {
+                name: "Elements",
+                type: {
+                    kind: "array",
+                    element: {
+                        kind: "or",
+                        items: [
+                            { kind: "reference", name: "VSImageElement" },
+                            { kind: "reference", name: "VSClassifiedTextElement" },
+                            { kind: "reference", name: "VSContainerElement" },
+                        ],
+                    },
+                },
+                documentation: "The child elements contained within this container.",
+            },
+            {
+                name: "_vs_type",
+                type: { kind: "stringLiteral", value: "ContainerElement" },
+                documentation: "VS type discriminator required by ObjectContentConverter for deserialization.",
+            },
+        ],
+        documentation: "A container element that groups other VS rich-content elements (images, classified text, or nested containers). Used to build the VS hover raw content that combines a symbol icon with colorized text.",
+    },
 ];
 
 const customEnumerations: Enumeration[] = [
+    {
+        name: "VSContainerElementStyle",
+        type: { kind: "base", name: "integer" },
+        values: [
+            { name: "Wrapped", value: 0, documentation: "Child elements are laid out inline, wrapping as needed (e.g. an icon next to a signature line)." },
+            { name: "Stacked", value: 1, documentation: "Child elements are stacked vertically, each on its own line (e.g. a signature line followed by documentation)." },
+        ],
+        documentation: "Layout style for a VSContainerElement's children, mirroring VS's Microsoft.VisualStudio.Text.Adornments.ContainerElementStyle.",
+    },
     {
         name: "LogVerbosity",
         type: { kind: "base", name: "integer" },
@@ -966,6 +1043,12 @@ function patchAndPreprocessModel() {
                     type: { kind: "base", name: "boolean" },
                     omitzeroValue: true,
                     documentation: "Whether the verbosity level can be increased for this hover.",
+                },
+                {
+                    name: "_vs_rawContent",
+                    type: { kind: "reference", name: "VSContainerElement" },
+                    optional: true,
+                    documentation: "VS-specific rich content (symbol icon + colorized/classified text) rendered by clients that support Visual Studio extensions, in place of `contents`.",
                 },
             );
         }

--- a/internal/lsp/lsproto/lsp_generated.go
+++ b/internal/lsp/lsproto/lsp_generated.go
@@ -1428,19 +1428,6 @@ func (s *DocumentDiagnosticParams) UnmarshalJSONFrom(dec *json.Decoder) error {
 	return unmarshalStruct(s, dec)
 }
 
-// A partial result for a document diagnostic report.
-//
-// Since: 3.17.0
-type DocumentDiagnosticReportPartialResult struct {
-	RelatedDocuments map[DocumentUri]FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport `json:"relatedDocuments" lsp:"required"`
-}
-
-var _ json.UnmarshalerFrom = (*DocumentDiagnosticReportPartialResult)(nil)
-
-func (s *DocumentDiagnosticReportPartialResult) UnmarshalJSONFrom(dec *json.Decoder) error {
-	return unmarshalStruct(s, dec)
-}
-
 // Cancellation data returned from a diagnostic request.
 //
 // Since: 3.17.0
@@ -4476,47 +4463,16 @@ func (s *RelatedUnchangedDocumentDiagnosticReport) UnmarshalJSONFrom(dec *json.D
 	return unmarshalStruct(s, dec)
 }
 
-// A diagnostic report with a full set of problems.
+// A partial result for a document diagnostic report.
 //
 // Since: 3.17.0
-type FullDocumentDiagnosticReport struct {
-	// A full document diagnostic report.
-	Kind StringLiteralFull `json:"kind" lsp:"required"`
-
-	// An optional result id. If provided it will
-	// be sent on the next diagnostic request for the
-	// same document.
-	ResultId *string `json:"resultId,omitzero"`
-
-	// The actual items.
-	Items []*Diagnostic `json:"items" lsp:"required"`
+type DocumentDiagnosticReportPartialResult struct {
+	RelatedDocuments map[DocumentUri]FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport `json:"relatedDocuments" lsp:"required"`
 }
 
-var _ json.UnmarshalerFrom = (*FullDocumentDiagnosticReport)(nil)
+var _ json.UnmarshalerFrom = (*DocumentDiagnosticReportPartialResult)(nil)
 
-func (s *FullDocumentDiagnosticReport) UnmarshalJSONFrom(dec *json.Decoder) error {
-	return unmarshalStruct(s, dec)
-}
-
-// A diagnostic report indicating that the last returned
-// report is still accurate.
-//
-// Since: 3.17.0
-type UnchangedDocumentDiagnosticReport struct {
-	// A document diagnostic report indicating
-	// no changes to the last result. A server can
-	// only return `unchanged` if result ids are
-	// provided.
-	Kind StringLiteralUnchanged `json:"kind" lsp:"required"`
-
-	// A result id which will be sent on the next
-	// diagnostic request for the same document.
-	ResultId string `json:"resultId" lsp:"required"`
-}
-
-var _ json.UnmarshalerFrom = (*UnchangedDocumentDiagnosticReport)(nil)
-
-func (s *UnchangedDocumentDiagnosticReport) UnmarshalJSONFrom(dec *json.Decoder) error {
+func (s *DocumentDiagnosticReportPartialResult) UnmarshalJSONFrom(dec *json.Decoder) error {
 	return unmarshalStruct(s, dec)
 }
 
@@ -6435,6 +6391,50 @@ type FileOperationPattern struct {
 var _ json.UnmarshalerFrom = (*FileOperationPattern)(nil)
 
 func (s *FileOperationPattern) UnmarshalJSONFrom(dec *json.Decoder) error {
+	return unmarshalStruct(s, dec)
+}
+
+// A diagnostic report with a full set of problems.
+//
+// Since: 3.17.0
+type FullDocumentDiagnosticReport struct {
+	// A full document diagnostic report.
+	Kind StringLiteralFull `json:"kind" lsp:"required"`
+
+	// An optional result id. If provided it will
+	// be sent on the next diagnostic request for the
+	// same document.
+	ResultId *string `json:"resultId,omitzero"`
+
+	// The actual items.
+	Items []*Diagnostic `json:"items" lsp:"required"`
+}
+
+var _ json.UnmarshalerFrom = (*FullDocumentDiagnosticReport)(nil)
+
+func (s *FullDocumentDiagnosticReport) UnmarshalJSONFrom(dec *json.Decoder) error {
+	return unmarshalStruct(s, dec)
+}
+
+// A diagnostic report indicating that the last returned
+// report is still accurate.
+//
+// Since: 3.17.0
+type UnchangedDocumentDiagnosticReport struct {
+	// A document diagnostic report indicating
+	// no changes to the last result. A server can
+	// only return `unchanged` if result ids are
+	// provided.
+	Kind StringLiteralUnchanged `json:"kind" lsp:"required"`
+
+	// A result id which will be sent on the next
+	// diagnostic request for the same document.
+	ResultId string `json:"resultId" lsp:"required"`
+}
+
+var _ json.UnmarshalerFrom = (*UnchangedDocumentDiagnosticReport)(nil)
+
+func (s *UnchangedDocumentDiagnosticReport) UnmarshalJSONFrom(dec *json.Decoder) error {
 	return unmarshalStruct(s, dec)
 }
 
@@ -11846,37 +11846,6 @@ func (o *StringOrMarkupContent) UnmarshalJSONFrom(dec *json.Decoder) error {
 	}
 }
 
-type FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport struct {
-	FullDocumentDiagnosticReport      *FullDocumentDiagnosticReport
-	UnchangedDocumentDiagnosticReport *UnchangedDocumentDiagnosticReport
-}
-
-var _ json.MarshalerTo = (*FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport)(nil)
-
-func (o *FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) MarshalJSONTo(enc *json.Encoder) error {
-	return marshalUnion(o, enc, "FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport", false)
-}
-
-var _ json.UnmarshalerFrom = (*FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport)(nil)
-
-func (o *FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) UnmarshalJSONFrom(dec *json.Decoder) error {
-	*o = FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport{}
-
-	data, err := dec.ReadValue()
-	if err != nil {
-		return err
-	}
-	switch string(jsonObjectRawField(data, "kind")) {
-	case `"full"`:
-		o.FullDocumentDiagnosticReport = new(FullDocumentDiagnosticReport)
-		return json.Unmarshal(data, o.FullDocumentDiagnosticReport)
-	case `"unchanged"`:
-		o.UnchangedDocumentDiagnosticReport = new(UnchangedDocumentDiagnosticReport)
-		return json.Unmarshal(data, o.UnchangedDocumentDiagnosticReport)
-	}
-	return errInvalidValue("FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport", data)
-}
-
 type WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport struct {
 	FullDocumentDiagnosticReport      *WorkspaceFullDocumentDiagnosticReport
 	UnchangedDocumentDiagnosticReport *WorkspaceUnchangedDocumentDiagnosticReport
@@ -12328,6 +12297,37 @@ func (o *TextEditOrAnnotatedTextEditOrSnippetTextEdit) UnmarshalJSONFrom(dec *js
 		o.TextEdit = new(TextEdit)
 		return json.Unmarshal(data, o.TextEdit)
 	}
+}
+
+type FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport struct {
+	FullDocumentDiagnosticReport      *FullDocumentDiagnosticReport
+	UnchangedDocumentDiagnosticReport *UnchangedDocumentDiagnosticReport
+}
+
+var _ json.MarshalerTo = (*FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport)(nil)
+
+func (o *FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) MarshalJSONTo(enc *json.Encoder) error {
+	return marshalUnion(o, enc, "FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport", false)
+}
+
+var _ json.UnmarshalerFrom = (*FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport)(nil)
+
+func (o *FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) UnmarshalJSONFrom(dec *json.Decoder) error {
+	*o = FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport{}
+
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
+	switch string(jsonObjectRawField(data, "kind")) {
+	case `"full"`:
+		o.FullDocumentDiagnosticReport = new(FullDocumentDiagnosticReport)
+		return json.Unmarshal(data, o.FullDocumentDiagnosticReport)
+	case `"unchanged"`:
+		o.UnchangedDocumentDiagnosticReport = new(UnchangedDocumentDiagnosticReport)
+		return json.Unmarshal(data, o.UnchangedDocumentDiagnosticReport)
+	}
+	return errInvalidValue("FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport", data)
 }
 
 type TextDocumentSyncOptionsOrKind struct {

--- a/internal/lsp/lsproto/lsp_generated.go
+++ b/internal/lsp/lsproto/lsp_generated.go
@@ -1428,6 +1428,19 @@ func (s *DocumentDiagnosticParams) UnmarshalJSONFrom(dec *json.Decoder) error {
 	return unmarshalStruct(s, dec)
 }
 
+// A partial result for a document diagnostic report.
+//
+// Since: 3.17.0
+type DocumentDiagnosticReportPartialResult struct {
+	RelatedDocuments map[DocumentUri]FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport `json:"relatedDocuments" lsp:"required"`
+}
+
+var _ json.UnmarshalerFrom = (*DocumentDiagnosticReportPartialResult)(nil)
+
+func (s *DocumentDiagnosticReportPartialResult) UnmarshalJSONFrom(dec *json.Decoder) error {
+	return unmarshalStruct(s, dec)
+}
+
 // Cancellation data returned from a diagnostic request.
 //
 // Since: 3.17.0
@@ -4463,16 +4476,47 @@ func (s *RelatedUnchangedDocumentDiagnosticReport) UnmarshalJSONFrom(dec *json.D
 	return unmarshalStruct(s, dec)
 }
 
-// A partial result for a document diagnostic report.
+// A diagnostic report with a full set of problems.
 //
 // Since: 3.17.0
-type DocumentDiagnosticReportPartialResult struct {
-	RelatedDocuments map[DocumentUri]FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport `json:"relatedDocuments" lsp:"required"`
+type FullDocumentDiagnosticReport struct {
+	// A full document diagnostic report.
+	Kind StringLiteralFull `json:"kind" lsp:"required"`
+
+	// An optional result id. If provided it will
+	// be sent on the next diagnostic request for the
+	// same document.
+	ResultId *string `json:"resultId,omitzero"`
+
+	// The actual items.
+	Items []*Diagnostic `json:"items" lsp:"required"`
 }
 
-var _ json.UnmarshalerFrom = (*DocumentDiagnosticReportPartialResult)(nil)
+var _ json.UnmarshalerFrom = (*FullDocumentDiagnosticReport)(nil)
 
-func (s *DocumentDiagnosticReportPartialResult) UnmarshalJSONFrom(dec *json.Decoder) error {
+func (s *FullDocumentDiagnosticReport) UnmarshalJSONFrom(dec *json.Decoder) error {
+	return unmarshalStruct(s, dec)
+}
+
+// A diagnostic report indicating that the last returned
+// report is still accurate.
+//
+// Since: 3.17.0
+type UnchangedDocumentDiagnosticReport struct {
+	// A document diagnostic report indicating
+	// no changes to the last result. A server can
+	// only return `unchanged` if result ids are
+	// provided.
+	Kind StringLiteralUnchanged `json:"kind" lsp:"required"`
+
+	// A result id which will be sent on the next
+	// diagnostic request for the same document.
+	ResultId string `json:"resultId" lsp:"required"`
+}
+
+var _ json.UnmarshalerFrom = (*UnchangedDocumentDiagnosticReport)(nil)
+
+func (s *UnchangedDocumentDiagnosticReport) UnmarshalJSONFrom(dec *json.Decoder) error {
 	return unmarshalStruct(s, dec)
 }
 
@@ -6391,50 +6435,6 @@ type FileOperationPattern struct {
 var _ json.UnmarshalerFrom = (*FileOperationPattern)(nil)
 
 func (s *FileOperationPattern) UnmarshalJSONFrom(dec *json.Decoder) error {
-	return unmarshalStruct(s, dec)
-}
-
-// A diagnostic report with a full set of problems.
-//
-// Since: 3.17.0
-type FullDocumentDiagnosticReport struct {
-	// A full document diagnostic report.
-	Kind StringLiteralFull `json:"kind" lsp:"required"`
-
-	// An optional result id. If provided it will
-	// be sent on the next diagnostic request for the
-	// same document.
-	ResultId *string `json:"resultId,omitzero"`
-
-	// The actual items.
-	Items []*Diagnostic `json:"items" lsp:"required"`
-}
-
-var _ json.UnmarshalerFrom = (*FullDocumentDiagnosticReport)(nil)
-
-func (s *FullDocumentDiagnosticReport) UnmarshalJSONFrom(dec *json.Decoder) error {
-	return unmarshalStruct(s, dec)
-}
-
-// A diagnostic report indicating that the last returned
-// report is still accurate.
-//
-// Since: 3.17.0
-type UnchangedDocumentDiagnosticReport struct {
-	// A document diagnostic report indicating
-	// no changes to the last result. A server can
-	// only return `unchanged` if result ids are
-	// provided.
-	Kind StringLiteralUnchanged `json:"kind" lsp:"required"`
-
-	// A result id which will be sent on the next
-	// diagnostic request for the same document.
-	ResultId string `json:"resultId" lsp:"required"`
-}
-
-var _ json.UnmarshalerFrom = (*UnchangedDocumentDiagnosticReport)(nil)
-
-func (s *UnchangedDocumentDiagnosticReport) UnmarshalJSONFrom(dec *json.Decoder) error {
 	return unmarshalStruct(s, dec)
 }
 
@@ -9372,7 +9372,7 @@ func (s *VSImageElement) UnmarshalJSONFrom(dec *json.Decoder) error {
 
 // A container element that groups other VS rich-content elements (images, classified text, or nested containers). Used to build the VS hover raw content that combines a symbol icon with colorized text.
 type VSContainerElement struct {
-	// Layout style for the child elements. Must be named exactly "Style" on the wire (not "ElementStyle") to match Microsoft.VisualStudio.LanguageServer.Protocol.ContainerElementConverter, which looks up this property by that literal name.
+	// Layout style for the child elements.
 	Style VSContainerElementStyle `json:"Style" lsp:"required"`
 
 	// The child elements contained within this container.
@@ -11846,6 +11846,37 @@ func (o *StringOrMarkupContent) UnmarshalJSONFrom(dec *json.Decoder) error {
 	}
 }
 
+type FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport struct {
+	FullDocumentDiagnosticReport      *FullDocumentDiagnosticReport
+	UnchangedDocumentDiagnosticReport *UnchangedDocumentDiagnosticReport
+}
+
+var _ json.MarshalerTo = (*FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport)(nil)
+
+func (o *FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) MarshalJSONTo(enc *json.Encoder) error {
+	return marshalUnion(o, enc, "FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport", false)
+}
+
+var _ json.UnmarshalerFrom = (*FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport)(nil)
+
+func (o *FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) UnmarshalJSONFrom(dec *json.Decoder) error {
+	*o = FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport{}
+
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
+	switch string(jsonObjectRawField(data, "kind")) {
+	case `"full"`:
+		o.FullDocumentDiagnosticReport = new(FullDocumentDiagnosticReport)
+		return json.Unmarshal(data, o.FullDocumentDiagnosticReport)
+	case `"unchanged"`:
+		o.UnchangedDocumentDiagnosticReport = new(UnchangedDocumentDiagnosticReport)
+		return json.Unmarshal(data, o.UnchangedDocumentDiagnosticReport)
+	}
+	return errInvalidValue("FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport", data)
+}
+
 type WorkspaceFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport struct {
 	FullDocumentDiagnosticReport      *WorkspaceFullDocumentDiagnosticReport
 	UnchangedDocumentDiagnosticReport *WorkspaceUnchangedDocumentDiagnosticReport
@@ -12297,37 +12328,6 @@ func (o *TextEditOrAnnotatedTextEditOrSnippetTextEdit) UnmarshalJSONFrom(dec *js
 		o.TextEdit = new(TextEdit)
 		return json.Unmarshal(data, o.TextEdit)
 	}
-}
-
-type FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport struct {
-	FullDocumentDiagnosticReport      *FullDocumentDiagnosticReport
-	UnchangedDocumentDiagnosticReport *UnchangedDocumentDiagnosticReport
-}
-
-var _ json.MarshalerTo = (*FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport)(nil)
-
-func (o *FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) MarshalJSONTo(enc *json.Encoder) error {
-	return marshalUnion(o, enc, "FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport", false)
-}
-
-var _ json.UnmarshalerFrom = (*FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport)(nil)
-
-func (o *FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport) UnmarshalJSONFrom(dec *json.Decoder) error {
-	*o = FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport{}
-
-	data, err := dec.ReadValue()
-	if err != nil {
-		return err
-	}
-	switch string(jsonObjectRawField(data, "kind")) {
-	case `"full"`:
-		o.FullDocumentDiagnosticReport = new(FullDocumentDiagnosticReport)
-		return json.Unmarshal(data, o.FullDocumentDiagnosticReport)
-	case `"unchanged"`:
-		o.UnchangedDocumentDiagnosticReport = new(UnchangedDocumentDiagnosticReport)
-		return json.Unmarshal(data, o.UnchangedDocumentDiagnosticReport)
-	}
-	return errInvalidValue("FullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport", data)
 }
 
 type TextDocumentSyncOptionsOrKind struct {

--- a/internal/lsp/lsproto/lsp_generated.go
+++ b/internal/lsp/lsproto/lsp_generated.go
@@ -2393,6 +2393,9 @@ type Hover struct {
 
 	// Whether the verbosity level can be increased for this hover.
 	CanIncreaseVerbosity bool `json:"canIncreaseVerbosity,omitzero" lsp:"nullable"`
+
+	// VS-specific rich content (symbol icon + colorized/classified text) rendered by clients that support Visual Studio extensions, in place of `contents`.
+	VSRawContent *VSContainerElement `json:"_vs_rawContent,omitzero"`
 }
 
 var _ json.UnmarshalerFrom = (*Hover)(nil)
@@ -9334,6 +9337,57 @@ func (s *VSClassifiedTextElement) UnmarshalJSONFrom(dec *json.Decoder) error {
 	return unmarshalStruct(s, dec)
 }
 
+// Identifies an image in a VS image catalog. Used to render symbol-kind icons (e.g. in hover tooltips).
+type VSImageId struct {
+	// The GUID of the image catalog containing this image.
+	Guid string `json:"Guid" lsp:"required"`
+
+	// The numeric identifier of the image within its catalog.
+	Id int32 `json:"Id" lsp:"required"`
+
+	// VS type discriminator required by ObjectContentConverter for deserialization.
+	VSType StringLiteralImageId `json:"_vs_type" lsp:"required"`
+}
+
+var _ json.UnmarshalerFrom = (*VSImageId)(nil)
+
+func (s *VSImageId) UnmarshalJSONFrom(dec *json.Decoder) error {
+	return unmarshalStruct(s, dec)
+}
+
+// An image element (e.g. a symbol-kind icon) for use in VS rich content such as hover tooltips.
+type VSImageElement struct {
+	// The image to display.
+	ImageId *VSImageId `json:"ImageId" lsp:"required"`
+
+	// VS type discriminator required by ObjectContentConverter for deserialization.
+	VSType StringLiteralImageElement `json:"_vs_type" lsp:"required"`
+}
+
+var _ json.UnmarshalerFrom = (*VSImageElement)(nil)
+
+func (s *VSImageElement) UnmarshalJSONFrom(dec *json.Decoder) error {
+	return unmarshalStruct(s, dec)
+}
+
+// A container element that groups other VS rich-content elements (images, classified text, or nested containers). Used to build the VS hover raw content that combines a symbol icon with colorized text.
+type VSContainerElement struct {
+	// Layout style for the child elements.
+	ElementStyle VSContainerElementStyle `json:"ElementStyle" lsp:"required"`
+
+	// The child elements contained within this container.
+	Elements []VSImageElementOrClassifiedTextElementOrContainerElement `json:"Elements" lsp:"required"`
+
+	// VS type discriminator required by ObjectContentConverter for deserialization.
+	VSType StringLiteralContainerElement `json:"_vs_type" lsp:"required"`
+}
+
+var _ json.UnmarshalerFrom = (*VSContainerElement)(nil)
+
+func (s *VSContainerElement) UnmarshalJSONFrom(dec *json.Decoder) error {
+	return unmarshalStruct(s, dec)
+}
+
 // CallHierarchyItemData is a placeholder for custom data preserved on a CallHierarchyItem.
 type CallHierarchyItemData struct{}
 
@@ -10411,6 +10465,28 @@ type TokenFormat string
 const (
 	TokenFormatRelative TokenFormat = "relative"
 )
+
+// Layout style for a VSContainerElement's children, mirroring VS's Microsoft.VisualStudio.Text.Adornments.ContainerElementStyle.
+type VSContainerElementStyle int32
+
+const (
+	// Child elements are laid out inline, wrapping as needed (e.g. an icon next to a signature line).
+	VSContainerElementStyleWrapped VSContainerElementStyle = 0
+	// Child elements are stacked vertically, each on its own line (e.g. a signature line followed by documentation).
+	VSContainerElementStyleStacked VSContainerElementStyle = 1
+)
+
+const _VSContainerElementStyle_name = "WrappedStacked"
+
+var _VSContainerElementStyle_index = [...]uint16{0, 7, 14}
+
+func (e VSContainerElementStyle) String() string {
+	i := int(e) - 0
+	if i < 0 || i >= len(_VSContainerElementStyle_index)-1 {
+		return fmt.Sprintf("VSContainerElementStyle(%d)", e)
+	}
+	return _VSContainerElementStyle_name[_VSContainerElementStyle_index[i]:_VSContainerElementStyle_index[i+1]]
+}
 
 // Log verbosity level, mirroring the VS Code LogLevel enum values.
 type LogVerbosity int32
@@ -13376,6 +13452,41 @@ func (o *BooleanOrClientSemanticTokensRequestFullDelta) UnmarshalJSONFrom(dec *j
 	}
 }
 
+type VSImageElementOrClassifiedTextElementOrContainerElement struct {
+	ImageElement          *VSImageElement
+	ClassifiedTextElement *VSClassifiedTextElement
+	ContainerElement      *VSContainerElement
+}
+
+var _ json.MarshalerTo = (*VSImageElementOrClassifiedTextElementOrContainerElement)(nil)
+
+func (o *VSImageElementOrClassifiedTextElementOrContainerElement) MarshalJSONTo(enc *json.Encoder) error {
+	return marshalUnion(o, enc, "VSImageElementOrClassifiedTextElementOrContainerElement", false)
+}
+
+var _ json.UnmarshalerFrom = (*VSImageElementOrClassifiedTextElementOrContainerElement)(nil)
+
+func (o *VSImageElementOrClassifiedTextElementOrContainerElement) UnmarshalJSONFrom(dec *json.Decoder) error {
+	*o = VSImageElementOrClassifiedTextElementOrContainerElement{}
+
+	data, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
+	switch string(jsonObjectRawField(data, "_vs_type")) {
+	case `"ContainerElement"`:
+		o.ContainerElement = new(VSContainerElement)
+		return json.Unmarshal(data, o.ContainerElement)
+	case `"ImageElement"`:
+		o.ImageElement = new(VSImageElement)
+		return json.Unmarshal(data, o.ImageElement)
+	case `"ClassifiedTextElement"`:
+		o.ClassifiedTextElement = new(VSClassifiedTextElement)
+		return json.Unmarshal(data, o.ClassifiedTextElement)
+	}
+	return errInvalidValue("VSImageElementOrClassifiedTextElementOrContainerElement", data)
+}
+
 type LocationOrLocationsOrDefinitionLinksOrNull struct {
 	Location        *Location
 	Locations       *[]Location
@@ -14941,6 +15052,72 @@ func (o *StringLiteralClassifiedTextElement) UnmarshalJSONFrom(dec *json.Decoder
 	}
 	if string(v) != `"ClassifiedTextElement"` {
 		return errLiteralMismatch("StringLiteralClassifiedTextElement", `"ClassifiedTextElement"`, v)
+	}
+	return nil
+}
+
+// StringLiteralImageId is a literal type for "ImageId"
+type StringLiteralImageId struct{}
+
+var _ json.MarshalerTo = StringLiteralImageId{}
+
+func (o StringLiteralImageId) MarshalJSONTo(enc *json.Encoder) error {
+	return enc.WriteValue(json.Value(`"ImageId"`))
+}
+
+var _ json.UnmarshalerFrom = &StringLiteralImageId{}
+
+func (o *StringLiteralImageId) UnmarshalJSONFrom(dec *json.Decoder) error {
+	v, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
+	if string(v) != `"ImageId"` {
+		return errLiteralMismatch("StringLiteralImageId", `"ImageId"`, v)
+	}
+	return nil
+}
+
+// StringLiteralImageElement is a literal type for "ImageElement"
+type StringLiteralImageElement struct{}
+
+var _ json.MarshalerTo = StringLiteralImageElement{}
+
+func (o StringLiteralImageElement) MarshalJSONTo(enc *json.Encoder) error {
+	return enc.WriteValue(json.Value(`"ImageElement"`))
+}
+
+var _ json.UnmarshalerFrom = &StringLiteralImageElement{}
+
+func (o *StringLiteralImageElement) UnmarshalJSONFrom(dec *json.Decoder) error {
+	v, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
+	if string(v) != `"ImageElement"` {
+		return errLiteralMismatch("StringLiteralImageElement", `"ImageElement"`, v)
+	}
+	return nil
+}
+
+// StringLiteralContainerElement is a literal type for "ContainerElement"
+type StringLiteralContainerElement struct{}
+
+var _ json.MarshalerTo = StringLiteralContainerElement{}
+
+func (o StringLiteralContainerElement) MarshalJSONTo(enc *json.Encoder) error {
+	return enc.WriteValue(json.Value(`"ContainerElement"`))
+}
+
+var _ json.UnmarshalerFrom = &StringLiteralContainerElement{}
+
+func (o *StringLiteralContainerElement) UnmarshalJSONFrom(dec *json.Decoder) error {
+	v, err := dec.ReadValue()
+	if err != nil {
+		return err
+	}
+	if string(v) != `"ContainerElement"` {
+		return errLiteralMismatch("StringLiteralContainerElement", `"ContainerElement"`, v)
 	}
 	return nil
 }

--- a/internal/lsp/lsproto/lsp_generated.go
+++ b/internal/lsp/lsproto/lsp_generated.go
@@ -9372,8 +9372,8 @@ func (s *VSImageElement) UnmarshalJSONFrom(dec *json.Decoder) error {
 
 // A container element that groups other VS rich-content elements (images, classified text, or nested containers). Used to build the VS hover raw content that combines a symbol icon with colorized text.
 type VSContainerElement struct {
-	// Layout style for the child elements.
-	ElementStyle VSContainerElementStyle `json:"ElementStyle" lsp:"required"`
+	// Layout style for the child elements. Must be named exactly "Style" on the wire (not "ElementStyle") to match Microsoft.VisualStudio.LanguageServer.Protocol.ContainerElementConverter, which looks up this property by that literal name.
+	Style VSContainerElementStyle `json:"Style" lsp:"required"`
 
 	// The child elements contained within this container.
 	Elements []VSImageElementOrClassifiedTextElementOrContainerElement `json:"Elements" lsp:"required"`

--- a/testdata/baselines/reference/fourslash/vSQuickInfo/quickInfoAliasVS.baseline
+++ b/testdata/baselines/reference/fourslash/vSQuickInfo/quickInfoAliasVS.baseline
@@ -1,0 +1,247 @@
+// === VSQuickInfo ===
+=== /b.ts ===
+// import { x } from "./a";
+// x;
+// ^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Stacked)
+// |   ContainerElement (Style=Wrapped)
+// |     ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x26C }
+// |     ClassifiedTextElement
+// |       [punctuation] "("
+// |       [text] "alias"
+// |       [punctuation] ") "
+// |       [keyword] "const "
+// |       [local name] "x"
+// |       [punctuation] ": "
+// |       [string] "0"
+// |   ClassifiedTextElement
+// |     [text] "Doc\n\n*@tag* — Tag text"
+// | ----------------------------------------------------------------------
+=== /c.ts ===
+// /**
+//  * Doc 2
+//  * @tag Tag text 2
+//  */
+// import {
+//     /**
+//      * Doc 3
+//      * @tag Tag text 3
+//      */
+//     x
+// } from "./a";
+// x;
+// ^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Stacked)
+// |   ContainerElement (Style=Wrapped)
+// |     ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x26C }
+// |     ClassifiedTextElement
+// |       [punctuation] "("
+// |       [text] "alias"
+// |       [punctuation] ") "
+// |       [keyword] "const "
+// |       [local name] "x"
+// |       [punctuation] ": "
+// |       [string] "0"
+// |   ClassifiedTextElement
+// |     [text] "Doc\n\n*@tag* — Tag text"
+// | ----------------------------------------------------------------------
+
+
+[
+  {
+    "marker": {
+      "Position": 26,
+      "LSPosition": {
+        "line": 1,
+        "character": 1
+      },
+      "Name": "b",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(alias) const x: 0\n```\nDoc\n\n*@tag* — Tag text"
+      },
+      "range": {
+        "start": {
+          "line": 1,
+          "character": 0
+        },
+        "end": {
+          "line": 1,
+          "character": 1
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 1,
+        "Elements": [
+          {
+            "Style": 0,
+            "Elements": [
+              {
+                "ImageId": {
+                  "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+                  "Id": 620,
+                  "_vs_type": "ImageId"
+                },
+                "_vs_type": "ImageElement"
+              },
+              {
+                "Runs": [
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": "(",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "text",
+                    "Text": "alias",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ") ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "keyword",
+                    "Text": "const ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "local name",
+                    "Text": "x",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ": ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "string",
+                    "Text": "0",
+                    "_vs_type": "ClassifiedTextRun"
+                  }
+                ],
+                "_vs_type": "ClassifiedTextElement"
+              }
+            ],
+            "_vs_type": "ContainerElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "text",
+                "Text": "Doc\n\n*@tag* — Tag text",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 118,
+      "LSPosition": {
+        "line": 11,
+        "character": 1
+      },
+      "Name": "c",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(alias) const x: 0\n```\nDoc\n\n*@tag* — Tag text"
+      },
+      "range": {
+        "start": {
+          "line": 11,
+          "character": 0
+        },
+        "end": {
+          "line": 11,
+          "character": 1
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 1,
+        "Elements": [
+          {
+            "Style": 0,
+            "Elements": [
+              {
+                "ImageId": {
+                  "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+                  "Id": 620,
+                  "_vs_type": "ImageId"
+                },
+                "_vs_type": "ImageElement"
+              },
+              {
+                "Runs": [
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": "(",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "text",
+                    "Text": "alias",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ") ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "keyword",
+                    "Text": "const ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "local name",
+                    "Text": "x",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ": ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "string",
+                    "Text": "0",
+                    "_vs_type": "ClassifiedTextRun"
+                  }
+                ],
+                "_vs_type": "ClassifiedTextElement"
+              }
+            ],
+            "_vs_type": "ContainerElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "text",
+                "Text": "Doc\n\n*@tag* — Tag text",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  }
+]

--- a/testdata/baselines/reference/fourslash/vSQuickInfo/quickInfoAliasVS.baseline
+++ b/testdata/baselines/reference/fourslash/vSQuickInfo/quickInfoAliasVS.baseline
@@ -16,7 +16,7 @@
 // |       [punctuation] ": "
 // |       [string] "0"
 // |   ClassifiedTextElement
-// |     [text] "Doc\n\n*@tag* — Tag text"
+// |     [text] "Doc"
 // | ----------------------------------------------------------------------
 === /c.ts ===
 // /**
@@ -45,7 +45,7 @@
 // |       [punctuation] ": "
 // |       [string] "0"
 // |   ClassifiedTextElement
-// |     [text] "Doc\n\n*@tag* — Tag text"
+// |     [text] "Doc"
 // | ----------------------------------------------------------------------
 
 
@@ -136,7 +136,7 @@
             "Runs": [
               {
                 "ClassificationTypeName": "text",
-                "Text": "Doc\n\n*@tag* — Tag text",
+                "Text": "Doc",
                 "_vs_type": "ClassifiedTextRun"
               }
             ],
@@ -233,7 +233,7 @@
             "Runs": [
               {
                 "ClassificationTypeName": "text",
-                "Text": "Doc\n\n*@tag* — Tag text",
+                "Text": "Doc",
                 "_vs_type": "ClassifiedTextRun"
               }
             ],

--- a/testdata/baselines/reference/fourslash/vSQuickInfo/quickInfoCommentsFunctionDeclarationVS.baseline
+++ b/testdata/baselines/reference/fourslash/vSQuickInfo/quickInfoCommentsFunctionDeclarationVS.baseline
@@ -1,0 +1,693 @@
+// === VSQuickInfo ===
+=== /quickInfoCommentsFunctionDeclarationVS.ts ===
+// /** This comment should appear for foo*/
+// function foo() {
+//          ^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Stacked)
+// |   ContainerElement (Style=Wrapped)
+// |     ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x758 }
+// |     ClassifiedTextElement
+// |       [keyword] "function "
+// |       [method name] "foo"
+// |       [punctuation] "("
+// |       [punctuation] ")"
+// |       [punctuation] ":"
+// |       [whitespace] " "
+// |       [keyword] "void"
+// |       [punctuation] ";"
+// |   ClassifiedTextElement
+// |     [text] "This comment should appear for foo"
+// | ----------------------------------------------------------------------
+// }
+// foo();
+// ^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Stacked)
+// |   ContainerElement (Style=Wrapped)
+// |     ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x758 }
+// |     ClassifiedTextElement
+// |       [keyword] "function "
+// |       [method name] "foo"
+// |       [punctuation] "("
+// |       [punctuation] ")"
+// |       [punctuation] ":"
+// |       [whitespace] " "
+// |       [keyword] "void"
+// |       [punctuation] ";"
+// |   ClassifiedTextElement
+// |     [text] "This comment should appear for foo"
+// | ----------------------------------------------------------------------
+// /** This is comment for function signature*/
+// function fooWithParameters(/** this is comment about a*/a: string,
+//          ^^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Stacked)
+// |   ContainerElement (Style=Wrapped)
+// |     ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x758 }
+// |     ClassifiedTextElement
+// |       [keyword] "function "
+// |       [method name] "fooWithParameters"
+// |       [punctuation] "("
+// |       [parameter name] "a"
+// |       [punctuation] ":"
+// |       [whitespace] " "
+// |       [keyword] "string"
+// |       [punctuation] ","
+// |       [whitespace] " "
+// |       [parameter name] "b"
+// |       [punctuation] ":"
+// |       [whitespace] " "
+// |       [keyword] "number"
+// |       [punctuation] ")"
+// |       [punctuation] ":"
+// |       [whitespace] " "
+// |       [keyword] "void"
+// |       [punctuation] ";"
+// |   ClassifiedTextElement
+// |     [text] "This is comment for function signature"
+// | ----------------------------------------------------------------------
+//     /** this is comment for b*/
+//     b: number) {
+//     var d = a;
+//         ^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x6D3 }
+// |   ClassifiedTextElement
+// |     [keyword] "var "
+// |     [local name] "d"
+// |     [punctuation] ": "
+// |     [keyword] "string"
+// | ----------------------------------------------------------------------
+// }
+// fooWithParameters("a",10);
+// ^^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Stacked)
+// |   ContainerElement (Style=Wrapped)
+// |     ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x758 }
+// |     ClassifiedTextElement
+// |       [keyword] "function "
+// |       [method name] "fooWithParameters"
+// |       [punctuation] "("
+// |       [parameter name] "a"
+// |       [punctuation] ":"
+// |       [whitespace] " "
+// |       [keyword] "string"
+// |       [punctuation] ","
+// |       [whitespace] " "
+// |       [parameter name] "b"
+// |       [punctuation] ":"
+// |       [whitespace] " "
+// |       [keyword] "number"
+// |       [punctuation] ")"
+// |       [punctuation] ":"
+// |       [whitespace] " "
+// |       [keyword] "void"
+// |       [punctuation] ";"
+// |   ClassifiedTextElement
+// |     [text] "This is comment for function signature"
+// | ----------------------------------------------------------------------
+// /**
+// * Does something
+// * @param a a string
+// */
+// declare function fn(a: string);
+// fn("hello");
+[
+  {
+    "marker": {
+      "Position": 51,
+      "LSPosition": {
+        "line": 1,
+        "character": 10
+      },
+      "Name": "1",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foo(): void;\n```\nThis comment should appear for foo"
+      },
+      "range": {
+        "start": {
+          "line": 1,
+          "character": 9
+        },
+        "end": {
+          "line": 1,
+          "character": 12
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 1,
+        "Elements": [
+          {
+            "Style": 0,
+            "Elements": [
+              {
+                "ImageId": {
+                  "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+                  "Id": 1880,
+                  "_vs_type": "ImageId"
+                },
+                "_vs_type": "ImageElement"
+              },
+              {
+                "Runs": [
+                  {
+                    "ClassificationTypeName": "keyword",
+                    "Text": "function ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "method name",
+                    "Text": "foo",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": "(",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ")",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ":",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "whitespace",
+                    "Text": " ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "keyword",
+                    "Text": "void",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ";",
+                    "_vs_type": "ClassifiedTextRun"
+                  }
+                ],
+                "_vs_type": "ClassifiedTextElement"
+              }
+            ],
+            "_vs_type": "ContainerElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "text",
+                "Text": "This comment should appear for foo",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 61,
+      "LSPosition": {
+        "line": 3,
+        "character": 1
+      },
+      "Name": "2",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foo(): void;\n```\nThis comment should appear for foo"
+      },
+      "range": {
+        "start": {
+          "line": 3,
+          "character": 0
+        },
+        "end": {
+          "line": 3,
+          "character": 3
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 1,
+        "Elements": [
+          {
+            "Style": 0,
+            "Elements": [
+              {
+                "ImageId": {
+                  "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+                  "Id": 1880,
+                  "_vs_type": "ImageId"
+                },
+                "_vs_type": "ImageElement"
+              },
+              {
+                "Runs": [
+                  {
+                    "ClassificationTypeName": "keyword",
+                    "Text": "function ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "method name",
+                    "Text": "foo",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": "(",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ")",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ":",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "whitespace",
+                    "Text": " ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "keyword",
+                    "Text": "void",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ";",
+                    "_vs_type": "ClassifiedTextRun"
+                  }
+                ],
+                "_vs_type": "ClassifiedTextElement"
+              }
+            ],
+            "_vs_type": "ContainerElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "text",
+                "Text": "This comment should appear for foo",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 123,
+      "LSPosition": {
+        "line": 5,
+        "character": 11
+      },
+      "Name": "5",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction fooWithParameters(a: string, b: number): void;\n```\nThis is comment for function signature"
+      },
+      "range": {
+        "start": {
+          "line": 5,
+          "character": 9
+        },
+        "end": {
+          "line": 5,
+          "character": 26
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 1,
+        "Elements": [
+          {
+            "Style": 0,
+            "Elements": [
+              {
+                "ImageId": {
+                  "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+                  "Id": 1880,
+                  "_vs_type": "ImageId"
+                },
+                "_vs_type": "ImageElement"
+              },
+              {
+                "Runs": [
+                  {
+                    "ClassificationTypeName": "keyword",
+                    "Text": "function ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "method name",
+                    "Text": "fooWithParameters",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": "(",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "parameter name",
+                    "Text": "a",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ":",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "whitespace",
+                    "Text": " ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "keyword",
+                    "Text": "string",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ",",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "whitespace",
+                    "Text": " ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "parameter name",
+                    "Text": "b",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ":",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "whitespace",
+                    "Text": " ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "keyword",
+                    "Text": "number",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ")",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ":",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "whitespace",
+                    "Text": " ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "keyword",
+                    "Text": "void",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ";",
+                    "_vs_type": "ClassifiedTextRun"
+                  }
+                ],
+                "_vs_type": "ClassifiedTextElement"
+              }
+            ],
+            "_vs_type": "ContainerElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "text",
+                "Text": "This is comment for function signature",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 236,
+      "LSPosition": {
+        "line": 8,
+        "character": 8
+      },
+      "Name": "6",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nvar d: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 8,
+          "character": 8
+        },
+        "end": {
+          "line": 8,
+          "character": 9
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1747,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "var ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "local name",
+                "Text": "d",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 257,
+      "LSPosition": {
+        "line": 10,
+        "character": 12
+      },
+      "Name": "8",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction fooWithParameters(a: string, b: number): void;\n```\nThis is comment for function signature"
+      },
+      "range": {
+        "start": {
+          "line": 10,
+          "character": 0
+        },
+        "end": {
+          "line": 10,
+          "character": 17
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 1,
+        "Elements": [
+          {
+            "Style": 0,
+            "Elements": [
+              {
+                "ImageId": {
+                  "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+                  "Id": 1880,
+                  "_vs_type": "ImageId"
+                },
+                "_vs_type": "ImageElement"
+              },
+              {
+                "Runs": [
+                  {
+                    "ClassificationTypeName": "keyword",
+                    "Text": "function ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "method name",
+                    "Text": "fooWithParameters",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": "(",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "parameter name",
+                    "Text": "a",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ":",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "whitespace",
+                    "Text": " ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "keyword",
+                    "Text": "string",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ",",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "whitespace",
+                    "Text": " ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "parameter name",
+                    "Text": "b",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ":",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "whitespace",
+                    "Text": " ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "keyword",
+                    "Text": "number",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ")",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ":",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "whitespace",
+                    "Text": " ",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "keyword",
+                    "Text": "void",
+                    "_vs_type": "ClassifiedTextRun"
+                  },
+                  {
+                    "ClassificationTypeName": "punctuation",
+                    "Text": ";",
+                    "_vs_type": "ClassifiedTextRun"
+                  }
+                ],
+                "_vs_type": "ClassifiedTextElement"
+              }
+            ],
+            "_vs_type": "ContainerElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "text",
+                "Text": "This is comment for function signature",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  }
+]

--- a/testdata/baselines/reference/fourslash/vSQuickInfo/quickInfoDisplayPartsClassMethodVS.baseline
+++ b/testdata/baselines/reference/fourslash/vSQuickInfo/quickInfoDisplayPartsClassMethodVS.baseline
@@ -1,0 +1,1732 @@
+// === VSQuickInfo ===
+=== /quickInfoDisplayPartsClassMethodVS.ts ===
+// class c {
+//     public publicMethod() { }
+//            ^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x758 }
+// |   ClassifiedTextElement
+// |     [punctuation] "("
+// |     [text] "method"
+// |     [punctuation] ") "
+// |     [method name] "c.publicMethod"
+// |     [punctuation] "("
+// |     [punctuation] ")"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "void"
+// |     [punctuation] ";"
+// | ----------------------------------------------------------------------
+//     private privateMethod() { }
+//             ^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x756 }
+// |   ClassifiedTextElement
+// |     [punctuation] "("
+// |     [text] "method"
+// |     [punctuation] ") "
+// |     [method name] "c.privateMethod"
+// |     [punctuation] "("
+// |     [punctuation] ")"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "void"
+// |     [punctuation] ";"
+// | ----------------------------------------------------------------------
+//     protected protectedMethod() { }
+//               ^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x757 }
+// |   ClassifiedTextElement
+// |     [punctuation] "("
+// |     [text] "method"
+// |     [punctuation] ") "
+// |     [method name] "c.protectedMethod"
+// |     [punctuation] "("
+// |     [punctuation] ")"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "void"
+// |     [punctuation] ";"
+// | ----------------------------------------------------------------------
+//     static staticMethod() { }
+//            ^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x758 }
+// |   ClassifiedTextElement
+// |     [punctuation] "("
+// |     [text] "method"
+// |     [punctuation] ") "
+// |     [method name] "c.staticMethod"
+// |     [punctuation] "("
+// |     [punctuation] ")"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "void"
+// |     [punctuation] ";"
+// | ----------------------------------------------------------------------
+//     private static privateStaticMethod() { }
+//                    ^^^^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x756 }
+// |   ClassifiedTextElement
+// |     [punctuation] "("
+// |     [text] "method"
+// |     [punctuation] ") "
+// |     [method name] "c.privateStaticMethod"
+// |     [punctuation] "("
+// |     [punctuation] ")"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "void"
+// |     [punctuation] ";"
+// | ----------------------------------------------------------------------
+//     protected static protectedStaticMethod() { }
+//                      ^^^^^^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x757 }
+// |   ClassifiedTextElement
+// |     [punctuation] "("
+// |     [text] "method"
+// |     [punctuation] ") "
+// |     [method name] "c.protectedStaticMethod"
+// |     [punctuation] "("
+// |     [punctuation] ")"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "void"
+// |     [punctuation] ";"
+// | ----------------------------------------------------------------------
+//     method() {
+//         this.publicMethod();
+//              ^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x758 }
+// |   ClassifiedTextElement
+// |     [punctuation] "("
+// |     [text] "method"
+// |     [punctuation] ") "
+// |     [method name] "c.publicMethod"
+// |     [punctuation] "("
+// |     [punctuation] ")"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "void"
+// |     [punctuation] ";"
+// | ----------------------------------------------------------------------
+//         this.privateMethod();
+//              ^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x756 }
+// |   ClassifiedTextElement
+// |     [punctuation] "("
+// |     [text] "method"
+// |     [punctuation] ") "
+// |     [method name] "c.privateMethod"
+// |     [punctuation] "("
+// |     [punctuation] ")"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "void"
+// |     [punctuation] ";"
+// | ----------------------------------------------------------------------
+//         this.protectedMethod();
+//              ^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x757 }
+// |   ClassifiedTextElement
+// |     [punctuation] "("
+// |     [text] "method"
+// |     [punctuation] ") "
+// |     [method name] "c.protectedMethod"
+// |     [punctuation] "("
+// |     [punctuation] ")"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "void"
+// |     [punctuation] ";"
+// | ----------------------------------------------------------------------
+//         c.staticMethod();
+//           ^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x758 }
+// |   ClassifiedTextElement
+// |     [punctuation] "("
+// |     [text] "method"
+// |     [punctuation] ") "
+// |     [method name] "c.staticMethod"
+// |     [punctuation] "("
+// |     [punctuation] ")"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "void"
+// |     [punctuation] ";"
+// | ----------------------------------------------------------------------
+//         c.privateStaticMethod();
+//           ^^^^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x756 }
+// |   ClassifiedTextElement
+// |     [punctuation] "("
+// |     [text] "method"
+// |     [punctuation] ") "
+// |     [method name] "c.privateStaticMethod"
+// |     [punctuation] "("
+// |     [punctuation] ")"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "void"
+// |     [punctuation] ";"
+// | ----------------------------------------------------------------------
+//         c.protectedStaticMethod();
+//           ^^^^^^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x757 }
+// |   ClassifiedTextElement
+// |     [punctuation] "("
+// |     [text] "method"
+// |     [punctuation] ") "
+// |     [method name] "c.protectedStaticMethod"
+// |     [punctuation] "("
+// |     [punctuation] ")"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "void"
+// |     [punctuation] ";"
+// | ----------------------------------------------------------------------
+//     }
+// }
+// var cInstance = new c();
+// cInstance.publicMethod();
+// ^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x6D3 }
+// |   ClassifiedTextElement
+// |     [keyword] "var "
+// |     [local name] "cInstance"
+// |     [punctuation] ": "
+// |     [class name] "c"
+// | ----------------------------------------------------------------------
+//           ^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x758 }
+// |   ClassifiedTextElement
+// |     [punctuation] "("
+// |     [text] "method"
+// |     [punctuation] ") "
+// |     [method name] "c.publicMethod"
+// |     [punctuation] "("
+// |     [punctuation] ")"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "void"
+// |     [punctuation] ";"
+// | ----------------------------------------------------------------------
+// c.staticMethod();
+// ^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x1D9 }
+// |   ClassifiedTextElement
+// |     [keyword] "class "
+// |     [class name] "c"
+// | ----------------------------------------------------------------------
+//   ^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x758 }
+// |   ClassifiedTextElement
+// |     [punctuation] "("
+// |     [text] "method"
+// |     [punctuation] ") "
+// |     [method name] "c.staticMethod"
+// |     [punctuation] "("
+// |     [punctuation] ")"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "void"
+// |     [punctuation] ";"
+// | ----------------------------------------------------------------------
+[
+  {
+    "marker": {
+      "Position": 21,
+      "LSPosition": {
+        "line": 1,
+        "character": 11
+      },
+      "Name": "1",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) c.publicMethod(): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 1,
+          "character": 11
+        },
+        "end": {
+          "line": 1,
+          "character": 23
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "method",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "c.publicMethod",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 52,
+      "LSPosition": {
+        "line": 2,
+        "character": 12
+      },
+      "Name": "2",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) c.privateMethod(): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 2,
+          "character": 12
+        },
+        "end": {
+          "line": 2,
+          "character": 25
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1878,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "method",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "c.privateMethod",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 86,
+      "LSPosition": {
+        "line": 3,
+        "character": 14
+      },
+      "Name": "21",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) c.protectedMethod(): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 3,
+          "character": 14
+        },
+        "end": {
+          "line": 3,
+          "character": 29
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1879,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "method",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "c.protectedMethod",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 119,
+      "LSPosition": {
+        "line": 4,
+        "character": 11
+      },
+      "Name": "3",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) c.staticMethod(): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 4,
+          "character": 11
+        },
+        "end": {
+          "line": 4,
+          "character": 23
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "method",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "c.staticMethod",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 157,
+      "LSPosition": {
+        "line": 5,
+        "character": 19
+      },
+      "Name": "4",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) c.privateStaticMethod(): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 5,
+          "character": 19
+        },
+        "end": {
+          "line": 5,
+          "character": 38
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1878,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "method",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "c.privateStaticMethod",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 204,
+      "LSPosition": {
+        "line": 6,
+        "character": 21
+      },
+      "Name": "41",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) c.protectedStaticMethod(): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 21
+        },
+        "end": {
+          "line": 6,
+          "character": 42
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1879,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "method",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "c.protectedStaticMethod",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 260,
+      "LSPosition": {
+        "line": 8,
+        "character": 13
+      },
+      "Name": "5",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) c.publicMethod(): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 8,
+          "character": 13
+        },
+        "end": {
+          "line": 8,
+          "character": 25
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "method",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "c.publicMethod",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 289,
+      "LSPosition": {
+        "line": 9,
+        "character": 13
+      },
+      "Name": "6",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) c.privateMethod(): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 9,
+          "character": 13
+        },
+        "end": {
+          "line": 9,
+          "character": 26
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1878,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "method",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "c.privateMethod",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 319,
+      "LSPosition": {
+        "line": 10,
+        "character": 13
+      },
+      "Name": "61",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) c.protectedMethod(): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 10,
+          "character": 13
+        },
+        "end": {
+          "line": 10,
+          "character": 28
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1879,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "method",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "c.protectedMethod",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 348,
+      "LSPosition": {
+        "line": 11,
+        "character": 10
+      },
+      "Name": "7",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) c.staticMethod(): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 11,
+          "character": 10
+        },
+        "end": {
+          "line": 11,
+          "character": 22
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "method",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "c.staticMethod",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 374,
+      "LSPosition": {
+        "line": 12,
+        "character": 10
+      },
+      "Name": "8",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) c.privateStaticMethod(): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 10
+        },
+        "end": {
+          "line": 12,
+          "character": 29
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1878,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "method",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "c.privateStaticMethod",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 407,
+      "LSPosition": {
+        "line": 13,
+        "character": 10
+      },
+      "Name": "81",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) c.protectedStaticMethod(): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 13,
+          "character": 10
+        },
+        "end": {
+          "line": 13,
+          "character": 31
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1879,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "method",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "c.protectedStaticMethod",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 465,
+      "LSPosition": {
+        "line": 17,
+        "character": 0
+      },
+      "Name": "9",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nvar cInstance: c\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 17,
+          "character": 0
+        },
+        "end": {
+          "line": 17,
+          "character": 9
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1747,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "var ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "local name",
+                "Text": "cInstance",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "class name",
+                "Text": "c",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 475,
+      "LSPosition": {
+        "line": 17,
+        "character": 10
+      },
+      "Name": "10",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) c.publicMethod(): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 17,
+          "character": 10
+        },
+        "end": {
+          "line": 17,
+          "character": 22
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "method",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "c.publicMethod",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 491,
+      "LSPosition": {
+        "line": 18,
+        "character": 0
+      },
+      "Name": "11",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nclass c\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 18,
+          "character": 0
+        },
+        "end": {
+          "line": 18,
+          "character": 1
+        }
+      },
+      "canIncreaseVerbosity": true,
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 473,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "class ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "class name",
+                "Text": "c",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 493,
+      "LSPosition": {
+        "line": 18,
+        "character": 2
+      },
+      "Name": "12",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(method) c.staticMethod(): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 18,
+          "character": 2
+        },
+        "end": {
+          "line": 18,
+          "character": 14
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "method",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "c.staticMethod",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  }
+]

--- a/testdata/baselines/reference/fourslash/vSQuickInfo/quickInfoDisplayPartsClassPropertyVS.baseline
+++ b/testdata/baselines/reference/fourslash/vSQuickInfo/quickInfoDisplayPartsClassPropertyVS.baseline
@@ -1,0 +1,1396 @@
+// === VSQuickInfo ===
+=== /quickInfoDisplayPartsClassPropertyVS.ts ===
+// class c {
+//     public publicProperty: string;
+//            ^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x984 }
+// |   ClassifiedTextElement
+// |     [punctuation] "("
+// |     [text] "property"
+// |     [punctuation] ") "
+// |     [property name] "c.publicProperty"
+// |     [punctuation] ": "
+// |     [keyword] "string"
+// | ----------------------------------------------------------------------
+//     private privateProperty: string;
+//             ^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x982 }
+// |   ClassifiedTextElement
+// |     [punctuation] "("
+// |     [text] "property"
+// |     [punctuation] ") "
+// |     [property name] "c.privateProperty"
+// |     [punctuation] ": "
+// |     [keyword] "string"
+// | ----------------------------------------------------------------------
+//     protected protectedProperty: string;
+//               ^^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x983 }
+// |   ClassifiedTextElement
+// |     [punctuation] "("
+// |     [text] "property"
+// |     [punctuation] ") "
+// |     [property name] "c.protectedProperty"
+// |     [punctuation] ": "
+// |     [keyword] "string"
+// | ----------------------------------------------------------------------
+//     static staticProperty: string;
+//            ^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x984 }
+// |   ClassifiedTextElement
+// |     [punctuation] "("
+// |     [text] "property"
+// |     [punctuation] ") "
+// |     [property name] "c.staticProperty"
+// |     [punctuation] ": "
+// |     [keyword] "string"
+// | ----------------------------------------------------------------------
+//     private static privateStaticProperty: string;
+//                    ^^^^^^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x982 }
+// |   ClassifiedTextElement
+// |     [punctuation] "("
+// |     [text] "property"
+// |     [punctuation] ") "
+// |     [property name] "c.privateStaticProperty"
+// |     [punctuation] ": "
+// |     [keyword] "string"
+// | ----------------------------------------------------------------------
+//     protected static protectedStaticProperty: string;
+//                      ^^^^^^^^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x983 }
+// |   ClassifiedTextElement
+// |     [punctuation] "("
+// |     [text] "property"
+// |     [punctuation] ") "
+// |     [property name] "c.protectedStaticProperty"
+// |     [punctuation] ": "
+// |     [keyword] "string"
+// | ----------------------------------------------------------------------
+//     method() {
+//         this.publicProperty;
+//              ^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x984 }
+// |   ClassifiedTextElement
+// |     [punctuation] "("
+// |     [text] "property"
+// |     [punctuation] ") "
+// |     [property name] "c.publicProperty"
+// |     [punctuation] ": "
+// |     [keyword] "string"
+// | ----------------------------------------------------------------------
+//         this.privateProperty;
+//              ^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x982 }
+// |   ClassifiedTextElement
+// |     [punctuation] "("
+// |     [text] "property"
+// |     [punctuation] ") "
+// |     [property name] "c.privateProperty"
+// |     [punctuation] ": "
+// |     [keyword] "string"
+// | ----------------------------------------------------------------------
+//         this.protectedProperty;
+//              ^^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x983 }
+// |   ClassifiedTextElement
+// |     [punctuation] "("
+// |     [text] "property"
+// |     [punctuation] ") "
+// |     [property name] "c.protectedProperty"
+// |     [punctuation] ": "
+// |     [keyword] "string"
+// | ----------------------------------------------------------------------
+//         c.staticProperty;
+//           ^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x984 }
+// |   ClassifiedTextElement
+// |     [punctuation] "("
+// |     [text] "property"
+// |     [punctuation] ") "
+// |     [property name] "c.staticProperty"
+// |     [punctuation] ": "
+// |     [keyword] "string"
+// | ----------------------------------------------------------------------
+//         c.privateStaticProperty;
+//           ^^^^^^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x982 }
+// |   ClassifiedTextElement
+// |     [punctuation] "("
+// |     [text] "property"
+// |     [punctuation] ") "
+// |     [property name] "c.privateStaticProperty"
+// |     [punctuation] ": "
+// |     [keyword] "string"
+// | ----------------------------------------------------------------------
+//         c.protectedStaticProperty;
+//           ^^^^^^^^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x983 }
+// |   ClassifiedTextElement
+// |     [punctuation] "("
+// |     [text] "property"
+// |     [punctuation] ") "
+// |     [property name] "c.protectedStaticProperty"
+// |     [punctuation] ": "
+// |     [keyword] "string"
+// | ----------------------------------------------------------------------
+//     }
+// }
+// var cInstance = new c();
+// cInstance.publicProperty;
+// ^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x6D3 }
+// |   ClassifiedTextElement
+// |     [keyword] "var "
+// |     [local name] "cInstance"
+// |     [punctuation] ": "
+// |     [class name] "c"
+// | ----------------------------------------------------------------------
+//           ^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x984 }
+// |   ClassifiedTextElement
+// |     [punctuation] "("
+// |     [text] "property"
+// |     [punctuation] ") "
+// |     [property name] "c.publicProperty"
+// |     [punctuation] ": "
+// |     [keyword] "string"
+// | ----------------------------------------------------------------------
+// c.staticProperty;
+// ^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x1D9 }
+// |   ClassifiedTextElement
+// |     [keyword] "class "
+// |     [class name] "c"
+// | ----------------------------------------------------------------------
+//   ^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x984 }
+// |   ClassifiedTextElement
+// |     [punctuation] "("
+// |     [text] "property"
+// |     [punctuation] ") "
+// |     [property name] "c.staticProperty"
+// |     [punctuation] ": "
+// |     [keyword] "string"
+// | ----------------------------------------------------------------------
+[
+  {
+    "marker": {
+      "Position": 21,
+      "LSPosition": {
+        "line": 1,
+        "character": 11
+      },
+      "Name": "1",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(property) c.publicProperty: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 1,
+          "character": 11
+        },
+        "end": {
+          "line": 1,
+          "character": 25
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 2436,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "property",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "property name",
+                "Text": "c.publicProperty",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 57,
+      "LSPosition": {
+        "line": 2,
+        "character": 12
+      },
+      "Name": "2",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(property) c.privateProperty: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 2,
+          "character": 12
+        },
+        "end": {
+          "line": 2,
+          "character": 27
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 2434,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "property",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "property name",
+                "Text": "c.privateProperty",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 96,
+      "LSPosition": {
+        "line": 3,
+        "character": 14
+      },
+      "Name": "21",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(property) c.protectedProperty: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 3,
+          "character": 14
+        },
+        "end": {
+          "line": 3,
+          "character": 31
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 2435,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "property",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "property name",
+                "Text": "c.protectedProperty",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 134,
+      "LSPosition": {
+        "line": 4,
+        "character": 11
+      },
+      "Name": "3",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(property) c.staticProperty: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 4,
+          "character": 11
+        },
+        "end": {
+          "line": 4,
+          "character": 25
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 2436,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "property",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "property name",
+                "Text": "c.staticProperty",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 177,
+      "LSPosition": {
+        "line": 5,
+        "character": 19
+      },
+      "Name": "4",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(property) c.privateStaticProperty: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 5,
+          "character": 19
+        },
+        "end": {
+          "line": 5,
+          "character": 40
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 2434,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "property",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "property name",
+                "Text": "c.privateStaticProperty",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 229,
+      "LSPosition": {
+        "line": 6,
+        "character": 21
+      },
+      "Name": "41",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(property) c.protectedStaticProperty: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 21
+        },
+        "end": {
+          "line": 6,
+          "character": 44
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 2435,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "property",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "property name",
+                "Text": "c.protectedStaticProperty",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 290,
+      "LSPosition": {
+        "line": 8,
+        "character": 13
+      },
+      "Name": "5",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(property) c.publicProperty: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 8,
+          "character": 13
+        },
+        "end": {
+          "line": 8,
+          "character": 27
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 2436,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "property",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "property name",
+                "Text": "c.publicProperty",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 319,
+      "LSPosition": {
+        "line": 9,
+        "character": 13
+      },
+      "Name": "6",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(property) c.privateProperty: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 9,
+          "character": 13
+        },
+        "end": {
+          "line": 9,
+          "character": 28
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 2434,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "property",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "property name",
+                "Text": "c.privateProperty",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 349,
+      "LSPosition": {
+        "line": 10,
+        "character": 13
+      },
+      "Name": "61",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(property) c.protectedProperty: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 10,
+          "character": 13
+        },
+        "end": {
+          "line": 10,
+          "character": 30
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 2435,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "property",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "property name",
+                "Text": "c.protectedProperty",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 378,
+      "LSPosition": {
+        "line": 11,
+        "character": 10
+      },
+      "Name": "7",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(property) c.staticProperty: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 11,
+          "character": 10
+        },
+        "end": {
+          "line": 11,
+          "character": 24
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 2436,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "property",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "property name",
+                "Text": "c.staticProperty",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 404,
+      "LSPosition": {
+        "line": 12,
+        "character": 10
+      },
+      "Name": "8",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(property) c.privateStaticProperty: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 10
+        },
+        "end": {
+          "line": 12,
+          "character": 31
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 2434,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "property",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "property name",
+                "Text": "c.privateStaticProperty",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 437,
+      "LSPosition": {
+        "line": 13,
+        "character": 10
+      },
+      "Name": "81",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(property) c.protectedStaticProperty: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 13,
+          "character": 10
+        },
+        "end": {
+          "line": 13,
+          "character": 33
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 2435,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "property",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "property name",
+                "Text": "c.protectedStaticProperty",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 495,
+      "LSPosition": {
+        "line": 17,
+        "character": 0
+      },
+      "Name": "9",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nvar cInstance: c\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 17,
+          "character": 0
+        },
+        "end": {
+          "line": 17,
+          "character": 9
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1747,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "var ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "local name",
+                "Text": "cInstance",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "class name",
+                "Text": "c",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 505,
+      "LSPosition": {
+        "line": 17,
+        "character": 10
+      },
+      "Name": "10",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(property) c.publicProperty: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 17,
+          "character": 10
+        },
+        "end": {
+          "line": 17,
+          "character": 24
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 2436,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "property",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "property name",
+                "Text": "c.publicProperty",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 521,
+      "LSPosition": {
+        "line": 18,
+        "character": 0
+      },
+      "Name": "11",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nclass c\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 18,
+          "character": 0
+        },
+        "end": {
+          "line": 18,
+          "character": 1
+        }
+      },
+      "canIncreaseVerbosity": true,
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 473,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "class ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "class name",
+                "Text": "c",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 523,
+      "LSPosition": {
+        "line": 18,
+        "character": 2
+      },
+      "Name": "12",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\n(property) c.staticProperty: string\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 18,
+          "character": 2
+        },
+        "end": {
+          "line": 18,
+          "character": 16
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 2436,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "text",
+                "Text": "property",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ") ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "property name",
+                "Text": "c.staticProperty",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ": ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  }
+]

--- a/testdata/baselines/reference/fourslash/vSQuickInfo/quickInfoDisplayPartsFunctionVS.baseline
+++ b/testdata/baselines/reference/fourslash/vSQuickInfo/quickInfoDisplayPartsFunctionVS.baseline
@@ -1,0 +1,2035 @@
+// === VSQuickInfo ===
+=== /quickInfoDisplayPartsFunctionVS.ts ===
+// function foo(param: string, optionalParam?: string, paramWithInitializer = "hello", ...restParam: string[]) {
+//          ^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x758 }
+// |   ClassifiedTextElement
+// |     [keyword] "function "
+// |     [method name] "foo"
+// |     [punctuation] "("
+// |     [parameter name] "param"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "string"
+// |     [punctuation] ","
+// |     [whitespace] " "
+// |     [parameter name] "optionalParam"
+// |     [punctuation] "?"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "string"
+// |     [punctuation] ","
+// |     [whitespace] " "
+// |     [parameter name] "paramWithInitializer"
+// |     [punctuation] "?"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "string"
+// |     [punctuation] ","
+// |     [whitespace] " "
+// |     [punctuation] "..."
+// |     [parameter name] "restParam"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "string"
+// |     [punctuation] "["
+// |     [punctuation] "]"
+// |     [punctuation] ")"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "void"
+// |     [punctuation] ";"
+// | ----------------------------------------------------------------------
+// }
+// function foowithoverload(a: string): string;
+//          ^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x758 }
+// |   ClassifiedTextElement
+// |     [keyword] "function "
+// |     [method name] "foowithoverload"
+// |     [punctuation] "("
+// |     [parameter name] "a"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "string"
+// |     [punctuation] ")"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "string"
+// |     [punctuation] ";"
+// | ----------------------------------------------------------------------
+// function foowithoverload(a: number): number;
+//          ^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x758 }
+// |   ClassifiedTextElement
+// |     [keyword] "function "
+// |     [method name] "foowithoverload"
+// |     [punctuation] "("
+// |     [parameter name] "a"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "number"
+// |     [punctuation] ")"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "number"
+// |     [punctuation] ";"
+// | ----------------------------------------------------------------------
+// function foowithoverload(a: any): any {
+//          ^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x758 }
+// |   ClassifiedTextElement
+// |     [keyword] "function "
+// |     [method name] "foowithoverload"
+// |     [punctuation] "("
+// |     [parameter name] "a"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "any"
+// |     [punctuation] ")"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "any"
+// |     [punctuation] ";"
+// | ----------------------------------------------------------------------
+//     return a;
+// }
+// function foowith3overload(a: string): string;
+//          ^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x758 }
+// |   ClassifiedTextElement
+// |     [keyword] "function "
+// |     [method name] "foowith3overload"
+// |     [punctuation] "("
+// |     [parameter name] "a"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "string"
+// |     [punctuation] ")"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "string"
+// |     [punctuation] ";"
+// | ----------------------------------------------------------------------
+// function foowith3overload(a: number): number;
+//          ^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x758 }
+// |   ClassifiedTextElement
+// |     [keyword] "function "
+// |     [method name] "foowith3overload"
+// |     [punctuation] "("
+// |     [parameter name] "a"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "number"
+// |     [punctuation] ")"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "number"
+// |     [punctuation] ";"
+// | ----------------------------------------------------------------------
+// function foowith3overload(a: boolean): boolean;
+//          ^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x758 }
+// |   ClassifiedTextElement
+// |     [keyword] "function "
+// |     [method name] "foowith3overload"
+// |     [punctuation] "("
+// |     [parameter name] "a"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "boolean"
+// |     [punctuation] ")"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "boolean"
+// |     [punctuation] ";"
+// | ----------------------------------------------------------------------
+// function foowith3overload(a: any): any {
+//          ^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x758 }
+// |   ClassifiedTextElement
+// |     [keyword] "function "
+// |     [method name] "foowith3overload"
+// |     [punctuation] "("
+// |     [parameter name] "a"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "any"
+// |     [punctuation] ")"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "any"
+// |     [punctuation] ";"
+// | ----------------------------------------------------------------------
+//     return a;
+// }
+// foo("hello");
+// ^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x758 }
+// |   ClassifiedTextElement
+// |     [keyword] "function "
+// |     [method name] "foo"
+// |     [punctuation] "("
+// |     [parameter name] "param"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "string"
+// |     [punctuation] ","
+// |     [whitespace] " "
+// |     [parameter name] "optionalParam"
+// |     [punctuation] "?"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "string"
+// |     [punctuation] ","
+// |     [whitespace] " "
+// |     [parameter name] "paramWithInitializer"
+// |     [punctuation] "?"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "string"
+// |     [punctuation] ","
+// |     [whitespace] " "
+// |     [punctuation] "..."
+// |     [parameter name] "restParam"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "string"
+// |     [punctuation] "["
+// |     [punctuation] "]"
+// |     [punctuation] ")"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "void"
+// |     [punctuation] ";"
+// | ----------------------------------------------------------------------
+// foowithoverload("hello");
+// ^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x758 }
+// |   ClassifiedTextElement
+// |     [keyword] "function "
+// |     [method name] "foowithoverload"
+// |     [punctuation] "("
+// |     [parameter name] "a"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "string"
+// |     [punctuation] ")"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "string"
+// |     [punctuation] ";"
+// | ----------------------------------------------------------------------
+// foowithoverload(10);
+// ^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x758 }
+// |   ClassifiedTextElement
+// |     [keyword] "function "
+// |     [method name] "foowithoverload"
+// |     [punctuation] "("
+// |     [parameter name] "a"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "number"
+// |     [punctuation] ")"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "number"
+// |     [punctuation] ";"
+// | ----------------------------------------------------------------------
+// foowith3overload("hello");
+// ^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x758 }
+// |   ClassifiedTextElement
+// |     [keyword] "function "
+// |     [method name] "foowith3overload"
+// |     [punctuation] "("
+// |     [parameter name] "a"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "string"
+// |     [punctuation] ")"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "string"
+// |     [punctuation] ";"
+// | ----------------------------------------------------------------------
+// foowith3overload(10);
+// ^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x758 }
+// |   ClassifiedTextElement
+// |     [keyword] "function "
+// |     [method name] "foowith3overload"
+// |     [punctuation] "("
+// |     [parameter name] "a"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "number"
+// |     [punctuation] ")"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "number"
+// |     [punctuation] ";"
+// | ----------------------------------------------------------------------
+// foowith3overload(true);
+// ^^^^^^^^^^^^^^^^
+// | ----------------------------------------------------------------------
+// | ContainerElement (Style=Wrapped)
+// |   ImageElement { Guid: ae27a6b0-e345-4288-96df-5eaf394ee369, Id: 0x758 }
+// |   ClassifiedTextElement
+// |     [keyword] "function "
+// |     [method name] "foowith3overload"
+// |     [punctuation] "("
+// |     [parameter name] "a"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "boolean"
+// |     [punctuation] ")"
+// |     [punctuation] ":"
+// |     [whitespace] " "
+// |     [keyword] "boolean"
+// |     [punctuation] ";"
+// | ----------------------------------------------------------------------
+[
+  {
+    "marker": {
+      "Position": 9,
+      "LSPosition": {
+        "line": 0,
+        "character": 9
+      },
+      "Name": "1",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foo(param: string, optionalParam?: string, paramWithInitializer?: string, ...restParam: string[]): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 9
+        },
+        "end": {
+          "line": 0,
+          "character": 12
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "function ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "foo",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "param",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ",",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "optionalParam",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "?",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ",",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "paramWithInitializer",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "?",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ",",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "...",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "restParam",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "[",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "]",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 121,
+      "LSPosition": {
+        "line": 2,
+        "character": 9
+      },
+      "Name": "2",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foowithoverload(a: string): string;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 2,
+          "character": 9
+        },
+        "end": {
+          "line": 2,
+          "character": 24
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "function ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "foowithoverload",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "a",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 166,
+      "LSPosition": {
+        "line": 3,
+        "character": 9
+      },
+      "Name": "3",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foowithoverload(a: number): number;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 3,
+          "character": 9
+        },
+        "end": {
+          "line": 3,
+          "character": 24
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "function ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "foowithoverload",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "a",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "number",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "number",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 211,
+      "LSPosition": {
+        "line": 4,
+        "character": 9
+      },
+      "Name": "4",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foowithoverload(a: any): any;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 4,
+          "character": 9
+        },
+        "end": {
+          "line": 4,
+          "character": 24
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "function ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "foowithoverload",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "a",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "any",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "any",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 267,
+      "LSPosition": {
+        "line": 7,
+        "character": 9
+      },
+      "Name": "5",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foowith3overload(a: string): string;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 7,
+          "character": 9
+        },
+        "end": {
+          "line": 7,
+          "character": 25
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "function ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "foowith3overload",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "a",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 313,
+      "LSPosition": {
+        "line": 8,
+        "character": 9
+      },
+      "Name": "6",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foowith3overload(a: number): number;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 8,
+          "character": 9
+        },
+        "end": {
+          "line": 8,
+          "character": 25
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "function ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "foowith3overload",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "a",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "number",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "number",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 359,
+      "LSPosition": {
+        "line": 9,
+        "character": 9
+      },
+      "Name": "7",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foowith3overload(a: boolean): boolean;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 9,
+          "character": 9
+        },
+        "end": {
+          "line": 9,
+          "character": 25
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "function ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "foowith3overload",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "a",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "boolean",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "boolean",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 407,
+      "LSPosition": {
+        "line": 10,
+        "character": 9
+      },
+      "Name": "8",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foowith3overload(a: any): any;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 10,
+          "character": 9
+        },
+        "end": {
+          "line": 10,
+          "character": 25
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "function ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "foowith3overload",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "a",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "any",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "any",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 455,
+      "LSPosition": {
+        "line": 13,
+        "character": 0
+      },
+      "Name": "9",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foo(param: string, optionalParam?: string, paramWithInitializer?: string, ...restParam: string[]): void;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 13,
+          "character": 0
+        },
+        "end": {
+          "line": 13,
+          "character": 3
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "function ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "foo",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "param",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ",",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "optionalParam",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "?",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ",",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "paramWithInitializer",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "?",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ",",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "...",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "restParam",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "[",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "]",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "void",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 469,
+      "LSPosition": {
+        "line": 14,
+        "character": 0
+      },
+      "Name": "10",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foowithoverload(a: string): string;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 14,
+          "character": 0
+        },
+        "end": {
+          "line": 14,
+          "character": 15
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "function ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "foowithoverload",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "a",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 495,
+      "LSPosition": {
+        "line": 15,
+        "character": 0
+      },
+      "Name": "11",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foowithoverload(a: number): number;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 15,
+          "character": 0
+        },
+        "end": {
+          "line": 15,
+          "character": 15
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "function ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "foowithoverload",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "a",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "number",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "number",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 516,
+      "LSPosition": {
+        "line": 16,
+        "character": 0
+      },
+      "Name": "12",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foowith3overload(a: string): string;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 16,
+          "character": 0
+        },
+        "end": {
+          "line": 16,
+          "character": 16
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "function ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "foowith3overload",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "a",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "string",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 543,
+      "LSPosition": {
+        "line": 17,
+        "character": 0
+      },
+      "Name": "13",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foowith3overload(a: number): number;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 17,
+          "character": 0
+        },
+        "end": {
+          "line": 17,
+          "character": 16
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "function ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "foowith3overload",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "a",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "number",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "number",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  },
+  {
+    "marker": {
+      "Position": 565,
+      "LSPosition": {
+        "line": 18,
+        "character": 0
+      },
+      "Name": "14",
+      "Data": {}
+    },
+    "item": {
+      "contents": {
+        "kind": "markdown",
+        "value": "```typescript\nfunction foowith3overload(a: boolean): boolean;\n```\n"
+      },
+      "range": {
+        "start": {
+          "line": 18,
+          "character": 0
+        },
+        "end": {
+          "line": 18,
+          "character": 16
+        }
+      },
+      "_vs_rawContent": {
+        "Style": 0,
+        "Elements": [
+          {
+            "ImageId": {
+              "Guid": "ae27a6b0-e345-4288-96df-5eaf394ee369",
+              "Id": 1880,
+              "_vs_type": "ImageId"
+            },
+            "_vs_type": "ImageElement"
+          },
+          {
+            "Runs": [
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "function ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "method name",
+                "Text": "foowith3overload",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": "(",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "parameter name",
+                "Text": "a",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "boolean",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ")",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ":",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "whitespace",
+                "Text": " ",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "keyword",
+                "Text": "boolean",
+                "_vs_type": "ClassifiedTextRun"
+              },
+              {
+                "ClassificationTypeName": "punctuation",
+                "Text": ";",
+                "_vs_type": "ClassifiedTextRun"
+              }
+            ],
+            "_vs_type": "ClassifiedTextElement"
+          }
+        ],
+        "_vs_type": "ContainerElement"
+      }
+    }
+  }
+]


### PR DESCRIPTION
Under Corsa (Native TS Preview), hover tooltips render as plain, uncolored Markdown — no symbol icon, no syntax coloring — unlike the legacy TSServer-backed hover, which VS renders as a rich icon + classified/colorized text via  Microsoft.VisualStudio.Text.Adornments  ( ImageElement  +  ClassifiedTextElement  wrapped in a  ContainerElement ).

This regression exists because Corsa's hover is served directly by tsgo's own LSP connection with no VS-specific adapter in between ( TypeScriptLanguageServerClient.cs  is a generic passthrough — there's no hover-specific C# code left for Corsa the way there was for the legacy Roslyn/TSServer path). Since there's no client-side code to add the icon/coloring after the fact, the only way to restore this is for the server (tsgo) to emit it directly.

Fixes AzDO bug 2800007 ("[Native TS Preview] Hover tooltip missing icon and classification coloring").

What this does

• Adds a VS-specific  _vs_rawContent  field to the  Hover  LSP response
• New types:  VSImageId ,  VSImageElement ,  VSContainerElement  (+  VSContainerElementStyle  enum for  Wrapped / Stacked ), all fully typed and roundtrippable — no raw-JSON escape hatches.
•  internal/ls/hovericon.go : maps a symbol's kind + modifiers (private/protected/public) to the matching VS  KnownImageIds  icon, mirroring what  TypeScript-VS 's legacy  ImageIdMapping.cs  does for the TSServer path. Values were extracted directly from the installed VS's  Microsoft.VisualStudio.ImageCatalog.dll  via  ildasm  (no NuGet/reflection path worked), not guessed.

What this intentionally doesn't do

• Icon selection stays server-side rather than moving to the VS client. The icon lookup (kind+modifiers → image ID) is a stateless table lookup that could live client-side, but computing the inputs ( kind ,  modifiers , alias resolution) genuinely requires checker/program state the client doesn't have, so splitting it further wasn't worth the complexity here.
