### PR TITLE
Add wasip1 npm build target

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -1486,8 +1486,8 @@ const mainNativePreviewPackage = {
 };
 
 /**
- * @typedef {"win32" | "linux" | "darwin" | "aix" | "android" | "freebsd" | "netbsd" | "openbsd" | "sunos"} OS
- * @typedef {"x64" | "arm" | "arm64" | "ia32" | "ppc64" | "loong64" | "mips64el" | "riscv64" | "s390x"} Arch
+ * @typedef {"win32" | "linux" | "darwin" | "aix" | "android" | "freebsd" | "netbsd" | "openbsd" | "sunos" | "wasip1"} OS
+ * @typedef {"x64" | "arm" | "arm64" | "ia32" | "ppc64" | "loong64" | "mips64el" | "riscv64" | "s390x" | "wasm"} Arch
  * @typedef {"Microsoft400" | "LinuxSign" | "MacDeveloperHarden" | "8020" | "VSCodePublisher"} Cert
  * @typedef {`${OS | "alpine"}-${Exclude<Arch, "arm"> | "armhf"}`} VSCodeTarget
  * @typedef {{ name: string; sourceDir: string }} VsixExtensionPackage
@@ -1534,7 +1534,7 @@ const platforms = [
     { os: "openbsd", arch: "arm64" },
     { os: "openbsd", arch: "x64" },
     { os: "sunos", arch: "x64" },
-    // Wasm?
+    { os: "wasip1", arch: "wasm" },
 ];
 
 const ignoredGoTargets = new Map([
@@ -1558,7 +1558,7 @@ const ignoredGoTargets = new Map([
 
 /**
  * @param {string} os
- * @returns {"windows" | "illumos" | "darwin" | "linux" | "aix" | "android" | "freebsd" | "netbsd" | "openbsd"}
+ * @returns {"windows" | "illumos" | "darwin" | "linux" | "aix" | "android" | "freebsd" | "netbsd" | "openbsd" | "wasip1"}
  */
 function nodeToGOOS(os) {
     switch (os) {
@@ -1573,6 +1573,7 @@ function nodeToGOOS(os) {
         case "freebsd":
         case "netbsd":
         case "openbsd":
+        case "wasip1":
             return os;
         default:
             throw new Error(`Unsupported OS: ${os}`);
@@ -1582,7 +1583,7 @@ function nodeToGOOS(os) {
 /**
  * @param {string} arch
  * @param {string} os
- * @returns {"amd64" | "386" | "mips64le" | "ppc64" | "ppc64le" | "arm" | "arm64" | "loong64" | "riscv64" | "s390x"}
+ * @returns {"amd64" | "386" | "mips64le" | "ppc64" | "ppc64le" | "arm" | "arm64" | "loong64" | "riscv64" | "s390x" | "wasm"}
  */
 function nodeToGOARCH(arch, os) {
     switch (arch) {
@@ -1599,6 +1600,7 @@ function nodeToGOARCH(arch, os) {
         case "loong64":
         case "riscv64":
         case "s390x":
+        case "wasm":
             return arch;
         default:
             throw new Error(`Unsupported ARCH: ${arch}`);
@@ -1609,7 +1611,7 @@ const getPlatforms = memoize(() => {
     const publishTag = getPublishTag();
     let supportedPlatforms = publishAsTypescript && publishTag !== "next"
         ? platforms
-        : platforms.filter(({ vsix }) => vsix);
+        : platforms.filter(({ os, vsix }) => vsix || os === "wasip1");
 
     if (!options.forRelease) {
         supportedPlatforms = supportedPlatforms.filter(({ os, arch }) => os === process.platform && arch === process.arch);
@@ -1697,6 +1699,7 @@ function goDistTargetToPlatform(target) {
         case "linux":
         case "netbsd":
         case "openbsd":
+        case "wasip1":
             nodeOs = target.GOOS;
             break;
         default:
@@ -1726,6 +1729,7 @@ function goDistTargetToPlatform(target) {
         case "loong64":
         case "riscv64":
         case "s390x":
+        case "wasm":
             nodeArch = target.GOARCH;
             break;
         default:
@@ -1863,7 +1867,7 @@ async function runBuildNativePreviewPackages() {
     const mainPackage = {
         ...inputPackageJson,
         name: mainNativePreviewPackage.npmPackageName,
-        optionalDependencies: Object.fromEntries(platforms.map(p => [p.npmPackageName, getVersion()])),
+        optionalDependencies: Object.fromEntries(platforms.filter(p => p.nodeOs !== "wasip1").map(p => [p.npmPackageName, getVersion()])),
     };
 
     const mainPackageDir = mainNativePreviewPackage.npmDir;
@@ -1923,8 +1927,8 @@ async function runBuildNativePreviewPackages() {
             imports: undefined,
             dependencies: undefined,
             name: npmPackageName,
-            os: [nodeOs],
-            cpu: [nodeArch],
+            os: nodeOs === "wasip1" ? undefined : [nodeOs],
+            cpu: nodeOs === "wasip1" ? undefined : [nodeArch],
             exports: {
                 "./package.json": "./package.json",
             },
@@ -1948,7 +1952,7 @@ async function runBuildNativePreviewPackages() {
 
         const exeName = nativePreviewExeName(nodeOs);
         await buildTsgo({
-            out: publishAsTypescript ? path.join(out, exeName) : out,
+            out: publishAsTypescript || nodeOs === "wasip1" ? path.join(out, exeName) : out,
             env: { GOOS: goos, GOARCH: goarch, GOARM: "6", CGO_ENABLED: "0" },
             extraFlags,
         });
@@ -1979,7 +1983,14 @@ export const signNativePreviewPackages = task({
  */
 function nativePreviewExeName(nodeOs) {
     const baseName = publishAsTypescript ? "tsc" : "tsgo";
-    return nodeOs === "win32" ? `${baseName}.exe` : baseName;
+    switch (nodeOs) {
+        case "win32":
+            return `${baseName}.exe`;
+        case "wasip1":
+            return `${baseName}.wasm`;
+        default:
+            return baseName;
+    }
 }
 
 async function runSignNativePreviewPackages() {

--- a/cmd/tsgo/api.go
+++ b/cmd/tsgo/api.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"os/signal"
 	"strings"
 	"syscall"
 
@@ -50,7 +49,7 @@ func runAPI(args []string) int {
 
 	s := api.NewStdioServer(options)
 
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	ctx, stop := notifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
 	if err := s.Run(ctx); err != nil {

--- a/cmd/tsgo/lsp.go
+++ b/cmd/tsgo/lsp.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"os/signal"
 	"syscall"
 	"time"
 
@@ -44,7 +43,7 @@ func runLSP(args []string) int {
 	defaultLibraryPath := bundled.LibPath()
 	typingsLocation := osvfs.GetGlobalTypingsCacheLocation()
 
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	ctx, stop := notifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
 	s := lsp.NewServer(&lsp.ServerOptions{

--- a/cmd/tsgo/main.go
+++ b/cmd/tsgo/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"runtime"
 	"syscall"
 
 	"github.com/microsoft/typescript-go/internal/core"
@@ -25,8 +26,15 @@ func runMain() int {
 			return runAPI(args[1:])
 		}
 	}
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	ctx, stop := notifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 	result := execute.CommandLine(ctx, newSystem(), args, nil)
 	return int(result.Status)
+}
+
+func notifyContext(parent context.Context, signals ...os.Signal) (context.Context, context.CancelFunc) {
+	if runtime.GOOS == "wasip1" {
+		return context.WithCancel(parent)
+	}
+	return signal.NotifyContext(parent, signals...)
 }


### PR DESCRIPTION
Fixes #4633
Fixes #4706

This does not bundle teh lib.d.ts files in the binary, but instead assumes that `tsc.wasm` will live in the right place, which implies the host has mounted the files. I feel like this is probably fine, but, maybe it's not.