### PR TITLE
Use canonical paths for the semantic tokens defaultLibrary check

### DIFF
--- a/internal/ls/semantictokens.go
+++ b/internal/ls/semantictokens.go
@@ -12,7 +12,6 @@ import (
 	"github.com/microsoft/typescript-go/internal/ls/lsconv"
 	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
 	"github.com/microsoft/typescript-go/internal/scanner"
-	"github.com/microsoft/typescript-go/internal/tspath"
 )
 
 // tokenTypes defines the order of token types for encoding
@@ -259,13 +258,13 @@ func (l *LanguageService) collectSemanticTokensInRange(ctx context.Context, c *c
 							tokenModifier |= tokenModifierLocal
 						}
 						declSourceFile := ast.GetSourceFileOfNode(decl)
-						if declSourceFile != nil && program.IsSourceFileDefaultLibrary(tspath.Path(declSourceFile.FileName())) {
+						if declSourceFile != nil && program.IsSourceFileDefaultLibrary(declSourceFile.Path()) {
 							tokenModifier |= tokenModifierDefaultLibrary
 						}
 					} else if symbol.Declarations != nil {
 						for _, decl := range symbol.Declarations {
 							declSourceFile := ast.GetSourceFileOfNode(decl)
-							if declSourceFile != nil && program.IsSourceFileDefaultLibrary(tspath.Path(declSourceFile.FileName())) {
+							if declSourceFile != nil && program.IsSourceFileDefaultLibrary(declSourceFile.Path()) {
 								tokenModifier |= tokenModifierDefaultLibrary
 								break
 							}

--- a/internal/lsp/server_semantictokens_test.go
+++ b/internal/lsp/server_semantictokens_test.go
@@ -91,3 +91,95 @@ func TestSemanticTokensCRLF(t *testing.T) {
 		t.Fatalf("Semantic tokens request failed: %s", msg.AsResponse().Error.Message)
 	}
 }
+
+// TestSemanticTokensDefaultLibraryCaseInsensitive reproduces #4635: on
+// case-insensitive file systems, tokens for default-library symbols never
+// carried the defaultLibrary modifier. The lib files map in the program is
+// keyed by canonical (lowercased) tspath.Path, but semantic tokens looked up
+// declarations by their raw case-preserving file name. With the default
+// library under a mixed-case directory (/TSLib), the lookup always missed.
+func TestSemanticTokensDefaultLibraryCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	libContent := `/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+declare const console: { log(msg: any): void; };
+`
+
+	files := map[string]string{
+		"/home/projects/tsconfig.json": `{"compilerOptions": {"lib": ["es5"]}}`,
+		"/home/projects/test.ts":       `console.log("hi");`,
+		"/TSLib/lib.es5.d.ts":          libContent,
+	}
+	// Case-insensitive VFS: canonical paths are lowercased, so the lib's
+	// canonical path (/tslib/lib.es5.d.ts) differs from its file name.
+	fs := vfstest.FromMap(files, false)
+
+	onServerRequest := func(_ context.Context, req *lsproto.RequestMessage) *lsproto.ResponseMessage {
+		if req.Method == lsproto.MethodClientRegisterCapability || req.Method == lsproto.MethodClientUnregisterCapability {
+			return &lsproto.ResponseMessage{ID: req.ID, JSONRPC: req.JSONRPC, Result: lsproto.Null{}}
+		}
+		return nil
+	}
+
+	client, closeClient := lsptestutil.NewLSPClient(t, lsp.ServerOptions{
+		Err: io.Discard, Cwd: "/home/projects", FS: fs, DefaultLibraryPath: "/TSLib",
+	}, onServerRequest)
+	t.Cleanup(func() { _ = closeClient() })
+
+	initMsg, _, ok := lsptestutil.SendRequest(t, client, lsproto.InitializeInfo, &lsproto.InitializeParams{
+		Capabilities: &lsproto.ClientCapabilities{
+			TextDocument: &lsproto.TextDocumentClientCapabilities{
+				SemanticTokens: &lsproto.SemanticTokensClientCapabilities{
+					Requests: &lsproto.ClientSemanticTokensRequestOptions{
+						Full: &lsproto.BooleanOrClientSemanticTokensRequestFullDelta{Boolean: new(true)},
+					},
+					TokenTypes:     []string{"namespace", "type", "class", "enum", "interface", "struct", "typeParameter", "parameter", "variable", "property", "enumMember", "event", "function", "method", "macro", "keyword", "modifier", "comment", "string", "number", "regexp", "operator", "decorator"},
+					TokenModifiers: []string{"declaration", "definition", "readonly", "static", "deprecated", "abstract", "async", "modification", "documentation", "defaultLibrary", "local"},
+				},
+			},
+		},
+	})
+	assert.Assert(t, ok && initMsg.AsResponse().Error == nil, "Initialize failed")
+	lsptestutil.SendNotification(t, client, lsproto.InitializedInfo, &lsproto.InitializedParams{})
+	<-client.Server.InitComplete()
+
+	uri := lsproto.DocumentUri("file:///home/projects/test.ts")
+	lsptestutil.SendNotification(t, client, lsproto.TextDocumentDidOpenInfo, &lsproto.DidOpenTextDocumentParams{
+		TextDocument: &lsproto.TextDocumentItem{Uri: uri, LanguageId: "typescript", Text: files["/home/projects/test.ts"]},
+	})
+
+	msg, result, ok := lsptestutil.SendRequest(t, client, lsproto.TextDocumentSemanticTokensFullInfo, &lsproto.SemanticTokensParams{
+		TextDocument: lsproto.TextDocumentIdentifier{Uri: uri},
+	})
+	assert.Assert(t, ok, "Semantic tokens request did not return a result")
+	if msg.AsResponse().Error != nil {
+		t.Fatalf("Semantic tokens request failed: %s", msg.AsResponse().Error.Message)
+	}
+	assert.Assert(t, result.SemanticTokens != nil, "Expected non-null semantic tokens")
+
+	data := result.SemanticTokens.Data
+	assert.Assert(t, len(data) >= 5 && len(data)%5 == 0, "Malformed semantic tokens data (len %d)", len(data))
+
+	// Tokens are encoded as 5 ints each; the 5th is the modifier bitset.
+	// defaultLibrary is index 9 in the TokenModifiers legend above.
+	const defaultLibraryBit = 1 << 9
+	hasDefaultLibrary := false
+	for i := 4; i < len(data); i += 5 {
+		if data[i]&defaultLibraryBit != 0 {
+			hasDefaultLibrary = true
+			break
+		}
+	}
+	assert.Assert(t, hasDefaultLibrary, "Expected at least one token with the defaultLibrary modifier (console is declared in the default library); data: %v", data)
+}


### PR DESCRIPTION
Fixes #4635

Program.IsSourceFileDefaultLibrary looks up a map keyed by canonical tspath.Path values, which are lowercased when the file system is case insensitive. The semantic tokens handler cast the case preserving FileName() instead, so on macOS and Windows the lookup always missed and no token ever carried the defaultLibrary modifier, which costs lib globals their themed editor colors. Both call sites now use declSourceFile.Path(), matching every other caller of IsSourceFileDefaultLibrary.

The regression test drives the LSP server over a case insensitive test file system with a minimal default lib under a mixed case directory, /TSLib/lib.es5.d.ts, mirroring the mixed case lib path precedent in the tsc test sys. It decodes semanticTokens/full and asserts at least one token carries the defaultLibrary modifier bit. The test fails without the two line fix and passes with it. go test on internal/lsp passes both semantic tokens tests, go vet is clean, gofmt is clean.

Disclosure per the contributing guidelines: this PR was authored with AI assistance, and I reviewed and verified the changes.