### PR TITLE
Handle extensionless root files gracefully instead of panicking

### DIFF
--- a/internal/compiler/fileloader.go
+++ b/internal/compiler/fileloader.go
@@ -214,6 +214,7 @@ func (p *fileLoader) addRootFileTask(fileName string, libFile *LibFile, includeR
 	}
 	if diagnostic != nil {
 		rootTask.normalizedFilePath = absPath
+		rootTask.failedLookup = true
 		rootTask.processingDiagnostics = []*processingDiagnostic{{
 			kind: processingDiagnosticKindExplainingFileInclude,
 			data: &includeExplainingDiagnostic{

--- a/internal/compiler/filesparser.go
+++ b/internal/compiler/filesparser.go
@@ -26,6 +26,7 @@ type parseTask struct {
 	loaded                      bool
 	startedSubTasks             bool
 	isForAutomaticTypeDirective bool
+	failedLookup                bool
 	includeReason               *FileIncludeReason
 	packageId                   module.PackageId
 
@@ -58,6 +59,11 @@ func (t *parseTask) load(loader *fileLoader) {
 	t.loaded = true
 	if t.isForAutomaticTypeDirective {
 		t.loadAutomaticTypeDirectives(loader)
+		return
+	}
+	if t.failedLookup {
+		// The root file name did not resolve to a supported extension; the task
+		// exists only to carry its processing diagnostic, so nothing is parsed.
 		return
 	}
 	if loader.opts.Tracing != nil {

--- a/internal/compiler/host.go
+++ b/internal/compiler/host.go
@@ -80,7 +80,7 @@ func (h *compilerHost) GetSourceFile(opts ast.SourceFileParseOptions) *ast.Sourc
 	if !ok {
 		return nil
 	}
-	return parser.ParseSourceFile(opts, text, core.GetScriptKindFromFileName(opts.FileName))
+	return parser.ParseSourceFile(opts, text, core.EnsureScriptKindFromFileName(opts.FileName))
 }
 
 func (h *compilerHost) GetResolvedProjectReference(fileName string, path tspath.Path) *tsoptions.ParsedCommandLine {

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -543,6 +543,16 @@ func GetScriptKindFromFileName(fileName string) ScriptKind {
 	return ScriptKindUnknown
 }
 
+// EnsureScriptKindFromFileName is like GetScriptKindFromFileName, but defaults to
+// ScriptKindTS when the file name has no recognized extension (e.g. files included
+// with allowNonTsExtensions), so the result is always safe to hand to the parser.
+func EnsureScriptKindFromFileName(fileName string) ScriptKind {
+	if kind := GetScriptKindFromFileName(fileName); kind != ScriptKindUnknown {
+		return kind
+	}
+	return ScriptKindTS
+}
+
 // Given a name and a list of names that are *not* equal to the name, return a spelling suggestion if there is one that is close enough.
 // Names less than length 3 only check for case-insensitive equality.
 //

--- a/internal/execute/tsctests/tsc_test.go
+++ b/internal/execute/tsctests/tsc_test.go
@@ -274,6 +274,25 @@ func TestTscMissingFiles(t *testing.T) {
 			commandLineArgs: []string{"-p", "./tsconfig.json"},
 		},
 		{
+			subScenario: "extensionless file in tsconfig exists",
+			files: FileMap{
+				"/home/src/workspaces/project/tsconfig.json": stringtestutil.Dedent(
+					`{
+					"files": ["./src/script"]
+					}`,
+				),
+				"/home/src/workspaces/project/src/script": `const n: number = "s";`,
+			},
+			commandLineArgs: []string{"-p", "./tsconfig.json"},
+		},
+		{
+			subScenario: "extensionless file on command line exists",
+			files: FileMap{
+				"/home/src/workspaces/project/script": `const n: number = "s";`,
+			},
+			commandLineArgs: []string{"script"},
+		},
+		{
 			subScenario: "extensionless file in extended tsconfig in different folder does not exist",
 			files: FileMap{
 				"/home/src/workspaces/project/src/tsconfig.json": stringtestutil.Dedent(

--- a/internal/fourslash/tests/goToSourceDefinitionExtensionlessMappedSource_test.go
+++ b/internal/fourslash/tests/goToSourceDefinitionExtensionlessMappedSource_test.go
@@ -1,0 +1,29 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+// A declaration map can name anything in its `sources`, including a file whose
+// name has no recognized extension. Parsing that file used to hit the parser's
+// "ScriptKind must be specified" assert and crash the request.
+func TestGoToSourceDefinitionExtensionlessMappedSource(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `// @Filename: /lib/helper.d.ts
+export declare function helper(): string;
+//# sourceMappingURL=helper.d.ts.map
+// @Filename: /lib/helper.d.ts.map
+{"version":3,"file":"helper.d.ts","sourceRoot":"","sources":["helper"],"names":[],"mappings":"AAAA,wBAAgB,MAAM,IAAI,MAAM,CAAC"}
+// @Filename: /lib/helper
+export function helper(): string { return ""; }
+// @Filename: /index.ts
+import { /*usage*/helper } from "./lib/helper";
+helper();`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineGoToSourceDefinition(t, "usage")
+}

--- a/internal/ls/sourcedefinition.go
+++ b/internal/ls/sourcedefinition.go
@@ -421,7 +421,9 @@ func (r *sourceDefResolver) getOrParseSourceFile(fileName string) *ast.SourceFil
 		sourceFile = parser.ParseSourceFile(
 			ast.SourceFileParseOptions{FileName: fileName, Path: r.ls.toPath(fileName)},
 			text,
-			core.GetScriptKindFromFileName(fileName),
+			// A declaration map's `sources` entries are arbitrary strings, so the
+			// file name here may not have a recognized extension.
+			core.EnsureScriptKindFromFileName(fileName),
 		)
 		binder.BindSourceFile(sourceFile)
 	}

--- a/internal/project/overlayfs.go
+++ b/internal/project/overlayfs.go
@@ -99,7 +99,7 @@ func (f *diskFile) IsOverlay() bool {
 }
 
 func (f *diskFile) Kind() core.ScriptKind {
-	return core.GetScriptKindFromFileName(f.fileName)
+	return core.EnsureScriptKindFromFileName(f.fileName)
 }
 
 func (f *diskFile) Clone() *diskFile {
@@ -312,7 +312,7 @@ func (fs *overlayFS) processChanges(changes []FileChange) (FileChangeSummary, ma
 			}
 			scriptKind := lsconv.LanguageKindToScriptKind(events.openChange.LanguageKind)
 			if scriptKind == core.ScriptKindUnknown {
-				scriptKind = core.GetScriptKindFromFileName(uri.FileName())
+				scriptKind = core.EnsureScriptKindFromFileName(uri.FileName())
 			}
 			newOverlays[path] = newOverlay(
 				uri.FileName(),

--- a/internal/project/overlayfs_test.go
+++ b/internal/project/overlayfs_test.go
@@ -17,6 +17,7 @@ func TestProcessChanges(t *testing.T) {
 		testFS := vfstest.FromMap(map[string]string{
 			"/test1.ts": "// existing content",
 			"/test2.ts": "// existing content",
+			"/script":   "// extensionless content",
 		}, false /* useCaseSensitiveFileNames */)
 		return newOverlayFS(
 			testFS,
@@ -179,6 +180,35 @@ func TestProcessChanges(t *testing.T) {
 		})
 
 		fh := fs.getFile(uri.FileName())
+		assert.Assert(t, fh != nil)
+		assert.Equal(t, fh.Kind(), core.ScriptKindTS)
+	})
+
+	t.Run("open extensionless file with unknown language kind falls back to TS", func(t *testing.T) {
+		t.Parallel()
+		fs := createOverlayFS()
+		uri := lsproto.DocumentUri("file:///script")
+
+		fs.processChanges([]FileChange{
+			{
+				Kind:         FileChangeKindOpen,
+				URI:          uri,
+				Version:      1,
+				Content:      "const x = 1;",
+				LanguageKind: lsproto.LanguageKind("plaintext"),
+			},
+		})
+
+		fh := fs.getFile(uri.FileName())
+		assert.Assert(t, fh != nil)
+		assert.Equal(t, fh.Kind(), core.ScriptKindTS)
+	})
+
+	t.Run("extensionless disk file falls back to TS", func(t *testing.T) {
+		t.Parallel()
+		fs := createOverlayFS()
+
+		fh := fs.getFile("/script")
 		assert.Assert(t, fh != nil)
 		assert.Equal(t, fh.Kind(), core.ScriptKindTS)
 	})

--- a/internal/project/session_test.go
+++ b/internal/project/session_test.go
@@ -111,6 +111,27 @@ func TestSession(t *testing.T) {
 			program := ls.GetProgram()
 			assert.Assert(t, program.GetSourceFile("/home/projects/TS/p1/index.js") != nil)
 		})
+
+		t.Run("inferred project extensionless file", func(t *testing.T) {
+			t.Parallel()
+			files := map[string]any{
+				"/home/projects/TS/p1/script": `const x = 1;`,
+			}
+			session, _ := projecttestutil.Setup(files)
+
+			session.DidOpenFile(context.Background(), "file:///home/projects/TS/p1/script", 1, files["/home/projects/TS/p1/script"].(string), lsproto.LanguageKind("plaintext"))
+
+			snapshot := session.Snapshot()
+			assert.Equal(t, len(snapshot.ProjectCollection.Projects()), 1)
+			assert.Assert(t, snapshot.ProjectCollection.InferredProject() != nil)
+
+			ls, err := session.GetLanguageService(context.Background(), "file:///home/projects/TS/p1/script")
+			assert.NilError(t, err)
+			program := ls.GetProgram()
+			file := program.GetSourceFile("/home/projects/TS/p1/script")
+			assert.Assert(t, file != nil)
+			assert.Equal(t, file.ScriptKind, core.ScriptKindTS)
+		})
 	})
 
 	t.Run("watchChange and didOpen in same batch rebuilds program", func(t *testing.T) {

--- a/testdata/baselines/reference/fourslash/goToSourceDefinition/goToSourceDefinitionExtensionlessMappedSource.baseline.jsonc
+++ b/testdata/baselines/reference/fourslash/goToSourceDefinition/goToSourceDefinitionExtensionlessMappedSource.baseline.jsonc
@@ -1,0 +1,7 @@
+// === goToSourceDefinition ===
+// === /lib/helper ===
+// <|export function [|helper|](): string { return ""; }|>
+
+// === /index.ts ===
+// import { /*GOTO SOURCE DEF*/helper } from "./lib/helper";
+// helper();

--- a/testdata/baselines/reference/tsc/commandLine/extensionless-file-in-tsconfig-exists.js
+++ b/testdata/baselines/reference/tsc/commandLine/extensionless-file-in-tsconfig-exists.js
@@ -1,0 +1,47 @@
+currentDirectory::/home/src/workspaces/project
+useCaseSensitiveFileNames::true
+Input::
+//// [/home/src/workspaces/project/src/script] *new* 
+const n: number = "s";
+//// [/home/src/workspaces/project/tsconfig.json] *new* 
+{
+                    "files": ["./src/script"]
+                    }
+
+tsgo -p ./tsconfig.json
+ExitStatus:: DiagnosticsPresent_OutputsGenerated
+Output::
+[91merror[0m[90m TS6231: [0mCould not resolve the path '/home/src/workspaces/project/src/script' with the extensions: '.ts', '.tsx', '.d.ts', '.cts', '.d.cts', '.mts', '.d.mts'.
+  The file is in the program because:
+    Part of 'files' list in tsconfig.json
+  [96mtsconfig.json[0m:[93m2[0m:[93m31[0m - File is matched by 'files' list specified here.
+    [7m2[0m                     "files": ["./src/script"]
+    [7m [0m [96m                              ~~~~~~~~~~~~~~[0m
+
+
+Found 1 error.
+
+//// [/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts] *Lib*
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+interface SymbolConstructor {
+    (desc?: string | number): symbol;
+    for(name: string): symbol;
+    readonly toStringTag: symbol;
+}
+declare var Symbol: SymbolConstructor;
+interface Symbol {
+    readonly [Symbol.toStringTag]: string;
+}
+declare const console: { log(msg: any): void; };
+

--- a/testdata/baselines/reference/tsc/commandLine/extensionless-file-on-command-line-exists.js
+++ b/testdata/baselines/reference/tsc/commandLine/extensionless-file-on-command-line-exists.js
@@ -1,0 +1,39 @@
+currentDirectory::/home/src/workspaces/project
+useCaseSensitiveFileNames::true
+Input::
+//// [/home/src/workspaces/project/script] *new* 
+const n: number = "s";
+
+tsgo script
+ExitStatus:: DiagnosticsPresent_OutputsGenerated
+Output::
+[91merror[0m[90m TS6231: [0mCould not resolve the path 'script' with the extensions: '.ts', '.tsx', '.d.ts', '.cts', '.d.cts', '.mts', '.d.mts'.
+  The file is in the program because:
+    Root file specified for compilation
+
+Found 1 error.
+
+//// [/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts] *Lib*
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+interface SymbolConstructor {
+    (desc?: string | number): symbol;
+    for(name: string): symbol;
+    readonly toStringTag: symbol;
+}
+declare var Symbol: SymbolConstructor;
+interface Symbol {
+    readonly [Symbol.toStringTag]: string;
+}
+declare const console: { log(msg: any): void; };
+


### PR DESCRIPTION
Fixes #4609

Any root file whose name has no extension crashed the compiler with a Go panic (`ScriptKind must be specified when parsing source file`) when the file exists on disk — from the CLI, from a tsconfig `files` entry, and through the LSP/API session path. TypeScript 6 rejects the same inputs gracefully with `TS6231`.

### Root cause

Two related gaps:

1. In the compiler, `addRootFileTask` already produced the correct `TS6231` diagnostic when an extensionless root file failed extension resolution, but still created a parse task for the unresolved path. `parseTask.load` only rejects *unsupported* extensions, not *missing* ones, so when the extensionless file existed it reached the parser with `ScriptKindUnknown` and hit the parser's assert.

2. Files that are legitimately included without a recognized extension (inferred projects force `allowNonTsExtensions`, so any extensionless open file qualifies) derive their script kind from the file name, which yields `Unknown` and reached the parser via the compiler host, `diskFile.Kind()`, or overlay creation. TypeScript 6's `ensureScriptKind` defaults unknown kinds to TS at the parse boundary; tsgo had no equivalent.

### Fix

- Root file tasks whose name fails extension resolution no longer parse the file; the task only carries its processing diagnostic. `tsc script` now reports `TS6231: Could not resolve the path 'script' with the extensions: ...` exactly like TypeScript 6.
- Added `core.EnsureScriptKindFromFileName` (unknown → TS, mirroring `ensureScriptKind` in strada) and used it at the three parse boundaries: `compilerHost.GetSourceFile`, `diskFile.Kind()`, and LSP overlay creation. The overlay change also means an unrecognized `languageId` combined with an extensionless file name can no longer reach the assert.

This may also address #4267, whose reported stack matches the project-path variant here.

### Tests

- Two new tsc baseline scenarios (`extensionless file in tsconfig exists`, `extensionless file on command line exists`) — both panicked before this change; the baselines now show the `TS6231` output matching TypeScript 6.
- `overlayfs` unit tests pinning the TS fallback for extensionless disk files and for overlays opened with an unknown language kind.
- An end-to-end session test opening an extensionless file in an inferred project and checking it is parsed as TS.

### Disclosure

Per the contributing guidelines: this patch was authored with AI assistance. I have read and understand the changes, and I will respond to review feedback myself.