### PR TITLE
Preserve JSDoc @property comments when reconstructing typedef types

### DIFF
--- a/internal/checker/nodebuilderimpl.go
+++ b/internal/checker/nodebuilderimpl.go
@@ -2605,10 +2605,34 @@ func (b *NodeBuilderImpl) addPropertyToElementList(propertySymbol *ast.Symbol, t
 	}
 	propertySignature := b.f.NewPropertySignatureDeclaration(modifiers, propertyName, optionalToken, propertyTypeNode, nil)
 
-	b.setCommentRange(propertySignature, propertySymbol.ValueDeclaration)
+	b.preserveCommentsOn(propertySignature, propertySymbol)
 	typeElements = append(typeElements, propertySignature)
 
 	return typeElements
+}
+
+// preserveCommentsOn copies documentation comments from a property symbol onto a synthesized node
+// for declaration emit. Properties declared via a JSDoc `@property`/`@typedef` tag are reparsed into
+// property signatures whose comment lives on a synthetic JSDoc rather than in a source comment range,
+// so it is reattached as a synthetic leading comment (mirroring the old emitter's `preserveCommentsOn`).
+// Otherwise the comment range of the value declaration is copied.
+func (b *NodeBuilderImpl) preserveCommentsOn(node *ast.Node, propertySymbol *ast.Symbol) {
+	jsdocPropertyDeclaration := core.Find(propertySymbol.Declarations, func(d *ast.Node) bool {
+		return d.Flags&ast.NodeFlagsReparsed != 0 && d.Flags&ast.NodeFlagsHasJSDoc != 0
+	})
+	if jsdocPropertyDeclaration != nil {
+		jsdoc := core.FirstOrNil(jsdocPropertyDeclaration.EagerJSDoc(ast.GetSourceFileOfNode(jsdocPropertyDeclaration)))
+		if jsdoc != nil {
+			commentText := scanner.GetTextOfJSDocComment(jsdoc.AsJSDoc().Comment)
+			if commentText != "" {
+				comment := "*\n * " + strings.ReplaceAll(commentText, "\n", "\n * ") + "\n "
+				b.e.AddSyntheticLeadingComment(node, ast.KindMultiLineCommentTrivia, comment, true /*hasTrailingNewLine*/)
+			}
+		}
+	} else if propertySymbol.ValueDeclaration != nil {
+		// Copy comments to node for declaration emit
+		b.setCommentRange(node, propertySymbol.ValueDeclaration)
+	}
 }
 
 func (b *NodeBuilderImpl) createTypeNodesFromResolvedType(resolvedType *StructuredType) *ast.NodeList {

--- a/testdata/baselines/reference/conformance/jsDeclarationsTypedefPropertyComments.js
+++ b/testdata/baselines/reference/conformance/jsDeclarationsTypedefPropertyComments.js
@@ -1,0 +1,53 @@
+//// [tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypedefPropertyComments.ts] ////
+
+//// [lib.js]
+/**
+ * @typedef {Object} Foo
+ * @property {boolean} bool Whether `.bool` is true or not
+ */
+export class C {
+    /** @returns {Foo} */
+    getFoo() { return { bool: false }; }
+}
+
+//// [main.js]
+import { C } from './lib.js';
+
+export class Main {
+    constructor() {
+        this.c = new C();
+    }
+
+    getFoo() { return { ...this.c.getFoo() }; }
+}
+
+
+
+
+//// [lib.d.ts]
+export type Foo = {
+    /**
+     * Whether `.bool` is true or not
+     */
+    bool: boolean;
+};
+/**
+ * @typedef {Object} Foo
+ * @property {boolean} bool Whether `.bool` is true or not
+ */
+export declare class C {
+    /** @returns {Foo} */
+    getFoo(): Foo;
+}
+//// [main.d.ts]
+import { C } from './lib.js';
+export declare class Main {
+    c: C;
+    constructor();
+    getFoo(): {
+        /**
+         * Whether `.bool` is true or not
+         */
+        bool: boolean;
+    };
+}

--- a/testdata/baselines/reference/conformance/jsDeclarationsTypedefPropertyComments.symbols
+++ b/testdata/baselines/reference/conformance/jsDeclarationsTypedefPropertyComments.symbols
@@ -1,0 +1,40 @@
+//// [tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypedefPropertyComments.ts] ////
+
+=== lib.js ===
+/**
+ * @typedef {Object} Foo
+ * @property {boolean} bool Whether `.bool` is true or not
+ */
+export class C {
+>C : Symbol(C, Decl(lib.js, 0, 0))
+
+    /** @returns {Foo} */
+    getFoo() { return { bool: false }; }
+>getFoo : Symbol(C.getFoo, Decl(lib.js, 4, 16))
+>bool : Symbol(bool, Decl(lib.js, 6, 23))
+}
+
+=== main.js ===
+import { C } from './lib.js';
+>C : Symbol(C, Decl(main.js, 0, 8))
+
+export class Main {
+>Main : Symbol(Main, Decl(main.js, 0, 29))
+
+    constructor() {
+        this.c = new C();
+>this.c : Symbol(Main.c, Decl(main.js, 3, 19))
+>this : Symbol(Main, Decl(main.js, 0, 29))
+>c : Symbol(Main.c, Decl(main.js, 3, 19))
+>C : Symbol(C, Decl(main.js, 0, 8))
+    }
+
+    getFoo() { return { ...this.c.getFoo() }; }
+>getFoo : Symbol(Main.getFoo, Decl(main.js, 5, 5))
+>this.c.getFoo : Symbol(C.getFoo, Decl(lib.js, 4, 16))
+>this.c : Symbol(Main.c, Decl(main.js, 3, 19))
+>this : Symbol(Main, Decl(main.js, 0, 29))
+>c : Symbol(Main.c, Decl(main.js, 3, 19))
+>getFoo : Symbol(C.getFoo, Decl(lib.js, 4, 16))
+}
+

--- a/testdata/baselines/reference/conformance/jsDeclarationsTypedefPropertyComments.types
+++ b/testdata/baselines/reference/conformance/jsDeclarationsTypedefPropertyComments.types
@@ -1,0 +1,46 @@
+//// [tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypedefPropertyComments.ts] ////
+
+=== lib.js ===
+/**
+ * @typedef {Object} Foo
+ * @property {boolean} bool Whether `.bool` is true or not
+ */
+export class C {
+>C : C
+
+    /** @returns {Foo} */
+    getFoo() { return { bool: false }; }
+>getFoo : () => Foo
+>{ bool: false } : { bool: false; }
+>bool : false
+>false : false
+}
+
+=== main.js ===
+import { C } from './lib.js';
+>C : typeof C
+
+export class Main {
+>Main : Main
+
+    constructor() {
+        this.c = new C();
+>this.c = new C() : C
+>this.c : any
+>this : this
+>c : any
+>new C() : C
+>C : typeof C
+    }
+
+    getFoo() { return { ...this.c.getFoo() }; }
+>getFoo : () => { bool: boolean; }
+>{ ...this.c.getFoo() } : { bool: boolean; }
+>this.c.getFoo() : import("./lib.js").Foo
+>this.c.getFoo : () => import("./lib.js").Foo
+>this.c : C
+>this : this
+>c : C
+>getFoo : () => import("./lib.js").Foo
+}
+

--- a/testdata/tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypedefPropertyComments.ts
+++ b/testdata/tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypedefPropertyComments.ts
@@ -1,0 +1,26 @@
+// @allowJs: true
+// @checkJs: true
+// @declaration: true
+// @emitDeclarationOnly: true
+// @outDir: ./out
+
+// @filename: lib.js
+/**
+ * @typedef {Object} Foo
+ * @property {boolean} bool Whether `.bool` is true or not
+ */
+export class C {
+    /** @returns {Foo} */
+    getFoo() { return { bool: false }; }
+}
+
+// @filename: main.js
+import { C } from './lib.js';
+
+export class Main {
+    constructor() {
+        this.c = new C();
+    }
+
+    getFoo() { return { ...this.c.getFoo() }; }
+}


### PR DESCRIPTION
Fixes #4352

## Problem

Block comments on `@property` entries of a `@typedef` were dropped when the structural type was reconstructed inline in another file. TypeScript 6 preserves them; `tsgo` did not.

```ts
// lib.js
/**
 * @typedef {Object} Foo
 * @property {boolean} bool Whether `.bool` is true or not
 */
export class C {
    /** @returns {Foo} */
    getFoo() { return { bool: false }; }
}

// main.js
import { C } from './lib.js';
export class Main {
    constructor() { this.c = new C(); }
    getFoo() { return { ...this.c.getFoo() }; }
}
```

`main.d.ts` before (comment lost):

```ts
getFoo(): {
    bool: boolean;
};
```

`main.d.ts` after (matches `tsc`):

```ts
getFoo(): {
    /**
     * Whether `.bool` is true or not
     */
    bool: boolean;
};
```

## Fix

The old JS `.d.ts` emitter copied comments onto synthesized property signatures via `preserveCommentsOn` / `setSyntheticLeadingComments`. The Go node builder used a raw `setCommentRange` in `addPropertyToElementList`, which drops comments for properties reparsed from `@typedef`/`@property` tags — their comment lives on a synthetic reparsed JSDoc rather than in a source comment range.

This reimplements `preserveCommentsOn` inside `addPropertyToElementList`: for a property whose declaration is a reparsed node carrying JSDoc, the comment text is reattached as a synthetic leading comment; otherwise the existing `setCommentRange` behavior is preserved. Only reparsed JS `@property` declarations take the new path, so TS declaration emit is unaffected.

## Tests

Adds `jsDeclarationsTypedefPropertyComments.ts` covering both the same-file type alias and the cross-file inline reconstruction. Full local compiler suite and `checker`/transformer package tests pass.

## AI usage disclosure

This change was authored with the assistance of an AI agent (Claude Code). I have read and understand the change and will discuss and revise it in review like any other contribution.
