### PR TITLE
Skip project recheck for no-op file watch events

### DIFF
--- a/internal/project/snapshot.go
+++ b/internal/project/snapshot.go
@@ -306,7 +306,7 @@ func (s *Snapshot) Clone(ctx context.Context, change SnapshotChange, overlays ma
 	} else {
 		change.fileChanges = fs.expandAndFilterWatchEvents(change.fileChanges)
 		change.fileChanges = s.fs.expandRealpathAliases(change.fileChanges)
-		fs.markDirtyFiles(change.fileChanges)
+		change.fileChanges = fs.markDirtyFiles(change.fileChanges)
 		change.fileChanges = fs.convertOpenAndCloseToChanges(change.fileChanges)
 	}
 

--- a/internal/project/snapshot_test.go
+++ b/internal/project/snapshot_test.go
@@ -234,6 +234,56 @@ func TestSnapshot(t *testing.T) {
 		session.WaitForBackgroundTasks()
 		assert.Equal(t, session.Snapshot(), preparedSnapshot)
 	})
+
+	t.Run("no-op watch change does not rebuild program", func(t *testing.T) {
+		t.Parallel()
+		files := map[string]any{
+			"/home/projects/TS/p1/tsconfig.json": "{}",
+			"/home/projects/TS/p1/index.ts":      "import { a } from './a'; console.log(a);",
+			"/home/projects/TS/p1/a.ts":          "export const a = 1;",
+		}
+		session := setup(files)
+		t.Cleanup(session.Close)
+		ctx := context.Background()
+		uri := lsproto.DocumentUri("file:///home/projects/TS/p1/index.ts")
+		configPath := tspath.Path("/home/projects/ts/p1/tsconfig.json")
+
+		session.DidOpenFile(ctx, uri, 1, files["/home/projects/TS/p1/index.ts"].(string), lsproto.LanguageKindTypeScript)
+		_, err := session.GetLanguageService(ctx, uri)
+		assert.NilError(t, err)
+
+		programBefore := session.Snapshot().ProjectCollection.ConfiguredProject(configPath).Program
+
+		// Send a watch change event for a project file whose content on disk is unchanged.
+		// This should not invalidate the program or trigger a recheck.
+		session.pendingFileChangesMu.Lock()
+		session.pendingFileChanges = append(session.pendingFileChanges, FileChange{
+			Kind: FileChangeKindWatchChange,
+			URI:  "file:///home/projects/TS/p1/a.ts",
+		})
+		session.pendingFileChangesMu.Unlock()
+		_, err = session.GetLanguageService(ctx, uri)
+		assert.NilError(t, err)
+
+		programAfter := session.Snapshot().ProjectCollection.ConfiguredProject(configPath).Program
+		assert.Equal(t, programBefore, programAfter, "no-op watch change should not rebuild the program")
+
+		// A watch change that reflects an actual content change on disk must still
+		// rebuild the program.
+		err = session.fs.fs.WriteFile("/home/projects/TS/p1/a.ts", "export const a = 2;")
+		assert.NilError(t, err)
+		session.pendingFileChangesMu.Lock()
+		session.pendingFileChanges = append(session.pendingFileChanges, FileChange{
+			Kind: FileChangeKindWatchChange,
+			URI:  "file:///home/projects/TS/p1/a.ts",
+		})
+		session.pendingFileChangesMu.Unlock()
+		_, err = session.GetLanguageService(ctx, uri)
+		assert.NilError(t, err)
+
+		programChanged := session.Snapshot().ProjectCollection.ConfiguredProject(configPath).Program
+		assert.Assert(t, programBefore != programChanged, "real watch change should rebuild the program")
+	})
 }
 
 func BenchmarkSnapshotCloneRefCost(b *testing.B) {

--- a/internal/project/snapshotfs.go
+++ b/internal/project/snapshotfs.go
@@ -527,7 +527,8 @@ func (s *snapshotFSBuilder) reloadEntryIfContentChanged(entry *dirty.SyncMapEntr
 		})
 		return true
 	}
