### PR TITLE
bundled/nativepath: survive kernel-reported paths that the process cannot see (PRoot link2symlink)

### DIFF
--- a/internal/bundled/noembed.go
+++ b/internal/bundled/noembed.go
@@ -54,9 +54,8 @@ func argv0Path() string {
 	return tspath.NormalizeSlashes(abs)
 }
 
-// sameAsExecutable reports whether path names the file the kernel reports as
-// the running executable. True when that file cannot be statted: a masked
-// filesystem leaves nothing to compare against.
+// sameAsExecutable reports whether path provably names the same file the
+// kernel reports as the running executable.
 func sameAsExecutable(path string) bool {
 	exe, err := os.Executable()
 	if err != nil {
@@ -64,7 +63,7 @@ func sameAsExecutable(path string) bool {
 	}
 	exeInfo, err := os.Stat(exe)
 	if err != nil {
-		return true
+		return false
 	}
 	info, err := os.Stat(path)
 	return err == nil && os.SameFile(exeInfo, info)

--- a/internal/bundled/noembed.go
+++ b/internal/bundled/noembed.go
@@ -3,8 +3,11 @@
 package bundled
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -29,18 +32,49 @@ var executableDir = sync.OnceValue(func() string {
 	return tspath.GetDirectoryPath(exe)
 })
 
+// argv0Dir returns the directory the executable was invoked from
+// (os.Args[0], resolved via PATH when bare, then symlink-walked per
+// component). It is the fallback when /proc/self/exe names the executable
+// somewhere its neighbours are not visible from — e.g. under PRoot's
+// link2symlink extension (Termux proot-distro on Android), which executes
+// hardlinked binaries out of a hidden symlink store that only the kernel
+// sees. Returns "" when no usable directory can be derived.
+func argv0Dir() string {
+	if len(os.Args) == 0 || os.Args[0] == "" {
+		return ""
+	}
+	argv0, err := exec.LookPath(os.Args[0])
+	if err != nil && !errors.Is(err, exec.ErrDot) {
+		return ""
+	}
+	abs, err := filepath.Abs(argv0)
+	if err != nil {
+		return ""
+	}
+	if walked, err := filepath.EvalSymlinks(abs); err == nil {
+		abs = walked
+	}
+	return tspath.GetDirectoryPath(tspath.NormalizeSlashes(abs))
+}
+
+func hasLibDTS(dir string) bool {
+	return osvfs.FS().Stat(tspath.CombinePaths(dir, "lib.d.ts")) != nil
+}
+
 var libPath = sync.OnceValue(func() string {
 	if testing.Testing() {
 		return TestingLibPath()
 	}
 	dir := executableDir()
-
-	libdts := tspath.CombinePaths(dir, "lib.d.ts")
-	if info := osvfs.FS().Stat(libdts); info == nil {
-		panic(fmt.Sprintf("bundled: %v does not exist; this executable may be misplaced", libdts))
+	if hasLibDTS(dir) {
+		return dir
 	}
 
-	return dir
+	if fallback := argv0Dir(); fallback != "" && fallback != dir && hasLibDTS(fallback) {
+		return fallback
+	}
+
+	panic(fmt.Sprintf("bundled: %v does not exist; this executable may be misplaced", tspath.CombinePaths(dir, "lib.d.ts")))
 })
 
 func IsBundled(path string) bool {

--- a/internal/bundled/noembed.go
+++ b/internal/bundled/noembed.go
@@ -32,14 +32,11 @@ var executableDir = sync.OnceValue(func() string {
 	return tspath.GetDirectoryPath(exe)
 })
 
-// argv0Dir returns the directory the executable was invoked from
-// (os.Args[0], resolved via PATH when bare, then symlink-walked per
-// component). It is the fallback when /proc/self/exe names the executable
-// somewhere its neighbours are not visible from — e.g. under PRoot's
-// link2symlink extension (Termux proot-distro on Android), which executes
-// hardlinked binaries out of a hidden symlink store that only the kernel
-// sees. Returns "" when no usable directory can be derived.
-func argv0Dir() string {
+// argv0Path returns the invocation path of the executable (os.Args[0],
+// resolved via PATH when bare, then symlink-walked), as a fallback for when
+// /proc/self/exe reports a path this process cannot see (e.g. under PRoot's
+// link2symlink). Returns "" when no usable path can be derived.
+func argv0Path() string {
 	if len(os.Args) == 0 || os.Args[0] == "" {
 		return ""
 	}
@@ -54,7 +51,23 @@ func argv0Dir() string {
 	if walked, err := filepath.EvalSymlinks(abs); err == nil {
 		abs = walked
 	}
-	return tspath.GetDirectoryPath(tspath.NormalizeSlashes(abs))
+	return tspath.NormalizeSlashes(abs)
+}
+
+// sameAsExecutable reports whether path names the file the kernel reports as
+// the running executable. True when that file cannot be statted: a masked
+// filesystem leaves nothing to compare against.
+func sameAsExecutable(path string) bool {
+	exe, err := os.Executable()
+	if err != nil {
+		return false
+	}
+	exeInfo, err := os.Stat(exe)
+	if err != nil {
+		return true
+	}
+	info, err := os.Stat(path)
+	return err == nil && os.SameFile(exeInfo, info)
 }
 
 func hasLibDTS(dir string) bool {
@@ -70,11 +83,22 @@ var libPath = sync.OnceValue(func() string {
 		return dir
 	}
 
-	if fallback := argv0Dir(); fallback != "" && fallback != dir && hasLibDTS(fallback) {
-		return fallback
+	// Only trust argv[0] when it names the very file the kernel says is
+	// running; a different file could be another installation with
+	// mismatched libs.
+	fallback := ""
+	if argv0 := argv0Path(); argv0 != "" && sameAsExecutable(argv0) {
+		fallback = tspath.GetDirectoryPath(argv0)
+		if fallback != dir && hasLibDTS(fallback) {
+			return fallback
+		}
 	}
 
-	panic(fmt.Sprintf("bundled: %v does not exist; this executable may be misplaced", tspath.CombinePaths(dir, "lib.d.ts")))
+	msg := fmt.Sprintf("bundled: %v does not exist", tspath.CombinePaths(dir, "lib.d.ts"))
+	if fallback != "" && fallback != dir {
+		msg += fmt.Sprintf(" (also checked %v)", tspath.CombinePaths(fallback, "lib.d.ts"))
+	}
+	panic(msg + "; this executable may be misplaced")
 })
 
 func IsBundled(path string) bool {

--- a/internal/bundled/noembed_test.go
+++ b/internal/bundled/noembed_test.go
@@ -1,0 +1,31 @@
+//go:build noembed
+
+package bundled
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestArgv0Path(t *testing.T) {
+	t.Parallel()
+
+	argv0 := argv0Path()
+	assert.Assert(t, argv0 != "")
+	assert.Assert(t, sameAsExecutable(argv0))
+}
+
+func TestSameAsExecutable(t *testing.T) {
+	t.Parallel()
+
+	exe, err := os.Executable()
+	assert.NilError(t, err)
+	assert.Assert(t, sameAsExecutable(exe))
+
+	other := filepath.Join(t.TempDir(), "other")
+	assert.NilError(t, os.WriteFile(other, []byte("not the executable"), 0o666))
+	assert.Assert(t, !sameAsExecutable(other))
+}

--- a/internal/nativepath/realpath_linux.go
+++ b/internal/nativepath/realpath_linux.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 
 	"golang.org/x/sys/unix"
@@ -29,18 +30,13 @@ import (
 // Falls back to filepath.EvalSymlinks if /proc is not available (e.g. containers
 // or chroots without procfs mounted).
 //
-// The kernel's answer is validated with one invariant: canonicalization may
-// only rename the final path component when that component is a symlink. If
-// the name changed but lstat reports a non-symlink, the filesystem view is
-// being virtualized behind the process's back — e.g. PRoot's link2symlink
-// extension (the default under Termux proot-distro on Android), which
-// emulates hardlinks with symlinks into a hidden store and masks them from
-// lstat/readlink, but cannot mask names the kernel hands back through /proc.
-// In that case we fall back to the per-component walk, which sees the same
-// masked view as glibc's realpath(3) and returns a path that is actually
-// usable by this process. The check costs no extra syscalls on the common
-// path (a string comparison), and one lstat when the final component was
-// renamed.
+// The kernel's answer is validated with one invariant: resolution may only
+// rename the final path component (beyond lexical cleanup and case) when that
+// component is a symlink. If it was renamed but lstat reports a non-symlink,
+// the filesystem view is virtualized behind the process's back (e.g. PRoot's
+// link2symlink); fall back to the per-component walk, which sees the same
+// view as the rest of the process. Costs a string comparison on the common
+// path, one lstat otherwise.
 
 const _procSelfFD = "/proc/self/fd/"
 
@@ -59,11 +55,12 @@ func Realpath(path string) (string, error) {
 		return "", err
 	}
 
-	if filepath.Base(resolved) != filepath.Base(path) {
-		if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink == 0 {
-			if walked, err := filepath.EvalSymlinks(path); err == nil {
-				return walked, nil
-			}
+	// Clean so trailing slashes and "." / ".." don't defeat the fast path;
+	// EqualFold so case-normalizing filesystems keep the kernel's answer.
+	cleaned := filepath.Clean(path)
+	if !strings.EqualFold(filepath.Base(resolved), filepath.Base(cleaned)) && !IsSymlinkOrReparsePoint(cleaned) {
+		if walked, err := filepath.EvalSymlinks(path); err == nil {
+			return walked, nil
 		}
 	}
 

--- a/internal/nativepath/realpath_linux.go
+++ b/internal/nativepath/realpath_linux.go
@@ -28,6 +28,19 @@ import (
 //
 // Falls back to filepath.EvalSymlinks if /proc is not available (e.g. containers
 // or chroots without procfs mounted).
+//
+// The kernel's answer is validated with one invariant: canonicalization may
+// only rename the final path component when that component is a symlink. If
+// the name changed but lstat reports a non-symlink, the filesystem view is
+// being virtualized behind the process's back — e.g. PRoot's link2symlink
+// extension (the default under Termux proot-distro on Android), which
+// emulates hardlinks with symlinks into a hidden store and masks them from
+// lstat/readlink, but cannot mask names the kernel hands back through /proc.
+// In that case we fall back to the per-component walk, which sees the same
+// masked view as glibc's realpath(3) and returns a path that is actually
+// usable by this process. The check costs no extra syscalls on the common
+// path (a string comparison), and one lstat when the final component was
+// renamed.
 
 const _procSelfFD = "/proc/self/fd/"
 
@@ -41,6 +54,23 @@ func Realpath(path string) (string, error) {
 		return filepath.EvalSymlinks(path)
 	}
 
+	resolved, err := procRealpath(path)
+	if err != nil {
+		return "", err
+	}
+
+	if filepath.Base(resolved) != filepath.Base(path) {
+		if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink == 0 {
+			if walked, err := filepath.EvalSymlinks(path); err == nil {
+				return walked, nil
+			}
+		}
+	}
+
+	return resolved, nil
+}
+
+func procRealpath(path string) (string, error) {
 	fd, err := ignoringEINTR(func() (int, error) {
 		return unix.Open(path, unix.O_CLOEXEC|unix.O_PATH, 0)
 	})

--- a/internal/nativepath/realpath_linux.go
+++ b/internal/nativepath/realpath_linux.go
@@ -30,13 +30,15 @@ import (
 // Falls back to filepath.EvalSymlinks if /proc is not available (e.g. containers
 // or chroots without procfs mounted).
 //
-// The kernel's answer is validated with one invariant: resolution may only
-// rename the final path component (beyond lexical cleanup and case) when that
-// component is a symlink. If it was renamed but lstat reports a non-symlink,
-// the filesystem view is virtualized behind the process's back (e.g. PRoot's
-// link2symlink); fall back to the per-component walk, which sees the same
-// view as the rest of the process. Costs a string comparison on the common
-// path, one lstat otherwise.
+// The kernel's answer is validated with one invariant: resolving symlinks in
+// the directory prefix may rewrite that prefix arbitrarily, but the base name
+// of the final component survives resolution unless that component is itself
+// a symlink — only the leaf can rename the leaf. If the base name changed
+// (beyond lexical cleanup and case) and lstat reports a non-symlink, the
+// filesystem view is being virtualized behind the process's back (e.g.
+// PRoot's link2symlink); fall back to the per-component walk, which sees the
+// same view as the rest of the process. Costs a string comparison on the
+// common path, one lstat otherwise.
 
 const _procSelfFD = "/proc/self/fd/"
 

--- a/internal/nativepath/realpath_linux_test.go
+++ b/internal/nativepath/realpath_linux_test.go
@@ -1,0 +1,76 @@
+package nativepath
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func mustRealpath(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := Realpath(path)
+	assert.NilError(t, err)
+	return resolved
+}
+
+func TestRealpath(t *testing.T) {
+	t.Parallel()
+
+	// Canonicalize the temp dir itself so expectations are not polluted by
+	// symlinks higher up in the temp path.
+	tmp := mustRealpath(t, t.TempDir())
+
+	t.Run("regular file resolves to itself", func(t *testing.T) {
+		t.Parallel()
+		file := filepath.Join(tmp, "regular.txt")
+		assert.NilError(t, os.WriteFile(file, []byte("hello"), 0o666))
+		assert.Equal(t, mustRealpath(t, file), file)
+	})
+
+	t.Run("directory symlink resolves, file name preserved", func(t *testing.T) {
+		t.Parallel()
+		// Mirrors the pnpm layout: the directory components are symlinked,
+		// the final component keeps its name.
+		target := filepath.Join(tmp, "store", "pkg")
+		assert.NilError(t, os.MkdirAll(target, 0o777))
+		file := filepath.Join(target, "index.d.ts")
+		assert.NilError(t, os.WriteFile(file, []byte("export {};"), 0o666))
+		link := filepath.Join(tmp, "linked-pkg")
+		assert.NilError(t, os.Symlink(target, link))
+
+		assert.Equal(t, mustRealpath(t, filepath.Join(link, "index.d.ts")), file)
+	})
+
+	t.Run("symlinked final component resolves to its target", func(t *testing.T) {
+		t.Parallel()
+		// A genuine symlink may rename the final component; the kernel's
+		// answer must be kept.
+		target := filepath.Join(tmp, "real-name.txt")
+		assert.NilError(t, os.WriteFile(target, []byte("hello"), 0o666))
+		link := filepath.Join(tmp, "other-name.txt")
+		assert.NilError(t, os.Symlink(target, link))
+
+		assert.Equal(t, mustRealpath(t, link), target)
+	})
+
+	t.Run("hardlink keeps the name it was opened by", func(t *testing.T) {
+		t.Parallel()
+		// Hardlinks are equal names for one inode: canonicalization must not
+		// swap one for the other. This is the invariant the masked-filesystem
+		// fallback relies on (see the package comment).
+		first := filepath.Join(tmp, "first-name.txt")
+		assert.NilError(t, os.WriteFile(first, []byte("hello"), 0o666))
+		second := filepath.Join(tmp, "second-name.txt")
+		assert.NilError(t, os.Link(first, second))
+
+		assert.Equal(t, mustRealpath(t, second), second)
+	})
+
+	t.Run("missing file errors", func(t *testing.T) {
+		t.Parallel()
+		_, err := Realpath(filepath.Join(tmp, "does-not-exist.txt"))
+		assert.Assert(t, err != nil)
+	})
+}

--- a/internal/nativepath/realpath_linux_test.go
+++ b/internal/nativepath/realpath_linux_test.go
@@ -18,9 +18,10 @@ func mustRealpath(t *testing.T, path string) string {
 func TestRealpath(t *testing.T) {
 	t.Parallel()
 
-	// Canonicalize the temp dir itself so expectations are not polluted by
-	// symlinks higher up in the temp path.
-	tmp := mustRealpath(t, t.TempDir())
+	// Canonicalize the temp dir with an independent oracle so expectations
+	// are not derived from the function under test.
+	tmp, err := filepath.EvalSymlinks(t.TempDir())
+	assert.NilError(t, err)
 
 	t.Run("regular file resolves to itself", func(t *testing.T) {
 		t.Parallel()
@@ -31,8 +32,9 @@ func TestRealpath(t *testing.T) {
 
 	t.Run("directory symlink resolves, file name preserved", func(t *testing.T) {
 		t.Parallel()
-		// Mirrors the pnpm layout: the directory components are symlinked,
-		// the final component keeps its name.
+		// Directory components are symlinked, the final component keeps its
+		// name — the generic layout produced by symlink-based package
+		// managers (e.g. pnpm).
 		target := filepath.Join(tmp, "store", "pkg")
 		assert.NilError(t, os.MkdirAll(target, 0o777))
 		file := filepath.Join(target, "index.d.ts")
@@ -66,6 +68,30 @@ func TestRealpath(t *testing.T) {
 		assert.NilError(t, os.Link(first, second))
 
 		assert.Equal(t, mustRealpath(t, second), second)
+	})
+
+	t.Run("trailing slash on a directory symlink", func(t *testing.T) {
+		t.Parallel()
+		target := filepath.Join(tmp, "trailing-target")
+		assert.NilError(t, os.MkdirAll(target, 0o777))
+		link := filepath.Join(tmp, "trailing-link")
+		assert.NilError(t, os.Symlink(target, link))
+
+		assert.Equal(t, mustRealpath(t, link+"/"), target)
+	})
+
+	t.Run("dot-dot across a directory symlink", func(t *testing.T) {
+		t.Parallel()
+		// Lexically "link/.." names the link's parent; resolved, it names
+		// the target's parent. Exercises the masked-view fallback branch
+		// (final component renamed, not a symlink) on any filesystem.
+		parent := filepath.Join(tmp, "dotdot-parent")
+		target := filepath.Join(parent, "child")
+		assert.NilError(t, os.MkdirAll(target, 0o777))
+		link := filepath.Join(tmp, "dotdot-link")
+		assert.NilError(t, os.Symlink(target, link))
+
+		assert.Equal(t, mustRealpath(t, link+"/.."), parent)
 	})
 
 	t.Run("missing file errors", func(t *testing.T) {

--- a/internal/nativepath/realpath_linux_test.go
+++ b/internal/nativepath/realpath_linux_test.go
@@ -15,13 +15,19 @@ func mustRealpath(t *testing.T, path string) string {
 	return resolved
 }
 
+// canonicalTempDir canonicalizes a fresh temp dir with an independent oracle
+// so expectations are not derived from the function under test.
+func canonicalTempDir(t *testing.T) string {
+	t.Helper()
+	tmp, err := filepath.EvalSymlinks(t.TempDir())
+	assert.NilError(t, err)
+	return tmp
+}
+
 func TestRealpath(t *testing.T) {
 	t.Parallel()
 
-	// Canonicalize the temp dir with an independent oracle so expectations
-	// are not derived from the function under test.
-	tmp, err := filepath.EvalSymlinks(t.TempDir())
-	assert.NilError(t, err)
+	tmp := canonicalTempDir(t)
 
 	t.Run("regular file resolves to itself", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
Fixes #4718.

**TL;DR:** Under PRoot's `link2symlink` extension — the default environment
of Termux `proot-distro` on Android — the paths the kernel reports through
`/proc` (`readlink("/proc/self/exe")`, `readlink("/proc/self/fd/N")`) name
files inside a hidden store that the process itself is not supposed to see.
`tsgo` is the only tool in the toolchain that consumes those kernel answers
directly — as an O(1) realpath optimization, and to locate its bundled libs —
so it panics at startup and mass-fails module resolution in an environment
where Node and the JS `tsc`, which resolve paths component by component, work
fine. This PR keeps both optimizations but validates their answers against
the process's own view of the filesystem and falls back to the portable
per-component walk when they diverge — trust-but-verify, no environment
sniffing. It is the Linux sibling of #2375 / #2381 (Windows: executable path
unusable at the same spot).

## Summary

`tsgo` crashes at startup — and, once past that, mass-fails module
resolution — inside any PRoot guest that uses the `link2symlink` extension,
which is the default environment of Termux `proot-distro` on Android. With
pnpm (hardlink installs) this makes the native compiler unusable there:

```
panic: bundled: /.l2s/lib.d.ts does not exist; this executable may be misplaced
```

```
error TS6054: File '/.l2s/.l2s.32b1…0001.0007' has an unsupported extension.
  The file is in the program because:
    Entry point for implicit type library 'node'
```

Minimal reproduction (4-stage script, plus full analysis):
https://github.com/dlecan/tsgo-proot-l2s-repro

## Root cause

PRoot's `link2symlink` emulates `link(2)` (forbidden for unprivileged apps
on Android) by replacing hardlinks with symlinks into a hidden store
(`/.l2s/.l2s.<hash>.<n>`), and masks `lstat`/`readlink` so guest processes
keep seeing ordinary regular files. The illusion holds for every path the
tracee passes into syscalls; it cannot hold for names the **kernel**
computes and hands back through `/proc`:

- `readlink("/proc/self/exe")` → the store file that was actually executed;
- `open(path, O_PATH)` + `readlink("/proc/self/fd/N")` — the O(1) trick in
  `internal/nativepath/realpath_linux.go` — → the store file that was
  actually opened, for *every* pnpm-hardlinked file.

So `internal/bundled` looks for `lib.d.ts` inside `/.l2s` (panic), and
every resolved `.d.ts`/`.d.cts`/`package.json` realpaths to an
extensionless `/.l2s/...` name, which module resolution then rejects
(TS2307/TS2591/TS6054). Node.js and the JS-based `tsc` are unaffected
because libuv/glibc `realpath(3)` walk component by component with exactly
the syscalls PRoot masks. This is the Linux sibling of #2375 (Windows,
`EvalSymlinks` failing on the executable path, fixed by #2381).

## Fix

Two independent, defensive fallbacks — no environment sniffing, no cost on
the happy path:

1. **`nativepath.Realpath` (Linux): validate the kernel's answer with an
   invariant.** Resolution may only rename the final path component (beyond
   lexical cleanup and case) when that component is a symlink. The
   comparison runs on the `filepath.Clean`ed input so trailing-slash / `.` /
   `..` spellings keep the fast path, and case-insensitively so
   case-normalizing filesystems (vfat, ext4 casefold, …) keep the kernel's
   canonical answer. Fast path unchanged: same final component (the
   overwhelmingly common case — zero extra syscalls), accept. Otherwise one
   `lstat`: if the final component is a symlink, the rename is legitimate
   (e.g. `bin/tsc → lib/tsc`), accept; if it is a regular file, the view is
   being virtualized behind the process's back — fall back to
   `filepath.EvalSymlinks`, which sees the same masked view as every other
   tool and returns a usable path.

2. **`bundled` (noembed): try `argv[0]` before panicking.** When
   `<dir(os.Executable())>/lib.d.ts` does not exist, derive the location
   from `os.Args[0]` (resolved via `exec.LookPath` when bare, then
   symlink-walked) and retry. The fallback is accepted only when `argv[0]`
   provably names the same file the kernel reports as the executable
   (`os.SameFile`, dev+inode) — so a misplaced binary can never silently
   pick up a *different* installation's lib files; it still fails fast, now
   naming both probed directories in the panic message. The npm `bin/tsc` shim always spawns the native
   binary by its real `node_modules` path, so this resolves the panic
   wherever `/proc/self/exe` is unusable. Only runs on the path that panics
   today.

## Validation

- `gofmt` / `go vet` clean; `hereby lint` (custom-gcl, `--build-tags
  noembed`) reports 0 issues; `go test ./internal/nativepath
  ./internal/bundled` passes with and without `-tags noembed`.
- New unit tests: regular files and hardlinks keep their opened name; a
  genuinely symlinked final component still resolves to its target;
  pnpm-style directory symlinks preserve the file name; trailing-slash and
  `..`-across-a-symlink inputs (the latter deterministically exercises the
  masked-view fallback branch on any filesystem); the noembed argv[0]
  helpers.
- Built `tsgo` from this branch (`-tags noembed`, linux/arm64) and ran the
  full A/B matrix **on the affected environment** (Termux proot-distro
  Ubuntu aarch64, pnpm hardlink install, no workaround applied):

  | Binary | Layout | Result |
  |---|---|---|
  | stock 7.0.2 | as installed by pnpm (hardlinked) | `panic: bundled: /.l2s/lib.d.ts does not exist` |
  | stock 7.0.2 | executable un-hardlinked by hand | `TS6054` on `/.l2s/...` for `@types/node`, `TS2307` on `zod/v4` |
  | patched | executable un-hardlinked | type-check **clean** (fix 1) |
  | patched | executable l2s-routed, incl. via the npm `bin/tsc` shim | `--version` and full type-check **clean** (fix 1 + 2) |

  The on-device matrix was run with the initial revision of this patch; the
  subsequent hardening (same-file guard on the argv[0] fallback,
  cleaned-path / case-insensitive comparison) is covered by the new unit
  tests.
- On regular Linux the behavior is byte-for-byte identical except in the
  final-component-renamed-but-not-a-symlink case described above.

## Disclosure

This patch was authored with AI assistance (Claude Code), per the
CONTRIBUTING guidance. I ([@dlecan](https://github.com/dlecan)) chose this
specific bug, reviewed and understand every line, validated it on the
affected physical device, and will personally respond to review feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
