### PR TITLE
Refresh config file diagnostics when a config file is saved

### DIFF
--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -411,6 +411,40 @@ func TestPushDiagnostics(t *testing.T) {
 		assert.Equal(t, len(lastTsconfigCall.Params.Diagnostics), 0, "expected no diagnostics after removing baseUrl option")
 	})
 
+	t.Run("updates diagnostics when an open config file is saved", func(t *testing.T) {
+		t.Parallel()
+		files := map[string]any{
+			"/src/tsconfig.json": `{"compilerOptions": {"target": "es2020"}}`,
+			"/src/index.ts":      "export const x = 1;",
+		}
+		session, utils := projecttestutil.Setup(files)
+		session.DidOpenFile(context.Background(), "file:///src/index.ts", 1, files["/src/index.ts"].(string), lsproto.LanguageKindTypeScript)
+		_, err := session.GetLanguageService(context.Background(), lsproto.DocumentUri("file:///src/index.ts"))
+		assert.NilError(t, err)
+		session.WaitForBackgroundTasks()
+
+		// Edit the config file in the editor and save it. No other request follows, so the
+		// save is what has to get the new diagnostics published.
+		newContent := `{"compilerOptions": {"target": "es5"}}`
+		session.DidOpenFile(context.Background(), "file:///src/tsconfig.json", 1, files["/src/tsconfig.json"].(string), lsproto.LanguageKindJSON)
+		session.DidChangeFile(context.Background(), "file:///src/tsconfig.json", 2, []lsproto.TextDocumentContentChangePartialOrWholeDocument{
+			{WholeDocument: &lsproto.TextDocumentContentChangeWholeDocument{Text: newContent}},
+		})
+		assert.NilError(t, utils.FS().WriteFile("/src/tsconfig.json", newContent))
+		session.DidSaveFile(context.Background(), "file:///src/tsconfig.json")
+		session.WaitForBackgroundTasks()
+
+		calls := utils.Client().PublishDiagnosticsCalls()
+		tsconfigCalls := filterDiagnosticsByURI(calls, "file:///src/tsconfig.json", 0)
+		assert.Assert(t, len(tsconfigCalls) > 0, "expected PublishDiagnostics call for tsconfig.json")
+		lastTsconfigCall := tsconfigCalls[len(tsconfigCalls)-1]
+
+		expectedMessage := "Option 'target=ES5' has been removed."
+		assert.Assert(t, slices.ContainsFunc(lastTsconfigCall.Params.Diagnostics, func(diag *lsproto.Diagnostic) bool {
+			return strings.Contains(diag.Message.AsString(), expectedMessage)
+		}), "expected removed target diagnostic on tsconfig.json, got: %v", lastTsconfigCall.Params.Diagnostics)
+	})
+
 	t.Run("does not publish for inferred projects", func(t *testing.T) {
 		t.Parallel()
 		files := map[string]any{

--- a/internal/project/session.go
+++ b/internal/project/session.go
@@ -44,6 +44,7 @@ const (
 	UpdateReasonRequestedLoadProjectTree
 	UpdateReasonRequestedLanguageServiceWithAutoImports
 	UpdateReasonIdleCleanDiskCache
+	UpdateReasonDidSaveConfigFile
 )
 
 // watchRequestTimeout is the maximum time to wait for the client to respond to
@@ -360,11 +361,32 @@ func (s *Session) DidChangeFile(ctx context.Context, uri lsproto.DocumentUri, ve
 func (s *Session) DidSaveFile(ctx context.Context, uri lsproto.DocumentUri) {
 	s.scheduleIdleCacheClean()
 	s.pendingFileChangesMu.Lock()
-	defer s.pendingFileChangesMu.Unlock()
 	s.pendingFileChanges = append(s.pendingFileChanges, FileChange{
 		Kind: FileChangeKindSave,
 		URI:  uri,
 	})
+	s.pendingFileChangesMu.Unlock()
+
+	if s.isConfigFile(uri) {
+		// Diagnostics for config files are only pushed as part of a snapshot update.
+		// Editing a config file usually isn't followed by any request that would flush
+		// the pending changes, so schedule an update to get its diagnostics republished.
+		s.ScheduleSnapshotUpdate(UpdateReasonDidSaveConfigFile)
+	}
+}
+
+// isConfigFile returns true if the given file is a config file known to the current
+// snapshot, or is named like one.
+func (s *Session) isConfigFile(uri lsproto.DocumentUri) bool {
+	fileName := uri.FileName()
+	baseName := tspath.GetBaseFileName(fileName)
+	snapshot := s.Snapshot()
+	if baseName == "tsconfig.json" || baseName == "jsconfig.json" ||
+		(snapshot.ConfigFileRegistry.customConfigFileName != "" && baseName == snapshot.ConfigFileRegistry.customConfigFileName) {
+		return true
+	}
+	// Configs pulled in by `extends` or project references can be named anything.
+	return snapshot.ConfigFileRegistry.GetConfig(snapshot.toPath(fileName)) != nil
 }
 
 func (s *Session) DidChangeWatchedFiles(ctx context.Context, changes []*lsproto.FileEvent) {

--- a/internal/project/snapshot.go
+++ b/internal/project/snapshot.go
@@ -268,6 +268,8 @@ func (s *Snapshot) Clone(ctx context.Context, change SnapshotChange, overlays ma
 			logger.Logf("Reason: DidOpenFile - %s", change.fileChanges.Opened)
 		case UpdateReasonDidCloseFile:
 			logger.Logf("Reason: DidCloseFile - %v", change.fileChanges.Closed)
+		case UpdateReasonDidSaveConfigFile:
+			logger.Logf("Reason: DidSaveConfigFile - %v", change.fileChanges.Changed)
 		case UpdateReasonDidChangeCompilerOptionsForInferredProjects:
 			logger.Logf("Reason: DidChangeCompilerOptionsForInferredProjects")
 		case UpdateReasonRequestedLanguageServicePendingChanges:


### PR DESCRIPTION
Fixes #4713.

## Problem

Diagnostics for `tsconfig.json` / `jsconfig.json` are push-only: they are published from `publishProgramDiagnostics` as part of a snapshot update. `DidChangeFile` and `DidSaveFile` only append to `pendingFileChanges`; neither schedules a snapshot update.

For a normal source file that is fine, because the client follows an edit with requests (diagnostic pulls, completions, …) that flush the pending changes. Editing a config file usually isn't followed by any request, so the edit sits in the pending queue and the config file keeps showing its old diagnostics until something unrelated happens to flush it.

Repro from the issue: open a `.ts` file, open `tsconfig.json`, set `"target": "es5"`, save — no `Option 'target=ES5' has been removed.` diagnostic appears, where 6.0 reports one.

## Fix

`DidSaveFile` schedules a (debounced) snapshot update when the saved file is a config file, which flushes the pending edit and republishes the config file's diagnostics. Config files are recognized by base name (including `customConfigFileName`) or by being present in the snapshot's `ConfigFileRegistry`, which also covers configs pulled in through `extends` / project references under a non-standard name.

Non-config saves are unchanged, so this adds no work to the common save path.

## Tests

Added `TestPushDiagnostics/updates diagnostics when an open config file is saved`: opens a config file, changes `target` to `es5`, saves, and asserts the diagnostic is published with no intervening request. It fails on `main` (no diagnostics published) and passes with this change.

---

This change was authored with AI assistance. I picked the issue, reviewed and tested the patch myself, and will handle review feedback.
