### PR TITLE
Fix stack overflow in `getExplicitTypeOfSymbol()` for self-referential `for...of`

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -642,6 +642,7 @@ type Checker struct {
 	reverseHomomorphicMappedCache               map[ReverseMappedTypeKey]*Type
 	iterationTypesCache                         map[IterationTypesKey]IterationTypes
 	markerTypes                                 collections.Set[*Type]
+	resolvingExplicitTypeOfSymbol               collections.Set[*ast.Symbol]
 	undefinedSymbol                             *ast.Symbol
 	argumentsSymbol                             *ast.Symbol
 	requireSymbol                               *ast.Symbol

--- a/internal/checker/flow.go
+++ b/internal/checker/flow.go
@@ -2133,6 +2133,10 @@ func (c *Checker) getTypeOfDottedName(node *ast.Node, diagnostic *ast.Diagnostic
 
 func (c *Checker) getExplicitTypeOfSymbol(symbol *ast.Symbol, diagnostic *ast.Diagnostic) *Type {
 	symbol = c.resolveSymbol(symbol)
+	if !c.resolvingExplicitTypeOfSymbol.AddIfAbsent(symbol) {
+		return nil
+	}
+	defer c.resolvingExplicitTypeOfSymbol.Delete(symbol)
 	if symbol.Flags&(ast.SymbolFlagsFunction|ast.SymbolFlagsMethod|ast.SymbolFlagsClass|ast.SymbolFlagsValueModule) != 0 {
 		return c.getTypeOfSymbol(symbol)
 	}

--- a/testdata/baselines/reference/compiler/forOfSelfReferentialDottedName.errors.txt
+++ b/testdata/baselines/reference/compiler/forOfSelfReferentialDottedName.errors.txt
@@ -1,0 +1,17 @@
+forOfSelfReferentialDottedName.ts(3,12): error TS7022: 'a' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
+forOfSelfReferentialDottedName.ts(3,17): error TS2448: Block-scoped variable 'a' used before its declaration.
+
+
+==== forOfSelfReferentialDottedName.ts (2 errors) ====
+    // A self-referential for-of iterable (`for (const a of a)`) plus a call and a
+    // later narrowing reference must not infinitely recurse in getExplicitTypeOfSymbol.
+    for (const a of a) {
+               ~
+!!! error TS7022: 'a' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
+                    ~
+!!! error TS2448: Block-scoped variable 'a' used before its declaration.
+!!! related TS2728 forOfSelfReferentialDottedName.ts:3:12: 'a' is declared here.
+        a();
+        a;
+    }
+    

--- a/testdata/baselines/reference/compiler/forOfSelfReferentialDottedName.js
+++ b/testdata/baselines/reference/compiler/forOfSelfReferentialDottedName.js
@@ -1,0 +1,19 @@
+//// [tests/cases/compiler/forOfSelfReferentialDottedName.ts] ////
+
+//// [forOfSelfReferentialDottedName.ts]
+// A self-referential for-of iterable (`for (const a of a)`) plus a call and a
+// later narrowing reference must not infinitely recurse in getExplicitTypeOfSymbol.
+for (const a of a) {
+    a();
+    a;
+}
+
+
+//// [forOfSelfReferentialDottedName.js]
+"use strict";
+// A self-referential for-of iterable (`for (const a of a)`) plus a call and a
+// later narrowing reference must not infinitely recurse in getExplicitTypeOfSymbol.
+for (const a of a) {
+    a();
+    a;
+}

--- a/testdata/baselines/reference/compiler/forOfSelfReferentialDottedName.symbols
+++ b/testdata/baselines/reference/compiler/forOfSelfReferentialDottedName.symbols
@@ -1,0 +1,16 @@
+//// [tests/cases/compiler/forOfSelfReferentialDottedName.ts] ////
+
+=== forOfSelfReferentialDottedName.ts ===
+// A self-referential for-of iterable (`for (const a of a)`) plus a call and a
+// later narrowing reference must not infinitely recurse in getExplicitTypeOfSymbol.
+for (const a of a) {
+>a : Symbol(a, Decl(forOfSelfReferentialDottedName.ts, 2, 10))
+>a : Symbol(a, Decl(forOfSelfReferentialDottedName.ts, 2, 10))
+
+    a();
+>a : Symbol(a, Decl(forOfSelfReferentialDottedName.ts, 2, 10))
+
+    a;
+>a : Symbol(a, Decl(forOfSelfReferentialDottedName.ts, 2, 10))
+}
+

--- a/testdata/baselines/reference/compiler/forOfSelfReferentialDottedName.types
+++ b/testdata/baselines/reference/compiler/forOfSelfReferentialDottedName.types
@@ -1,0 +1,17 @@
+//// [tests/cases/compiler/forOfSelfReferentialDottedName.ts] ////
+
+=== forOfSelfReferentialDottedName.ts ===
+// A self-referential for-of iterable (`for (const a of a)`) plus a call and a
+// later narrowing reference must not infinitely recurse in getExplicitTypeOfSymbol.
+for (const a of a) {
+>a : any
+>a : any
+
+    a();
+>a() : any
+>a : any
+
+    a;
+>a : any
+}
+

--- a/testdata/tests/cases/compiler/forOfSelfReferentialDottedName.ts
+++ b/testdata/tests/cases/compiler/forOfSelfReferentialDottedName.ts
@@ -1,0 +1,6 @@
+// A self-referential for-of iterable (`for (const a of a)`) plus a call and a
+// later narrowing reference must not infinitely recurse in getExplicitTypeOfSymbol.
+for (const a of a) {
+    a();
+    a;
+}


### PR DESCRIPTION
Fixes an issue uncovered in https://github.com/microsoft/typescript-go/issues/4532#issuecomment-4879803515; with a self-referential type whose iterable is the loop variable itself (`for (const a of a)`), `getExplicitTypeOfSymbol()` faces unbound recursion. This PR fixes that by keeping a set in the checker keyed by the symbol, which guards the function with `AddIfAbsent` and otherwise removes the symbol from the set at the end of the function.