### PR TITLE
Show repopulate info in readable buildinfo

### DIFF
--- a/internal/execute/tsctests/readablebuildinfo.go
+++ b/internal/execute/tsctests/readablebuildinfo.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/microsoft/typescript-go/internal/ast"
 	"github.com/microsoft/typescript-go/internal/collections"
 	"github.com/microsoft/typescript-go/internal/core"
 	"github.com/microsoft/typescript-go/internal/diagnostics"
@@ -57,19 +58,27 @@ type readableBuildInfoFileInfo struct {
 
 type readableBuildInfoDiagnostic struct {
 	// incrementalBuildInfoFileId if it is for a File thats other than its stored for
-	File               string                         `json:"file,omitzero"`
-	NoFile             bool                           `json:"noFile,omitzero"`
-	Pos                int                            `json:"pos,omitzero"`
-	End                int                            `json:"end,omitzero"`
-	Code               int32                          `json:"code,omitzero"`
-	Category           diagnostics.Category           `json:"category,omitzero"`
-	MessageKey         diagnostics.Key                `json:"messageKey,omitzero"`
-	MessageArgs        []string                       `json:"messageArgs,omitzero"`
-	MessageChain       []*readableBuildInfoDiagnostic `json:"messageChain,omitzero"`
-	RelatedInformation []*readableBuildInfoDiagnostic `json:"relatedInformation,omitzero"`
-	ReportsUnnecessary bool                           `json:"reportsUnnecessary,omitzero"`
-	ReportsDeprecated  bool                           `json:"reportsDeprecated,omitzero"`
-	SkippedOnNoEmit    bool                           `json:"skippedOnNoEmit,omitzero"`
+	File               string                           `json:"file,omitzero"`
+	NoFile             bool                             `json:"noFile,omitzero"`
+	Pos                int                              `json:"pos,omitzero"`
+	End                int                              `json:"end,omitzero"`
+	Code               int32                            `json:"code,omitzero"`
+	Category           diagnostics.Category             `json:"category,omitzero"`
+	MessageKey         diagnostics.Key                  `json:"messageKey,omitzero"`
+	MessageArgs        []string                         `json:"messageArgs,omitzero"`
+	MessageChain       []*readableBuildInfoDiagnostic   `json:"messageChain,omitzero"`
+	RelatedInformation []*readableBuildInfoDiagnostic   `json:"relatedInformation,omitzero"`
+	ReportsUnnecessary bool                             `json:"reportsUnnecessary,omitzero"`
+	ReportsDeprecated  bool                             `json:"reportsDeprecated,omitzero"`
+	SkippedOnNoEmit    bool                             `json:"skippedOnNoEmit,omitzero"`
+	RepopulateInfo     *readableBuildInfoRepopulateInfo `json:"repopulateInfo,omitzero"`
+}
+
+type readableBuildInfoRepopulateInfo struct {
+	Kind            ast.RepopulateDiagnosticKind `json:"kind"`
+	ModuleReference string                       `json:"moduleReference,omitzero"`
+	Mode            core.ResolutionMode          `json:"mode,omitzero"`
+	PackageName     string                       `json:"packageName,omitzero"`
 }
 
 type readableBuildInfoDiagnosticsOfFile struct {
@@ -265,8 +274,21 @@ func (r *readableBuildInfo) toReadableBuildInfoDiagnostic(diagnostics []*increme
 			ReportsUnnecessary: d.ReportsUnnecessary,
 			ReportsDeprecated:  d.ReportsDeprecated,
 			SkippedOnNoEmit:    d.SkippedOnNoEmit,
+			RepopulateInfo:     toReadableBuildInfoRepopulateInfo(d.RepopulateInfo),
 		}
 	})
