### PR TITLE
Return all files from getFilesAffectedBy when a changed file affects global scope

### DIFF
--- a/internal/execute/incremental/affectedfileshandler.go
+++ b/internal/execute/incremental/affectedfileshandler.go
@@ -117,8 +117,6 @@ func (h *affectedFilesHandler) getFilesAffectedBy(path tspath.Path) []*ast.Sourc
 		return []*ast.SourceFile{file}
 	}
 
-	// When a change affects the global scope, every file other than the default library files is affected,
-	// so that dependents get their cached semantic diagnostics removed even when no reference edge leads to them.
 	if info, _ := h.program.snapshot.fileInfos.Load(file.Path()); info.affectsGlobalScope {
 		h.hasAllFilesExcludingDefaultLibraryFile.Store(true)
 		return h.program.snapshot.getAllFilesExcludingDefaultLibraryFile(h.program.program, file)

--- a/internal/execute/incremental/affectedfileshandler.go
+++ b/internal/execute/incremental/affectedfileshandler.go
@@ -117,9 +117,11 @@ func (h *affectedFilesHandler) getFilesAffectedBy(path tspath.Path) []*ast.Sourc
 		return []*ast.SourceFile{file}
 	}
 
+	// When a change affects the global scope, every file other than the default library files is affected,
+	// so that dependents get their cached semantic diagnostics removed even when no reference edge leads to them.
 	if info, _ := h.program.snapshot.fileInfos.Load(file.Path()); info.affectsGlobalScope {
 		h.hasAllFilesExcludingDefaultLibraryFile.Store(true)
-		h.program.snapshot.getAllFilesExcludingDefaultLibraryFile(h.program.program, file)
+		return h.program.snapshot.getAllFilesExcludingDefaultLibraryFile(h.program.program, file)
 	}
 
 	if h.program.snapshot.options.IsolatedModules.IsTrue() {

--- a/internal/execute/tsctests/tscbuild_test.go
+++ b/internal/execute/tsctests/tscbuild_test.go
@@ -1008,6 +1008,63 @@ func TestBuildFileDelete(t *testing.T) {
 
 func TestBuildDependencyUpdate(t *testing.T) {
 	t.Parallel()
+	// Project shape shared by the batched dependency update scenarios:
+	// src/consumer.ts depends on dep-a only through src/middle.ts, whose .d.ts
+	// signature does not change when dep-a's type gains a member. src/env.ts
+	// pulls in dep-b, whose .d.ts augments the global scope.
+	getBatchDependencyUpdateFiles := func() FileMap {
+		return FileMap{
+			"/home/src/workspaces/project/tsconfig.json": stringtestutil.Dedent(`
+				{
+					"compilerOptions": {
+						"composite": true,
+						"outDir": "dist",
+						"strict": true
+					},
+					"include": ["src/**/*"]
+				}
+			`),
+			"/home/src/workspaces/project/src/consumer.ts": stringtestutil.Dedent(`
+				import type { Kind } from "./middle";
+				export function describe(kind: Kind): string {
+					switch (kind) {
+						case "a":
+							return "first";
+						case "b":
+							return "second";
+					}
+				}
+			`),
+			"/home/src/workspaces/project/src/middle.ts": `export type { Kind } from "dep-a";`,
+			"/home/src/workspaces/project/src/env.ts":    `import "dep-b";`,
+			"/home/src/workspaces/project/node_modules/dep-a/package.json": stringtestutil.Dedent(`
+				{
+					"name": "dep-a",
+					"version": "1.0.0",
+					"types": "index.d.ts"
+				}
+			`),
+			"/home/src/workspaces/project/node_modules/dep-a/index.d.ts": `export type Kind = "a" | "b";`,
+			"/home/src/workspaces/project/node_modules/dep-b/package.json": stringtestutil.Dedent(`
+				{
+					"name": "dep-b",
+					"version": "1.0.0",
+					"types": "index.d.ts"
+				}
+			`),
+			"/home/src/workspaces/project/node_modules/dep-b/index.d.ts": stringtestutil.Dedent(`
+				declare global {
+					interface DepBGlobal {
+						marker: string;
+					}
+				}
+				export {};
+			`),
+		}
+	}
+	updateDepAWithBreakingTypeChange := func(sys *TestSys) {
+		sys.writeFileNoError("/home/src/workspaces/project/node_modules/dep-a/index.d.ts", `export type Kind = "a" | "b" | "c";`)
+	}
 	testCases := []*tscInput{
 		{
 			// https://github.com/microsoft/typescript-go/issues/2666
@@ -1202,6 +1259,88 @@ func TestBuildDependencyUpdate(t *testing.T) {
 					caption: "update absolute non-root dependency with breaking type change",
 					edit: func(sys *TestSys) {
 						sys.writeFileNoError("D:/work/deps/dep.d.ts", "export declare const myValue: number;")
+					},
+				},
+			},
+		},
+		{
+			subScenario:     "rebuilds transitive dependents when dependency update batch includes a global scope change",
+			files:           getBatchDependencyUpdateFiles(),
+			cwd:             "/home/src/workspaces/project",
+			commandLineArgs: []string{"--b", "--verbose"},
+			edits: []*tscEdit{
+				{
+					caption: "update dep-a with a breaking type change and dep-b with a global scope change in one batch",
+					edit: func(sys *TestSys) {
+						updateDepAWithBreakingTypeChange(sys)
+						sys.writeFileNoError("/home/src/workspaces/project/node_modules/dep-b/index.d.ts", stringtestutil.Dedent(`
+							declare global {
+								interface DepBGlobal {
+									marker: string;
+									extra: number;
+								}
+							}
+							export {};
+						`))
+					},
+				},
+				noChange,
+			},
+		},
+		{
+			// Control for the batched scenario: the same dep-a break without dep-b's global scope change.
+			subScenario:     "rebuilds transitive dependents when dependency update batch has no global scope change",
+			files:           getBatchDependencyUpdateFiles(),
+			cwd:             "/home/src/workspaces/project",
+			commandLineArgs: []string{"--b", "--verbose"},
+			edits: []*tscEdit{
+				{
+					caption: "update dep-a with a breaking type change",
+					edit:    updateDepAWithBreakingTypeChange,
+				},
+			},
+		},
+		{
+			subScenario: "rebuilds files using globals when global scope dependency is updated",
+			files: FileMap{
+				"/home/src/workspaces/project/tsconfig.json": stringtestutil.Dedent(`
+					{
+						"compilerOptions": {
+							"composite": true,
+							"outDir": "dist",
+							"strict": true
+						},
+						"include": ["src/**/*"]
+					}
+				`),
+				"/home/src/workspaces/project/src/env.ts":  `import "dep-b";`,
+				"/home/src/workspaces/project/src/user.ts": `export const marker: string = globalMarker;`,
+				"/home/src/workspaces/project/node_modules/dep-b/package.json": stringtestutil.Dedent(`
+					{
+						"name": "dep-b",
+						"version": "1.0.0",
+						"types": "index.d.ts"
+					}
+				`),
+				"/home/src/workspaces/project/node_modules/dep-b/index.d.ts": stringtestutil.Dedent(`
+					declare global {
+						var globalMarker: string;
+					}
+					export {};
+				`),
+			},
+			cwd:             "/home/src/workspaces/project",
+			commandLineArgs: []string{"--b", "--verbose"},
+			edits: []*tscEdit{
+				{
+					caption: "update dep-b changing the type of a global",
+					edit: func(sys *TestSys) {
+						sys.writeFileNoError("/home/src/workspaces/project/node_modules/dep-b/index.d.ts", stringtestutil.Dedent(`
+							declare global {
+								var globalMarker: number;
+							}
+							export {};
+						`))
 					},
 				},
 			},

--- a/testdata/baselines/reference/tsbuild/dependencyUpdate/rebuilds-files-using-globals-when-global-scope-dependency-is-updated.js
+++ b/testdata/baselines/reference/tsbuild/dependencyUpdate/rebuilds-files-using-globals-when-global-scope-dependency-is-updated.js
@@ -1,0 +1,325 @@
+currentDirectory::/home/src/workspaces/project
+useCaseSensitiveFileNames::true
+Input::
+//// [/home/src/workspaces/project/node_modules/dep-b/index.d.ts] *new* 
+declare global {
+    var globalMarker: string;
+}
+export {};
+//// [/home/src/workspaces/project/node_modules/dep-b/package.json] *new* 
+{
+    "name": "dep-b",
+    "version": "1.0.0",
+    "types": "index.d.ts"
+}
+//// [/home/src/workspaces/project/src/env.ts] *new* 
+import "dep-b";
+//// [/home/src/workspaces/project/src/user.ts] *new* 
+export const marker: string = globalMarker;
+//// [/home/src/workspaces/project/tsconfig.json] *new* 
+{
+    "compilerOptions": {
+        "composite": true,
+        "outDir": "dist",
+        "strict": true
+    },
+    "include": ["src/**/*"]
+}
+
+tsgo --b --verbose
+ExitStatus:: Success
+Output::
+[[90mHH:MM:SS AM[0m] Projects in this build: 
+    * tsconfig.json
+
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output file 'dist/tsconfig.tsbuildinfo' does not exist
+
+[[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
+
+//// [/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts] *Lib*
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+interface SymbolConstructor {
+    (desc?: string | number): symbol;
+    for(name: string): symbol;
+    readonly toStringTag: symbol;
+}
+declare var Symbol: SymbolConstructor;
+interface Symbol {
+    readonly [Symbol.toStringTag]: string;
+}
+declare const console: { log(msg: any): void; };
+//// [/home/src/workspaces/project/dist/src/env.d.ts] *new* 
+import "dep-b";
+
+//// [/home/src/workspaces/project/dist/src/env.js] *new* 
+import "dep-b";
+
+//// [/home/src/workspaces/project/dist/src/user.d.ts] *new* 
+export declare const marker: string;
+
+//// [/home/src/workspaces/project/dist/src/user.js] *new* 
+export const marker = globalMarker;
+
+//// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo] *new* 
+{"version":"FakeTSVersion","root":[[3,4]],"packageJsons":["../node_modules/dep-b/package.json"],"fileNames":["lib.es2025.full.d.ts","../node_modules/dep-b/index.d.ts","../src/env.ts","../src/user.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"cd032fb5030949e5f19325decfe193f4-declare global {\n    var globalMarker: string;\n}\nexport {};","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"fcc1d4c4b073cc5a548e7244f608884c-import \"dep-b\";","signature":"9fb8fd76a089f5d7d03937148c718fd8-import \"dep-b\";\n","impliedNodeFormat":1},{"version":"8e795fc4632e557befae4a0de611e036-export const marker: string = globalMarker;","signature":"62128710b5d65ffc36c246ad1f599f44-export declare const marker: string;\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./","strict":true},"referencedMap":[[3,1]],"latestChangedDtsFile":"./src/user.d.ts"}
+//// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
+{
+  "version": "FakeTSVersion",
+  "root": [
+    {
+      "files": [
+        "../src/env.ts",
+        "../src/user.ts"
+      ],
+      "original": [
+        3,
+        4
+      ]
+    }
+  ],
+  "packageJsons": [
+    "../node_modules/dep-b/package.json"
+  ],
+  "fileNames": [
+    "lib.es2025.full.d.ts",
+    "../node_modules/dep-b/index.d.ts",
+    "../src/env.ts",
+    "../src/user.ts"
+  ],
+  "fileInfos": [
+    {
+      "fileName": "lib.es2025.full.d.ts",
+      "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "signature": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "affectsGlobalScope": true,
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true,
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "../node_modules/dep-b/index.d.ts",
+      "version": "cd032fb5030949e5f19325decfe193f4-declare global {\n    var globalMarker: string;\n}\nexport {};",
+      "signature": "cd032fb5030949e5f19325decfe193f4-declare global {\n    var globalMarker: string;\n}\nexport {};",
+      "affectsGlobalScope": true,
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "cd032fb5030949e5f19325decfe193f4-declare global {\n    var globalMarker: string;\n}\nexport {};",
+        "affectsGlobalScope": true,
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "../src/env.ts",
+      "version": "fcc1d4c4b073cc5a548e7244f608884c-import \"dep-b\";",
+      "signature": "9fb8fd76a089f5d7d03937148c718fd8-import \"dep-b\";\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "fcc1d4c4b073cc5a548e7244f608884c-import \"dep-b\";",
+        "signature": "9fb8fd76a089f5d7d03937148c718fd8-import \"dep-b\";\n",
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "../src/user.ts",
+      "version": "8e795fc4632e557befae4a0de611e036-export const marker: string = globalMarker;",
+      "signature": "62128710b5d65ffc36c246ad1f599f44-export declare const marker: string;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "8e795fc4632e557befae4a0de611e036-export const marker: string = globalMarker;",
+        "signature": "62128710b5d65ffc36c246ad1f599f44-export declare const marker: string;\n",
+        "impliedNodeFormat": 1
+      }
+    }
+  ],
+  "fileIdsList": [
+    [
+      "../node_modules/dep-b/index.d.ts"
+    ]
+  ],
+  "options": {
+    "composite": true,
+    "outDir": "./",
+    "strict": true
+  },
+  "referencedMap": {
+    "../src/env.ts": [
+      "../node_modules/dep-b/index.d.ts"
+    ]
+  },
+  "latestChangedDtsFile": "./src/user.d.ts",
+  "size": 1638
+}
+
+tsconfig.json::
+SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
+*refresh*    /home/src/workspaces/project/node_modules/dep-b/index.d.ts
+*refresh*    /home/src/workspaces/project/src/env.ts
+*refresh*    /home/src/workspaces/project/src/user.ts
+Signatures::
+(stored at emit) /home/src/workspaces/project/src/env.ts
+(stored at emit) /home/src/workspaces/project/src/user.ts
+
+
+Edit [0]:: update dep-b changing the type of a global
+//// [/home/src/workspaces/project/node_modules/dep-b/index.d.ts] *modified* 
+declare global {
+    var globalMarker: number;
+}
+export {};
+
+tsgo --b --verbose
+ExitStatus:: DiagnosticsPresent_OutputsGenerated
+Output::
+[[90mHH:MM:SS AM[0m] Projects in this build: 
+    * tsconfig.json
+
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output 'dist/tsconfig.tsbuildinfo' is older than input 'node_modules/dep-b/index.d.ts'
+
+[[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
+
+[96msrc/user.ts[0m:[93m1[0m:[93m14[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
+
+[7m1[0m export const marker: string = globalMarker;
+[7m [0m [91m             ~~~~~~[0m
+
+
+Found 1 error in src/user.ts[90m:1[0m
+
+//// [/home/src/workspaces/project/dist/src/env.js] *rewrite with same content*
+//// [/home/src/workspaces/project/dist/src/user.js] *rewrite with same content*
+//// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo] *modified* 
+{"version":"FakeTSVersion","root":[[3,4]],"packageJsons":["../node_modules/dep-b/package.json"],"fileNames":["lib.es2025.full.d.ts","../node_modules/dep-b/index.d.ts","../src/env.ts","../src/user.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"7913b3844cab0fd9a89d3aaee6d67888-declare global {\n    var globalMarker: number;\n}\nexport {};","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"fcc1d4c4b073cc5a548e7244f608884c-import \"dep-b\";","signature":"9fb8fd76a089f5d7d03937148c718fd8-import \"dep-b\";\n","impliedNodeFormat":1},{"version":"8e795fc4632e557befae4a0de611e036-export const marker: string = globalMarker;","signature":"62128710b5d65ffc36c246ad1f599f44-export declare const marker: string;\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"composite":true,"outDir":"./","strict":true},"referencedMap":[[3,1]],"semanticDiagnosticsPerFile":[[4,[{"pos":13,"end":19,"code":2322,"category":1,"messageKey":"Type_0_is_not_assignable_to_type_1_2322","messageArgs":["number","string"]}]]],"latestChangedDtsFile":"./src/user.d.ts"}
+//// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
+{
+  "version": "FakeTSVersion",
+  "root": [
+    {
+      "files": [
+        "../src/env.ts",
+        "../src/user.ts"
+      ],
+      "original": [
+        3,
+        4
+      ]
+    }
+  ],
+  "packageJsons": [
+    "../node_modules/dep-b/package.json"
+  ],
+  "fileNames": [
+    "lib.es2025.full.d.ts",
+    "../node_modules/dep-b/index.d.ts",
+    "../src/env.ts",
+    "../src/user.ts"
+  ],
+  "fileInfos": [
+    {
+      "fileName": "lib.es2025.full.d.ts",
+      "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "signature": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "affectsGlobalScope": true,
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true,
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "../node_modules/dep-b/index.d.ts",
+      "version": "7913b3844cab0fd9a89d3aaee6d67888-declare global {\n    var globalMarker: number;\n}\nexport {};",
+      "signature": "7913b3844cab0fd9a89d3aaee6d67888-declare global {\n    var globalMarker: number;\n}\nexport {};",
+      "affectsGlobalScope": true,
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "7913b3844cab0fd9a89d3aaee6d67888-declare global {\n    var globalMarker: number;\n}\nexport {};",
+        "affectsGlobalScope": true,
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "../src/env.ts",
+      "version": "fcc1d4c4b073cc5a548e7244f608884c-import \"dep-b\";",
+      "signature": "9fb8fd76a089f5d7d03937148c718fd8-import \"dep-b\";\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "fcc1d4c4b073cc5a548e7244f608884c-import \"dep-b\";",
+        "signature": "9fb8fd76a089f5d7d03937148c718fd8-import \"dep-b\";\n",
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "../src/user.ts",
+      "version": "8e795fc4632e557befae4a0de611e036-export const marker: string = globalMarker;",
+      "signature": "62128710b5d65ffc36c246ad1f599f44-export declare const marker: string;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "8e795fc4632e557befae4a0de611e036-export const marker: string = globalMarker;",
+        "signature": "62128710b5d65ffc36c246ad1f599f44-export declare const marker: string;\n",
+        "impliedNodeFormat": 1
+      }
+    }
+  ],
+  "fileIdsList": [
+    [
+      "../node_modules/dep-b/index.d.ts"
+    ]
+  ],
+  "options": {
+    "composite": true,
+    "outDir": "./",
+    "strict": true
+  },
+  "referencedMap": {
+    "../src/env.ts": [
+      "../node_modules/dep-b/index.d.ts"
+    ]
+  },
+  "semanticDiagnosticsPerFile": [
+    [
+      "../src/user.ts",
+      [
+        {
+          "pos": 13,
+          "end": 19,
+          "code": 2322,
+          "category": 1,
+          "messageKey": "Type_0_is_not_assignable_to_type_1_2322",
+          "messageArgs": [
+            "number",
+            "string"
+          ]
+        }
+      ]
+    ]
+  ],
+  "latestChangedDtsFile": "./src/user.d.ts",
+  "size": 1809
+}
+
+tsconfig.json::
+SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
+*refresh*    /home/src/workspaces/project/node_modules/dep-b/index.d.ts
+*refresh*    /home/src/workspaces/project/src/env.ts
+*refresh*    /home/src/workspaces/project/src/user.ts
+Signatures::
+(used version)   /home/src/workspaces/project/node_modules/dep-b/index.d.ts
+(computed .d.ts) /home/src/workspaces/project/src/env.ts
+(computed .d.ts) /home/src/workspaces/project/src/user.ts

--- a/testdata/baselines/reference/tsbuild/dependencyUpdate/rebuilds-transitive-dependents-when-dependency-update-batch-has-no-global-scope-change.js
+++ b/testdata/baselines/reference/tsbuild/dependencyUpdate/rebuilds-transitive-dependents-when-dependency-update-batch-has-no-global-scope-change.js
@@ -1,0 +1,429 @@
+currentDirectory::/home/src/workspaces/project
+useCaseSensitiveFileNames::true
+Input::
+//// [/home/src/workspaces/project/node_modules/dep-a/index.d.ts] *new* 
+export type Kind = "a" | "b";
+//// [/home/src/workspaces/project/node_modules/dep-a/package.json] *new* 
+{
+    "name": "dep-a",
+    "version": "1.0.0",
+    "types": "index.d.ts"
+}
+//// [/home/src/workspaces/project/node_modules/dep-b/index.d.ts] *new* 
+declare global {
+    interface DepBGlobal {
+        marker: string;
+    }
+}
+export {};
+//// [/home/src/workspaces/project/node_modules/dep-b/package.json] *new* 
+{
+    "name": "dep-b",
+    "version": "1.0.0",
+    "types": "index.d.ts"
+}
+//// [/home/src/workspaces/project/src/consumer.ts] *new* 
+import type { Kind } from "./middle";
+export function describe(kind: Kind): string {
+    switch (kind) {
+        case "a":
+            return "first";
+        case "b":
+            return "second";
+    }
+}
+//// [/home/src/workspaces/project/src/env.ts] *new* 
+import "dep-b";
+//// [/home/src/workspaces/project/src/middle.ts] *new* 
+export type { Kind } from "dep-a";
+//// [/home/src/workspaces/project/tsconfig.json] *new* 
+{
+    "compilerOptions": {
+        "composite": true,
+        "outDir": "dist",
+        "strict": true
+    },
+    "include": ["src/**/*"]
+}
+
+tsgo --b --verbose
+ExitStatus:: Success
+Output::
+[[90mHH:MM:SS AM[0m] Projects in this build: 
+    * tsconfig.json
+
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output file 'dist/tsconfig.tsbuildinfo' does not exist
+
+[[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
+
+//// [/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts] *Lib*
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+interface SymbolConstructor {
+    (desc?: string | number): symbol;
+    for(name: string): symbol;
+    readonly toStringTag: symbol;
+}
+declare var Symbol: SymbolConstructor;
+interface Symbol {
+    readonly [Symbol.toStringTag]: string;
+}
+declare const console: { log(msg: any): void; };
+//// [/home/src/workspaces/project/dist/src/consumer.d.ts] *new* 
+import type { Kind } from "./middle";
+export declare function describe(kind: Kind): string;
+
+//// [/home/src/workspaces/project/dist/src/consumer.js] *new* 
+export function describe(kind) {
+    switch (kind) {
+        case "a":
+            return "first";
+        case "b":
+            return "second";
+    }
+}
+
+//// [/home/src/workspaces/project/dist/src/env.d.ts] *new* 
+import "dep-b";
+
+//// [/home/src/workspaces/project/dist/src/env.js] *new* 
+import "dep-b";
+
+//// [/home/src/workspaces/project/dist/src/middle.d.ts] *new* 
+export type { Kind } from "dep-a";
+
+//// [/home/src/workspaces/project/dist/src/middle.js] *new* 
+export {};
+
+//// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo] *new* 
+{"version":"FakeTSVersion","root":[[3,4],6],"packageJsons":["../node_modules/dep-a/package.json","../node_modules/dep-b/package.json"],"fileNames":["lib.es2025.full.d.ts","../node_modules/dep-a/index.d.ts","../src/middle.ts","../src/consumer.ts","../node_modules/dep-b/index.d.ts","../src/env.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"7285be383f876947b8aaab3a6c0cb768-export type Kind = \"a\" | \"b\";",{"version":"c4e56d4d984b8f64c79f77ff5567b1ee-export type { Kind } from \"dep-a\";","signature":"df2d778f658765e085183f887f4c1fae-export type { Kind } from \"dep-a\";\n","impliedNodeFormat":1},{"version":"0bb05d7e49a1dc35d9c9a5249d6aefec-import type { Kind } from \"./middle\";\nexport function describe(kind: Kind): string {\n    switch (kind) {\n        case \"a\":\n            return \"first\";\n        case \"b\":\n            return \"second\";\n    }\n}","signature":"8b084aefefe47768ddf637170d0ce7f9-import type { Kind } from \"./middle\";\nexport declare function describe(kind: Kind): string;\n","impliedNodeFormat":1},{"version":"a94fea4b430695b9dbaf2f04eab64c1e-declare global {\n    interface DepBGlobal {\n        marker: string;\n    }\n}\nexport {};","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"fcc1d4c4b073cc5a548e7244f608884c-import \"dep-b\";","signature":"9fb8fd76a089f5d7d03937148c718fd8-import \"dep-b\";\n","impliedNodeFormat":1}],"fileIdsList":[[3],[5],[2]],"options":{"composite":true,"outDir":"./","strict":true},"referencedMap":[[4,1],[6,2],[3,3]],"latestChangedDtsFile":"./src/env.d.ts"}
+//// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
+{
+  "version": "FakeTSVersion",
+  "root": [
+    {
+      "files": [
+        "../src/middle.ts",
+        "../src/consumer.ts"
+      ],
+      "original": [
+        3,
+        4
+      ]
+    },
+    {
+      "files": [
+        "../src/env.ts"
+      ],
+      "original": 6
+    }
+  ],
+  "packageJsons": [
+    "../node_modules/dep-a/package.json",
+    "../node_modules/dep-b/package.json"
+  ],
+  "fileNames": [
+    "lib.es2025.full.d.ts",
+    "../node_modules/dep-a/index.d.ts",
+    "../src/middle.ts",
+    "../src/consumer.ts",
+    "../node_modules/dep-b/index.d.ts",
+    "../src/env.ts"
+  ],
+  "fileInfos": [
+    {
+      "fileName": "lib.es2025.full.d.ts",
+      "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "signature": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "affectsGlobalScope": true,
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true,
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "../node_modules/dep-a/index.d.ts",
+      "version": "7285be383f876947b8aaab3a6c0cb768-export type Kind = \"a\" | \"b\";",
+      "signature": "7285be383f876947b8aaab3a6c0cb768-export type Kind = \"a\" | \"b\";",
+      "impliedNodeFormat": "CommonJS"
+    },
+    {
+      "fileName": "../src/middle.ts",
+      "version": "c4e56d4d984b8f64c79f77ff5567b1ee-export type { Kind } from \"dep-a\";",
+      "signature": "df2d778f658765e085183f887f4c1fae-export type { Kind } from \"dep-a\";\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "c4e56d4d984b8f64c79f77ff5567b1ee-export type { Kind } from \"dep-a\";",
+        "signature": "df2d778f658765e085183f887f4c1fae-export type { Kind } from \"dep-a\";\n",
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "../src/consumer.ts",
+      "version": "0bb05d7e49a1dc35d9c9a5249d6aefec-import type { Kind } from \"./middle\";\nexport function describe(kind: Kind): string {\n    switch (kind) {\n        case \"a\":\n            return \"first\";\n        case \"b\":\n            return \"second\";\n    }\n}",
+      "signature": "8b084aefefe47768ddf637170d0ce7f9-import type { Kind } from \"./middle\";\nexport declare function describe(kind: Kind): string;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "0bb05d7e49a1dc35d9c9a5249d6aefec-import type { Kind } from \"./middle\";\nexport function describe(kind: Kind): string {\n    switch (kind) {\n        case \"a\":\n            return \"first\";\n        case \"b\":\n            return \"second\";\n    }\n}",
+        "signature": "8b084aefefe47768ddf637170d0ce7f9-import type { Kind } from \"./middle\";\nexport declare function describe(kind: Kind): string;\n",
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "../node_modules/dep-b/index.d.ts",
+      "version": "a94fea4b430695b9dbaf2f04eab64c1e-declare global {\n    interface DepBGlobal {\n        marker: string;\n    }\n}\nexport {};",
+      "signature": "a94fea4b430695b9dbaf2f04eab64c1e-declare global {\n    interface DepBGlobal {\n        marker: string;\n    }\n}\nexport {};",
+      "affectsGlobalScope": true,
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "a94fea4b430695b9dbaf2f04eab64c1e-declare global {\n    interface DepBGlobal {\n        marker: string;\n    }\n}\nexport {};",
+        "affectsGlobalScope": true,
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "../src/env.ts",
+      "version": "fcc1d4c4b073cc5a548e7244f608884c-import \"dep-b\";",
+      "signature": "9fb8fd76a089f5d7d03937148c718fd8-import \"dep-b\";\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "fcc1d4c4b073cc5a548e7244f608884c-import \"dep-b\";",
+        "signature": "9fb8fd76a089f5d7d03937148c718fd8-import \"dep-b\";\n",
+        "impliedNodeFormat": 1
+      }
+    }
+  ],
+  "fileIdsList": [
+    [
+      "../src/middle.ts"
+    ],
+    [
+      "../node_modules/dep-b/index.d.ts"
+    ],
+    [
+      "../node_modules/dep-a/index.d.ts"
+    ]
+  ],
+  "options": {
+    "composite": true,
+    "outDir": "./",
+    "strict": true
+  },
+  "referencedMap": {
+    "../src/consumer.ts": [
+      "../src/middle.ts"
+    ],
+    "../src/env.ts": [
+      "../node_modules/dep-b/index.d.ts"
+    ],
+    "../src/middle.ts": [
+      "../node_modules/dep-a/index.d.ts"
+    ]
+  },
+  "latestChangedDtsFile": "./src/env.d.ts",
+  "size": 2282
+}
+
+tsconfig.json::
+SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
+*refresh*    /home/src/workspaces/project/node_modules/dep-a/index.d.ts
+*refresh*    /home/src/workspaces/project/src/middle.ts
+*refresh*    /home/src/workspaces/project/src/consumer.ts
+*refresh*    /home/src/workspaces/project/node_modules/dep-b/index.d.ts
+*refresh*    /home/src/workspaces/project/src/env.ts
+Signatures::
+(stored at emit) /home/src/workspaces/project/src/middle.ts
+(stored at emit) /home/src/workspaces/project/src/consumer.ts
+(stored at emit) /home/src/workspaces/project/src/env.ts
+
+
+Edit [0]:: update dep-a with a breaking type change
+//// [/home/src/workspaces/project/node_modules/dep-a/index.d.ts] *modified* 
+export type Kind = "a" | "b" | "c";
+
+tsgo --b --verbose
+ExitStatus:: DiagnosticsPresent_OutputsGenerated
+Output::
+[[90mHH:MM:SS AM[0m] Projects in this build: 
+    * tsconfig.json
+
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output 'dist/tsconfig.tsbuildinfo' is older than input 'node_modules/dep-a/index.d.ts'
+
+[[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
+
+[96msrc/consumer.ts[0m:[93m2[0m:[93m39[0m - [91merror[0m[90m TS2366: [0mFunction lacks ending return statement and return type does not include 'undefined'.
+
+[7m2[0m export function describe(kind: Kind): string {
+[7m [0m [91m                                      ~~~~~~[0m
+
+
+Found 1 error in src/consumer.ts[90m:2[0m
+
+//// [/home/src/workspaces/project/dist/src/middle.js] *rewrite with same content*
+//// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo] *modified* 
+{"version":"FakeTSVersion","root":[[3,4],6],"packageJsons":["../node_modules/dep-a/package.json","../node_modules/dep-b/package.json"],"fileNames":["lib.es2025.full.d.ts","../node_modules/dep-a/index.d.ts","../src/middle.ts","../src/consumer.ts","../node_modules/dep-b/index.d.ts","../src/env.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"a4e0198c11df73a2e4b2aeeeedc6b0df-export type Kind = \"a\" | \"b\" | \"c\";",{"version":"c4e56d4d984b8f64c79f77ff5567b1ee-export type { Kind } from \"dep-a\";","signature":"df2d778f658765e085183f887f4c1fae-export type { Kind } from \"dep-a\";\n","impliedNodeFormat":1},{"version":"0bb05d7e49a1dc35d9c9a5249d6aefec-import type { Kind } from \"./middle\";\nexport function describe(kind: Kind): string {\n    switch (kind) {\n        case \"a\":\n            return \"first\";\n        case \"b\":\n            return \"second\";\n    }\n}","signature":"8b084aefefe47768ddf637170d0ce7f9-import type { Kind } from \"./middle\";\nexport declare function describe(kind: Kind): string;\n","impliedNodeFormat":1},{"version":"a94fea4b430695b9dbaf2f04eab64c1e-declare global {\n    interface DepBGlobal {\n        marker: string;\n    }\n}\nexport {};","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"fcc1d4c4b073cc5a548e7244f608884c-import \"dep-b\";","signature":"9fb8fd76a089f5d7d03937148c718fd8-import \"dep-b\";\n","impliedNodeFormat":1}],"fileIdsList":[[3],[5],[2]],"options":{"composite":true,"outDir":"./","strict":true},"referencedMap":[[4,1],[6,2],[3,3]],"semanticDiagnosticsPerFile":[[4,[{"pos":76,"end":82,"code":2366,"category":1,"messageKey":"Function_lacks_ending_return_statement_and_return_type_does_not_include_undefined_2366"}]]],"latestChangedDtsFile":"./src/env.d.ts"}
+//// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
+{
+  "version": "FakeTSVersion",
+  "root": [
+    {
+      "files": [
+        "../src/middle.ts",
+        "../src/consumer.ts"
+      ],
+      "original": [
+        3,
+        4
+      ]
+    },
+    {
+      "files": [
+        "../src/env.ts"
+      ],
+      "original": 6
+    }
+  ],
+  "packageJsons": [
+    "../node_modules/dep-a/package.json",
+    "../node_modules/dep-b/package.json"
+  ],
+  "fileNames": [
+    "lib.es2025.full.d.ts",
+    "../node_modules/dep-a/index.d.ts",
+    "../src/middle.ts",
+    "../src/consumer.ts",
+    "../node_modules/dep-b/index.d.ts",
+    "../src/env.ts"
+  ],
+  "fileInfos": [
+    {
+      "fileName": "lib.es2025.full.d.ts",
+      "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "signature": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "affectsGlobalScope": true,
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true,
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "../node_modules/dep-a/index.d.ts",
+      "version": "a4e0198c11df73a2e4b2aeeeedc6b0df-export type Kind = \"a\" | \"b\" | \"c\";",
+      "signature": "a4e0198c11df73a2e4b2aeeeedc6b0df-export type Kind = \"a\" | \"b\" | \"c\";",
+      "impliedNodeFormat": "CommonJS"
+    },
+    {
+      "fileName": "../src/middle.ts",
+      "version": "c4e56d4d984b8f64c79f77ff5567b1ee-export type { Kind } from \"dep-a\";",
+      "signature": "df2d778f658765e085183f887f4c1fae-export type { Kind } from \"dep-a\";\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "c4e56d4d984b8f64c79f77ff5567b1ee-export type { Kind } from \"dep-a\";",
+        "signature": "df2d778f658765e085183f887f4c1fae-export type { Kind } from \"dep-a\";\n",
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "../src/consumer.ts",
+      "version": "0bb05d7e49a1dc35d9c9a5249d6aefec-import type { Kind } from \"./middle\";\nexport function describe(kind: Kind): string {\n    switch (kind) {\n        case \"a\":\n            return \"first\";\n        case \"b\":\n            return \"second\";\n    }\n}",
+      "signature": "8b084aefefe47768ddf637170d0ce7f9-import type { Kind } from \"./middle\";\nexport declare function describe(kind: Kind): string;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "0bb05d7e49a1dc35d9c9a5249d6aefec-import type { Kind } from \"./middle\";\nexport function describe(kind: Kind): string {\n    switch (kind) {\n        case \"a\":\n            return \"first\";\n        case \"b\":\n            return \"second\";\n    }\n}",
+        "signature": "8b084aefefe47768ddf637170d0ce7f9-import type { Kind } from \"./middle\";\nexport declare function describe(kind: Kind): string;\n",
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "../node_modules/dep-b/index.d.ts",
+      "version": "a94fea4b430695b9dbaf2f04eab64c1e-declare global {\n    interface DepBGlobal {\n        marker: string;\n    }\n}\nexport {};",
+      "signature": "a94fea4b430695b9dbaf2f04eab64c1e-declare global {\n    interface DepBGlobal {\n        marker: string;\n    }\n}\nexport {};",
+      "affectsGlobalScope": true,
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "a94fea4b430695b9dbaf2f04eab64c1e-declare global {\n    interface DepBGlobal {\n        marker: string;\n    }\n}\nexport {};",
+        "affectsGlobalScope": true,
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "../src/env.ts",
+      "version": "fcc1d4c4b073cc5a548e7244f608884c-import \"dep-b\";",
+      "signature": "9fb8fd76a089f5d7d03937148c718fd8-import \"dep-b\";\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "fcc1d4c4b073cc5a548e7244f608884c-import \"dep-b\";",
+        "signature": "9fb8fd76a089f5d7d03937148c718fd8-import \"dep-b\";\n",
+        "impliedNodeFormat": 1
+      }
+    }
+  ],
+  "fileIdsList": [
+    [
+      "../src/middle.ts"
+    ],
+    [
+      "../node_modules/dep-b/index.d.ts"
+    ],
+    [
+      "../node_modules/dep-a/index.d.ts"
+    ]
+  ],
+  "options": {
+    "composite": true,
+    "outDir": "./",
+    "strict": true
+  },
+  "referencedMap": {
+    "../src/consumer.ts": [
+      "../src/middle.ts"
+    ],
+    "../src/env.ts": [
+      "../node_modules/dep-b/index.d.ts"
+    ],
+    "../src/middle.ts": [
+      "../node_modules/dep-a/index.d.ts"
+    ]
+  },
+  "semanticDiagnosticsPerFile": [
+    [
+      "../src/consumer.ts",
+      [
+        {
+          "pos": 76,
+          "end": 82,
+          "code": 2366,
+          "category": 1,
+          "messageKey": "Function_lacks_ending_return_statement_and_return_type_does_not_include_undefined_2366"
+        }
+      ]
+    ]
+  ],
+  "latestChangedDtsFile": "./src/env.d.ts",
+  "size": 2474
+}
+
+tsconfig.json::
+SemanticDiagnostics::
+*refresh*    /home/src/workspaces/project/node_modules/dep-a/index.d.ts
+*refresh*    /home/src/workspaces/project/src/middle.ts
+*refresh*    /home/src/workspaces/project/src/consumer.ts
+Signatures::
+(used version)   /home/src/workspaces/project/node_modules/dep-a/index.d.ts
+(computed .d.ts) /home/src/workspaces/project/src/middle.ts
+(stored at emit) /home/src/workspaces/project/src/consumer.ts

--- a/testdata/baselines/reference/tsbuild/dependencyUpdate/rebuilds-transitive-dependents-when-dependency-update-batch-includes-a-global-scope-change.js
+++ b/testdata/baselines/reference/tsbuild/dependencyUpdate/rebuilds-transitive-dependents-when-dependency-update-batch-includes-a-global-scope-change.js
@@ -1,0 +1,470 @@
+currentDirectory::/home/src/workspaces/project
+useCaseSensitiveFileNames::true
+Input::
+//// [/home/src/workspaces/project/node_modules/dep-a/index.d.ts] *new* 
+export type Kind = "a" | "b";
+//// [/home/src/workspaces/project/node_modules/dep-a/package.json] *new* 
+{
+    "name": "dep-a",
+    "version": "1.0.0",
+    "types": "index.d.ts"
+}
+//// [/home/src/workspaces/project/node_modules/dep-b/index.d.ts] *new* 
+declare global {
+    interface DepBGlobal {
+        marker: string;
+    }
+}
+export {};
+//// [/home/src/workspaces/project/node_modules/dep-b/package.json] *new* 
+{
+    "name": "dep-b",
+    "version": "1.0.0",
+    "types": "index.d.ts"
+}
+//// [/home/src/workspaces/project/src/consumer.ts] *new* 
+import type { Kind } from "./middle";
+export function describe(kind: Kind): string {
+    switch (kind) {
+        case "a":
+            return "first";
+        case "b":
+            return "second";
+    }
+}
+//// [/home/src/workspaces/project/src/env.ts] *new* 
+import "dep-b";
+//// [/home/src/workspaces/project/src/middle.ts] *new* 
+export type { Kind } from "dep-a";
+//// [/home/src/workspaces/project/tsconfig.json] *new* 
+{
+    "compilerOptions": {
+        "composite": true,
+        "outDir": "dist",
+        "strict": true
+    },
+    "include": ["src/**/*"]
+}
+
+tsgo --b --verbose
+ExitStatus:: Success
+Output::
+[[90mHH:MM:SS AM[0m] Projects in this build: 
+    * tsconfig.json
+
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output file 'dist/tsconfig.tsbuildinfo' does not exist
+
+[[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
+
+//// [/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts] *Lib*
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+interface SymbolConstructor {
+    (desc?: string | number): symbol;
+    for(name: string): symbol;
+    readonly toStringTag: symbol;
+}
+declare var Symbol: SymbolConstructor;
+interface Symbol {
+    readonly [Symbol.toStringTag]: string;
+}
+declare const console: { log(msg: any): void; };
+//// [/home/src/workspaces/project/dist/src/consumer.d.ts] *new* 
+import type { Kind } from "./middle";
+export declare function describe(kind: Kind): string;
+
+//// [/home/src/workspaces/project/dist/src/consumer.js] *new* 
+export function describe(kind) {
+    switch (kind) {
+        case "a":
+            return "first";
+        case "b":
+            return "second";
+    }
+}
+
+//// [/home/src/workspaces/project/dist/src/env.d.ts] *new* 
+import "dep-b";
+
+//// [/home/src/workspaces/project/dist/src/env.js] *new* 
+import "dep-b";
+
+//// [/home/src/workspaces/project/dist/src/middle.d.ts] *new* 
+export type { Kind } from "dep-a";
+
+//// [/home/src/workspaces/project/dist/src/middle.js] *new* 
+export {};
+
+//// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo] *new* 
+{"version":"FakeTSVersion","root":[[3,4],6],"packageJsons":["../node_modules/dep-a/package.json","../node_modules/dep-b/package.json"],"fileNames":["lib.es2025.full.d.ts","../node_modules/dep-a/index.d.ts","../src/middle.ts","../src/consumer.ts","../node_modules/dep-b/index.d.ts","../src/env.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"7285be383f876947b8aaab3a6c0cb768-export type Kind = \"a\" | \"b\";",{"version":"c4e56d4d984b8f64c79f77ff5567b1ee-export type { Kind } from \"dep-a\";","signature":"df2d778f658765e085183f887f4c1fae-export type { Kind } from \"dep-a\";\n","impliedNodeFormat":1},{"version":"0bb05d7e49a1dc35d9c9a5249d6aefec-import type { Kind } from \"./middle\";\nexport function describe(kind: Kind): string {\n    switch (kind) {\n        case \"a\":\n            return \"first\";\n        case \"b\":\n            return \"second\";\n    }\n}","signature":"8b084aefefe47768ddf637170d0ce7f9-import type { Kind } from \"./middle\";\nexport declare function describe(kind: Kind): string;\n","impliedNodeFormat":1},{"version":"a94fea4b430695b9dbaf2f04eab64c1e-declare global {\n    interface DepBGlobal {\n        marker: string;\n    }\n}\nexport {};","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"fcc1d4c4b073cc5a548e7244f608884c-import \"dep-b\";","signature":"9fb8fd76a089f5d7d03937148c718fd8-import \"dep-b\";\n","impliedNodeFormat":1}],"fileIdsList":[[3],[5],[2]],"options":{"composite":true,"outDir":"./","strict":true},"referencedMap":[[4,1],[6,2],[3,3]],"latestChangedDtsFile":"./src/env.d.ts"}
+//// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
+{
+  "version": "FakeTSVersion",
+  "root": [
+    {
+      "files": [
+        "../src/middle.ts",
+        "../src/consumer.ts"
+      ],
+      "original": [
+        3,
+        4
+      ]
+    },
+    {
+      "files": [
+        "../src/env.ts"
+      ],
+      "original": 6
+    }
+  ],
+  "packageJsons": [
+    "../node_modules/dep-a/package.json",
+    "../node_modules/dep-b/package.json"
+  ],
+  "fileNames": [
+    "lib.es2025.full.d.ts",
+    "../node_modules/dep-a/index.d.ts",
+    "../src/middle.ts",
+    "../src/consumer.ts",
+    "../node_modules/dep-b/index.d.ts",
+    "../src/env.ts"
+  ],
+  "fileInfos": [
+    {
+      "fileName": "lib.es2025.full.d.ts",
+      "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "signature": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "affectsGlobalScope": true,
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true,
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "../node_modules/dep-a/index.d.ts",
+      "version": "7285be383f876947b8aaab3a6c0cb768-export type Kind = \"a\" | \"b\";",
+      "signature": "7285be383f876947b8aaab3a6c0cb768-export type Kind = \"a\" | \"b\";",
+      "impliedNodeFormat": "CommonJS"
+    },
+    {
+      "fileName": "../src/middle.ts",
+      "version": "c4e56d4d984b8f64c79f77ff5567b1ee-export type { Kind } from \"dep-a\";",
+      "signature": "df2d778f658765e085183f887f4c1fae-export type { Kind } from \"dep-a\";\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "c4e56d4d984b8f64c79f77ff5567b1ee-export type { Kind } from \"dep-a\";",
+        "signature": "df2d778f658765e085183f887f4c1fae-export type { Kind } from \"dep-a\";\n",
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "../src/consumer.ts",
+      "version": "0bb05d7e49a1dc35d9c9a5249d6aefec-import type { Kind } from \"./middle\";\nexport function describe(kind: Kind): string {\n    switch (kind) {\n        case \"a\":\n            return \"first\";\n        case \"b\":\n            return \"second\";\n    }\n}",
+      "signature": "8b084aefefe47768ddf637170d0ce7f9-import type { Kind } from \"./middle\";\nexport declare function describe(kind: Kind): string;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "0bb05d7e49a1dc35d9c9a5249d6aefec-import type { Kind } from \"./middle\";\nexport function describe(kind: Kind): string {\n    switch (kind) {\n        case \"a\":\n            return \"first\";\n        case \"b\":\n            return \"second\";\n    }\n}",
+        "signature": "8b084aefefe47768ddf637170d0ce7f9-import type { Kind } from \"./middle\";\nexport declare function describe(kind: Kind): string;\n",
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "../node_modules/dep-b/index.d.ts",
+      "version": "a94fea4b430695b9dbaf2f04eab64c1e-declare global {\n    interface DepBGlobal {\n        marker: string;\n    }\n}\nexport {};",
+      "signature": "a94fea4b430695b9dbaf2f04eab64c1e-declare global {\n    interface DepBGlobal {\n        marker: string;\n    }\n}\nexport {};",
+      "affectsGlobalScope": true,
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "a94fea4b430695b9dbaf2f04eab64c1e-declare global {\n    interface DepBGlobal {\n        marker: string;\n    }\n}\nexport {};",
+        "affectsGlobalScope": true,
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "../src/env.ts",
+      "version": "fcc1d4c4b073cc5a548e7244f608884c-import \"dep-b\";",
+      "signature": "9fb8fd76a089f5d7d03937148c718fd8-import \"dep-b\";\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "fcc1d4c4b073cc5a548e7244f608884c-import \"dep-b\";",
+        "signature": "9fb8fd76a089f5d7d03937148c718fd8-import \"dep-b\";\n",
+        "impliedNodeFormat": 1
+      }
+    }
+  ],
+  "fileIdsList": [
+    [
+      "../src/middle.ts"
+    ],
+    [
+      "../node_modules/dep-b/index.d.ts"
+    ],
+    [
+      "../node_modules/dep-a/index.d.ts"
+    ]
+  ],
+  "options": {
+    "composite": true,
+    "outDir": "./",
+    "strict": true
+  },
+  "referencedMap": {
+    "../src/consumer.ts": [
+      "../src/middle.ts"
+    ],
+    "../src/env.ts": [
+      "../node_modules/dep-b/index.d.ts"
+    ],
+    "../src/middle.ts": [
+      "../node_modules/dep-a/index.d.ts"
+    ]
+  },
+  "latestChangedDtsFile": "./src/env.d.ts",
+  "size": 2282
+}
+
+tsconfig.json::
+SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
+*refresh*    /home/src/workspaces/project/node_modules/dep-a/index.d.ts
+*refresh*    /home/src/workspaces/project/src/middle.ts
+*refresh*    /home/src/workspaces/project/src/consumer.ts
+*refresh*    /home/src/workspaces/project/node_modules/dep-b/index.d.ts
+*refresh*    /home/src/workspaces/project/src/env.ts
+Signatures::
+(stored at emit) /home/src/workspaces/project/src/middle.ts
+(stored at emit) /home/src/workspaces/project/src/consumer.ts
+(stored at emit) /home/src/workspaces/project/src/env.ts
+
+
+Edit [0]:: update dep-a with a breaking type change and dep-b with a global scope change in one batch
+//// [/home/src/workspaces/project/node_modules/dep-a/index.d.ts] *modified* 
+export type Kind = "a" | "b" | "c";
+//// [/home/src/workspaces/project/node_modules/dep-b/index.d.ts] *modified* 
+declare global {
+    interface DepBGlobal {
+        marker: string;
+        extra: number;
+    }
+}
+export {};
+
+tsgo --b --verbose
+ExitStatus:: DiagnosticsPresent_OutputsGenerated
+Output::
+[[90mHH:MM:SS AM[0m] Projects in this build: 
+    * tsconfig.json
+
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because output 'dist/tsconfig.tsbuildinfo' is older than input 'node_modules/dep-a/index.d.ts'
+
+[[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
+
+[96msrc/consumer.ts[0m:[93m2[0m:[93m39[0m - [91merror[0m[90m TS2366: [0mFunction lacks ending return statement and return type does not include 'undefined'.
+
+[7m2[0m export function describe(kind: Kind): string {
+[7m [0m [91m                                      ~~~~~~[0m
+
+
+Found 1 error in src/consumer.ts[90m:2[0m
+
+//// [/home/src/workspaces/project/dist/src/consumer.js] *rewrite with same content*
+//// [/home/src/workspaces/project/dist/src/env.js] *rewrite with same content*
+//// [/home/src/workspaces/project/dist/src/middle.js] *rewrite with same content*
+//// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo] *modified* 
+{"version":"FakeTSVersion","root":[[3,4],6],"packageJsons":["../node_modules/dep-a/package.json","../node_modules/dep-b/package.json"],"fileNames":["lib.es2025.full.d.ts","../node_modules/dep-a/index.d.ts","../src/middle.ts","../src/consumer.ts","../node_modules/dep-b/index.d.ts","../src/env.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"a4e0198c11df73a2e4b2aeeeedc6b0df-export type Kind = \"a\" | \"b\" | \"c\";",{"version":"c4e56d4d984b8f64c79f77ff5567b1ee-export type { Kind } from \"dep-a\";","signature":"df2d778f658765e085183f887f4c1fae-export type { Kind } from \"dep-a\";\n","impliedNodeFormat":1},{"version":"0bb05d7e49a1dc35d9c9a5249d6aefec-import type { Kind } from \"./middle\";\nexport function describe(kind: Kind): string {\n    switch (kind) {\n        case \"a\":\n            return \"first\";\n        case \"b\":\n            return \"second\";\n    }\n}","signature":"8b084aefefe47768ddf637170d0ce7f9-import type { Kind } from \"./middle\";\nexport declare function describe(kind: Kind): string;\n","impliedNodeFormat":1},{"version":"5364f0cc80bb7f0d214b5e9af5f5dc54-declare global {\n    interface DepBGlobal {\n        marker: string;\n        extra: number;\n    }\n}\nexport {};","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"fcc1d4c4b073cc5a548e7244f608884c-import \"dep-b\";","signature":"9fb8fd76a089f5d7d03937148c718fd8-import \"dep-b\";\n","impliedNodeFormat":1}],"fileIdsList":[[3],[5],[2]],"options":{"composite":true,"outDir":"./","strict":true},"referencedMap":[[4,1],[6,2],[3,3]],"semanticDiagnosticsPerFile":[[4,[{"pos":76,"end":82,"code":2366,"category":1,"messageKey":"Function_lacks_ending_return_statement_and_return_type_does_not_include_undefined_2366"}]]],"latestChangedDtsFile":"./src/env.d.ts"}
+//// [/home/src/workspaces/project/dist/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
+{
+  "version": "FakeTSVersion",
+  "root": [
+    {
+      "files": [
+        "../src/middle.ts",
+        "../src/consumer.ts"
+      ],
+      "original": [
+        3,
+        4
+      ]
+    },
+    {
+      "files": [
+        "../src/env.ts"
+      ],
+      "original": 6
+    }
+  ],
+  "packageJsons": [
+    "../node_modules/dep-a/package.json",
+    "../node_modules/dep-b/package.json"
+  ],
+  "fileNames": [
+    "lib.es2025.full.d.ts",
+    "../node_modules/dep-a/index.d.ts",
+    "../src/middle.ts",
+    "../src/consumer.ts",
+    "../node_modules/dep-b/index.d.ts",
+    "../src/env.ts"
+  ],
+  "fileInfos": [
+    {
+      "fileName": "lib.es2025.full.d.ts",
+      "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "signature": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "affectsGlobalScope": true,
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true,
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "../node_modules/dep-a/index.d.ts",
+      "version": "a4e0198c11df73a2e4b2aeeeedc6b0df-export type Kind = \"a\" | \"b\" | \"c\";",
+      "signature": "a4e0198c11df73a2e4b2aeeeedc6b0df-export type Kind = \"a\" | \"b\" | \"c\";",
+      "impliedNodeFormat": "CommonJS"
+    },
+    {
+      "fileName": "../src/middle.ts",
+      "version": "c4e56d4d984b8f64c79f77ff5567b1ee-export type { Kind } from \"dep-a\";",
+      "signature": "df2d778f658765e085183f887f4c1fae-export type { Kind } from \"dep-a\";\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "c4e56d4d984b8f64c79f77ff5567b1ee-export type { Kind } from \"dep-a\";",
+        "signature": "df2d778f658765e085183f887f4c1fae-export type { Kind } from \"dep-a\";\n",
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "../src/consumer.ts",
+      "version": "0bb05d7e49a1dc35d9c9a5249d6aefec-import type { Kind } from \"./middle\";\nexport function describe(kind: Kind): string {\n    switch (kind) {\n        case \"a\":\n            return \"first\";\n        case \"b\":\n            return \"second\";\n    }\n}",
+      "signature": "8b084aefefe47768ddf637170d0ce7f9-import type { Kind } from \"./middle\";\nexport declare function describe(kind: Kind): string;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "0bb05d7e49a1dc35d9c9a5249d6aefec-import type { Kind } from \"./middle\";\nexport function describe(kind: Kind): string {\n    switch (kind) {\n        case \"a\":\n            return \"first\";\n        case \"b\":\n            return \"second\";\n    }\n}",
+        "signature": "8b084aefefe47768ddf637170d0ce7f9-import type { Kind } from \"./middle\";\nexport declare function describe(kind: Kind): string;\n",
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "../node_modules/dep-b/index.d.ts",
+      "version": "5364f0cc80bb7f0d214b5e9af5f5dc54-declare global {\n    interface DepBGlobal {\n        marker: string;\n        extra: number;\n    }\n}\nexport {};",
+      "signature": "5364f0cc80bb7f0d214b5e9af5f5dc54-declare global {\n    interface DepBGlobal {\n        marker: string;\n        extra: number;\n    }\n}\nexport {};",
+      "affectsGlobalScope": true,
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "5364f0cc80bb7f0d214b5e9af5f5dc54-declare global {\n    interface DepBGlobal {\n        marker: string;\n        extra: number;\n    }\n}\nexport {};",
+        "affectsGlobalScope": true,
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "../src/env.ts",
+      "version": "fcc1d4c4b073cc5a548e7244f608884c-import \"dep-b\";",
+      "signature": "9fb8fd76a089f5d7d03937148c718fd8-import \"dep-b\";\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "fcc1d4c4b073cc5a548e7244f608884c-import \"dep-b\";",
+        "signature": "9fb8fd76a089f5d7d03937148c718fd8-import \"dep-b\";\n",
+        "impliedNodeFormat": 1
+      }
+    }
+  ],
+  "fileIdsList": [
+    [
+      "../src/middle.ts"
+    ],
+    [
+      "../node_modules/dep-b/index.d.ts"
+    ],
+    [
+      "../node_modules/dep-a/index.d.ts"
+    ]
+  ],
+  "options": {
+    "composite": true,
+    "outDir": "./",
+    "strict": true
+  },
+  "referencedMap": {
+    "../src/consumer.ts": [
+      "../src/middle.ts"
+    ],
+    "../src/env.ts": [
+      "../node_modules/dep-b/index.d.ts"
+    ],
+    "../src/middle.ts": [
+      "../node_modules/dep-a/index.d.ts"
+    ]
+  },
+  "semanticDiagnosticsPerFile": [
+    [
+      "../src/consumer.ts",
+      [
+        {
+          "pos": 76,
+          "end": 82,
+          "code": 2366,
+          "category": 1,
+          "messageKey": "Function_lacks_ending_return_statement_and_return_type_does_not_include_undefined_2366"
+        }
+      ]
+    ]
+  ],
+  "latestChangedDtsFile": "./src/env.d.ts",
+  "size": 2498
+}
+
+tsconfig.json::
+SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
+*refresh*    /home/src/workspaces/project/node_modules/dep-a/index.d.ts
+*refresh*    /home/src/workspaces/project/src/middle.ts
+*refresh*    /home/src/workspaces/project/src/consumer.ts
+*refresh*    /home/src/workspaces/project/node_modules/dep-b/index.d.ts
+*refresh*    /home/src/workspaces/project/src/env.ts
+Signatures::
+(used version)   /home/src/workspaces/project/node_modules/dep-a/index.d.ts
+(computed .d.ts) /home/src/workspaces/project/src/middle.ts
+(computed .d.ts) /home/src/workspaces/project/src/consumer.ts
+(used version)   /home/src/workspaces/project/node_modules/dep-b/index.d.ts
+(computed .d.ts) /home/src/workspaces/project/src/env.ts
+
+
+Edit [1]:: no change
+
+tsgo --b --verbose
+ExitStatus:: DiagnosticsPresent_OutputsGenerated
+Output::
+[[90mHH:MM:SS AM[0m] Projects in this build: 
+    * tsconfig.json
+
+[[90mHH:MM:SS AM[0m] Project 'tsconfig.json' is out of date because buildinfo file 'dist/tsconfig.tsbuildinfo' indicates that program needs to report errors.
+
+[[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
+
+[96msrc/consumer.ts[0m:[93m2[0m:[93m39[0m - [91merror[0m[90m TS2366: [0mFunction lacks ending return statement and return type does not include 'undefined'.
+
+[7m2[0m export function describe(kind: Kind): string {
+[7m [0m [91m                                      ~~~~~~[0m
+
+
+Found 1 error in src/consumer.ts[90m:2[0m
+
+
+tsconfig.json::
+SemanticDiagnostics::
+Signatures::

--- a/testdata/baselines/reference/tsbuild/noEmit/dts-errors-with-incremental-as-modules.js
+++ b/testdata/baselines/reference/tsbuild/noEmit/dts-errors-with-incremental-as-modules.js
@@ -442,7 +442,7 @@ Output::
 Found 1 error in a.ts[90m:1[0m
 
 //// [/home/src/projects/project/tsconfig.tsbuildinfo] *modified* 
-{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"54435c7adb578d59d7e39dd2f567250e-const a = class { private p = 10; };","signature":"e4289913a1e3c6021f5a6745f65d4044-declare const a: {\n    new (): {\n        p: number;\n    };\n};\n\n(6,1): error4094: Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094\np\n\n(6,1): error9027: Add_a_type_annotation_to_the_variable_0_9027\na\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;","signature":"eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n","impliedNodeFormat":1}],"options":{"declaration":true},"emitDiagnosticsPerFile":[[2,[{"pos":6,"end":7,"code":4094,"category":1,"messageKey":"Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094","messageArgs":["p"],"relatedInformation":[{"pos":6,"end":7,"code":9027,"category":1,"messageKey":"Add_a_type_annotation_to_the_variable_0_9027","messageArgs":["a"]}]}]]],"affectedFilesPendingEmit":[[2,17]]}
+{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"54435c7adb578d59d7e39dd2f567250e-const a = class { private p = 10; };","signature":"e4289913a1e3c6021f5a6745f65d4044-declare const a: {\n    new (): {\n        p: number;\n    };\n};\n\n(6,1): error4094: Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094\np\n\n(6,1): error9027: Add_a_type_annotation_to_the_variable_0_9027\na\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;","signature":"eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n","impliedNodeFormat":1}],"options":{"declaration":true},"emitDiagnosticsPerFile":[[2,[{"pos":6,"end":7,"code":4094,"category":1,"messageKey":"Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094","messageArgs":["p"],"relatedInformation":[{"pos":6,"end":7,"code":9027,"category":1,"messageKey":"Add_a_type_annotation_to_the_variable_0_9027","messageArgs":["a"]}]}]]],"affectedFilesPendingEmit":[[2,17],[3,17]]}
 //// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
 {
   "version": "FakeTSVersion",
@@ -541,17 +541,27 @@ Found 1 error in a.ts[90m:1[0m
         2,
         17
       ]
+    ],
+    [
+      "./b.ts",
+      "Js|DtsEmit",
+      [
+        3,
+        17
+      ]
     ]
   ],
-  "size": 1875
+  "size": 1882
 }
 
 tsconfig.json::
 SemanticDiagnostics::
 *refresh*    /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
 *refresh*    /home/src/projects/project/a.ts
+*refresh*    /home/src/projects/project/b.ts
 Signatures::
 (computed .d.ts) /home/src/projects/project/a.ts
+(computed .d.ts) /home/src/projects/project/b.ts
 
 
 Edit [6]:: Emit when error
@@ -584,6 +594,8 @@ const a = class {
     p = 10;
 };
 
+//// [/home/src/projects/project/b.d.ts] *rewrite with same content*
+//// [/home/src/projects/project/b.js] *rewrite with same content*
 //// [/home/src/projects/project/tsconfig.tsbuildinfo] *modified* 
 {"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"54435c7adb578d59d7e39dd2f567250e-const a = class { private p = 10; };","signature":"e4289913a1e3c6021f5a6745f65d4044-declare const a: {\n    new (): {\n        p: number;\n    };\n};\n\n(6,1): error4094: Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094\np\n\n(6,1): error9027: Add_a_type_annotation_to_the_variable_0_9027\na\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;","signature":"eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n","impliedNodeFormat":1}],"options":{"declaration":true},"emitDiagnosticsPerFile":[[2,[{"pos":6,"end":7,"code":4094,"category":1,"messageKey":"Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094","messageArgs":["p"],"relatedInformation":[{"pos":6,"end":7,"code":9027,"category":1,"messageKey":"Add_a_type_annotation_to_the_variable_0_9027","messageArgs":["a"]}]}]]]}
 //// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 

--- a/testdata/baselines/reference/tsbuild/noEmit/dts-errors-without-dts-enabled-with-incremental-as-modules.js
+++ b/testdata/baselines/reference/tsbuild/noEmit/dts-errors-without-dts-enabled-with-incremental-as-modules.js
@@ -348,7 +348,7 @@ Output::
 [[90mHH:MM:SS AM[0m] Building project 'tsconfig.json'...
 
 //// [/home/src/projects/project/tsconfig.tsbuildinfo] *modified* 
-{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"54435c7adb578d59d7e39dd2f567250e-const a = class { private p = 10; };","signature":"e4289913a1e3c6021f5a6745f65d4044-declare const a: {\n    new (): {\n        p: number;\n    };\n};\n\n(6,1): error4094: Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094\np\n\n(6,1): error9027: Add_a_type_annotation_to_the_variable_0_9027\na\n","affectsGlobalScope":true,"impliedNodeFormat":1},"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;"],"options":{"declaration":false},"affectedFilesPendingEmit":[2]}
+{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"54435c7adb578d59d7e39dd2f567250e-const a = class { private p = 10; };","signature":"e4289913a1e3c6021f5a6745f65d4044-declare const a: {\n    new (): {\n        p: number;\n    };\n};\n\n(6,1): error4094: Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094\np\n\n(6,1): error9027: Add_a_type_annotation_to_the_variable_0_9027\na\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;","signature":"eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n","impliedNodeFormat":1}],"options":{"declaration":false},"affectedFilesPendingEmit":[2,3]}
 //// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
 {
   "version": "FakeTSVersion",
@@ -398,8 +398,13 @@ Output::
     {
       "fileName": "./b.ts",
       "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "signature": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "impliedNodeFormat": "CommonJS"
+      "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
+        "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+        "impliedNodeFormat": 1
+      }
     }
   ],
   "options": {
@@ -410,17 +415,24 @@ Output::
       "./a.ts",
       "Js",
       2
+    ],
+    [
+      "./b.ts",
+      "Js",
+      3
     ]
   ],
-  "size": 1421
+  "size": 1535
 }
 
 tsconfig.json::
 SemanticDiagnostics::
 *refresh*    /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
 *refresh*    /home/src/projects/project/a.ts
+*refresh*    /home/src/projects/project/b.ts
 Signatures::
 (computed .d.ts) /home/src/projects/project/a.ts
+(computed .d.ts) /home/src/projects/project/b.ts
 
 
 Edit [6]:: Emit when error
@@ -441,8 +453,9 @@ const a = class {
     p = 10;
 };
 
+//// [/home/src/projects/project/b.js] *rewrite with same content*
 //// [/home/src/projects/project/tsconfig.tsbuildinfo] *modified* 
-{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"54435c7adb578d59d7e39dd2f567250e-const a = class { private p = 10; };","signature":"e4289913a1e3c6021f5a6745f65d4044-declare const a: {\n    new (): {\n        p: number;\n    };\n};\n\n(6,1): error4094: Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094\np\n\n(6,1): error9027: Add_a_type_annotation_to_the_variable_0_9027\na\n","affectsGlobalScope":true,"impliedNodeFormat":1},"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;"],"options":{"declaration":false}}
+{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"54435c7adb578d59d7e39dd2f567250e-const a = class { private p = 10; };","signature":"e4289913a1e3c6021f5a6745f65d4044-declare const a: {\n    new (): {\n        p: number;\n    };\n};\n\n(6,1): error4094: Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094\np\n\n(6,1): error9027: Add_a_type_annotation_to_the_variable_0_9027\na\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;","signature":"eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n","impliedNodeFormat":1}],"options":{"declaration":false}}
 //// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
 {
   "version": "FakeTSVersion",
@@ -492,14 +505,19 @@ const a = class {
     {
       "fileName": "./b.ts",
       "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "signature": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "impliedNodeFormat": "CommonJS"
+      "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
+        "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+        "impliedNodeFormat": 1
+      }
     }
   ],
   "options": {
     "declaration": false
   },
-  "size": 1390
+  "size": 1502
 }
 
 tsconfig.json::

--- a/testdata/baselines/reference/tsbuild/noEmit/semantic-errors-with-incremental-as-modules.js
+++ b/testdata/baselines/reference/tsbuild/noEmit/semantic-errors-with-incremental-as-modules.js
@@ -395,7 +395,7 @@ Output::
 Found 1 error in a.ts[90m:1[0m
 
 //// [/home/src/projects/project/tsconfig.tsbuildinfo] *modified* 
-{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"903d9216256112700b1325b61dcb7717-const a: number = \"hello\"","signature":"a87bf21f13058d40be607df702228523-declare const a: number;\n","affectsGlobalScope":true,"impliedNodeFormat":1},"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;"],"options":{"declaration":false},"semanticDiagnosticsPerFile":[[2,[{"pos":6,"end":7,"code":2322,"category":1,"messageKey":"Type_0_is_not_assignable_to_type_1_2322","messageArgs":["string","number"]}]]],"affectedFilesPendingEmit":[2]}
+{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"903d9216256112700b1325b61dcb7717-const a: number = \"hello\"","signature":"a87bf21f13058d40be607df702228523-declare const a: number;\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;","signature":"eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n","impliedNodeFormat":1}],"options":{"declaration":false},"semanticDiagnosticsPerFile":[[2,[{"pos":6,"end":7,"code":2322,"category":1,"messageKey":"Type_0_is_not_assignable_to_type_1_2322","messageArgs":["string","number"]}]]],"affectedFilesPendingEmit":[2,3]}
 //// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
 {
   "version": "FakeTSVersion",
@@ -445,8 +445,13 @@ Found 1 error in a.ts[90m:1[0m
     {
       "fileName": "./b.ts",
       "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "signature": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "impliedNodeFormat": "CommonJS"
+      "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
+        "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+        "impliedNodeFormat": 1
+      }
     }
   ],
   "options": {
@@ -475,17 +480,24 @@ Found 1 error in a.ts[90m:1[0m
       "./a.ts",
       "Js",
       2
+    ],
+    [
+      "./b.ts",
+      "Js",
+      3
     ]
   ],
-  "size": 1366
+  "size": 1480
 }
 
 tsconfig.json::
 SemanticDiagnostics::
 *refresh*    /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
 *refresh*    /home/src/projects/project/a.ts
+*refresh*    /home/src/projects/project/b.ts
 Signatures::
 (computed .d.ts) /home/src/projects/project/a.ts
+(computed .d.ts) /home/src/projects/project/b.ts
 
 
 Edit [6]:: Emit when error
@@ -512,8 +524,9 @@ Found 1 error in a.ts[90m:1[0m
 "use strict";
 const a = "hello";
 
+//// [/home/src/projects/project/b.js] *rewrite with same content*
 //// [/home/src/projects/project/tsconfig.tsbuildinfo] *modified* 
-{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"903d9216256112700b1325b61dcb7717-const a: number = \"hello\"","signature":"a87bf21f13058d40be607df702228523-declare const a: number;\n","affectsGlobalScope":true,"impliedNodeFormat":1},"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;"],"options":{"declaration":false},"semanticDiagnosticsPerFile":[[2,[{"pos":6,"end":7,"code":2322,"category":1,"messageKey":"Type_0_is_not_assignable_to_type_1_2322","messageArgs":["string","number"]}]]]}
+{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"903d9216256112700b1325b61dcb7717-const a: number = \"hello\"","signature":"a87bf21f13058d40be607df702228523-declare const a: number;\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;","signature":"eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n","impliedNodeFormat":1}],"options":{"declaration":false},"semanticDiagnosticsPerFile":[[2,[{"pos":6,"end":7,"code":2322,"category":1,"messageKey":"Type_0_is_not_assignable_to_type_1_2322","messageArgs":["string","number"]}]]]}
 //// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
 {
   "version": "FakeTSVersion",
@@ -563,8 +576,13 @@ const a = "hello";
     {
       "fileName": "./b.ts",
       "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "signature": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "impliedNodeFormat": "CommonJS"
+      "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
+        "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+        "impliedNodeFormat": 1
+      }
     }
   ],
   "options": {
@@ -588,7 +606,7 @@ const a = "hello";
       ]
     ]
   ],
-  "size": 1335
+  "size": 1447
 }
 
 tsconfig.json::

--- a/testdata/baselines/reference/tsbuild/noEmit/syntax-errors-with-incremental-as-modules.js
+++ b/testdata/baselines/reference/tsbuild/noEmit/syntax-errors-with-incremental-as-modules.js
@@ -482,8 +482,9 @@ Found 1 error in a.ts[90m:1[0m
 "use strict";
 const a = "hello;
 
+//// [/home/src/projects/project/b.js] *rewrite with same content*
 //// [/home/src/projects/project/tsconfig.tsbuildinfo] *modified* 
-{"version":"FakeTSVersion","errors":true,"root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"d8a5f356bd133a6882ecbde29426bdcb-const a = \"hello","signature":"64868e4042512db835b5b3c3226ab323-declare const a = \"hello\";\n","affectsGlobalScope":true,"impliedNodeFormat":1},"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;"],"options":{"declaration":false},"semanticDiagnosticsPerFile":[1,2]}
+{"version":"FakeTSVersion","errors":true,"root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"d8a5f356bd133a6882ecbde29426bdcb-const a = \"hello","signature":"64868e4042512db835b5b3c3226ab323-declare const a = \"hello\";\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;","signature":"eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n","impliedNodeFormat":1}],"options":{"declaration":false},"semanticDiagnosticsPerFile":[1,2,3]}
 //// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
 {
   "version": "FakeTSVersion",
@@ -534,8 +535,13 @@ const a = "hello;
     {
       "fileName": "./b.ts",
       "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "signature": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "impliedNodeFormat": "CommonJS"
+      "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
+        "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+        "impliedNodeFormat": 1
+      }
     }
   ],
   "options": {
@@ -543,17 +549,20 @@ const a = "hello;
   },
   "semanticDiagnosticsPerFile": [
     "lib.es2025.full.d.ts",
-    "./a.ts"
+    "./a.ts",
+    "./b.ts"
   ],
-  "size": 1209
+  "size": 1323
 }
 
 tsconfig.json::
 SemanticDiagnostics::
 *not cached* /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
 *not cached* /home/src/projects/project/a.ts
+*not cached* /home/src/projects/project/b.ts
 Signatures::
 (computed .d.ts) /home/src/projects/project/a.ts
+(computed .d.ts) /home/src/projects/project/b.ts
 
 
 Edit [7]:: no change
@@ -581,4 +590,5 @@ tsconfig.json::
 SemanticDiagnostics::
 *not cached* /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
 *not cached* /home/src/projects/project/a.ts
+*not cached* /home/src/projects/project/b.ts
 Signatures::

--- a/testdata/baselines/reference/tsbuildWatch/noEmit/does-not-go-in-loop-when-watching-when-no-files-are-emitted-with-incremental.js
+++ b/testdata/baselines/reference/tsbuildWatch/noEmit/does-not-go-in-loop-when-watching-when-no-files-are-emitted-with-incremental.js
@@ -250,5 +250,7 @@ tsconfig.json::
 SemanticDiagnostics::
 *refresh*    /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
 *refresh*    /user/username/projects/myproject/a.js
+*refresh*    /user/username/projects/myproject/b.ts
 Signatures::
 (computed .d.ts) /user/username/projects/myproject/a.js
+(computed .d.ts) /user/username/projects/myproject/b.ts

--- a/testdata/baselines/reference/tsbuildWatch/noEmit/dts-errors-with-incremental-as-modules.js
+++ b/testdata/baselines/reference/tsbuildWatch/noEmit/dts-errors-with-incremental-as-modules.js
@@ -447,7 +447,7 @@ Output::
 [[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
 
 //// [/home/src/projects/project/tsconfig.tsbuildinfo] *modified* 
-{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"54435c7adb578d59d7e39dd2f567250e-const a = class { private p = 10; };","signature":"e4289913a1e3c6021f5a6745f65d4044-declare const a: {\n    new (): {\n        p: number;\n    };\n};\n\n(6,1): error4094: Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094\np\n\n(6,1): error9027: Add_a_type_annotation_to_the_variable_0_9027\na\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;","signature":"eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n","impliedNodeFormat":1}],"options":{"declaration":true},"emitDiagnosticsPerFile":[[2,[{"pos":6,"end":7,"code":4094,"category":1,"messageKey":"Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094","messageArgs":["p"],"relatedInformation":[{"pos":6,"end":7,"code":9027,"category":1,"messageKey":"Add_a_type_annotation_to_the_variable_0_9027","messageArgs":["a"]}]}]]],"affectedFilesPendingEmit":[[2,17]]}
+{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"54435c7adb578d59d7e39dd2f567250e-const a = class { private p = 10; };","signature":"e4289913a1e3c6021f5a6745f65d4044-declare const a: {\n    new (): {\n        p: number;\n    };\n};\n\n(6,1): error4094: Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094\np\n\n(6,1): error9027: Add_a_type_annotation_to_the_variable_0_9027\na\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;","signature":"eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n","impliedNodeFormat":1}],"options":{"declaration":true},"emitDiagnosticsPerFile":[[2,[{"pos":6,"end":7,"code":4094,"category":1,"messageKey":"Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094","messageArgs":["p"],"relatedInformation":[{"pos":6,"end":7,"code":9027,"category":1,"messageKey":"Add_a_type_annotation_to_the_variable_0_9027","messageArgs":["a"]}]}]]],"affectedFilesPendingEmit":[[2,17],[3,17]]}
 //// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
 {
   "version": "FakeTSVersion",
@@ -546,9 +546,17 @@ Output::
         2,
         17
       ]
+    ],
+    [
+      "./b.ts",
+      "Js|DtsEmit",
+      [
+        3,
+        17
+      ]
     ]
   ],
-  "size": 1875
+  "size": 1882
 }
 
 Watch Registrations::
@@ -559,8 +567,10 @@ tsconfig.json::
 SemanticDiagnostics::
 *refresh*    /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
 *refresh*    /home/src/projects/project/a.ts
+*refresh*    /home/src/projects/project/b.ts
 Signatures::
 (computed .d.ts) /home/src/projects/project/a.ts
+(computed .d.ts) /home/src/projects/project/b.ts
 
 
 Edit [4]:: Emit when error
@@ -600,6 +610,8 @@ const a = class {
     p = 10;
 };
 
+//// [/home/src/projects/project/b.d.ts] *rewrite with same content*
+//// [/home/src/projects/project/b.js] *rewrite with same content*
 //// [/home/src/projects/project/tsconfig.tsbuildinfo] *modified* 
 {"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"54435c7adb578d59d7e39dd2f567250e-const a = class { private p = 10; };","signature":"e4289913a1e3c6021f5a6745f65d4044-declare const a: {\n    new (): {\n        p: number;\n    };\n};\n\n(6,1): error4094: Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094\np\n\n(6,1): error9027: Add_a_type_annotation_to_the_variable_0_9027\na\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;","signature":"eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n","impliedNodeFormat":1}],"options":{"declaration":true},"emitDiagnosticsPerFile":[[2,[{"pos":6,"end":7,"code":4094,"category":1,"messageKey":"Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094","messageArgs":["p"],"relatedInformation":[{"pos":6,"end":7,"code":9027,"category":1,"messageKey":"Add_a_type_annotation_to_the_variable_0_9027","messageArgs":["a"]}]}]]]}
 //// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 

--- a/testdata/baselines/reference/tsbuildWatch/noEmit/dts-errors-without-dts-enabled-with-incremental-as-modules.js
+++ b/testdata/baselines/reference/tsbuildWatch/noEmit/dts-errors-without-dts-enabled-with-incremental-as-modules.js
@@ -376,7 +376,7 @@ Output::
 [[90mHH:MM:SS AM[0m] Found 0 errors. Watching for file changes.
 
 //// [/home/src/projects/project/tsconfig.tsbuildinfo] *modified* 
-{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"54435c7adb578d59d7e39dd2f567250e-const a = class { private p = 10; };","signature":"e4289913a1e3c6021f5a6745f65d4044-declare const a: {\n    new (): {\n        p: number;\n    };\n};\n\n(6,1): error4094: Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094\np\n\n(6,1): error9027: Add_a_type_annotation_to_the_variable_0_9027\na\n","affectsGlobalScope":true,"impliedNodeFormat":1},"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;"],"options":{"declaration":false},"affectedFilesPendingEmit":[2]}
+{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"54435c7adb578d59d7e39dd2f567250e-const a = class { private p = 10; };","signature":"e4289913a1e3c6021f5a6745f65d4044-declare const a: {\n    new (): {\n        p: number;\n    };\n};\n\n(6,1): error4094: Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094\np\n\n(6,1): error9027: Add_a_type_annotation_to_the_variable_0_9027\na\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;","signature":"eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n","impliedNodeFormat":1}],"options":{"declaration":false},"affectedFilesPendingEmit":[2,3]}
 //// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
 {
   "version": "FakeTSVersion",
@@ -426,8 +426,13 @@ Output::
     {
       "fileName": "./b.ts",
       "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "signature": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "impliedNodeFormat": "CommonJS"
+      "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
+        "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+        "impliedNodeFormat": 1
+      }
     }
   ],
   "options": {
@@ -438,9 +443,14 @@ Output::
       "./a.ts",
       "Js",
       2
+    ],
+    [
+      "./b.ts",
+      "Js",
+      3
     ]
   ],
-  "size": 1421
+  "size": 1535
 }
 
 Watch Registrations::
@@ -451,8 +461,10 @@ tsconfig.json::
 SemanticDiagnostics::
 *refresh*    /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
 *refresh*    /home/src/projects/project/a.ts
+*refresh*    /home/src/projects/project/b.ts
 Signatures::
 (computed .d.ts) /home/src/projects/project/a.ts
+(computed .d.ts) /home/src/projects/project/b.ts
 
 
 Edit [4]:: Emit when error
@@ -483,8 +495,9 @@ const a = class {
     p = 10;
 };
 
+//// [/home/src/projects/project/b.js] *rewrite with same content*
 //// [/home/src/projects/project/tsconfig.tsbuildinfo] *modified* 
-{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"54435c7adb578d59d7e39dd2f567250e-const a = class { private p = 10; };","signature":"e4289913a1e3c6021f5a6745f65d4044-declare const a: {\n    new (): {\n        p: number;\n    };\n};\n\n(6,1): error4094: Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094\np\n\n(6,1): error9027: Add_a_type_annotation_to_the_variable_0_9027\na\n","affectsGlobalScope":true,"impliedNodeFormat":1},"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;"],"options":{"declaration":false}}
+{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"54435c7adb578d59d7e39dd2f567250e-const a = class { private p = 10; };","signature":"e4289913a1e3c6021f5a6745f65d4044-declare const a: {\n    new (): {\n        p: number;\n    };\n};\n\n(6,1): error4094: Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094\np\n\n(6,1): error9027: Add_a_type_annotation_to_the_variable_0_9027\na\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;","signature":"eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n","impliedNodeFormat":1}],"options":{"declaration":false}}
 //// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
 {
   "version": "FakeTSVersion",
@@ -534,14 +547,19 @@ const a = class {
     {
       "fileName": "./b.ts",
       "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "signature": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "impliedNodeFormat": "CommonJS"
+      "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
+        "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+        "impliedNodeFormat": 1
+      }
     }
   ],
   "options": {
     "declaration": false
   },
-  "size": 1390
+  "size": 1502
 }
 
 Watch Registrations::

--- a/testdata/baselines/reference/tsbuildWatch/noEmit/semantic-errors-with-incremental-as-modules.js
+++ b/testdata/baselines/reference/tsbuildWatch/noEmit/semantic-errors-with-incremental-as-modules.js
@@ -404,7 +404,7 @@ Output::
 [[90mHH:MM:SS AM[0m] Found 1 error. Watching for file changes.
 
 //// [/home/src/projects/project/tsconfig.tsbuildinfo] *modified* 
-{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"903d9216256112700b1325b61dcb7717-const a: number = \"hello\"","signature":"a87bf21f13058d40be607df702228523-declare const a: number;\n","affectsGlobalScope":true,"impliedNodeFormat":1},"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;"],"options":{"declaration":false},"semanticDiagnosticsPerFile":[[2,[{"pos":6,"end":7,"code":2322,"category":1,"messageKey":"Type_0_is_not_assignable_to_type_1_2322","messageArgs":["string","number"]}]]],"affectedFilesPendingEmit":[2]}
+{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"903d9216256112700b1325b61dcb7717-const a: number = \"hello\"","signature":"a87bf21f13058d40be607df702228523-declare const a: number;\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;","signature":"eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n","impliedNodeFormat":1}],"options":{"declaration":false},"semanticDiagnosticsPerFile":[[2,[{"pos":6,"end":7,"code":2322,"category":1,"messageKey":"Type_0_is_not_assignable_to_type_1_2322","messageArgs":["string","number"]}]]],"affectedFilesPendingEmit":[2,3]}
 //// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
 {
   "version": "FakeTSVersion",
@@ -454,8 +454,13 @@ Output::
     {
       "fileName": "./b.ts",
       "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "signature": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "impliedNodeFormat": "CommonJS"
+      "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
+        "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+        "impliedNodeFormat": 1
+      }
     }
   ],
   "options": {
@@ -484,9 +489,14 @@ Output::
       "./a.ts",
       "Js",
       2
+    ],
+    [
+      "./b.ts",
+      "Js",
+      3
     ]
   ],
-  "size": 1366
+  "size": 1480
 }
 
 Watch Registrations::
@@ -497,8 +507,10 @@ tsconfig.json::
 SemanticDiagnostics::
 *refresh*    /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
 *refresh*    /home/src/projects/project/a.ts
+*refresh*    /home/src/projects/project/b.ts
 Signatures::
 (computed .d.ts) /home/src/projects/project/a.ts
+(computed .d.ts) /home/src/projects/project/b.ts
 
 
 Edit [4]:: Emit when error
@@ -532,8 +544,9 @@ Output::
 "use strict";
 const a = "hello";
 
+//// [/home/src/projects/project/b.js] *rewrite with same content*
 //// [/home/src/projects/project/tsconfig.tsbuildinfo] *modified* 
-{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"903d9216256112700b1325b61dcb7717-const a: number = \"hello\"","signature":"a87bf21f13058d40be607df702228523-declare const a: number;\n","affectsGlobalScope":true,"impliedNodeFormat":1},"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;"],"options":{"declaration":false},"semanticDiagnosticsPerFile":[[2,[{"pos":6,"end":7,"code":2322,"category":1,"messageKey":"Type_0_is_not_assignable_to_type_1_2322","messageArgs":["string","number"]}]]]}
+{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"903d9216256112700b1325b61dcb7717-const a: number = \"hello\"","signature":"a87bf21f13058d40be607df702228523-declare const a: number;\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;","signature":"eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n","impliedNodeFormat":1}],"options":{"declaration":false},"semanticDiagnosticsPerFile":[[2,[{"pos":6,"end":7,"code":2322,"category":1,"messageKey":"Type_0_is_not_assignable_to_type_1_2322","messageArgs":["string","number"]}]]]}
 //// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
 {
   "version": "FakeTSVersion",
@@ -583,8 +596,13 @@ const a = "hello";
     {
       "fileName": "./b.ts",
       "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "signature": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "impliedNodeFormat": "CommonJS"
+      "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
+        "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+        "impliedNodeFormat": 1
+      }
     }
   ],
   "options": {
@@ -608,7 +626,7 @@ const a = "hello";
       ]
     ]
   ],
-  "size": 1335
+  "size": 1447
 }
 
 Watch Registrations::

--- a/testdata/baselines/reference/tsbuildWatch/noEmit/syntax-errors-with-incremental-as-modules.js
+++ b/testdata/baselines/reference/tsbuildWatch/noEmit/syntax-errors-with-incremental-as-modules.js
@@ -499,8 +499,9 @@ Output::
 "use strict";
 const a = "hello;
 
+//// [/home/src/projects/project/b.js] *rewrite with same content*
 //// [/home/src/projects/project/tsconfig.tsbuildinfo] *modified* 
-{"version":"FakeTSVersion","errors":true,"root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"d8a5f356bd133a6882ecbde29426bdcb-const a = \"hello","signature":"64868e4042512db835b5b3c3226ab323-declare const a = \"hello\";\n","affectsGlobalScope":true,"impliedNodeFormat":1},"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;"],"options":{"declaration":false},"semanticDiagnosticsPerFile":[1,2]}
+{"version":"FakeTSVersion","errors":true,"root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"d8a5f356bd133a6882ecbde29426bdcb-const a = \"hello","signature":"64868e4042512db835b5b3c3226ab323-declare const a = \"hello\";\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;","signature":"eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n","impliedNodeFormat":1}],"options":{"declaration":false},"semanticDiagnosticsPerFile":[1,2,3]}
 //// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
 {
   "version": "FakeTSVersion",
@@ -551,8 +552,13 @@ const a = "hello;
     {
       "fileName": "./b.ts",
       "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "signature": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "impliedNodeFormat": "CommonJS"
+      "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
+        "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+        "impliedNodeFormat": 1
+      }
     }
   ],
   "options": {
@@ -560,9 +566,10 @@ const a = "hello;
   },
   "semanticDiagnosticsPerFile": [
     "lib.es2025.full.d.ts",
-    "./a.ts"
+    "./a.ts",
+    "./b.ts"
   ],
-  "size": 1209
+  "size": 1323
 }
 
 Watch Registrations::
@@ -573,8 +580,10 @@ tsconfig.json::
 SemanticDiagnostics::
 *not cached* /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
 *not cached* /home/src/projects/project/a.ts
+*not cached* /home/src/projects/project/b.ts
 Signatures::
 (computed .d.ts) /home/src/projects/project/a.ts
+(computed .d.ts) /home/src/projects/project/b.ts
 
 
 Edit [5]:: no Emit run when error
@@ -613,4 +622,5 @@ tsconfig.json::
 SemanticDiagnostics::
 *not cached* /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
 *not cached* /home/src/projects/project/a.ts
+*not cached* /home/src/projects/project/b.ts
 Signatures::

--- a/testdata/baselines/reference/tsc/incremental/when-global-file-is-added,-the-signatures-are-updated.js
+++ b/testdata/baselines/reference/tsc/incremental/when-global-file-is-added,-the-signatures-are-updated.js
@@ -541,6 +541,8 @@ Errors  Files
      1  src/anotherFileWithSameReferenes.ts[90m:2[0m
      1  src/main.ts[90m:3[0m
 
+//// [/home/src/workspaces/project/src/anotherFileWithSameReferenes.js] *rewrite with same content*
+//// [/home/src/workspaces/project/src/filePresent.js] *rewrite with same content*
 //// [/home/src/workspaces/project/src/main.js] *modified* 
 "use strict";
 /// <reference path="./newFile.ts"/>
@@ -684,9 +686,13 @@ function foo() { return 20; }
 tsconfig.json::
 SemanticDiagnostics::
 *refresh*    /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
+*refresh*    /home/src/workspaces/project/src/filePresent.ts
+*refresh*    /home/src/workspaces/project/src/anotherFileWithSameReferenes.ts
 *refresh*    /home/src/workspaces/project/src/newFile.ts
 *refresh*    /home/src/workspaces/project/src/main.ts
 Signatures::
+(computed .d.ts) /home/src/workspaces/project/src/filePresent.ts
+(computed .d.ts) /home/src/workspaces/project/src/anotherFileWithSameReferenes.ts
 (computed .d.ts) /home/src/workspaces/project/src/newFile.ts
 (computed .d.ts) /home/src/workspaces/project/src/main.ts
 
@@ -706,7 +712,9 @@ declare function something2(): number;
 "use strict";
 function something2() { return 20; }
 
+//// [/home/src/workspaces/project/src/filePresent.js] *rewrite with same content*
 //// [/home/src/workspaces/project/src/main.js] *rewrite with same content*
+//// [/home/src/workspaces/project/src/newFile.js] *rewrite with same content*
 //// [/home/src/workspaces/project/tsconfig.tsbuildinfo] *modified* 
 {"version":"FakeTSVersion","root":[[2,6]],"fileNames":["lib.es2025.full.d.ts","./src/filePresent.ts","./src/fileNotFound.ts","./src/anotherFileWithSameReferenes.ts","./src/newFile.ts","./src/main.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"90fb0189e81698eb72c5c92453cf2ab4-function something() { return 10; }","signature":"427bfa05de25170a9630b13346cde60c-declare function something(): number;\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"d97745dab1d2c6dc05ce702bd0c7145d-function something2() { return 20; }","signature":"6bc942031a42ec462dd78d556924caf0-declare function something2(): number;\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"e70a47c0753d68cebbf1d60d9abf7212-/// <reference path=\"./filePresent.ts\"/>\n/// <reference path=\"./fileNotFound.ts\"/>\nfunction anotherFileWithSameReferenes() { }","signature":"d30ad74c2e698ad06cc29f2ea6d12014-declare function anotherFileWithSameReferenes(): void;\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"cf329dc888a898a1403ba3e35c2ec68e-function foo() { return 20; }","signature":"67af86f8c5b618332b620488f3be2c41-declare function foo(): number;\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"bc6af6fddab57e87e44b7bf54d933e49-/// <reference path=\"./newFile.ts\"/>\n/// <reference path=\"./filePresent.ts\"/>\n/// <reference path=\"./fileNotFound.ts\"/>\nfunction main() { }something();something();foo();","signature":"50f7afe296d55bfece856bfb6f7ad6c9-declare function main(): void;\n","affectsGlobalScope":true,"impliedNodeFormat":1}],"fileIdsList":[[2,3],[2,3,5]],"options":{"composite":true},"referencedMap":[[4,1],[6,2]],"latestChangedDtsFile":"./src/fileNotFound.d.ts"}
 //// [/home/src/workspaces/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
@@ -846,12 +854,16 @@ function something2() { return 20; }
 tsconfig.json::
 SemanticDiagnostics::
 *refresh*    /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
+*refresh*    /home/src/workspaces/project/src/filePresent.ts
 *refresh*    /home/src/workspaces/project/src/fileNotFound.ts
 *refresh*    /home/src/workspaces/project/src/anotherFileWithSameReferenes.ts
+*refresh*    /home/src/workspaces/project/src/newFile.ts
 *refresh*    /home/src/workspaces/project/src/main.ts
 Signatures::
+(computed .d.ts) /home/src/workspaces/project/src/filePresent.ts
 (computed .d.ts) /home/src/workspaces/project/src/fileNotFound.ts
 (computed .d.ts) /home/src/workspaces/project/src/anotherFileWithSameReferenes.ts
+(computed .d.ts) /home/src/workspaces/project/src/newFile.ts
 (computed .d.ts) /home/src/workspaces/project/src/main.ts
 
 

--- a/testdata/baselines/reference/tsc/noEmit/dts-errors-with-incremental-as-modules.js
+++ b/testdata/baselines/reference/tsc/noEmit/dts-errors-with-incremental-as-modules.js
@@ -403,7 +403,7 @@ Output::
 Found 1 error in a.ts[90m:1[0m
 
 //// [/home/src/projects/project/tsconfig.tsbuildinfo] *modified* 
-{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"54435c7adb578d59d7e39dd2f567250e-const a = class { private p = 10; };","signature":"e4289913a1e3c6021f5a6745f65d4044-declare const a: {\n    new (): {\n        p: number;\n    };\n};\n\n(6,1): error4094: Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094\np\n\n(6,1): error9027: Add_a_type_annotation_to_the_variable_0_9027\na\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;","signature":"eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n","impliedNodeFormat":1}],"options":{"declaration":true},"emitDiagnosticsPerFile":[[2,[{"pos":6,"end":7,"code":4094,"category":1,"messageKey":"Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094","messageArgs":["p"],"relatedInformation":[{"pos":6,"end":7,"code":9027,"category":1,"messageKey":"Add_a_type_annotation_to_the_variable_0_9027","messageArgs":["a"]}]}]]],"affectedFilesPendingEmit":[[2,17]]}
+{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"54435c7adb578d59d7e39dd2f567250e-const a = class { private p = 10; };","signature":"e4289913a1e3c6021f5a6745f65d4044-declare const a: {\n    new (): {\n        p: number;\n    };\n};\n\n(6,1): error4094: Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094\np\n\n(6,1): error9027: Add_a_type_annotation_to_the_variable_0_9027\na\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;","signature":"eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n","impliedNodeFormat":1}],"options":{"declaration":true},"emitDiagnosticsPerFile":[[2,[{"pos":6,"end":7,"code":4094,"category":1,"messageKey":"Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094","messageArgs":["p"],"relatedInformation":[{"pos":6,"end":7,"code":9027,"category":1,"messageKey":"Add_a_type_annotation_to_the_variable_0_9027","messageArgs":["a"]}]}]]],"affectedFilesPendingEmit":[[2,17],[3,17]]}
 //// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
 {
   "version": "FakeTSVersion",
@@ -502,17 +502,27 @@ Found 1 error in a.ts[90m:1[0m
         2,
         17
       ]
+    ],
+    [
+      "./b.ts",
+      "Js|DtsEmit",
+      [
+        3,
+        17
+      ]
     ]
   ],
-  "size": 1875
+  "size": 1882
 }
 
 tsconfig.json::
 SemanticDiagnostics::
 *refresh*    /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
 *refresh*    /home/src/projects/project/a.ts
+*refresh*    /home/src/projects/project/b.ts
 Signatures::
 (computed .d.ts) /home/src/projects/project/a.ts
+(computed .d.ts) /home/src/projects/project/b.ts
 
 
 Edit [6]:: Emit when error
@@ -538,6 +548,8 @@ const a = class {
     p = 10;
 };
 
+//// [/home/src/projects/project/b.d.ts] *rewrite with same content*
+//// [/home/src/projects/project/b.js] *rewrite with same content*
 //// [/home/src/projects/project/tsconfig.tsbuildinfo] *modified* 
 {"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"54435c7adb578d59d7e39dd2f567250e-const a = class { private p = 10; };","signature":"e4289913a1e3c6021f5a6745f65d4044-declare const a: {\n    new (): {\n        p: number;\n    };\n};\n\n(6,1): error4094: Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094\np\n\n(6,1): error9027: Add_a_type_annotation_to_the_variable_0_9027\na\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;","signature":"eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n","impliedNodeFormat":1}],"options":{"declaration":true},"emitDiagnosticsPerFile":[[2,[{"pos":6,"end":7,"code":4094,"category":1,"messageKey":"Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094","messageArgs":["p"],"relatedInformation":[{"pos":6,"end":7,"code":9027,"category":1,"messageKey":"Add_a_type_annotation_to_the_variable_0_9027","messageArgs":["a"]}]}]]]}
 //// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 

--- a/testdata/baselines/reference/tsc/noEmit/dts-errors-without-dts-enabled-with-incremental-as-modules.js
+++ b/testdata/baselines/reference/tsc/noEmit/dts-errors-without-dts-enabled-with-incremental-as-modules.js
@@ -314,7 +314,7 @@ tsgo --noEmit
 ExitStatus:: Success
 Output::
 //// [/home/src/projects/project/tsconfig.tsbuildinfo] *modified* 
-{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"54435c7adb578d59d7e39dd2f567250e-const a = class { private p = 10; };","signature":"e4289913a1e3c6021f5a6745f65d4044-declare const a: {\n    new (): {\n        p: number;\n    };\n};\n\n(6,1): error4094: Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094\np\n\n(6,1): error9027: Add_a_type_annotation_to_the_variable_0_9027\na\n","affectsGlobalScope":true,"impliedNodeFormat":1},"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;"],"options":{"declaration":false},"affectedFilesPendingEmit":[2]}
+{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"54435c7adb578d59d7e39dd2f567250e-const a = class { private p = 10; };","signature":"e4289913a1e3c6021f5a6745f65d4044-declare const a: {\n    new (): {\n        p: number;\n    };\n};\n\n(6,1): error4094: Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094\np\n\n(6,1): error9027: Add_a_type_annotation_to_the_variable_0_9027\na\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;","signature":"eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n","impliedNodeFormat":1}],"options":{"declaration":false},"affectedFilesPendingEmit":[2,3]}
 //// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
 {
   "version": "FakeTSVersion",
@@ -364,8 +364,13 @@ Output::
     {
       "fileName": "./b.ts",
       "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "signature": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "impliedNodeFormat": "CommonJS"
+      "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
+        "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+        "impliedNodeFormat": 1
+      }
     }
   ],
   "options": {
@@ -376,17 +381,24 @@ Output::
       "./a.ts",
       "Js",
       2
+    ],
+    [
+      "./b.ts",
+      "Js",
+      3
     ]
   ],
-  "size": 1421
+  "size": 1535
 }
 
 tsconfig.json::
 SemanticDiagnostics::
 *refresh*    /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
 *refresh*    /home/src/projects/project/a.ts
+*refresh*    /home/src/projects/project/b.ts
 Signatures::
 (computed .d.ts) /home/src/projects/project/a.ts
+(computed .d.ts) /home/src/projects/project/b.ts
 
 
 Edit [6]:: Emit when error
@@ -400,8 +412,9 @@ const a = class {
     p = 10;
 };
 
+//// [/home/src/projects/project/b.js] *rewrite with same content*
 //// [/home/src/projects/project/tsconfig.tsbuildinfo] *modified* 
-{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"54435c7adb578d59d7e39dd2f567250e-const a = class { private p = 10; };","signature":"e4289913a1e3c6021f5a6745f65d4044-declare const a: {\n    new (): {\n        p: number;\n    };\n};\n\n(6,1): error4094: Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094\np\n\n(6,1): error9027: Add_a_type_annotation_to_the_variable_0_9027\na\n","affectsGlobalScope":true,"impliedNodeFormat":1},"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;"],"options":{"declaration":false}}
+{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"54435c7adb578d59d7e39dd2f567250e-const a = class { private p = 10; };","signature":"e4289913a1e3c6021f5a6745f65d4044-declare const a: {\n    new (): {\n        p: number;\n    };\n};\n\n(6,1): error4094: Property_0_of_exported_anonymous_class_type_may_not_be_private_or_protected_4094\np\n\n(6,1): error9027: Add_a_type_annotation_to_the_variable_0_9027\na\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;","signature":"eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n","impliedNodeFormat":1}],"options":{"declaration":false}}
 //// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
 {
   "version": "FakeTSVersion",
@@ -451,14 +464,19 @@ const a = class {
     {
       "fileName": "./b.ts",
       "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "signature": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "impliedNodeFormat": "CommonJS"
+      "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
+        "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+        "impliedNodeFormat": 1
+      }
     }
   ],
   "options": {
     "declaration": false
   },
-  "size": 1390
+  "size": 1502
 }
 
 tsconfig.json::

--- a/testdata/baselines/reference/tsc/noEmit/semantic-errors-with-incremental-as-modules.js
+++ b/testdata/baselines/reference/tsc/noEmit/semantic-errors-with-incremental-as-modules.js
@@ -356,7 +356,7 @@ Output::
 Found 1 error in a.ts[90m:1[0m
 
 //// [/home/src/projects/project/tsconfig.tsbuildinfo] *modified* 
-{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"903d9216256112700b1325b61dcb7717-const a: number = \"hello\"","signature":"a87bf21f13058d40be607df702228523-declare const a: number;\n","affectsGlobalScope":true,"impliedNodeFormat":1},"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;"],"options":{"declaration":false},"semanticDiagnosticsPerFile":[[2,[{"pos":6,"end":7,"code":2322,"category":1,"messageKey":"Type_0_is_not_assignable_to_type_1_2322","messageArgs":["string","number"]}]]],"affectedFilesPendingEmit":[2]}
+{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"903d9216256112700b1325b61dcb7717-const a: number = \"hello\"","signature":"a87bf21f13058d40be607df702228523-declare const a: number;\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;","signature":"eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n","impliedNodeFormat":1}],"options":{"declaration":false},"semanticDiagnosticsPerFile":[[2,[{"pos":6,"end":7,"code":2322,"category":1,"messageKey":"Type_0_is_not_assignable_to_type_1_2322","messageArgs":["string","number"]}]]],"affectedFilesPendingEmit":[2,3]}
 //// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
 {
   "version": "FakeTSVersion",
@@ -406,8 +406,13 @@ Found 1 error in a.ts[90m:1[0m
     {
       "fileName": "./b.ts",
       "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "signature": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "impliedNodeFormat": "CommonJS"
+      "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
+        "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+        "impliedNodeFormat": 1
+      }
     }
   ],
   "options": {
@@ -436,17 +441,24 @@ Found 1 error in a.ts[90m:1[0m
       "./a.ts",
       "Js",
       2
+    ],
+    [
+      "./b.ts",
+      "Js",
+      3
     ]
   ],
-  "size": 1366
+  "size": 1480
 }
 
 tsconfig.json::
 SemanticDiagnostics::
 *refresh*    /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
 *refresh*    /home/src/projects/project/a.ts
+*refresh*    /home/src/projects/project/b.ts
 Signatures::
 (computed .d.ts) /home/src/projects/project/a.ts
+(computed .d.ts) /home/src/projects/project/b.ts
 
 
 Edit [6]:: Emit when error
@@ -466,8 +478,9 @@ Found 1 error in a.ts[90m:1[0m
 "use strict";
 const a = "hello";
 
+//// [/home/src/projects/project/b.js] *rewrite with same content*
 //// [/home/src/projects/project/tsconfig.tsbuildinfo] *modified* 
-{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"903d9216256112700b1325b61dcb7717-const a: number = \"hello\"","signature":"a87bf21f13058d40be607df702228523-declare const a: number;\n","affectsGlobalScope":true,"impliedNodeFormat":1},"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;"],"options":{"declaration":false},"semanticDiagnosticsPerFile":[[2,[{"pos":6,"end":7,"code":2322,"category":1,"messageKey":"Type_0_is_not_assignable_to_type_1_2322","messageArgs":["string","number"]}]]]}
+{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"903d9216256112700b1325b61dcb7717-const a: number = \"hello\"","signature":"a87bf21f13058d40be607df702228523-declare const a: number;\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;","signature":"eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n","impliedNodeFormat":1}],"options":{"declaration":false},"semanticDiagnosticsPerFile":[[2,[{"pos":6,"end":7,"code":2322,"category":1,"messageKey":"Type_0_is_not_assignable_to_type_1_2322","messageArgs":["string","number"]}]]]}
 //// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
 {
   "version": "FakeTSVersion",
@@ -517,8 +530,13 @@ const a = "hello";
     {
       "fileName": "./b.ts",
       "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "signature": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "impliedNodeFormat": "CommonJS"
+      "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
+        "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+        "impliedNodeFormat": 1
+      }
     }
   ],
   "options": {
@@ -542,7 +560,7 @@ const a = "hello";
       ]
     ]
   ],
-  "size": 1335
+  "size": 1447
 }
 
 tsconfig.json::

--- a/testdata/baselines/reference/tsc/noEmit/syntax-errors-with-incremental-as-modules.js
+++ b/testdata/baselines/reference/tsc/noEmit/syntax-errors-with-incremental-as-modules.js
@@ -436,8 +436,9 @@ Found 1 error in a.ts[90m:1[0m
 "use strict";
 const a = "hello;
 
+//// [/home/src/projects/project/b.js] *rewrite with same content*
 //// [/home/src/projects/project/tsconfig.tsbuildinfo] *modified* 
-{"version":"FakeTSVersion","errors":true,"root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"d8a5f356bd133a6882ecbde29426bdcb-const a = \"hello","signature":"64868e4042512db835b5b3c3226ab323-declare const a = \"hello\";\n","affectsGlobalScope":true,"impliedNodeFormat":1},"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;"],"options":{"declaration":false},"semanticDiagnosticsPerFile":[1,2]}
+{"version":"FakeTSVersion","errors":true,"root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"d8a5f356bd133a6882ecbde29426bdcb-const a = \"hello","signature":"64868e4042512db835b5b3c3226ab323-declare const a = \"hello\";\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;","signature":"eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n","impliedNodeFormat":1}],"options":{"declaration":false},"semanticDiagnosticsPerFile":[1,2,3]}
 //// [/home/src/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
 {
   "version": "FakeTSVersion",
@@ -488,8 +489,13 @@ const a = "hello;
     {
       "fileName": "./b.ts",
       "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "signature": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
-      "impliedNodeFormat": "CommonJS"
+      "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "907abc8137ceb88f0ddd6eccfa92d573-export const b = 10;",
+        "signature": "eaed5dafb4668e1b7c86b65b584b776a-export declare const b = 10;\n",
+        "impliedNodeFormat": 1
+      }
     }
   ],
   "options": {
@@ -497,17 +503,20 @@ const a = "hello;
   },
   "semanticDiagnosticsPerFile": [
     "lib.es2025.full.d.ts",
-    "./a.ts"
+    "./a.ts",
+    "./b.ts"
   ],
-  "size": 1209
+  "size": 1323
 }
 
 tsconfig.json::
 SemanticDiagnostics::
 *not cached* /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
 *not cached* /home/src/projects/project/a.ts
+*not cached* /home/src/projects/project/b.ts
 Signatures::
 (computed .d.ts) /home/src/projects/project/a.ts
+(computed .d.ts) /home/src/projects/project/b.ts
 
 
 Edit [7]:: no change
@@ -528,4 +537,5 @@ tsconfig.json::
 SemanticDiagnostics::
 *not cached* /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
 *not cached* /home/src/projects/project/a.ts
+*not cached* /home/src/projects/project/b.ts
 Signatures::

--- a/testdata/baselines/reference/tsc/noEmitOnError/when-declarationMap-changes.js
+++ b/testdata/baselines/reference/tsc/noEmitOnError/when-declarationMap-changes.js
@@ -151,7 +151,7 @@ Output::
 Found 1 error in a.ts[90m:1[0m
 
 //// [/home/src/workspaces/project/tsconfig.tsbuildinfo] *modified* 
-{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"6792320cbdee0286d2b3e83ff1d9fcc1-const x: 20 = 10;","signature":"c4dd771ef0ee0838482d28bc7dea6269-declare const x: 20;\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"4448aee3ffd6eaf52054c6f2413c128a-const y = 10;","signature":"b0061f8cf6b7f4ef02673fae62fc90dd-declare const y = 10;\n","affectsGlobalScope":true,"impliedNodeFormat":1}],"options":{"composite":true,"declaration":true,"declarationMap":true,"noEmitOnError":true},"semanticDiagnosticsPerFile":[[2,[{"pos":6,"end":7,"code":2322,"category":1,"messageKey":"Type_0_is_not_assignable_to_type_1_2322","messageArgs":["10","20"]}]]],"affectedFilesPendingEmit":[2,[3,48]],"latestChangedDtsFile":"./b.d.ts","emitSignatures":[[2,["4be7af7f970696121f4f582a5d074177-declare const x = 10;\n"]],[3,[]]]}
+{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"6792320cbdee0286d2b3e83ff1d9fcc1-const x: 20 = 10;","signature":"c4dd771ef0ee0838482d28bc7dea6269-declare const x: 20;\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"4448aee3ffd6eaf52054c6f2413c128a-const y = 10;","signature":"b0061f8cf6b7f4ef02673fae62fc90dd-declare const y = 10;\n","affectsGlobalScope":true,"impliedNodeFormat":1}],"options":{"composite":true,"declaration":true,"declarationMap":true,"noEmitOnError":true},"semanticDiagnosticsPerFile":[[2,[{"pos":6,"end":7,"code":2322,"category":1,"messageKey":"Type_0_is_not_assignable_to_type_1_2322","messageArgs":["10","20"]}]]],"affectedFilesPendingEmit":[2,3],"latestChangedDtsFile":"./b.d.ts","emitSignatures":[[2,["4be7af7f970696121f4f582a5d074177-declare const x = 10;\n"]],[3,[]]]}
 //// [/home/src/workspaces/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
 {
   "version": "FakeTSVersion",
@@ -244,11 +244,8 @@ Found 1 error in a.ts[90m:1[0m
     ],
     [
       "./b.ts",
-      "DtsEmit|DtsMap",
-      [
-        3,
-        48
-      ]
+      "Js|Dts|DtsMap",
+      3
     ]
   ],
   "latestChangedDtsFile": "./b.d.ts",
@@ -273,15 +270,17 @@ Found 1 error in a.ts[90m:1[0m
       ]
     }
   ],
-  "size": 1659
+  "size": 1654
 }
 
 tsconfig.json::
 SemanticDiagnostics::
 *refresh*    /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
 *refresh*    /home/src/workspaces/project/a.ts
+*refresh*    /home/src/workspaces/project/b.ts
 Signatures::
 (computed .d.ts) /home/src/workspaces/project/a.ts
+(computed .d.ts) /home/src/workspaces/project/b.ts
 
 
 Edit [1]:: fix error declarationMap
@@ -302,6 +301,7 @@ declare const y = 10;
 //# sourceMappingURL=b.d.ts.map
 //// [/home/src/workspaces/project/b.d.ts.map] *new* 
 {"version":3,"file":"b.d.ts","sourceRoot":"","sources":["b.ts"],"names":[],"mappings":"AAAA,QAAA,MAAM,CAAC,KAAK,CAAC"}
+//// [/home/src/workspaces/project/b.js] *rewrite with same content*
 //// [/home/src/workspaces/project/tsconfig.tsbuildinfo] *modified* 
 {"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"4447ab8c90027f28bdaff9f2056779ce-const x = 10;","signature":"4be7af7f970696121f4f582a5d074177-declare const x = 10;\n","affectsGlobalScope":true,"impliedNodeFormat":1},{"version":"4448aee3ffd6eaf52054c6f2413c128a-const y = 10;","signature":"b0061f8cf6b7f4ef02673fae62fc90dd-declare const y = 10;\n","affectsGlobalScope":true,"impliedNodeFormat":1}],"options":{"composite":true,"declaration":true,"declarationMap":true,"noEmitOnError":true},"latestChangedDtsFile":"./b.d.ts"}
 //// [/home/src/workspaces/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
@@ -378,5 +378,7 @@ tsconfig.json::
 SemanticDiagnostics::
 *refresh*    /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
 *refresh*    /home/src/workspaces/project/a.ts
+*refresh*    /home/src/workspaces/project/b.ts
 Signatures::
 (computed .d.ts) /home/src/workspaces/project/a.ts
+(computed .d.ts) /home/src/workspaces/project/b.ts


### PR DESCRIPTION
Fixes #4664

This is a 6.0/7.0 behavior difference in `--build`/`--incremental`
invalidation (in-scope per CONTRIBUTING's bridge-release policy).

## What

When a changed file `affectsGlobalScope`, `getFilesAffectedBy` now returns
the all-files-excluding-default-library set — the set it already computed and
cached — instead of falling through to the reverse-reference walk. This is
Strada's behavior: `getFilesAffectedByUpdatedShapeWhenModuleEmit`
(`src/compiler/builderState.ts`) returns
`getAllFilesExcludingDefaultLibraryFile(...)` for a global-scope shape
change.

## Why

`getFilesAffectedBy` set `hasAllFilesExcludingDefaultLibraryFile` and primed
the all-files cache on a global-scope change, but still returned only the
changed file plus its reverse closure bounded by unchanged .d.ts signatures.
`handleDtsMayChangeOfAffectedFile` takes an early return for every affected
file when that flag is set, skipping the reverse-`referencedBy` invalidation
that removes dependents' cached semantic diagnostics. Strada's equivalent
early return (`src/compiler/builder.ts`, `handleDtsMayChangeOfAffectedFile`)
is safe only because its affected set is all files; tsgo kept the early
return but dropped the all-files set.

Consequences on main (see linked issue for a CLI repro and mechanism detail):

- a lone global-scope .d.ts content change does not re-check files that use
  the global without importing the changed module — the incremental build
  stays green while a clean build errors;
- because the flag is handler-global, one global-scope file in a changed
  batch (the shape of a package-manager dependency bump) suppresses dependent
  invalidation for every other changed file in that batch;
- the buildinfo then records the affected files as fully-checked-clean
  (absence of a `semanticDiagnosticsPerFile` entry), so the false green is
  durable across subsequent builds.

## Test coverage

Three new `tsbuild/dependencyUpdate` scenarios in
`internal/execute/tsctests/tscbuild_test.go`:

- `rebuilds transitive dependents when dependency update batch includes a
  global scope change` — dep-A breaking change + dep-B `declare global`
  change in one batch; the break surfaces in a consumer connected to dep-A
  only through a module whose .d.ts signature does not change; includes a
  no-change follow-up edit showing durability. Failed on unmodified main via
  the harness's incremental-vs-clean diff (incremental missed TS2366).
- `rebuilds transitive dependents when dependency update batch has no global
  scope change` — control arm; behaved correctly before and after.
- `rebuilds files using globals when global scope dependency is updated` —
  lone global-scope content change violating a non-importing user. Failed on
  unmodified main (incremental missed TS2322).

## Baseline impact

15 existing baselines change, uniformly the intended class: after a
global-scope file changes, the other files are now refreshed — recomputed
.d.ts signatures (`*refresh*` / `(computed .d.ts)` in program baselines),
cached diagnostics dropped, and files queued for full emit
(`affectedFilesPendingEmit` gains the sibling files; same-content rewrites
appear in output listings):

- `tsc/incremental/when-global-file-is-added,-the-signatures-are-updated` —
  the scenario's titular signatures are now actually updated for sibling
  files.
- `tsc|tsbuild|tsbuildWatch/noEmit/*-with-incremental-as-modules` (12 files)
  — these scenarios edit `a.ts` into a non-module (global) file mid-scenario;
  `b.ts` is now refreshed and queued for emit when that happens.
- `tsc/noEmitOnError/when-declarationMap-changes`,
  `tsbuildWatch/noEmit/does-not-go-in-loop-when-watching-...` — same class
  (the watch scenario's actual concern, not looping, is unchanged).

Performance note: a global-scope change now invalidates and re-checks all
non-library files, like Strada. The all-files set is computed once per
build (cached on the snapshot), and per-file handling stays on the existing
early-return path (`removeSemanticDiagnosticsOf` + signature update), so the
cost profile matches Strada's for the same transition; builds with no
global-scope change in the batch are unaffected.

## Validation

- `go test ./internal/execute/...` — green.
- `go test ./...` — green (macOS; TypeScript-submodule-gated tests skipped —
  submodule not cloned locally).
- CLI three-way check on the linked issue's repro: `typescript@6.0.3` errors
  on the incremental rebuild, unmodified main exits 0 silently, this branch
  errors identically to 6.0 and to a clean build.

## Disclosure

Per CONTRIBUTING's AI-assistance policy: this patch was authored with an AI
coding agent (Claude Code). I have read and understood the change, chose this
specific issue myself, and will shepherd it through review personally.
