### PR TITLE
Error with a suggestion of '.' for empty project reference paths

### DIFF
--- a/internal/diagnostics/diagnostics_generated.go
+++ b/internal/diagnostics/diagnostics_generated.go
@@ -3738,6 +3738,8 @@ var The_value_0_cannot_be_used_here = &Message{code: 18050, category: CategoryEr
 
 var Compiler_option_0_cannot_be_given_an_empty_string = &Message{code: 18051, category: CategoryError, key: "Compiler_option_0_cannot_be_given_an_empty_string_18051", text: "Compiler option '{0}' cannot be given an empty string."}
 
+var A_project_reference_path_cannot_be_an_empty_string_Did_you_mean = &Message{code: 18052, category: CategoryError, key: "A_project_reference_path_cannot_be_an_empty_string_Did_you_mean_18052", text: "A project reference path cannot be an empty string. Did you mean '.'?"}
+
 var Its_type_0_is_not_a_valid_JSX_element_type = &Message{code: 18053, category: CategoryError, key: "Its_type_0_is_not_a_valid_JSX_element_type_18053", text: "Its type '{0}' is not a valid JSX element type."}
 
 var X_await_using_statements_cannot_be_used_inside_a_class_static_block = &Message{code: 18054, category: CategoryError, key: "await_using_statements_cannot_be_used_inside_a_class_static_block_18054", text: "'await using' statements cannot be used inside a class static block."}
@@ -8048,6 +8050,8 @@ func keyToMessage(key Key) *Message {
 		return The_value_0_cannot_be_used_here
 	case "Compiler_option_0_cannot_be_given_an_empty_string_18051":
 		return Compiler_option_0_cannot_be_given_an_empty_string
+	case "A_project_reference_path_cannot_be_an_empty_string_Did_you_mean_18052":
+		return A_project_reference_path_cannot_be_an_empty_string_Did_you_mean
 	case "Its_type_0_is_not_a_valid_JSX_element_type_18053":
 		return Its_type_0_is_not_a_valid_JSX_element_type
 	case "await_using_statements_cannot_be_used_inside_a_class_static_block_18054":

--- a/internal/diagnostics/extraDiagnosticMessages.json
+++ b/internal/diagnostics/extraDiagnosticMessages.json
@@ -43,6 +43,10 @@
         "category": "Error",
         "code": 5090
     },
+    "A project reference path cannot be an empty string. Did you mean '.'?": {
+        "category": "Error",
+        "code": 18052
+    },
     "A JSDoc '@type' tag on a function must have a signature with the correct number of arguments.": {
         "category": "Error",
         "code": 8030

--- a/internal/tsoptions/tsconfigparsing.go
+++ b/internal/tsoptions/tsconfigparsing.go
@@ -1358,7 +1358,7 @@ func parseJsonConfigFileContentWorker(
 					continue
 				}
 				if ref.reference.Path == "" {
-					errors = append(errors, createDiagnosticAtProjectReferenceProperty(sourceFile, index, "path", diagnostics.Compiler_option_0_cannot_be_given_an_empty_string, "reference.path"))
+					errors = append(errors, createDiagnosticAtProjectReferenceProperty(sourceFile, index, "path", diagnostics.A_project_reference_path_cannot_be_an_empty_string_Did_you_mean))
 					continue
 				}
 				if ref.hasCircular && !ref.circularValid {

--- a/internal/tsoptions/tsconfigparsing_test.go
+++ b/internal/tsoptions/tsconfigparsing_test.go
@@ -303,6 +303,19 @@ var parseJsonConfigFileTests = []parseJsonConfigTestCase{
 		}},
 	},
 	{
+		title:               "generates errors for empty reference path",
+		noSubmoduleBaseline: true,
+		input: []testConfig{{
+			jsonText: `{
+                "references": [{ "path": "" }],
+                "files": ["a.ts"]
+            }`,
+			configFileName: "/apath/tsconfig.json",
+			basePath:       "/apath",
+			allFileList:    map[string]string{"/apath/a.ts": ""},
+		}},
+	},
+	{
 		title: "exclude outDir unless overridden",
 		input: []testConfig{{
 			jsonText: `{

--- a/testdata/baselines/reference/config/tsconfigParsing/generates errors for empty reference path with json api.js
+++ b/testdata/baselines/reference/config/tsconfigParsing/generates errors for empty reference path with json api.js
@@ -1,0 +1,24 @@
+Fs::
+//// [/apath/a.ts]
+
+
+//// [/apath/tsconfig.json]
+{
+                "references": [{ "path": "" }],
+                "files": ["a.ts"]
+            }
+
+
+configFileName:: /apath/tsconfig.json
+CompilerOptions::
+{
+  "configFilePath": "/apath/tsconfig.json"
+}
+
+TypeAcquisition::
+{}
+
+FileNames::
+/apath/a.ts
+Errors::
+[91merror[0m[90m TS18052: [0mA project reference path cannot be an empty string. Did you mean '.'?

--- a/testdata/baselines/reference/config/tsconfigParsing/generates errors for empty reference path with jsonSourceFile api.js
+++ b/testdata/baselines/reference/config/tsconfigParsing/generates errors for empty reference path with jsonSourceFile api.js
@@ -1,0 +1,28 @@
+Fs::
+//// [/apath/a.ts]
+
+
+//// [/apath/tsconfig.json]
+{
+                "references": [{ "path": "" }],
+                "files": ["a.ts"]
+            }
+
+
+configFileName:: /apath/tsconfig.json
+CompilerOptions::
+{
+  "configFilePath": "/apath/tsconfig.json"
+}
+
+TypeAcquisition::
+{}
+
+FileNames::
+/apath/a.ts
+Errors::
+[96mtsconfig.json[0m:[93m2[0m:[93m42[0m - [91merror[0m[90m TS18052: [0mA project reference path cannot be an empty string. Did you mean '.'?
+
+[7m2[0m                 "references": [{ "path": "" }],
+[7m [0m [91m                                         ~~[0m
+

--- a/testdata/baselines/reference/tsbuild/configFileErrors/reports-invalid-project-reference-fields.js
+++ b/testdata/baselines/reference/tsbuild/configFileErrors/reports-invalid-project-reference-fields.js
@@ -60,7 +60,7 @@ Output::
 [7m9[0m         { "path": "./utils", "circular": "yes" },
 [7m [0m [91m                                         ~~~~~[0m
 
-[96mtsconfig.json[0m:[93m10[0m:[93m19[0m - [91merror[0m[90m TS18051: [0mCompiler option 'reference.path' cannot be given an empty string.
+[96mtsconfig.json[0m:[93m10[0m:[93m19[0m - [91merror[0m[90m TS18052: [0mA project reference path cannot be an empty string. Did you mean '.'?
 
 [7m10[0m         { "path": "" },
 [7m  [0m [91m                  ~~[0m


### PR DESCRIPTION
Fixes #4484

An empty "path" in a project reference now reports a dedicated diagnostic, TS18052: A project reference path cannot be an empty string. Did you mean '.'? Previously it reported the generic TS18051 empty string message, added incidentally by #4494 for the non string panic in #4269, without the suggestion discussed in #4484.

Code 18052 is unused in this repo, in the pinned Strada submodule, and across testdata. The message lives in extraDiagnosticMessages.json since it intentionally diverges from Strada, and the new tsconfigParsing test case is marked noSubmoduleBaseline for the same reason.

Verified with go test on internal/tsoptions (209 passed) and the TestBuildConfigFileErrors tsbuild suite (6 passed), go vet clean, go build clean, hereby format clean. The only change to the existing tsbuild baseline is the empty path line switching from TS18051 to TS18052.

Disclosure per the contributing guidelines: this PR was authored with AI assistance, and I reviewed and verified the changes.