### PR TITLE
Add an LSP init flag that enables flaky diagnostics tracking

### DIFF
--- a/_extension/package.json
+++ b/_extension/package.json
@@ -206,6 +206,9 @@
                             "%native-preview.trackFlakyDiagnostics.auto%"
                         ],
                         "default": "auto",
+                        "tags": [
+                            "experimental"
+                        ],
                         "description": "%native-preview.trackFlakyDiagnostics.description%",
                         "scope": "window"
                     }

--- a/_extension/package.json
+++ b/_extension/package.json
@@ -190,6 +190,24 @@
                         "default": "auto",
                         "description": "%native-preview.showFailedResponses.description%",
                         "scope": "window"
+                    },
+                    "js/ts.server.trackFlakyDiagnostics": {
+                        "type": "string",
+                        "enum": [
+                            "panic",
+                            "log",
+                            "never",
+                            "auto"
+                        ],
+                        "enumDescriptions": [
+                            "%native-preview.trackFlakyDiagnostics.panic%",
+                            "%native-preview.trackFlakyDiagnostics.log%",
+                            "%native-preview.trackFlakyDiagnostics.never%",
+                            "%native-preview.trackFlakyDiagnostics.auto%"
+                        ],
+                        "default": "auto",
+                        "description": "%native-preview.trackFlakyDiagnostics.description%",
+                        "scope": "window"
                     }
                 }
             }

--- a/_extension/package.nls.json
+++ b/_extension/package.nls.json
@@ -35,5 +35,10 @@
     "native-preview.showFailedResponses.always": "Always show a notification when a request fails.",
     "native-preview.showFailedResponses.never": "Never show a notification when a request fails.",
     "native-preview.showFailedResponses.auto": "Show a notification only on VS Code Insiders.",
+    "native-preview.trackFlakyDiagnostics.description": "Controls whether an additional diagnostics pass is performed to check for and log flaky diagnostics",
+    "native-preview.trackFlakyDiagnostics.panic": "Panic when a flaky diagnostic is detected.",
+    "native-preview.trackFlakyDiagnostics.log": "Log an error when a flaky diagnostic is detected.",
+    "native-preview.trackFlakyDiagnostics.never": "Never perform flaky diagnostic checking and logging.",
+    "native-preview.trackFlakyDiagnostics.auto": "Perform flaky diagnostic logging only on VS Code Insiders.",
     "developer": "Developer"
 }

