### PR TITLE
Optimize construction of union types

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -10673,7 +10673,7 @@ func (c *Checker) getInstantiationExpressionType(exprType *Type, node *ast.Node)
 				hasSignatures = hasSignatures || len(resolved.CallSignatures()) != 0 || len(resolved.ConstructSignatures()) != 0
 				hasApplicableSignature = hasApplicableSignature || len(callSignatures) != 0 || len(constructSignatures) != 0
 				if !core.Same(callSignatures, resolved.CallSignatures()) || !core.Same(constructSignatures, resolved.ConstructSignatures()) {
-					result := c.newObjectType(ObjectFlagsAnonymous|ObjectFlagsInstantiationExpressionType, c.newSymbol(ast.SymbolFlagsNone, ast.InternalSymbolNameInstantiationExpression))
+					result := c.newObjectType(ObjectFlagsAnonymous|ObjectFlagsInstantiationExpressionType, t.symbol)
 					c.setStructuredTypeMembers(result, resolved.members, callSignatures, constructSignatures, resolved.indexInfos)
 					result.AsInstantiationExpressionType().node = node
 					return result
@@ -15599,6 +15599,7 @@ func (c *Checker) getTypeWithSyntheticDefaultImportType(t *Type, symbol *ast.Sym
 		var syntheticType *Type
 		if hasSyntheticDefault {
 			anonymousSymbol := c.newSymbol(ast.SymbolFlagsTypeLiteral, ast.InternalSymbolNameType)
+			anonymousSymbol.Declarations = originalSymbol.Declarations
 			defaultContainingObject := c.createDefaultPropertyWrapperForModule(symbol, originalSymbol, anonymousSymbol)
 			c.valueSymbolLinks.Get(anonymousSymbol).resolvedType = defaultContainingObject
 			if c.isValidSpreadType(t) {
@@ -15655,6 +15656,10 @@ func (c *Checker) createDefaultPropertyWrapperForModule(symbol *ast.Symbol, orig
 	c.valueSymbolLinks.Get(newSymbol).nameType = c.getStringLiteralType("default")
 	c.aliasSymbolLinks.Get(newSymbol).aliasTarget = c.resolveSymbol(symbol)
 	memberTable[ast.InternalSymbolNameDefault] = newSymbol
+	if anonymousSymbol == nil && originalSymbol != nil {
+		anonymousSymbol = c.newSymbol(ast.SymbolFlagsObjectLiteral, ast.InternalSymbolNameObject)
+		anonymousSymbol.Declarations = originalSymbol.Declarations
+	}
 	return c.newAnonymousType(anonymousSymbol, memberTable, nil, nil, nil)
 }
 
@@ -25594,7 +25599,7 @@ func (c *Checker) getUnionTypeEx(types []*Type, unionReduction UnionReduction, a
 }
 
 func (c *Checker) getUnionTypeWorker(types []*Type, unionReduction UnionReduction, alias *TypeAlias, origin *Type) *Type {
-	typeSet, includes := c.addTypesToUnion(make([]*Type, 0, len(types)), 0, types)
+	typeSet, includes := c.addTypesToUnion(types)
 	if unionReduction != UnionReductionNone {
 		if includes&TypeFlagsAnyOrUnknown != 0 {
 			if includes&TypeFlagsAny != 0 {
@@ -25701,29 +25706,15 @@ func (c *Checker) UnionTypes() iter.Seq[*Type] {
 	return maps.Values(c.unionTypes)
 }
 
-func (c *Checker) addTypesToUnion(typeSet []*Type, includes TypeFlags, types []*Type) ([]*Type, TypeFlags) {
-	var lastType *Type
-	for _, t := range types {
-		if t != lastType {
-			if t.flags&TypeFlagsUnion != 0 {
-				u := t.AsUnionType()
-				if t.alias != nil || u.origin != nil {
-					includes |= TypeFlagsUnion
-				}
-				typeSet, includes = c.addTypesToUnion(typeSet, includes, u.types)
-			} else {
-				typeSet, includes = c.addTypeToUnion(typeSet, includes, t)
-			}
-			lastType = t
+func (c *Checker) addTypesToUnion(sourceTypes []*Type) ([]*Type, TypeFlags) {
+	types := make([]*Type, 0, len(sourceTypes))
+	var includes TypeFlags
+	addType := func(t *Type) {
+		flags := t.flags
+		// We ignore 'never' types in unions
+		if flags&TypeFlagsNever != 0 {
+			return
 		}
-	}
-	return typeSet, includes
-}
-
-func (c *Checker) addTypeToUnion(typeSet []*Type, includes TypeFlags, t *Type) ([]*Type, TypeFlags) {
-	flags := t.flags
-	// We ignore 'never' types in unions
-	if flags&TypeFlagsNever == 0 {
 		includes |= flags & TypeFlagsIncludesMask
 		if flags&TypeFlagsInstantiable != 0 {
 			includes |= TypeFlagsIncludesInstantiable
@@ -25741,13 +25732,41 @@ func (c *Checker) addTypeToUnion(typeSet []*Type, includes TypeFlags, t *Type) (
 			if t.objectFlags&ObjectFlagsContainsWideningType == 0 {
 				includes |= TypeFlagsIncludesNonWideningType
 			}
-		} else {
-			if index, ok := slices.BinarySearchFunc(typeSet, t, CompareTypes); !ok {
-				typeSet = slices.Insert(typeSet, index, t)
+			return
+		}
+		types = append(types, t)
+	}
+	var lastType *Type
+	for _, t := range sourceTypes {
+		if t != lastType {
+			if t.flags&TypeFlagsUnion != 0 {
+				u := t.AsUnionType()
+				if t.alias != nil || u.origin != nil {
+					includes |= TypeFlagsUnion
+				}
+				for _, s := range u.types {
+					addType(s)
+				}
+			} else {
+				addType(t)
 			}
+			lastType = t
 		}
 	}
-	return typeSet, includes
+	if len(types) >= 2 {
+		// Sort and deduplicate types
+		slices.SortStableFunc(types, CompareTypes)
+		unique := 1
+		for _, t := range types[1:] {
+			if t != types[unique-1] {
+				types[unique] = t
+				unique++
+			}
+		}
+		clear(types[unique:])
+		types = types[:unique]
+	}
+	return types, includes
 }
 
 func (c *Checker) addNamedUnions(namedUnions []*Type, types []*Type) []*Type {
@@ -27157,7 +27176,7 @@ func (c *Checker) getSuggestionForNonexistentIndexSignature(objectType *Type, ex
 
 func (c *Checker) getSuggestedTypeForNonexistentStringLiteralType(source *Type, target *Type) *Type {
 	candidates := core.FilterSeq(target.Types(), func(t *Type) bool { return t.flags&TypeFlagsStringLiteral != 0 })
-	return core.GetSpellingSuggestion(getStringLiteralValue(source), candidates, getStringLiteralValue, CompareTypes)
+	return core.GetSpellingSuggestionWithMaxCandidateCount(getStringLiteralValue(source), candidates, getStringLiteralValue, CompareTypes, 1000)
 }
 
 func getIndexNodeForAccessExpression(accessNode *ast.Node) *ast.Node {

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -557,6 +557,14 @@ func GetScriptKindFromFileName(fileName string) ScriptKind {
 //
 // @internal
 func GetSpellingSuggestion[T any](name string, candidates iter.Seq[T], getName func(T) string, compare func(T, T) int) T {
+	return getSpellingSuggestion(name, candidates, getName, compare, 0 /*maxCandidates*/)
+}
+
+func GetSpellingSuggestionWithMaxCandidateCount[T any](name string, candidates iter.Seq[T], getName func(T) string, compare func(T, T) int, maxCandidates int) T {
+	return getSpellingSuggestion(name, candidates, getName, compare, maxCandidates)
+}
+
+func getSpellingSuggestion[T any](name string, candidates iter.Seq[T], getName func(T) string, compare func(T, T) int, maxCandidates int) T {
 	runeName := []rune(name)
 	maximumLengthDifference := max(2, int(float64(len(runeName))*0.34))
 	bestDistance := math.Floor(float64(len(runeName))*0.4) + 0.9 // If the best result is worse than this, don't bother.
@@ -564,7 +572,13 @@ func GetSpellingSuggestion[T any](name string, candidates iter.Seq[T], getName f
 	defer levenshteinBuffersPool.Put(buffers)
 	var bestCandidate T
 	hasBest := false
+	checkedCandidates := 0
 	for candidate := range candidates {
+		checkedCandidates++
+		if maxCandidates > 0 && checkedCandidates > maxCandidates {
+			var zero T
+			return zero
+		}
 		candidateName := getName(candidate)
 		maxLen := max(len(candidateName), len(runeName))
 		minLen := min(len(candidateName), len(runeName))

--- a/testdata/baselines/reference/compiler/largeStringLiteralUnionSuggestion.errors.txt
+++ b/testdata/baselines/reference/compiler/largeStringLiteralUnionSuggestion.errors.txt
@@ -1,0 +1,13 @@
+largeStringLiteralUnionSuggestion.ts(6,7): error TS2322: Type '"zzzz"' is not assignable to type '"a000" | "a001" | "a002" | "a003" | "a004" | "a005" | "a006" | "a007" | "a008" | "a009" | "a010" | "a011" | "a012" | "a013" | "a014" | "a015" | "a016" | "a017" | "a018" | "a019" | "a020" | ... 10978 more ... | "k999"'.
+
+
+==== largeStringLiteralUnionSuggestion.ts (1 errors) ====
+    type Prefix = "a" | "b" | "c" | "d" | "e" | "f" | "g" | "h" | "i" | "j" | "k";
+    type Digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9";
+    type LargeStringLiteralUnion = `${Prefix}${Digit}${Digit}${Digit}`;
+    
+    const ok: LargeStringLiteralUnion = "a000";
+    const bad: LargeStringLiteralUnion = "zzzz";
+          ~~~
+!!! error TS2322: Type '"zzzz"' is not assignable to type '"a000" | "a001" | "a002" | "a003" | "a004" | "a005" | "a006" | "a007" | "a008" | "a009" | "a010" | "a011" | "a012" | "a013" | "a014" | "a015" | "a016" | "a017" | "a018" | "a019" | "a020" | ... 10978 more ... | "k999"'.
+    

--- a/testdata/baselines/reference/submodule/conformance/instantiationExpressions.types
+++ b/testdata/baselines/reference/submodule/conformance/instantiationExpressions.types
@@ -349,8 +349,8 @@ function f32(f: (<T>(a: T) => T) | { x: string }) {
 >x : string
 
     let fs = f<string>;  // ((a: string) => string) | { x: string }
->fs : { x: string; } | ((a: string) => string)
->f<string> : { x: string; } | ((a: string) => string)
+>fs : ((a: string) => string) | { x: string; }
+>f<string> : ((a: string) => string) | { x: string; }
 >f : (<T>(a: T) => T) | { x: string; }
 }
 

--- a/testdata/baselines/reference/submodule/conformance/instantiationExpressions.types.diff
+++ b/testdata/baselines/reference/submodule/conformance/instantiationExpressions.types.diff
@@ -40,3 +40,13 @@
  >Array : ArrayConstructor
 
  type T21 = typeof Array<string>;  // new (...) => string[]
+@@= skipped -275, +275 lines =@@
+ >x : string
+
+     let fs = f<string>;  // ((a: string) => string) | { x: string }
+->fs : { x: string; } | ((a: string) => string)
+->f<string> : { x: string; } | ((a: string) => string)
++>fs : ((a: string) => string) | { x: string; }
++>f<string> : ((a: string) => string) | { x: string; }
+ >f : (<T>(a: T) => T) | { x: string; }
+ }

--- a/testdata/tests/cases/compiler/largeStringLiteralUnionSuggestion.ts
+++ b/testdata/tests/cases/compiler/largeStringLiteralUnionSuggestion.ts
@@ -1,0 +1,11 @@
+// @strict: true
+// @noEmit: true
+// @noErrorTruncation: false
+// @noTypesAndSymbols: true
+
+type Prefix = "a" | "b" | "c" | "d" | "e" | "f" | "g" | "h" | "i" | "j" | "k";
+type Digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9";
+type LargeStringLiteralUnion = `${Prefix}${Digit}${Digit}${Digit}`;
+
+const ok: LargeStringLiteralUnion = "a000";
+const bad: LargeStringLiteralUnion = "zzzz";


### PR DESCRIPTION
This PR builds on the idea in #4474 and switches union type construction to always collect, sort, and deduplicate constituent types instead of using binary insertion (which doesn't scale well). The PR adopts the limit on large string literal union suggestions from #4474 and also copies the test from that PR.

The PR includes a fix to an instability that resulted from deferred assignment of type and symbol IDs: When symbols have the same name and no associated declarations, we'll compare the symbols by ID. Since IDs are lazily created, the first symbol for which we request an ID gets the lowest ID. This means that type order can end up depending on the order in which a sorting algorithm compares the symbols associated with two types--which isn't good. The fix in the PR is to associate symbols (with declarations) in a few locations where we previously didn't.

I probably should have based this PR on #4474, but had already gone down the separate path.