### PR TITLE
Fix over-eager `isMatchingConstructorReference` function

### DIFF
--- a/internal/checker/flow.go
+++ b/internal/checker/flow.go
@@ -736,12 +736,13 @@ func (c *Checker) narrowTypeByDiscriminant(t *Type, access *ast.Node, narrowType
 }
 
 func (c *Checker) isMatchingConstructorReference(f *FlowState, expr *ast.Node) bool {
-	if ast.IsAccessExpression(expr) {
-		if accessedName, ok := c.getAccessedPropertyName(expr); ok && accessedName == "constructor" && c.isMatchingReference(f.reference, expr.Expression()) {
-			return true
-		}
+	var name *ast.Node
+	if ast.IsPropertyAccessExpression(expr) {
+		name = expr.AsPropertyAccessExpression().Name()
+	} else if ast.IsElementAccessExpression(expr) && ast.IsStringLiteralLike(expr.AsElementAccessExpression().ArgumentExpression) {
+		name = expr.AsElementAccessExpression().ArgumentExpression
 	}
-	return false
+	return name != nil && name.Text() == "constructor" && c.isMatchingReference(f.reference, expr.Expression())
 }
 
 func (c *Checker) narrowTypeByConstructor(t *Type, operator ast.Kind, identifier *ast.Node, assumeTrue bool) *Type {

--- a/testdata/baselines/reference/compiler/controlFlowNoCircularity.symbols
+++ b/testdata/baselines/reference/compiler/controlFlowNoCircularity.symbols
@@ -1,0 +1,56 @@
+//// [tests/cases/compiler/controlFlowNoCircularity.ts] ////
+
+=== controlFlowNoCircularity.ts ===
+// https://github.com/microsoft/typescript-go/issues/4673
+
+export function repro(board: number[][], pos: number | undefined): void {
+>repro : Symbol(repro, Decl(controlFlowNoCircularity.ts, 0, 0))
+>board : Symbol(board, Decl(controlFlowNoCircularity.ts, 2, 22))
+>pos : Symbol(pos, Decl(controlFlowNoCircularity.ts, 2, 40))
+
+  if (!pos) return;
+>pos : Symbol(pos, Decl(controlFlowNoCircularity.ts, 2, 40))
+
+  for (const pattern of [{ target: [-1, -1], intermediate: [-1, 0] }]) {
+>pattern : Symbol(pattern, Decl(controlFlowNoCircularity.ts, 4, 12))
+>target : Symbol(target, Decl(controlFlowNoCircularity.ts, 4, 26))
+>intermediate : Symbol(intermediate, Decl(controlFlowNoCircularity.ts, 4, 44))
+
+    const targetR = pos + pattern.target[0];
+>targetR : Symbol(targetR, Decl(controlFlowNoCircularity.ts, 5, 9))
+>pos : Symbol(pos, Decl(controlFlowNoCircularity.ts, 2, 40))
+>pattern.target : Symbol(target, Decl(controlFlowNoCircularity.ts, 4, 26))
+>pattern : Symbol(pattern, Decl(controlFlowNoCircularity.ts, 4, 12))
+>target : Symbol(target, Decl(controlFlowNoCircularity.ts, 4, 26))
+
+    const targetC = pos + pattern.target[1];
+>targetC : Symbol(targetC, Decl(controlFlowNoCircularity.ts, 6, 9))
+>pos : Symbol(pos, Decl(controlFlowNoCircularity.ts, 2, 40))
+>pattern.target : Symbol(target, Decl(controlFlowNoCircularity.ts, 4, 26))
+>pattern : Symbol(pattern, Decl(controlFlowNoCircularity.ts, 4, 12))
+>target : Symbol(target, Decl(controlFlowNoCircularity.ts, 4, 26))
+
+    if (board[targetR][targetC] !== 0) {}
+>board : Symbol(board, Decl(controlFlowNoCircularity.ts, 2, 22))
+>targetR : Symbol(targetR, Decl(controlFlowNoCircularity.ts, 5, 9))
+>targetC : Symbol(targetC, Decl(controlFlowNoCircularity.ts, 6, 9))
+
+    const [ir, ic] = pattern.intermediate;
+>ir : Symbol(ir, Decl(controlFlowNoCircularity.ts, 8, 11))
+>ic : Symbol(ic, Decl(controlFlowNoCircularity.ts, 8, 14))
+>pattern.intermediate : Symbol(intermediate, Decl(controlFlowNoCircularity.ts, 4, 44))
+>pattern : Symbol(pattern, Decl(controlFlowNoCircularity.ts, 4, 12))
+>intermediate : Symbol(intermediate, Decl(controlFlowNoCircularity.ts, 4, 44))
+
+    const midC = ic;
+>midC : Symbol(midC, Decl(controlFlowNoCircularity.ts, 9, 9))
+>ic : Symbol(ic, Decl(controlFlowNoCircularity.ts, 8, 14))
+
+    if (board[ir][midC] === 0) {
+>board : Symbol(board, Decl(controlFlowNoCircularity.ts, 2, 22))
+>ir : Symbol(ir, Decl(controlFlowNoCircularity.ts, 8, 11))
+>midC : Symbol(midC, Decl(controlFlowNoCircularity.ts, 9, 9))
+    }
+  }
+}
+

--- a/testdata/baselines/reference/compiler/controlFlowNoCircularity.types
+++ b/testdata/baselines/reference/compiler/controlFlowNoCircularity.types
@@ -1,0 +1,82 @@
+//// [tests/cases/compiler/controlFlowNoCircularity.ts] ////
+
+=== controlFlowNoCircularity.ts ===
+// https://github.com/microsoft/typescript-go/issues/4673
+
+export function repro(board: number[][], pos: number | undefined): void {
+>repro : (board: number[][], pos: number | undefined) => void
+>board : number[][]
+>pos : number | undefined
+
+  if (!pos) return;
+>!pos : boolean
+>pos : number | undefined
+
+  for (const pattern of [{ target: [-1, -1], intermediate: [-1, 0] }]) {
+>pattern : { target: number[]; intermediate: number[]; }
+>[{ target: [-1, -1], intermediate: [-1, 0] }] : { target: number[]; intermediate: number[]; }[]
+>{ target: [-1, -1], intermediate: [-1, 0] } : { target: number[]; intermediate: number[]; }
+>target : number[]
+>[-1, -1] : number[]
+>-1 : -1
+>1 : 1
+>-1 : -1
+>1 : 1
+>intermediate : number[]
+>[-1, 0] : number[]
+>-1 : -1
+>1 : 1
+>0 : 0
+
+    const targetR = pos + pattern.target[0];
+>targetR : number
+>pos + pattern.target[0] : number
+>pos : number
+>pattern.target[0] : number
+>pattern.target : number[]
+>pattern : { target: number[]; intermediate: number[]; }
+>target : number[]
+>0 : 0
+
+    const targetC = pos + pattern.target[1];
+>targetC : number
+>pos + pattern.target[1] : number
+>pos : number
+>pattern.target[1] : number
+>pattern.target : number[]
+>pattern : { target: number[]; intermediate: number[]; }
+>target : number[]
+>1 : 1
+
+    if (board[targetR][targetC] !== 0) {}
+>board[targetR][targetC] !== 0 : boolean
+>board[targetR][targetC] : number
+>board[targetR] : number[]
+>board : number[][]
+>targetR : number
+>targetC : number
+>0 : 0
+
+    const [ir, ic] = pattern.intermediate;
+>ir : number
+>ic : number
+>pattern.intermediate : number[]
+>pattern : { target: number[]; intermediate: number[]; }
+>intermediate : number[]
+
+    const midC = ic;
+>midC : number
+>ic : number
+
+    if (board[ir][midC] === 0) {
+>board[ir][midC] === 0 : boolean
+>board[ir][midC] : number
+>board[ir] : number[]
+>board : number[][]
+>ir : number
+>midC : number
+>0 : 0
+    }
+  }
+}
+

--- a/testdata/tests/cases/compiler/controlFlowNoCircularity.ts
+++ b/testdata/tests/cases/compiler/controlFlowNoCircularity.ts
@@ -1,0 +1,16 @@
+// @noEmit: true
+
+// https://github.com/microsoft/typescript-go/issues/4673
+
+export function repro(board: number[][], pos: number | undefined): void {
+  if (!pos) return;
+  for (const pattern of [{ target: [-1, -1], intermediate: [-1, 0] }]) {
+    const targetR = pos + pattern.target[0];
+    const targetC = pos + pattern.target[1];
+    if (board[targetR][targetC] !== 0) {}
+    const [ir, ic] = pattern.intermediate;
+    const midC = ic;
+    if (board[ir][midC] === 0) {
+    }
+  }
+}


### PR DESCRIPTION
This fixes the `isMatchingConstructorFunction` to more closely match in original in Strada.

Fixes #4673.