### PR TITLE
Fix build mode setup stall on large solutions

### DIFF
--- a/internal/execute/build/orchestrator.go
+++ b/internal/execute/build/orchestrator.go
@@ -417,7 +417,7 @@ func (o *Orchestrator) packageJsonLookupChanged(packageJson string, changedPaths
 }
 
 func (o *Orchestrator) computeDesiredWatches() map[string]bool {
-	desiredDirs := make(map[string]bool)
+	desiredDirs := watchmanager.NewDirWatchSet(o.comparePathsOptions)
 
 	for i := range o.order {
 		config := o.order[i]
@@ -427,9 +427,7 @@ func (o *Orchestrator) computeDesiredWatches() map[string]bool {
 		// Watch config file directory
 		configDir := tspath.GetDirectoryPath(task.config)
 		realConfigDir := o.host.FS().Realpath(configDir)
-		if _, has := desiredDirs[realConfigDir]; !has {
-			desiredDirs[realConfigDir] = false
-		}
+		desiredDirs.Set(realConfigDir, false)
 
 		if task.resolved == nil {
 			continue
@@ -439,29 +437,21 @@ func (o *Orchestrator) computeDesiredWatches() map[string]bool {
 		for _, cfgPath := range task.resolved.ExtendedSourceFiles() {
 			realPath := o.host.FS().Realpath(cfgPath)
 			dir := tspath.GetDirectoryPath(realPath)
-			if _, has := desiredDirs[dir]; !has {
-				desiredDirs[dir] = false
-			}
+			desiredDirs.Set(dir, false)
 		}
 
 		// Wildcard directories from tsconfig
 		for dir, recursive := range task.resolved.WildcardDirectories() {
 			realDir := o.host.FS().Realpath(dir)
-			if existing, has := desiredDirs[realDir]; has {
-				desiredDirs[realDir] = existing || recursive
-			} else {
-				desiredDirs[realDir] = recursive
-			}
+			desiredDirs.Set(realDir, recursive)
 		}
 
 		// Input file directories not already covered
 		for _, fileName := range task.resolved.FileNames() {
 			absPath := tspath.GetNormalizedAbsolutePath(fileName, o.opts.Sys.GetCurrentDirectory())
 			dir := tspath.GetDirectoryPath(absPath)
-			if !watchmanager.IsDirCoveredByWatch(desiredDirs, dir, o.comparePathsOptions) {
-				if watchmanager.CanWatchDirectory(dir) {
-					desiredDirs[dir] = false
-				}
+			if !desiredDirs.Covered(dir) && watchmanager.CanWatchDirectory(dir) {
+				desiredDirs.Set(dir, false)
 			}
 		}
 
@@ -479,10 +469,8 @@ func (o *Orchestrator) computeDesiredWatches() map[string]bool {
 					continue
 				}
 				dir := tspath.GetDirectoryPath(absPath)
-				if !watchmanager.IsDirCoveredByWatch(desiredDirs, dir, o.comparePathsOptions) {
-					if watchmanager.CanWatchDirectory(dir) {
-						desiredDirs[dir] = false
-					}
+				if !desiredDirs.Covered(dir) && watchmanager.CanWatchDirectory(dir) {
+					desiredDirs.Set(dir, false)
 				}
 			}
 			for packageJson := range bi.buildInfo.GetPackageJsons(buildInfoDir) {
@@ -497,16 +485,16 @@ func (o *Orchestrator) computeDesiredWatches() map[string]bool {
 		}
 	}
 
-	return o.wm.ResolveDesiredDirs(desiredDirs)
+	return o.wm.ResolveDesiredDirs(desiredDirs.Dirs())
 }
 
-func (o *Orchestrator) addWatchDir(desiredDirs map[string]bool, dir string) {
-	if !watchmanager.IsDirCoveredByWatch(desiredDirs, dir, o.comparePathsOptions) && watchmanager.CanWatchDirectory(dir) {
-		desiredDirs[dir] = false
+func (o *Orchestrator) addWatchDir(desiredDirs *watchmanager.DirWatchSet, dir string) {
+	if !desiredDirs.Covered(dir) && watchmanager.CanWatchDirectory(dir) {
+		desiredDirs.Set(dir, false)
 	}
 }
 
-func (o *Orchestrator) addPackageJsonWatchDirs(desiredDirs map[string]bool, packageJson string) {
+func (o *Orchestrator) addPackageJsonWatchDirs(desiredDirs *watchmanager.DirWatchSet, packageJson string) {
 	dir := tspath.GetDirectoryPath(packageJson)
 	dirs := []string{dir}
 	foundNodeModules := false

--- a/internal/execute/tsctests/mock_watch_backend.go
+++ b/internal/execute/tsctests/mock_watch_backend.go
@@ -11,6 +11,7 @@ import (
 	"github.com/microsoft/typescript-go/internal/execute/watchmanager"
 	"github.com/microsoft/typescript-go/internal/fswatch"
 	"github.com/microsoft/typescript-go/internal/testutil/fsbaselineutil"
+	"github.com/microsoft/typescript-go/internal/tspath"
 )
 
 // MockWatchBackend implements watchmanager.WatchBackend for testing. It
@@ -19,9 +20,10 @@ import (
 // SendEvents, which routes them only through watches whose paths
 // match, enforcing that tests fail if the wrong watches are set up.
 type MockWatchBackend struct {
-	mu              sync.Mutex
-	Dirs            map[string]*MockWatch
-	DirectoryExists func(string) bool // if set, WatchDirectory fails for non-existent dirs
+	mu                        sync.Mutex
+	Dirs                      map[string]*MockWatch
+	DirectoryExists           func(string) bool // if set, WatchDirectory fails for non-existent dirs
+	UseCaseSensitiveFileNames bool
 }
 
 var _ watchmanager.WatchBackend = (*MockWatchBackend)(nil)
@@ -109,7 +111,7 @@ func (m *MockWatchBackend) SendEvents(events []fswatch.Event) {
 			if w.Ignore != nil && w.Ignore(e.Path) {
 				continue
 			}
-			if !pathIsUnder(e.Path, w.Path, w.Recursive) {
+			if !pathIsUnder(e.Path, w.Path, w.Recursive, m.UseCaseSensitiveFileNames) {
 				continue
 			}
 			if t, ok := targets[w]; ok {
@@ -162,7 +164,11 @@ func (m *MockWatchBackend) SendChangedPaths(changes []fsbaselineutil.FileChange)
 
 // pathIsUnder reports whether eventPath is inside dir. If recursive is
 // false, only direct children match.
-func pathIsUnder(eventPath, dir string, recursive bool) bool {
+func pathIsUnder(eventPath, dir string, recursive, useCaseSensitiveFileNames bool) bool {
+	if !useCaseSensitiveFileNames {
+		eventPath = tspath.GetCanonicalFileName(eventPath, false)
+		dir = tspath.GetCanonicalFileName(dir, false)
+	}
 	if !strings.HasPrefix(eventPath, dir) {
 		return false
 	}

--- a/internal/execute/tsctests/sys.go
+++ b/internal/execute/tsctests/sys.go
@@ -135,6 +135,7 @@ func newTestSys(tscInput *tscInput, forIncrementalCorrectness bool) *TestSys {
 	sys.forIncrementalCorrectness = forIncrementalCorrectness
 	sys.mockWatchBackend = NewMockWatchBackend()
 	sys.mockWatchBackend.DirectoryExists = sys.fs.FS.DirectoryExists
+	sys.mockWatchBackend.UseCaseSensitiveFileNames = !tscInput.ignoreCase
 	sys.fsDiffer = &fsbaselineutil.FSDiffer{
 		FS:           sys.fs.FS.(iovfs.FsWithSys),
 		DefaultLibs:  func() *collections.SyncSet[string] { return sys.fs.defaultLibs },

--- a/internal/execute/watcher.go
+++ b/internal/execute/watcher.go
@@ -184,18 +184,19 @@ func (w *Watcher) computeDesiredWatches(seenFilePaths []string) map[string]bool 
 	// Resolve ancestor fallbacks first so coverage checks use final dirs.
 	resolvedDirs := w.wm.ResolveDesiredDirs(desiredDirs)
 
-	opts := w.comparePathsOptions()
+	coverage := watchmanager.NewDirWatchSet(w.comparePathsOptions())
+	for dir, recursive := range resolvedDirs {
+		coverage.Set(dir, recursive)
+	}
 	for _, filePath := range seenFilePaths {
 		dir := tspath.GetDirectoryPath(filePath)
-		if !watchmanager.IsDirCoveredByWatch(resolvedDirs, dir, opts) {
-			if watchmanager.CanWatchDirectory(dir) {
-				resolvedDirs[dir] = false
-			}
+		if !coverage.Covered(dir) && watchmanager.CanWatchDirectory(dir) {
+			coverage.Set(dir, false)
 		}
 	}
 
 	// Re-resolve in case newly added dirs don't exist
-	return w.wm.ResolveDesiredDirs(resolvedDirs)
+	return w.wm.ResolveDesiredDirs(coverage.Dirs())
 }
 
 func (w *Watcher) reconcileWatches(seenFilePaths []string) error {

--- a/internal/execute/watchmanager/watchmanager.go
+++ b/internal/execute/watchmanager/watchmanager.go
@@ -311,9 +311,9 @@ func (wm *WatchManager) createDirWatches(updates []dirWatchUpdate) error {
 // already present in the set, or when it is contained within a recursive watch
 // directory already in the set.
 type DirWatchSet struct {
-	opts tspath.ComparePathsOptions
-	dirs map[string]bool
-	present map[string]struct{}
+	opts      tspath.ComparePathsOptions
+	dirs      map[string]bool
+	present   map[string]struct{}
 	recursive []string
 }
 

--- a/internal/execute/watchmanager/watchmanager.go
+++ b/internal/execute/watchmanager/watchmanager.go
@@ -306,17 +306,53 @@ func (wm *WatchManager) createDirWatches(updates []dirWatchUpdate) error {
 	return nil
 }
 
-func IsDirCoveredByWatch(dirs map[string]bool, dir string, opts tspath.ComparePathsOptions) bool {
-	for wdir, recursive := range dirs {
-		if recursive {
-			if tspath.ContainsPath(wdir, dir, opts) {
-				return true
-			}
-		} else if tspath.ComparePaths(dir, wdir, opts) == 0 {
+// DirWatchSet accumulates the set of directories that should be watched while
+// answering coverage queries efficiently. A directory is "covered" when it is
+// already present in the set, or when it is contained within a recursive watch
+// directory already in the set.
+type DirWatchSet struct {
+	opts tspath.ComparePathsOptions
+	dirs map[string]bool
+	present map[string]struct{}
+	recursive []string
+}
+
+func NewDirWatchSet(opts tspath.ComparePathsOptions) *DirWatchSet {
+	return &DirWatchSet{
+		opts:    opts,
+		dirs:    make(map[string]bool),
+		present: make(map[string]struct{}),
+	}
+}
+
+func (s *DirWatchSet) canonical(dir string) string {
+	return tspath.GetCanonicalFileName(dir, s.opts.UseCaseSensitiveFileNames)
+}
+
+func (s *DirWatchSet) Set(dir string, recursive bool) {
+	existing, has := s.dirs[dir]
+	newRecursive := existing || recursive
+	s.dirs[dir] = newRecursive
+	s.present[s.canonical(dir)] = struct{}{}
+	if newRecursive && (!has || !existing) {
+		s.recursive = append(s.recursive, dir)
+	}
+}
+
+func (s *DirWatchSet) Covered(dir string) bool {
+	if _, has := s.present[s.canonical(dir)]; has {
+		return true
+	}
+	for _, wdir := range s.recursive {
+		if tspath.ContainsPath(wdir, dir, s.opts) {
 			return true
 		}
 	}
 	return false
+}
+
+func (s *DirWatchSet) Dirs() map[string]bool {
+	return s.dirs
 }
 
 func (wm *WatchManager) IsPathUnderWatch(path string, opts tspath.ComparePathsOptions) bool {

--- a/internal/execute/watchmanager/watchmanager.go
+++ b/internal/execute/watchmanager/watchmanager.go
@@ -306,24 +306,19 @@ func (wm *WatchManager) createDirWatches(updates []dirWatchUpdate) error {
 	return nil
 }
 
-type dirWatchEntry struct {
-	path      string
-	recursive bool
-}
-
 // DirWatchSet accumulates the set of directories that should be watched while
 // answering coverage queries efficiently. A directory is "covered" when it is
 // already present in the set, or when it is contained within a recursive watch
 // directory already in the set.
 type DirWatchSet struct {
 	opts tspath.ComparePathsOptions
-	dirs map[string]dirWatchEntry
+	dirs map[string]bool
 }
 
 func NewDirWatchSet(opts tspath.ComparePathsOptions) *DirWatchSet {
 	return &DirWatchSet{
 		opts: opts,
-		dirs: make(map[string]dirWatchEntry),
+		dirs: make(map[string]bool),
 	}
 }
 
@@ -332,13 +327,8 @@ func (s *DirWatchSet) canonical(dir string) string {
 }
 
 func (s *DirWatchSet) Set(dir string, recursive bool) {
-	key := s.canonical(dir)
-	entry, has := s.dirs[key]
-	if !has {
-		entry.path = dir
-	}
-	entry.recursive = entry.recursive || recursive
-	s.dirs[key] = entry
+	dir = s.canonical(dir)
+	s.dirs[dir] = s.dirs[dir] || recursive
 }
 
 func (s *DirWatchSet) Covered(dir string) bool {
@@ -349,7 +339,7 @@ func (s *DirWatchSet) Covered(dir string) bool {
 	rootLength := tspath.GetRootLength(dir)
 	for len(dir) > rootLength {
 		dir = tspath.GetDirectoryPath(dir)
-		if entry, has := s.dirs[dir]; has && entry.recursive {
+		if s.dirs[dir] {
 			return true
 		}
 	}
@@ -357,11 +347,7 @@ func (s *DirWatchSet) Covered(dir string) bool {
 }
 
 func (s *DirWatchSet) Dirs() map[string]bool {
-	dirs := make(map[string]bool, len(s.dirs))
-	for _, entry := range s.dirs {
-		dirs[entry.path] = entry.recursive
-	}
-	return dirs
+	return s.dirs
 }
 
 func (wm *WatchManager) IsPathUnderWatch(path string, opts tspath.ComparePathsOptions) bool {

--- a/internal/execute/watchmanager/watchmanager.go
+++ b/internal/execute/watchmanager/watchmanager.go
@@ -306,22 +306,24 @@ func (wm *WatchManager) createDirWatches(updates []dirWatchUpdate) error {
 	return nil
 }
 
+type dirWatchEntry struct {
+	path      string
+	recursive bool
+}
+
 // DirWatchSet accumulates the set of directories that should be watched while
 // answering coverage queries efficiently. A directory is "covered" when it is
 // already present in the set, or when it is contained within a recursive watch
 // directory already in the set.
 type DirWatchSet struct {
-	opts      tspath.ComparePathsOptions
-	dirs      map[string]bool
-	present   map[string]struct{}
-	recursive []string
+	opts tspath.ComparePathsOptions
+	dirs map[string]dirWatchEntry
 }
 
 func NewDirWatchSet(opts tspath.ComparePathsOptions) *DirWatchSet {
 	return &DirWatchSet{
-		opts:    opts,
-		dirs:    make(map[string]bool),
-		present: make(map[string]struct{}),
+		opts: opts,
+		dirs: make(map[string]dirWatchEntry),
 	}
 }
 
@@ -330,21 +332,24 @@ func (s *DirWatchSet) canonical(dir string) string {
 }
 
 func (s *DirWatchSet) Set(dir string, recursive bool) {
-	existing, has := s.dirs[dir]
-	newRecursive := existing || recursive
-	s.dirs[dir] = newRecursive
-	s.present[s.canonical(dir)] = struct{}{}
-	if newRecursive && (!has || !existing) {
-		s.recursive = append(s.recursive, dir)
+	key := s.canonical(dir)
+	entry, has := s.dirs[key]
+	if !has {
+		entry.path = dir
 	}
+	entry.recursive = entry.recursive || recursive
+	s.dirs[key] = entry
 }
 
 func (s *DirWatchSet) Covered(dir string) bool {
-	if _, has := s.present[s.canonical(dir)]; has {
+	dir = s.canonical(dir)
+	if _, has := s.dirs[dir]; has {
 		return true
 	}
-	for _, wdir := range s.recursive {
-		if tspath.ContainsPath(wdir, dir, s.opts) {
+	rootLength := tspath.GetRootLength(dir)
+	for len(dir) > rootLength {
+		dir = tspath.GetDirectoryPath(dir)
+		if entry, has := s.dirs[dir]; has && entry.recursive {
 			return true
 		}
 	}
@@ -352,7 +357,11 @@ func (s *DirWatchSet) Covered(dir string) bool {
 }
 
 func (s *DirWatchSet) Dirs() map[string]bool {
-	return s.dirs
+	dirs := make(map[string]bool, len(s.dirs))
+	for _, entry := range s.dirs {
+		dirs[entry.path] = entry.recursive
+	}
+	return dirs
 }
 
 func (wm *WatchManager) IsPathUnderWatch(path string, opts tspath.ComparePathsOptions) bool {

--- a/internal/execute/watchmanager/watchmanager_test.go
+++ b/internal/execute/watchmanager/watchmanager_test.go
@@ -1,0 +1,130 @@
+package watchmanager
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/tspath"
+	"gotest.tools/v3/assert"
+)
+
+var (
+	caseSensitiveOpts   = tspath.ComparePathsOptions{UseCaseSensitiveFileNames: true, CurrentDirectory: "/repo"}
+	caseInsensitiveOpts = tspath.ComparePathsOptions{UseCaseSensitiveFileNames: false, CurrentDirectory: "/repo"}
+)
+
+// TestDirWatchSetCoverage checks the core coverage rules: a recursive watch
+// covers itself and all descendants, while a non-recursive watch covers only
+// itself. Ancestors and unrelated paths are never covered.
+func TestDirWatchSetCoverage(t *testing.T) {
+	t.Parallel()
+
+	set := NewDirWatchSet(caseSensitiveOpts)
+	set.Set("/repo/src", true)             // recursive
+	set.Set("/repo/config", false)         // non-recursive
+	set.Set("/repo/node_modules/a", false) // non-recursive
+
+	tests := []struct {
+		dir  string
+		want bool
+	}{
+		{"/repo/src", true},             // exact recursive
+		{"/repo/src/nested", true},      // descendant of recursive
+		{"/repo/src/nested/deep", true}, // deep descendant of recursive
+		{"/repo/config", true},          // exact non-recursive
+		{"/repo/config/nested", false},  // descendant of non-recursive: NOT covered
+		{"/repo/node_modules/a", true},  // exact non-recursive
+		{"/repo/node_modules/b", false}, // sibling, absent
+		{"/repo", false},                // ancestor of watched dirs: NOT covered
+		{"/other", false},               // unrelated
+	}
+	for _, tt := range tests {
+		assert.Equal(t, set.Covered(tt.dir), tt.want, "Covered(%q)", tt.dir)
+	}
+}
+
+// TestDirWatchSetCaseSensitive verifies that on a case-sensitive filesystem a
+// differently-cased directory is a distinct, uncovered directory.
+func TestDirWatchSetCaseSensitive(t *testing.T) {
+	t.Parallel()
+
+	set := NewDirWatchSet(caseSensitiveOpts)
+	set.Set("/repo/node_modules/a", false)
+	set.Set("/repo/Src", true)
+
+	assert.Assert(t, set.Covered("/repo/node_modules/a"))
+	assert.Assert(t, !set.Covered("/repo/node_modules/A"), "case-sensitive FS must not cover differently-cased dir")
+	assert.Assert(t, set.Covered("/repo/Src/nested"), "recursive descendant with matching case is covered")
+	assert.Assert(t, !set.Covered("/repo/src/nested"), "case-sensitive FS must not cover differently-cased descendant")
+}
+
+// TestDirWatchSetCaseInsensitive verifies that on a case-insensitive filesystem
+// coverage ignores casing for both exact matches and recursive containment.
+func TestDirWatchSetCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	set := NewDirWatchSet(caseInsensitiveOpts)
+	set.Set("/repo/node_modules/a", false)
+	set.Set("/repo/Src", true)
+
+	assert.Assert(t, set.Covered("/repo/node_modules/A"), "exact match should be case-insensitive")
+	assert.Assert(t, set.Covered("/REPO/NODE_MODULES/a"), "exact match should be case-insensitive across components")
+	assert.Assert(t, set.Covered("/repo/src/nested/deep"), "recursive containment should be case-insensitive")
+}
+
+// TestDirWatchSetPreservesCasing verifies Dirs returns original-cased keys so
+// watch registration uses the real path even on case-insensitive filesystems.
+func TestDirWatchSetPreservesCasing(t *testing.T) {
+	t.Parallel()
+
+	set := NewDirWatchSet(caseInsensitiveOpts)
+	set.Set("/repo/Node_Modules/PkgName", false)
+
+	_, ok := set.Dirs()["/repo/Node_Modules/PkgName"]
+	assert.Assert(t, ok, "Dirs must preserve original casing for watch registration")
+	_, lowered := set.Dirs()["/repo/node_modules/pkgname"]
+	assert.Assert(t, !lowered, "Dirs must not contain a canonicalized (lowercased) key")
+}
+
+// TestDirWatchSetUpgradeToRecursive verifies that upgrading a directory from
+// non-recursive to recursive begins covering its descendants.
+func TestDirWatchSetUpgradeToRecursive(t *testing.T) {
+	t.Parallel()
+
+	set := NewDirWatchSet(caseSensitiveOpts)
+	set.Set("/repo/src", false)
+	assert.Assert(t, set.Covered("/repo/src"))
+	assert.Assert(t, !set.Covered("/repo/src/nested"), "descendant not covered while non-recursive")
+
+	set.Set("/repo/src", true)
+	assert.Assert(t, set.Covered("/repo/src/nested"), "descendant covered after upgrade to recursive")
+	assert.Equal(t, set.Dirs()["/repo/src"], true)
+}
+
+// TestDirWatchSetNeverDowngrades verifies a recursive watch is not downgraded by
+// a subsequent non-recursive Set of the same directory.
+func TestDirWatchSetNeverDowngrades(t *testing.T) {
+	t.Parallel()
+
+	set := NewDirWatchSet(caseSensitiveOpts)
+	set.Set("/repo/src", true)
+	set.Set("/repo/src", false)
+
+	assert.Equal(t, set.Dirs()["/repo/src"], true)
+	assert.Assert(t, set.Covered("/repo/src/nested"), "recursive coverage retained after non-recursive Set")
+}
+
+// TestDirWatchSetDirs verifies the emitted map reflects every added directory
+// with the expected recursive flags.
+func TestDirWatchSetDirs(t *testing.T) {
+	t.Parallel()
+
+	set := NewDirWatchSet(caseSensitiveOpts)
+	set.Set("/repo/a", false)
+	set.Set("/repo/b", true)
+	set.Set("/repo/a", false) // duplicate non-recursive add is idempotent
+
+	dirs := set.Dirs()
+	assert.Equal(t, len(dirs), 2)
+	assert.Equal(t, dirs["/repo/a"], false)
+	assert.Equal(t, dirs["/repo/b"], true)
+}

--- a/internal/execute/watchmanager/watchmanager_test.go
+++ b/internal/execute/watchmanager/watchmanager_test.go
@@ -71,18 +71,25 @@ func TestDirWatchSetCaseInsensitive(t *testing.T) {
 	assert.Assert(t, set.Covered("/repo/src/nested/deep"), "recursive containment should be case-insensitive")
 }
 
-// TestDirWatchSetPreservesCasing verifies Dirs returns original-cased keys so
-// watch registration uses the real path even on case-insensitive filesystems.
-func TestDirWatchSetPreservesCasing(t *testing.T) {
+// TestDirWatchSetCanonicalDedup verifies that on a case-insensitive filesystem
+// directories that differ only by casing collapse to a single watch entry, while
+// Dirs preserves the original casing of the first-seen path for registration.
+func TestDirWatchSetCanonicalDedup(t *testing.T) {
 	t.Parallel()
 
-	set := NewDirWatchSet(caseInsensitiveOpts)
-	set.Set("/repo/Node_Modules/PkgName", false)
+	insensitive := NewDirWatchSet(caseInsensitiveOpts)
+	insensitive.Set("/repo/Node_Modules/PkgName", false)
+	insensitive.Set("/repo/node_modules/pkgname", false) // same dir, different casing
 
-	_, ok := set.Dirs()["/repo/Node_Modules/PkgName"]
-	assert.Assert(t, ok, "Dirs must preserve original casing for watch registration")
-	_, lowered := set.Dirs()["/repo/node_modules/pkgname"]
-	assert.Assert(t, !lowered, "Dirs must not contain a canonicalized (lowercased) key")
+	dirs := insensitive.Dirs()
+	assert.Equal(t, len(dirs), 1, "differently-cased dirs must collapse to one entry")
+	_, original := dirs["/repo/Node_Modules/PkgName"]
+	assert.Assert(t, original, "Dirs must preserve the original casing of the first-seen path")
+
+	sensitive := NewDirWatchSet(caseSensitiveOpts)
+	sensitive.Set("/repo/Node_Modules/PkgName", false)
+	sensitive.Set("/repo/node_modules/pkgname", false) // distinct dirs when case-sensitive
+	assert.Equal(t, len(sensitive.Dirs()), 2, "case-sensitive FS keeps differently-cased dirs distinct")
 }
 
 // TestDirWatchSetUpgradeToRecursive verifies that upgrading a directory from

--- a/internal/execute/watchmanager/watchmanager_test.go
+++ b/internal/execute/watchmanager/watchmanager_test.go
@@ -72,8 +72,8 @@ func TestDirWatchSetCaseInsensitive(t *testing.T) {
 }
 
 // TestDirWatchSetCanonicalDedup verifies that on a case-insensitive filesystem
-// directories that differ only by casing collapse to a single watch entry, while
-// Dirs preserves the original casing of the first-seen path for registration.
+// directories that differ only by casing collapse to a single canonical entry,
+// while a case-sensitive filesystem keeps them distinct.
 func TestDirWatchSetCanonicalDedup(t *testing.T) {
 	t.Parallel()
 
@@ -83,8 +83,8 @@ func TestDirWatchSetCanonicalDedup(t *testing.T) {
 
 	dirs := insensitive.Dirs()
 	assert.Equal(t, len(dirs), 1, "differently-cased dirs must collapse to one entry")
-	_, original := dirs["/repo/Node_Modules/PkgName"]
-	assert.Assert(t, original, "Dirs must preserve the original casing of the first-seen path")
+	_, canonical := dirs["/repo/node_modules/pkgname"]
+	assert.Assert(t, canonical, "Dirs must be keyed by the canonicalized path")
 
 	sensitive := NewDirWatchSet(caseSensitiveOpts)
 	sensitive.Set("/repo/Node_Modules/PkgName", false)

--- a/testdata/baselines/reference/tsbuildWatch/dependencyUpdate/watches-absolute-non-root-dependency-updates.js
+++ b/testdata/baselines/reference/tsbuildWatch/dependencyUpdate/watches-absolute-non-root-dependency-updates.js
@@ -133,10 +133,10 @@ export const value = myValue;
 
 Watch Registrations::
 Directory watches::
-  C:/home/src/tslibs/TS/Lib
-  C:/work/project
-  C:/work/project/src (recursive)
-  D:/work/deps
+  c:/home/src/tslibs/ts/lib
+  c:/work/project
+  c:/work/project/src (recursive)
+  d:/work/deps
 tsconfig.json::
 SemanticDiagnostics::
 *refresh*    C:/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
@@ -257,10 +257,10 @@ Output::
 
 Watch Registrations::
 Directory watches::
-  C:/home/src/tslibs/TS/Lib
-  C:/work/project
-  C:/work/project/src (recursive)
-  D:/work/deps
+  c:/home/src/tslibs/ts/lib
+  c:/work/project
+  c:/work/project/src (recursive)
+  d:/work/deps
 tsconfig.json::
 SemanticDiagnostics::
 *refresh*    D:/work/deps/dep.d.ts


### PR DESCRIPTION
Fixes #4614 

On a large `tsc -b --watch` project-references solution, `Found 0 errors. Watching for file changes` prints within a few seconds, but filesystem watches aren't registers until `computeDesiredWatches` returns, which can take tens of seconds. Edits are also silently dropped during this timeframe.

`computeDesiredWatches` calls `IsDirCoveredByWatch` once per input file, buildinfo file, and `package.json` ancestor across all projects, which linearly scans the entire `DesiredDirs` map on every call. The set construction here is essentially O(files x dirs); by using a new data structure called `DirWatchSet`, we can reduce this to O(files x recursive dirs). In the case of the example given in the linked issue, the ~1,534 desired dirs drop to ~15 recursive dirs while the number of files remains the same.