### PR TITLE
fix: include static private identifier properties in matching

### DIFF
--- a/internal/checker/relater.go
+++ b/internal/checker/relater.go
@@ -986,7 +986,6 @@ func (c *Checker) getUnmatchedPropertiesWorker(source *Type, target *Type, requi
 	for _, targetProp := range properties {
 		// TODO: remove this when we support static private identifier fields and find other solutions to get privateNamesAndStaticFields test to pass
 		if isStaticPrivateIdentifierProperty(targetProp) {
-			continue
 		}
 		if requireOptionalProperties || targetProp.Flags&ast.SymbolFlagsOptional == 0 && targetProp.CheckFlags&ast.CheckFlagsPartial == 0 {
 			sourceProp := c.getPropertyOfType(source, targetProp.Name)


### PR DESCRIPTION
Removed the early continue for static private identifier properties in relater.go.

This allows static private identifier properties to participate in property matching inside getUnmatchedPropertiesWorker, addressing the behavior observed with privateNamesAndStaticFields cases.

Further adjustments may be needed depending on the intended checker behavior.