### PR TITLE
Fix variadic tuple relation position mapping

### DIFF
--- a/internal/checker/relater.go
+++ b/internal/checker/relater.go
@@ -4115,7 +4115,7 @@ func (r *Relater) propertiesRelatedTo(source *Type, target *Type, reportErrors b
 			} else {
 				sourceRest = true
 			}
-			targetHasRestElement := target.TargetTupleType().combinedFlags&ElementFlagsVariable != 0
+			targetHasVariableElement := target.TargetTupleType().combinedFlags&ElementFlagsVariable != 0
 			var sourceMinLength int
 			if isTupleType(source) {
 				sourceMinLength = source.TargetTupleType().minLength
@@ -4129,13 +4129,13 @@ func (r *Relater) propertiesRelatedTo(source *Type, target *Type, reportErrors b
 				}
 				return TernaryFalse
 			}
-			if !targetHasRestElement && targetArity < sourceMinLength {
+			if !targetHasVariableElement && targetArity < sourceMinLength {
 				if reportErrors {
 					r.reportError(diagnostics.Source_has_0_element_s_but_target_allows_only_1, sourceMinLength, targetArity)
 				}
 				return TernaryFalse
 			}
-			if !targetHasRestElement && (sourceRest || targetArity < sourceArity) {
+			if !targetHasVariableElement && (sourceRest || targetArity < sourceArity) {
 				if reportErrors {
 					if sourceMinLength < targetMinLength {
 						r.reportError(diagnostics.Target_requires_0_element_s_but_source_may_have_fewer, targetMinLength)
@@ -4147,8 +4147,8 @@ func (r *Relater) propertiesRelatedTo(source *Type, target *Type, reportErrors b
 			}
 			sourceTypeArguments := r.c.getTypeArguments(source)
 			targetTypeArguments := r.c.getTypeArguments(target)
-			targetStartCount := getStartElementCount(target.TargetTupleType(), ElementFlagsNonRest)
-			targetEndCount := getEndElementCount(target.TargetTupleType(), ElementFlagsNonRest)
+			targetStartCount := getStartElementCount(target.TargetTupleType(), ElementFlagsFixed)
+			targetEndCount := getEndElementCount(target.TargetTupleType(), ElementFlagsFixed)
 			canExcludeDiscriminants := excludedProperties.Len() != 0
 			for sourcePosition := range sourceArity {
 				var sourceFlags ElementFlags
@@ -4159,18 +4159,23 @@ func (r *Relater) propertiesRelatedTo(source *Type, target *Type, reportErrors b
 				}
 				sourcePositionFromEnd := sourceArity - 1 - sourcePosition
 				var targetPosition int
-				if targetHasRestElement && sourcePosition >= targetStartCount {
-					targetPosition = targetArity - 1 - min(sourcePositionFromEnd, targetEndCount)
+				if targetHasVariableElement && sourcePosition >= targetStartCount {
+					if sourcePositionFromEnd < targetEndCount && sourceFlags&ElementFlagsVariadic == 0 {
+						targetPosition = targetArity - 1 - sourcePositionFromEnd
+					} else {
+						targetPosition = min(sourcePosition, targetArity-1-targetEndCount)
+					}
 				} else {
 					targetPosition = sourcePosition
 				}
-				targetFlags := ElementFlagsNone
-				if targetPosition >= 0 {
-					targetFlags = target.TargetTupleType().elementInfos[targetPosition].flags
-				}
+				targetFlags := target.TargetTupleType().elementInfos[targetPosition].flags
 				if targetFlags&ElementFlagsVariadic != 0 && sourceFlags&ElementFlagsVariadic == 0 {
 					if reportErrors {
-						r.reportError(diagnostics.Source_provides_no_match_for_variadic_element_at_position_0_in_target, targetPosition)
+						if sourcePosition > targetStartCount {
+							r.reportError(diagnostics.Target_allows_only_0_element_s_but_source_may_have_more, targetArity)
+						} else {
+							r.reportError(diagnostics.Source_provides_no_match_for_variadic_element_at_position_0_in_target, targetPosition)
+						}
 					}
 					return TernaryFalse
 				}
@@ -4206,7 +4211,8 @@ func (r *Relater) propertiesRelatedTo(source *Type, target *Type, reportErrors b
 				related := r.isRelatedToEx(sourceType, targetCheckType, RecursionFlagsBoth, reportErrors, nil /*headMessage*/, intersectionState)
 				if related == TernaryFalse {
 					if reportErrors && (targetArity > 1 || sourceArity > 1) {
-						if targetHasRestElement && sourcePosition >= targetStartCount && sourcePositionFromEnd >= targetEndCount && targetStartCount != sourceArity-targetEndCount-1 {
+						targetMiddleLength := targetArity - targetEndCount - targetStartCount
+						if targetHasVariableElement && targetMiddleLength == 1 && sourcePosition >= targetStartCount && sourcePositionFromEnd >= targetEndCount && targetStartCount != sourceArity-targetEndCount-1 {
 							r.reportError(diagnostics.Type_at_positions_0_through_1_in_source_is_not_compatible_with_type_at_position_2_in_target, targetStartCount, sourceArity-targetEndCount-1, targetPosition)
 						} else {
 							r.reportError(diagnostics.Type_at_position_0_in_source_is_not_compatible_with_type_at_position_1_in_target, sourcePosition, targetPosition)

--- a/testdata/baselines/reference/compiler/variadicTupleRelationPositionMapping.errors.txt
+++ b/testdata/baselines/reference/compiler/variadicTupleRelationPositionMapping.errors.txt
@@ -1,0 +1,64 @@
+variadicTupleRelationPositionMapping.ts(13,3): error TS2344: Type '[...A, boolean, boolean, boolean, boolean]' does not satisfy the constraint '[...A, boolean]'.
+  Target allows only 2 element(s) but source may have more.
+variadicTupleRelationPositionMapping.ts(30,31): error TS2344: Type '[...A, boolean, boolean, ...B, boolean]' does not satisfy the constraint '[...A, boolean, ...B, boolean]'.
+  Target allows only 4 element(s) but source may have more.
+variadicTupleRelationPositionMapping.ts(44,3): error TS2344: Type '[...T, boolean]' does not satisfy the constraint '[boolean, ...T, boolean]'.
+  Source has 2 element(s) but target requires 3.
+
+
+==== variadicTupleRelationPositionMapping.ts (3 errors) ====
+    type TrailingElement<
+      A extends unknown[],
+      Result extends [...A, boolean],
+    > = Result;
+    
+    type MatchingTrailingElement<A extends unknown[]> = TrailingElement<
+      A,
+      [...A, boolean]
+    >;
+    
+    type ExcessTrailingElements<A extends unknown[]> = TrailingElement<
+      A,
+      [...A, boolean, boolean, boolean, boolean]
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2344: Type '[...A, boolean, boolean, boolean, boolean]' does not satisfy the constraint '[...A, boolean]'.
+!!! error TS2344:   Target allows only 2 element(s) but source may have more.
+    >;
+    
+    type TwoVariadicElements<
+      A extends unknown[],
+      B extends unknown[],
+      Result extends [...A, boolean, ...B, boolean],
+    > = Result;
+    
+    type MatchingTwoVariadicElements<
+      A extends unknown[],
+      B extends unknown[],
+    > = TwoVariadicElements<A, B, [...A, boolean, ...B, boolean]>;
+    
+    type ExcessMiddleElement<
+      A extends unknown[],
+      B extends unknown[],
+    > = TwoVariadicElements<A, B, [...A, boolean, boolean, ...B, boolean]>;
+                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2344: Type '[...A, boolean, boolean, ...B, boolean]' does not satisfy the constraint '[...A, boolean, ...B, boolean]'.
+!!! error TS2344:   Target allows only 4 element(s) but source may have more.
+    
+    type FixedPrefixAndSuffix<
+      T extends unknown[],
+      Result extends [boolean, ...T, boolean],
+    > = Result;
+    
+    type MatchingFixedPrefixAndSuffix<T extends unknown[]> = FixedPrefixAndSuffix<
+      T,
+      [boolean, ...T, boolean]
+    >;
+    
+    type MissingFixedPrefix<T extends unknown[]> = FixedPrefixAndSuffix<
+      T,
+      [...T, boolean]
+      ~~~~~~~~~~~~~~~
+!!! error TS2344: Type '[...T, boolean]' does not satisfy the constraint '[boolean, ...T, boolean]'.
+!!! error TS2344:   Source has 2 element(s) but target requires 3.
+    >;
+    

--- a/testdata/baselines/reference/compiler/variadicTupleRelationPositionMapping.symbols
+++ b/testdata/baselines/reference/compiler/variadicTupleRelationPositionMapping.symbols
@@ -1,0 +1,130 @@
+//// [tests/cases/compiler/variadicTupleRelationPositionMapping.ts] ////
+
+=== variadicTupleRelationPositionMapping.ts ===
+type TrailingElement<
+>TrailingElement : Symbol(TrailingElement, Decl(variadicTupleRelationPositionMapping.ts, 0, 0))
+
+  A extends unknown[],
+>A : Symbol(A, Decl(variadicTupleRelationPositionMapping.ts, 0, 21))
+
+  Result extends [...A, boolean],
+>Result : Symbol(Result, Decl(variadicTupleRelationPositionMapping.ts, 1, 22))
+>A : Symbol(A, Decl(variadicTupleRelationPositionMapping.ts, 0, 21))
+
+> = Result;
+>Result : Symbol(Result, Decl(variadicTupleRelationPositionMapping.ts, 1, 22))
+
+type MatchingTrailingElement<A extends unknown[]> = TrailingElement<
+>MatchingTrailingElement : Symbol(MatchingTrailingElement, Decl(variadicTupleRelationPositionMapping.ts, 3, 11))
+>A : Symbol(A, Decl(variadicTupleRelationPositionMapping.ts, 5, 29))
+>TrailingElement : Symbol(TrailingElement, Decl(variadicTupleRelationPositionMapping.ts, 0, 0))
+
+  A,
+>A : Symbol(A, Decl(variadicTupleRelationPositionMapping.ts, 5, 29))
+
+  [...A, boolean]
+>A : Symbol(A, Decl(variadicTupleRelationPositionMapping.ts, 5, 29))
+
+>;
+
+type ExcessTrailingElements<A extends unknown[]> = TrailingElement<
+>ExcessTrailingElements : Symbol(ExcessTrailingElements, Decl(variadicTupleRelationPositionMapping.ts, 8, 2))
+>A : Symbol(A, Decl(variadicTupleRelationPositionMapping.ts, 10, 28))
+>TrailingElement : Symbol(TrailingElement, Decl(variadicTupleRelationPositionMapping.ts, 0, 0))
+
+  A,
+>A : Symbol(A, Decl(variadicTupleRelationPositionMapping.ts, 10, 28))
+
+  [...A, boolean, boolean, boolean, boolean]
+>A : Symbol(A, Decl(variadicTupleRelationPositionMapping.ts, 10, 28))
+
+>;
+
+type TwoVariadicElements<
+>TwoVariadicElements : Symbol(TwoVariadicElements, Decl(variadicTupleRelationPositionMapping.ts, 13, 2))
+
+  A extends unknown[],
+>A : Symbol(A, Decl(variadicTupleRelationPositionMapping.ts, 15, 25))
+
+  B extends unknown[],
+>B : Symbol(B, Decl(variadicTupleRelationPositionMapping.ts, 16, 22))
+
+  Result extends [...A, boolean, ...B, boolean],
+>Result : Symbol(Result, Decl(variadicTupleRelationPositionMapping.ts, 17, 22))
+>A : Symbol(A, Decl(variadicTupleRelationPositionMapping.ts, 15, 25))
+>B : Symbol(B, Decl(variadicTupleRelationPositionMapping.ts, 16, 22))
+
+> = Result;
+>Result : Symbol(Result, Decl(variadicTupleRelationPositionMapping.ts, 17, 22))
+
+type MatchingTwoVariadicElements<
+>MatchingTwoVariadicElements : Symbol(MatchingTwoVariadicElements, Decl(variadicTupleRelationPositionMapping.ts, 19, 11))
+
+  A extends unknown[],
+>A : Symbol(A, Decl(variadicTupleRelationPositionMapping.ts, 21, 33))
+
+  B extends unknown[],
+>B : Symbol(B, Decl(variadicTupleRelationPositionMapping.ts, 22, 22))
+
+> = TwoVariadicElements<A, B, [...A, boolean, ...B, boolean]>;
+>TwoVariadicElements : Symbol(TwoVariadicElements, Decl(variadicTupleRelationPositionMapping.ts, 13, 2))
+>A : Symbol(A, Decl(variadicTupleRelationPositionMapping.ts, 21, 33))
+>B : Symbol(B, Decl(variadicTupleRelationPositionMapping.ts, 22, 22))
+>A : Symbol(A, Decl(variadicTupleRelationPositionMapping.ts, 21, 33))
+>B : Symbol(B, Decl(variadicTupleRelationPositionMapping.ts, 22, 22))
+
+type ExcessMiddleElement<
+>ExcessMiddleElement : Symbol(ExcessMiddleElement, Decl(variadicTupleRelationPositionMapping.ts, 24, 62))
+
+  A extends unknown[],
+>A : Symbol(A, Decl(variadicTupleRelationPositionMapping.ts, 26, 25))
+
+  B extends unknown[],
+>B : Symbol(B, Decl(variadicTupleRelationPositionMapping.ts, 27, 22))
+
+> = TwoVariadicElements<A, B, [...A, boolean, boolean, ...B, boolean]>;
+>TwoVariadicElements : Symbol(TwoVariadicElements, Decl(variadicTupleRelationPositionMapping.ts, 13, 2))
+>A : Symbol(A, Decl(variadicTupleRelationPositionMapping.ts, 26, 25))
+>B : Symbol(B, Decl(variadicTupleRelationPositionMapping.ts, 27, 22))
+>A : Symbol(A, Decl(variadicTupleRelationPositionMapping.ts, 26, 25))
+>B : Symbol(B, Decl(variadicTupleRelationPositionMapping.ts, 27, 22))
+
+type FixedPrefixAndSuffix<
+>FixedPrefixAndSuffix : Symbol(FixedPrefixAndSuffix, Decl(variadicTupleRelationPositionMapping.ts, 29, 71))
+
+  T extends unknown[],
+>T : Symbol(T, Decl(variadicTupleRelationPositionMapping.ts, 31, 26))
+
+  Result extends [boolean, ...T, boolean],
+>Result : Symbol(Result, Decl(variadicTupleRelationPositionMapping.ts, 32, 22))
+>T : Symbol(T, Decl(variadicTupleRelationPositionMapping.ts, 31, 26))
+
+> = Result;
+>Result : Symbol(Result, Decl(variadicTupleRelationPositionMapping.ts, 32, 22))
+
+type MatchingFixedPrefixAndSuffix<T extends unknown[]> = FixedPrefixAndSuffix<
+>MatchingFixedPrefixAndSuffix : Symbol(MatchingFixedPrefixAndSuffix, Decl(variadicTupleRelationPositionMapping.ts, 34, 11))
+>T : Symbol(T, Decl(variadicTupleRelationPositionMapping.ts, 36, 34))
+>FixedPrefixAndSuffix : Symbol(FixedPrefixAndSuffix, Decl(variadicTupleRelationPositionMapping.ts, 29, 71))
+
+  T,
+>T : Symbol(T, Decl(variadicTupleRelationPositionMapping.ts, 36, 34))
+
+  [boolean, ...T, boolean]
+>T : Symbol(T, Decl(variadicTupleRelationPositionMapping.ts, 36, 34))
+
+>;
+
+type MissingFixedPrefix<T extends unknown[]> = FixedPrefixAndSuffix<
+>MissingFixedPrefix : Symbol(MissingFixedPrefix, Decl(variadicTupleRelationPositionMapping.ts, 39, 2))
+>T : Symbol(T, Decl(variadicTupleRelationPositionMapping.ts, 41, 24))
+>FixedPrefixAndSuffix : Symbol(FixedPrefixAndSuffix, Decl(variadicTupleRelationPositionMapping.ts, 29, 71))
+
+  T,
+>T : Symbol(T, Decl(variadicTupleRelationPositionMapping.ts, 41, 24))
+
+  [...T, boolean]
+>T : Symbol(T, Decl(variadicTupleRelationPositionMapping.ts, 41, 24))
+
+>;
+

--- a/testdata/baselines/reference/compiler/variadicTupleRelationPositionMapping.types
+++ b/testdata/baselines/reference/compiler/variadicTupleRelationPositionMapping.types
@@ -1,0 +1,67 @@
+//// [tests/cases/compiler/variadicTupleRelationPositionMapping.ts] ////
+
+=== variadicTupleRelationPositionMapping.ts ===
+type TrailingElement<
+>TrailingElement : Result
+
+  A extends unknown[],
+  Result extends [...A, boolean],
+> = Result;
+
+type MatchingTrailingElement<A extends unknown[]> = TrailingElement<
+>MatchingTrailingElement : [...A, boolean]
+
+  A,
+  [...A, boolean]
+>;
+
+type ExcessTrailingElements<A extends unknown[]> = TrailingElement<
+>ExcessTrailingElements : [...A, boolean, boolean, boolean, boolean]
+
+  A,
+  [...A, boolean, boolean, boolean, boolean]
+>;
+
+type TwoVariadicElements<
+>TwoVariadicElements : Result
+
+  A extends unknown[],
+  B extends unknown[],
+  Result extends [...A, boolean, ...B, boolean],
+> = Result;
+
+type MatchingTwoVariadicElements<
+>MatchingTwoVariadicElements : [...A, boolean, ...B, boolean]
+
+  A extends unknown[],
+  B extends unknown[],
+> = TwoVariadicElements<A, B, [...A, boolean, ...B, boolean]>;
+
+type ExcessMiddleElement<
+>ExcessMiddleElement : [...A, boolean, boolean, ...B, boolean]
+
+  A extends unknown[],
+  B extends unknown[],
+> = TwoVariadicElements<A, B, [...A, boolean, boolean, ...B, boolean]>;
+
+type FixedPrefixAndSuffix<
+>FixedPrefixAndSuffix : Result
+
+  T extends unknown[],
+  Result extends [boolean, ...T, boolean],
+> = Result;
+
+type MatchingFixedPrefixAndSuffix<T extends unknown[]> = FixedPrefixAndSuffix<
+>MatchingFixedPrefixAndSuffix : [boolean, ...T, boolean]
+
+  T,
+  [boolean, ...T, boolean]
+>;
+
+type MissingFixedPrefix<T extends unknown[]> = FixedPrefixAndSuffix<
+>MissingFixedPrefix : [...T, boolean]
+
+  T,
+  [...T, boolean]
+>;
+

--- a/testdata/tests/cases/compiler/variadicTupleRelationPositionMapping.ts
+++ b/testdata/tests/cases/compiler/variadicTupleRelationPositionMapping.ts
@@ -1,0 +1,48 @@
+// @strict: true
+// @noEmit: true
+
+type TrailingElement<
+  A extends unknown[],
+  Result extends [...A, boolean],
+> = Result;
+
+type MatchingTrailingElement<A extends unknown[]> = TrailingElement<
+  A,
+  [...A, boolean]
+>;
+
+type ExcessTrailingElements<A extends unknown[]> = TrailingElement<
+  A,
+  [...A, boolean, boolean, boolean, boolean]
+>;
+
+type TwoVariadicElements<
+  A extends unknown[],
+  B extends unknown[],
+  Result extends [...A, boolean, ...B, boolean],
+> = Result;
+
+type MatchingTwoVariadicElements<
+  A extends unknown[],
+  B extends unknown[],
+> = TwoVariadicElements<A, B, [...A, boolean, ...B, boolean]>;
+
+type ExcessMiddleElement<
+  A extends unknown[],
+  B extends unknown[],
+> = TwoVariadicElements<A, B, [...A, boolean, boolean, ...B, boolean]>;
+
+type FixedPrefixAndSuffix<
+  T extends unknown[],
+  Result extends [boolean, ...T, boolean],
+> = Result;
+
+type MatchingFixedPrefixAndSuffix<T extends unknown[]> = FixedPrefixAndSuffix<
+  T,
+  [boolean, ...T, boolean]
+>;
+
+type MissingFixedPrefix<T extends unknown[]> = FixedPrefixAndSuffix<
+  T,
+  [...T, boolean]
+>;


### PR DESCRIPTION
Fixes #4727

## Analysis

`propertiesRelatedTo` aligns source tuple elements with target tuple elements before comparing their types. For a target such as `[...A, boolean]`, the existing code counted `ElementFlagsNonRest` elements when determining the fixed prefix and suffix. Because `NonRest` includes variadic elements, both counts covered the entire target tuple.

When relating `[...A, boolean, boolean, boolean, boolean]` to that target, this caused a source element to map to target position `-1`. The code avoided reading element flags for a negative position, but subsequently indexed `targetTypeArguments[targetPosition]`, causing the panic reported in #4727.

## Fix

Count only fixed elements when determining tuple prefix and suffix boundaries. Map fixed source suffix elements from the end of the target, and map remaining elements to the target's variable section. This keeps target positions valid and preserves the intended alignment for tuples with one or multiple variadic sections.

The change also reports the existing excess-element diagnostic when a fixed source element cannot match a target variadic element, and limits the range diagnostic to targets with one variable middle element.

Added a compiler regression test covering:

- the original recursive variadic tuple crash,
- valid trailing-element alignment,
- multiple variadic sections,
- excess middle elements,
- and fixed prefix/suffix alignment.

## AI Assistance Disclosure

I used OpenAI Codex to assist with reproducing the crash, tracing the tuple-position calculation, implementing the fix, and running validation. I reviewed the resulting code and baselines, understand the root cause and implementation, and will personally address review feedback.

## Copilot Checklist

I successfully ran these commands at the end of my session, and they completed without error:

- [x] `npx hereby build`
- [ ] `npx hereby test`
- [x] `npx hereby lint`
- [x] `npx hereby format`

The focused regression test passed:

```
go test ./internal/testrunner -run 'TestLocal/variadicTupleRelationPositionMapping' -v
```

The full `npx hereby test` run was attempted on Windows. It was unable to complete because the host exhausted virtual memory while linking parallel Go test binaries, and the filesystem watcher symlink tests also require a Windows privilege unavailable in the current shell. The failures occurred outside the changed checker code; the repository CI remains the authoritative full-suite validation.
