### PR TITLE
Fix compiler panic on arrow function visibility diagnostics (Fixes #4629)

### DIFF
--- a/internal/transformers/declarations/diagnostics.go
+++ b/internal/transformers/declarations/diagnostics.go
@@ -21,10 +21,16 @@ func wrapSimpleDiagnosticSelector(node *ast.Node, selector func(node *ast.Node, 
 		if diagnosticMessage == nil {
 			return nil
 		}
+
+		typeName := ast.GetNameOfDeclaration(node)
+		if typeName == nil {
+			typeName = node // Fallback ensures we always have a node for diagnostic formatting (avoids missing-argument panics).
+		}
+
 		return &SymbolAccessibilityDiagnostic{
 			errorNode:         node,
 			diagnosticMessage: diagnosticMessage,
-			typeName:          ast.GetNameOfDeclaration(node),
+			typeName:          typeName,
 		}
 	}
 }
@@ -137,6 +143,14 @@ func getMethodNameVisibilityDiagnosticMessage(node *ast.Node, symbolAccessibilit
 }
 
 func createGetSymbolAccessibilityDiagnosticForNode(node *ast.Node) GetSymbolAccessibilityDiagnostic {
+	// Arrow functions and their parameters do not emit visibility diagnostics directly.
+	// We catch them here to prevent routing them to handlers that will panic.
+	if node.Kind == ast.KindArrowFunction || (node.Parent != nil && node.Parent.Kind == ast.KindArrowFunction) {
+		return func(printer.SymbolAccessibilityResult) *SymbolAccessibilityDiagnostic {
+			return nil
+		}
+	}
+
 	if ast.IsVariableDeclaration(node) || ast.IsPropertyDeclaration(node) || ast.IsPropertySignatureDeclaration(node) || ast.IsPropertyAccessExpression(node) || ast.IsElementAccessExpression(node) || ast.IsBinaryExpression(node) || ast.IsBindingElement(node) || ast.IsConstructorDeclaration(node) {
 		return wrapSimpleDiagnosticSelector(node, getVariableDeclarationTypeVisibilityDiagnosticMessage)
 	} else if ast.IsSetAccessorDeclaration(node) || ast.IsGetAccessorDeclaration(node) {

--- a/testdata/baselines/reference/compiler/arrowFunctionVisibilityPanic.errors.txt
+++ b/testdata/baselines/reference/compiler/arrowFunctionVisibilityPanic.errors.txt
@@ -1,0 +1,16 @@
+arrowFunctionVisibilityPanic.ts(5,14): error TS4025: Exported variable 'funcWithPrivateParam' has or is using private name 'PrivateType'.
+
+
+==== arrowFunctionVisibilityPanic.ts (1 errors) ====
+    // Regression test for #4629
+    // This forces the compiler to trigger a symbol-accessibility diagnostic 
+    // for an ArrowFunction by using a locally scoped (unnameable) type.
+    
+    export const funcWithPrivateParam = (() => {
+                 ~~~~~~~~~~~~~~~~~~~~
+!!! error TS4025: Exported variable 'funcWithPrivateParam' has or is using private name 'PrivateType'.
+        interface PrivateType {
+            secret: string;
+        }
+        return (p: PrivateType) => p;
+    })();

--- a/testdata/baselines/reference/compiler/arrowFunctionVisibilityPanic.js
+++ b/testdata/baselines/reference/compiler/arrowFunctionVisibilityPanic.js
@@ -1,0 +1,21 @@
+//// [tests/cases/compiler/arrowFunctionVisibilityPanic.ts] ////
+
+//// [arrowFunctionVisibilityPanic.ts]
+// Regression test for #4629
+// This forces the compiler to trigger a symbol-accessibility diagnostic 
+// for an ArrowFunction by using a locally scoped (unnameable) type.
+
+export const funcWithPrivateParam = (() => {
+    interface PrivateType {
+        secret: string;
+    }
+    return (p: PrivateType) => p;
+})();
+
+//// [arrowFunctionVisibilityPanic.js]
+// Regression test for #4629
+// This forces the compiler to trigger a symbol-accessibility diagnostic 
+// for an ArrowFunction by using a locally scoped (unnameable) type.
+export const funcWithPrivateParam = (() => {
+    return (p) => p;
+})();

--- a/testdata/baselines/reference/compiler/arrowFunctionVisibilityPanic.symbols
+++ b/testdata/baselines/reference/compiler/arrowFunctionVisibilityPanic.symbols
@@ -1,0 +1,22 @@
+//// [tests/cases/compiler/arrowFunctionVisibilityPanic.ts] ////
+
+=== arrowFunctionVisibilityPanic.ts ===
+// Regression test for #4629
+// This forces the compiler to trigger a symbol-accessibility diagnostic 
+// for an ArrowFunction by using a locally scoped (unnameable) type.
+
+export const funcWithPrivateParam = (() => {
+>funcWithPrivateParam : Symbol(funcWithPrivateParam, Decl(arrowFunctionVisibilityPanic.ts, 4, 12))
+
+    interface PrivateType {
+>PrivateType : Symbol(PrivateType, Decl(arrowFunctionVisibilityPanic.ts, 4, 44))
+
+        secret: string;
+>secret : Symbol(PrivateType.secret, Decl(arrowFunctionVisibilityPanic.ts, 5, 27))
+    }
+    return (p: PrivateType) => p;
+>p : Symbol(p, Decl(arrowFunctionVisibilityPanic.ts, 8, 12))
+>PrivateType : Symbol(PrivateType, Decl(arrowFunctionVisibilityPanic.ts, 4, 44))
+>p : Symbol(p, Decl(arrowFunctionVisibilityPanic.ts, 8, 12))
+
+})();

--- a/testdata/baselines/reference/compiler/arrowFunctionVisibilityPanic.types
+++ b/testdata/baselines/reference/compiler/arrowFunctionVisibilityPanic.types
@@ -1,0 +1,23 @@
+//// [tests/cases/compiler/arrowFunctionVisibilityPanic.ts] ////
+
+=== arrowFunctionVisibilityPanic.ts ===
+// Regression test for #4629
+// This forces the compiler to trigger a symbol-accessibility diagnostic 
+// for an ArrowFunction by using a locally scoped (unnameable) type.
+
+export const funcWithPrivateParam = (() => {
+>funcWithPrivateParam : (p: PrivateType) => PrivateType
+>(() => {    interface PrivateType {        secret: string;    }    return (p: PrivateType) => p;})() : (p: PrivateType) => PrivateType
+>(() => {    interface PrivateType {        secret: string;    }    return (p: PrivateType) => p;}) : () => (p: PrivateType) => PrivateType
+>() => {    interface PrivateType {        secret: string;    }    return (p: PrivateType) => p;} : () => (p: PrivateType) => PrivateType
+
+    interface PrivateType {
+        secret: string;
+>secret : string
+    }
+    return (p: PrivateType) => p;
+>(p: PrivateType) => p : (p: PrivateType) => PrivateType
+>p : PrivateType
+>p : PrivateType
+
+})();

--- a/testdata/tests/cases/compiler/arrowFunctionVisibilityPanic.ts
+++ b/testdata/tests/cases/compiler/arrowFunctionVisibilityPanic.ts
@@ -1,0 +1,12 @@
+// @declaration: true
+
+// Regression test for #4629
+// This forces the compiler to trigger a symbol-accessibility diagnostic 
+// for an ArrowFunction by using a locally scoped (unnameable) type.
+
+export const funcWithPrivateParam = (() => {
+    interface PrivateType {
+        secret: string;
+    }
+    return (p: PrivateType) => p;
+})();


### PR DESCRIPTION
# Pull Request: Fix compiler panic on arrow function visibility diagnostics

## Description
This PR resolves two compiler panics occurring during the declaration emit phase:

1. **Arrow Function Panic**: The compiler attempts to generate visibility diagnostics for parameters/return types of `KindArrowFunction` nodes, which leads to an unhandled case panic.
2. **Formatting Panic**: For anonymous exports (e.g., `export = () => {}`), `ast.GetNameOfDeclaration` returns `nil`. This leaves the diagnostic template with missing arguments, causing `diagnostics.Format` to panic due to index out-of-bounds.

## Changes

### 1. Centralized Arrow Function Guard
Added a check in `createGetSymbolAccessibilityDiagnosticForNode` to return `nil` early for arrow functions, matching upstream behavior.

### 2. Anonymous Node Fallback
Updated `wrapSimpleDiagnosticSelector` to fallback to the node itself when `GetNameOfDeclaration` returns `nil`. This ensures the diagnostic formatter always receives the required argument count.