### PR TITLE
Fix hover documentation for intersected properties

### DIFF
--- a/internal/fourslash/tests/hoverIntersectionPropertyDocumentation_test.go
+++ b/internal/fourslash/tests/hoverIntersectionPropertyDocumentation_test.go
@@ -1,0 +1,34 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestHoverIntersectionPropertyDocumentation(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+
+	const content = `
+interface A {
+    /** interface A */
+    prop: () => number;
+}
+
+interface B {
+    /** interface B */
+    prop: () => number;
+}
+
+type C = A & B;
+declare const c: C;
+
+c./*1*/prop;
+`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+
+	f.VerifyQuickInfoAt(t, "1", "(property) prop: () => number", "interface A\ninterface B")
+}

--- a/internal/ls/hover.go
+++ b/internal/ls/hover.go
@@ -101,6 +101,13 @@ func (l *LanguageService) getQuickInfoAndDocumentationForSymbol(c *checker.Check
 	if documentation != "" {
 		return quickInfo, documentation
 	}
+	// Synthetic union and intersection properties can have declarations without a value declaration.
+	if info.declaration == nil && symbol != nil {
+		documentation = l.getDocumentationFromDeclarations(c, symbol, symbol.Declarations, node, contentFormat, false /*commentOnly*/)
+		if documentation != "" {
+			return quickInfo, documentation
+		}
+	}
 
 	return quickInfo, l.documentationFromAlias(c, symbol, node, contentFormat)
 }

--- a/internal/ls/jsdoc.go
+++ b/internal/ls/jsdoc.go
@@ -28,16 +28,25 @@ func (l *LanguageService) GetSymbolDocumentationComment(c *checker.Checker, symb
 	if symbol == nil {
 		return ""
 	}
+	return l.getDocumentationFromDeclarations(c, symbol, symbol.Declarations, nil, lsproto.MarkupKindPlainText, true /*commentOnly*/)
+}
+
+// getDocumentationFromDeclarations gathers and deduplicates documentation from a set of declarations.
+func (l *LanguageService) getDocumentationFromDeclarations(c *checker.Checker, symbol *ast.Symbol, declarations []*ast.Node, location *ast.Node, contentFormat lsproto.MarkupKind, commentOnly bool) string {
 	var parts []string
 	var seen collections.Set[*ast.Node]
-	for _, decl := range symbol.Declarations {
+	for _, decl := range declarations {
 		if decl == nil {
 			continue
 		}
 		if !seen.AddIfAbsent(decl) {
 			continue
 		}
-		if doc := l.getDocumentationFromDeclaration(c, symbol, decl, decl, lsproto.MarkupKindPlainText, true /*commentOnly*/); doc != "" && !slices.Contains(parts, doc) {
+		documentationLocation := location
+		if documentationLocation == nil {
+			documentationLocation = decl
+		}
+		if doc := l.getDocumentationFromDeclaration(c, symbol, decl, documentationLocation, contentFormat, commentOnly); doc != "" && !slices.Contains(parts, doc) {
 			parts = append(parts, doc)
 		}
 	}


### PR DESCRIPTION
Fixes microsoft/TypeScript#63640.

Synthetic intersection properties can have multiple declarations but no value declaration. Hover documentation previously only inspected the value declaration, causing the merged JSDoc to be lost.

This change falls back to gathering and deduplicating documentation from all symbol declarations and adds a regression test.

This change was developed with assistance from OpenAI Codex. I reviewed and understand the patch and will respond to review feedback.