### PR TITLE
Add lint rule for identifying common patterns in the checker that lead to inconsistent diagnostic output

### DIFF
--- a/_tools/customlint/checkchildren.go
+++ b/_tools/customlint/checkchildren.go
@@ -165,7 +165,8 @@ func reachableChecksAfter(ret inspector.Cursor, checks []inspector.Cursor) []ins
 		}
 	}
 
-	for cur := ret; ; {
+	cur := ret
+	for {
 		parent := cur.Parent()
 		switch p := parent.Node().(type) {
 		case nil, *ast.FuncDecl, *ast.FuncLit:

--- a/_tools/customlint/checkchildren.go
+++ b/_tools/customlint/checkchildren.go
@@ -232,6 +232,7 @@ func appendChecksIn(reachable []*ast.CallExpr, n ast.Node, checkCalls []*ast.Cal
 	}
 	return reachable
 }
+
 func isSwitchClause(n ast.Node) bool {
 	switch n.(type) {
 	case *ast.CaseClause, *ast.CommClause:

--- a/_tools/customlint/checkchildren.go
+++ b/_tools/customlint/checkchildren.go
@@ -60,9 +60,9 @@ type checkChildrenPass struct {
 func (p *checkChildrenPass) run() (any, error) {
 	in := p.pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
 
-	// Collect all methods in the package, keyed by name, and the set of method
-	// names dispatched from the worker functions.
-	methodsByName := make(map[string]*ast.FuncDecl)
+	// Collect a cursor for every method in the package, keyed by name, and the
+	// set of method names dispatched from the worker functions.
+	methods := make(map[string]inspector.Cursor)
 	handlerNames := make(map[string]struct{})
 
 	for cursor := range in.Root().Preorder((*ast.FuncDecl)(nil)) {
@@ -71,18 +71,16 @@ func (p *checkChildrenPass) run() (any, error) {
 		if !ok {
 			continue
 		}
-		methodsByName[fd.Name.Name] = fd
+		methods[fd.Name.Name] = cursor
 		if checkWorkerFuncs[fd.Name.Name] {
 			collectDispatchedMethods(fd, recv, handlerNames)
 		}
 	}
 
 	for name := range handlerNames {
-		fd := methodsByName[name]
-		if fd == nil || fd.Body == nil {
-			continue
+		if cursor, ok := methods[name]; ok && cursor.Node().(*ast.FuncDecl).Body != nil {
+			p.analyzeMethod(cursor)
 		}
-		p.analyzeMethod(fd)
 	}
 
 	return nil, nil
@@ -103,26 +101,26 @@ func collectDispatchedMethods(fd *ast.FuncDecl, recv string, out map[string]stru
 	})
 }
 
-func (p *checkChildrenPass) analyzeMethod(fd *ast.FuncDecl) {
+func (p *checkChildrenPass) analyzeMethod(method inspector.Cursor) {
+	fd := method.Node().(*ast.FuncDecl)
 	recv, ok := receiverIdent(fd)
 	if !ok {
 		return
 	}
 
-	// Collect the child-checking calls and the explicit returns that belong to
-	// this method. Nested function literals are skipped: they have their own
-	// control flow and returns, which are not this method's concern.
-	var checkCalls []*ast.CallExpr
-	var returns []*ast.ReturnStmt
-	ast.Inspect(fd.Body, func(n ast.Node) bool {
-		switch n := n.(type) {
+	// Collect cursors for the child-checking calls and the explicit returns that
+	// belong to this method. Nested function literals are skipped: they have
+	// their own control flow and returns, which are not this method's concern.
+	var checks, returns []inspector.Cursor
+	method.Inspect([]ast.Node{(*ast.FuncLit)(nil), (*ast.ReturnStmt)(nil), (*ast.CallExpr)(nil)}, func(c inspector.Cursor) bool {
+		switch n := c.Node().(type) {
 		case *ast.FuncLit:
 			return false
 		case *ast.ReturnStmt:
-			returns = append(returns, n)
+			returns = append(returns, c)
 		case *ast.CallExpr:
 			if name, isCall := receiverCallName(n, recv); isCall && isChildCheckName(name) {
-				checkCalls = append(checkCalls, n)
+				checks = append(checks, c)
 			}
 		}
 		return true
@@ -130,22 +128,21 @@ func (p *checkChildrenPass) analyzeMethod(fd *ast.FuncDecl) {
 
 	// If the method never checks any children, there is nothing to enforce:
 	// either the node kind is a leaf, or checking is delegated elsewhere.
-	if len(checkCalls) == 0 {
+	if len(checks) == 0 {
 		return
 	}
 
-	parent := buildParentMap(fd)
 	for _, ret := range returns {
-		for _, call := range reachableChecksAfter(ret, checkCalls, parent) {
+		for _, call := range reachableChecksAfter(ret, checks) {
 			// A return that only fires when the child is absent (a `nil` guard on
 			// the very expression the later call would check) is fine: there is
 			// nothing to check on that path.
-			if child := firstArg(call); child != nil && guardedNil(ret, child, parent) {
+			if child := firstArg(call.Node().(*ast.CallExpr)); child != nil && guardedNil(ret, child) {
 				continue
 			}
 			p.pass.Report(analysis.Diagnostic{
-				Pos:     ret.Pos(),
-				End:     ret.End(),
+				Pos:     ret.Node().Pos(),
+				End:     ret.Node().End(),
 				Message: fd.Name.Name + " returns before checking its child nodes; check children (e.g. via checkExpression, checkSourceElement, or resolveCall) on all paths so diagnostics are stable regardless of traversal order",
 			})
 			break
@@ -154,83 +151,52 @@ func (p *checkChildrenPass) analyzeMethod(fd *ast.FuncDecl) {
 }
 
 // reachableChecksAfter returns the child-checking calls that would execute after
-// `start` if it fell through instead of returning. Walking up the ancestor
-// chain, only statements that genuinely follow `start` in execution order are
-// considered; mutually exclusive branches (the other arm of an if, sibling
-// switch cases) are not, while loop bodies are revisited in full.
-func reachableChecksAfter(start ast.Node, checkCalls []*ast.CallExpr, parent map[ast.Node]ast.Node) []*ast.CallExpr {
-	var reachable []*ast.CallExpr
-	child := start
-	for {
-		switch p := parent[child].(type) {
-		case nil:
-			return reachable
-		case *ast.FuncDecl, *ast.FuncLit:
+// `ret` if it fell through instead of returning. Walking up the ancestors, only
+// statements that genuinely follow `ret` in execution order are considered:
+// mutually exclusive branches (the other arm of an if, sibling switch cases) are
+// not, while loop bodies are revisited in full.
+func reachableChecksAfter(ret inspector.Cursor, checks []inspector.Cursor) []inspector.Cursor {
+	var reachable []inspector.Cursor
+	appendContained := func(scope inspector.Cursor) {
+		for _, check := range checks {
+			if scope.Contains(check) {
+				reachable = append(reachable, check)
+			}
+		}
+	}
+
+	for cur := ret; ; {
+		parent := cur.Parent()
+		switch p := parent.Node().(type) {
+		case nil, *ast.FuncDecl, *ast.FuncLit:
 			// Reached the enclosing function without finding a later check.
 			return reachable
-		case *ast.BlockStmt:
-			// Sibling switch/select clauses are alternatives, not successors.
-			if !isSwitchClause(child) {
-				reachable = appendChecksAfter(reachable, p.List, child, checkCalls)
+		case *ast.BlockStmt, *ast.CaseClause, *ast.CommClause:
+			// Statements after `cur` execute after it, but sibling switch/select
+			// clauses are alternatives, not successors.
+			if !isSwitchClause(cur.Node()) {
+				for sib, ok := cur.NextSibling(); ok; sib, ok = sib.NextSibling() {
+					appendContained(sib)
+				}
 			}
-			child = p
-		case *ast.CaseClause:
-			reachable = appendChecksAfter(reachable, p.Body, child, checkCalls)
-			child = p
-		case *ast.CommClause:
-			reachable = appendChecksAfter(reachable, p.Body, child, checkCalls)
-			child = p
 		case *ast.ForStmt:
-			// Falling through the loop body re-runs the whole loop.
-			if p.Body == child {
-				reachable = appendChecksIn(reachable, p.Body, checkCalls)
+			// Falling through the loop body re-runs the body, post, and condition.
+			if cur.Node() == p.Body {
+				appendContained(cur)
 				if p.Post != nil {
-					reachable = appendChecksIn(reachable, p.Post, checkCalls)
+					appendContained(parent.Child(p.Post))
 				}
 				if p.Cond != nil {
-					reachable = appendChecksIn(reachable, p.Cond, checkCalls)
+					appendContained(parent.Child(p.Cond))
 				}
 			}
-			child = p
 		case *ast.RangeStmt:
-			if p.Body == child {
-				reachable = appendChecksIn(reachable, p.Body, checkCalls)
+			if cur.Node() == p.Body {
+				appendContained(cur)
 			}
-			child = p
-		default:
-			child = p
 		}
+		cur = parent
 	}
-}
-
-// appendChecksAfter appends the child-checks contained in the statements that
-// follow `child` in `list`.
-func appendChecksAfter[T ast.Stmt](reachable []*ast.CallExpr, list []T, child ast.Node, checkCalls []*ast.CallExpr) []*ast.CallExpr {
-	idx := -1
-	for i, s := range list {
-		if ast.Node(s) == child {
-			idx = i
-			break
-		}
-	}
-	if idx < 0 {
-		return reachable
-	}
-	for _, s := range list[idx+1:] {
-		reachable = appendChecksIn(reachable, s, checkCalls)
-	}
-	return reachable
-}
-
-// appendChecksIn appends the child-checks whose call lies within the source
-// range of n.
-func appendChecksIn(reachable []*ast.CallExpr, n ast.Node, checkCalls []*ast.CallExpr) []*ast.CallExpr {
-	for _, call := range checkCalls {
-		if n.Pos() <= call.Pos() && call.Pos() < n.End() {
-			reachable = append(reachable, call)
-		}
-	}
-	return reachable
 }
 
 func isSwitchClause(n ast.Node) bool {
@@ -249,26 +215,24 @@ func firstArg(call *ast.CallExpr) ast.Expr {
 	return call.Args[0]
 }
 
-// guardedNil reports whether every path from an enclosing `if` guard to `ret`
-// establishes that `childExpr` is nil, i.e. the return only fires when the
-// child that a later call would check is absent.
-func guardedNil(ret ast.Node, childExpr ast.Expr, parent map[ast.Node]ast.Node) bool {
-	child := ret
-	for {
-		switch p := parent[child].(type) {
+// guardedNil reports whether an enclosing `if` guard proves that `childExpr` is
+// nil on the path to `ret`, i.e. the return only fires when the child that a
+// later call would check is absent.
+func guardedNil(ret inspector.Cursor, childExpr ast.Expr) bool {
+	for cur := ret; ; {
+		parent := cur.Parent()
+		switch p := parent.Node().(type) {
 		case nil, *ast.FuncDecl, *ast.FuncLit:
 			return false
 		case *ast.IfStmt:
-			if p.Body == child && condImpliesNil(p.Cond, childExpr, true) {
+			if cur.Node() == p.Body && condImpliesNil(p.Cond, childExpr, true) {
 				return true
 			}
-			if p.Else == child && condImpliesNil(p.Cond, childExpr, false) {
+			if cur.Node() == p.Else && condImpliesNil(p.Cond, childExpr, false) {
 				return true
 			}
-			child = p
-		default:
-			child = p
 		}
+		cur = parent
 	}
 }
 
@@ -330,24 +294,6 @@ func equalExpr(a, b ast.Expr) bool {
 	default:
 		return false
 	}
-}
-
-// buildParentMap maps each node in fd to its parent node.
-func buildParentMap(fd *ast.FuncDecl) map[ast.Node]ast.Node {
-	parent := make(map[ast.Node]ast.Node)
-	stack := make([]ast.Node, 0, 32)
-	ast.Inspect(fd, func(n ast.Node) bool {
-		if n == nil {
-			stack = stack[:len(stack)-1]
-			return true
-		}
-		if len(stack) > 0 {
-			parent[n] = stack[len(stack)-1]
-		}
-		stack = append(stack, n)
-		return true
-	})
-	return parent
 }
 
 // isChildCheckName reports whether a method name recursively checks a child node.

--- a/_tools/customlint/checkchildren.go
+++ b/_tools/customlint/checkchildren.go
@@ -1,0 +1,382 @@
+package customlint
+
+import (
+	"go/ast"
+	"go/token"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+// checkChildrenAnalyzer flags `return` statements in checker methods that are
+// dispatched from `checkSourceElementWorker` / `checkExpressionWorker` and that
+// exit the method before its child nodes have been checked.
+//
+// Methods like `checkReturnStatement` contain grammar/error `return`s that fire
+// before the child expression is ever checked (e.g. via `checkExpression`).
+// When such a return is taken the child is never checked, so the set of
+// diagnostics produced depends on whether the child happens to be checked
+// elsewhere first. Requiring children to always be checked - even on error
+// paths - keeps diagnostics stable regardless of traversal order.
+//
+// A return is flagged when a child-checking call is reachable *after* it: that
+// is what makes the return "early". Checking children up front - even
+// conditionally, e.g.
+//
+//	var exprType *Type
+//	if node.Expression() != nil {
+//		exprType = c.checkExpressionCached(node.Expression())
+//	}
+//	if c.grammarError(node) {
+//		return
+//	}
+//
+// is therefore accepted, because the child has already been given its chance to
+// be checked before the return.
+var checkChildrenAnalyzer = &analysis.Analyzer{
+	Name: "checkchildren",
+	Doc:  "finds early returns in checker dispatch methods that skip checking child nodes",
+	Requires: []*analysis.Analyzer{
+		inspect.Analyzer,
+	},
+	Run: func(pass *analysis.Pass) (any, error) {
+		return (&checkChildrenPass{pass: pass}).run()
+	},
+}
+
+// checkWorkerFuncs are the dispatch methods whose switch cases enumerate the
+// per-node-kind checker methods we want to analyze.
+var checkWorkerFuncs = map[string]bool{
+	"checkSourceElementWorker": true,
+	"checkExpressionWorker":    true,
+}
+
+type checkChildrenPass struct {
+	pass *analysis.Pass
+}
+
+func (p *checkChildrenPass) run() (any, error) {
+	in := p.pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	// Collect all methods in the package, keyed by name, and the set of method
+	// names dispatched from the worker functions.
+	methodsByName := make(map[string]*ast.FuncDecl)
+	handlerNames := make(map[string]struct{})
+
+	for cursor := range in.Root().Preorder((*ast.FuncDecl)(nil)) {
+		fd := cursor.Node().(*ast.FuncDecl)
+		recv, ok := receiverIdent(fd)
+		if !ok {
+			continue
+		}
+		methodsByName[fd.Name.Name] = fd
+		if checkWorkerFuncs[fd.Name.Name] {
+			collectDispatchedMethods(fd, recv, handlerNames)
+		}
+	}
+
+	for name := range handlerNames {
+		fd := methodsByName[name]
+		if fd == nil || fd.Body == nil {
+			continue
+		}
+		p.analyzeMethod(fd)
+	}
+
+	return nil, nil
+}
+
+// collectDispatchedMethods records every `recv.<method>(...)` call appearing in
+// the body of a worker function.
+func collectDispatchedMethods(fd *ast.FuncDecl, recv string, out map[string]struct{}) {
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if name, ok := receiverCallName(call, recv); ok {
+			out[name] = struct{}{}
+		}
+		return true
+	})
+}
+
+func (p *checkChildrenPass) analyzeMethod(fd *ast.FuncDecl) {
+	recv, ok := receiverIdent(fd)
+	if !ok {
+		return
+	}
+
+	// Collect the child-checking calls and the explicit returns that belong to
+	// this method. Nested function literals are skipped: they have their own
+	// control flow and returns, which are not this method's concern.
+	var checkCalls []*ast.CallExpr
+	var returns []*ast.ReturnStmt
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		switch n := n.(type) {
+		case *ast.FuncLit:
+			return false
+		case *ast.ReturnStmt:
+			returns = append(returns, n)
+		case *ast.CallExpr:
+			if name, isCall := receiverCallName(n, recv); isCall && isChildCheckName(name) {
+				checkCalls = append(checkCalls, n)
+			}
+		}
+		return true
+	})
+
+	// If the method never checks any children, there is nothing to enforce:
+	// either the node kind is a leaf, or checking is delegated elsewhere.
+	if len(checkCalls) == 0 {
+		return
+	}
+
+	parent := buildParentMap(fd)
+	for _, ret := range returns {
+		for _, call := range reachableChecksAfter(ret, checkCalls, parent) {
+			// A return that only fires when the child is absent (a `nil` guard on
+			// the very expression the later call would check) is fine: there is
+			// nothing to check on that path.
+			if child := firstArg(call); child != nil && guardedNil(ret, child, parent) {
+				continue
+			}
+			p.pass.Report(analysis.Diagnostic{
+				Pos:     ret.Pos(),
+				End:     ret.End(),
+				Message: fd.Name.Name + " returns before checking its child nodes; check children (e.g. via checkExpression, checkSourceElement, or resolveCall) on all paths so diagnostics are stable regardless of traversal order",
+			})
+			break
+		}
+	}
+}
+
+// reachableChecksAfter returns the child-checking calls that would execute after
+// `start` if it fell through instead of returning. Walking up the ancestor
+// chain, only statements that genuinely follow `start` in execution order are
+// considered; mutually exclusive branches (the other arm of an if, sibling
+// switch cases) are not, while loop bodies are revisited in full.
+func reachableChecksAfter(start ast.Node, checkCalls []*ast.CallExpr, parent map[ast.Node]ast.Node) []*ast.CallExpr {
+	var reachable []*ast.CallExpr
+	child := start
+	for {
+		switch p := parent[child].(type) {
+		case nil:
+			return reachable
+		case *ast.FuncDecl, *ast.FuncLit:
+			// Reached the enclosing function without finding a later check.
+			return reachable
+		case *ast.BlockStmt:
+			// Sibling switch/select clauses are alternatives, not successors.
+			if !isSwitchClause(child) {
+				reachable = appendChecksAfter(reachable, p.List, child, checkCalls)
+			}
+			child = p
+		case *ast.CaseClause:
+			reachable = appendChecksAfter(reachable, p.Body, child, checkCalls)
+			child = p
+		case *ast.CommClause:
+			reachable = appendChecksAfter(reachable, p.Body, child, checkCalls)
+			child = p
+		case *ast.ForStmt:
+			// Falling through the loop body re-runs the whole loop.
+			if p.Body == child {
+				reachable = appendChecksIn(reachable, p.Body, checkCalls)
+				if p.Post != nil {
+					reachable = appendChecksIn(reachable, p.Post, checkCalls)
+				}
+				if p.Cond != nil {
+					reachable = appendChecksIn(reachable, p.Cond, checkCalls)
+				}
+			}
+			child = p
+		case *ast.RangeStmt:
+			if p.Body == child {
+				reachable = appendChecksIn(reachable, p.Body, checkCalls)
+			}
+			child = p
+		default:
+			child = p
+		}
+	}
+}
+
+// appendChecksAfter appends the child-checks contained in the statements that
+// follow `child` in `list`.
+func appendChecksAfter[T ast.Stmt](reachable []*ast.CallExpr, list []T, child ast.Node, checkCalls []*ast.CallExpr) []*ast.CallExpr {
+	idx := -1
+	for i, s := range list {
+		if ast.Node(s) == child {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return reachable
+	}
+	for _, s := range list[idx+1:] {
+		reachable = appendChecksIn(reachable, s, checkCalls)
+	}
+	return reachable
+}
+
+// appendChecksIn appends the child-checks whose call lies within the source
+// range of n.
+func appendChecksIn(reachable []*ast.CallExpr, n ast.Node, checkCalls []*ast.CallExpr) []*ast.CallExpr {
+	for _, call := range checkCalls {
+		if n.Pos() <= call.Pos() && call.Pos() < n.End() {
+			reachable = append(reachable, call)
+		}
+	}
+	return reachable
+}
+func isSwitchClause(n ast.Node) bool {
+	switch n.(type) {
+	case *ast.CaseClause, *ast.CommClause:
+		return true
+	}
+	return false
+}
+
+// firstArg returns the first argument of a call, or nil if it has none.
+func firstArg(call *ast.CallExpr) ast.Expr {
+	if len(call.Args) == 0 {
+		return nil
+	}
+	return call.Args[0]
+}
+
+// guardedNil reports whether every path from an enclosing `if` guard to `ret`
+// establishes that `childExpr` is nil, i.e. the return only fires when the
+// child that a later call would check is absent.
+func guardedNil(ret ast.Node, childExpr ast.Expr, parent map[ast.Node]ast.Node) bool {
+	child := ret
+	for {
+		switch p := parent[child].(type) {
+		case nil, *ast.FuncDecl, *ast.FuncLit:
+			return false
+		case *ast.IfStmt:
+			if p.Body == child && condImpliesNil(p.Cond, childExpr, true) {
+				return true
+			}
+			if p.Else == child && condImpliesNil(p.Cond, childExpr, false) {
+				return true
+			}
+			child = p
+		default:
+			child = p
+		}
+	}
+}
+
+// condImpliesNil reports whether `cond` evaluating to `condIsTrue` implies that
+// `childExpr` is nil, i.e. `childExpr == nil` (when true) or `childExpr != nil`
+// (when false).
+func condImpliesNil(cond ast.Expr, childExpr ast.Expr, condIsTrue bool) bool {
+	bin, ok := cond.(*ast.BinaryExpr)
+	if !ok {
+		return false
+	}
+	wantOp := token.EQL
+	if !condIsTrue {
+		wantOp = token.NEQ
+	}
+	if bin.Op != wantOp {
+		return false
+	}
+	return (isNilIdent(bin.Y) && equalExpr(bin.X, childExpr)) ||
+		(isNilIdent(bin.X) && equalExpr(bin.Y, childExpr))
+}
+
+func isNilIdent(e ast.Expr) bool {
+	id, ok := e.(*ast.Ident)
+	return ok && id.Name == "nil"
+}
+
+// equalExpr reports whether two expressions are structurally identical for the
+// simple forms used to identify child nodes (identifiers, selectors, and calls
+// such as `node.Expression()`).
+func equalExpr(a, b ast.Expr) bool {
+	switch a := a.(type) {
+	case *ast.Ident:
+		b, ok := b.(*ast.Ident)
+		return ok && a.Name == b.Name
+	case *ast.SelectorExpr:
+		b, ok := b.(*ast.SelectorExpr)
+		return ok && a.Sel.Name == b.Sel.Name && equalExpr(a.X, b.X)
+	case *ast.CallExpr:
+		b, ok := b.(*ast.CallExpr)
+		if !ok || len(a.Args) != len(b.Args) || !equalExpr(a.Fun, b.Fun) {
+			return false
+		}
+		for i := range a.Args {
+			if !equalExpr(a.Args[i], b.Args[i]) {
+				return false
+			}
+		}
+		return true
+	case *ast.ParenExpr:
+		b, ok := b.(*ast.ParenExpr)
+		return ok && equalExpr(a.X, b.X)
+	case *ast.IndexExpr:
+		b, ok := b.(*ast.IndexExpr)
+		return ok && equalExpr(a.X, b.X) && equalExpr(a.Index, b.Index)
+	case *ast.BasicLit:
+		b, ok := b.(*ast.BasicLit)
+		return ok && a.Kind == b.Kind && a.Value == b.Value
+	default:
+		return false
+	}
+}
+
+// buildParentMap maps each node in fd to its parent node.
+func buildParentMap(fd *ast.FuncDecl) map[ast.Node]ast.Node {
+	parent := make(map[ast.Node]ast.Node)
+	stack := make([]ast.Node, 0, 32)
+	ast.Inspect(fd, func(n ast.Node) bool {
+		if n == nil {
+			stack = stack[:len(stack)-1]
+			return true
+		}
+		if len(stack) > 0 {
+			parent[n] = stack[len(stack)-1]
+		}
+		stack = append(stack, n)
+		return true
+	})
+	return parent
+}
+
+// isChildCheckName reports whether a method name recursively checks a child node.
+func isChildCheckName(name string) bool {
+	return strings.HasPrefix(name, "checkExpression") ||
+		strings.HasPrefix(name, "checkSourceElement") ||
+		name == "resolveCall"
+}
+
+// receiverCallName returns the method name of a `recv.<method>(...)` call.
+func receiverCallName(call *ast.CallExpr, recv string) (string, bool) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return "", false
+	}
+	x, ok := sel.X.(*ast.Ident)
+	if !ok || x.Name != recv {
+		return "", false
+	}
+	return sel.Sel.Name, true
+}
+
+// receiverIdent returns the name of a method's single receiver variable.
+func receiverIdent(fd *ast.FuncDecl) (string, bool) {
+	if fd.Recv == nil || len(fd.Recv.List) != 1 {
+		return "", false
+	}
+	names := fd.Recv.List[0].Names
+	if len(names) != 1 {
+		return "", false
+	}
+	return names[0].Name, true
+}

--- a/_tools/customlint/plugin.go
+++ b/_tools/customlint/plugin.go
@@ -16,6 +16,7 @@ type plugin struct{}
 func (f *plugin) BuildAnalyzers() ([]*analysis.Analyzer, error) {
 	return []*analysis.Analyzer{
 		bitclearAnalyzer,
+		checkChildrenAnalyzer,
 		cleanupAnalyzer,
 		emptyCaseAnalyzer,
 		forbidParentAccessAnalyzer,

--- a/_tools/customlint/testdata/checkchildren/checkchildren.go
+++ b/_tools/customlint/testdata/checkchildren/checkchildren.go
@@ -1,0 +1,119 @@
+package checkchildren
+
+type Node struct{}
+
+func (n *Node) Expression() *Node { return nil }
+
+type Type struct{}
+
+type CheckMode int
+
+type Checker struct {
+	errorType *Type
+}
+
+func (c *Checker) checkExpression(node *Node, checkMode CheckMode) *Type { return nil }
+
+func (c *Checker) checkExpressionCached(node *Node) *Type { return nil }
+
+func (c *Checker) checkSourceElement(node *Node) {}
+
+func (c *Checker) resolveCall(node *Node) *Type { return nil }
+
+func (c *Checker) grammarError(node *Node) bool { return false }
+
+func (c *Checker) checkSourceElementWorker(node *Node) {
+	switch {
+	case node == nil:
+		c.checkChecksFirst(node)
+	case node != nil:
+		c.checkEarlyReturn(node)
+		c.checkConditionalUpfront(node)
+	default:
+		c.checkLeaf(node)
+	}
+}
+
+func (c *Checker) checkExpressionWorker(node *Node, checkMode CheckMode) *Type {
+	switch {
+	case node == nil:
+		return c.checkCallLike(node)
+	case node != nil:
+		return c.checkNilGuardedReturn(node)
+	default:
+		return c.checkReturnsInReturn(node)
+	}
+}
+
+// checkChecksFirst checks its child before any early return, so it is fine.
+func (c *Checker) checkChecksFirst(node *Node) {
+	c.checkExpressionCached(node)
+	if c.grammarError(node) {
+		return
+	}
+}
+
+// checkEarlyReturn returns before its child is ever checked, so both returns
+// are flagged.
+func (c *Checker) checkEarlyReturn(node *Node) {
+	if c.grammarError(node) {
+		return
+	}
+	if node == nil {
+		return
+	}
+	c.checkExpressionCached(node)
+}
+
+// checkLeaf never checks any children, so its early return is not flagged.
+func (c *Checker) checkLeaf(node *Node) {
+	if c.grammarError(node) {
+		return
+	}
+}
+
+// checkConditionalUpfront checks its child up front (guarded by the child's
+// existence) before the early return, so the early return is not flagged.
+func (c *Checker) checkConditionalUpfront(node *Node) {
+	var exprType *Type
+	if node.Expression() != nil {
+		exprType = c.checkExpressionCached(node.Expression())
+	}
+	if c.grammarError(node) {
+		return
+	}
+	_ = exprType
+}
+
+// checkCallLike returns errorType before resolving the call's children, so the
+// early return is flagged.
+func (c *Checker) checkCallLike(node *Node) *Type {
+	if c.grammarError(node) {
+		return c.errorType
+	}
+	return c.resolveCall(node)
+}
+
+// checkReturnsInReturn checks its child as part of the return expression, so it
+// is fine.
+func (c *Checker) checkReturnsInReturn(node *Node) *Type {
+	return c.checkExpression(node, 0)
+}
+
+// checkNilGuardedReturn returns early only when the child it would check is
+// absent (a nil guard on that same child), so the early return is not flagged.
+func (c *Checker) checkNilGuardedReturn(node *Node) *Type {
+	c.grammarError(node)
+	if node.Expression() == nil {
+		return c.errorType
+	}
+	return c.checkExpression(node.Expression(), 0)
+}
+
+// checkNeverDispatched is not reachable from a worker, so it is never analyzed.
+func (c *Checker) checkNeverDispatched(node *Node) *Type {
+	if c.grammarError(node) {
+		return c.errorType
+	}
+	return c.checkExpression(node, 0)
+}

--- a/_tools/customlint/testdata/checkchildren/checkchildren.go
+++ b/_tools/customlint/testdata/checkchildren/checkchildren.go
@@ -53,8 +53,10 @@ func (c *Checker) checkChecksFirst(node *Node) {
 	}
 }
 
-// checkEarlyReturn returns before its child is ever checked, so both returns
-// are flagged.
+// checkEarlyReturn returns before its child is ever checked.
+// The first return is flagged as an issue since it doesn't check
+// children, while the second is not since it checks nilness, presumably to prove
+// that the children don't exist to check.
 func (c *Checker) checkEarlyReturn(node *Node) {
 	if c.grammarError(node) {
 		return

--- a/_tools/customlint/testdata/checkchildren/checkchildren.go.golden
+++ b/_tools/customlint/testdata/checkchildren/checkchildren.go.golden
@@ -53,8 +53,10 @@
 		}
 	}
 	
-	// checkEarlyReturn returns before its child is ever checked, so both returns
-	// are flagged.
+	// checkEarlyReturn returns before its child is ever checked.
+	// The first return is flagged as an issue since it doesn't check
+	// children, while the second is not since it checks nilness, presumably to prove
+	// that the children don't exist to check.
 	func (c *Checker) checkEarlyReturn(node *Node) {
 		if c.grammarError(node) {
 			return

--- a/_tools/customlint/testdata/checkchildren/checkchildren.go.golden
+++ b/_tools/customlint/testdata/checkchildren/checkchildren.go.golden
@@ -1,0 +1,124 @@
+	package checkchildren
+	
+	type Node struct{}
+	
+	func (n *Node) Expression() *Node { return nil }
+	
+	type Type struct{}
+	
+	type CheckMode int
+	
+	type Checker struct {
+		errorType *Type
+	}
+	
+	func (c *Checker) checkExpression(node *Node, checkMode CheckMode) *Type { return nil }
+	
+	func (c *Checker) checkExpressionCached(node *Node) *Type { return nil }
+	
+	func (c *Checker) checkSourceElement(node *Node) {}
+	
+	func (c *Checker) resolveCall(node *Node) *Type { return nil }
+	
+	func (c *Checker) grammarError(node *Node) bool { return false }
+	
+	func (c *Checker) checkSourceElementWorker(node *Node) {
+		switch {
+		case node == nil:
+			c.checkChecksFirst(node)
+		case node != nil:
+			c.checkEarlyReturn(node)
+			c.checkConditionalUpfront(node)
+		default:
+			c.checkLeaf(node)
+		}
+	}
+	
+	func (c *Checker) checkExpressionWorker(node *Node, checkMode CheckMode) *Type {
+		switch {
+		case node == nil:
+			return c.checkCallLike(node)
+		case node != nil:
+			return c.checkNilGuardedReturn(node)
+		default:
+			return c.checkReturnsInReturn(node)
+		}
+	}
+	
+	// checkChecksFirst checks its child before any early return, so it is fine.
+	func (c *Checker) checkChecksFirst(node *Node) {
+		c.checkExpressionCached(node)
+		if c.grammarError(node) {
+			return
+		}
+	}
+	
+	// checkEarlyReturn returns before its child is ever checked, so both returns
+	// are flagged.
+	func (c *Checker) checkEarlyReturn(node *Node) {
+		if c.grammarError(node) {
+			return
+			~~~~~~
+!!! checkchildren: checkEarlyReturn returns before checking its child nodes; check children (e.g. via checkExpression, checkSourceElement, or resolveCall) on all paths so diagnostics are stable regardless of traversal order
+		}
+		if node == nil {
+			return
+		}
+		c.checkExpressionCached(node)
+	}
+	
+	// checkLeaf never checks any children, so its early return is not flagged.
+	func (c *Checker) checkLeaf(node *Node) {
+		if c.grammarError(node) {
+			return
+		}
+	}
+	
+	// checkConditionalUpfront checks its child up front (guarded by the child's
+	// existence) before the early return, so the early return is not flagged.
+	func (c *Checker) checkConditionalUpfront(node *Node) {
+		var exprType *Type
+		if node.Expression() != nil {
+			exprType = c.checkExpressionCached(node.Expression())
+		}
+		if c.grammarError(node) {
+			return
+		}
+		_ = exprType
+	}
+	
+	// checkCallLike returns errorType before resolving the call's children, so the
+	// early return is flagged.
+	func (c *Checker) checkCallLike(node *Node) *Type {
+		if c.grammarError(node) {
+			return c.errorType
+			~~~~~~~~~~~~~~~~~~
+!!! checkchildren: checkCallLike returns before checking its child nodes; check children (e.g. via checkExpression, checkSourceElement, or resolveCall) on all paths so diagnostics are stable regardless of traversal order
+		}
+		return c.resolveCall(node)
+	}
+	
+	// checkReturnsInReturn checks its child as part of the return expression, so it
+	// is fine.
+	func (c *Checker) checkReturnsInReturn(node *Node) *Type {
+		return c.checkExpression(node, 0)
+	}
+	
+	// checkNilGuardedReturn returns early only when the child it would check is
+	// absent (a nil guard on that same child), so the early return is not flagged.
+	func (c *Checker) checkNilGuardedReturn(node *Node) *Type {
+		c.grammarError(node)
+		if node.Expression() == nil {
+			return c.errorType
+		}
+		return c.checkExpression(node.Expression(), 0)
+	}
+	
+	// checkNeverDispatched is not reachable from a worker, so it is never analyzed.
+	func (c *Checker) checkNeverDispatched(node *Node) *Type {
+		if c.grammarError(node) {
+			return c.errorType
+		}
+		return c.checkExpression(node, 0)
+	}
+	

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -1561,6 +1561,11 @@ func (c *Checker) checkAndReportErrorForMissingPrefix(errorLocation *ast.Node, n
 }
 
 func (c *Checker) onFailedToResolveSymbol(errorLocation *ast.Node, name string, meaning ast.SymbolFlags, nameNotFoundMessage *diagnostics.Message) {
+	// The `const` in a `const` assertion (`x as const`) is a syntactic marker, not a real
+	// type reference, and must never be resolved or reported as an unresolvable name.
+	if isConstTypeReferenceName(errorLocation) {
+		return
+	}
 	if errorLocation != nil && (errorLocation.Parent.Kind == ast.KindJSDocLink ||
 		c.checkAndReportErrorForMissingPrefix(errorLocation, name) ||
 		c.checkAndReportErrorForExtendingInterface(errorLocation) ||
@@ -1636,7 +1641,11 @@ func (c *Checker) checkAndReportErrorForUsingNamespaceAsTypeOrValue(errorLocatio
 	if meaning&(ast.SymbolFlagsValue&^ast.SymbolFlagsType) != 0 {
 		symbol := c.resolveSymbol(c.resolveName(errorLocation, name, ast.SymbolFlagsNamespaceModule, nil /*nameNotFoundMessage*/, false /*isUse*/, false /*excludeGlobals*/))
 		if symbol != nil {
-			c.error(errorLocation, diagnostics.Cannot_use_namespace_0_as_a_value, name)
+			// `export = ns` may legitimately reference a namespace; checkExportAssignment decides
+			// whether that is an error, so don't report "cannot use namespace as a value" here.
+			if !isExportAssignmentExpressionName(errorLocation) {
+				c.error(errorLocation, diagnostics.Cannot_use_namespace_0_as_a_value, name)
+			}
 			return true
 		}
 	} else if meaning&(ast.SymbolFlagsType&^ast.SymbolFlagsValue) != 0 {
@@ -1672,6 +1681,11 @@ func (c *Checker) checkAndReportErrorForUsingTypeAsValue(errorLocation *ast.Node
 		if symbol != nil {
 			allFlags := c.getSymbolFlags(symbol)
 			if allFlags&ast.SymbolFlagsValue == 0 {
+				// `export = SomeType` may legitimately reference a type-only name; checkExportAssignment
+				// decides whether that is an error, so don't report "used as a value" here.
+				if isExportAssignmentExpressionName(errorLocation) {
+					return true
+				}
 				if isES2015OrLaterConstructorName(name) {
 					c.error(errorLocation, diagnostics.X_0_only_refers_to_a_type_but_is_being_used_as_a_value_here_Do_you_need_to_change_your_target_library_Try_changing_the_lib_compiler_option_to_es2015_or_later, name)
 				} else if c.maybeMappedType(errorLocation, symbol) {
@@ -3038,6 +3052,9 @@ func (c *Checker) getDeprecatedSuggestionNode(node *ast.Node) *ast.Node {
 }
 
 func (c *Checker) checkTypePredicate(node *ast.Node) {
+	// Always check the predicate's type so nested type errors are reported even when the
+	// predicate is in an invalid position, keeping diagnostics stable.
+	c.checkSourceElement(node.Type())
 	parent := c.getTypePredicateParent(node)
 	if parent == nil {
 		// The parent must not be valid.
@@ -3049,7 +3066,6 @@ func (c *Checker) checkTypePredicate(node *ast.Node) {
 	if typePredicate == nil {
 		return
 	}
-	c.checkSourceElement(node.Type())
 	parameterName := node.AsTypePredicateNode().ParameterName
 	if typePredicate.kind != TypePredicateKindThis && typePredicate.kind != TypePredicateKindAssertsThis {
 		if typePredicate.parameterIndex >= 0 {
@@ -4067,6 +4083,14 @@ func (c *Checker) checkBreakOrContinueStatement(node *ast.Node) {
 }
 
 func (c *Checker) checkReturnStatement(node *ast.Node) {
+	// Always check the return expression so its identifiers are resolved even when the
+	// return statement is misplaced (grammar error), keeping diagnostics stable
+	// regardless of traversal order.
+	exprNode := node.Expression()
+	exprType := c.undefinedType
+	if exprNode != nil {
+		exprType = c.checkExpressionCached(exprNode)
+	}
 	if c.checkGrammarStatementInAmbientContext(node) {
 		return
 	}
@@ -4082,12 +4106,7 @@ func (c *Checker) checkReturnStatement(node *ast.Node) {
 	signature := c.getSignatureFromDeclaration(container)
 	returnType := c.getReturnTypeOfSignature(signature)
 	functionFlags := ast.GetFunctionFlags(container)
-	exprNode := node.Expression()
 	if c.strictNullChecks || exprNode != nil || returnType.flags&TypeFlagsNever != 0 {
-		exprType := c.undefinedType
-		if exprNode != nil {
-			exprType = c.checkExpressionCached(exprNode)
-		}
 		if ast.IsSetAccessorDeclaration(container) {
 			if exprNode != nil {
 				c.error(node, diagnostics.Setters_cannot_return_a_value)
@@ -5562,6 +5581,10 @@ func isContainedByNamespace(node *ast.Node) bool {
 
 func (c *Checker) checkExportAssignment(node *ast.Node) {
 	isExportEquals := node.AsExportAssignment().IsExportEquals
+	// Always check the exported expression so its identifiers are resolved even when the
+	// export assignment is misplaced (grammar error), keeping diagnostics stable
+	// regardless of traversal order.
+	exprType := c.checkExpressionCached(node.Expression())
 	illegalContextMessage := core.IfElse(isExportEquals,
 		diagnostics.An_export_assignment_must_be_at_the_top_level_of_a_file_or_module_declaration,
 		diagnostics.A_default_export_must_be_at_the_top_level_of_a_file_or_module_declaration)
@@ -5593,7 +5616,6 @@ func (c *Checker) checkExportAssignment(node *ast.Node) {
 			// If not a value, we're interpreting the identifier as a type export, along the lines of (`export { Id as default }`)
 			if c.getSymbolFlags(sym)&ast.SymbolFlagsValue != 0 {
 				// However if it is a value, we need to check it's being used correctly
-				c.checkExpressionCached(id)
 				if !isIllegalExportDefaultInCJS && node.Flags&ast.NodeFlagsAmbient == 0 && c.compilerOptions.VerbatimModuleSyntax.IsTrue() && typeOnlyDeclaration != nil {
 					message := core.IfElse(isExportEquals,
 						diagnostics.An_export_declaration_must_reference_a_real_value_when_verbatimModuleSyntax_is_enabled_but_0_resolves_to_a_type_only_declaration,
@@ -5626,13 +5648,7 @@ func (c *Checker) checkExportAssignment(node *ast.Node) {
 					c.addTypeOnlyDeclarationRelatedInfo(c.error(id, message, id.Text(), c.getIsolatedModulesLikeFlagName()), typeOnlyDeclaration, id.Text())
 				}
 			}
-		} else {
-			c.checkExpressionCached(id)
-			// doesn't resolve, check as expression to mark as error
 		}
-
-	} else {
-		c.checkExpressionCached(node.Expression())
 	}
 	if isIllegalExportDefaultInCJS {
 		c.error(node, getVerbatimModuleSyntaxErrorMessage(node))
@@ -5644,8 +5660,7 @@ func (c *Checker) checkExportAssignment(node *ast.Node) {
 	c.checkExternalModuleExports(container)
 	if typeNode := node.Type(); typeNode != nil && node.Kind == ast.KindExportAssignment {
 		t := c.getTypeFromTypeNode(typeNode)
-		initializerType := c.checkExpressionCached(node.Expression())
-		c.checkTypeAssignableToAndOptionallyElaborate(initializerType, t, node.Expression(), node.Expression(), nil /*headMessage*/, nil)
+		c.checkTypeAssignableToAndOptionallyElaborate(exprType, t, node.Expression(), node.Expression(), nil /*headMessage*/, nil)
 	}
 	if (node.Flags&ast.NodeFlagsAmbient != 0) && !ast.IsEntityNameExpression(node.Expression()) {
 		c.grammarErrorOnNode(node.Expression(), diagnostics.The_expression_of_an_export_assignment_must_be_an_identifier_or_qualified_name_in_an_ambient_context)
@@ -6874,7 +6889,9 @@ func (c *Checker) checkTypeAliasDeclaration(node *ast.Node) {
 			len(typeParameters) == 1 && intrinsicTypeKinds[node.Name().Text()] != IntrinsicTypeKindUnknown) {
 			c.error(typeNode, diagnostics.The_intrinsic_keyword_can_only_be_used_to_declare_compiler_provided_intrinsic_types)
 		}
-		return
+		// The `intrinsic` keyword is a leaf type node with no child nodes to check,
+		// so skipping the checkSourceElement below visits nothing.
+		return //nolint:customlint // intrinsic keyword has no children to check
 	}
 	c.checkSourceElement(typeNode)
 	c.registerForUnusedIdentifiersCheck(node)
@@ -8251,7 +8268,8 @@ func (c *Checker) checkImportCallExpression(node *ast.Node) *Type {
 	c.checkGrammarImportCallExpression(node)
 	args := node.Arguments()
 	if len(args) == 0 {
-		return c.createPromiseReturnType(node, c.anyType)
+		// No call arguments exist, so there are no child expressions to check.
+		return c.createPromiseReturnType(node, c.anyType) //nolint:customlint // no arguments to check
 	}
 	specifier := args[0]
 	specifierType := c.checkExpressionCached(specifier)
@@ -10602,7 +10620,9 @@ func (c *Checker) checkTypeOfExpression(node *ast.Node) *Type {
 
 func (c *Checker) checkNonNullAssertion(node *ast.Node) *Type {
 	if node.Flags&ast.NodeFlagsOptionalChain != 0 {
-		return c.checkNonNullChain(node)
+		// checkNonNullChain checks the same operand expression (node.Expression()),
+		// so the child is still visited on this branch.
+		return c.checkNonNullChain(node) //nolint:customlint // checkNonNullChain checks the operand
 	}
 	return c.GetNonNullableType(c.checkExpression(node.Expression()))
 }
@@ -10930,6 +10950,14 @@ func (c *Checker) checkSpreadExpression(node *ast.Node, checkMode CheckMode) *Ty
 
 func (c *Checker) checkYieldExpression(node *ast.Node) *Type {
 	c.checkGrammarYieldExpression(node)
+	// Always check the operand so its identifiers are resolved even when the yield is
+	// outside a generator, keeping diagnostics stable regardless of traversal order.
+	var yieldExpressionType *Type
+	if node.Expression() != nil {
+		yieldExpressionType = c.checkExpression(node.Expression())
+	} else {
+		yieldExpressionType = c.undefinedWideningType
+	}
 	fn := ast.GetContainingFunction(node)
 	if fn == nil {
 		return c.anyType
@@ -10962,12 +10990,6 @@ func (c *Checker) checkYieldExpression(node *ast.Node) *Type {
 	}
 	signatureYieldType := core.OrElse(iterationTypes.yieldType, c.anyType)
 	signatureNextType := core.OrElse(iterationTypes.nextType, c.anyType)
-	var yieldExpressionType *Type
-	if node.Expression() != nil {
-		yieldExpressionType = c.checkExpression(node.Expression())
-	} else {
-		yieldExpressionType = c.undefinedWideningType
-	}
 	yieldedType := c.getYieldedTypeOfYieldExpression(node, yieldExpressionType, signatureNextType, isAsync)
 	if returnType != nil && yieldedType != nil {
 		c.checkTypeAssignableToAndOptionallyElaborate(yieldedType, signatureYieldType, core.OrElse(node.Expression(), node), node.Expression(), nil, nil)
@@ -12269,6 +12291,10 @@ func (c *Checker) checkAssertion(node *ast.Node, checkMode CheckMode) *Type {
 	}
 	typeNode := node.Type()
 	exprType := c.checkExpressionEx(node.Expression(), checkMode)
+	// Always check the type node so its identifiers are resolved. resolveName knows not
+	// to resolve (or report an error for) the `const` in a `const` assertion, so this is
+	// safe even for `x as const` and keeps diagnostics stable regardless of traversal order.
+	c.checkSourceElement(typeNode)
 	if isConstTypeReference(typeNode) {
 		if !c.isValidConstAssertionArgument(node.Expression()) {
 			c.error(node.Expression(), diagnostics.A_const_assertion_can_only_be_applied_to_references_to_enum_members_or_string_number_boolean_array_or_object_literals)
@@ -12277,7 +12303,6 @@ func (c *Checker) checkAssertion(node *ast.Node, checkMode CheckMode) *Type {
 	}
 	links := c.assertionLinks.Get(node)
 	links.exprType = exprType
-	c.checkSourceElement(typeNode)
 	c.checkNodeDeferred(node)
 	return c.getTypeFromTypeNode(typeNode)
 }
@@ -13118,7 +13143,9 @@ func (c *Checker) checkObjectLiteral(node *ast.Node, checkMode CheckMode) *Type 
 		if ast.IsInJSFile(node) && !ast.IsInJsonFile(node) {
 			result.objectFlags |= ObjectFlagsJSLiteral
 		}
-		return result
+		// An expando object literal has no property children (len == 0), so there
+		// is nothing to check here.
+		return result //nolint:customlint // expando object literal has no property children to check
 	}
 	inDestructuringPattern := ast.IsAssignmentTarget(node)
 	// Grammar checking
@@ -23022,11 +23049,9 @@ func (c *Checker) getIntendedTypeFromJSDocTypeReference(node *ast.Node) *Type {
 func (c *Checker) getSymbolFromTypeReference(node *ast.Node) *ast.Symbol {
 	links := c.symbolNodeLinks.Get(node)
 	if links.resolvedSymbol == nil {
-		if isConstTypeReference(node) && ast.IsAssertionExpression(node.Parent) {
-			links.resolvedSymbol = c.unknownSymbol
-		} else {
-			links.resolvedSymbol = c.resolveTypeReferenceName(node, ast.SymbolFlagsType, false /*ignoreErrors*/)
-		}
+		// The `const` in a `const` assertion resolves to nothing; resolveName knows not to
+		// report an error for it, so no special-casing is needed here.
+		links.resolvedSymbol = c.resolveTypeReferenceName(node, ast.SymbolFlagsType, false /*ignoreErrors*/)
 	}
 	return links.resolvedSymbol
 }
@@ -28116,15 +28141,12 @@ func (c *Checker) markLinkedReferences(location *ast.Node, hint ReferenceHint, p
 				!ast.IsAssignmentTarget(parent.Parent) {
 				return
 			}
-			res := ast.FindManyAncestors(location, ast.IsMetaProperty, ast.IsDecorator, ast.IsYieldExpression, ast.IsForInOrOfStatement, ast.IsComputedPropertyName, ast.IsHeritageClause, ast.IsExportAssignment, ast.IsReturnStatement)
+			res := ast.FindManyAncestors(location, ast.IsMetaProperty, ast.IsDecorator, ast.IsForInOrOfStatement, ast.IsComputedPropertyName, ast.IsHeritageClause)
 			metaProperty := res[0]
 			decorator := res[1]
-			yieldExpr := res[2]
-			forNode := res[3]
-			computedName := res[4]
-			heritageClause := res[5]
-			exportAssignment := res[6]
-			returnStatement := res[7]
+			forNode := res[2]
+			computedName := res[3]
+			heritageClause := res[4]
 			if metaProperty != nil {
 				return // identifiers in meta properties shouldn't be resolved, but are expressions, so must be filtered
 			}
@@ -28135,16 +28157,6 @@ func (c *Checker) markLinkedReferences(location *ast.Node, hint ReferenceHint, p
 				// decorator expressions must still be resolved and marked for emit.
 				decorated := decorator.Parent
 				if decorated != nil && !ast.NodeCanBeDecorated(c.legacyDecorators, decorated, decorated.Parent, decorated.Parent.Parent) {
-					return
-				}
-			}
-			// The operand of a 'yield' expression is only checked when the containing function is a
-			// generator. Outside a generator (or outside any function), checkYieldExpression returns
-			// early and never checks the operand, so resolving identifiers in it here would report a
-			// spurious "Cannot find name" diagnostic.
-			if yieldExpr != nil {
-				fn := ast.GetContainingFunction(yieldExpr)
-				if fn == nil || ast.GetFunctionFlags(fn)&ast.FunctionFlagsGenerator == 0 {
 					return
 				}
 			}
@@ -28186,21 +28198,6 @@ func (c *Checker) markLinkedReferences(location *ast.Node, hint ReferenceHint, p
 						location != firstExtends && !ast.IsNodeDescendantOf(location, firstExtends) {
 						return
 					}
-				}
-			}
-			// An `export =` / `export default` inside a namespace/module block is a grammar error;
-			// checkExportAssignment reports it and returns without resolving the expression, so
-			// resolving identifiers in it here would report a spurious "Cannot find name" diagnostic.
-			if exportAssignment != nil && isContainedByNamespace(exportAssignment) {
-				return
-			}
-			// A `return` statement outside of any function body (or inside a class static block) is a
-			// grammar error; checkReturnStatement reports it and returns without checking the return
-			// expression, so resolving identifiers in it here would report a spurious diagnostic.
-			if returnStatement != nil {
-				container := getContainingFunctionOrClassStaticBlock(returnStatement)
-				if container == nil || ast.IsClassStaticBlockDeclaration(container) {
-					return
 				}
 			}
 			// Identifiers in expression contexts are emitted, so we need to follow their referenced aliases and mark them as used

--- a/internal/checker/utilities.go
+++ b/internal/checker/utilities.go
@@ -129,6 +129,29 @@ func isConstTypeReference(node *ast.Node) bool {
 	return ast.IsTypeReferenceNode(node) && len(node.TypeArguments()) == 0 && ast.IsIdentifier(node.AsTypeReferenceNode().TypeName) && node.AsTypeReferenceNode().TypeName.Text() == "const"
 }
 
+// isConstTypeReferenceName reports whether node is the `const` type name of a `const`
+// assertion (`x as const` / `<const>x`), which must not be resolved as a real name.
+func isConstTypeReferenceName(node *ast.Node) bool {
+	return node != nil && ast.IsIdentifier(node) &&
+		node.Parent != nil && isConstTypeReference(node.Parent) &&
+		node.Parent.Parent != nil && ast.IsAssertionExpression(node.Parent.Parent)
+}
+
+// isExportAssignmentExpressionName reports whether node is (the root entity name of) the
+// expression of an `export =` / `export default` assignment. Referencing a namespace or
+// type-only name there is legal, and checkExportAssignment decides whether it is an error,
+// so checkIdentifier must not report a value-usage error for it.
+func isExportAssignmentExpressionName(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	current := node
+	for current.Parent != nil && ast.IsPropertyAccessOrQualifiedName(current.Parent) {
+		current = current.Parent
+	}
+	return current.Parent != nil && ast.IsExportAssignment(current.Parent) && current.Parent.Expression() == current
+}
+
 func GetSingleVariableOfVariableStatement(node *ast.Node) *ast.Node {
 	if !ast.IsVariableStatement(node) {
 		return nil

--- a/internal/testutil/tsbaseline/error_baseline.go
+++ b/internal/testutil/tsbaseline/error_baseline.go
@@ -41,6 +41,11 @@ func DoErrorBaseline(t *testing.T, baselinePath string, inputFiles []*harnessuti
 		errorBaseline = baseline.NoContent
 	}
 	baseline.Run(t, baselinePath, errorBaseline, opts)
+	if core.Some(errors, func(d *ast.Diagnostic) bool {
+		return d.Code() == -1
+	}) {
+		t.Fatalf("Found diagnostic with code -1, which is used to log critical assertion violations in the baseline. Inspect and fix those failures.")
+	}
 }
 
 func minimalDiagnosticsToString(diagnostics []diagnosticwriter.Diagnostic, pretty bool) string {

--- a/testdata/baselines/reference/compiler/checkChildrenAlwaysChecked.errors.txt
+++ b/testdata/baselines/reference/compiler/checkChildrenAlwaysChecked.errors.txt
@@ -1,0 +1,40 @@
+exportAssignmentInNamespace.ts(3,5): error TS1063: An export assignment cannot be used in a namespace.
+exportAssignmentInNamespace.ts(3,14): error TS2304: Cannot find name 'exportOperandName'.
+returnInStaticBlock.ts(4,9): error TS18041: A 'return' statement cannot be used inside a class static block.
+returnInStaticBlock.ts(4,16): error TS2304: Cannot find name 'returnOperandName'.
+yieldOutsideGenerator.ts(3,5): error TS1163: A 'yield' expression is only allowed in a generator body.
+yieldOutsideGenerator.ts(3,11): error TS2304: Cannot find name 'yieldOperandName'.
+
+
+==== yieldOutsideGenerator.ts (2 errors) ====
+    function notAGenerator() {
+        // The operand is now checked even though the yield is not in a generator.
+        yield yieldOperandName;
+        ~~~~~
+!!! error TS1163: A 'yield' expression is only allowed in a generator body.
+              ~~~~~~~~~~~~~~~~
+!!! error TS2304: Cannot find name 'yieldOperandName'.
+    }
+    
+==== returnInStaticBlock.ts (2 errors) ====
+    class C {
+        static {
+            // The expression is now checked even though `return` is illegal here.
+            return returnOperandName;
+            ~~~~~~
+!!! error TS18041: A 'return' statement cannot be used inside a class static block.
+                   ~~~~~~~~~~~~~~~~~
+!!! error TS2304: Cannot find name 'returnOperandName'.
+        }
+    }
+    
+==== exportAssignmentInNamespace.ts (2 errors) ====
+    namespace N {
+        // The expression is now checked even though `export =` is illegal here.
+        export = exportOperandName;
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1063: An export assignment cannot be used in a namespace.
+                 ~~~~~~~~~~~~~~~~~
+!!! error TS2304: Cannot find name 'exportOperandName'.
+    }
+    

--- a/testdata/baselines/reference/compiler/checkChildrenAlwaysChecked.symbols
+++ b/testdata/baselines/reference/compiler/checkChildrenAlwaysChecked.symbols
@@ -1,0 +1,28 @@
+//// [tests/cases/compiler/checkChildrenAlwaysChecked.ts] ////
+
+=== yieldOutsideGenerator.ts ===
+function notAGenerator() {
+>notAGenerator : Symbol(notAGenerator, Decl(yieldOutsideGenerator.ts, 0, 0))
+
+    // The operand is now checked even though the yield is not in a generator.
+    yield yieldOperandName;
+}
+
+=== returnInStaticBlock.ts ===
+class C {
+>C : Symbol(C, Decl(returnInStaticBlock.ts, 0, 0))
+
+    static {
+        // The expression is now checked even though `return` is illegal here.
+        return returnOperandName;
+    }
+}
+
+=== exportAssignmentInNamespace.ts ===
+namespace N {
+>N : Symbol(N, Decl(exportAssignmentInNamespace.ts, 0, 0))
+
+    // The expression is now checked even though `export =` is illegal here.
+    export = exportOperandName;
+}
+

--- a/testdata/baselines/reference/compiler/checkChildrenAlwaysChecked.types
+++ b/testdata/baselines/reference/compiler/checkChildrenAlwaysChecked.types
@@ -1,0 +1,32 @@
+//// [tests/cases/compiler/checkChildrenAlwaysChecked.ts] ////
+
+=== yieldOutsideGenerator.ts ===
+function notAGenerator() {
+>notAGenerator : () => void
+
+    // The operand is now checked even though the yield is not in a generator.
+    yield yieldOperandName;
+>yield yieldOperandName : any
+>yieldOperandName : any
+}
+
+=== returnInStaticBlock.ts ===
+class C {
+>C : C
+
+    static {
+        // The expression is now checked even though `return` is illegal here.
+        return returnOperandName;
+>returnOperandName : any
+    }
+}
+
+=== exportAssignmentInNamespace.ts ===
+namespace N {
+>N : typeof N
+
+    // The expression is now checked even though `export =` is illegal here.
+    export = exportOperandName;
+>exportOperandName : any
+}
+

--- a/testdata/baselines/reference/submodule/compiler/constructorWithIncompleteTypeAnnotation.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/constructorWithIncompleteTypeAnnotation.errors.txt
@@ -1,4 +1,3 @@
-error TS-1: Pre-emit (93) and post-emit (94) diagnostic counts do not match! This can indicate that a semantic _error_ was added by the emit resolver - such an error may not be reflected on the command line or in the editor, but may be captured in a baseline here!
 constructorWithIncompleteTypeAnnotation.ts(11,13): error TS2503: Cannot find namespace 'module'.
 constructorWithIncompleteTypeAnnotation.ts(11,13): error TS2591: Cannot find name 'module'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
 constructorWithIncompleteTypeAnnotation.ts(11,19): error TS1005: ';' expected.
@@ -60,9 +59,11 @@ constructorWithIncompleteTypeAnnotation.ts(235,24): error TS2552: Cannot find na
 constructorWithIncompleteTypeAnnotation.ts(235,27): error TS1005: ',' expected.
 constructorWithIncompleteTypeAnnotation.ts(235,28): error TS2693: 'number' only refers to a type, but is being used as a value here.
 constructorWithIncompleteTypeAnnotation.ts(235,36): error TS1005: ';' expected.
+constructorWithIncompleteTypeAnnotation.ts(236,20): error TS2552: Cannot find name 'val'. Did you mean 'eval'?
 constructorWithIncompleteTypeAnnotation.ts(238,9): error TS1128: Declaration or statement expected.
 constructorWithIncompleteTypeAnnotation.ts(238,16): error TS2304: Cannot find name 'method2'.
 constructorWithIncompleteTypeAnnotation.ts(238,26): error TS1005: ';' expected.
+constructorWithIncompleteTypeAnnotation.ts(239,29): error TS7017: Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.
 constructorWithIncompleteTypeAnnotation.ts(241,5): error TS1128: Declaration or statement expected.
 constructorWithIncompleteTypeAnnotation.ts(246,25): error TS2551: Property 'method1' does not exist on type 'B'. Did you mean 'method2'?
 constructorWithIncompleteTypeAnnotation.ts(254,9): error TS2390: Constructor implementation is missing.
@@ -94,10 +95,7 @@ constructorWithIncompleteTypeAnnotation.ts(259,55): error TS1005: ';' expected.
 constructorWithIncompleteTypeAnnotation.ts(261,1): error TS1128: Declaration or statement expected.
 
 
-!!! error TS-1: Pre-emit (93) and post-emit (94) diagnostic counts do not match! This can indicate that a semantic _error_ was added by the emit resolver - such an error may not be reflected on the command line or in the editor, but may be captured in a baseline here!
-!!! related TS-1: The excess diagnostics are:
-!!! related TS7017 constructorWithIncompleteTypeAnnotation.ts:239:29: Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.
-==== constructorWithIncompleteTypeAnnotation.ts (93 errors) ====
+==== constructorWithIncompleteTypeAnnotation.ts (95 errors) ====
     declare module "fs" {
         export class File {
             constructor(filename: string);
@@ -461,6 +459,9 @@ constructorWithIncompleteTypeAnnotation.ts(261,1): error TS1128: Declaration or 
                                        ~
 !!! error TS1005: ';' expected.
                 return val;
+                       ~~~
+!!! error TS2552: Cannot find name 'val'. Did you mean 'eval'?
+!!! related TS2728 lib.es5.d.ts:--:--: 'eval' is declared here.
             }
             public method2() {
             ~~~~~~
@@ -470,6 +471,8 @@ constructorWithIncompleteTypeAnnotation.ts(261,1): error TS1128: Declaration or 
                              ~
 !!! error TS1005: ';' expected.
                 return 2 * this.method1(2);
+                                ~~~~~~~
+!!! error TS7017: Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.
             }
         }
         ~

--- a/testdata/baselines/reference/submodule/compiler/multiLinePropertyAccessAndArrowFunctionIndent1.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/multiLinePropertyAccessAndArrowFunctionIndent1.errors.txt
@@ -1,18 +1,23 @@
-error TS-1: Pre-emit (1) and post-emit (5) diagnostic counts do not match! This can indicate that a semantic _error_ was added by the emit resolver - such an error may not be reflected on the command line or in the editor, but may be captured in a baseline here!
 multiLinePropertyAccessAndArrowFunctionIndent1.ts(1,1): error TS1108: A 'return' statement can only be used within a function body.
+multiLinePropertyAccessAndArrowFunctionIndent1.ts(1,18): error TS2304: Cannot find name 'role'.
+multiLinePropertyAccessAndArrowFunctionIndent1.ts(2,18): error TS2304: Cannot find name 'Role'.
+multiLinePropertyAccessAndArrowFunctionIndent1.ts(4,26): error TS2503: Cannot find namespace 'ng'.
+multiLinePropertyAccessAndArrowFunctionIndent1.ts(4,53): error TS2304: Cannot find name 'Role'.
 
 
-!!! error TS-1: Pre-emit (1) and post-emit (5) diagnostic counts do not match! This can indicate that a semantic _error_ was added by the emit resolver - such an error may not be reflected on the command line or in the editor, but may be captured in a baseline here!
-!!! related TS-1: The excess diagnostics are:
-!!! related TS2304 multiLinePropertyAccessAndArrowFunctionIndent1.ts:1:18: Cannot find name 'role'.
-!!! related TS2304 multiLinePropertyAccessAndArrowFunctionIndent1.ts:2:18: Cannot find name 'Role'.
-!!! related TS2503 multiLinePropertyAccessAndArrowFunctionIndent1.ts:4:26: Cannot find namespace 'ng'.
-!!! related TS2304 multiLinePropertyAccessAndArrowFunctionIndent1.ts:4:53: Cannot find name 'Role'.
-==== multiLinePropertyAccessAndArrowFunctionIndent1.ts (1 errors) ====
+==== multiLinePropertyAccessAndArrowFunctionIndent1.ts (5 errors) ====
     return this.edit(role)
     ~~~~~~
 !!! error TS1108: A 'return' statement can only be used within a function body.
+                     ~~~~
+!!! error TS2304: Cannot find name 'role'.
         .then((role: Role) =>
+                     ~~~~
+!!! error TS2304: Cannot find name 'Role'.
             this.roleService.add(role)
                 .then((data: ng.IHttpPromiseCallbackArg<Role>) => data.data));
+                             ~~
+!!! error TS2503: Cannot find namespace 'ng'.
+                                                        ~~~~
+!!! error TS2304: Cannot find name 'Role'.
     

--- a/testdata/baselines/reference/submodule/compiler/parseErrorIncorrectReturnToken.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/parseErrorIncorrectReturnToken.errors.txt
@@ -1,17 +1,14 @@
-error TS-1: Pre-emit (7) and post-emit (8) diagnostic counts do not match! This can indicate that a semantic _error_ was added by the emit resolver - such an error may not be reflected on the command line or in the editor, but may be captured in a baseline here!
 parseErrorIncorrectReturnToken.ts(2,17): error TS1005: ':' expected.
 parseErrorIncorrectReturnToken.ts(4,22): error TS1005: '=>' expected.
 parseErrorIncorrectReturnToken.ts(4,24): error TS2693: 'string' only refers to a type, but is being used as a value here.
 parseErrorIncorrectReturnToken.ts(9,18): error TS1005: '{' expected.
 parseErrorIncorrectReturnToken.ts(9,21): error TS1434: Unexpected keyword or identifier.
 parseErrorIncorrectReturnToken.ts(9,21): error TS2693: 'string' only refers to a type, but is being used as a value here.
+parseErrorIncorrectReturnToken.ts(10,16): error TS2304: Cannot find name 'n'.
 parseErrorIncorrectReturnToken.ts(12,1): error TS1128: Declaration or statement expected.
 
 
-!!! error TS-1: Pre-emit (7) and post-emit (8) diagnostic counts do not match! This can indicate that a semantic _error_ was added by the emit resolver - such an error may not be reflected on the command line or in the editor, but may be captured in a baseline here!
-!!! related TS-1: The excess diagnostics are:
-!!! related TS2304 parseErrorIncorrectReturnToken.ts:10:16: Cannot find name 'n'.
-==== parseErrorIncorrectReturnToken.ts (7 errors) ====
+==== parseErrorIncorrectReturnToken.ts (8 errors) ====
     type F1 = {
         (n: number) => string; // should be : not =>
                     ~~
@@ -34,6 +31,8 @@ parseErrorIncorrectReturnToken.ts(12,1): error TS1128: Declaration or statement 
                         ~~~~~~
 !!! error TS2693: 'string' only refers to a type, but is being used as a value here.
             return n.toString();
+                   ~
+!!! error TS2304: Cannot find name 'n'.
         }
     };
     ~

--- a/testdata/baselines/reference/submodule/compiler/reachabilityChecksNoCrash1.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/reachabilityChecksNoCrash1.errors.txt
@@ -32,10 +32,11 @@ reachabilityChecksNoCrash1.ts(4,9): error TS18004: No value exists in scope for 
 reachabilityChecksNoCrash1.ts(4,12): error TS1005: ',' expected.
 reachabilityChecksNoCrash1.ts(4,24): error TS2304: Cannot find name 'v'.
 reachabilityChecksNoCrash1.ts(4,26): error TS1005: ',' expected.
+reachabilityChecksNoCrash1.ts(6,12): error TS2304: Cannot find name 'out'.
 reachabilityChecksNoCrash1.ts(7,1): error TS1109: Expression expected.
 
 
-==== reachabilityChecksNoCrash1.ts (35 errors) ====
+==== reachabilityChecksNoCrash1.ts (36 errors) ====
     export async function arrayFromAsync<T>(asyncIterable!: AsyncIterable<T>): Promise<T[]> {
                           ~~~~~~~~~~~~~~
 !!! error TS7010: 'arrayFromAsync', which lacks return-type annotation, implicitly has an 'any' return type.
@@ -114,6 +115,8 @@ reachabilityChecksNoCrash1.ts(7,1): error TS1109: Expression expected.
     ~~~~~
 !!! error TS2365: Operator '>' cannot be applied to types 'boolean' and '{ const: never[]; for: any; of: any; asyncIterable: any; out: any; "": any; }'.
         return out;
+               ~~~
+!!! error TS2304: Cannot find name 'out'.
     }
     ~
 !!! error TS1109: Expression expected.

--- a/testdata/baselines/reference/submodule/conformance/YieldExpression12_es6.errors.txt
+++ b/testdata/baselines/reference/submodule/conformance/YieldExpression12_es6.errors.txt
@@ -1,11 +1,14 @@
 YieldExpression12_es6.ts(3,6): error TS1163: A 'yield' expression is only allowed in a generator body.
+YieldExpression12_es6.ts(3,12): error TS2304: Cannot find name 'foo'.
 
 
-==== YieldExpression12_es6.ts (1 errors) ====
+==== YieldExpression12_es6.ts (2 errors) ====
     class C {
       constructor() {
          yield foo
          ~~~~~
 !!! error TS1163: A 'yield' expression is only allowed in a generator body.
+               ~~~
+!!! error TS2304: Cannot find name 'foo'.
       }
     }

--- a/testdata/baselines/reference/submodule/conformance/YieldExpression14_es6.errors.txt
+++ b/testdata/baselines/reference/submodule/conformance/YieldExpression14_es6.errors.txt
@@ -1,11 +1,14 @@
 YieldExpression14_es6.ts(3,6): error TS1163: A 'yield' expression is only allowed in a generator body.
+YieldExpression14_es6.ts(3,12): error TS2663: Cannot find name 'foo'. Did you mean the instance member 'this.foo'?
 
 
-==== YieldExpression14_es6.ts (1 errors) ====
+==== YieldExpression14_es6.ts (2 errors) ====
     class C {
       foo() {
          yield foo
          ~~~~~
 !!! error TS1163: A 'yield' expression is only allowed in a generator body.
+               ~~~
+!!! error TS2663: Cannot find name 'foo'. Did you mean the instance member 'this.foo'?
       }
     }

--- a/testdata/baselines/reference/submodule/conformance/YieldExpression15_es6.errors.txt
+++ b/testdata/baselines/reference/submodule/conformance/YieldExpression15_es6.errors.txt
@@ -1,9 +1,12 @@
 YieldExpression15_es6.ts(2,6): error TS1163: A 'yield' expression is only allowed in a generator body.
+YieldExpression15_es6.ts(2,12): error TS2304: Cannot find name 'foo'.
 
 
-==== YieldExpression15_es6.ts (1 errors) ====
+==== YieldExpression15_es6.ts (2 errors) ====
     var v = () => {
          yield foo
          ~~~~~
 !!! error TS1163: A 'yield' expression is only allowed in a generator body.
+               ~~~
+!!! error TS2304: Cannot find name 'foo'.
       }

--- a/testdata/baselines/reference/submodule/conformance/YieldExpression17_es6.errors.txt
+++ b/testdata/baselines/reference/submodule/conformance/YieldExpression17_es6.errors.txt
@@ -1,10 +1,13 @@
 YieldExpression17_es6.ts(1,15): error TS2378: A 'get' accessor must return a value.
 YieldExpression17_es6.ts(1,23): error TS1163: A 'yield' expression is only allowed in a generator body.
+YieldExpression17_es6.ts(1,29): error TS2304: Cannot find name 'foo'.
 
 
-==== YieldExpression17_es6.ts (2 errors) ====
+==== YieldExpression17_es6.ts (3 errors) ====
     var v = { get foo() { yield foo; } }
                   ~~~
 !!! error TS2378: A 'get' accessor must return a value.
                           ~~~~~
 !!! error TS1163: A 'yield' expression is only allowed in a generator body.
+                                ~~~
+!!! error TS2304: Cannot find name 'foo'.

--- a/testdata/baselines/reference/submodule/conformance/YieldExpression2_es6.errors.txt
+++ b/testdata/baselines/reference/submodule/conformance/YieldExpression2_es6.errors.txt
@@ -1,7 +1,10 @@
 YieldExpression2_es6.ts(1,1): error TS1163: A 'yield' expression is only allowed in a generator body.
+YieldExpression2_es6.ts(1,7): error TS2304: Cannot find name 'foo'.
 
 
-==== YieldExpression2_es6.ts (1 errors) ====
+==== YieldExpression2_es6.ts (2 errors) ====
     yield foo;
     ~~~~~
 !!! error TS1163: A 'yield' expression is only allowed in a generator body.
+          ~~~
+!!! error TS2304: Cannot find name 'foo'.

--- a/testdata/baselines/reference/submodule/conformance/jsdocDisallowedInTypescript.errors.txt
+++ b/testdata/baselines/reference/submodule/conformance/jsdocDisallowedInTypescript.errors.txt
@@ -7,12 +7,14 @@ jsdocDisallowedInTypescript.ts(7,34): error TS2695: Left side of comma operator 
 jsdocDisallowedInTypescript.ts(7,42): error TS2693: 'string' only refers to a type, but is being used as a value here.
 jsdocDisallowedInTypescript.ts(7,48): error TS1005: ';' expected.
 jsdocDisallowedInTypescript.ts(7,49): error TS1128: Declaration or statement expected.
+jsdocDisallowedInTypescript.ts(8,16): error TS2304: Cannot find name 'ctor'.
 jsdocDisallowedInTypescript.ts(10,10): error TS7010: 'hof2', which lacks return-type annotation, implicitly has an 'any' return type.
 jsdocDisallowedInTypescript.ts(10,18): error TS2552: Cannot find name 'function'. Did you mean 'Function'?
 jsdocDisallowedInTypescript.ts(10,26): error TS1005: ',' expected.
 jsdocDisallowedInTypescript.ts(10,27): error TS2730: An arrow function cannot have a 'this' parameter.
 jsdocDisallowedInTypescript.ts(10,41): error TS7006: Parameter 'string' implicitly has an 'any' type.
 jsdocDisallowedInTypescript.ts(10,56): error TS1005: '=>' expected.
+jsdocDisallowedInTypescript.ts(11,18): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number[]'.
 jsdocDisallowedInTypescript.ts(14,13): error TS1110: Type expected.
 jsdocDisallowedInTypescript.ts(15,8): error TS2552: Cannot find name 'function'. Did you mean 'Function'?
 jsdocDisallowedInTypescript.ts(15,16): error TS1005: ',' expected.
@@ -26,7 +28,7 @@ jsdocDisallowedInTypescript.ts(15,46): error TS7006: Parameter 'm' implicitly ha
 jsdocDisallowedInTypescript.ts(18,5): error TS2322: Type 'undefined' is not assignable to type 'number | null'.
 
 
-==== jsdocDisallowedInTypescript.ts (26 errors) ====
+==== jsdocDisallowedInTypescript.ts (28 errors) ====
     // grammar error from checker
     var ara: Array.<number> = [1,2,3];
     
@@ -54,6 +56,8 @@ jsdocDisallowedInTypescript.ts(18,5): error TS2322: Type 'undefined' is not assi
                                                     ~
 !!! error TS1128: Declaration or statement expected.
         return new ctor('hi');
+                   ~~~~
+!!! error TS2304: Cannot find name 'ctor'.
     }
     function hof2(f: function(this: number, string): string) {
              ~~~~
@@ -70,6 +74,8 @@ jsdocDisallowedInTypescript.ts(18,5): error TS2322: Type 'undefined' is not assi
                                                            ~
 !!! error TS1005: '=>' expected.
         return f(12, 'hullo');
+                     ~~~~~~~
+!!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'number[]'.
     }
     var whatevs: * = 1001;
     var ques: ? = 'what';

--- a/testdata/baselines/reference/submodule/conformance/parserErrorRecovery_ModuleElement1.errors.txt
+++ b/testdata/baselines/reference/submodule/conformance/parserErrorRecovery_ModuleElement1.errors.txt
@@ -1,13 +1,19 @@
+parserErrorRecovery_ModuleElement1.ts(1,8): error TS2304: Cannot find name 'foo'.
 parserErrorRecovery_ModuleElement1.ts(2,1): error TS1128: Declaration or statement expected.
+parserErrorRecovery_ModuleElement1.ts(3,8): error TS2304: Cannot find name 'bar'.
 parserErrorRecovery_ModuleElement1.ts(4,1): error TS1128: Declaration or statement expected.
 
 
-==== parserErrorRecovery_ModuleElement1.ts (2 errors) ====
+==== parserErrorRecovery_ModuleElement1.ts (4 errors) ====
     return foo;
+           ~~~
+!!! error TS2304: Cannot find name 'foo'.
     }
     ~
 !!! error TS1128: Declaration or statement expected.
     return bar;
+           ~~~
+!!! error TS2304: Cannot find name 'bar'.
     }
     ~
 !!! error TS1128: Declaration or statement expected.

--- a/testdata/baselines/reference/submodule/conformance/parserExportAssignment5.errors.txt
+++ b/testdata/baselines/reference/submodule/conformance/parserExportAssignment5.errors.txt
@@ -1,9 +1,12 @@
 parserExportAssignment5.ts(2,5): error TS1063: An export assignment cannot be used in a namespace.
+parserExportAssignment5.ts(2,14): error TS2304: Cannot find name 'A'.
 
 
-==== parserExportAssignment5.ts (1 errors) ====
+==== parserExportAssignment5.ts (2 errors) ====
     namespace M {
         export = A;
         ~~~~~~~~~~~
 !!! error TS1063: An export assignment cannot be used in a namespace.
+                 ~
+!!! error TS2304: Cannot find name 'A'.
     }

--- a/testdata/baselines/reference/submodule/conformance/parserExportAssignment9.errors.txt
+++ b/testdata/baselines/reference/submodule/conformance/parserExportAssignment9.errors.txt
@@ -1,16 +1,24 @@
 parserExportAssignment9.ts(2,3): error TS1319: A default export can only be used in an ECMAScript-style module.
+parserExportAssignment9.ts(2,18): error TS2552: Cannot find name 'foo'. Did you mean 'Foo'?
 parserExportAssignment9.ts(6,3): error TS1319: A default export can only be used in an ECMAScript-style module.
+parserExportAssignment9.ts(6,18): error TS2552: Cannot find name 'bar'. Did you mean 'Bar'?
 
 
-==== parserExportAssignment9.ts (2 errors) ====
+==== parserExportAssignment9.ts (4 errors) ====
     namespace Foo {
       export default foo;
       ~~~~~~~~~~~~~~~~~~~
 !!! error TS1319: A default export can only be used in an ECMAScript-style module.
+                     ~~~
+!!! error TS2552: Cannot find name 'foo'. Did you mean 'Foo'?
+!!! related TS2728 parserExportAssignment9.ts:1:11: 'Foo' is declared here.
     }
     
     namespace Bar {
       export default bar;
       ~~~~~~~~~~~~~~~~~~~
 !!! error TS1319: A default export can only be used in an ECMAScript-style module.
+                     ~~~
+!!! error TS2552: Cannot find name 'bar'. Did you mean 'Bar'?
+!!! related TS2728 parserExportAssignment9.ts:5:11: 'Bar' is declared here.
     }

--- a/testdata/baselines/reference/submodule/conformance/parserStatementIsNotAMemberVariableDeclaration1(alwaysstrict=true).errors.txt
+++ b/testdata/baselines/reference/submodule/conformance/parserStatementIsNotAMemberVariableDeclaration1(alwaysstrict=true).errors.txt
@@ -1,12 +1,9 @@
-error TS-1: Pre-emit (2) and post-emit (3) diagnostic counts do not match! This can indicate that a semantic _error_ was added by the emit resolver - such an error may not be reflected on the command line or in the editor, but may be captured in a baseline here!
 parserStatementIsNotAMemberVariableDeclaration1.ts(1,1): error TS1108: A 'return' statement can only be used within a function body.
 parserStatementIsNotAMemberVariableDeclaration1.ts(6,5): error TS1212: Identifier expected. 'private' is a reserved word in strict mode.
+parserStatementIsNotAMemberVariableDeclaration1.ts(6,5): error TS2304: Cannot find name 'private'.
 
 
-!!! error TS-1: Pre-emit (2) and post-emit (3) diagnostic counts do not match! This can indicate that a semantic _error_ was added by the emit resolver - such an error may not be reflected on the command line or in the editor, but may be captured in a baseline here!
-!!! related TS-1: The excess diagnostics are:
-!!! related TS2304 parserStatementIsNotAMemberVariableDeclaration1.ts:6:5: Cannot find name 'private'.
-==== parserStatementIsNotAMemberVariableDeclaration1.ts (2 errors) ====
+==== parserStatementIsNotAMemberVariableDeclaration1.ts (3 errors) ====
     return {
     ~~~~~~
 !!! error TS1108: A 'return' statement can only be used within a function body.
@@ -17,6 +14,8 @@ parserStatementIsNotAMemberVariableDeclaration1.ts(6,5): error TS1212: Identifie
         private[key] = value;
         ~~~~~~~
 !!! error TS1212: Identifier expected. 'private' is a reserved word in strict mode.
+        ~~~~~~~
+!!! error TS2304: Cannot find name 'private'.
     
       }
     

--- a/testdata/baselines/reference/submoduleAccepted/compiler/constructorWithIncompleteTypeAnnotation.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/constructorWithIncompleteTypeAnnotation.errors.txt.diff
@@ -1,6 +1,11 @@
 --- old.constructorWithIncompleteTypeAnnotation.errors.txt
 +++ new.constructorWithIncompleteTypeAnnotation.errors.txt
-@@= skipped -42, +42 lines =@@
+@@= skipped -0, +0 lines =@@
+-error TS-1: Pre-emit (93) and post-emit (94) diagnostic counts do not match! This can indicate that a semantic _error_ was added by the emit resolver - such an error may not be reflected on the command line or in the editor, but may be captured in a baseline here!
+ constructorWithIncompleteTypeAnnotation.ts(11,13): error TS2503: Cannot find namespace 'module'.
+ constructorWithIncompleteTypeAnnotation.ts(11,13): error TS2591: Cannot find name 'module'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
+ constructorWithIncompleteTypeAnnotation.ts(11,19): error TS1005: ';' expected.
+@@= skipped -42, +41 lines =@@
  constructorWithIncompleteTypeAnnotation.ts(159,30): error TS1005: '{' expected.
  constructorWithIncompleteTypeAnnotation.ts(159,31): error TS2304: Cannot find name 'Property'.
  constructorWithIncompleteTypeAnnotation.ts(166,13): error TS2365: Operator '+=' cannot be applied to types 'number' and 'void'.
@@ -18,7 +23,27 @@
  constructorWithIncompleteTypeAnnotation.ts(235,27): error TS1005: ',' expected.
  constructorWithIncompleteTypeAnnotation.ts(235,28): error TS2693: 'number' only refers to a type, but is being used as a value here.
  constructorWithIncompleteTypeAnnotation.ts(235,36): error TS1005: ';' expected.
-@@= skipped -176, +176 lines =@@
++constructorWithIncompleteTypeAnnotation.ts(236,20): error TS2552: Cannot find name 'val'. Did you mean 'eval'?
+ constructorWithIncompleteTypeAnnotation.ts(238,9): error TS1128: Declaration or statement expected.
+ constructorWithIncompleteTypeAnnotation.ts(238,16): error TS2304: Cannot find name 'method2'.
+ constructorWithIncompleteTypeAnnotation.ts(238,26): error TS1005: ';' expected.
++constructorWithIncompleteTypeAnnotation.ts(239,29): error TS7017: Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.
+ constructorWithIncompleteTypeAnnotation.ts(241,5): error TS1128: Declaration or statement expected.
+ constructorWithIncompleteTypeAnnotation.ts(246,25): error TS2551: Property 'method1' does not exist on type 'B'. Did you mean 'method2'?
+ constructorWithIncompleteTypeAnnotation.ts(254,9): error TS2390: Constructor implementation is missing.
+@@= skipped -38, +40 lines =@@
+ constructorWithIncompleteTypeAnnotation.ts(261,1): error TS1128: Declaration or statement expected.
+
+
+-!!! error TS-1: Pre-emit (93) and post-emit (94) diagnostic counts do not match! This can indicate that a semantic _error_ was added by the emit resolver - such an error may not be reflected on the command line or in the editor, but may be captured in a baseline here!
+-!!! related TS-1: The excess diagnostics are:
+-!!! related TS7017 constructorWithIncompleteTypeAnnotation.ts:239:29: Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.
+-==== constructorWithIncompleteTypeAnnotation.ts (93 errors) ====
++==== constructorWithIncompleteTypeAnnotation.ts (95 errors) ====
+     declare module "fs" {
+         export class File {
+             constructor(filename: string);
+@@= skipped -138, +135 lines =@@
                  var undef = undefined;
      
                  var  _\uD4A5\u7204\uC316\uE59F  = local;
@@ -46,3 +71,22 @@
                                ~
  !!! error TS1005: ',' expected.
                                 ~~~~~~
+@@= skipped -8, +9 lines =@@
+                                        ~
+ !!! error TS1005: ';' expected.
+                 return val;
++                       ~~~
++!!! error TS2552: Cannot find name 'val'. Did you mean 'eval'?
++!!! related TS2728 lib.es5.d.ts:--:--: 'eval' is declared here.
+             }
+             public method2() {
+             ~~~~~~
+@@= skipped -9, +12 lines =@@
+                              ~
+ !!! error TS1005: ';' expected.
+                 return 2 * this.method1(2);
++                                ~~~~~~~
++!!! error TS7017: Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.
+             }
+         }
+         ~

--- a/testdata/baselines/reference/submoduleAccepted/compiler/multiLinePropertyAccessAndArrowFunctionIndent1.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/multiLinePropertyAccessAndArrowFunctionIndent1.errors.txt.diff
@@ -1,0 +1,36 @@
+--- old.multiLinePropertyAccessAndArrowFunctionIndent1.errors.txt
++++ new.multiLinePropertyAccessAndArrowFunctionIndent1.errors.txt
+@@= skipped -0, +0 lines =@@
+-error TS-1: Pre-emit (1) and post-emit (5) diagnostic counts do not match! This can indicate that a semantic _error_ was added by the emit resolver - such an error may not be reflected on the command line or in the editor, but may be captured in a baseline here!
+ multiLinePropertyAccessAndArrowFunctionIndent1.ts(1,1): error TS1108: A 'return' statement can only be used within a function body.
+-
+-
+-!!! error TS-1: Pre-emit (1) and post-emit (5) diagnostic counts do not match! This can indicate that a semantic _error_ was added by the emit resolver - such an error may not be reflected on the command line or in the editor, but may be captured in a baseline here!
+-!!! related TS-1: The excess diagnostics are:
+-!!! related TS2304 multiLinePropertyAccessAndArrowFunctionIndent1.ts:1:18: Cannot find name 'role'.
+-!!! related TS2304 multiLinePropertyAccessAndArrowFunctionIndent1.ts:2:18: Cannot find name 'Role'.
+-!!! related TS2503 multiLinePropertyAccessAndArrowFunctionIndent1.ts:4:26: Cannot find namespace 'ng'.
+-!!! related TS2304 multiLinePropertyAccessAndArrowFunctionIndent1.ts:4:53: Cannot find name 'Role'.
+-==== multiLinePropertyAccessAndArrowFunctionIndent1.ts (1 errors) ====
++multiLinePropertyAccessAndArrowFunctionIndent1.ts(1,18): error TS2304: Cannot find name 'role'.
++multiLinePropertyAccessAndArrowFunctionIndent1.ts(2,18): error TS2304: Cannot find name 'Role'.
++multiLinePropertyAccessAndArrowFunctionIndent1.ts(4,26): error TS2503: Cannot find namespace 'ng'.
++multiLinePropertyAccessAndArrowFunctionIndent1.ts(4,53): error TS2304: Cannot find name 'Role'.
++
++
++==== multiLinePropertyAccessAndArrowFunctionIndent1.ts (5 errors) ====
+     return this.edit(role)
+     ~~~~~~
+ !!! error TS1108: A 'return' statement can only be used within a function body.
++                     ~~~~
++!!! error TS2304: Cannot find name 'role'.
+         .then((role: Role) =>
++                     ~~~~
++!!! error TS2304: Cannot find name 'Role'.
+             this.roleService.add(role)
+                 .then((data: ng.IHttpPromiseCallbackArg<Role>) => data.data));
++                             ~~
++!!! error TS2503: Cannot find namespace 'ng'.
++                                                        ~~~~
++!!! error TS2304: Cannot find name 'Role'.
+     

--- a/testdata/baselines/reference/submoduleAccepted/compiler/parseErrorIncorrectReturnToken.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/parseErrorIncorrectReturnToken.errors.txt.diff
@@ -1,0 +1,31 @@
+--- old.parseErrorIncorrectReturnToken.errors.txt
++++ new.parseErrorIncorrectReturnToken.errors.txt
+@@= skipped -0, +0 lines =@@
+-error TS-1: Pre-emit (7) and post-emit (8) diagnostic counts do not match! This can indicate that a semantic _error_ was added by the emit resolver - such an error may not be reflected on the command line or in the editor, but may be captured in a baseline here!
+ parseErrorIncorrectReturnToken.ts(2,17): error TS1005: ':' expected.
+ parseErrorIncorrectReturnToken.ts(4,22): error TS1005: '=>' expected.
+ parseErrorIncorrectReturnToken.ts(4,24): error TS2693: 'string' only refers to a type, but is being used as a value here.
+ parseErrorIncorrectReturnToken.ts(9,18): error TS1005: '{' expected.
+ parseErrorIncorrectReturnToken.ts(9,21): error TS1434: Unexpected keyword or identifier.
+ parseErrorIncorrectReturnToken.ts(9,21): error TS2693: 'string' only refers to a type, but is being used as a value here.
++parseErrorIncorrectReturnToken.ts(10,16): error TS2304: Cannot find name 'n'.
+ parseErrorIncorrectReturnToken.ts(12,1): error TS1128: Declaration or statement expected.
+
+
+-!!! error TS-1: Pre-emit (7) and post-emit (8) diagnostic counts do not match! This can indicate that a semantic _error_ was added by the emit resolver - such an error may not be reflected on the command line or in the editor, but may be captured in a baseline here!
+-!!! related TS-1: The excess diagnostics are:
+-!!! related TS2304 parseErrorIncorrectReturnToken.ts:10:16: Cannot find name 'n'.
+-==== parseErrorIncorrectReturnToken.ts (7 errors) ====
++==== parseErrorIncorrectReturnToken.ts (8 errors) ====
+     type F1 = {
+         (n: number) => string; // should be : not =>
+                     ~~
+@@= skipped -33, +30 lines =@@
+                         ~~~~~~
+ !!! error TS2693: 'string' only refers to a type, but is being used as a value here.
+             return n.toString();
++                   ~
++!!! error TS2304: Cannot find name 'n'.
+         }
+     };
+     ~

--- a/testdata/baselines/reference/submoduleAccepted/compiler/reachabilityChecksNoCrash1.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/compiler/reachabilityChecksNoCrash1.errors.txt.diff
@@ -9,12 +9,28 @@
  reachabilityChecksNoCrash1.ts(1,84): error TS2304: Cannot find name 'T'.
  reachabilityChecksNoCrash1.ts(1,86): error TS1011: An element access expression should take an argument.
  reachabilityChecksNoCrash1.ts(2,11): error TS1005: ':' expected.
-@@= skipped -100, +100 lines =@@
+@@= skipped -20, +20 lines =@@
+ reachabilityChecksNoCrash1.ts(4,12): error TS1005: ',' expected.
+ reachabilityChecksNoCrash1.ts(4,24): error TS2304: Cannot find name 'v'.
+ reachabilityChecksNoCrash1.ts(4,26): error TS1005: ',' expected.
++reachabilityChecksNoCrash1.ts(6,12): error TS2304: Cannot find name 'out'.
+ reachabilityChecksNoCrash1.ts(7,1): error TS1109: Expression expected.
+
+
+-==== reachabilityChecksNoCrash1.ts (35 errors) ====
++==== reachabilityChecksNoCrash1.ts (36 errors) ====
+     export async function arrayFromAsync<T>(asyncIterable!: AsyncIterable<T>): Promise<T[]> {
+                           ~~~~~~~~~~~~~~
+ !!! error TS7010: 'arrayFromAsync', which lacks return-type annotation, implicitly has an 'any' return type.
+@@= skipped -80, +81 lines =@@
  !!! error TS1005: ',' expected.
          }
      ~~~~~
 -!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and '{ const: any; for: any; of: any; asyncIterable: any; out: any; "": any; }'.
 +!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and '{ const: never[]; for: any; of: any; asyncIterable: any; out: any; "": any; }'.
          return out;
++               ~~~
++!!! error TS2304: Cannot find name 'out'.
      }
      ~
+ !!! error TS1109: Expression expected.

--- a/testdata/baselines/reference/submoduleAccepted/conformance/YieldExpression12_es6.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/conformance/YieldExpression12_es6.errors.txt.diff
@@ -1,0 +1,20 @@
+--- old.YieldExpression12_es6.errors.txt
++++ new.YieldExpression12_es6.errors.txt
+@@= skipped -0, +0 lines =@@
+ YieldExpression12_es6.ts(3,6): error TS1163: A 'yield' expression is only allowed in a generator body.
+-
+-
+-==== YieldExpression12_es6.ts (1 errors) ====
++YieldExpression12_es6.ts(3,12): error TS2304: Cannot find name 'foo'.
++
++
++==== YieldExpression12_es6.ts (2 errors) ====
+     class C {
+       constructor() {
+          yield foo
+          ~~~~~
+ !!! error TS1163: A 'yield' expression is only allowed in a generator body.
++               ~~~
++!!! error TS2304: Cannot find name 'foo'.
+       }
+     }

--- a/testdata/baselines/reference/submoduleAccepted/conformance/YieldExpression14_es6.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/conformance/YieldExpression14_es6.errors.txt.diff
@@ -1,0 +1,20 @@
+--- old.YieldExpression14_es6.errors.txt
++++ new.YieldExpression14_es6.errors.txt
+@@= skipped -0, +0 lines =@@
+ YieldExpression14_es6.ts(3,6): error TS1163: A 'yield' expression is only allowed in a generator body.
+-
+-
+-==== YieldExpression14_es6.ts (1 errors) ====
++YieldExpression14_es6.ts(3,12): error TS2663: Cannot find name 'foo'. Did you mean the instance member 'this.foo'?
++
++
++==== YieldExpression14_es6.ts (2 errors) ====
+     class C {
+       foo() {
+          yield foo
+          ~~~~~
+ !!! error TS1163: A 'yield' expression is only allowed in a generator body.
++               ~~~
++!!! error TS2663: Cannot find name 'foo'. Did you mean the instance member 'this.foo'?
+       }
+     }

--- a/testdata/baselines/reference/submoduleAccepted/conformance/YieldExpression15_es6.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/conformance/YieldExpression15_es6.errors.txt.diff
@@ -1,0 +1,18 @@
+--- old.YieldExpression15_es6.errors.txt
++++ new.YieldExpression15_es6.errors.txt
+@@= skipped -0, +0 lines =@@
+ YieldExpression15_es6.ts(2,6): error TS1163: A 'yield' expression is only allowed in a generator body.
+-
+-
+-==== YieldExpression15_es6.ts (1 errors) ====
++YieldExpression15_es6.ts(2,12): error TS2304: Cannot find name 'foo'.
++
++
++==== YieldExpression15_es6.ts (2 errors) ====
+     var v = () => {
+          yield foo
+          ~~~~~
+ !!! error TS1163: A 'yield' expression is only allowed in a generator body.
++               ~~~
++!!! error TS2304: Cannot find name 'foo'.
+       }

--- a/testdata/baselines/reference/submoduleAccepted/conformance/YieldExpression17_es6.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/conformance/YieldExpression17_es6.errors.txt.diff
@@ -1,0 +1,19 @@
+--- old.YieldExpression17_es6.errors.txt
++++ new.YieldExpression17_es6.errors.txt
+@@= skipped -0, +0 lines =@@
+ YieldExpression17_es6.ts(1,15): error TS2378: A 'get' accessor must return a value.
+ YieldExpression17_es6.ts(1,23): error TS1163: A 'yield' expression is only allowed in a generator body.
+-
+-
+-==== YieldExpression17_es6.ts (2 errors) ====
++YieldExpression17_es6.ts(1,29): error TS2304: Cannot find name 'foo'.
++
++
++==== YieldExpression17_es6.ts (3 errors) ====
+     var v = { get foo() { yield foo; } }
+                   ~~~
+ !!! error TS2378: A 'get' accessor must return a value.
+                           ~~~~~
+ !!! error TS1163: A 'yield' expression is only allowed in a generator body.
++                                ~~~
++!!! error TS2304: Cannot find name 'foo'.

--- a/testdata/baselines/reference/submoduleAccepted/conformance/YieldExpression2_es6.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/conformance/YieldExpression2_es6.errors.txt.diff
@@ -1,0 +1,16 @@
+--- old.YieldExpression2_es6.errors.txt
++++ new.YieldExpression2_es6.errors.txt
+@@= skipped -0, +0 lines =@@
+ YieldExpression2_es6.ts(1,1): error TS1163: A 'yield' expression is only allowed in a generator body.
+-
+-
+-==== YieldExpression2_es6.ts (1 errors) ====
++YieldExpression2_es6.ts(1,7): error TS2304: Cannot find name 'foo'.
++
++
++==== YieldExpression2_es6.ts (2 errors) ====
+     yield foo;
+     ~~~~~
+ !!! error TS1163: A 'yield' expression is only allowed in a generator body.
++          ~~~
++!!! error TS2304: Cannot find name 'foo'.

--- a/testdata/baselines/reference/submoduleAccepted/conformance/jsdocDisallowedInTypescript.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/conformance/jsdocDisallowedInTypescript.errors.txt.diff
@@ -21,12 +21,14 @@
 +jsdocDisallowedInTypescript.ts(7,42): error TS2693: 'string' only refers to a type, but is being used as a value here.
 +jsdocDisallowedInTypescript.ts(7,48): error TS1005: ';' expected.
 +jsdocDisallowedInTypescript.ts(7,49): error TS1128: Declaration or statement expected.
++jsdocDisallowedInTypescript.ts(8,16): error TS2304: Cannot find name 'ctor'.
 +jsdocDisallowedInTypescript.ts(10,10): error TS7010: 'hof2', which lacks return-type annotation, implicitly has an 'any' return type.
 +jsdocDisallowedInTypescript.ts(10,18): error TS2552: Cannot find name 'function'. Did you mean 'Function'?
 +jsdocDisallowedInTypescript.ts(10,26): error TS1005: ',' expected.
 +jsdocDisallowedInTypescript.ts(10,27): error TS2730: An arrow function cannot have a 'this' parameter.
 +jsdocDisallowedInTypescript.ts(10,41): error TS7006: Parameter 'string' implicitly has an 'any' type.
 +jsdocDisallowedInTypescript.ts(10,56): error TS1005: '=>' expected.
++jsdocDisallowedInTypescript.ts(11,18): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number[]'.
 +jsdocDisallowedInTypescript.ts(14,13): error TS1110: Type expected.
 +jsdocDisallowedInTypescript.ts(15,8): error TS2552: Cannot find name 'function'. Did you mean 'Function'?
 +jsdocDisallowedInTypescript.ts(15,16): error TS1005: ',' expected.
@@ -47,7 +49,7 @@
 -==== jsdocDisallowedInTypescript.ts (16 errors) ====
 +
 +
-+==== jsdocDisallowedInTypescript.ts (26 errors) ====
++==== jsdocDisallowedInTypescript.ts (28 errors) ====
      // grammar error from checker
      var ara: Array.<number> = [1,2,3];
 -                  ~
@@ -83,6 +85,8 @@
 +                                                    ~
 +!!! error TS1128: Declaration or statement expected.
          return new ctor('hi');
++                   ~~~~
++!!! error TS2304: Cannot find name 'ctor'.
      }
      function hof2(f: function(this: number, string): string) {
 -                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -101,8 +105,9 @@
 +                                                           ~
 +!!! error TS1005: '=>' expected.
          return f(12, 'hullo');
--                     ~~~~~~~
+                      ~~~~~~~
 -!!! error TS2554: Expected 1 arguments, but got 2.
++!!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'number[]'.
      }
      var whatevs: * = 1001;
 -                 ~

--- a/testdata/baselines/reference/submoduleAccepted/conformance/parserErrorRecovery_ModuleElement1.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/conformance/parserErrorRecovery_ModuleElement1.errors.txt.diff
@@ -1,0 +1,23 @@
+--- old.parserErrorRecovery_ModuleElement1.errors.txt
++++ new.parserErrorRecovery_ModuleElement1.errors.txt
+@@= skipped -0, +0 lines =@@
++parserErrorRecovery_ModuleElement1.ts(1,8): error TS2304: Cannot find name 'foo'.
+ parserErrorRecovery_ModuleElement1.ts(2,1): error TS1128: Declaration or statement expected.
++parserErrorRecovery_ModuleElement1.ts(3,8): error TS2304: Cannot find name 'bar'.
+ parserErrorRecovery_ModuleElement1.ts(4,1): error TS1128: Declaration or statement expected.
+
+
+-==== parserErrorRecovery_ModuleElement1.ts (2 errors) ====
++==== parserErrorRecovery_ModuleElement1.ts (4 errors) ====
+     return foo;
++           ~~~
++!!! error TS2304: Cannot find name 'foo'.
+     }
+     ~
+ !!! error TS1128: Declaration or statement expected.
+     return bar;
++           ~~~
++!!! error TS2304: Cannot find name 'bar'.
+     }
+     ~
+ !!! error TS1128: Declaration or statement expected.

--- a/testdata/baselines/reference/submoduleAccepted/conformance/parserExportAssignment5.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/conformance/parserExportAssignment5.errors.txt.diff
@@ -1,0 +1,18 @@
+--- old.parserExportAssignment5.errors.txt
++++ new.parserExportAssignment5.errors.txt
+@@= skipped -0, +0 lines =@@
+ parserExportAssignment5.ts(2,5): error TS1063: An export assignment cannot be used in a namespace.
+-
+-
+-==== parserExportAssignment5.ts (1 errors) ====
++parserExportAssignment5.ts(2,14): error TS2304: Cannot find name 'A'.
++
++
++==== parserExportAssignment5.ts (2 errors) ====
+     namespace M {
+         export = A;
+         ~~~~~~~~~~~
+ !!! error TS1063: An export assignment cannot be used in a namespace.
++                 ~
++!!! error TS2304: Cannot find name 'A'.
+     }

--- a/testdata/baselines/reference/submoduleAccepted/conformance/parserExportAssignment9.errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/conformance/parserExportAssignment9.errors.txt.diff
@@ -1,0 +1,30 @@
+--- old.parserExportAssignment9.errors.txt
++++ new.parserExportAssignment9.errors.txt
+@@= skipped -0, +0 lines =@@
+ parserExportAssignment9.ts(2,3): error TS1319: A default export can only be used in an ECMAScript-style module.
++parserExportAssignment9.ts(2,18): error TS2552: Cannot find name 'foo'. Did you mean 'Foo'?
+ parserExportAssignment9.ts(6,3): error TS1319: A default export can only be used in an ECMAScript-style module.
+-
+-
+-==== parserExportAssignment9.ts (2 errors) ====
++parserExportAssignment9.ts(6,18): error TS2552: Cannot find name 'bar'. Did you mean 'Bar'?
++
++
++==== parserExportAssignment9.ts (4 errors) ====
+     namespace Foo {
+       export default foo;
+       ~~~~~~~~~~~~~~~~~~~
+ !!! error TS1319: A default export can only be used in an ECMAScript-style module.
++                     ~~~
++!!! error TS2552: Cannot find name 'foo'. Did you mean 'Foo'?
++!!! related TS2728 parserExportAssignment9.ts:1:11: 'Foo' is declared here.
+     }
+     
+     namespace Bar {
+       export default bar;
+       ~~~~~~~~~~~~~~~~~~~
+ !!! error TS1319: A default export can only be used in an ECMAScript-style module.
++                     ~~~
++!!! error TS2552: Cannot find name 'bar'. Did you mean 'Bar'?
++!!! related TS2728 parserExportAssignment9.ts:5:11: 'Bar' is declared here.
+     }

--- a/testdata/baselines/reference/submoduleAccepted/conformance/parserStatementIsNotAMemberVariableDeclaration1(alwaysstrict=true).errors.txt.diff
+++ b/testdata/baselines/reference/submoduleAccepted/conformance/parserStatementIsNotAMemberVariableDeclaration1(alwaysstrict=true).errors.txt.diff
@@ -1,0 +1,28 @@
+--- old.parserStatementIsNotAMemberVariableDeclaration1(alwaysstrict=true).errors.txt
++++ new.parserStatementIsNotAMemberVariableDeclaration1(alwaysstrict=true).errors.txt
+@@= skipped -0, +0 lines =@@
+-error TS-1: Pre-emit (2) and post-emit (3) diagnostic counts do not match! This can indicate that a semantic _error_ was added by the emit resolver - such an error may not be reflected on the command line or in the editor, but may be captured in a baseline here!
+ parserStatementIsNotAMemberVariableDeclaration1.ts(1,1): error TS1108: A 'return' statement can only be used within a function body.
+ parserStatementIsNotAMemberVariableDeclaration1.ts(6,5): error TS1212: Identifier expected. 'private' is a reserved word in strict mode.
+-
+-
+-!!! error TS-1: Pre-emit (2) and post-emit (3) diagnostic counts do not match! This can indicate that a semantic _error_ was added by the emit resolver - such an error may not be reflected on the command line or in the editor, but may be captured in a baseline here!
+-!!! related TS-1: The excess diagnostics are:
+-!!! related TS2304 parserStatementIsNotAMemberVariableDeclaration1.ts:6:5: Cannot find name 'private'.
+-==== parserStatementIsNotAMemberVariableDeclaration1.ts (2 errors) ====
++parserStatementIsNotAMemberVariableDeclaration1.ts(6,5): error TS2304: Cannot find name 'private'.
++
++
++==== parserStatementIsNotAMemberVariableDeclaration1.ts (3 errors) ====
+     return {
+     ~~~~~~
+ !!! error TS1108: A 'return' statement can only be used within a function body.
+@@= skipped -16, +13 lines =@@
+         private[key] = value;
+         ~~~~~~~
+ !!! error TS1212: Identifier expected. 'private' is a reserved word in strict mode.
++        ~~~~~~~
++!!! error TS2304: Cannot find name 'private'.
+     
+       }
+     

--- a/testdata/submoduleAccepted.txt
+++ b/testdata/submoduleAccepted.txt
@@ -1453,3 +1453,24 @@ conformance/jsdocDisallowedInTypescript.errors.txt.diff
 
 # Differing/better spans/related info for some errors
 compiler/constructorWithIncompleteTypeAnnotation.errors.txt.diff
+
+## checkchildren: dispatch methods now always check their child nodes ##
+# The checker methods dispatched from checkSourceElementWorker/checkExpressionWorker
+# (checkReturnStatement, checkYieldExpression, checkExportAssignment, checkTypePredicate,
+# checkAssertion) now always check their child nodes, even when an early return fires for a
+# grammar error or a misplaced construct (e.g. `yield`/`return` outside a function, `export =`
+# in a namespace). This keeps diagnostics stable regardless of traversal order and removes the
+# emit-resolver "pre-emit/post-emit diagnostic counts do not match" instability. The TypeScript
+# submodule skips these children on error paths (surfacing the diagnostics only lazily via the
+# emit resolver, if at all), so we now report some additional, correct diagnostics up front.
+compiler/multiLinePropertyAccessAndArrowFunctionIndent1.errors.txt.diff
+compiler/parseErrorIncorrectReturnToken.errors.txt.diff
+conformance/parserErrorRecovery_ModuleElement1.errors.txt.diff
+conformance/parserExportAssignment5.errors.txt.diff
+conformance/parserExportAssignment9.errors.txt.diff
+conformance/parserStatementIsNotAMemberVariableDeclaration1(alwaysstrict=true).errors.txt.diff
+conformance/YieldExpression12_es6.errors.txt.diff
+conformance/YieldExpression14_es6.errors.txt.diff
+conformance/YieldExpression15_es6.errors.txt.diff
+conformance/YieldExpression17_es6.errors.txt.diff
+conformance/YieldExpression2_es6.errors.txt.diff

--- a/testdata/tests/cases/compiler/checkChildrenAlwaysChecked.ts
+++ b/testdata/tests/cases/compiler/checkChildrenAlwaysChecked.ts
@@ -1,0 +1,22 @@
+// @strict: true
+// @noEmit: true
+
+// @filename: yieldOutsideGenerator.ts
+function notAGenerator() {
+    // The operand is now checked even though the yield is not in a generator.
+    yield yieldOperandName;
+}
+
+// @filename: returnInStaticBlock.ts
+class C {
+    static {
+        // The expression is now checked even though `return` is illegal here.
+        return returnOperandName;
+    }
+}
+
+// @filename: exportAssignmentInNamespace.ts
+namespace N {
+    // The expression is now checked even though `export =` is illegal here.
+    export = exportOperandName;
+}


### PR DESCRIPTION
And fix the issues it flags, fixing the `TS-1` diagnostic consistency issues we inherited from strada, and also allowing some simplification of the fixes I'd already made for new ones to `markLinkedReferences`.

This removes the remaining `TS-1` consistency issues we inherited from strada in:
```
constructorWithIncompleteTypeAnnotation
multiLinePropertyAccessAndArrowFunctionIndent1
parseErrorIncorrectReturnToken
parserStatementIsNotAMemberVariableDeclaration1
```

Generally, the approach taken to fix them is an anti-brittle one - we no longer skip actually checking the children in the affected cases (`yield`, `return`, `export =`) when a grammar error is present, allowing us to always report the same diagnostic regardless of if checking starts inside the node with a grammar error or outside it. In some cases (like `export =`), this meant pushing some logic for the error into the child (eg, `resolveName` now knows not to report errors on `as const` or `export = typeName` since those either... aren't errors, or, in cases where they are, something other-than-resolveName will report them).

All up, that removes the last errors in our tests, allowing me to add the test failure I described in #4527 and finally say:
Fixes #4527