-	if xxh3.HashString128(content) == cachedHash {
+	newHash := xxh3.HashString128(content)
+	if newHash == cachedHash {
 		entry.Locked(func(e dirty.Value[*diskFile]) {
 			if e.Value() != nil && !e.Value().MatchesDiskText() {
 				e.Change(func(file *diskFile) {
@@ -543,7 +544,7 @@ func (s *snapshotFSBuilder) reloadEntryIfContentChanged(entry *dirty.SyncMapEntr
 		}
 		e.Change(func(file *diskFile) {
 			file.content = content
-			file.hash = xxh3.HashString128(content)
+			file.hash = newHash
 			file.needsReload = false
 		})
 	})

--- a/internal/project/snapshotfs.go
+++ b/internal/project/snapshotfs.go
@@ -479,7 +479,8 @@ func (s *snapshotFSBuilder) invalidateNodeModulesCache() {
 
 func (s *snapshotFSBuilder) markDirtyFiles(change FileChangeSummary) FileChangeSummary {
 	if change.Changed.Len() > 0 {
-		var filteredChanged collections.Set[lsproto.DocumentUri]
+		var filteredChanged collections.SyncSet[lsproto.DocumentUri]
+		wg := core.NewWorkGroup(false)
 		for uri := range change.Changed.Keys() {
 			path := s.toPath(uri.FileName())
 			if _, ok := s.overlays[path]; ok {
@@ -491,11 +492,18 @@ func (s *snapshotFSBuilder) markDirtyFiles(change FileChangeSummary) FileChangeS
 				filteredChanged.Add(uri)
 				continue
 			}
-			if s.reloadEntryIfContentChanged(entry) {
-				filteredChanged.Add(uri)
-			}
+			wg.Queue(func() {
+				if s.reloadEntryIfContentChanged(entry) {
+					filteredChanged.Add(uri)
+				}
+			})
 		}
-		change.Changed = filteredChanged
+		wg.RunAndWait()
+		newChanged := collections.NewSetWithSizeHint[lsproto.DocumentUri](filteredChanged.Size())
+		for uri := range filteredChanged.Keys() {
+			newChanged.Add(uri)
+		}
+		change.Changed = *newChanged
 	}
 	for uri := range change.Deleted.Keys() {
 		path := s.toPath(uri.FileName())
@@ -507,48 +515,37 @@ func (s *snapshotFSBuilder) markDirtyFiles(change FileChangeSummary) FileChangeS
 }
 
 func (s *snapshotFSBuilder) reloadEntryIfContentChanged(entry *dirty.SyncMapEntry[tspath.Path, *diskFile]) (changed bool) {
-	var fileName string
-	var cachedHash xxh3.Uint128
+	file := entry.Value()
+	if file == nil {
+		return true
+	}
+	content, ok := s.fs.ReadFile(file.fileName)
+	changed = true
 	entry.Locked(func(e dirty.Value[*diskFile]) {
-		if e.Value() != nil {
-			fileName = e.Value().fileName
-			cachedHash = e.Value().hash
+		cur := e.Value()
+		if cur == nil {
+			return
 		}
-	})
-	if fileName == "" {
-		return true
-	}
-	content, ok := s.fs.ReadFile(fileName)
-	if !ok {
-		entry.Locked(func(e dirty.Value[*diskFile]) {
-			if e.Value() != nil {
-				e.Delete()
-			}
-		})
-		return true
-	}
-	newHash := xxh3.HashString128(content)
-	if newHash == cachedHash {
-		entry.Locked(func(e dirty.Value[*diskFile]) {
-			if e.Value() != nil && !e.Value().MatchesDiskText() {
+		if !ok {
+			e.Delete()
+			return
+		}
+		if content == cur.content {
+			changed = false
+			if !cur.MatchesDiskText() {
 				e.Change(func(file *diskFile) {
 					file.needsReload = false
 				})
 			}
-		})
-		return false
-	}
-	entry.Locked(func(e dirty.Value[*diskFile]) {
-		if e.Value() == nil {
 			return
 		}
 		e.Change(func(file *diskFile) {
 			file.content = content
-			file.hash = newHash
+			file.hash = xxh3.HashString128(content)
 			file.needsReload = false
 		})
 	})
-	return true
+	return changed
 }
 
 // expandRealpathAliases adds synthetic URIs to the Changed and Deleted sets for

--- a/internal/project/snapshotfs.go
+++ b/internal/project/snapshotfs.go
@@ -477,14 +477,25 @@ func (s *snapshotFSBuilder) invalidateNodeModulesCache() {
 	})
 }
 
-func (s *snapshotFSBuilder) markDirtyFiles(change FileChangeSummary) {
-	for uri := range change.Changed.Keys() {
-		path := s.toPath(uri.FileName())
-		if entry, ok := s.diskFiles.Load(path); ok {
-			entry.Change(func(file *diskFile) {
-				file.needsReload = true
-			})
+func (s *snapshotFSBuilder) markDirtyFiles(change FileChangeSummary) FileChangeSummary {
+	if change.Changed.Len() > 0 {
+		var filteredChanged collections.Set[lsproto.DocumentUri]
+		for uri := range change.Changed.Keys() {
+			path := s.toPath(uri.FileName())
+			if _, ok := s.overlays[path]; ok {
+				filteredChanged.Add(uri)
+				continue
+			}
+			entry, ok := s.diskFiles.Load(path)
+			if !ok {
+				filteredChanged.Add(uri)
+				continue
+			}
+			if s.reloadEntryIfContentChanged(entry) {
+				filteredChanged.Add(uri)
+			}
 		}
+		change.Changed = filteredChanged
 	}
 	for uri := range change.Deleted.Keys() {
 		path := s.toPath(uri.FileName())
@@ -492,6 +503,51 @@ func (s *snapshotFSBuilder) markDirtyFiles(change FileChangeSummary) {
 			entry.Delete()
 		}
 	}
+	return change
+}
+
+func (s *snapshotFSBuilder) reloadEntryIfContentChanged(entry *dirty.SyncMapEntry[tspath.Path, *diskFile]) (changed bool) {
+	var fileName string
+	var cachedHash xxh3.Uint128
+	entry.Locked(func(e dirty.Value[*diskFile]) {
+		if e.Value() != nil {
+			fileName = e.Value().fileName
+			cachedHash = e.Value().hash
+		}
+	})
+	if fileName == "" {
+		return true
+	}
+	content, ok := s.fs.ReadFile(fileName)
+	if !ok {
+		entry.Locked(func(e dirty.Value[*diskFile]) {
+			if e.Value() != nil {
+				e.Delete()
+			}
+		})
+		return true
+	}
+	if xxh3.HashString128(content) == cachedHash {
+		entry.Locked(func(e dirty.Value[*diskFile]) {
+			if e.Value() != nil && !e.Value().MatchesDiskText() {
+				e.Change(func(file *diskFile) {
+					file.needsReload = false
+				})
+			}
+		})
+		return false
+	}
+	entry.Locked(func(e dirty.Value[*diskFile]) {
+		if e.Value() == nil {
+			return
+		}
+		e.Change(func(file *diskFile) {
+			file.content = content
+			file.hash = xxh3.HashString128(content)
+			file.needsReload = false
+		})
+	})
+	return true
 }
 
 // expandRealpathAliases adds synthetic URIs to the Changed and Deleted sets for


### PR DESCRIPTION
Fixes #4595
Fixes #4593

When the editor sends a `workspace/didChangeWatchFiles` event for a project file, the server marks the file dirty and invalidates the type-check state without checking whether the file has actually changed. This fix addresses two bugs - first, a file with byte-identical content or an event fired with no disk write costs a full program re-check (#4593). Second, watch events arrive in batches, and each separate batch invalidates state and triggers `workspace/diagnostic/refresh`, which cancels the in-flight diagnostic pull and reissues it. Each fresh re-check takes longer than the gap between batches, leading to the check/cancel/recheck storm (#4595).