### PR TITLE
Fix parsing of `as`/`satisfies` between `**` operators

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -4582,6 +4582,15 @@ func (p *Parser) parseBinaryExpressionOrHigher(precedence ast.OperatorPrecedence
 	return p.parseBinaryExpressionRest(precedence, leftOperand, pos)
 }
 
+// shouldConsumeBinaryOperator reports whether an operator binds before the operator represented by currentPrecedence.
+// At equal precedence, only the right-associative exponentiation operator binds first.
+func shouldConsumeBinaryOperator(operator ast.Kind, operatorPrecedence ast.OperatorPrecedence, currentPrecedence ast.OperatorPrecedence) bool {
+	if operatorPrecedence > currentPrecedence {
+		return true
+	}
+	return operatorPrecedence == currentPrecedence && operator == ast.KindAsteriskAsteriskToken
+}
+
 func (p *Parser) parseBinaryExpressionRest(precedence ast.OperatorPrecedence, leftOperand *ast.Expression, pos int) *ast.Expression {
 	lastOperand := leftOperand
 	for {
@@ -4610,13 +4619,7 @@ func (p *Parser) parseBinaryExpressionRest(precedence ast.OperatorPrecedence, le
 		//            ^^token; leftOperand = b. Return b ** c to the caller as a rightOperand
 		//      a ** b - c
 		//             ^token; leftOperand = b. Return b to the caller as a rightOperand
-		var consumeCurrentOperator bool
-		if operator == ast.KindAsteriskAsteriskToken {
-			consumeCurrentOperator = newPrecedence >= precedence
-		} else {
-			consumeCurrentOperator = newPrecedence > precedence
-		}
-		if !consumeCurrentOperator {
+		if !shouldConsumeBinaryOperator(operator, newPrecedence, precedence) {
 			break
 		}
 		if operator == ast.KindInKeyword && p.inDisallowInContext() {
@@ -4632,10 +4635,9 @@ func (p *Parser) parseBinaryExpressionRest(precedence ast.OperatorPrecedence, le
 				break
 			} else {
 				p.nextToken()
-				// When we have 'a ## b as SomeType' or 'a ## b satisfies SomeType', where ## is some binary
-				// operator, we want to stop parsing on any following operator with a higher precedence than ##
-				// because continuing would make it impossible to erase the `as` or `satisfies` without changing
-				// the meaning of the expression. See https://github.com/microsoft/TypeScript/issues/63527.
+				// When we have 'a ## b as SomeType $$ c' or 'a ## b satisfies SomeType $$ c', where ## and $$
+				// are binary operators, we want to stop parsing when $$ would bind before ## after erasing the
+				// assertion. See https://github.com/microsoft/TypeScript/issues/63527.
 				lastPrecedence := ast.OperatorPrecedenceHighest
 				if ast.IsBinaryExpression(lastOperand) {
 					lastPrecedence = ast.GetBinaryOperatorPrecedence(lastOperand.AsBinaryExpression().OperatorToken.Kind)
@@ -4645,8 +4647,10 @@ func (p *Parser) parseBinaryExpressionRest(precedence ast.OperatorPrecedence, le
 				} else {
 					leftOperand = p.makeAsExpression(leftOperand, p.parseType())
 				}
-				// Stop if the precedence of the next operator is too high.
-				if ast.GetBinaryOperatorPrecedence(p.reScanGreaterThanToken()) > lastPrecedence {
+				// Stop if the next operator would bind before the last operator when the assertion is erased.
+				nextOperator := p.reScanGreaterThanToken()
+				nextPrecedence := ast.GetBinaryOperatorPrecedence(nextOperator)
+				if shouldConsumeBinaryOperator(nextOperator, nextPrecedence, lastPrecedence) {
 					break
 				}
 			}

--- a/testdata/baselines/reference/compiler/disallowUnerasableAssertion.errors.txt
+++ b/testdata/baselines/reference/compiler/disallowUnerasableAssertion.errors.txt
@@ -2,17 +2,21 @@ disallowUnerasableAssertion.ts(9,36): error TS1005: ',' expected.
 disallowUnerasableAssertion.ts(10,43): error TS1005: ',' expected.
 disallowUnerasableAssertion.ts(33,37): error TS1005: ',' expected.
 disallowUnerasableAssertion.ts(34,44): error TS1005: ',' expected.
-disallowUnerasableAssertion.ts(39,43): error TS1005: ',' expected.
-disallowUnerasableAssertion.ts(40,57): error TS1005: ',' expected.
-disallowUnerasableAssertion.ts(63,44): error TS1005: ',' expected.
-disallowUnerasableAssertion.ts(64,58): error TS1005: ',' expected.
+disallowUnerasableAssertion.ts(41,37): error TS1005: ',' expected.
+disallowUnerasableAssertion.ts(42,44): error TS1005: ',' expected.
+disallowUnerasableAssertion.ts(47,43): error TS1005: ',' expected.
+disallowUnerasableAssertion.ts(48,57): error TS1005: ',' expected.
+disallowUnerasableAssertion.ts(71,44): error TS1005: ',' expected.
+disallowUnerasableAssertion.ts(72,58): error TS1005: ',' expected.
+disallowUnerasableAssertion.ts(79,44): error TS1005: ',' expected.
+disallowUnerasableAssertion.ts(80,58): error TS1005: ',' expected.
 
 
-==== disallowUnerasableAssertion.ts (8 errors) ====
+==== disallowUnerasableAssertion.ts (12 errors) ====
     // https://github.com/microsoft/TypeScript/issues/63527
     
-    // Expressions of the form 'a ## b as T $$ c' where ## has lower precedence than $$ are errors
-    // because 'as T' cannot be erased without changing the meaning of the expressions.
+    // Expressions of the form 'a ## b as T $$ c' are errors when $$ would bind before ## after
+    // erasing 'as T', changing the meaning of the expression.
     
     export const x01 = 1 as number * 2;
     export const x02 = 1 as any as number * 2;
@@ -52,6 +56,18 @@ disallowUnerasableAssertion.ts(64,58): error TS1005: ',' expected.
                                                ~
 !!! error TS1005: ',' expected.
     
+    // Equal-precedence left-associative operators preserve their grouping when assertions are erased.
+    export const x25 = 2 * 3 as number * 2;
+    export const x26 = 2 * 3 as any as number * 2;
+    
+    // Equal-precedence right-associative operators do not.
+    export const x27 = 2 ** 3 as number ** 2;  // Error
+                                        ~~
+!!! error TS1005: ',' expected.
+    export const x28 = 2 ** 3 as any as number ** 2;  // Error
+                                               ~~
+!!! error TS1005: ',' expected.
+    
     export const y01 = 1 satisfies number * 2;
     export const y02 = 1 satisfies any satisfies number * 2;
     
@@ -88,5 +104,17 @@ disallowUnerasableAssertion.ts(64,58): error TS1005: ',' expected.
 !!! error TS1005: ',' expected.
     export const y24 = 1 >> 1 satisfies any satisfies number + 2;  // Error
                                                              ~
+!!! error TS1005: ',' expected.
+    
+    // Equal-precedence left-associative operators preserve their grouping when assertions are erased.
+    export const y25 = 2 * 3 satisfies number * 2;
+    export const y26 = 2 * 3 satisfies any satisfies number * 2;
+    
+    // Equal-precedence right-associative operators do not.
+    export const y27 = 2 ** 3 satisfies number ** 2;  // Error
+                                               ~~
+!!! error TS1005: ',' expected.
+    export const y28 = 2 ** 3 satisfies any satisfies number ** 2;  // Error
+                                                             ~~
 !!! error TS1005: ',' expected.
     

--- a/testdata/baselines/reference/compiler/disallowUnerasableAssertion.js
+++ b/testdata/baselines/reference/compiler/disallowUnerasableAssertion.js
@@ -3,8 +3,8 @@
 //// [disallowUnerasableAssertion.ts]
 // https://github.com/microsoft/TypeScript/issues/63527
 
-// Expressions of the form 'a ## b as T $$ c' where ## has lower precedence than $$ are errors
-// because 'as T' cannot be erased without changing the meaning of the expressions.
+// Expressions of the form 'a ## b as T $$ c' are errors when $$ would bind before ## after
+// erasing 'as T', changing the meaning of the expression.
 
 export const x01 = 1 as number * 2;
 export const x02 = 1 as any as number * 2;
@@ -36,6 +36,14 @@ export const x22 = 1 + 1 as any as number >> 2;
 export const x23 = 1 >> 1 as number + 2;  // Error
 export const x24 = 1 >> 1 as any as number + 2;  // Error
 
+// Equal-precedence left-associative operators preserve their grouping when assertions are erased.
+export const x25 = 2 * 3 as number * 2;
+export const x26 = 2 * 3 as any as number * 2;
+
+// Equal-precedence right-associative operators do not.
+export const x27 = 2 ** 3 as number ** 2;  // Error
+export const x28 = 2 ** 3 as any as number ** 2;  // Error
+
 export const y01 = 1 satisfies number * 2;
 export const y02 = 1 satisfies any satisfies number * 2;
 
@@ -66,11 +74,19 @@ export const y22 = 1 + 1 satisfies any satisfies number >> 2;
 export const y23 = 1 >> 1 satisfies number + 2;  // Error
 export const y24 = 1 >> 1 satisfies any satisfies number + 2;  // Error
 
+// Equal-precedence left-associative operators preserve their grouping when assertions are erased.
+export const y25 = 2 * 3 satisfies number * 2;
+export const y26 = 2 * 3 satisfies any satisfies number * 2;
+
+// Equal-precedence right-associative operators do not.
+export const y27 = 2 ** 3 satisfies number ** 2;  // Error
+export const y28 = 2 ** 3 satisfies any satisfies number ** 2;  // Error
+
 
 //// [disallowUnerasableAssertion.js]
 // https://github.com/microsoft/TypeScript/issues/63527
-// Expressions of the form 'a ## b as T $$ c' where ## has lower precedence than $$ are errors
-// because 'as T' cannot be erased without changing the meaning of the expressions.
+// Expressions of the form 'a ## b as T $$ c' are errors when $$ would bind before ## after
+// erasing 'as T', changing the meaning of the expression.
 export const x01 = 1 * 2;
 export const x02 = 1 * 2;
 export const x03 = 1 + 1;
@@ -99,6 +115,14 @@ export const x23 = 1 >> 1;
 +2; // Error
 export const x24 = 1 >> 1;
 +2; // Error
+// Equal-precedence left-associative operators preserve their grouping when assertions are erased.
+export const x25 = 2 * 3 * 2;
+export const x26 = 2 * 3 * 2;
+// Equal-precedence right-associative operators do not.
+export const x27 = 2 ** 3;
+ ** 2; // Error
+export const x28 = 2 ** 3;
+ ** 2; // Error
 export const y01 = 1 * 2;
 export const y02 = 1 * 2;
 export const y03 = 1 + 1;
@@ -127,3 +151,11 @@ export const y23 = 1 >> 1;
 +2; // Error
 export const y24 = 1 >> 1;
 +2; // Error
+// Equal-precedence left-associative operators preserve their grouping when assertions are erased.
+export const y25 = 2 * 3 * 2;
+export const y26 = 2 * 3 * 2;
+// Equal-precedence right-associative operators do not.
+export const y27 = 2 ** 3;
+ ** 2; // Error
+export const y28 = 2 ** 3;
+ ** 2; // Error

--- a/testdata/baselines/reference/compiler/disallowUnerasableAssertion.symbols
+++ b/testdata/baselines/reference/compiler/disallowUnerasableAssertion.symbols
@@ -3,8 +3,8 @@
 === disallowUnerasableAssertion.ts ===
 // https://github.com/microsoft/TypeScript/issues/63527
 
-// Expressions of the form 'a ## b as T $$ c' where ## has lower precedence than $$ are errors
-// because 'as T' cannot be erased without changing the meaning of the expressions.
+// Expressions of the form 'a ## b as T $$ c' are errors when $$ would bind before ## after
+// erasing 'as T', changing the meaning of the expression.
 
 export const x01 = 1 as number * 2;
 >x01 : Symbol(x01, Decl(disallowUnerasableAssertion.ts, 5, 12))
@@ -78,75 +78,103 @@ export const x23 = 1 >> 1 as number + 2;  // Error
 export const x24 = 1 >> 1 as any as number + 2;  // Error
 >x24 : Symbol(x24, Decl(disallowUnerasableAssertion.ts, 33, 12))
 
+// Equal-precedence left-associative operators preserve their grouping when assertions are erased.
+export const x25 = 2 * 3 as number * 2;
+>x25 : Symbol(x25, Decl(disallowUnerasableAssertion.ts, 36, 12))
+
+export const x26 = 2 * 3 as any as number * 2;
+>x26 : Symbol(x26, Decl(disallowUnerasableAssertion.ts, 37, 12))
+
+// Equal-precedence right-associative operators do not.
+export const x27 = 2 ** 3 as number ** 2;  // Error
+>x27 : Symbol(x27, Decl(disallowUnerasableAssertion.ts, 40, 12))
+
+export const x28 = 2 ** 3 as any as number ** 2;  // Error
+>x28 : Symbol(x28, Decl(disallowUnerasableAssertion.ts, 41, 12))
+
 export const y01 = 1 satisfies number * 2;
->y01 : Symbol(y01, Decl(disallowUnerasableAssertion.ts, 35, 12))
+>y01 : Symbol(y01, Decl(disallowUnerasableAssertion.ts, 43, 12))
 
 export const y02 = 1 satisfies any satisfies number * 2;
->y02 : Symbol(y02, Decl(disallowUnerasableAssertion.ts, 36, 12))
+>y02 : Symbol(y02, Decl(disallowUnerasableAssertion.ts, 44, 12))
 
 export const y03 = 1 + 1 satisfies number * 2;  // Error
->y03 : Symbol(y03, Decl(disallowUnerasableAssertion.ts, 38, 12))
+>y03 : Symbol(y03, Decl(disallowUnerasableAssertion.ts, 46, 12))
 
 export const y04 = 1 + 1 satisfies any satisfies number * 2;  // Error
->y04 : Symbol(y04, Decl(disallowUnerasableAssertion.ts, 39, 12))
+>y04 : Symbol(y04, Decl(disallowUnerasableAssertion.ts, 47, 12))
 
 export const y05 = 1 satisfies number + 1 * 2;
->y05 : Symbol(y05, Decl(disallowUnerasableAssertion.ts, 40, 12))
+>y05 : Symbol(y05, Decl(disallowUnerasableAssertion.ts, 48, 12))
 
 export const y06 = 1 satisfies any satisfies number + 1 * 2;
->y06 : Symbol(y06, Decl(disallowUnerasableAssertion.ts, 41, 12))
+>y06 : Symbol(y06, Decl(disallowUnerasableAssertion.ts, 49, 12))
 
 export const y07 = 1 * 1 satisfies number + 2;
->y07 : Symbol(y07, Decl(disallowUnerasableAssertion.ts, 43, 12))
+>y07 : Symbol(y07, Decl(disallowUnerasableAssertion.ts, 51, 12))
 
 export const y08 = 1 * 1 satisfies any satisfies number + 2;
->y08 : Symbol(y08, Decl(disallowUnerasableAssertion.ts, 44, 12))
+>y08 : Symbol(y08, Decl(disallowUnerasableAssertion.ts, 52, 12))
 
 export const y09 = 1 satisfies number * 1 + 2;
->y09 : Symbol(y09, Decl(disallowUnerasableAssertion.ts, 45, 12))
+>y09 : Symbol(y09, Decl(disallowUnerasableAssertion.ts, 53, 12))
 
 export const y10 = 1 satisfies any satisfies number * 1 + 2;
->y10 : Symbol(y10, Decl(disallowUnerasableAssertion.ts, 46, 12))
+>y10 : Symbol(y10, Decl(disallowUnerasableAssertion.ts, 54, 12))
 
 export const y11 = (1 + 1 satisfies number) * 2;
->y11 : Symbol(y11, Decl(disallowUnerasableAssertion.ts, 48, 12))
+>y11 : Symbol(y11, Decl(disallowUnerasableAssertion.ts, 56, 12))
 
 export const y12 = (1 + 1 satisfies any satisfies number) * 2;
->y12 : Symbol(y12, Decl(disallowUnerasableAssertion.ts, 49, 12))
+>y12 : Symbol(y12, Decl(disallowUnerasableAssertion.ts, 57, 12))
 
 export const y13 = (1 satisfies number + 1) * 2;
->y13 : Symbol(y13, Decl(disallowUnerasableAssertion.ts, 50, 12))
+>y13 : Symbol(y13, Decl(disallowUnerasableAssertion.ts, 58, 12))
 
 export const y14 = (1 satisfies any satisfies number + 1) * 2;
->y14 : Symbol(y14, Decl(disallowUnerasableAssertion.ts, 51, 12))
+>y14 : Symbol(y14, Decl(disallowUnerasableAssertion.ts, 59, 12))
 
 export const y15 = 1 + 1 satisfies number === 2;
->y15 : Symbol(y15, Decl(disallowUnerasableAssertion.ts, 53, 12))
+>y15 : Symbol(y15, Decl(disallowUnerasableAssertion.ts, 61, 12))
 
 export const y16 = 1 + 1 satisfies any satisfies number === 2;
->y16 : Symbol(y16, Decl(disallowUnerasableAssertion.ts, 54, 12))
+>y16 : Symbol(y16, Decl(disallowUnerasableAssertion.ts, 62, 12))
 
 export const y17 = 1 + 1 satisfies number > 2;
->y17 : Symbol(y17, Decl(disallowUnerasableAssertion.ts, 55, 12))
+>y17 : Symbol(y17, Decl(disallowUnerasableAssertion.ts, 63, 12))
 
 export const y18 = 1 + 1 satisfies any satisfies number > 2;
->y18 : Symbol(y18, Decl(disallowUnerasableAssertion.ts, 56, 12))
+>y18 : Symbol(y18, Decl(disallowUnerasableAssertion.ts, 64, 12))
 
 export const y19 = 1 + 1 satisfies number >= 2;
->y19 : Symbol(y19, Decl(disallowUnerasableAssertion.ts, 57, 12))
+>y19 : Symbol(y19, Decl(disallowUnerasableAssertion.ts, 65, 12))
 
 export const y20 = 1 + 1 satisfies any satisfies number >= 2;
->y20 : Symbol(y20, Decl(disallowUnerasableAssertion.ts, 58, 12))
+>y20 : Symbol(y20, Decl(disallowUnerasableAssertion.ts, 66, 12))
 
 export const y21 = 1 + 1 satisfies number >> 2;
->y21 : Symbol(y21, Decl(disallowUnerasableAssertion.ts, 60, 12))
+>y21 : Symbol(y21, Decl(disallowUnerasableAssertion.ts, 68, 12))
 
 export const y22 = 1 + 1 satisfies any satisfies number >> 2;
->y22 : Symbol(y22, Decl(disallowUnerasableAssertion.ts, 61, 12))
+>y22 : Symbol(y22, Decl(disallowUnerasableAssertion.ts, 69, 12))
 
 export const y23 = 1 >> 1 satisfies number + 2;  // Error
->y23 : Symbol(y23, Decl(disallowUnerasableAssertion.ts, 62, 12))
+>y23 : Symbol(y23, Decl(disallowUnerasableAssertion.ts, 70, 12))
 
 export const y24 = 1 >> 1 satisfies any satisfies number + 2;  // Error
->y24 : Symbol(y24, Decl(disallowUnerasableAssertion.ts, 63, 12))
+>y24 : Symbol(y24, Decl(disallowUnerasableAssertion.ts, 71, 12))
+
+// Equal-precedence left-associative operators preserve their grouping when assertions are erased.
+export const y25 = 2 * 3 satisfies number * 2;
+>y25 : Symbol(y25, Decl(disallowUnerasableAssertion.ts, 74, 12))
+
+export const y26 = 2 * 3 satisfies any satisfies number * 2;
+>y26 : Symbol(y26, Decl(disallowUnerasableAssertion.ts, 75, 12))
+
+// Equal-precedence right-associative operators do not.
+export const y27 = 2 ** 3 satisfies number ** 2;  // Error
+>y27 : Symbol(y27, Decl(disallowUnerasableAssertion.ts, 78, 12))
+
+export const y28 = 2 ** 3 satisfies any satisfies number ** 2;  // Error
+>y28 : Symbol(y28, Decl(disallowUnerasableAssertion.ts, 79, 12))
 

--- a/testdata/baselines/reference/compiler/disallowUnerasableAssertion.types
+++ b/testdata/baselines/reference/compiler/disallowUnerasableAssertion.types
@@ -3,8 +3,8 @@
 === disallowUnerasableAssertion.ts ===
 // https://github.com/microsoft/TypeScript/issues/63527
 
-// Expressions of the form 'a ## b as T $$ c' where ## has lower precedence than $$ are errors
-// because 'as T' cannot be erased without changing the meaning of the expressions.
+// Expressions of the form 'a ## b as T $$ c' are errors when $$ would bind before ## after
+// erasing 'as T', changing the meaning of the expression.
 
 export const x01 = 1 as number * 2;
 >x01 : number
@@ -236,6 +236,48 @@ export const x24 = 1 >> 1 as any as number + 2;  // Error
 >+ 2 : 2
 >2 : 2
 
+// Equal-precedence left-associative operators preserve their grouping when assertions are erased.
+export const x25 = 2 * 3 as number * 2;
+>x25 : number
+>2 * 3 as number * 2 : number
+>2 * 3 as number : number
+>2 * 3 : number
+>2 : 2
+>3 : 3
+>2 : 2
+
+export const x26 = 2 * 3 as any as number * 2;
+>x26 : number
+>2 * 3 as any as number * 2 : number
+>2 * 3 as any as number : number
+>2 * 3 as any : any
+>2 * 3 : number
+>2 : 2
+>3 : 3
+>2 : 2
+
+// Equal-precedence right-associative operators do not.
+export const x27 = 2 ** 3 as number ** 2;  // Error
+>x27 : number
+>2 ** 3 as number : number
+>2 ** 3 : number
+>2 : 2
+>3 : 3
+>** 2 : number
+> : any
+>2 : 2
+
+export const x28 = 2 ** 3 as any as number ** 2;  // Error
+>x28 : number
+>2 ** 3 as any as number : number
+>2 ** 3 as any : any
+>2 ** 3 : number
+>2 : 2
+>3 : 3
+>** 2 : number
+> : any
+>2 : 2
+
 export const y01 = 1 satisfies number * 2;
 >y01 : number
 >1 satisfies number * 2 : number
@@ -464,5 +506,47 @@ export const y24 = 1 >> 1 satisfies any satisfies number + 2;  // Error
 >1 : 1
 >1 : 1
 >+ 2 : 2
+>2 : 2
+
+// Equal-precedence left-associative operators preserve their grouping when assertions are erased.
+export const y25 = 2 * 3 satisfies number * 2;
+>y25 : number
+>2 * 3 satisfies number * 2 : number
+>2 * 3 satisfies number : number
+>2 * 3 : number
+>2 : 2
+>3 : 3
+>2 : 2
+
+export const y26 = 2 * 3 satisfies any satisfies number * 2;
+>y26 : number
+>2 * 3 satisfies any satisfies number * 2 : number
+>2 * 3 satisfies any satisfies number : number
+>2 * 3 satisfies any : number
+>2 * 3 : number
+>2 : 2
+>3 : 3
+>2 : 2
+
+// Equal-precedence right-associative operators do not.
+export const y27 = 2 ** 3 satisfies number ** 2;  // Error
+>y27 : number
+>2 ** 3 satisfies number : number
+>2 ** 3 : number
+>2 : 2
+>3 : 3
+>** 2 : number
+> : any
+>2 : 2
+
+export const y28 = 2 ** 3 satisfies any satisfies number ** 2;  // Error
+>y28 : number
+>2 ** 3 satisfies any satisfies number : number
+>2 ** 3 satisfies any : number
+>2 ** 3 : number
+>2 : 2
+>3 : 3
+>** 2 : number
+> : any
 >2 : 2
 

--- a/testdata/tests/cases/compiler/disallowUnerasableAssertion.ts
+++ b/testdata/tests/cases/compiler/disallowUnerasableAssertion.ts
@@ -1,7 +1,7 @@
 // https://github.com/microsoft/TypeScript/issues/63527
 
-// Expressions of the form 'a ## b as T $$ c' where ## has lower precedence than $$ are errors
-// because 'as T' cannot be erased without changing the meaning of the expressions.
+// Expressions of the form 'a ## b as T $$ c' are errors when $$ would bind before ## after
+// erasing 'as T', changing the meaning of the expression.
 
 export const x01 = 1 as number * 2;
 export const x02 = 1 as any as number * 2;
@@ -33,6 +33,14 @@ export const x22 = 1 + 1 as any as number >> 2;
 export const x23 = 1 >> 1 as number + 2;  // Error
 export const x24 = 1 >> 1 as any as number + 2;  // Error
 
+// Equal-precedence left-associative operators preserve their grouping when assertions are erased.
+export const x25 = 2 * 3 as number * 2;
+export const x26 = 2 * 3 as any as number * 2;
+
+// Equal-precedence right-associative operators do not.
+export const x27 = 2 ** 3 as number ** 2;  // Error
+export const x28 = 2 ** 3 as any as number ** 2;  // Error
+
 export const y01 = 1 satisfies number * 2;
 export const y02 = 1 satisfies any satisfies number * 2;
 
@@ -62,3 +70,11 @@ export const y21 = 1 + 1 satisfies number >> 2;
 export const y22 = 1 + 1 satisfies any satisfies number >> 2;
 export const y23 = 1 >> 1 satisfies number + 2;  // Error
 export const y24 = 1 >> 1 satisfies any satisfies number + 2;  // Error
+
+// Equal-precedence left-associative operators preserve their grouping when assertions are erased.
+export const y25 = 2 * 3 satisfies number * 2;
+export const y26 = 2 * 3 satisfies any satisfies number * 2;
+
+// Equal-precedence right-associative operators do not.
+export const y27 = 2 ** 3 satisfies number ** 2;  // Error
+export const y28 = 2 ** 3 satisfies any satisfies number ** 2;  // Error


### PR DESCRIPTION
Follow-up to #4192.

Accounts for `**` being right-associative when rejecting `as`/`satisfies` expressions that cannot be safely erased. Adds regression coverage for direct and chained forms.

- Close: microsoft/TypeScript#63661