### PR TITLE
Fix nil pointer dereference in signature help for error-recovered parameter types

### DIFF
--- a/internal/checker/nodebuilderimpl.go
+++ b/internal/checker/nodebuilderimpl.go
@@ -497,7 +497,7 @@ func (b *NodeBuilderImpl) canReuseExistingJSTypeNode(existing *ast.TypeNode, t *
 }
 
 func (b *NodeBuilderImpl) tryGetResolvedSymbolFromTypeNode(node *ast.Node) *ast.Symbol {
-	if node == nil {
+	if node == nil || node.Parent == nil {
 		return nil
 	}
 	b.ch.getTypeFromTypeNode(node)
@@ -2857,6 +2857,9 @@ func (b *NodeBuilderImpl) createAnonymousTypeNodeEx(t *Type, forceClassExpansion
 
 func (b *NodeBuilderImpl) getTypeFromTypeNode(node *ast.TypeNode, noMappedTypes bool) *Type {
 	// !!! noMappedTypes optional param support
+	if node.Parent == nil {
+		return b.ch.errorType
+	}
 	t := b.ch.getTypeFromTypeNode(node)
 	if b.ctx.mapper == nil {
 		return t

--- a/internal/fourslash/tests/signatureHelpUnresolvedTypeErrorRecovery_test.go
+++ b/internal/fourslash/tests/signatureHelpUnresolvedTypeErrorRecovery_test.go
@@ -1,0 +1,26 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+// Building a call's signature label reuses the callee's declared parameter type node. A
+// grammar-recovered, incomplete property (`a?: U =`) alongside a well-formed property that
+// references an unresolved type (`b?: (p: U) => void`) routes serialization through the
+// node-reuse path. Resolving the reference on a copied node whose parent is unset must not
+// panic (nil pointer dereference during type-node serialization).
+func TestSignatureHelpUnresolvedTypeInErrorRecoveredSignature(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `function f(x: {
+    a?: U =
+    b?: (p: U) => void
+}) {}
+f(/*a*/);`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyBaselineSignatureHelp(t)
+}

--- a/testdata/baselines/reference/fourslash/signatureHelp/signatureHelpUnresolvedTypeInErrorRecoveredSignature.baseline
+++ b/testdata/baselines/reference/fourslash/signatureHelp/signatureHelpUnresolvedTypeInErrorRecoveredSignature.baseline
@@ -1,0 +1,38 @@
+// === SignatureHelp ===
+=== /signatureHelpUnresolvedTypeInErrorRecoveredSignature.ts ===
+// function f(x: {
+//     a?: U =
+//     b?: (p: U) => void
+// }) {}
+// f();
+//   ^
+// | ----------------------------------------------------------------------
+// | f(**x: { a?: U; }**): void
+// | ----------------------------------------------------------------------
+[
+  {
+    "marker": {
+      "Position": 59,
+      "LSPosition": {
+        "line": 4,
+        "character": 2
+      },
+      "Name": "a",
+      "Data": {}
+    },
+    "item": {
+      "signatures": [
+        {
+          "label": "f(x: { a?: U; }): void",
+          "parameters": [
+            {
+              "label": "x: { a?: U; }"
+            }
+          ],
+          "activeParameter": 0
+        }
+      ],
+      "activeSignature": 0
+    }
+  }
+]


### PR DESCRIPTION
Fixes an issue uncovered in https://github.com/microsoft/typescript-go/issues/4532#issuecomment-4879803367; Signature help builds a call's signature label by reusing the callee's parameter type node through the node-reuse path. When that parameter type contains a grammar-recovered, incomplete member alongside a well-formed member referencing an unresolved type, the node builder serializes the reused type node by producing detached clones with `DeepCloneNode()`. Resolving this detached clone's type/symbol tries to walk ancestors, but the node's parents are `nil` and some paths need to be protected.