### PR TITLE
Store value symbol links inline on checker-created symbols

### DIFF
--- a/internal/ast/symbol.go
+++ b/internal/ast/symbol.go
@@ -18,6 +18,9 @@ type Symbol struct {
 	id               atomic.Uint64
 	Parent           *Symbol
 	ExportSymbol     *Symbol
+	// CheckerData is side data attached by the one Checker that created this symbol; nil on
+	// binder-created symbols, which are shared between checkers. Owned by the checker package.
+	CheckerData any
 }
 
 func (s *Symbol) IsExternalModule() bool {

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -675,7 +675,7 @@ type Checker struct {
 	jsxElementLinks                             core.LinkStore[*ast.Node, JsxElementLinks]
 	computedNameLinks                           core.LinkStore[*ast.Node, ComputedNameNodeLinks]
 	symbolReferenceLinks                        core.LinkStore[*ast.Symbol, SymbolReferenceLinks]
-	valueSymbolLinks                            symbolArenaLinkStore[ValueSymbolLinks]
+	binderValueSymbolLinks                      symbolArenaLinkStore[ValueSymbolLinks]
 	mappedSymbolLinks                           core.LinkStore[*ast.Symbol, MappedSymbolLinks]
 	deferredSymbolLinks                         core.LinkStore[*ast.Symbol, DeferredSymbolLinks]
 	aliasSymbolLinks                            core.LinkStore[*ast.Symbol, AliasSymbolLinks]

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -1341,10 +1341,10 @@ func (c *Checker) initializeChecker() {
 		}
 	}
 	c.addUndefinedToGlobalsOrErrorOnRedeclaration()
-	c.valueSymbolLinks.Get(c.undefinedSymbol).resolvedType = c.undefinedWideningType
-	c.valueSymbolLinks.Get(c.argumentsSymbol).resolvedType = c.getGlobalType("IArguments", 0 /*arity*/, true /*reportErrors*/)
-	c.valueSymbolLinks.Get(c.unknownSymbol).resolvedType = c.errorType
-	c.valueSymbolLinks.Get(c.globalThisSymbol).resolvedType = c.newObjectType(ObjectFlagsAnonymous, c.globalThisSymbol)
+	c.getValueSymbolLinks(c.undefinedSymbol).resolvedType = c.undefinedWideningType
+	c.getValueSymbolLinks(c.argumentsSymbol).resolvedType = c.getGlobalType("IArguments", 0 /*arity*/, true /*reportErrors*/)
+	c.getValueSymbolLinks(c.unknownSymbol).resolvedType = c.errorType
+	c.getValueSymbolLinks(c.globalThisSymbol).resolvedType = c.newObjectType(ObjectFlagsAnonymous, c.globalThisSymbol)
 	// Initialize special types
 	c.globalArrayType = c.getGlobalType("Array", 1 /*arity*/, true /*reportErrors*/)
 	c.globalObjectType = c.getGlobalType("Object", 0 /*arity*/, true /*reportErrors*/)
@@ -3459,7 +3459,7 @@ func (c *Checker) checkFunctionOrMethodDeclaration(node *ast.Node) {
 
 func (c *Checker) checkFunctionOrConstructorSymbol(symbol *ast.Symbol) {
 	// Only check the symbol once
-	if links := c.valueSymbolLinks.Get(symbol); !links.functionOrConstructorChecked {
+	if links := c.getValueSymbolLinks(symbol); !links.functionOrConstructorChecked {
 		links.functionOrConstructorChecked = true
 		c.checkFunctionOrConstructorSymbolWorker(symbol)
 	}
@@ -5447,7 +5447,7 @@ func (c *Checker) getTypeFromImportAttributes(node *ast.Node) *Type {
 		members := make(ast.SymbolTable)
 		for _, attr := range node.AsImportAttributes().Attributes.Nodes {
 			member := c.newSymbol(ast.SymbolFlagsProperty, attr.Name().Text())
-			c.valueSymbolLinks.Get(member).resolvedType = c.getRegularTypeOfLiteralType(c.checkExpression(attr.AsImportAttribute().Value))
+			c.getValueSymbolLinks(member).resolvedType = c.getRegularTypeOfLiteralType(c.checkExpression(attr.AsImportAttribute().Value))
 			members[member.Name] = member
 		}
 		t := c.newAnonymousType(symbol, members, nil, nil, nil)
@@ -10401,7 +10401,7 @@ func (c *Checker) assignNonContextualParameterTypes(signature *Signature) {
 }
 
 func (c *Checker) assignParameterType(parameter *ast.Symbol, contextualType *Type) {
-	links := c.valueSymbolLinks.Get(parameter)
+	links := c.getValueSymbolLinks(parameter)
 	if links.resolvedType != nil {
 		return
 	}
@@ -10432,7 +10432,7 @@ func (c *Checker) assignBindingElementTypes(pattern *ast.Node, parentType *Type)
 		if name != nil {
 			t := c.getBindingElementTypeFromParentType(element, parentType, false /*noTupleBoundsCheck*/)
 			if ast.IsIdentifier(name) {
-				c.valueSymbolLinks.Get(c.getSymbolOfDeclaration(element)).resolvedType = t
+				c.getValueSymbolLinks(c.getSymbolOfDeclaration(element)).resolvedType = t
 			} else {
 				c.assignBindingElementTypes(name, t)
 			}
@@ -11906,7 +11906,7 @@ func (c *Checker) forEachProperty(prop *ast.Symbol, callback func(p *ast.Symbol)
 	if prop.CheckFlags&ast.CheckFlagsSynthetic == 0 {
 		return callback(prop)
 	}
-	for _, t := range c.valueSymbolLinks.Get(prop).containingType.Types() {
+	for _, t := range c.getValueSymbolLinks(prop).containingType.Types() {
 		p := c.getPropertyOfType(t, prop.Name)
 		if p != nil && c.forEachProperty(p, callback) {
 			return true
@@ -13236,7 +13236,7 @@ func (c *Checker) checkObjectLiteral(node *ast.Node, checkMode CheckMode) *Type 
 			} else {
 				prop = c.newSymbolEx(ast.SymbolFlagsProperty|member.Flags, member.Name, checkFlags)
 			}
-			links := c.valueSymbolLinks.Get(prop)
+			links := c.getValueSymbolLinks(prop)
 			if nameType != nil {
 				links.nameType = nameType
 			}
@@ -13442,7 +13442,7 @@ func (c *Checker) getSpreadType(left *Type, right *Type, symbol *ast.Symbol, obj
 				declarations := core.Concatenate(leftProp.Declarations, rightProp.Declarations)
 				flags := ast.SymbolFlagsProperty | (leftProp.Flags & ast.SymbolFlagsOptional)
 				result := c.newSymbol(flags, leftProp.Name)
-				links := c.valueSymbolLinks.Get(result)
+				links := c.getValueSymbolLinks(result)
 				// Optimization: avoid calculating the union type if spreading into the exact same type.
 				// This is common, e.g. spreading one options bag into another where the bags have the
 				// same type, or have properties which overlap. If the unions are large, it may turn out
@@ -13458,7 +13458,7 @@ func (c *Checker) getSpreadType(left *Type, right *Type, symbol *ast.Symbol, obj
 				c.spreadLinks.Get(result).leftSpread = leftProp
 				c.spreadLinks.Get(result).rightSpread = rightProp
 				result.Declarations = declarations
-				links.nameType = c.valueSymbolLinks.Get(leftProp).nameType
+				links.nameType = c.getValueSymbolLinks(leftProp).nameType
 				members[leftProp.Name] = result
 			}
 		} else {
@@ -13538,14 +13538,14 @@ func (c *Checker) tryMergeUnionOfObjectTypeAndEmptyObject(t *Type, readonly bool
 			isSetonlyAccessor := prop.Flags&ast.SymbolFlagsSetAccessor != 0 && prop.Flags&ast.SymbolFlagsGetAccessor == 0
 			flags := ast.SymbolFlagsProperty | ast.SymbolFlagsOptional
 			result := c.newSymbolEx(flags, prop.Name, prop.CheckFlags&ast.CheckFlagsLate|core.IfElse(readonly, ast.CheckFlagsReadonly, 0))
-			links := c.valueSymbolLinks.Get(result)
+			links := c.getValueSymbolLinks(result)
 			if isSetonlyAccessor {
 				links.resolvedType = c.undefinedType
 			} else {
 				links.resolvedType = c.addOptionalityEx(c.getTypeOfSymbol(prop), true /*isProperty*/, true /*isOptional*/)
 			}
 			result.Declarations = prop.Declarations
-			links.nameType = c.valueSymbolLinks.Get(prop).nameType
+			links.nameType = c.getValueSymbolLinks(prop).nameType
 			c.mappedSymbolLinks.Get(result).syntheticOrigin = prop
 			members[prop.Name] = result
 		}
@@ -13568,14 +13568,14 @@ func (c *Checker) getSpreadSymbol(prop *ast.Symbol, readonly bool) *ast.Symbol {
 	}
 	flags := ast.SymbolFlagsProperty | (prop.Flags & ast.SymbolFlagsOptional)
 	result := c.newSymbolEx(flags, prop.Name, prop.CheckFlags&ast.CheckFlagsLate|core.IfElse(readonly, ast.CheckFlagsReadonly, 0))
-	links := c.valueSymbolLinks.Get(result)
+	links := c.getValueSymbolLinks(result)
 	if isSetonlyAccessor {
 		links.resolvedType = c.undefinedType
 	} else {
 		links.resolvedType = c.getTypeOfSymbol(prop)
 	}
 	result.Declarations = prop.Declarations
-	links.nameType = c.valueSymbolLinks.Get(prop).nameType
+	links.nameType = c.getValueSymbolLinks(prop).nameType
 	c.mappedSymbolLinks.Get(result).syntheticOrigin = prop
 	return result
 }
@@ -14064,13 +14064,13 @@ func (c *Checker) newSymbolEx(flags ast.SymbolFlags, name string, checkFlags ast
 
 func (c *Checker) newParameter(name string, t *Type) *ast.Symbol {
 	symbol := c.newSymbol(ast.SymbolFlagsFunctionScopedVariable, name)
-	c.valueSymbolLinks.Get(symbol).resolvedType = t
+	c.getValueSymbolLinks(symbol).resolvedType = t
 	return symbol
 }
 
 func (c *Checker) newProperty(name string, t *Type) *ast.Symbol {
 	symbol := c.newSymbol(ast.SymbolFlagsProperty, name)
-	c.valueSymbolLinks.Get(symbol).resolvedType = t
+	c.getValueSymbolLinks(symbol).resolvedType = t
 	return symbol
 }
 
@@ -15637,7 +15637,7 @@ func (c *Checker) getTypeWithSyntheticDefaultImportType(t *Type, symbol *ast.Sym
 			anonymousSymbol := c.newSymbol(ast.SymbolFlagsTypeLiteral, ast.InternalSymbolNameType)
 			anonymousSymbol.Declarations = originalSymbol.Declarations
 			defaultContainingObject := c.createDefaultPropertyWrapperForModule(symbol, originalSymbol, anonymousSymbol)
-			c.valueSymbolLinks.Get(anonymousSymbol).resolvedType = defaultContainingObject
+			c.getValueSymbolLinks(anonymousSymbol).resolvedType = defaultContainingObject
 			if c.isValidSpreadType(t) {
 				syntheticType = c.getSpreadType(t, defaultContainingObject, anonymousSymbol, 0 /*objectFlags*/, false /*readonly*/)
 			} else {
@@ -15689,7 +15689,7 @@ func (c *Checker) createDefaultPropertyWrapperForModule(symbol *ast.Symbol, orig
 	memberTable := make(ast.SymbolTable)
 	newSymbol := c.newSymbol(ast.SymbolFlagsAlias, ast.InternalSymbolNameDefault)
 	newSymbol.Parent = originalSymbol
-	c.valueSymbolLinks.Get(newSymbol).nameType = c.getStringLiteralType("default")
+	c.getValueSymbolLinks(newSymbol).nameType = c.getStringLiteralType("default")
 	c.aliasSymbolLinks.Get(newSymbol).aliasTarget = c.resolveSymbol(symbol)
 	memberTable[ast.InternalSymbolNameDefault] = newSymbol
 	if anonymousSymbol == nil && originalSymbol != nil {
@@ -15710,7 +15710,7 @@ func (c *Checker) cloneTypeAsModuleType(symbol *ast.Symbol, moduleType *Type, re
 	links.target = symbol
 	links.originatingImport = referenceParent
 	resolvedModuleType := c.resolveStructuredTypeMembers(moduleType)
-	c.valueSymbolLinks.Get(result).resolvedType = c.newAnonymousType(result, resolvedModuleType.members, nil, nil, resolvedModuleType.indexInfos)
+	c.getValueSymbolLinks(result).resolvedType = c.newAnonymousType(result, resolvedModuleType.members, nil, nil, resolvedModuleType.indexInfos)
 	return result
 }
 
@@ -16035,7 +16035,7 @@ func (c *Checker) lateBindMember(parent *ast.Symbol, earlySymbols ast.SymbolTabl
 				}
 				lateSymbol = c.newSymbolEx(ast.SymbolFlagsNone, memberName, ast.CheckFlagsLate)
 			}
-			c.valueSymbolLinks.Get(lateSymbol).nameType = t
+			c.getValueSymbolLinks(lateSymbol).nameType = t
 			c.addDeclarationToLateBoundSymbol(lateSymbol, decl, symbolFlags)
 			if lateSymbol.Parent == nil {
 				lateSymbol.Parent = parent
@@ -16380,7 +16380,7 @@ func (c *Checker) getDeclarationOfAliasSymbol(symbol *ast.Symbol) *ast.Node {
 }
 
 func (c *Checker) getTypeOfSymbolWithDeferredType(symbol *ast.Symbol) *Type {
-	links := c.valueSymbolLinks.Get(symbol)
+	links := c.getValueSymbolLinks(symbol)
 	if links.resolvedType == nil {
 		deferred := c.deferredSymbolLinks.Get(symbol)
 		if deferred.parent.flags&TypeFlagsUnion != 0 {
@@ -16393,7 +16393,7 @@ func (c *Checker) getTypeOfSymbolWithDeferredType(symbol *ast.Symbol) *Type {
 }
 
 func (c *Checker) getWriteTypeOfSymbolWithDeferredType(symbol *ast.Symbol) *Type {
-	links := c.valueSymbolLinks.Get(symbol)
+	links := c.getValueSymbolLinks(symbol)
 	if links.writeType == nil {
 		deferred := c.deferredSymbolLinks.Get(symbol)
 		if len(deferred.writeConstituents) != 0 {
@@ -16417,7 +16417,7 @@ func (c *Checker) getWriteTypeOfSymbol(symbol *ast.Symbol) *Type {
 		if symbol.CheckFlags&ast.CheckFlagsDeferredType != 0 {
 			return c.getWriteTypeOfSymbolWithDeferredType(symbol)
 		}
-		links := c.valueSymbolLinks.Get(symbol)
+		links := c.getValueSymbolLinks(symbol)
 		return core.OrElse(links.writeType, links.resolvedType)
 	}
 	if symbol.Flags&ast.SymbolFlagsProperty != 0 {
@@ -16507,7 +16507,7 @@ func (c *Checker) getNonMissingTypeOfSymbol(symbol *ast.Symbol) *Type {
 }
 
 func (c *Checker) getTypeOfInstantiatedSymbol(symbol *ast.Symbol) *Type {
-	links := c.valueSymbolLinks.Get(symbol)
+	links := c.getValueSymbolLinks(symbol)
 	if links.resolvedType == nil {
 		links.resolvedType = c.instantiateType(c.getTypeOfSymbol(links.target), links.mapper)
 	}
@@ -16515,7 +16515,7 @@ func (c *Checker) getTypeOfInstantiatedSymbol(symbol *ast.Symbol) *Type {
 }
 
 func (c *Checker) getWriteTypeOfInstantiatedSymbol(symbol *ast.Symbol) *Type {
-	links := c.valueSymbolLinks.Get(symbol)
+	links := c.getValueSymbolLinks(symbol)
 	if links.writeType == nil {
 		links.writeType = c.instantiateType(c.getWriteTypeOfSymbol(links.target), links.mapper)
 	}
@@ -16523,7 +16523,7 @@ func (c *Checker) getWriteTypeOfInstantiatedSymbol(symbol *ast.Symbol) *Type {
 }
 
 func (c *Checker) getTypeOfVariableOrParameterOrProperty(symbol *ast.Symbol) *Type {
-	links := c.valueSymbolLinks.Get(symbol)
+	links := c.getValueSymbolLinks(symbol)
 	if links.resolvedType == nil {
 		t := c.getTypeOfVariableOrParameterOrPropertyWorker(symbol)
 		if t == nil {
@@ -16820,7 +16820,7 @@ func (c *Checker) padObjectLiteralType(t *Type, pattern *ast.Node) *Type {
 	}
 	for _, e := range missingElements {
 		symbol := c.newSymbol(ast.SymbolFlagsProperty|ast.SymbolFlagsOptional, c.getPropertyNameFromBindingElement(e))
-		c.valueSymbolLinks.Get(symbol).resolvedType = c.getTypeFromBindingElement(e, false /*includePatternInType*/, false /*reportErrors*/)
+		c.getValueSymbolLinks(symbol).resolvedType = c.getTypeFromBindingElement(e, false /*includePatternInType*/, false /*reportErrors*/)
 		members[symbol.Name] = symbol
 	}
 	result := c.newAnonymousType(t.symbol, members, nil, nil, c.getIndexInfosOfType(t))
@@ -16883,7 +16883,7 @@ func (c *Checker) getWidenedLiteralTypeForInitializer(declaration *ast.Node, t *
 }
 
 func (c *Checker) getTypeOfFuncClassEnumModule(symbol *ast.Symbol) *Type {
-	links := c.valueSymbolLinks.Get(symbol)
+	links := c.getValueSymbolLinks(symbol)
 	if links.resolvedType == nil {
 		links.resolvedType = c.getTypeOfFuncClassEnumModuleWorker(symbol)
 	}
@@ -17677,7 +17677,7 @@ func (c *Checker) getTypeForBindingElementParent(node *ast.Node, checkMode Check
 	if checkMode == CheckModeNormal {
 		// We can use a cached resolved type if no optionality was included in that type.
 		if symbol := c.getSymbolOfDeclaration(node); symbol != nil {
-			if resolvedType := c.valueSymbolLinks.Get(symbol).resolvedType; resolvedType != nil && !(c.strictNullChecks && isOptionalDeclaration(node)) {
+			if resolvedType := c.getValueSymbolLinks(symbol).resolvedType; resolvedType != nil && !(c.strictNullChecks && isOptionalDeclaration(node)) {
 				return resolvedType
 			}
 		}
@@ -17918,7 +17918,7 @@ func (c *Checker) getTypeFromObjectBindingPattern(pattern *ast.Node, includePatt
 		text := getPropertyNameFromType(exprType)
 		flags := ast.SymbolFlagsProperty | core.IfElse(e.Initializer() != nil, ast.SymbolFlagsOptional, 0)
 		symbol := c.newSymbol(flags, text)
-		c.valueSymbolLinks.Get(symbol).resolvedType = c.getTypeFromBindingElement(e, includePatternInType, reportErrors)
+		c.getValueSymbolLinks(symbol).resolvedType = c.getTypeFromBindingElement(e, includePatternInType, reportErrors)
 		members[symbol.Name] = symbol
 	}
 	var indexInfos []*IndexInfo
@@ -18482,7 +18482,7 @@ func (c *Checker) getUndefinedProperty(prop *ast.Symbol) *ast.Symbol {
 }
 
 func (c *Checker) getTypeOfEnumMember(symbol *ast.Symbol) *Type {
-	links := c.valueSymbolLinks.Get(symbol)
+	links := c.getValueSymbolLinks(symbol)
 	if links.resolvedType == nil {
 		links.resolvedType = c.getDeclaredTypeOfEnumMember(symbol)
 	}
@@ -18490,7 +18490,7 @@ func (c *Checker) getTypeOfEnumMember(symbol *ast.Symbol) *Type {
 }
 
 func (c *Checker) getTypeOfAccessors(symbol *ast.Symbol) *Type {
-	links := c.valueSymbolLinks.Get(symbol)
+	links := c.getValueSymbolLinks(symbol)
 	if links.resolvedType == nil {
 		if !c.pushTypeResolution(symbol, TypeSystemPropertyNameType) {
 			return c.errorType
@@ -18545,7 +18545,7 @@ func (c *Checker) getTypeOfAccessors(symbol *ast.Symbol) *Type {
 }
 
 func (c *Checker) getWriteTypeOfAccessors(symbol *ast.Symbol) *Type {
-	links := c.valueSymbolLinks.Get(symbol)
+	links := c.getValueSymbolLinks(symbol)
 	if links.writeType == nil {
 		if !c.pushTypeResolution(symbol, TypeSystemPropertyNameWriteType) {
 			return c.errorType
@@ -18577,7 +18577,7 @@ func (c *Checker) getWriteTypeOfAccessors(symbol *ast.Symbol) *Type {
 }
 
 func (c *Checker) getTypeOfAlias(symbol *ast.Symbol) *Type {
-	links := c.valueSymbolLinks.Get(symbol)
+	links := c.getValueSymbolLinks(symbol)
 	if links.resolvedType == nil {
 		if !c.pushTypeResolution(symbol, TypeSystemPropertyNameType) {
 			return c.errorType
@@ -18777,7 +18777,7 @@ func (c *Checker) findResolutionCycleStartIndex(target TypeSystemEntity, propert
 func (c *Checker) typeResolutionHasProperty(r *TypeResolution) bool {
 	switch r.propertyName {
 	case TypeSystemPropertyNameType:
-		return c.valueSymbolLinks.Get(r.target.(*ast.Symbol)).resolvedType != nil
+		return c.getValueSymbolLinks(r.target.(*ast.Symbol)).resolvedType != nil
 	case TypeSystemPropertyNameDeclaredType:
 		return c.typeAliasLinks.Get(r.target.(*ast.Symbol)).declaredType != nil
 	case TypeSystemPropertyNameResolvedTypeArguments:
@@ -18793,7 +18793,7 @@ func (c *Checker) typeResolutionHasProperty(r *TypeResolution) bool {
 	case TypeSystemPropertyNameInitializerIsUndefined:
 		return c.nodeLinks.Get(r.target.(*ast.Node)).flags&NodeCheckFlagsInitializerIsUndefinedComputed != 0
 	case TypeSystemPropertyNameWriteType:
-		return c.valueSymbolLinks.Get(r.target.(*ast.Symbol)).writeType != nil
+		return c.getValueSymbolLinks(r.target.(*ast.Symbol)).writeType != nil
 	case TypeSystemPropertyNameAliasTarget:
 		return c.aliasSymbolLinks.Get(r.target.(*ast.Symbol)).aliasTarget != nil
 	}
@@ -20735,7 +20735,7 @@ func (c *Checker) instantiateSymbol(symbol *ast.Symbol, m *TypeMapper) *ast.Symb
 	if symbol == nil {
 		return nil
 	}
-	links := c.valueSymbolLinks.Get(symbol)
+	links := c.getValueSymbolLinks(symbol)
 	if m != nil && m.MapsThisOnly() && isThisless(symbol) {
 		return symbol
 	}
@@ -20764,7 +20764,7 @@ func (c *Checker) instantiateSymbol(symbol *ast.Symbol, m *TypeMapper) *ast.Symb
 	result.Declarations = symbol.Declarations
 	result.Parent = symbol.Parent
 	result.ValueDeclaration = symbol.ValueDeclaration
-	resultLinks := c.valueSymbolLinks.Get(result)
+	resultLinks := c.getValueSymbolLinks(result)
 	resultLinks.target = symbol
 	resultLinks.mapper = m
 	resultLinks.nameType = links.nameType
@@ -20898,7 +20898,7 @@ func (c *Checker) resolveMappedTypeMembers(t *Type) {
 			// are distinct types with the same property name. Make the resulting
 			// property symbol's name type be the union of those enum member types.
 			if existingProp := members[propName]; existingProp != nil {
-				valueLinks := c.valueSymbolLinks.Get(existingProp)
+				valueLinks := c.getValueSymbolLinks(existingProp)
 				valueLinks.nameType = c.getUnionType([]*Type{valueLinks.nameType, propNameType})
 				mappedLinks := c.mappedSymbolLinks.Get(existingProp)
 				mappedLinks.keyType = c.getUnionType([]*Type{mappedLinks.keyType, keyType})
@@ -20916,7 +20916,7 @@ func (c *Checker) resolveMappedTypeMembers(t *Type) {
 				}
 				prop := c.newSymbol(ast.SymbolFlagsProperty|core.IfElse(isOptional, ast.SymbolFlagsOptional, 0), propName)
 				prop.CheckFlags = lateFlag | ast.CheckFlagsMapped | core.IfElse(isReadonly, ast.CheckFlagsReadonly, 0) | core.IfElse(stripOptional, ast.CheckFlagsStripOptional, 0)
-				valueLinks := c.valueSymbolLinks.Get(prop)
+				valueLinks := c.getValueSymbolLinks(prop)
 				valueLinks.containingType = t
 				valueLinks.nameType = propNameType
 				mappedLinks := c.mappedSymbolLinks.Get(prop)
@@ -20963,7 +20963,7 @@ func (c *Checker) resolveMappedTypeMembers(t *Type) {
 }
 
 func (c *Checker) getTypeOfMappedSymbol(symbol *ast.Symbol) *Type {
-	links := c.valueSymbolLinks.Get(symbol)
+	links := c.getValueSymbolLinks(symbol)
 	if links.resolvedType == nil {
 		mappedType := links.containingType
 		if !c.pushTypeResolution(symbol, TypeSystemPropertyNameType) {
@@ -21246,7 +21246,7 @@ func (c *Checker) combineUnionOrIntersectionParameters(left *Signature, right *S
 		}
 		paramSymbol := c.newSymbolEx(ast.SymbolFlagsFunctionScopedVariable|core.IfElse(isOptional && !isRestParam, ast.SymbolFlagsOptional, 0), paramName,
 			core.IfElse(isRestParam, ast.CheckFlagsRestParameter, core.IfElse(isOptional, ast.CheckFlagsOptionalParameter, 0)))
-		links := c.valueSymbolLinks.Get(paramSymbol)
+		links := c.getValueSymbolLinks(paramSymbol)
 		if isRestParam {
 			links.resolvedType = c.createArrayType(combinedParamType)
 		} else {
@@ -21256,7 +21256,7 @@ func (c *Checker) combineUnionOrIntersectionParameters(left *Signature, right *S
 	}
 	if needsExtraRestElement {
 		restParamSymbol := c.newSymbolEx(ast.SymbolFlagsFunctionScopedVariable, "args", ast.CheckFlagsRestParameter)
-		links := c.valueSymbolLinks.Get(restParamSymbol)
+		links := c.getValueSymbolLinks(restParamSymbol)
 		links.resolvedType = c.createArrayType(c.getTypeAtPosition(shorter, longestCount))
 		if shorter == right {
 			links.resolvedType = c.instantiateType(links.resolvedType, mapper)
@@ -21550,7 +21550,7 @@ func (c *Checker) createUnionOrIntersectionProperty(containingType *Type, name s
 		var singlePropType *Type
 		var singlePropMapper *TypeMapper
 		if singleProp.Flags&ast.SymbolFlagsTransient != 0 {
-			links := c.valueSymbolLinks.Get(singleProp)
+			links := c.getValueSymbolLinks(singleProp)
 			singlePropType = links.resolvedType
 			singlePropMapper = links.mapper
 		}
@@ -21558,7 +21558,7 @@ func (c *Checker) createUnionOrIntersectionProperty(containingType *Type, name s
 		if singleProp.ValueDeclaration != nil {
 			clone.Parent = singleProp.ValueDeclaration.Symbol().Parent
 		}
-		links := c.valueSymbolLinks.Get(clone)
+		links := c.getValueSymbolLinks(clone)
 		links.containingType = containingType
 		links.mapper = singlePropMapper
 		links.writeType = c.getWriteTypeOfSymbol(singleProp)
@@ -21584,7 +21584,7 @@ func (c *Checker) createUnionOrIntersectionProperty(containingType *Type, name s
 		t := c.getTypeOfSymbol(prop)
 		if firstType == nil {
 			firstType = t
-			nameType = c.valueSymbolLinks.Get(prop).nameType
+			nameType = c.getValueSymbolLinks(prop).nameType
 		}
 		writeType := c.getWriteTypeOfSymbol(prop)
 		if writeTypes != nil || writeType != t {
@@ -21612,7 +21612,7 @@ func (c *Checker) createUnionOrIntersectionProperty(containingType *Type, name s
 		// Inherit information about parent type.
 		result.Parent = firstValueDeclaration.Symbol().Parent
 	}
-	links := c.valueSymbolLinks.Get(result)
+	links := c.getValueSymbolLinks(result)
 	links.containingType = containingType
 	links.nameType = nameType
 	if len(propTypes) > 2 {
@@ -21644,7 +21644,7 @@ func (c *Checker) getTargetSymbol(s *ast.Symbol) *ast.Symbol {
 	// so we'll need to get back original 'target' symbol to work with correct set of flags
 	// NOTE: cast to TransientSymbol should be safe because only TransientSymbols have CheckFlags.Instantiated
 	if s != nil && s.CheckFlags&ast.CheckFlagsInstantiated != 0 {
-		return c.valueSymbolLinks.Get(s).target
+		return c.getValueSymbolLinks(s).target
 	}
 	return s
 }
@@ -21686,10 +21686,10 @@ func (c *Checker) createSymbolWithType(source *ast.Symbol, t *Type) *ast.Symbol 
 	symbol.Declarations = source.Declarations
 	symbol.Parent = source.Parent
 	symbol.ValueDeclaration = source.ValueDeclaration
-	links := c.valueSymbolLinks.Get(symbol)
+	links := c.getValueSymbolLinks(symbol)
 	links.resolvedType = t
 	links.target = source
-	links.nameType = c.valueSymbolLinks.Get(source).nameType
+	links.nameType = c.getValueSymbolLinks(source).nameType
 	return symbol
 }
 
@@ -24668,7 +24668,7 @@ func (c *Checker) getGlobalImportMetaExpressionType() *Type {
 		importMetaType := c.getGlobalImportMetaType()
 		metaPropertySymbol := c.newSymbolEx(ast.SymbolFlagsProperty, "meta", ast.CheckFlagsReadonly)
 		metaPropertySymbol.Parent = symbol
-		c.valueSymbolLinks.Get(metaPropertySymbol).resolvedType = importMetaType
+		c.getValueSymbolLinks(metaPropertySymbol).resolvedType = importMetaType
 		members := createSymbolTable([]*ast.Symbol{metaPropertySymbol})
 		symbol.Members = members
 		c.deferredGlobalImportMetaExpressionType = c.newAnonymousType(symbol, members, nil, nil, nil)
@@ -24771,7 +24771,7 @@ func (c *Checker) createTupleTargetType(elementInfos []TupleElementInfo, readonl
 			combinedFlags |= flags
 			if combinedFlags&ElementFlagsVariable == 0 {
 				property := c.newSymbolEx(ast.SymbolFlagsProperty|core.IfElse(flags&ElementFlagsOptional != 0, ast.SymbolFlagsOptional, 0), strconv.Itoa(i), core.IfElse(readonly, ast.CheckFlagsReadonly, 0))
-				c.valueSymbolLinks.Get(property).resolvedType = typeParameter
+				c.getValueSymbolLinks(property).resolvedType = typeParameter
 				// c.valueSymbolLinks.get(property).tupleLabelDeclaration = elementInfos[i].labeledDeclaration
 				members[property.Name] = property
 			}
@@ -24780,13 +24780,13 @@ func (c *Checker) createTupleTargetType(elementInfos []TupleElementInfo, readonl
 	fixedLength := len(members)
 	lengthSymbol := c.newSymbolEx(ast.SymbolFlagsProperty, "length", core.IfElse(readonly, ast.CheckFlagsReadonly, 0))
 	if combinedFlags&ElementFlagsVariable != 0 {
-		c.valueSymbolLinks.Get(lengthSymbol).resolvedType = c.numberType
+		c.getValueSymbolLinks(lengthSymbol).resolvedType = c.numberType
 	} else {
 		var literalTypes []*Type
 		for i := minLength; i <= arity; i++ {
 			literalTypes = append(literalTypes, c.getNumberLiteralType(jsnum.Number(i)))
 		}
-		c.valueSymbolLinks.Get(lengthSymbol).resolvedType = c.getUnionType(literalTypes)
+		c.getValueSymbolLinks(lengthSymbol).resolvedType = c.getUnionType(literalTypes)
 	}
 	members[lengthSymbol.Name] = lengthSymbol
 	t := c.newObjectType(ObjectFlagsTuple|ObjectFlagsReference, nil)
@@ -26704,7 +26704,7 @@ func (c *Checker) getLiteralTypeFromProperties(t *Type, include TypeFlags, inclu
 
 func (c *Checker) getLiteralTypeFromProperty(prop *ast.Symbol, include TypeFlags, includeNonPublic bool) *Type {
 	if includeNonPublic || getDeclarationModifierFlagsFromSymbol(prop)&ast.ModifierFlagsNonPublicAccessibilityModifier == 0 {
-		t := c.valueSymbolLinks.Get(c.getLateBoundSymbol(prop)).nameType
+		t := c.getValueSymbolLinks(c.getLateBoundSymbol(prop)).nameType
 		if t == nil {
 			if prop.Name == ast.InternalSymbolNameDefault {
 				t = c.getStringLiteralType("default")
@@ -27683,7 +27683,7 @@ func (c *Checker) markPropertyAsReferenced(prop *ast.Symbol, nodeForCheckWriteOn
 	}
 	target := prop
 	if prop.CheckFlags&ast.CheckFlagsInstantiated != 0 {
-		target = c.valueSymbolLinks.Get(prop).target
+		target = c.getValueSymbolLinks(prop).target
 	}
 	c.symbolReferenceLinks.Get(target).referenceKinds |= ast.SymbolFlagsAll
 }
@@ -27703,7 +27703,7 @@ func (c *Checker) expandSignatureParametersWithTupleMembers(signature *Signature
 			checkFlags = ast.CheckFlagsOptionalParameter
 		}
 		symbol := c.newSymbolEx(ast.SymbolFlagsFunctionScopedVariable, associatedNames[i], checkFlags)
-		links := c.valueSymbolLinks.Get(symbol)
+		links := c.getValueSymbolLinks(symbol)
 		if flags&ElementFlagsRest != 0 {
 			links.resolvedType = c.createArrayType(t)
 		} else {
@@ -29851,7 +29851,7 @@ func (c *Checker) getContextualTypeForObjectLiteralElement(element *ast.Node, co
 			// in the type. It will just be "__computed", which does not appear in any
 			// SymbolTable.
 			symbol := c.getSymbolOfDeclaration(element)
-			return c.getTypeOfPropertyOfContextualTypeEx(t, symbol.Name, c.valueSymbolLinks.Get(symbol).nameType)
+			return c.getTypeOfPropertyOfContextualTypeEx(t, symbol.Name, c.getValueSymbolLinks(symbol).nameType)
 		}
 		if ast.HasDynamicName(element) {
 			name := ast.GetNameOfDeclaration(element)
@@ -30584,7 +30584,7 @@ func (c *Checker) getTypeFromIndexInfosOfContextualType(t *Type, name string, na
 
 func (c *Checker) isCircularMappedProperty(symbol *ast.Symbol) bool {
 	if symbol.CheckFlags&ast.CheckFlagsMapped != 0 {
-		links := c.valueSymbolLinks.Get(symbol)
+		links := c.getValueSymbolLinks(symbol)
 		return links.resolvedType == nil && c.findResolutionCycleStartIndex(symbol, TypeSystemPropertyNameType) >= 0
 	}
 	return false
@@ -32020,7 +32020,7 @@ func (c *Checker) getApplicableIndexSymbol(t *Type, keyType *Type) *ast.Symbol {
 				symbol.Declarations = declarations
 				symbol.ValueDeclaration = declarations[0]
 				symbol.Parent = t.symbol
-				links := c.valueSymbolLinks.Get(symbol)
+				links := c.getValueSymbolLinks(symbol)
 				links.resolvedType = info.valueType
 				info.indexSymbol = symbol
 			}

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -659,7 +659,7 @@ type Checker struct {
 	propertiesTypes                             map[PropertiesTypesKey]*Type
 	diagnostics                                 ast.DiagnosticsCollection
 	suggestionDiagnostics                       ast.DiagnosticsCollection
-	symbolArena                                 core.Arena[ast.Symbol]
+	symbolArena                                 core.Arena[transientSymbol]
 	signatureArena                              core.Arena[Signature]
 	indexInfoArena                              core.Arena[IndexInfo]
 	mergedSymbols                               map[*ast.Symbol]*ast.Symbol
@@ -14048,9 +14048,11 @@ func (c *Checker) hasParseDiagnostics(sourceFile *ast.SourceFile) bool {
 
 func (c *Checker) newSymbol(flags ast.SymbolFlags, name string) *ast.Symbol {
 	c.SymbolCount++
-	result := c.symbolArena.New()
+	entry := c.symbolArena.New()
+	result := &entry.symbol
 	result.Flags = flags | ast.SymbolFlagsTransient
 	result.Name = name
+	result.CheckerData = &entry.data
 	return result
 }
 

--- a/internal/checker/exports.go
+++ b/internal/checker/exports.go
@@ -79,7 +79,7 @@ func (c *Checker) GetUnionType(types []*Type) *Type {
 }
 
 func (c *Checker) GetNameTypeOfSymbol(symbol *ast.Symbol) *Type {
-	if links := c.valueSymbolLinks.TryGet(symbol); links != nil {
+	if links := c.tryGetValueSymbolLinks(symbol); links != nil {
 		return links.nameType
 	}
 	return nil

--- a/internal/checker/exports.go
+++ b/internal/checker/exports.go
@@ -79,10 +79,10 @@ func (c *Checker) GetUnionType(types []*Type) *Type {
 }
 
 func (c *Checker) GetNameTypeOfSymbol(symbol *ast.Symbol) *Type {
-	if !c.valueSymbolLinks.Has(symbol) {
-		return nil
+	if links := c.valueSymbolLinks.TryGet(symbol); links != nil {
+		return links.nameType
 	}
-	return c.valueSymbolLinks.TryGet(symbol).nameType
+	return nil
 }
 
 func IsTypeUsableAsPropertyName(t *Type) bool {

--- a/internal/checker/inference.go
+++ b/internal/checker/inference.go
@@ -1121,7 +1121,7 @@ func (c *Checker) resolveReverseMappedTypeMembers(t *Type) {
 		checkFlags := ast.CheckFlagsReverseMapped | core.IfElse(readonlyMask && c.isReadonlySymbol(prop), ast.CheckFlagsReadonly, 0)
 		inferredProp := c.newSymbolEx(ast.SymbolFlagsProperty|prop.Flags&optionalMask, prop.Name, checkFlags)
 		inferredProp.Declarations = prop.Declarations
-		c.valueSymbolLinks.Get(inferredProp).nameType = c.valueSymbolLinks.Get(prop).nameType
+		c.getValueSymbolLinks(inferredProp).nameType = c.getValueSymbolLinks(prop).nameType
 		links := c.ReverseMappedSymbolLinks.Get(inferredProp)
 		links.propertyType = c.getTypeOfSymbol(prop)
 		constraintTarget := r.constraintType.AsIndexType().target
@@ -1143,7 +1143,7 @@ func (c *Checker) resolveReverseMappedTypeMembers(t *Type) {
 }
 
 func (c *Checker) getTypeOfReverseMappedSymbol(symbol *ast.Symbol) *Type {
-	links := c.valueSymbolLinks.Get(symbol)
+	links := c.getValueSymbolLinks(symbol)
 	if links.resolvedType == nil {
 		reverseLinks := c.ReverseMappedSymbolLinks.Get(symbol)
 		links.resolvedType = core.OrElse(c.inferReverseMappedType(reverseLinks.propertyType, reverseLinks.mappedType, reverseLinks.constraintType), c.unknownType)
@@ -1234,7 +1234,7 @@ func (c *Checker) createEmptyObjectTypeFromStringLiteral(t *Type) *Type {
 		}
 		name := getStringLiteralValue(t)
 		literalProp := c.newSymbol(ast.SymbolFlagsProperty, name)
-		c.valueSymbolLinks.Get(literalProp).resolvedType = c.anyType
+		c.getValueSymbolLinks(literalProp).resolvedType = c.anyType
 		if t.symbol != nil {
 			literalProp.Declarations = t.symbol.Declarations
 			literalProp.ValueDeclaration = t.symbol.ValueDeclaration

--- a/internal/checker/jsx.go
+++ b/internal/checker/jsx.go
@@ -746,7 +746,7 @@ func (c *Checker) createJsxAttributesTypeFromAttributesProperty(openingLikeEleme
 				if member.ValueDeclaration != nil {
 					attributeSymbol.ValueDeclaration = member.ValueDeclaration
 				}
-				links := c.valueSymbolLinks.Get(attributeSymbol)
+				links := c.getValueSymbolLinks(attributeSymbol)
 				links.resolvedType = exprType
 				links.target = member
 				attributesTable[attributeSymbol.Name] = attributeSymbol
@@ -838,7 +838,7 @@ func (c *Checker) createJsxAttributesTypeFromAttributesProperty(openingLikeEleme
 			}
 			// If there are children in the body of JSX element, create dummy attribute "children" with the union of children types so that it will pass the attribute checking process
 			childrenPropSymbol := c.newSymbol(ast.SymbolFlagsProperty, jsxChildrenPropertyName)
-			links := c.valueSymbolLinks.Get(childrenPropSymbol)
+			links := c.getValueSymbolLinks(childrenPropSymbol)
 			switch {
 			case len(childTypes) == 1:
 				links.resolvedType = childTypes[0]
@@ -1183,7 +1183,7 @@ func (c *Checker) createSignatureForJSXIntrinsic(node *ast.Node, result *Type) *
 	// returnNode := typeSymbol && c.nodeBuilder.symbolToEntityName(typeSymbol, ast.SymbolFlagsType, node)
 	// declaration := factory.createFunctionTypeNode(nil, []ParameterDeclaration{factory.createParameterDeclaration(nil, nil /*dotDotDotToken*/, "props", nil /*questionToken*/, c.nodeBuilder.typeToTypeNode(result, node))}, ifElse(returnNode != nil, factory.createTypeReferenceNode(returnNode, nil /*typeArguments*/), factory.createKeywordTypeNode(ast.KindAnyKeyword)))
 	parameterSymbol := c.newSymbol(ast.SymbolFlagsFunctionScopedVariable, "props")
-	c.valueSymbolLinks.Get(parameterSymbol).resolvedType = result
+	c.getValueSymbolLinks(parameterSymbol).resolvedType = result
 	return c.newSignature(SignatureFlagsNone, nil, nil, nil, []*ast.Symbol{parameterSymbol}, elementType, nil, 1)
 }
 

--- a/internal/checker/nodebuilderimpl.go
+++ b/internal/checker/nodebuilderimpl.go
@@ -583,8 +583,8 @@ func (b *NodeBuilderImpl) symbolToNode(symbol *ast.Symbol, meaning ast.SymbolFla
 				return name
 			}
 		}
-		if b.ch.valueSymbolLinks.Has(symbol) {
-			nameType := b.ch.valueSymbolLinks.Get(symbol).nameType
+		if links := b.ch.valueSymbolLinks.TryGet(symbol); links != nil {
+			nameType := links.nameType
 			if nameType != nil && nameType.flags&(TypeFlagsEnumLiteral|TypeFlagsUniqueESSymbol) != 0 {
 				oldEnclosing := b.ctx.enclosingDeclaration
 				b.ctx.enclosingDeclaration = nameType.symbol.ValueDeclaration
@@ -934,8 +934,8 @@ func isDefaultBindingContext(location *ast.Node) bool {
 }
 
 func (b *NodeBuilderImpl) getNameOfSymbolFromNameType(symbol *ast.Symbol) string {
-	if b.ch.valueSymbolLinks.Has(symbol) {
-		nameType := b.ch.valueSymbolLinks.Get(symbol).nameType
+	if links := b.ch.valueSymbolLinks.TryGet(symbol); links != nil {
+		nameType := links.nameType
 		if nameType == nil {
 			return ""
 		}
@@ -992,7 +992,7 @@ func (b *NodeBuilderImpl) getNameOfSymbolAsWritten(symbol *ast.Symbol) string {
 			// 	return symbol.Name
 			// }
 			if ast.IsComputedPropertyName(name) && symbol.CheckFlags&ast.CheckFlagsLate == 0 {
-				if b.ch.valueSymbolLinks.Has(symbol) && b.ch.valueSymbolLinks.Get(symbol).nameType != nil && b.ch.valueSymbolLinks.Get(symbol).nameType.flags&TypeFlagsStringOrNumberLiteral != 0 {
+				if links := b.ch.valueSymbolLinks.TryGet(symbol); links != nil && links.nameType != nil && links.nameType.flags&TypeFlagsStringOrNumberLiteral != 0 {
 					result := b.getNameOfSymbolFromNameType(symbol)
 					if len(result) > 0 {
 						return result
@@ -2440,10 +2440,11 @@ func (b *NodeBuilderImpl) getPropertyNameNodeForSymbol(symbol *ast.Symbol) *ast.
 
 // See getNameForSymbolFromNameType for a stringy equivalent
 func (b *NodeBuilderImpl) getPropertyNameNodeForSymbolFromNameType(symbol *ast.Symbol, singleQuote bool, stringNamed bool, isMethod bool) *ast.Node {
-	if !b.ch.valueSymbolLinks.Has(symbol) {
+	links := b.ch.valueSymbolLinks.TryGet(symbol)
+	if links == nil {
 		return nil
 	}
-	nameType := b.ch.valueSymbolLinks.TryGet(symbol).nameType
+	nameType := links.nameType
 	if nameType == nil {
 		return nil
 	}

--- a/internal/checker/nodebuilderimpl.go
+++ b/internal/checker/nodebuilderimpl.go
@@ -583,7 +583,7 @@ func (b *NodeBuilderImpl) symbolToNode(symbol *ast.Symbol, meaning ast.SymbolFla
 				return name
 			}
 		}
-		if links := b.ch.valueSymbolLinks.TryGet(symbol); links != nil {
+		if links := b.ch.tryGetValueSymbolLinks(symbol); links != nil {
 			nameType := links.nameType
 			if nameType != nil && nameType.flags&(TypeFlagsEnumLiteral|TypeFlagsUniqueESSymbol) != 0 {
 				oldEnclosing := b.ctx.enclosingDeclaration
@@ -934,7 +934,7 @@ func isDefaultBindingContext(location *ast.Node) bool {
 }
 
 func (b *NodeBuilderImpl) getNameOfSymbolFromNameType(symbol *ast.Symbol) string {
-	if links := b.ch.valueSymbolLinks.TryGet(symbol); links != nil {
+	if links := b.ch.tryGetValueSymbolLinks(symbol); links != nil {
 		nameType := links.nameType
 		if nameType == nil {
 			return ""
@@ -992,7 +992,7 @@ func (b *NodeBuilderImpl) getNameOfSymbolAsWritten(symbol *ast.Symbol) string {
 			// 	return symbol.Name
 			// }
 			if ast.IsComputedPropertyName(name) && symbol.CheckFlags&ast.CheckFlagsLate == 0 {
-				if links := b.ch.valueSymbolLinks.TryGet(symbol); links != nil && links.nameType != nil && links.nameType.flags&TypeFlagsStringOrNumberLiteral != 0 {
+				if links := b.ch.tryGetValueSymbolLinks(symbol); links != nil && links.nameType != nil && links.nameType.flags&TypeFlagsStringOrNumberLiteral != 0 {
 					result := b.getNameOfSymbolFromNameType(symbol)
 					if len(result) > 0 {
 						return result
@@ -1975,7 +1975,7 @@ func (c *Checker) getExpandedParameters(sig *Signature, skipUnionExpanding bool)
 					checkFlags = ast.CheckFlagsOptionalParameter
 				}
 				symbol := c.newSymbolEx(ast.SymbolFlagsFunctionScopedVariable, name, checkFlags)
-				links := c.valueSymbolLinks.Get(symbol)
+				links := c.getValueSymbolLinks(symbol)
 				if flags&ElementFlagsRest != 0 {
 					links.resolvedType = c.createArrayType(t)
 				} else {
@@ -2440,7 +2440,7 @@ func (b *NodeBuilderImpl) getPropertyNameNodeForSymbol(symbol *ast.Symbol) *ast.
 
 // See getNameForSymbolFromNameType for a stringy equivalent
 func (b *NodeBuilderImpl) getPropertyNameNodeForSymbolFromNameType(symbol *ast.Symbol, singleQuote bool, stringNamed bool, isMethod bool) *ast.Node {
-	links := b.ch.valueSymbolLinks.TryGet(symbol)
+	links := b.ch.tryGetValueSymbolLinks(symbol)
 	if links == nil {
 		return nil
 	}
@@ -2514,7 +2514,7 @@ func (b *NodeBuilderImpl) addPropertyToElementList(propertySymbol *ast.Symbol, t
 		if !b.ch.isErrorType(propertyType) && !b.ch.isErrorType(writeType) {
 			propDeclaration := ast.GetDeclarationOfKind(propertySymbol, ast.KindPropertyDeclaration)
 			if propertyType != writeType || propertySymbol.Parent != nil && propertySymbol.Parent.Flags&ast.SymbolFlagsClass != 0 && propDeclaration == nil {
-				symbolMapper := b.ch.valueSymbolLinks.Get(propertySymbol).mapper
+				symbolMapper := b.ch.getValueSymbolLinks(propertySymbol).mapper
 				if getterDeclaration := ast.GetDeclarationOfKind(propertySymbol, ast.KindGetAccessor); getterDeclaration != nil {
 					getterSignature := b.ch.getSignatureFromDeclaration(getterDeclaration)
 					if symbolMapper != nil {
@@ -2549,7 +2549,7 @@ func (b *NodeBuilderImpl) addPropertyToElementList(propertySymbol *ast.Symbol, t
 				typeElements = append(typeElements, fakeGetterDeclaration)
 
 				setterParam := b.ch.newSymbol(ast.SymbolFlagsFunctionScopedVariable, "arg")
-				b.ch.valueSymbolLinks.Get(setterParam).resolvedType = writeType
+				b.ch.getValueSymbolLinks(setterParam).resolvedType = writeType
 				fakeSetterSignature := b.ch.newSignature(SignatureFlagsNone, nil, nil, nil, []*ast.Symbol{setterParam}, b.ch.voidType, nil, 0)
 				fakeSetterDeclaration := b.signatureToSignatureDeclarationHelper(fakeSetterSignature, ast.KindSetAccessor, &SignatureToSignatureDeclarationOptions{
 					name: propertyName,
@@ -3569,7 +3569,7 @@ func (b *NodeBuilderImpl) lookupInstantiatedTypeArgumentNodes(chain []*ast.Symbo
 		}
 
 		params := b.getTypeParametersOfClassOrInterface(targetSymbol)
-		targetMapper := b.ch.valueSymbolLinks.Get(nextSymbol).mapper
+		targetMapper := b.ch.getValueSymbolLinks(nextSymbol).mapper
 		if targetMapper != nil {
 			params = core.Map(params, targetMapper.Map)
 		}

--- a/internal/checker/services.go
+++ b/internal/checker/services.go
@@ -443,8 +443,8 @@ func (c *Checker) tryGetTarget(symbol *ast.Symbol) *ast.Symbol {
 	var target *ast.Symbol
 	next := symbol
 	for {
-		if c.valueSymbolLinks.Has(next) {
-			next = c.valueSymbolLinks.Get(next).target
+		if links := c.valueSymbolLinks.TryGet(next); links != nil {
+			next = links.target
 		} else if c.exportTypeLinks.Has(next) {
 			next = c.exportTypeLinks.Get(next).target
 		} else {

--- a/internal/checker/services.go
+++ b/internal/checker/services.go
@@ -363,7 +363,7 @@ func runWithoutResolvedSignatureCaching[T any](c *Checker, node *ast.Node, fn fu
 			cachedResolvedSignatures[signatureLinks] = signatureLinks.resolvedSignature
 			signatureLinks.resolvedSignature = nil
 			if ast.IsFunctionExpressionOrArrowFunction(ancestorNode) {
-				symbolLinks := c.valueSymbolLinks.Get(c.getSymbolOfDeclaration(ancestorNode))
+				symbolLinks := c.getValueSymbolLinks(c.getSymbolOfDeclaration(ancestorNode))
 				resolvedType := symbolLinks.resolvedType
 				cachedTypes[symbolLinks] = resolvedType
 				symbolLinks.resolvedType = nil
@@ -402,7 +402,7 @@ func (c *Checker) GetRootSymbols(symbol *ast.Symbol) []*ast.Symbol {
 }
 
 func (c *Checker) GetMappedTypeSymbolOfProperty(symbol *ast.Symbol) *ast.Symbol {
-	if valueLinks := c.valueSymbolLinks.TryGet(symbol); valueLinks != nil {
+	if valueLinks := c.tryGetValueSymbolLinks(symbol); valueLinks != nil {
 		return valueLinks.containingType.symbol
 	}
 	return nil
@@ -411,7 +411,7 @@ func (c *Checker) GetMappedTypeSymbolOfProperty(symbol *ast.Symbol) *ast.Symbol 
 func (c *Checker) getImmediateRootSymbols(symbol *ast.Symbol) []*ast.Symbol {
 	if symbol.CheckFlags&ast.CheckFlagsSynthetic != 0 {
 		return core.MapNonNil(
-			c.valueSymbolLinks.Get(symbol).containingType.Types(),
+			c.getValueSymbolLinks(symbol).containingType.Types(),
 			func(t *Type) *ast.Symbol {
 				return c.getPropertyOfType(t, symbol.Name)
 			},
@@ -443,7 +443,7 @@ func (c *Checker) tryGetTarget(symbol *ast.Symbol) *ast.Symbol {
 	var target *ast.Symbol
 	next := symbol
 	for {
-		if links := c.valueSymbolLinks.TryGet(next); links != nil {
+		if links := c.tryGetValueSymbolLinks(next); links != nil {
 			next = links.target
 		} else if c.exportTypeLinks.Has(next) {
 			next = c.exportTypeLinks.Get(next).target

--- a/internal/checker/symbollinks.go
+++ b/internal/checker/symbollinks.go
@@ -4,7 +4,7 @@ import "github.com/microsoft/typescript-go/internal/ast"
 
 // transientSymbol co-allocates a checker-created symbol with its value symbol links, reached via
 // symbol.CheckerData. Such symbols are owned by the creating Checker alone and must never be
-// handed to another checker; binder symbols use c.valueSymbolLinks (only via the accessors).
+// handed to another checker; binder symbols use c.binderValueSymbolLinks (only via the accessors).
 type transientSymbol struct {
 	symbol ast.Symbol
 	data   checkerSymbolData
@@ -22,7 +22,7 @@ func (c *Checker) getValueSymbolLinks(symbol *ast.Symbol) *ValueSymbolLinks {
 			return &data.valueLinks
 		}
 	}
-	return c.valueSymbolLinks.Get(symbol)
+	return c.binderValueSymbolLinks.Get(symbol)
 }
 
 func (c *Checker) tryGetValueSymbolLinks(symbol *ast.Symbol) *ValueSymbolLinks {
@@ -34,5 +34,5 @@ func (c *Checker) tryGetValueSymbolLinks(symbol *ast.Symbol) *ValueSymbolLinks {
 			return nil
 		}
 	}
-	return c.valueSymbolLinks.TryGet(symbol)
+	return c.binderValueSymbolLinks.TryGet(symbol)
 }

--- a/internal/checker/symbollinks.go
+++ b/internal/checker/symbollinks.go
@@ -1,0 +1,38 @@
+package checker
+
+import "github.com/microsoft/typescript-go/internal/ast"
+
+// transientSymbol co-allocates a checker-created symbol with its value symbol links, reached via
+// symbol.CheckerData. Such symbols are owned by the creating Checker alone and must never be
+// handed to another checker; binder symbols use c.valueSymbolLinks (only via the accessors).
+type transientSymbol struct {
+	symbol ast.Symbol
+	data   checkerSymbolData
+}
+
+type checkerSymbolData struct {
+	valueLinks    ValueSymbolLinks
+	hasValueLinks bool
+}
+
+func (c *Checker) getValueSymbolLinks(symbol *ast.Symbol) *ValueSymbolLinks {
+	if symbol != nil {
+		if data, ok := symbol.CheckerData.(*checkerSymbolData); ok {
+			data.hasValueLinks = true
+			return &data.valueLinks
+		}
+	}
+	return c.valueSymbolLinks.Get(symbol)
+}
+
+func (c *Checker) tryGetValueSymbolLinks(symbol *ast.Symbol) *ValueSymbolLinks {
+	if symbol != nil {
+		if data, ok := symbol.CheckerData.(*checkerSymbolData); ok {
+			if data.hasValueLinks {
+				return &data.valueLinks
+			}
+			return nil
+		}
+	}
+	return c.valueSymbolLinks.TryGet(symbol)
+}


### PR DESCRIPTION
## Context

Since #4329, value symbol links live in a paged store indexed by symbol ID, which already removed the hash map probes they used to cost. What remains is the machinery around each access: loading or assigning the symbol's ID, walking the page table, and, on first touch, allocating the links struct in a separate arena. On a full `--noEmit` check of VS Code's `src` project, the paged store handles 47.5M accesses and 7.1M links allocations, and 11.4M of those accesses plus 5.5M of those allocations belong to symbols the checker created itself.

Those symbols are only ever seen by the checker that created them, so this PR stores their links directly on the symbol: the checker's arena now hands out a `transientSymbol`, an `ast.Symbol` plus an inline `checkerSymbolData` block reached through the new `ast.Symbol.CheckerData` field. An access becomes a single pointer chase with no ID, no page walk, and no separate allocation. Binder symbols are shared across checkers and stay on the per-checker paged store with `CheckerData` nil. TypeScript does the same thing: `TransientSymbol` carries its `SymbolLinks` inline.

The work is split into four commits:

1. Collapse paired `Has` + `Get`/`TryGet` lookups into a single `TryGet` at the few sites that used them.
2. Add the inline storage and the `getValueSymbolLinks`/`tryGetValueSymbolLinks` accessors.
3. Mechanically switch every call site over to the accessors.
4. Rename the remaining store to `binderValueSymbolLinks`.


### Performance

Measured on VS Code's `src` project with `--noEmit` against main including #4329:

| Configuration |   main | this PR |  median time |
| ------------- | -----: | ------: | -----------: |
| 1 checker     | 19.4 s |  19.3 s | within noise |
| 4 checkers    | 6.23 s |  5.99 s |        −3.8% |
| 8 checkers    | 4.33 s |  4.02 s |        −7.1% |

### Memory

* Every `ast.Symbol` grows by 16 bytes for the new `CheckerData` field, including binder symbols that never use it.
* Checker-created symbols no longer need a separately allocated links struct or a slot in the paged store, and since IDs interleave across checkers, one skipped slot on a hot page saves more than 8 bytes once several checkers are running.
* The balance depends on the checker count: a small increase at the default, a clear win at higher parallelism.

| Configuration |    main | this PR |
| ------------- | ------: | ------: |
| 1 checker     | 4286 MB | 4402 MB |
| 4 checkers    | 5208 MB | 5232 MB |
| 8 checkers    | 6028 MB | 5843 MB |

This PR was assisted by Claude Code.