### PR TITLE
Fix declaration emit synthesizing extensionless import() specifier under allowImportingTsExtensions + nodenext

### DIFF
--- a/internal/modulespecifiers/preferences.go
+++ b/internal/modulespecifiers/preferences.go
@@ -174,7 +174,13 @@ func GetAllowedEndingsInPreferredOrder(
 	moduleResolution := compilerOptions.GetModuleResolutionKind()
 	moduleResolutionIsNodeNext := core.ModuleResolutionKindNode16 <= moduleResolution && moduleResolution <= core.ModuleResolutionKindNodeNext
 	allowImportingTsExtension := shouldAllowImportingTsExtension(compilerOptions, importingSourceFile.FileName())
-	if syntaxImpliedNodeFormat == core.ResolutionModeESM && moduleResolutionIsNodeNext {
+	// TypeScript uses `(syntaxImpliedNodeFormat ?? impliedNodeFormat)` here - fall back to the
+	// file's default resolution mode when no syntax-implied mode is given.
+	effectiveSyntaxMode := syntaxImpliedNodeFormat
+	if effectiveSyntaxMode == core.ResolutionModeNone {
+		effectiveSyntaxMode = resolutionMode
+	}
+	if effectiveSyntaxMode == core.ResolutionModeESM && moduleResolutionIsNodeNext {
 		if allowImportingTsExtension {
 			return []ModuleSpecifierEnding{ModuleSpecifierEndingTsExtension, ModuleSpecifierEndingJsExtension}
 		}

--- a/testdata/baselines/reference/compiler/declarationEmitImportSpecifierWithTsExtensionRelativeImport.js
+++ b/testdata/baselines/reference/compiler/declarationEmitImportSpecifierWithTsExtensionRelativeImport.js
@@ -1,0 +1,28 @@
+//// [tests/cases/compiler/declarationEmitImportSpecifierWithTsExtensionRelativeImport.ts] ////
+
+//// [package.json]
+{ "type": "module" }
+
+//// [package.json]
+{ "name": "mylib", "version": "1.0.0", "main": "./lib/index.js" }
+
+//// [Box.d.ts]
+export interface Box<T> { readonly value: T }
+export declare function box<T>(value: T): Box<T>;
+
+//// [helper.ts]
+import * as B from 'mylib/lib/Box.js';
+export const inner = B.box('hello');
+
+//// [mod.ts]
+import { inner } from './helper.ts';
+export const out = inner;
+
+
+
+
+//// [helper.d.ts]
+import * as B from 'mylib/lib/Box.js';
+export declare const inner: B.Box<string>;
+//// [mod.d.ts]
+export declare const out: import("mylib/lib/Box.js").Box<string>;

--- a/testdata/baselines/reference/compiler/declarationEmitImportSpecifierWithTsExtensionRelativeImport.symbols
+++ b/testdata/baselines/reference/compiler/declarationEmitImportSpecifierWithTsExtensionRelativeImport.symbols
@@ -1,0 +1,35 @@
+//// [tests/cases/compiler/declarationEmitImportSpecifierWithTsExtensionRelativeImport.ts] ////
+
+=== /node_modules/mylib/lib/Box.d.ts ===
+export interface Box<T> { readonly value: T }
+>Box : Symbol(Box, Decl(Box.d.ts, 0, 0))
+>T : Symbol(T, Decl(Box.d.ts, 0, 21))
+>value : Symbol(Box.value, Decl(Box.d.ts, 0, 25))
+>T : Symbol(T, Decl(Box.d.ts, 0, 21))
+
+export declare function box<T>(value: T): Box<T>;
+>box : Symbol(box, Decl(Box.d.ts, 0, 45))
+>T : Symbol(T, Decl(Box.d.ts, 1, 28))
+>value : Symbol(value, Decl(Box.d.ts, 1, 31))
+>T : Symbol(T, Decl(Box.d.ts, 1, 28))
+>Box : Symbol(Box, Decl(Box.d.ts, 0, 0))
+>T : Symbol(T, Decl(Box.d.ts, 1, 28))
+
+=== /helper.ts ===
+import * as B from 'mylib/lib/Box.js';
+>B : Symbol(B, Decl(helper.ts, 0, 6))
+
+export const inner = B.box('hello');
+>inner : Symbol(inner, Decl(helper.ts, 1, 12))
+>B.box : Symbol(B.box, Decl(Box.d.ts, 0, 45))
+>B : Symbol(B, Decl(helper.ts, 0, 6))
+>box : Symbol(B.box, Decl(Box.d.ts, 0, 45))
+
+=== /mod.ts ===
+import { inner } from './helper.ts';
+>inner : Symbol(inner, Decl(mod.ts, 0, 8))
+
+export const out = inner;
+>out : Symbol(out, Decl(mod.ts, 1, 12))
+>inner : Symbol(inner, Decl(mod.ts, 0, 8))
+

--- a/testdata/baselines/reference/compiler/declarationEmitImportSpecifierWithTsExtensionRelativeImport.types
+++ b/testdata/baselines/reference/compiler/declarationEmitImportSpecifierWithTsExtensionRelativeImport.types
@@ -1,0 +1,30 @@
+//// [tests/cases/compiler/declarationEmitImportSpecifierWithTsExtensionRelativeImport.ts] ////
+
+=== /node_modules/mylib/lib/Box.d.ts ===
+export interface Box<T> { readonly value: T }
+>value : T
+
+export declare function box<T>(value: T): Box<T>;
+>box : <T>(value: T) => Box<T>
+>value : T
+
+=== /helper.ts ===
+import * as B from 'mylib/lib/Box.js';
+>B : typeof B
+
+export const inner = B.box('hello');
+>inner : B.Box<string>
+>B.box('hello') : B.Box<string>
+>B.box : <T>(value: T) => B.Box<T>
+>B : typeof B
+>box : <T>(value: T) => B.Box<T>
+>'hello' : "hello"
+
+=== /mod.ts ===
+import { inner } from './helper.ts';
+>inner : import("mylib/lib/Box.js").Box<string>
+
+export const out = inner;
+>out : import("mylib/lib/Box.js").Box<string>
+>inner : import("mylib/lib/Box.js").Box<string>
+

--- a/testdata/tests/cases/compiler/declarationEmitImportSpecifierWithTsExtensionRelativeImport.ts
+++ b/testdata/tests/cases/compiler/declarationEmitImportSpecifierWithTsExtensionRelativeImport.ts
@@ -1,0 +1,26 @@
+// @module: nodenext
+// @declaration: true
+// @emitDeclarationOnly: true
+// @allowImportingTsExtensions: true
+
+// Regression test for https://github.com/microsoft/typescript-go/issues/4616
+// When a file uses `.ts` extension relative imports with allowImportingTsExtensions,
+// declaration emit should preserve `.js` extensions on non-relative (node_modules) imports.
+
+// @Filename: /package.json
+{ "type": "module" }
+
+// @Filename: /node_modules/mylib/package.json
+{ "name": "mylib", "version": "1.0.0", "main": "./lib/index.js" }
+
+// @Filename: /node_modules/mylib/lib/Box.d.ts
+export interface Box<T> { readonly value: T }
+export declare function box<T>(value: T): Box<T>;
+
+// @Filename: /helper.ts
+import * as B from 'mylib/lib/Box.js';
+export const inner = B.box('hello');
+
+// @Filename: /mod.ts
+import { inner } from './helper.ts';
+export const out = inner;


### PR DESCRIPTION
When using `allowImportingTsExtensions: true` with `.ts`-extension relative imports under `module: nodenext`, declaration emit was generating invalid extensionless `import()` type references for node_modules packages — `import("mylib/lib/Box")` instead of `import("mylib/lib/Box.js")` — causing `TS2307` errors in the emitted `.d.ts`.

## Root cause

`GetAllowedEndingsInPreferredOrder` in `preferences.go` checked the ESM+NodeNext special case as:

```go
if syntaxImpliedNodeFormat == core.ResolutionModeESM && moduleResolutionIsNodeNext {
```

TypeScript 6 uses `(syntaxImpliedNodeFormat ?? impliedNodeFormat)`, falling back to the file's implied node format when `syntaxImpliedNodeFormat` is not provided. The Go port was missing this fallback.

When `tryGetModuleNameAsNodeModule` calls with `ResolutionModeNone`, the ESM check was always `false`, yielding `[TsExtension, Minimal, JsExtension, Index]` instead of the correct `[TsExtension, JsExtension]`. With `Minimal` before `JsExtension`, `processEnding` picked the extensionless form for `.d.ts` declaration files.

## Fix

- **`internal/modulespecifiers/preferences.go`**: When `syntaxImpliedNodeFormat` is `ResolutionModeNone`, fall back to `resolutionMode` (the file's default) before the ESM+NodeNext check — matching TypeScript's `??` semantics.

- **`testdata/tests/cases/compiler/declarationEmitImportSpecifierWithTsExtensionRelativeImport.ts`**: Regression test covering the exact repro: ESM package, `.ts`-extension relative import chain, node_modules subpath with `.js` extension, verified `mod.d.ts` output is now `import("mylib/lib/Box.js").Box<string>` with no `TS2307`.

<!-- START COPILOT CODING AGENT SUFFIX -->

- Fixes #4616