### PR TITLE
Reorganize AST to prevent duplicate fields

### DIFF
--- a/_packages/native-preview/src/ast/ast.generated.ts
+++ b/_packages/native-preview/src/ast/ast.generated.ts
@@ -436,7 +436,8 @@ export interface ModifiersBase extends Node {
     readonly modifiers?: NodeArray<ModifierLike>;
     readonly modifierFlags: ModifierFlags;
 }
-export interface FunctionLikeBase extends DeclarationBase {
+export interface FunctionLikeBase extends Node {
+    readonly _declarationBrand: any;
     readonly typeParameters?: NodeArray<TypeParameterDeclaration>;
     readonly parameters: NodeArray<ParameterDeclaration>;
     readonly type?: TypeNode;
@@ -450,7 +451,8 @@ export interface FunctionLikeWithBodyBase extends FunctionLikeBase, BodyBase {
     readonly _functionLikeDeclarationBrand: any;
     readonly body?: BlockOrExpression;
 }
-export interface ClassLikeBase extends DeclarationBase, ModifiersBase {
+export interface ClassLikeBase extends ModifiersBase {
+    readonly _declarationBrand: any;
     readonly name?: Identifier;
     readonly typeParameters?: NodeArray<TypeParameterDeclaration>;
     readonly heritageClauses?: NodeArray<HeritageClause>;
@@ -473,7 +475,8 @@ export interface TypeElementBase extends Node {
 export interface ClassElementBase extends Node {
     readonly _classElementBrand: any;
 }
-export interface NamedMemberBase extends DeclarationBase, ModifiersBase {
+export interface NamedMemberBase extends ModifiersBase {
+    readonly _declarationBrand: any;
     readonly name: PropertyName;
     readonly postfixToken?: QuestionToken | ExclamationToken;
 }
@@ -637,7 +640,7 @@ export interface FunctionDeclaration extends DeclarationBase, StatementBase, Mod
 export interface ClassDeclaration extends DeclarationBase, StatementBase, ClassLikeBase {
     readonly kind: SyntaxKind.ClassDeclaration;
 }
-export interface ClassExpression extends PrimaryExpressionBase, ClassLikeBase {
+export interface ClassExpression extends DeclarationBase, PrimaryExpressionBase, ClassLikeBase {
     readonly kind: SyntaxKind.ClassExpression;
 }
 export interface HeritageClause extends NodeBase {
@@ -658,7 +661,7 @@ export interface TypeAliasDeclaration extends DeclarationBase, StatementBase, Mo
     readonly typeParameters?: NodeArray<TypeParameterDeclaration>;
     readonly type: TypeNode;
 }
-export interface EnumMember extends NodeBase, NamedMemberBase {
+export interface EnumMember extends DeclarationBase, NodeBase, NamedMemberBase {
     readonly kind: SyntaxKind.EnumMember;
     readonly initializer?: Expression;
 }
@@ -729,11 +732,11 @@ export interface ConstructorDeclaration extends NodeBase, DeclarationBase, Modif
     readonly kind: SyntaxKind.Constructor;
     readonly body?: FunctionBody;
 }
-export interface GetAccessorDeclaration extends NamedMemberBase, FunctionLikeWithBodyBase, TypeElementBase, ClassElementBase, ObjectLiteralElementBase, NodeBase {
+export interface GetAccessorDeclaration extends DeclarationBase, NamedMemberBase, FunctionLikeWithBodyBase, TypeElementBase, ClassElementBase, ObjectLiteralElementBase, NodeBase {
     readonly kind: SyntaxKind.GetAccessor;
     readonly body?: FunctionBody;
 }
-export interface SetAccessorDeclaration extends NamedMemberBase, FunctionLikeWithBodyBase, TypeElementBase, ClassElementBase, ObjectLiteralElementBase, NodeBase {
+export interface SetAccessorDeclaration extends DeclarationBase, NamedMemberBase, FunctionLikeWithBodyBase, TypeElementBase, ClassElementBase, ObjectLiteralElementBase, NodeBase {
     readonly kind: SyntaxKind.SetAccessor;
     readonly body?: FunctionBody;
 }
@@ -741,19 +744,19 @@ export interface IndexSignatureDeclaration extends NodeBase, DeclarationBase, Mo
     readonly kind: SyntaxKind.IndexSignature;
     readonly type: TypeNode;
 }
-export interface MethodSignatureDeclaration extends NodeBase, NamedMemberBase, FunctionLikeBase, TypeElementBase {
+export interface MethodSignatureDeclaration extends DeclarationBase, NodeBase, NamedMemberBase, FunctionLikeBase, TypeElementBase {
     readonly kind: SyntaxKind.MethodSignature;
 }
-export interface MethodDeclaration extends NodeBase, NamedMemberBase, FunctionLikeWithBodyBase, ClassElementBase, ObjectLiteralElementBase {
+export interface MethodDeclaration extends DeclarationBase, NodeBase, NamedMemberBase, FunctionLikeWithBodyBase, ClassElementBase, ObjectLiteralElementBase {
     readonly kind: SyntaxKind.MethodDeclaration;
     readonly body?: FunctionBody;
 }
-export interface PropertySignatureDeclaration extends NodeBase, NamedMemberBase, TypeElementBase {
+export interface PropertySignatureDeclaration extends DeclarationBase, NodeBase, NamedMemberBase, TypeElementBase {
     readonly kind: SyntaxKind.PropertySignature;
     readonly type: TypeNode;
     readonly initializer: Expression;
 }
-export interface PropertyDeclaration extends NodeBase, NamedMemberBase, ClassElementBase {
+export interface PropertyDeclaration extends DeclarationBase, NodeBase, NamedMemberBase, ClassElementBase {
     readonly kind: SyntaxKind.PropertyDeclaration;
     readonly type?: TypeNode;
     readonly initializer?: Expression;
@@ -909,12 +912,12 @@ export interface SpreadAssignment extends NodeBase, DeclarationBase, ObjectLiter
     readonly kind: SyntaxKind.SpreadAssignment;
     readonly expression: Expression;
 }
-export interface PropertyAssignment extends NodeBase, NamedMemberBase, ObjectLiteralElementBase {
+export interface PropertyAssignment extends DeclarationBase, NodeBase, NamedMemberBase, ObjectLiteralElementBase {
     readonly kind: SyntaxKind.PropertyAssignment;
     readonly type: TypeNode;
     readonly initializer: Expression;
 }
-export interface ShorthandPropertyAssignment extends NodeBase, NamedMemberBase, ObjectLiteralElementBase {
+export interface ShorthandPropertyAssignment extends DeclarationBase, NodeBase, NamedMemberBase, ObjectLiteralElementBase {
     readonly kind: SyntaxKind.ShorthandPropertyAssignment;
     readonly type: TypeNode;
     readonly equalsToken?: EqualsToken;
@@ -944,10 +947,10 @@ export interface TypeAssertion extends UnaryExpressionBase {
 export interface KeywordTypeNode<TKind extends KeywordTypeSyntaxKind = KeywordTypeSyntaxKind> extends TypeNodeBase {
     readonly kind: TKind;
 }
-export interface UnionTypeNode extends TypeNodeBase, UnionOrIntersectionTypeNodeBase {
+export interface UnionTypeNode extends UnionOrIntersectionTypeNodeBase {
     readonly kind: SyntaxKind.UnionType;
 }
-export interface IntersectionTypeNode extends TypeNodeBase, UnionOrIntersectionTypeNodeBase {
+export interface IntersectionTypeNode extends UnionOrIntersectionTypeNodeBase {
     readonly kind: SyntaxKind.IntersectionType;
 }
 export interface ConditionalTypeNode extends TypeNodeBase {
@@ -1048,10 +1051,10 @@ export interface ParenthesizedTypeNode extends TypeNodeBase {
     readonly kind: SyntaxKind.ParenthesizedType;
     readonly type: TypeNode;
 }
-export interface FunctionTypeNode extends TypeNodeBase, ModifiersBase, FunctionLikeBase {
+export interface FunctionTypeNode extends DeclarationBase, TypeNodeBase, ModifiersBase, FunctionLikeBase {
     readonly kind: SyntaxKind.FunctionType;
 }
-export interface ConstructorTypeNode extends TypeNodeBase, ModifiersBase, FunctionLikeBase {
+export interface ConstructorTypeNode extends DeclarationBase, TypeNodeBase, ModifiersBase, FunctionLikeBase {
     readonly kind: SyntaxKind.ConstructorType;
 }
 export interface TemplateHead extends NodeBase, TemplateLiteralLikeNodeBase {
@@ -1254,7 +1257,7 @@ export interface JSDocTypedefTag extends JSDocTagBase {
     readonly typeExpression?: Node;
     readonly name?: JSDocFullName;
 }
-export interface JSDocSignature extends JSDocTypeBase, FunctionLikeBase {
+export interface JSDocSignature extends DeclarationBase, JSDocTypeBase, FunctionLikeBase {
     readonly kind: SyntaxKind.JSDocSignature;
 }
 export interface JSDocNameReference extends TypeNodeBase {

--- a/_packages/native-preview/src/ast/ast.generated.ts
+++ b/_packages/native-preview/src/ast/ast.generated.ts
@@ -462,7 +462,7 @@ export interface LiteralLikeNodeBase extends Node {
     readonly text: string;
     readonly tokenFlags: TokenFlags;
 }
-export interface LiteralExpressionBase extends LiteralLikeNodeBase, PrimaryExpressionBase {
+export interface LiteralExpressionBase extends PrimaryExpressionBase, LiteralLikeNodeBase {
     readonly _literalExpressionBrand: any;
 }
 export interface TemplateLiteralLikeNodeBase extends LiteralLikeNodeBase {
@@ -632,15 +632,15 @@ export interface BindingElement extends NodeBase, DeclarationBase {
 export interface MissingDeclaration extends StatementBase, DeclarationBase, ModifiersBase {
     readonly kind: SyntaxKind.MissingDeclaration;
 }
-export interface FunctionDeclaration extends DeclarationBase, StatementBase, ModifiersBase, FunctionLikeWithBodyBase {
+export interface FunctionDeclaration extends StatementBase, DeclarationBase, ModifiersBase, FunctionLikeWithBodyBase {
     readonly kind: SyntaxKind.FunctionDeclaration;
     readonly name?: Identifier;
     readonly body?: FunctionBody;
 }
-export interface ClassDeclaration extends DeclarationBase, StatementBase, ClassLikeBase {
+export interface ClassDeclaration extends StatementBase, DeclarationBase, ClassLikeBase {
     readonly kind: SyntaxKind.ClassDeclaration;
 }
-export interface ClassExpression extends DeclarationBase, PrimaryExpressionBase, ClassLikeBase {
+export interface ClassExpression extends PrimaryExpressionBase, DeclarationBase, ClassLikeBase {
     readonly kind: SyntaxKind.ClassExpression;
 }
 export interface HeritageClause extends NodeBase {
@@ -648,24 +648,24 @@ export interface HeritageClause extends NodeBase {
     readonly token: SyntaxKind.ExtendsKeyword | SyntaxKind.ImplementsKeyword;
     readonly types: NodeArray<ExpressionWithTypeArguments>;
 }
-export interface InterfaceDeclaration extends DeclarationBase, StatementBase, ModifiersBase {
+export interface InterfaceDeclaration extends StatementBase, DeclarationBase, ModifiersBase {
     readonly kind: SyntaxKind.InterfaceDeclaration;
     readonly name: Identifier;
     readonly typeParameters?: NodeArray<TypeParameterDeclaration>;
     readonly heritageClauses?: NodeArray<HeritageClause>;
     readonly members: NodeArray<TypeElement>;
 }
-export interface TypeAliasDeclaration extends DeclarationBase, StatementBase, ModifiersBase {
+export interface TypeAliasDeclaration extends StatementBase, DeclarationBase, ModifiersBase {
     readonly kind: SyntaxKind.TypeAliasDeclaration;
     readonly name: Identifier;
     readonly typeParameters?: NodeArray<TypeParameterDeclaration>;
     readonly type: TypeNode;
 }
-export interface EnumMember extends DeclarationBase, NodeBase, NamedMemberBase {
+export interface EnumMember extends NodeBase, DeclarationBase, NamedMemberBase {
     readonly kind: SyntaxKind.EnumMember;
     readonly initializer?: Expression;
 }
-export interface EnumDeclaration extends DeclarationBase, StatementBase, ModifiersBase {
+export interface EnumDeclaration extends StatementBase, DeclarationBase, ModifiersBase {
     readonly kind: SyntaxKind.EnumDeclaration;
     readonly name: Identifier;
     readonly members: NodeArray<EnumMember>;
@@ -698,13 +698,13 @@ export interface NamedImports extends NodeBase {
     readonly kind: SyntaxKind.NamedImports;
     readonly elements: NodeArray<ImportSpecifier>;
 }
-export interface ExportAssignment extends DeclarationBase, StatementBase, ModifiersBase {
+export interface ExportAssignment extends StatementBase, DeclarationBase, ModifiersBase {
     readonly kind: SyntaxKind.ExportAssignment;
     readonly isExportEquals: boolean;
     readonly type: TypeNode;
     readonly expression: Expression;
 }
-export interface NamespaceExportDeclaration extends DeclarationBase, StatementBase, ModifiersBase {
+export interface NamespaceExportDeclaration extends StatementBase, DeclarationBase, ModifiersBase {
     readonly kind: SyntaxKind.NamespaceExportDeclaration;
     readonly name: Identifier;
 }
@@ -732,11 +732,11 @@ export interface ConstructorDeclaration extends NodeBase, DeclarationBase, Modif
     readonly kind: SyntaxKind.Constructor;
     readonly body?: FunctionBody;
 }
-export interface GetAccessorDeclaration extends DeclarationBase, NamedMemberBase, FunctionLikeWithBodyBase, TypeElementBase, ClassElementBase, ObjectLiteralElementBase, NodeBase {
+export interface GetAccessorDeclaration extends NodeBase, DeclarationBase, NamedMemberBase, FunctionLikeWithBodyBase, TypeElementBase, ClassElementBase, ObjectLiteralElementBase {
     readonly kind: SyntaxKind.GetAccessor;
     readonly body?: FunctionBody;
 }
-export interface SetAccessorDeclaration extends DeclarationBase, NamedMemberBase, FunctionLikeWithBodyBase, TypeElementBase, ClassElementBase, ObjectLiteralElementBase, NodeBase {
+export interface SetAccessorDeclaration extends NodeBase, DeclarationBase, NamedMemberBase, FunctionLikeWithBodyBase, TypeElementBase, ClassElementBase, ObjectLiteralElementBase {
     readonly kind: SyntaxKind.SetAccessor;
     readonly body?: FunctionBody;
 }
@@ -744,19 +744,19 @@ export interface IndexSignatureDeclaration extends NodeBase, DeclarationBase, Mo
     readonly kind: SyntaxKind.IndexSignature;
     readonly type: TypeNode;
 }
-export interface MethodSignatureDeclaration extends DeclarationBase, NodeBase, NamedMemberBase, FunctionLikeBase, TypeElementBase {
+export interface MethodSignatureDeclaration extends NodeBase, DeclarationBase, NamedMemberBase, FunctionLikeBase, TypeElementBase {
     readonly kind: SyntaxKind.MethodSignature;
 }
-export interface MethodDeclaration extends DeclarationBase, NodeBase, NamedMemberBase, FunctionLikeWithBodyBase, ClassElementBase, ObjectLiteralElementBase {
+export interface MethodDeclaration extends NodeBase, DeclarationBase, NamedMemberBase, FunctionLikeWithBodyBase, ClassElementBase, ObjectLiteralElementBase {
     readonly kind: SyntaxKind.MethodDeclaration;
     readonly body?: FunctionBody;
 }
-export interface PropertySignatureDeclaration extends DeclarationBase, NodeBase, NamedMemberBase, TypeElementBase {
+export interface PropertySignatureDeclaration extends NodeBase, DeclarationBase, NamedMemberBase, TypeElementBase {
     readonly kind: SyntaxKind.PropertySignature;
     readonly type: TypeNode;
     readonly initializer: Expression;
 }
-export interface PropertyDeclaration extends DeclarationBase, NodeBase, NamedMemberBase, ClassElementBase {
+export interface PropertyDeclaration extends NodeBase, DeclarationBase, NamedMemberBase, ClassElementBase {
     readonly kind: SyntaxKind.PropertyDeclaration;
     readonly type?: TypeNode;
     readonly initializer?: Expression;
@@ -912,12 +912,12 @@ export interface SpreadAssignment extends NodeBase, DeclarationBase, ObjectLiter
     readonly kind: SyntaxKind.SpreadAssignment;
     readonly expression: Expression;
 }
-export interface PropertyAssignment extends DeclarationBase, NodeBase, NamedMemberBase, ObjectLiteralElementBase {
+export interface PropertyAssignment extends NodeBase, DeclarationBase, NamedMemberBase, ObjectLiteralElementBase {
     readonly kind: SyntaxKind.PropertyAssignment;
     readonly type: TypeNode;
     readonly initializer: Expression;
 }
-export interface ShorthandPropertyAssignment extends DeclarationBase, NodeBase, NamedMemberBase, ObjectLiteralElementBase {
+export interface ShorthandPropertyAssignment extends NodeBase, DeclarationBase, NamedMemberBase, ObjectLiteralElementBase {
     readonly kind: SyntaxKind.ShorthandPropertyAssignment;
     readonly type: TypeNode;
     readonly equalsToken?: EqualsToken;
@@ -1051,10 +1051,10 @@ export interface ParenthesizedTypeNode extends TypeNodeBase {
     readonly kind: SyntaxKind.ParenthesizedType;
     readonly type: TypeNode;
 }
-export interface FunctionTypeNode extends DeclarationBase, TypeNodeBase, ModifiersBase, FunctionLikeBase {
+export interface FunctionTypeNode extends TypeNodeBase, DeclarationBase, ModifiersBase, FunctionLikeBase {
     readonly kind: SyntaxKind.FunctionType;
 }
-export interface ConstructorTypeNode extends DeclarationBase, TypeNodeBase, ModifiersBase, FunctionLikeBase {
+export interface ConstructorTypeNode extends TypeNodeBase, DeclarationBase, ModifiersBase, FunctionLikeBase {
     readonly kind: SyntaxKind.ConstructorType;
 }
 export interface TemplateHead extends NodeBase, TemplateLiteralLikeNodeBase {
@@ -1130,7 +1130,7 @@ export interface JsxAttribute extends NodeBase, DeclarationBase {
     readonly name: JsxAttributeName;
     readonly initializer?: JsxAttributeValue;
 }
-export interface JsxSpreadAttribute extends ObjectLiteralElementBase, NodeBase {
+export interface JsxSpreadAttribute extends NodeBase, ObjectLiteralElementBase {
     readonly kind: SyntaxKind.JsxSpreadAttribute;
     readonly expression: Expression;
 }
@@ -1257,26 +1257,26 @@ export interface JSDocTypedefTag extends JSDocTagBase {
     readonly typeExpression?: Node;
     readonly name?: JSDocFullName;
 }
-export interface JSDocSignature extends DeclarationBase, JSDocTypeBase, FunctionLikeBase {
+export interface JSDocSignature extends JSDocTypeBase, DeclarationBase, FunctionLikeBase {
     readonly kind: SyntaxKind.JSDocSignature;
 }
 export interface JSDocNameReference extends TypeNodeBase {
     readonly kind: SyntaxKind.JSDocNameReference;
     readonly name: EntityName;
 }
-export interface ModuleDeclaration extends DeclarationBase, StatementBase, ModifiersBase, BodyBase {
+export interface ModuleDeclaration extends StatementBase, DeclarationBase, ModifiersBase, BodyBase {
     readonly kind: SyntaxKind.ModuleDeclaration;
     readonly keyword: SyntaxKind.ModuleKeyword | SyntaxKind.NamespaceKeyword;
     readonly name: ModuleName;
     readonly body?: ModuleBody;
 }
-export interface ImportEqualsDeclaration extends DeclarationBase, StatementBase, ModifiersBase {
+export interface ImportEqualsDeclaration extends StatementBase, DeclarationBase, ModifiersBase {
     readonly kind: SyntaxKind.ImportEqualsDeclaration;
     readonly isTypeOnly: boolean;
     readonly name: Identifier;
     readonly moduleReference: ModuleReference;
 }
-export interface ExportDeclaration extends DeclarationBase, StatementBase, ModifiersBase {
+export interface ExportDeclaration extends StatementBase, DeclarationBase, ModifiersBase {
     readonly kind: SyntaxKind.ExportDeclaration;
     readonly isTypeOnly: boolean;
     readonly exportClause?: NamedExportBindings;

--- a/_scripts/ast.json
+++ b/_scripts/ast.json
@@ -1053,8 +1053,8 @@
         },
         "LiteralExpressionBase": {
             "extends": [
-                "LiteralLikeNodeBase",
-                "PrimaryExpressionBase"
+                "PrimaryExpressionBase",
+                "LiteralLikeNodeBase"
             ],
             "brand": "_literalExpressionBrand"
         },
@@ -1105,6 +1105,7 @@
         },
         "AccessorDeclarationBase": {
             "extends": [
+                "NodeBase",
                 "DeclarationBase",
                 "NamedMemberBase",
                 "FunctionLikeWithBodyBase",
@@ -1112,14 +1113,13 @@
                 "TypeElementBase",
                 "ClassElementBase",
                 "ObjectLiteralElementBase",
-                "CompositeBase",
-                "NodeBase"
+                "CompositeBase"
             ]
         },
         "FunctionOrConstructorTypeNodeBase": {
             "extends": [
-                "DeclarationBase",
                 "TypeNodeBase",
+                "DeclarationBase",
                 "ModifiersBase",
                 "FunctionLikeBase"
             ]
@@ -1825,8 +1825,8 @@
             },
             "FunctionDeclaration": {
                 "extends": [
-                    "DeclarationBase",
                     "StatementBase",
+                    "DeclarationBase",
                     "ExportableBase",
                     "ModifiersBase",
                     "FunctionLikeWithBodyBase",
@@ -1882,8 +1882,8 @@
             },
             "ClassDeclaration": {
                 "extends": [
-                    "DeclarationBase",
                     "StatementBase",
+                    "DeclarationBase",
                     "ClassLikeBase"
                 ],
                 "members": [
@@ -1911,8 +1911,8 @@
             },
             "ClassExpression": {
                 "extends": [
-                    "DeclarationBase",
                     "PrimaryExpressionBase",
+                    "DeclarationBase",
                     "ClassLikeBase"
                 ],
                 "members": [
@@ -1961,8 +1961,8 @@
             },
             "InterfaceDeclaration": {
                 "extends": [
-                    "DeclarationBase",
                     "StatementBase",
+                    "DeclarationBase",
                     "ExportableBase",
                     "ModifiersBase",
                     "TypeSyntaxBase"
@@ -2003,8 +2003,8 @@
                     "JSTypeAliasDeclaration"
                 ],
                 "extends": [
-                    "DeclarationBase",
                     "StatementBase",
+                    "DeclarationBase",
                     "ExportableBase",
                     "ModifiersBase",
                     "LocalsContainerBase",
@@ -2035,8 +2035,8 @@
             },
             "EnumMember": {
                 "extends": [
-                    "DeclarationBase",
                     "NodeBase",
+                    "DeclarationBase",
                     "NamedMemberBase",
                     "CompositeBase"
                 ],
@@ -2054,8 +2054,8 @@
             },
             "EnumDeclaration": {
                 "extends": [
-                    "DeclarationBase",
                     "StatementBase",
+                    "DeclarationBase",
                     "ExportableBase",
                     "ModifiersBase",
                     "CompositeBase"
@@ -2178,8 +2178,8 @@
             },
             "ExportAssignment": {
                 "extends": [
-                    "DeclarationBase",
                     "StatementBase",
+                    "DeclarationBase",
                     "ModifiersBase",
                     "CompositeBase"
                 ],
@@ -2204,8 +2204,8 @@
             },
             "NamespaceExportDeclaration": {
                 "extends": [
-                    "DeclarationBase",
                     "StatementBase",
+                    "DeclarationBase",
                     "ModifiersBase",
                     "TypeSyntaxBase"
                 ],
@@ -2481,8 +2481,8 @@
             "MethodSignatureDeclaration": {
                 "kind": "MethodSignature",
                 "extends": [
-                    "DeclarationBase",
                     "NodeBase",
+                    "DeclarationBase",
                     "NamedMemberBase",
                     "FunctionLikeBase",
                     "TypeElementBase",
@@ -2518,8 +2518,8 @@
             },
             "MethodDeclaration": {
                 "extends": [
-                    "DeclarationBase",
                     "NodeBase",
+                    "DeclarationBase",
                     "NamedMemberBase",
                     "FunctionLikeWithBodyBase",
                     "FlowNodeBase",
@@ -2574,8 +2574,8 @@
             "PropertySignatureDeclaration": {
                 "kind": "PropertySignature",
                 "extends": [
-                    "DeclarationBase",
                     "NodeBase",
+                    "DeclarationBase",
                     "NamedMemberBase",
                     "TypeElementBase",
                     "TypeSyntaxBase"
@@ -2606,8 +2606,8 @@
             },
             "PropertyDeclaration": {
                 "extends": [
-                    "DeclarationBase",
                     "NodeBase",
+                    "DeclarationBase",
                     "NamedMemberBase",
                     "ClassElementBase",
                     "CompositeBase"
@@ -3335,8 +3335,8 @@
             },
             "PropertyAssignment": {
                 "extends": [
-                    "DeclarationBase",
                     "NodeBase",
+                    "DeclarationBase",
                     "NamedMemberBase",
                     "ObjectLiteralElementBase",
                     "CompositeBase"
@@ -3367,8 +3367,8 @@
             },
             "ShorthandPropertyAssignment": {
                 "extends": [
-                    "DeclarationBase",
                     "NodeBase",
+                    "DeclarationBase",
                     "NamedMemberBase",
                     "ObjectLiteralElementBase",
                     "CompositeBase"
@@ -4197,8 +4197,8 @@
             },
             "JsxSpreadAttribute": {
                 "extends": [
-                    "ObjectLiteralElementBase",
-                    "NodeBase"
+                    "NodeBase",
+                    "ObjectLiteralElementBase"
                 ],
                 "members": [
                     {
@@ -4728,8 +4728,8 @@
             },
             "JSDocSignature": {
                 "extends": [
-                    "DeclarationBase",
                     "JSDocTypeBase",
+                    "DeclarationBase",
                     "FunctionLikeBase"
                 ],
                 "members": [
@@ -4782,8 +4782,8 @@
             },
             "ModuleDeclaration": {
                 "extends": [
-                    "DeclarationBase",
                     "StatementBase",
+                    "DeclarationBase",
                     "ExportableBase",
                     "ModifiersBase",
                     "LocalsContainerBase",
@@ -4816,8 +4816,8 @@
             },
             "ImportEqualsDeclaration": {
                 "extends": [
-                    "DeclarationBase",
                     "StatementBase",
+                    "DeclarationBase",
                     "ExportableBase",
                     "ModifiersBase",
                     "CompositeBase"
@@ -4844,8 +4844,8 @@
             },
             "ExportDeclaration": {
                 "extends": [
-                    "DeclarationBase",
                     "StatementBase",
+                    "DeclarationBase",
                     "ModifiersBase",
                     "CompositeBase"
                 ],

--- a/_scripts/ast.json
+++ b/_scripts/ast.json
@@ -955,8 +955,8 @@
             "extends": []
         },
         "FunctionLikeBase": {
+            "brand": "_declarationBrand",
             "extends": [
-                "DeclarationBase",
                 "LocalsContainerBase"
             ],
             "fields": {
@@ -1011,8 +1011,8 @@
             "brand": "_functionLikeDeclarationBrand"
         },
         "ClassLikeBase": {
+            "brand": "_declarationBrand",
             "extends": [
-                "DeclarationBase",
                 "ExportableBase",
                 "ModifiersBase",
                 "LocalsContainerBase",
@@ -1080,8 +1080,8 @@
             "extends": []
         },
         "NamedMemberBase": {
+            "brand": "_declarationBrand",
             "extends": [
-                "DeclarationBase",
                 "ModifiersBase"
             ],
             "fields": {
@@ -1105,6 +1105,7 @@
         },
         "AccessorDeclarationBase": {
             "extends": [
+                "DeclarationBase",
                 "NamedMemberBase",
                 "FunctionLikeWithBodyBase",
                 "FlowNodeBase",
@@ -1117,6 +1118,7 @@
         },
         "FunctionOrConstructorTypeNodeBase": {
             "extends": [
+                "DeclarationBase",
                 "TypeNodeBase",
                 "ModifiersBase",
                 "FunctionLikeBase"
@@ -1909,6 +1911,7 @@
             },
             "ClassExpression": {
                 "extends": [
+                    "DeclarationBase",
                     "PrimaryExpressionBase",
                     "ClassLikeBase"
                 ],
@@ -2032,6 +2035,7 @@
             },
             "EnumMember": {
                 "extends": [
+                    "DeclarationBase",
                     "NodeBase",
                     "NamedMemberBase",
                     "CompositeBase"
@@ -2477,6 +2481,7 @@
             "MethodSignatureDeclaration": {
                 "kind": "MethodSignature",
                 "extends": [
+                    "DeclarationBase",
                     "NodeBase",
                     "NamedMemberBase",
                     "FunctionLikeBase",
@@ -2513,6 +2518,7 @@
             },
             "MethodDeclaration": {
                 "extends": [
+                    "DeclarationBase",
                     "NodeBase",
                     "NamedMemberBase",
                     "FunctionLikeWithBodyBase",
@@ -2568,6 +2574,7 @@
             "PropertySignatureDeclaration": {
                 "kind": "PropertySignature",
                 "extends": [
+                    "DeclarationBase",
                     "NodeBase",
                     "NamedMemberBase",
                     "TypeElementBase",
@@ -2599,6 +2606,7 @@
             },
             "PropertyDeclaration": {
                 "extends": [
+                    "DeclarationBase",
                     "NodeBase",
                     "NamedMemberBase",
                     "ClassElementBase",
@@ -3327,6 +3335,7 @@
             },
             "PropertyAssignment": {
                 "extends": [
+                    "DeclarationBase",
                     "NodeBase",
                     "NamedMemberBase",
                     "ObjectLiteralElementBase",
@@ -3358,6 +3367,7 @@
             },
             "ShorthandPropertyAssignment": {
                 "extends": [
+                    "DeclarationBase",
                     "NodeBase",
                     "NamedMemberBase",
                     "ObjectLiteralElementBase",
@@ -3478,7 +3488,6 @@
             "UnionTypeNode": {
                 "kind": "UnionType",
                 "extends": [
-                    "TypeNodeBase",
                     "UnionOrIntersectionTypeNodeBase"
                 ],
                 "members": [
@@ -3492,7 +3501,6 @@
             "IntersectionTypeNode": {
                 "kind": "IntersectionType",
                 "extends": [
-                    "TypeNodeBase",
                     "UnionOrIntersectionTypeNodeBase"
                 ],
                 "members": [
@@ -3872,7 +3880,6 @@
             "FunctionTypeNode": {
                 "kind": "FunctionType",
                 "extends": [
-                    "TypeNodeBase",
                     "FunctionOrConstructorTypeNodeBase"
                 ],
                 "members": [
@@ -3894,7 +3901,6 @@
             "ConstructorTypeNode": {
                 "kind": "ConstructorType",
                 "extends": [
-                    "TypeNodeBase",
                     "FunctionOrConstructorTypeNodeBase"
                 ],
                 "members": [
@@ -4722,6 +4728,7 @@
             },
             "JSDocSignature": {
                 "extends": [
+                    "DeclarationBase",
                     "JSDocTypeBase",
                     "FunctionLikeBase"
                 ],
@@ -5090,7 +5097,10 @@
                 "members": [
                     {
                         "name": "Kind",
-                        "type": ["SyntaxKind.JSDocParameterTag", "SyntaxKind.JSDocPropertyTag"],
+                        "type": [
+                            "SyntaxKind.JSDocParameterTag",
+                            "SyntaxKind.JSDocPropertyTag"
+                        ],
                         "inherited": true
                     },
                     {

--- a/_scripts/generate-go-ast.ts
+++ b/_scripts/generate-go-ast.ts
@@ -141,15 +141,6 @@ function generateHeader(w: CodeWriter) {
 
 /**
  * Verifies that nothing inherits a base along more than one path.
- *
- * A Go embedded base is real storage, not interface inheritance, so a base reached twice
- * is stored twice. Go resolves promoted selectors to the shallowest copy, which means the
- * duplicate compiles and "works" while wasting memory and leaving a zero-valued shadow
- * copy that any explicitly-qualified access would silently read.
- *
- * Fix violations in ast.json rather than here. If the redundant `extends` edge exists only
- * to brand the generated TypeScript interface, drop the edge and give the base a `brand`
- * instead: that keeps the interface identical without contributing Go storage.
  */
 function verifyNoDuplicateBases(): void {
     const problems: string[] = [];
@@ -176,10 +167,6 @@ function verifyNoDuplicateBases(): void {
 
 /**
  * Verifies that the inheritance path containing NodeBase is embedded first.
- *
- * NodeDefault.AsNode relies on the embedded Node being at offset zero in every concrete
- * node struct. It is not enough for NodeBase to be reachable exactly once: any base stored
- * before that path shifts Node away from the start of the struct.
  */
 function verifyNodeBaseAtOffsetZero(): void {
     const containsNodeBase = (key: string): boolean => {

--- a/_scripts/generate-go-ast.ts
+++ b/_scripts/generate-go-ast.ts
@@ -187,14 +187,17 @@ function verifyNodeBaseAtOffsetZero(): void {
         return api.getBase(key)?.extendsKeys.some(containsNodeBase) ?? false;
     };
     const problems: string[] = [];
-    const check = (name: string, extendsKeys: string[]) => {
+    const check = (name: string, extendsKeys: string[], requireNodeBase: boolean) => {
         const nodeBaseIndex = extendsKeys.findIndex(containsNodeBase);
-        if (nodeBaseIndex > 0) {
+        if (nodeBaseIndex < 0 && requireNodeBase) {
+            problems.push(`${name} does not embed NodeBase`);
+        }
+        else if (nodeBaseIndex > 0) {
             problems.push(`${name} embeds ${extendsKeys[nodeBaseIndex]} after ${extendsKeys.slice(0, nodeBaseIndex).join(", ")}`);
         }
     };
-    for (const base of api.bases()) check(base.key, base.extendsKeys);
-    for (const node of api.nodes()) check(node.name, node.extendsKeys);
+    for (const base of api.bases()) check(base.key, base.extendsKeys, false);
+    for (const node of api.nodes()) check(node.name, node.extendsKeys, true);
 
     if (problems.length > 0) {
         throw new Error(`ast.json does not embed NodeBase at offset zero:\n  ${problems.sort().join("\n  ")}`);

--- a/_scripts/generate-go-ast.ts
+++ b/_scripts/generate-go-ast.ts
@@ -174,7 +174,35 @@ function verifyNoDuplicateBases(): void {
     }
 }
 
+/**
+ * Verifies that the inheritance path containing NodeBase is embedded first.
+ *
+ * NodeDefault.AsNode relies on the embedded Node being at offset zero in every concrete
+ * node struct. It is not enough for NodeBase to be reachable exactly once: any base stored
+ * before that path shifts Node away from the start of the struct.
+ */
+function verifyNodeBaseAtOffsetZero(): void {
+    const containsNodeBase = (key: string): boolean => {
+        if (key === "NodeBase") return true;
+        return api.getBase(key)?.extendsKeys.some(containsNodeBase) ?? false;
+    };
+    const problems: string[] = [];
+    const check = (name: string, extendsKeys: string[]) => {
+        const nodeBaseIndex = extendsKeys.findIndex(containsNodeBase);
+        if (nodeBaseIndex > 0) {
+            problems.push(`${name} embeds ${extendsKeys[nodeBaseIndex]} after ${extendsKeys.slice(0, nodeBaseIndex).join(", ")}`);
+        }
+    };
+    for (const base of api.bases()) check(base.key, base.extendsKeys);
+    for (const node of api.nodes()) check(node.name, node.extendsKeys);
+
+    if (problems.length > 0) {
+        throw new Error(`ast.json does not embed NodeBase at offset zero:\n  ${problems.sort().join("\n  ")}`);
+    }
+}
+
 verifyNoDuplicateBases();
+verifyNodeBaseAtOffsetZero();
 
 function generateStructDef(w: CodeWriter, node: NodeType) {
     const structName = node.name;

--- a/_scripts/generate-go-ast.ts
+++ b/_scripts/generate-go-ast.ts
@@ -139,13 +139,87 @@ function generateHeader(w: CodeWriter) {
 
 // ── Generate struct definitions ────────────────────────────────────────────
 
+/**
+ * Bases that must be "hoisted" so each Go struct stores them exactly once.
+ *
+ * A Go embedded base is real storage, not interface inheritance. When a node lists a
+ * base directly *and* also inherits it through a composite base (e.g. FunctionDeclaration
+ * lists DeclarationBase while FunctionLikeBase also embeds it), the struct ends up with
+ * two copies. Go resolves promoted selectors to the shallowest one, so the duplicate
+ * compiles and "works" while wasting memory and leaving a zero-valued shadow copy that
+ * any explicitly-qualified access would silently read.
+ *
+ * These bases are therefore stripped from every composite base struct and embedded
+ * directly in each concrete node instead: exactly one copy, always at depth 1. Depth 1
+ * also keeps their accessors (DeclarationData, etc.) shallower than NodeDefault's
+ * nil-returning fallbacks, which is what makes the selectors unambiguous.
+ *
+ * This is a Go-only concern. The schema in ast.json is left alone so that the generated
+ * TypeScript, where `extends` is structural and duplication is free, is unaffected.
+ */
+const hoistedBases = new Set<string>();
+
+function inheritsBase(key: string, target: string): boolean {
+    for (const ext of api.getBase(key)?.extendsKeys ?? []) {
+        if (ext === target || inheritsBase(ext, target)) return true;
+    }
+    return false;
+}
+
+/** Computes the Go embeddings for a struct, ensuring each base is stored exactly once. */
+function goEmbeddings(extendsKeys: string[], concrete: boolean): string[] {
+    // Composite bases never store a hoisted base; concrete nodes keep the ones they list.
+    const kept = extendsKeys.filter(key => !hoistedBases.has(key) || concrete);
+    if (!concrete) return kept;
+
+    // Re-attach any hoisted base the node only inherited indirectly.
+    const missing = [...hoistedBases].filter(base => !kept.includes(base) && extendsKeys.some(key => key === base || inheritsBase(key, base)));
+    return [...missing, ...kept];
+}
+
+/** Counts how many copies of each base a node's Go struct would store as currently configured. */
+function countStoredCopies(node: NodeType): Map<string, number> {
+    const copies = new Map<string, number>();
+    const walk = (keys: string[]) => {
+        for (const ext of keys) {
+            copies.set(ext, (copies.get(ext) ?? 0) + 1);
+            walk(goEmbeddings(api.getBase(ext)?.extendsKeys ?? [], /*concrete*/ false));
+        }
+    };
+    walk(goEmbeddings(node.extendsKeys, /*concrete*/ true));
+    return copies;
+}
+
+function computeHoistedBases(): void {
+    // Hoisting a base can resolve duplicates of everything nested inside it, so hoist the
+    // outermost offenders first and re-measure, rather than hoisting the whole cascade.
+    for (;;) {
+        const duplicated = new Set<string>();
+        for (const node of api.nodes()) {
+            for (const [base, count] of countStoredCopies(node)) {
+                if (count > 1) duplicated.add(base);
+            }
+        }
+        if (duplicated.size === 0) return;
+
+        // Keep only offenders that aren't already contained in another offender.
+        const roots = [...duplicated].filter(base => ![...duplicated].some(other => other !== base && inheritsBase(other, base)));
+        if (roots.length === 0) {
+            throw new Error(`Unable to resolve duplicated embedded bases: ${[...duplicated].sort().join(", ")}`);
+        }
+        for (const base of roots) hoistedBases.add(base);
+    }
+}
+
+computeHoistedBases();
+
 function generateStructDef(w: CodeWriter, node: NodeType) {
     const structName = node.name;
     w.write(`type ${structName} struct {`);
     w.push();
 
     // Embeddings from extends (each maps to a Go struct via convention)
-    for (const ext of node.extendsKeys) {
+    for (const ext of goEmbeddings(node.extendsKeys, /*concrete*/ true)) {
         w.write(ext);
     }
 
@@ -232,7 +306,7 @@ function generateBaseStructDefs(w: CodeWriter) {
 
         const structName = base.key;
 
-        const goExts = base.extendsKeys;
+        const goExts = goEmbeddings(base.extendsKeys, /*concrete*/ false);
 
         w.write(`type ${structName} struct {`);
         w.push();

--- a/_scripts/generate-go-ast.ts
+++ b/_scripts/generate-go-ast.ts
@@ -140,78 +140,41 @@ function generateHeader(w: CodeWriter) {
 // ── Generate struct definitions ────────────────────────────────────────────
 
 /**
- * Bases that must be "hoisted" so each Go struct stores them exactly once.
+ * Verifies that nothing inherits a base along more than one path.
  *
- * A Go embedded base is real storage, not interface inheritance. When a node lists a
- * base directly *and* also inherits it through a composite base (e.g. FunctionDeclaration
- * lists DeclarationBase while FunctionLikeBase also embeds it), the struct ends up with
- * two copies. Go resolves promoted selectors to the shallowest one, so the duplicate
- * compiles and "works" while wasting memory and leaving a zero-valued shadow copy that
- * any explicitly-qualified access would silently read.
+ * A Go embedded base is real storage, not interface inheritance, so a base reached twice
+ * is stored twice. Go resolves promoted selectors to the shallowest copy, which means the
+ * duplicate compiles and "works" while wasting memory and leaving a zero-valued shadow
+ * copy that any explicitly-qualified access would silently read.
  *
- * These bases are therefore stripped from every composite base struct and embedded
- * directly in each concrete node instead: exactly one copy, always at depth 1. Depth 1
- * also keeps their accessors (DeclarationData, etc.) shallower than NodeDefault's
- * nil-returning fallbacks, which is what makes the selectors unambiguous.
- *
- * This is a Go-only concern. The schema in ast.json is left alone so that the generated
- * TypeScript, where `extends` is structural and duplication is free, is unaffected.
+ * Fix violations in ast.json rather than here. If the redundant `extends` edge exists only
+ * to brand the generated TypeScript interface, drop the edge and give the base a `brand`
+ * instead: that keeps the interface identical without contributing Go storage.
  */
-const hoistedBases = new Set<string>();
-
-function inheritsBase(key: string, target: string): boolean {
-    for (const ext of api.getBase(key)?.extendsKeys ?? []) {
-        if (ext === target || inheritsBase(ext, target)) return true;
-    }
-    return false;
-}
-
-/** Computes the Go embeddings for a struct, ensuring each base is stored exactly once. */
-function goEmbeddings(extendsKeys: string[], concrete: boolean): string[] {
-    // Composite bases never store a hoisted base; concrete nodes keep the ones they list.
-    const kept = extendsKeys.filter(key => !hoistedBases.has(key) || concrete);
-    if (!concrete) return kept;
-
-    // Re-attach any hoisted base the node only inherited indirectly.
-    const missing = [...hoistedBases].filter(base => !kept.includes(base) && extendsKeys.some(key => key === base || inheritsBase(key, base)));
-    return [...missing, ...kept];
-}
-
-/** Counts how many copies of each base a node's Go struct would store as currently configured. */
-function countStoredCopies(node: NodeType): Map<string, number> {
-    const copies = new Map<string, number>();
-    const walk = (keys: string[]) => {
-        for (const ext of keys) {
-            copies.set(ext, (copies.get(ext) ?? 0) + 1);
-            walk(goEmbeddings(api.getBase(ext)?.extendsKeys ?? [], /*concrete*/ false));
+function verifyNoDuplicateBases(): void {
+    const problems: string[] = [];
+    const check = (name: string, extendsKeys: string[]) => {
+        const copies = new Map<string, number>();
+        const walk = (keys: string[]) => {
+            for (const key of keys) {
+                copies.set(key, (copies.get(key) ?? 0) + 1);
+                walk(api.getBase(key)?.extendsKeys ?? []);
+            }
+        };
+        walk(extendsKeys);
+        for (const [base, count] of copies) {
+            if (count > 1) problems.push(`${name} inherits ${base} ${count} times`);
         }
     };
-    walk(goEmbeddings(node.extendsKeys, /*concrete*/ true));
-    return copies;
-}
+    for (const base of api.bases()) check(base.key, base.extendsKeys);
+    for (const node of api.nodes()) check(node.name, node.extendsKeys);
 
-function computeHoistedBases(): void {
-    // Hoisting a base can resolve duplicates of everything nested inside it, so hoist the
-    // outermost offenders first and re-measure, rather than hoisting the whole cascade.
-    for (;;) {
-        const duplicated = new Set<string>();
-        for (const node of api.nodes()) {
-            for (const [base, count] of countStoredCopies(node)) {
-                if (count > 1) duplicated.add(base);
-            }
-        }
-        if (duplicated.size === 0) return;
-
-        // Keep only offenders that aren't already contained in another offender.
-        const roots = [...duplicated].filter(base => ![...duplicated].some(other => other !== base && inheritsBase(other, base)));
-        if (roots.length === 0) {
-            throw new Error(`Unable to resolve duplicated embedded bases: ${[...duplicated].sort().join(", ")}`);
-        }
-        for (const base of roots) hoistedBases.add(base);
+    if (problems.length > 0) {
+        throw new Error(`ast.json declares duplicate embedded bases:\n  ${problems.sort().join("\n  ")}`);
     }
 }
 
-computeHoistedBases();
+verifyNoDuplicateBases();
 
 function generateStructDef(w: CodeWriter, node: NodeType) {
     const structName = node.name;
@@ -219,7 +182,7 @@ function generateStructDef(w: CodeWriter, node: NodeType) {
     w.push();
 
     // Embeddings from extends (each maps to a Go struct via convention)
-    for (const ext of goEmbeddings(node.extendsKeys, /*concrete*/ true)) {
+    for (const ext of node.extendsKeys) {
         w.write(ext);
     }
 
@@ -306,7 +269,7 @@ function generateBaseStructDefs(w: CodeWriter) {
 
         const structName = base.key;
 
-        const goExts = goEmbeddings(base.extendsKeys, /*concrete*/ false);
+        const goExts = base.extendsKeys;
 
         w.write(`type ${structName} struct {`);
         w.push();

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -1921,7 +1921,6 @@ func (node *ExportSpecifier) computeSubtreeFacts() SubtreeFacts {
 
 // NamedMemberBase
 
-func (node *NamedMemberBase) DeclarationData() *DeclarationBase    { return &node.DeclarationBase }
 func (node *NamedMemberBase) Modifiers() *ModifierList             { return node.modifiers }
 func (node *NamedMemberBase) setModifiers(modifiers *ModifierList) { node.modifiers = modifiers }
 func (node *NamedMemberBase) Name() *DeclarationName               { return node.name }
@@ -2260,10 +2259,6 @@ func (node *ImportAttributesNode) GetResolutionModeOverride( /* !!! grammarError
 }
 
 // FunctionOrConstructorTypeNodeBase
-
-func (node *FunctionOrConstructorTypeNodeBase) DeclarationData() *DeclarationBase {
-	return node.FunctionLikeBase.DeclarationData()
-}
 
 func (node *TemplateLiteralLikeNodeBase) LiteralLikeData() *LiteralLikeNodeBase {
 	return &node.LiteralLikeNodeBase

--- a/internal/ast/ast_generated.go
+++ b/internal/ast/ast_generated.go
@@ -116,10 +116,13 @@ type TypeNodeBase struct {
 }
 
 type NodeWithTypeArgumentsBase struct {
+	TypeNodeBase
 	TypeArguments *TypeList // Optional
 }
 
-type JSDocTypeBase struct{}
+type JSDocTypeBase struct {
+	TypeNodeBase
+}
 
 type DeclarationBase struct {
 	Symbol *Symbol
@@ -207,6 +210,7 @@ type NamedMemberBase struct {
 type ObjectLiteralElementBase struct{}
 
 type AccessorDeclarationBase struct {
+	DeclarationBase
 	NamedMemberBase
 	FunctionLikeWithBodyBase
 	FlowNodeBase
@@ -218,11 +222,14 @@ type AccessorDeclarationBase struct {
 }
 
 type FunctionOrConstructorTypeNodeBase struct {
+	DeclarationBase
+	TypeNodeBase
 	ModifiersBase
 	FunctionLikeBase
 }
 
 type UnionOrIntersectionTypeNodeBase struct {
+	TypeNodeBase
 	Types *TypeList
 }
 
@@ -3089,7 +3096,6 @@ func IsConstructorDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type GetAccessorDeclaration struct {
-	DeclarationBase
 	AccessorDeclarationBase
 }
 
@@ -3143,7 +3149,6 @@ func IsGetAccessorDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type SetAccessorDeclaration struct {
-	DeclarationBase
 	AccessorDeclarationBase
 }
 
@@ -5121,7 +5126,6 @@ func IsKeywordTypeNode(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type UnionTypeNode struct {
-	TypeNodeBase
 	UnionOrIntersectionTypeNodeBase
 }
 
@@ -5159,7 +5163,6 @@ func IsUnionTypeNode(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type IntersectionTypeNode struct {
-	TypeNodeBase
 	UnionOrIntersectionTypeNodeBase
 }
 
@@ -5401,7 +5404,6 @@ func IsIndexedAccessTypeNode(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type TypeReferenceNode struct {
-	TypeNodeBase
 	NodeWithTypeArgumentsBase
 	TypeName *EntityName
 }
@@ -5680,7 +5682,6 @@ func IsImportAttributes(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type TypeQueryNode struct {
-	TypeNodeBase
 	NodeWithTypeArgumentsBase
 	ExprName *EntityName
 }
@@ -6018,8 +6019,6 @@ func IsParenthesizedTypeNode(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type FunctionTypeNode struct {
-	DeclarationBase
-	TypeNodeBase
 	FunctionOrConstructorTypeNodeBase
 }
 
@@ -6059,8 +6058,6 @@ func IsFunctionTypeNode(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type ConstructorTypeNode struct {
-	DeclarationBase
-	TypeNodeBase
 	FunctionOrConstructorTypeNodeBase
 }
 
@@ -6951,7 +6948,6 @@ func IsJSDocTypeExpression(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type JSDocNonNullableType struct {
-	TypeNodeBase
 	JSDocTypeBase
 	Type *TypeNode
 }
@@ -6990,7 +6986,6 @@ func IsJSDocNonNullableType(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type JSDocNullableType struct {
-	TypeNodeBase
 	JSDocTypeBase
 	Type *TypeNode
 }
@@ -7029,7 +7024,6 @@ func IsJSDocNullableType(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type JSDocAllType struct {
-	TypeNodeBase
 	JSDocTypeBase
 }
 
@@ -7051,7 +7045,6 @@ func IsJSDocAllType(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type JSDocVariadicType struct {
-	TypeNodeBase
 	JSDocTypeBase
 	Type *TypeNode
 }
@@ -7090,7 +7083,6 @@ func IsJSDocVariadicType(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type JSDocOptionalType struct {
-	TypeNodeBase
 	JSDocTypeBase
 	Type *TypeNode
 }
@@ -7947,7 +7939,6 @@ func IsJSDocTypedefTag(node *Node) bool {
 
 type JSDocSignature struct {
 	DeclarationBase
-	TypeNodeBase
 	JSDocTypeBase
 	FunctionLikeBase
 }
@@ -8193,7 +8184,6 @@ func IsExportDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type ImportTypeNode struct {
-	TypeNodeBase
 	NodeWithTypeArgumentsBase
 	IsTypeOf   bool
 	Argument   *TypeNode
@@ -8596,7 +8586,6 @@ func IsSyntheticReferenceExpression(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type JSDocTypeLiteral struct {
-	TypeNodeBase
 	JSDocTypeBase
 	DeclarationBase
 	JSDocPropertyTags []*Node // Optional

--- a/internal/ast/ast_generated.go
+++ b/internal/ast/ast_generated.go
@@ -116,13 +116,10 @@ type TypeNodeBase struct {
 }
 
 type NodeWithTypeArgumentsBase struct {
-	TypeNodeBase
 	TypeArguments *TypeList // Optional
 }
 
-type JSDocTypeBase struct {
-	TypeNodeBase
-}
+type JSDocTypeBase struct{}
 
 type DeclarationBase struct {
 	Symbol *Symbol
@@ -152,7 +149,6 @@ type CompositeBase struct {
 type TypeSyntaxBase struct{}
 
 type FunctionLikeBase struct {
-	DeclarationBase
 	LocalsContainerBase
 	TypeParameters *TypeParameterList // Optional
 	Parameters     *ParameterList
@@ -172,7 +168,6 @@ type FunctionLikeWithBodyBase struct {
 }
 
 type ClassLikeBase struct {
-	DeclarationBase
 	ExportableBase
 	ModifiersBase
 	LocalsContainerBase
@@ -204,7 +199,6 @@ type TypeElementBase struct{}
 type ClassElementBase struct{}
 
 type NamedMemberBase struct {
-	DeclarationBase
 	ModifiersBase
 	name         *PropertyName
 	PostfixToken *TokenNode // Optional
@@ -224,13 +218,11 @@ type AccessorDeclarationBase struct {
 }
 
 type FunctionOrConstructorTypeNodeBase struct {
-	TypeNodeBase
 	ModifiersBase
 	FunctionLikeBase
 }
 
 type UnionOrIntersectionTypeNodeBase struct {
-	TypeNodeBase
 	Types *TypeList
 }
 
@@ -2099,6 +2091,7 @@ func IsClassDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type ClassExpression struct {
+	DeclarationBase
 	PrimaryExpressionBase
 	ClassLikeBase
 }
@@ -2329,6 +2322,7 @@ func IsJSTypeAliasDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type EnumMember struct {
+	DeclarationBase
 	NodeBase
 	NamedMemberBase
 	CompositeBase
@@ -3095,6 +3089,7 @@ func IsConstructorDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type GetAccessorDeclaration struct {
+	DeclarationBase
 	AccessorDeclarationBase
 }
 
@@ -3148,6 +3143,7 @@ func IsGetAccessorDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type SetAccessorDeclaration struct {
+	DeclarationBase
 	AccessorDeclarationBase
 }
 
@@ -3246,6 +3242,7 @@ func IsIndexSignatureDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type MethodSignatureDeclaration struct {
+	DeclarationBase
 	NodeBase
 	NamedMemberBase
 	FunctionLikeBase
@@ -3301,6 +3298,7 @@ func IsMethodSignatureDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type MethodDeclaration struct {
+	DeclarationBase
 	NodeBase
 	NamedMemberBase
 	FunctionLikeWithBodyBase
@@ -3364,6 +3362,7 @@ func IsMethodDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type PropertySignatureDeclaration struct {
+	DeclarationBase
 	NodeBase
 	NamedMemberBase
 	TypeElementBase
@@ -3418,6 +3417,7 @@ func IsPropertySignatureDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type PropertyDeclaration struct {
+	DeclarationBase
 	NodeBase
 	NamedMemberBase
 	ClassElementBase
@@ -4779,6 +4779,7 @@ func IsSpreadAssignment(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type PropertyAssignment struct {
+	DeclarationBase
 	NodeBase
 	NamedMemberBase
 	ObjectLiteralElementBase
@@ -4833,6 +4834,7 @@ func IsPropertyAssignment(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type ShorthandPropertyAssignment struct {
+	DeclarationBase
 	NodeBase
 	NamedMemberBase
 	ObjectLiteralElementBase
@@ -5399,6 +5401,7 @@ func IsIndexedAccessTypeNode(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type TypeReferenceNode struct {
+	TypeNodeBase
 	NodeWithTypeArgumentsBase
 	TypeName *EntityName
 }
@@ -5677,6 +5680,7 @@ func IsImportAttributes(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type TypeQueryNode struct {
+	TypeNodeBase
 	NodeWithTypeArgumentsBase
 	ExprName *EntityName
 }
@@ -6014,6 +6018,7 @@ func IsParenthesizedTypeNode(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type FunctionTypeNode struct {
+	DeclarationBase
 	TypeNodeBase
 	FunctionOrConstructorTypeNodeBase
 }
@@ -6054,6 +6059,7 @@ func IsFunctionTypeNode(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type ConstructorTypeNode struct {
+	DeclarationBase
 	TypeNodeBase
 	FunctionOrConstructorTypeNodeBase
 }
@@ -6945,6 +6951,7 @@ func IsJSDocTypeExpression(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type JSDocNonNullableType struct {
+	TypeNodeBase
 	JSDocTypeBase
 	Type *TypeNode
 }
@@ -6983,6 +6990,7 @@ func IsJSDocNonNullableType(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type JSDocNullableType struct {
+	TypeNodeBase
 	JSDocTypeBase
 	Type *TypeNode
 }
@@ -7021,6 +7029,7 @@ func IsJSDocNullableType(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type JSDocAllType struct {
+	TypeNodeBase
 	JSDocTypeBase
 }
 
@@ -7042,6 +7051,7 @@ func IsJSDocAllType(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type JSDocVariadicType struct {
+	TypeNodeBase
 	JSDocTypeBase
 	Type *TypeNode
 }
@@ -7080,6 +7090,7 @@ func IsJSDocVariadicType(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type JSDocOptionalType struct {
+	TypeNodeBase
 	JSDocTypeBase
 	Type *TypeNode
 }
@@ -7935,6 +7946,8 @@ func IsJSDocTypedefTag(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type JSDocSignature struct {
+	DeclarationBase
+	TypeNodeBase
 	JSDocTypeBase
 	FunctionLikeBase
 }
@@ -8180,6 +8193,7 @@ func IsExportDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type ImportTypeNode struct {
+	TypeNodeBase
 	NodeWithTypeArgumentsBase
 	IsTypeOf   bool
 	Argument   *TypeNode
@@ -8582,6 +8596,7 @@ func IsSyntheticReferenceExpression(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type JSDocTypeLiteral struct {
+	TypeNodeBase
 	JSDocTypeBase
 	DeclarationBase
 	JSDocPropertyTags []*Node // Optional

--- a/internal/ast/ast_generated.go
+++ b/internal/ast/ast_generated.go
@@ -187,8 +187,8 @@ type LiteralLikeNodeBase struct {
 }
 
 type LiteralExpressionBase struct {
-	LiteralLikeNodeBase
 	PrimaryExpressionBase
+	LiteralLikeNodeBase
 }
 
 type TemplateLiteralLikeNodeBase struct {
@@ -210,6 +210,7 @@ type NamedMemberBase struct {
 type ObjectLiteralElementBase struct{}
 
 type AccessorDeclarationBase struct {
+	NodeBase
 	DeclarationBase
 	NamedMemberBase
 	FunctionLikeWithBodyBase
@@ -218,12 +219,11 @@ type AccessorDeclarationBase struct {
 	ClassElementBase
 	ObjectLiteralElementBase
 	CompositeBase
-	NodeBase
 }
 
 type FunctionOrConstructorTypeNodeBase struct {
-	DeclarationBase
 	TypeNodeBase
+	DeclarationBase
 	ModifiersBase
 	FunctionLikeBase
 }
@@ -1985,8 +1985,8 @@ func IsMissingDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type FunctionDeclaration struct {
-	DeclarationBase
 	StatementBase
+	DeclarationBase
 	ExportableBase
 	ModifiersBase
 	FunctionLikeWithBodyBase
@@ -2047,8 +2047,8 @@ func IsFunctionDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type ClassDeclaration struct {
-	DeclarationBase
 	StatementBase
+	DeclarationBase
 	ClassLikeBase
 }
 
@@ -2098,8 +2098,8 @@ func IsClassDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type ClassExpression struct {
-	DeclarationBase
 	PrimaryExpressionBase
+	DeclarationBase
 	ClassLikeBase
 }
 
@@ -2190,8 +2190,8 @@ func IsHeritageClause(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type InterfaceDeclaration struct {
-	DeclarationBase
 	StatementBase
+	DeclarationBase
 	ExportableBase
 	ModifiersBase
 	TypeSyntaxBase
@@ -2247,8 +2247,8 @@ func IsInterfaceDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type TypeAliasDeclaration struct {
-	DeclarationBase
 	StatementBase
+	DeclarationBase
 	ExportableBase
 	ModifiersBase
 	LocalsContainerBase
@@ -2329,8 +2329,8 @@ func IsJSTypeAliasDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type EnumMember struct {
-	DeclarationBase
 	NodeBase
+	DeclarationBase
 	NamedMemberBase
 	CompositeBase
 	Initializer *Expression // Optional
@@ -2375,8 +2375,8 @@ func IsEnumMember(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type EnumDeclaration struct {
-	DeclarationBase
 	StatementBase
+	DeclarationBase
 	ExportableBase
 	ModifiersBase
 	CompositeBase
@@ -2726,8 +2726,8 @@ func IsNamedImports(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type ExportAssignment struct {
-	DeclarationBase
 	StatementBase
+	DeclarationBase
 	ModifiersBase
 	CompositeBase
 	IsExportEquals bool
@@ -2772,8 +2772,8 @@ func IsExportAssignment(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type NamespaceExportDeclaration struct {
-	DeclarationBase
 	StatementBase
+	DeclarationBase
 	ModifiersBase
 	TypeSyntaxBase
 	name *IdentifierNode
@@ -3247,8 +3247,8 @@ func IsIndexSignatureDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type MethodSignatureDeclaration struct {
-	DeclarationBase
 	NodeBase
+	DeclarationBase
 	NamedMemberBase
 	FunctionLikeBase
 	TypeElementBase
@@ -3303,8 +3303,8 @@ func IsMethodSignatureDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type MethodDeclaration struct {
-	DeclarationBase
 	NodeBase
+	DeclarationBase
 	NamedMemberBase
 	FunctionLikeWithBodyBase
 	FlowNodeBase
@@ -3367,8 +3367,8 @@ func IsMethodDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type PropertySignatureDeclaration struct {
-	DeclarationBase
 	NodeBase
+	DeclarationBase
 	NamedMemberBase
 	TypeElementBase
 	TypeSyntaxBase
@@ -3422,8 +3422,8 @@ func IsPropertySignatureDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type PropertyDeclaration struct {
-	DeclarationBase
 	NodeBase
+	DeclarationBase
 	NamedMemberBase
 	ClassElementBase
 	CompositeBase
@@ -4784,8 +4784,8 @@ func IsSpreadAssignment(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type PropertyAssignment struct {
-	DeclarationBase
 	NodeBase
+	DeclarationBase
 	NamedMemberBase
 	ObjectLiteralElementBase
 	CompositeBase
@@ -4839,8 +4839,8 @@ func IsPropertyAssignment(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type ShorthandPropertyAssignment struct {
-	DeclarationBase
 	NodeBase
+	DeclarationBase
 	NamedMemberBase
 	ObjectLiteralElementBase
 	CompositeBase
@@ -6688,8 +6688,8 @@ func IsJsxAttribute(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type JsxSpreadAttribute struct {
-	ObjectLiteralElementBase
 	NodeBase
+	ObjectLiteralElementBase
 	Expression *Expression
 }
 
@@ -7938,8 +7938,8 @@ func IsJSDocTypedefTag(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type JSDocSignature struct {
-	DeclarationBase
 	JSDocTypeBase
+	DeclarationBase
 	FunctionLikeBase
 }
 
@@ -8030,8 +8030,8 @@ func IsSourceFile(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type ModuleDeclaration struct {
-	DeclarationBase
 	StatementBase
+	DeclarationBase
 	ExportableBase
 	ModifiersBase
 	LocalsContainerBase
@@ -8082,8 +8082,8 @@ func IsModuleDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type ImportEqualsDeclaration struct {
-	DeclarationBase
 	StatementBase
+	DeclarationBase
 	ExportableBase
 	ModifiersBase
 	CompositeBase
@@ -8133,8 +8133,8 @@ func IsImportEqualsDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type ExportDeclaration struct {
-	DeclarationBase
 	StatementBase
+	DeclarationBase
 	ModifiersBase
 	CompositeBase
 	IsTypeOnly      bool


### PR DESCRIPTION
While working on some stuff related to method wrapping, copilot randomly told me that we had accidentally duplicated a bunch of structs in our fun AST embedding layout, including `UnionTypeNode`, `IntersectionTypeNode`, `FunctionTypeNode`, `ConstructorTypeNode`, `FunctionExpression`, `MethodDeclaration`, and `GetAccessorDeclaration`.

Thankfully, the AST is now generated, so, fixing this is fairly easy and saves memory:

```
goos: linux
goarch: amd64
pkg: github.com/microsoft/typescript-go/internal/parser
cpu: AMD Ryzen AI 9 HX 370 w/ Radeon 890M           
                                                      │   old.txt    │               new.txt               │
                                                      │    sec/op    │    sec/op     vs base               │
Parse/empty.ts-24                                       399.4n ± 17%   415.8n ± 16%       ~ (p=0.123 n=10)
Parse/checker.ts-24                                     34.11m ±  8%   33.32m ±  5%       ~ (p=0.579 n=10)
Parse/dom.generated.d.ts-24                             13.08m ±  7%   13.49m ±  9%       ~ (p=0.631 n=10)
Parse/Herebyfile.mjs-24                                 509.0µ ±  4%   502.6µ ±  7%       ~ (p=0.436 n=10)
Parse/jsxComplexSignatureHasApplicabilityError.tsx-24   140.2µ ±  6%   136.3µ ±  1%       ~ (p=0.105 n=10)
geomean                                                 417.7µ         418.3µ        +0.13%
```
```
                                                      │   old.txt    │                new.txt                │
                                                      │     B/op     │     B/op      vs base                 │
Parse/empty.ts-24                                       1.048Ki ± 0%   1.048Ki ± 0%       ~ (p=1.000 n=10) ¹
Parse/checker.ts-24                                     26.43Mi ± 0%   26.26Mi ± 0%  -0.67% (p=0.000 n=10)
Parse/dom.generated.d.ts-24                             11.08Mi ± 0%   10.81Mi ± 0%  -2.44% (p=0.000 n=10)
Parse/Herebyfile.mjs-24                                 462.5Ki ± 0%   461.2Ki ± 0%  -0.28% (p=0.000 n=10)
Parse/jsxComplexSignatureHasApplicabilityError.tsx-24   175.6Ki ± 0%   171.8Ki ± 0%  -2.15% (p=0.000 n=10)
geomean                                                 482.4Ki        477.0Ki       -1.11%
¹ all samples are equal
```
```
                                                      │   old.txt   │               new.txt                │
                                                      │  allocs/op  │  allocs/op   vs base                 │
Parse/empty.ts-24                                        4.000 ± 0%    4.000 ± 0%       ~ (p=1.000 n=10) ¹
Parse/checker.ts-24                                     12.02k ± 0%   12.01k ± 0%  -0.02% (p=0.000 n=10)
Parse/dom.generated.d.ts-24                             2.864k ± 0%   2.862k ± 0%  -0.07% (p=0.000 n=10)
Parse/Herebyfile.mjs-24                                 1.119k ± 0%   1.119k ± 0%       ~ (p=1.000 n=10) ¹
Parse/jsxComplexSignatureHasApplicabilityError.tsx-24    196.0 ± 0%    196.0 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                  496.6         496.5       -0.02%
¹ all samples are equal
```

Also, reorder inheritance so that `Node` is always first in the structs; this was not the case for many!