### PR TITLE
Expose getFullyQualifiedName on the API Checker

### DIFF
--- a/_packages/native-preview/src/api/async/api.ts
+++ b/_packages/native-preview/src/api/async/api.ts
@@ -1514,6 +1514,18 @@ export class Checker {
         return this.objectRegistry.getOrCreateSymbol(data);
     }
 
+    /**
+     * Get the fully qualified name of a symbol, walking up its parent chain
+     * (e.g. `"/path/to/module".Namespace.Name`).
+     */
+    async getFullyQualifiedName(symbol: Symbol): Promise<string> {
+        return this.client.apiRequest<string>("getFullyQualifiedName", {
+            snapshot: this.snapshotId,
+            project: this.project.id,
+            symbol: symbol.id,
+        });
+    }
+
     async getImmediateAliasedSymbol(symbol: Symbol): Promise<Symbol | undefined> {
         const data = await this.client.apiRequest<SymbolResponse | null>("getImmediateAliasedSymbol", {
             snapshot: this.snapshotId,

--- a/_packages/native-preview/src/api/sync/api.ts
+++ b/_packages/native-preview/src/api/sync/api.ts
@@ -1522,6 +1522,18 @@ export class Checker {
         return this.objectRegistry.getOrCreateSymbol(data);
     }
 
+    /**
+     * Get the fully qualified name of a symbol, walking up its parent chain
+     * (e.g. `"/path/to/module".Namespace.Name`).
+     */
+    getFullyQualifiedName(symbol: Symbol): string {
+        return this.client.apiRequest<string>("getFullyQualifiedName", {
+            snapshot: this.snapshotId,
+            project: this.project.id,
+            symbol: symbol.id,
+        });
+    }
+
     getImmediateAliasedSymbol(symbol: Symbol): Symbol | undefined {
         const data = this.client.apiRequest<SymbolResponse | null>("getImmediateAliasedSymbol", {
             snapshot: this.snapshotId,

--- a/_packages/native-preview/test/async/api.test.ts
+++ b/_packages/native-preview/test/async/api.test.ts
@@ -3664,6 +3664,40 @@ describe("Checker - getAliasedSymbol", () => {
     });
 });
 
+describe("Checker - getFullyQualifiedName", () => {
+    test("returns module-qualified names for exported symbols and dotted names for members", async () => {
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/index.ts": `
+export namespace Outer {
+    export class Inner {}
+}
+export class Standalone {}
+`,
+        });
+        try {
+            const snapshot = await api.updateSnapshot({ openProject: "/tsconfig.json" });
+            const project = snapshot.getProject("/tsconfig.json")!;
+            const sourceFile = await project.program.getSourceFile("/src/index.ts");
+            assert.ok(sourceFile);
+            const moduleSymbol = await project.checker.getSymbolAtLocation(sourceFile);
+            assert.ok(moduleSymbol);
+            const exports = await project.checker.getExportsOfModule(moduleSymbol);
+            const standalone = exports.find(e => e.name === "Standalone");
+            assert.ok(standalone);
+            assert.equal(await project.checker.getFullyQualifiedName(standalone), `"/src/index".Standalone`);
+            const outer = exports.find(e => e.name === "Outer");
+            assert.ok(outer);
+            const inner = (await outer.getExports()).get("Inner" as __String);
+            assert.ok(inner);
+            assert.equal(await project.checker.getFullyQualifiedName(inner), `"/src/index".Outer.Inner`);
+        }
+        finally {
+            await api.close();
+        }
+    });
+});
+
 describe("Checker - getExportsOfModule", () => {
     test("returns all exports including re-exports via 'export *'", async () => {
         const api = spawnAPI({

--- a/_packages/native-preview/test/sync/api.test.ts
+++ b/_packages/native-preview/test/sync/api.test.ts
@@ -3672,6 +3672,40 @@ describe("Checker - getAliasedSymbol", () => {
     });
 });
 
+describe("Checker - getFullyQualifiedName", () => {
+    test("returns module-qualified names for exported symbols and dotted names for members", () => {
+        const api = spawnAPI({
+            "/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+            "/src/index.ts": `
+export namespace Outer {
+    export class Inner {}
+}
+export class Standalone {}
+`,
+        });
+        try {
+            const snapshot = api.updateSnapshot({ openProject: "/tsconfig.json" });
+            const project = snapshot.getProject("/tsconfig.json")!;
+            const sourceFile = project.program.getSourceFile("/src/index.ts");
+            assert.ok(sourceFile);
+            const moduleSymbol = project.checker.getSymbolAtLocation(sourceFile);
+            assert.ok(moduleSymbol);
+            const exports = project.checker.getExportsOfModule(moduleSymbol);
+            const standalone = exports.find(e => e.name === "Standalone");
+            assert.ok(standalone);
+            assert.equal(project.checker.getFullyQualifiedName(standalone), `"/src/index".Standalone`);
+            const outer = exports.find(e => e.name === "Outer");
+            assert.ok(outer);
+            const inner = (outer.getExports()).get("Inner" as __String);
+            assert.ok(inner);
+            assert.equal(project.checker.getFullyQualifiedName(inner), `"/src/index".Outer.Inner`);
+        }
+        finally {
+            api.close();
+        }
+    });
+});
+
 describe("Checker - getExportsOfModule", () => {
     test("returns all exports including re-exports via 'export *'", () => {
         const api = spawnAPI({

--- a/internal/api/proto.go
+++ b/internal/api/proto.go
@@ -155,6 +155,7 @@ const (
 	MethodGetExportSpecifierLocalTarget     Method = "getExportSpecifierLocalTargetSymbol"
 	MethodGetAliasedSymbol                  Method = "getAliasedSymbol"
 	MethodGetImmediateAliasedSymbol         Method = "getImmediateAliasedSymbol"
+	MethodGetFullyQualifiedName             Method = "getFullyQualifiedName"
 	MethodGetExportsOfModule                Method = "getExportsOfModule"
 	MethodGetMemberInModuleExports          Method = "getMemberInModuleExports"
 	MethodGetJSDocTags                      Method = "getJsDocTags"
@@ -460,6 +461,7 @@ var unmarshalers = map[Method]func([]byte) (any, error){
 	MethodGetExportSpecifierLocalTarget:     unmarshallerFor[CheckerNodeParams],
 	MethodGetAliasedSymbol:                  unmarshallerFor[CheckerSymbolParams],
 	MethodGetImmediateAliasedSymbol:         unmarshallerFor[CheckerSymbolParams],
+	MethodGetFullyQualifiedName:             unmarshallerFor[CheckerSymbolParams],
 	MethodGetExportsOfModule:                unmarshallerFor[CheckerSymbolParams],
 	MethodGetMemberInModuleExports:          unmarshallerFor[GetMemberInModuleExportsParams],
 	MethodGetJSDocTags:                      unmarshallerFor[CheckerSymbolParams],

--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -742,6 +742,8 @@ func (s *Session) HandleRequest(ctx context.Context, method string, params json.
 		return s.handleGetAliasedSymbol(ctx, parsed.(*CheckerSymbolParams))
 	case string(MethodGetImmediateAliasedSymbol):
 		return s.handleGetImmediateAliasedSymbol(ctx, parsed.(*CheckerSymbolParams))
+	case string(MethodGetFullyQualifiedName):
+		return s.handleGetFullyQualifiedName(ctx, parsed.(*CheckerSymbolParams))
 	case string(MethodGetExportsOfModule):
 		return s.handleGetExportsOfModule(ctx, parsed.(*CheckerSymbolParams))
 	case string(MethodGetMemberInModuleExports):
@@ -2688,6 +2690,26 @@ func (s *Session) handleGetAliasedSymbol(ctx context.Context, params *CheckerSym
 	}
 
 	return setup.newSymbolResponse(setup.checker.GetAliasedSymbol(symbol)), nil
+}
+
+// handleGetFullyQualifiedName returns the fully qualified name of a symbol
+// (e.g. `"/path/to/module".Namespace.Name`).
+func (s *Session) handleGetFullyQualifiedName(ctx context.Context, params *CheckerSymbolParams) (string, error) {
+	setup, err := s.setupChecker(ctx, params.Snapshot, params.Project)
+	if err != nil {
+		return "", err
+	}
+	defer setup.done()
+
+	symbol, err := setup.resolveSymbolHandle(params.Symbol)
+	if err != nil {
+		return "", err
+	}
+	if symbol == nil {
+		return "", nil
+	}
+
+	return setup.checker.GetFullyQualifiedName(symbol), nil
 }
 
 // handleGetImmediateAliasedSymbol resolves one level of alias indirection.

--- a/internal/checker/exports.go
+++ b/internal/checker/exports.go
@@ -290,6 +290,12 @@ func (c *Checker) GetApparentType(t *Type) *Type {
 	return c.getApparentType(t)
 }
 
+// GetFullyQualifiedName returns the fully qualified name of a symbol, walking up
+// its parent chain (e.g. `"/path/to/module".Namespace.Name`).
+func (c *Checker) GetFullyQualifiedName(symbol *ast.Symbol) string {
+	return c.getFullyQualifiedName(symbol, nil /*containingLocation*/)
+}
+
 func (c *Checker) GetBaseConstructorTypeOfClass(t *Type) *Type {
 	return c.getBaseConstructorTypeOfClass(t)
 }


### PR DESCRIPTION
## Summary
This adds `checker.getFullyQualifiedName(symbol)` to the unstable API, for parity with the classic public `TypeChecker.getFullyQualifiedName`.

## Why we need this change?
Tools that build on the Compiler API rely on this method for symbol identification. For example, [jsii]( https://github.com/aws/jsii-compiler)  — the multi-language binding generator behind the AWS CDK, one of the largest TypeScript codebases — calls it ~357k times when compiling aws-cdk-lib, its single most-called checker API, — and it is currently the only checker API in jsii's extraction hot path with no equivalent here.

## Notes 
### Implementation
The checker already had the internal `getFullyQualifiedName`; this change only wires it up following the existing `CheckerSymbolParams` pattern (Go handler + async client method; the sync client and tests are generated via `generateSync`).

### Tests
Added sync/async client tests covering module-qualified names (`"/src/index".Standalone`) and nested members (`"/src/index".Outer.Inner`). `go test ./internal/api/...` and the native-preview client test suites pass (196/196 each).