--- a/_extension/src/client.ts
+++ b/_extension/src/client.ts
@@ -161,6 +161,12 @@ export class Client implements vscode.Disposable {
             ?? readNativePreviewConfig<string | undefined>("pprofDir", undefined);
         const pprofArgs = pprofDir ? ["--pprofDir", pprofDir] : [];
 
+        const flakesFlag = vscode.workspace
+            .getConfiguration("js/ts")
+            .get<"panic" | "log" | "never" | "auto">("server.trackFlakyDiagnostics", "auto");
+        const effectiveflakesFlag = flakesFlag === "auto" ? (isInsiders() ? "log" : "never") : flakesFlag;
+        const flakesArgs = effectiveflakesFlag !== "never" ? ["--trackFlakyDiagnostics", effectiveflakesFlag] : [];
+
         const goMemLimit = readNativePreviewConfig<string | undefined>("server.goMemLimit", undefined)
             ?? readNativePreviewConfig<string | undefined>("goMemLimit", undefined);
         const env = { ...process.env };
@@ -178,13 +184,13 @@ export class Client implements vscode.Disposable {
         const serverOptions: ServerOptions = {
             run: {
                 command: this.exe.path,
-                args: ["--lsp", ...pprofArgs],
+                args: ["--lsp", ...pprofArgs, ...flakesArgs],
                 transport: TransportKind.stdio,
                 options: { env },
             },
             debug: {
                 command: this.exe.path,
-                args: ["--lsp", ...pprofArgs],
+                args: ["--lsp", ...pprofArgs, ...flakesArgs],
                 transport: TransportKind.stdio,
                 options: { env },
             },

--- a/_extension/src/client.ts
+++ b/_extension/src/client.ts
@@ -165,7 +165,6 @@ export class Client implements vscode.Disposable {
             .getConfiguration("js/ts")
             .get<"panic" | "log" | "never" | "auto">("server.trackFlakyDiagnostics", "auto");
         const effectiveflakesFlag = flakesFlag === "auto" ? (isInsiders() ? "log" : "never") : flakesFlag;
-        const flakesArgs = effectiveflakesFlag !== "never" ? ["--trackFlakyDiagnostics", effectiveflakesFlag] : [];
 
         const goMemLimit = readNativePreviewConfig<string | undefined>("server.goMemLimit", undefined)
             ?? readNativePreviewConfig<string | undefined>("goMemLimit", undefined);
@@ -184,13 +183,13 @@ export class Client implements vscode.Disposable {
         const serverOptions: ServerOptions = {
             run: {
                 command: this.exe.path,
-                args: ["--lsp", ...pprofArgs, ...flakesArgs],
+                args: ["--lsp", ...pprofArgs],
                 transport: TransportKind.stdio,
                 options: { env },
             },
             debug: {
                 command: this.exe.path,
-                args: ["--lsp", ...pprofArgs, ...flakesArgs],
+                args: ["--lsp", ...pprofArgs],
                 transport: TransportKind.stdio,
                 options: { env },
             },
@@ -199,6 +198,7 @@ export class Client implements vscode.Disposable {
         // Refresh the initial log verbosity in case the output channel's log
         // level changed between construction and start.
         this.clientOptions.initializationOptions.logVerbosity = this.outputChannel.logLevel;
+        this.clientOptions.initializationOptions.trackFlakyDiagnostics = effectiveflakesFlag !== "never" ? (effectiveflakesFlag === "panic" ? 2 : 1) : 0;
 
         this.client = new NativePreviewLanguageClient(
             "js/ts",

--- a/cmd/tsgo/lsp.go
+++ b/cmd/tsgo/lsp.go
@@ -25,6 +25,7 @@ func runLSP(args []string) int {
 	_ = pipe
 	socket := flag.String("socket", "", "use socket for communication")
 	_ = socket
+	logFlakes := flag.String("trackFlakyDiagnostics", "log", "perform an additional diagnostics pass to check for and log flaky diagnostics")
 	if err := flag.Parse(args); err != nil {
 		return 2
 	}
@@ -63,6 +64,18 @@ func runLSP(args []string) int {
 		ProgressDelay:      250 * time.Millisecond,
 		SetParentProcessID: newParentProcessWatchdog(ctx, stop),
 	})
+
+	switch *logFlakes {
+	case "log":
+		s.SetFlakeLogging(lsp.FlakeLogLevelLog)
+	case "panic":
+		s.SetFlakeLogging(lsp.FlakeLogLevelPanic)
+	case "none":
+		s.SetFlakeLogging(lsp.FlakeLogLevelNone)
+	default:
+		fmt.Fprintln(os.Stderr, "invalid value for trackFlakyDiagnostics:", *logFlakes)
+		return 1
+	}
 
 	if err := s.Run(ctx); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cmd/tsgo/lsp.go
+++ b/cmd/tsgo/lsp.go
@@ -25,7 +25,6 @@ func runLSP(args []string) int {
 	_ = pipe
 	socket := flag.String("socket", "", "use socket for communication")
 	_ = socket
-	logFlakes := flag.String("trackFlakyDiagnostics", "none", "perform an additional diagnostics pass to check for and log flaky diagnostics")
 	if err := flag.Parse(args); err != nil {
 		return 2
 	}
@@ -64,18 +63,6 @@ func runLSP(args []string) int {
 		ProgressDelay:      250 * time.Millisecond,
 		SetParentProcessID: newParentProcessWatchdog(ctx, stop),
 	})
-
-	switch *logFlakes {
-	case "log":
-		s.SetFlakeLogging(lsp.FlakeLogLevelLog)
-	case "panic":
-		s.SetFlakeLogging(lsp.FlakeLogLevelPanic)
-	case "none":
-		s.SetFlakeLogging(lsp.FlakeLogLevelNone)
-	default:
-		fmt.Fprintln(os.Stderr, "invalid value for trackFlakyDiagnostics:", *logFlakes)
-		return 1
-	}
 
 	if err := s.Run(ctx); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cmd/tsgo/lsp.go
+++ b/cmd/tsgo/lsp.go
@@ -25,7 +25,7 @@ func runLSP(args []string) int {
 	_ = pipe
 	socket := flag.String("socket", "", "use socket for communication")
 	_ = socket
-	logFlakes := flag.String("trackFlakyDiagnostics", "log", "perform an additional diagnostics pass to check for and log flaky diagnostics")
+	logFlakes := flag.String("trackFlakyDiagnostics", "none", "perform an additional diagnostics pass to check for and log flaky diagnostics")
 	if err := flag.Parse(args); err != nil {
 		return 2
 	}

--- a/internal/lsp/lsproto/_generate/generate.mts
+++ b/internal/lsp/lsproto/_generate/generate.mts
@@ -68,6 +68,12 @@ const customStructures: Structure[] = [
                 optional: true,
                 documentation: "The initial log verbosity level, matching the client's output channel log level at startup. Subsequent changes are sent via custom/setLogVerbosity.",
             },
+            {
+                name: "trackFlakyDiagnostics",
+                type: { kind: "reference", name: "DiagnosticFlakeLogLevel" },
+                optional: true,
+                documentation: "The level at which we track flaky diagnostics, if at all.",
+            },
         ],
         documentation: "InitializationOptions contains user-provided initialization options.",
     },
@@ -699,6 +705,16 @@ const customEnumerations: Enumeration[] = [
             { name: "Error", value: 5, documentation: "Errors only." },
         ],
         documentation: "Log verbosity level, mirroring the VS Code LogLevel enum values.",
+    },
+    {
+        name: "DiagnosticFlakeLogLevel",
+        type: { kind: "base", name: "integer" },
+        values: [
+            { name: "Off", value: 0, documentation: "All flake logging disabled." },
+            { name: "Log", value: 1, documentation: "Log flaky diagnostics to the error log." },
+            { name: "Panic", value: 2, documentation: "Panic on flaky diagnostics." },
+        ],
+        documentation: "Behavior for tracking and logging flaky diagnostics.",
     },
     {
         name: "VSReferenceKind",

--- a/internal/lsp/lsproto/lsp_generated.go
+++ b/internal/lsp/lsproto/lsp_generated.go
@@ -8790,6 +8790,9 @@ type InitializationOptions struct {
 
 	// The initial log verbosity level, matching the client's output channel log level at startup. Subsequent changes are sent via custom/setLogVerbosity.
 	LogVerbosity *LogVerbosity `json:"logVerbosity,omitzero"`
+
+	// The level at which we track flaky diagnostics, if at all.
+	TrackFlakyDiagnostics *DiagnosticFlakeLogLevel `json:"trackFlakyDiagnostics,omitzero"`
 }
 
 var _ json.UnmarshalerFrom = (*InitializationOptions)(nil)
@@ -10516,6 +10519,30 @@ func (e LogVerbosity) String() string {
 		return fmt.Sprintf("LogVerbosity(%d)", e)
 	}
 	return _LogVerbosity_name[_LogVerbosity_index[i]:_LogVerbosity_index[i+1]]
+}
+
+// Behavior for tracking and logging flaky diagnostics.
+type DiagnosticFlakeLogLevel int32
+
+const (
+	// All flake logging disabled.
+	DiagnosticFlakeLogLevelOff DiagnosticFlakeLogLevel = 0
+	// Log flaky diagnostics to the error log.
+	DiagnosticFlakeLogLevelLog DiagnosticFlakeLogLevel = 1
+	// Panic on flaky diagnostics.
+	DiagnosticFlakeLogLevelPanic DiagnosticFlakeLogLevel = 2
+)
+
+const _DiagnosticFlakeLogLevel_name = "OffLogPanic"
+
+var _DiagnosticFlakeLogLevel_index = [...]uint16{0, 3, 6, 11}
+
+func (e DiagnosticFlakeLogLevel) String() string {
+	i := int(e) - 0
+	if i < 0 || i >= len(_DiagnosticFlakeLogLevel_index)-1 {
+		return fmt.Sprintf("DiagnosticFlakeLogLevel(%d)", e)
+	}
+	return _DiagnosticFlakeLogLevel_name[_DiagnosticFlakeLogLevel_index[i]:_DiagnosticFlakeLogLevel_index[i+1]]
 }
 
 type VSReferenceKind int32

--- a/internal/lsp/lsproto/util.go
+++ b/internal/lsp/lsproto/util.go
@@ -3,6 +3,7 @@ package lsproto
 import (
 	"cmp"
 	"fmt"
+	"strconv"
 	"strings"
 )
 

--- a/internal/lsp/lsproto/util.go
+++ b/internal/lsp/lsproto/util.go
@@ -43,7 +43,7 @@ func (m IntegerOrString) AsString() string {
 	if m.String != nil {
 		codeStr = *m.String
 	} else if m.Integer != nil {
-		codeStr = fmt.Sprintf("%v", *m.Integer)
+		codeStr = strconv.Itoa(int(*m.Integer))
 	} else {
 		codeStr = "-1"
 	}

--- a/internal/lsp/lsproto/util.go
+++ b/internal/lsp/lsproto/util.go
@@ -4,7 +4,6 @@ import (
 	"cmp"
 	"fmt"
 	"strconv"
-	"strings"
 )
 
 // Implements a cmp.Compare like function for two Position
@@ -87,26 +86,20 @@ func diagnosticMessagesEqual(message1 StringOrMarkupContent, message2 StringOrMa
 	return false
 }
 
-func CompareDiagnostics(preEmit []*Diagnostic, postEmit []*Diagnostic, sanitizedDiffEnabled bool) (string, string) {
-	sanitizedMsgBuilder := strings.Builder{}
-	msgBuilder := strings.Builder{}
-	for _, elem := range preEmit {
-		if !diagnosticExistsInSlice(elem, postEmit) {
-			msgBuilder.WriteString(fmt.Sprintf("Diagnostic `%v` was present before emit but not after emit\n", elem.AsString()))
-			if sanitizedDiffEnabled {
-				sanitizedMsgBuilder.WriteString(fmt.Sprintf("Diagnostic %v was present before emit but not after emit\n", elem.CodeAsString()))
-			}
+func CompareDiagnostics(list1 []*Diagnostic, list2 []*Diagnostic) ([]*Diagnostic, []*Diagnostic) {
+	missingFromList1 := []*Diagnostic{}
+	missingFromList2 := []*Diagnostic{}
+	for _, elem := range list1 {
+		if !diagnosticExistsInSlice(elem, list2) {
+			missingFromList2 = append(missingFromList2, elem)
 		}
 	}
-	for _, elem := range postEmit {
-		if !diagnosticExistsInSlice(elem, preEmit) {
-			msgBuilder.WriteString(fmt.Sprintf("Diagnostic `%v` was present after emit but not before emit\n", elem.AsString()))
-			if sanitizedDiffEnabled {
-				sanitizedMsgBuilder.WriteString(fmt.Sprintf("Diagnostic %v was present after emit but not before emit\n", elem.CodeAsString()))
-			}
+	for _, elem := range list2 {
+		if !diagnosticExistsInSlice(elem, list1) {
+			missingFromList1 = append(missingFromList1, elem)
 		}
 	}
-	return msgBuilder.String(), sanitizedMsgBuilder.String()
+	return missingFromList1, missingFromList2
 }
 
 func (elem *Diagnostic) AsString() string {

--- a/internal/lsp/lsproto/util.go
+++ b/internal/lsp/lsproto/util.go
@@ -2,6 +2,8 @@ package lsproto
 
 import (
 	"cmp"
+	"fmt"
+	"strings"
 )
 
 // Implements a cmp.Compare like function for two Position
@@ -34,4 +36,82 @@ func (m StringOrMarkupContent) AsString() string {
 		return m.MarkupContent.Value
 	}
 	return ""
+}
+
+func (m IntegerOrString) AsString() string {
+	codeStr := ""
+	if m.String != nil {
+		codeStr = *m.String
+	} else if m.Integer != nil {
+		codeStr = fmt.Sprintf("%v", *m.Integer)
+	} else {
+		codeStr = "-1"
+	}
+	return codeStr
+}
+
+func diagnosticExistsInSlice(elem *Diagnostic, diags []*Diagnostic) bool {
+	for _, diag := range diags {
+		if diagnosticsEqual(elem, diag) {
+			return true
+		}
+	}
+	return false
+}
+
+func diagnosticsEqual(diag1 *Diagnostic, diag2 *Diagnostic) bool {
+	if diagnosticCodesEqual(diag1.Code, diag2.Code) && diagnosticMessagesEqual(diag1.Message, diag2.Message) && CompareRanges(diag1.Range, diag2.Range) == 0 {
+		return true
+	}
+	return false
+}
+
+func diagnosticCodesEqual(code1 *IntegerOrString, code2 *IntegerOrString) bool {
+	if code1.String != nil && code2.String != nil {
+		return *code1.String == *code2.String
+	}
+	if code1.Integer != nil && code2.Integer != nil {
+		return *code1.Integer == *code2.Integer
+	}
+	return false
+}
+
+func diagnosticMessagesEqual(message1 StringOrMarkupContent, message2 StringOrMarkupContent) bool {
+	if message1.String != nil && message2.String != nil {
+		return *message1.String == *message2.String
+	}
+	if message1.MarkupContent != nil && message2.MarkupContent != nil {
+		return message1.MarkupContent.Kind == message2.MarkupContent.Kind && message1.MarkupContent.Value == message2.MarkupContent.Value
+	}
+	return false
+}
+
+func CompareDiagnostics(preEmit []*Diagnostic, postEmit []*Diagnostic, sanitizedDiffEnabled bool) (string, string) {
+	sanitizedMsgBuilder := strings.Builder{}
+	msgBuilder := strings.Builder{}
+	for _, elem := range preEmit {
+		if !diagnosticExistsInSlice(elem, postEmit) {
+			msgBuilder.WriteString(fmt.Sprintf("Diagnostic `%v` was present before emit but not after emit\n", elem.AsString()))
+			if sanitizedDiffEnabled {
+				sanitizedMsgBuilder.WriteString(fmt.Sprintf("Diagnostic %v was present before emit but not after emit\n", elem.CodeAsString()))
+			}
+		}
+	}
+	for _, elem := range postEmit {
+		if !diagnosticExistsInSlice(elem, preEmit) {
+			msgBuilder.WriteString(fmt.Sprintf("Diagnostic `%v` was present after emit but not before emit\n", elem.AsString()))
+			if sanitizedDiffEnabled {
+				sanitizedMsgBuilder.WriteString(fmt.Sprintf("Diagnostic %v was present after emit but not before emit\n", elem.CodeAsString()))
+			}
+		}
+	}
+	return msgBuilder.String(), sanitizedMsgBuilder.String()
+}
+
+func (elem *Diagnostic) AsString() string {
+	return fmt.Sprintf("%v (%v:%v-%v:%v): %v", elem.Code.AsString(), elem.Range.Start.Line, elem.Range.Start.Character, elem.Range.End.Line, elem.Range.End.Character, elem.Message.AsString())
+}
+
+func (elem *Diagnostic) CodeAsString() string {
+	return fmt.Sprintf("Code(%v)", elem.Code.AsString())
 }

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -219,19 +219,7 @@ type Server struct {
 
 	startWatchdog func(parentPID int)
 
-	flakeLogging FlakeLogLevel
-}
-
-type FlakeLogLevel int
-
-const (
-	FlakeLogLevelNone FlakeLogLevel = iota
-	FlakeLogLevelLog
-	FlakeLogLevelPanic
-)
-
-func (s *Server) SetFlakeLogging(level FlakeLogLevel) {
-	s.flakeLogging = level
+	flakeLogging lsproto.DiagnosticFlakeLogLevel
 }
 
 func (s *Server) Session() *project.Session { return s.session }
@@ -1054,16 +1042,7 @@ func (s *Server) handleInitialize(ctx context.Context, params *lsproto.Initializ
 		}
 	}
 	if s.initializationOptions.TrackFlakyDiagnostics != nil {
-		switch *s.initializationOptions.TrackFlakyDiagnostics {
-		case lsproto.DiagnosticFlakeLogLevelOff:
-			s.flakeLogging = FlakeLogLevelNone
-		case lsproto.DiagnosticFlakeLogLevelLog:
-			s.flakeLogging = FlakeLogLevelLog
-		case lsproto.DiagnosticFlakeLogLevelPanic:
-			s.flakeLogging = FlakeLogLevelPanic
-		default:
-			return nil, fmt.Errorf("invalid value for trackFlakyDiagnostics: %v", *s.initializationOptions.TrackFlakyDiagnostics)
-		}
+		s.flakeLogging = *s.initializationOptions.TrackFlakyDiagnostics
 	}
 	s.clientCapabilities = params.Capabilities.Resolve()
 	if s.clientCapabilities.Window.WorkDoneProgress {
@@ -1390,7 +1369,7 @@ func (s *Server) handleSetLogVerbosity(_ context.Context, params *lsproto.SetLog
 
 func (s *Server) handleDocumentDiagnostic(ctx context.Context, ls *ls.LanguageService, params *lsproto.DocumentDiagnosticParams) (lsproto.DocumentDiagnosticResponse, error) {
 	ctx = core.WithCheckerLifetime(ctx, core.CheckerLifetimeDiagnostics)
-	if s.flakeLogging == FlakeLogLevelNone {
+	if s.flakeLogging == lsproto.DiagnosticFlakeLogLevelOff {
 		return ls.ProvideDiagnostics(ctx, params.TextDocument.Uri)
 	}
 	direct, err := ls.ProvideDiagnostics(ctx, params.TextDocument.Uri)
@@ -1426,7 +1405,7 @@ func (s *Server) handleDocumentDiagnostic(ctx context.Context, ls *ls.LanguageSe
 		})
 	}
 
-	if s.flakeLogging == FlakeLogLevelPanic {
+	if s.flakeLogging == lsproto.DiagnosticFlakeLogLevelPanic {
 		panic("flaky diagnostic(s) logged:\n" + diff)
 	}
 	return direct, err

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/microsoft/typescript-go/internal/api"
 	"github.com/microsoft/typescript-go/internal/collections"
+	"github.com/microsoft/typescript-go/internal/compiler"
 	"github.com/microsoft/typescript-go/internal/core"
 	"github.com/microsoft/typescript-go/internal/diagnostics"
 	"github.com/microsoft/typescript-go/internal/fswatch"
@@ -217,6 +218,20 @@ type Server struct {
 	projectProgress *projectLoadingProgress
 
 	startWatchdog func(parentPID int)
+
+	flakeLogging FlakeLogLevel
+}
+
+type FlakeLogLevel int
+
+const (
+	FlakeLogLevelNone FlakeLogLevel = iota
+	FlakeLogLevelLog
+	FlakeLogLevelPanic
+)
+
+func (s *Server) SetFlakeLogging(level FlakeLogLevel) {
+	s.flakeLogging = level
 }
 
 func (s *Server) Session() *project.Session { return s.session }
@@ -1363,7 +1378,46 @@ func (s *Server) handleSetLogVerbosity(_ context.Context, params *lsproto.SetLog
 
 func (s *Server) handleDocumentDiagnostic(ctx context.Context, ls *ls.LanguageService, params *lsproto.DocumentDiagnosticParams) (lsproto.DocumentDiagnosticResponse, error) {
 	ctx = core.WithCheckerLifetime(ctx, core.CheckerLifetimeDiagnostics)
-	return ls.ProvideDiagnostics(ctx, params.TextDocument.Uri)
+	if s.flakeLogging == FlakeLogLevelNone {
+		return ls.ProvideDiagnostics(ctx, params.TextDocument.Uri)
+	}
+	direct, err := ls.ProvideDiagnostics(ctx, params.TextDocument.Uri)
+	if err != nil {
+		return direct, err
+	}
+	ls.GetProgram().Emit(ctx, compiler.EmitOptions{
+		WriteFile: func(fileName, text string, data *compiler.WriteFileData) error {
+			// do nothing
+			return nil
+		},
+	})
+	secondary, err2 := ls.ProvideDiagnostics(ctx, params.TextDocument.Uri)
+	if err2 != nil {
+		return direct, err
+	}
+	diff, sanitizedDiff := lsproto.CompareDiagnostics(direct.FullDocumentDiagnosticReport.Items, secondary.FullDocumentDiagnosticReport.Items, s.telemetryEnabled)
+	if diff == "" {
+		return direct, err
+	}
+
+	s.logger.Error(diff)
+
+	if s.telemetryEnabled {
+		_ = sendNotification(s, lsproto.TelemetryEventInfo, lsproto.TelemetryEvent{
+			RequestFailureTelemetryEvent: &lsproto.RequestFailureTelemetryEvent{
+				Properties: &lsproto.RequestFailureTelemetryProperties{
+					ErrorCode:     lsproto.ErrorCodeInternalError.String(),
+					RequestMethod: "textDocument.diagnostic.flakeLog",
+					Stack:         sanitizedDiff,
+				},
+			},
+		})
+	}
+
+	if s.flakeLogging == FlakeLogLevelPanic {
+		panic("flaky diagnostic(s) logged:\n" + diff)
+	}
+	return direct, err
 }
 
 func (s *Server) handleHover(ctx context.Context, ls *ls.LanguageService, params *lsproto.HoverParams) (lsproto.HoverResponse, error) {

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1053,6 +1053,18 @@ func (s *Server) handleInitialize(ctx context.Context, params *lsproto.Initializ
 			s.logger.SetVerbosity(v)
 		}
 	}
+	if s.initializationOptions.TrackFlakyDiagnostics != nil {
+		switch *s.initializationOptions.TrackFlakyDiagnostics {
+		case lsproto.DiagnosticFlakeLogLevelOff:
+			s.flakeLogging = FlakeLogLevelNone
+		case lsproto.DiagnosticFlakeLogLevelLog:
+			s.flakeLogging = FlakeLogLevelLog
+		case lsproto.DiagnosticFlakeLogLevelPanic:
+			s.flakeLogging = FlakeLogLevelPanic
+		default:
+			return nil, fmt.Errorf("invalid value for trackFlakyDiagnostics: %v", *s.initializationOptions.TrackFlakyDiagnostics)
+		}
+	}
 	s.clientCapabilities = params.Capabilities.Resolve()
 	if s.clientCapabilities.Window.WorkDoneProgress {
 		s.projectProgress = newProjectLoadingProgress(s, s.progressDelay)

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1386,14 +1386,17 @@ func (s *Server) handleDocumentDiagnostic(ctx context.Context, ls *ls.LanguageSe
 	if err2 != nil {
 		return direct, err
 	}
-	diff, sanitizedDiff := lsproto.CompareDiagnostics(direct.FullDocumentDiagnosticReport.Items, secondary.FullDocumentDiagnosticReport.Items, s.telemetryEnabled)
-	if diff == "" {
+	missingFromPre, missingFromPost := lsproto.CompareDiagnostics(direct.FullDocumentDiagnosticReport.Items, secondary.FullDocumentDiagnosticReport.Items)
+	if len(missingFromPre) == 0 && len(missingFromPost) == 0 {
 		return direct, err
 	}
+
+	diff := generateDiagnosticDiffString(missingFromPre, missingFromPost, (*lsproto.Diagnostic).AsString)
 
 	s.logger.Error(diff)
 
 	if s.telemetryEnabled {
+		sanitizedDiff := generateDiagnosticDiffString(missingFromPre, missingFromPost, (*lsproto.Diagnostic).CodeAsString)
 		_ = sendNotification(s, lsproto.TelemetryEventInfo, lsproto.TelemetryEvent{
 			RequestFailureTelemetryEvent: &lsproto.RequestFailureTelemetryEvent{
 				Properties: &lsproto.RequestFailureTelemetryProperties{
@@ -1409,6 +1412,17 @@ func (s *Server) handleDocumentDiagnostic(ctx context.Context, ls *ls.LanguageSe
 		panic("flaky diagnostic(s) logged:\n" + diff)
 	}
 	return direct, err
+}
+
+func generateDiagnosticDiffString(missingFromPre []*lsproto.Diagnostic, missingFromPost []*lsproto.Diagnostic, stringifier func(*lsproto.Diagnostic) string) string {
+	var b strings.Builder
+	for _, elem := range missingFromPre {
+		b.WriteString(fmt.Sprintf("Diagnostic %v was present after emit but not before emit\n", stringifier(elem)))
+	}
+	for _, elem := range missingFromPost {
+		b.WriteString(fmt.Sprintf("Diagnostic %v was present before emit but not after emit\n", stringifier(elem)))
+	}
+	return b.String()
 }
 
 func (s *Server) handleHover(ctx context.Context, ls *ls.LanguageService, params *lsproto.HoverParams) (lsproto.HoverResponse, error) {


### PR DESCRIPTION
Specifically, the `--lsp` flag now allows a `trackFlakyDiagnostics` server init flag with values of `none`, `log`, or `panic`, which configure the LSP server to do extra work to track if and when we return diagnostics that users might find flaky or weirdly conditional. Correspondingly, there is a `js/ts.server.trackFlakyDiagnostics` flag with values `log`, `panic`, `never`, or `auto`. `auto` meaning `log` on vscode insiders or `never` elsewhere, operating similarly to the existing `js/ts.server.showFailedResponses` setting.

Under `panic` mode it panics and crashes the LS, like so:
<img width="613" height="77" alt="image" src="https://github.com/user-attachments/assets/b9c4dbdd-fa4a-4bc7-b60a-2f0713ea8e6d" />
otherwise under `log` mode it only quietly logs the error like so:
<img width="753" height="47" alt="image" src="https://github.com/user-attachments/assets/9b36ca35-0e2c-4e03-b6e2-bacf1e02215d" />

This can allow our fuzzer, end users, or telemetry to capture when the checker has an issue like those exposed in our tests over in #4527, and assist in tracking down the root cause so we *don't* have spurious errors that only-sometimes-appear.