### PR TITLE
Optimize `getAssignmentReducedType` in CFA

### DIFF
--- a/internal/checker/flow.go
+++ b/internal/checker/flow.go
@@ -2411,7 +2411,12 @@ func (c *Checker) typeMaybeAssignableTo(source *Type, target *Type) bool {
 	if source.flags&TypeFlagsUnion == 0 {
 		return c.isTypeAssignableTo(source, target)
 	}
-	for _, t := range source.AsUnionType().types {
+	// Quick exit when source union contains the target type
+	if containsType(source.Types(), target) {
+		return true
+	}
+	// Otherwise, check if any constituent type of the source union is assignable to the target type
+	for _, t := range source.Types() {
 		if c.isTypeAssignableTo(t, target) {
 			return true
 		}


### PR DESCRIPTION
This PR fixes `getAssignmentReducedType` in control flow analysis to not exhibit quadratic behavior when the `declaredType` and `assignedType` arguments are both large union types. With the fix, the slow repro in https://github.com/microsoft/TypeScript/issues/63653 now type-checks at the same speed as the fast repro.

Fixes https://github.com/microsoft/TypeScript/issues/63653.