### PR TITLE
[api] Use super(length) to avoid RemoteNodeArray array subclass deopt

### DIFF
--- a/_packages/native-preview/src/api/node/node.generated.ts
+++ b/_packages/native-preview/src/api/node/node.generated.ts
@@ -74,13 +74,12 @@ export class RemoteNodeList extends Array<RemoteNode> implements NodeArray<Remot
     private sourceFile: SourceFileInfo;
 
     constructor(view: DataView, index: number, parent: RemoteNode, sourceFile: SourceFileInfo, offsetNodes: number) {
-        super();
+        super(view.getUint32(offsetNodes + index * NODE_LEN + NODE_OFFSET_DATA, true));
         this.view = view;
         this.index = index;
         this.parent = parent;
         this.sourceFile = sourceFile;
         this._byteIndex = offsetNodes + index * NODE_LEN;
-        this.length = this.data;
         this._cursorNodeIndex = index + 1;
 
         const length = this.length;

--- a/_scripts/generate-encoder.ts
+++ b/_scripts/generate-encoder.ts
@@ -1549,13 +1549,12 @@ function emitRemoteNodeList(w: CodeWriter) {
     w.write(`    private sourceFile: SourceFileInfo;`);
     w.write(``);
     w.write(`    constructor(view: DataView, index: number, parent: RemoteNode, sourceFile: SourceFileInfo, offsetNodes: number) {`);
-    w.write(`        super();`);
+    w.write(`        super(view.getUint32(offsetNodes + index * NODE_LEN + NODE_OFFSET_DATA, true));`);
     w.write(`        this.view = view;`);
     w.write(`        this.index = index;`);
     w.write(`        this.parent = parent;`);
     w.write(`        this.sourceFile = sourceFile;`);
     w.write(`        this._byteIndex = offsetNodes + index * NODE_LEN;`);
-    w.write(`        this.length = this.data;`);
     w.write(`        this._cursorNodeIndex = index + 1;`);
     w.write(``);
     w.write(`        const length = this.length;`);


### PR DESCRIPTION
This makes the materialization benchmarks ~30% faster:

Scenario | Before | After | Speedup
-- | -- | -- | --
materialize program.ts | 693 ops/s | 960 ops/s | ~1.39×
materialize checker.ts | 48 ops/s | 62 ops/s | ~1.29×