+}
+
+func toReadableBuildInfoRepopulateInfo(info *incremental.BuildInfoRepopulateInfo) *readableBuildInfoRepopulateInfo {
+	if info == nil {
+		return nil
+	}
+	return &readableBuildInfoRepopulateInfo{
+		Kind:            info.Kind,
+		ModuleReference: info.ModuleReference,
+		Mode:            info.Mode,
+		PackageName:     info.PackageName,
+	}
 }
 
 func (r *readableBuildInfo) toReadableBuildInfoDiagnosticsOfFile(diagnostics *incremental.BuildInfoDiagnosticsOfFile) *readableBuildInfoDiagnosticsOfFile {

--- a/testdata/baselines/reference/tsc/composite/synthetic-jsx-import-of-ESM-module-from-CJS-module-error-on-jsx-element.js
+++ b/testdata/baselines/reference/tsc/composite/synthetic-jsx-import-of-ESM-module-from-CJS-module-error-on-jsx-element.js
@@ -128,7 +128,10 @@ exports.default = (0, jsx_runtime_1.jsx)("div", {});
               "end": 21,
               "code": 1483,
               "category": 3,
-              "messageKey": "To_convert_this_file_to_an_ECMAScript_module_create_a_local_package_json_file_with_type_Colon_module_1483"
+              "messageKey": "To_convert_this_file_to_an_ECMAScript_module_create_a_local_package_json_file_with_type_Colon_module_1483",
+              "repopulateInfo": {
+                "kind": 1
+              }
             }
           ]
         }

--- a/testdata/baselines/reference/tsc/moduleResolution/alternateResult.js
+++ b/testdata/baselines/reference/tsc/moduleResolution/alternateResult.js
@@ -424,7 +424,12 @@ export {};
               "messageArgs": [
                 "/home/src/projects/project/node_modules/foo/index.d.ts",
                 "foo"
-              ]
+              ],
+              "repopulateInfo": {
+                "kind": 2,
+                "moduleReference": "foo",
+                "mode": 99
+              }
             }
           ]
         },
@@ -448,7 +453,12 @@ export {};
               "messageArgs": [
                 "/home/src/projects/project/node_modules/@types/bar/index.d.ts",
                 "@types/bar"
-              ]
+              ],
+              "repopulateInfo": {
+                "kind": 2,
+                "moduleReference": "bar",
+                "mode": 99
+              }
             }
           ]
         }
@@ -1614,7 +1624,12 @@ Found 1 error in index.mts[90m:1[0m
               "messageArgs": [
                 "/home/src/projects/project/node_modules/foo/index.d.ts",
                 "foo"
-              ]
+              ],
+              "repopulateInfo": {
+                "kind": 2,
+                "moduleReference": "foo",
+                "mode": 99
+              }
             }
           ]
         }
@@ -2146,7 +2161,12 @@ Found 1 error in index.mts[90m:4[0m
               "messageArgs": [
                 "/home/src/projects/project/node_modules/@types/bar2/index.d.ts",
                 "@types/bar2"
-              ]
+              ],
+              "repopulateInfo": {
+                "kind": 2,
+                "moduleReference": "bar2",
+                "mode": 99
+              }
             }
           ]
         }
@@ -2479,7 +2499,12 @@ Found 2 errors in the same file, starting at: index.mts[90m:3[0m
               "messageArgs": [
                 "/home/src/projects/project/node_modules/foo2/index.d.ts",
                 "foo2"
-              ]
+              ],
+              "repopulateInfo": {
+                "kind": 2,
+                "moduleReference": "foo2",
+                "mode": 99
+              }
             }
           ]
         },
@@ -2503,7 +2528,12 @@ Found 2 errors in the same file, starting at: index.mts[90m:3[0m
               "messageArgs": [
                 "/home/src/projects/project/node_modules/@types/bar2/index.d.ts",
                 "@types/bar2"
-              ]
+              ],
+              "repopulateInfo": {
+                "kind": 2,
+                "moduleReference": "bar2",
+                "mode": 99
+              }
             }
           ]
         }

--- a/testdata/baselines/reference/tsc/moduleResolution/package-json-scope.js
+++ b/testdata/baselines/reference/tsc/moduleResolution/package-json-scope.js
@@ -217,7 +217,10 @@ exports.x = 10;
               "messageArgs": [
                 ".mts",
                 "/home/src/workspaces/project/package.json"
-              ]
+              ],
+              "repopulateInfo": {
+                "kind": 1
+              }
             }
           ]
         }


### PR DESCRIPTION
I forgot to add this to the readable buildinfo baselines in #3353; I think I assumed the readable info was automatic, but no, it's not.

Found while working on something else.