### PR TITLE
Fix quadratic slowdown when renaming files with duplicate unresolved imports

### DIFF
--- a/internal/fourslash/tests/getEditsForFileRename_duplicateUnresolvedImports_test.go
+++ b/internal/fourslash/tests/getEditsForFileRename_duplicateUnresolvedImports_test.go
@@ -1,0 +1,63 @@
+package fourslash_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+// A single file that imports the same *unresolvable* module many times used to force
+// file-rename to rescan every file in the program once per import, producing
+// O(imports * files) work and multi-second renames on large codebases
+// (microsoft/typescript-go#4610). The rename must still complete and update the
+// resolvable relative import to the renamed file, leaving the unresolvable imports alone.
+func TestGetEditsForFileRename_duplicateUnresolvedImports(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+
+	const numFiles = 60   // simulates a large program
+	const numImports = 60 // simulates the pathological repeated-import file
+
+	var content strings.Builder
+	content.WriteString("// @Filename: /tsconfig.json\n{ \"compilerOptions\": { \"allowJs\": true } }\n")
+
+	for i := range numFiles {
+		fi := itoaSmall(i)
+		content.WriteString("// @Filename: /src/file" + fi + ".ts\nexport const v" + fi + " = " + fi + ";\n")
+	}
+
+	// The pathological file: imports the same unresolvable module many times,
+	// plus one resolvable relative import that should be updated by the rename.
+	content.WriteString("// @Filename: /pkg/ugly.ts\n")
+	for range numImports {
+		content.WriteString("import \"@some/unresolved-module\";\n")
+	}
+	content.WriteString("import { v0 } from \"../src/file0\";\n")
+
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content.String())
+	defer done()
+
+	var expected strings.Builder
+	for range numImports {
+		expected.WriteString("import \"@some/unresolved-module\";\n")
+	}
+	expected.WriteString("import { v0 } from \"../src/file0-renamed\";\n")
+
+	f.VerifyWillRenameFilesEdits(t, "/src/file0.ts", "/src/file0-renamed.ts", map[string]string{
+		"/pkg/ugly.ts": expected.String(),
+	}, nil /*preferences*/)
+}
+
+func itoaSmall(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}

--- a/internal/ls/file_rename.go
+++ b/internal/ls/file_rename.go
@@ -24,6 +24,11 @@ type toImport struct {
 	updated     bool
 }
 
+type movedFile struct {
+	sourceFile  *ast.SourceFile
+	newFileName string
+}
+
 func (l *LanguageService) GetEditsForFileRename(ctx context.Context, oldURI lsproto.DocumentUri, newURI lsproto.DocumentUri) []lsproto.TextDocumentEditOrCreateFileOrRenameFileOrDeleteFile {
 	program := l.GetProgram()
 	oldPath := oldURI.FileName()
@@ -202,6 +207,13 @@ func (l *LanguageService) updateImportsForFileRename(program *compiler.Program, 
 	defer done()
 	moduleSpecifierPreferences := l.UserPreferences().ModuleSpecifierPreferences()
 
+	var movedFiles []movedFile
+	for _, sourceFile := range allFiles {
+		if newFileName, ok := oldToNew(sourceFile.FileName()); ok {
+			movedFiles = append(movedFiles, movedFile{sourceFile: sourceFile, newFileName: newFileName})
+		}
+	}
+
 	for _, sourceFile := range allFiles {
 		oldFileName := sourceFile.FileName()
 		newFromOld, fileMoved := oldToNew(sourceFile.FileName())
@@ -221,7 +233,7 @@ func (l *LanguageService) updateImportsForFileRename(program *compiler.Program, 
 		}
 
 		for _, importStringLiteral := range sourceFile.Imports() {
-			updated := l.getUpdatedImportSpecifier(program, checker, sourceFile, importStringLiteral, oldToNew, newImportFromPath, fileMoved, moduleSpecifierPreferences)
+			updated := l.getUpdatedImportSpecifier(program, checker, sourceFile, importStringLiteral, oldToNew, movedFiles, newImportFromPath, fileMoved, moduleSpecifierPreferences)
 			if updated != "" && updated != importStringLiteral.Text() {
 				changeTracker.ReplaceRangeWithText(sourceFile, l.converters.ToLSPRange(sourceFile, createStringTextRange(sourceFile, importStringLiteral)), updated)
 			}
@@ -236,6 +248,7 @@ func (l *LanguageService) getUpdatedImportSpecifier(
 	sourceFile *ast.SourceFile, // old importing source file
 	importLiteral *ast.StringLiteralLike,
 	oldToNew pathUpdater,
+	movedFiles []movedFile,
 	newImportFromPath string,
 	importingSourceFileMoved bool,
 	userPreferences modulespecifiers.UserPreferences,
@@ -248,8 +261,8 @@ func (l *LanguageService) getUpdatedImportSpecifier(
 	target := getSourceFileToImport(program, sourceFile, importLiteral, oldToNew)
 
 	if target == nil {
-		// First fall back: try every file in the program to see if any of them would match the import specifier, and if so, obtain the updated specifier for that file.
-		if updated := getUpdatedImportSpecifierFromMovedSourceFiles(program, sourceFile, importLiteral, oldToNew, newImportFromPath, userPreferences); updated != "" && updated != importLiteral.Text() {
+		// First fall back: try every file affected by the rename to see if any of them would match the import specifier, and if so, obtain the updated specifier for that file.
+		if updated := getUpdatedImportSpecifierFromMovedSourceFiles(program, sourceFile, importLiteral, movedFiles, newImportFromPath, userPreferences); updated != "" && updated != importLiteral.Text() {
 			return updated
 		}
 		// Fall back to a regular path update for unresolved module.
@@ -296,23 +309,18 @@ func getSourceFileToImport(
 	return nil
 }
 
-// As a fall back for unresolved modules, we'll check all files in the program to see if any of them would match
+// As a fall back for unresolved modules, we'll check every file affected by the rename to see if any of them would match
 // the import specifier, and if so, we'll obtain the updated specifier for that file.
-func getUpdatedImportSpecifierFromMovedSourceFiles(program *compiler.Program, sourceFile *ast.SourceFile, importLiteral *ast.StringLiteralLike, oldToNew pathUpdater, importingSourceFileName string, userPreferences modulespecifiers.UserPreferences) string {
+func getUpdatedImportSpecifierFromMovedSourceFiles(program *compiler.Program, sourceFile *ast.SourceFile, importLiteral *ast.StringLiteralLike, movedFiles []movedFile, importingSourceFileName string, userPreferences modulespecifiers.UserPreferences) string {
 	resolutionMode := program.GetModeForUsageLocation(sourceFile, importLiteral)
-	for _, candidate := range program.GetSourceFiles() {
-		newFileName, ok := oldToNew(candidate.FileName())
-		if !ok {
-			continue
-		}
-
+	for _, candidate := range movedFiles {
 		oldSpecifier := modulespecifiers.UpdateModuleSpecifier(
 			program.Options(),
 			program,
 			sourceFile,
 			importingSourceFileName,
 			importLiteral.Text(),
-			candidate.FileName(),
+			candidate.sourceFile.FileName(),
 			userPreferences,
 			modulespecifiers.ModuleSpecifierOptions{
 				OverrideImportMode: resolutionMode,
@@ -328,7 +336,7 @@ func getUpdatedImportSpecifierFromMovedSourceFiles(program *compiler.Program, so
 			sourceFile,
 			importingSourceFileName,
 			importLiteral.Text(),
-			newFileName,
+			candidate.newFileName,
 			userPreferences,
 			modulespecifiers.ModuleSpecifierOptions{
 				OverrideImportMode: resolutionMode,


### PR DESCRIPTION
Fixes #4610

`updateImportsForFileRename` iterates every source file x every import. When an import doesn't resolve, `getUpdatedImportSpecifier` falls back to `getUpdatedImportSpecifierFromMovedSourceFiles`, which scans all source files per unresolved import literal. In the issue repro, a dts file imports the same unresolvable module hundreds of times, which causes a single rename to take ~15s (vs <1s in strada). This is fixed by precomputing candidates that the rename actually moves (`oldToNew(candidate)` succeeds) once per rename instead of rescanning sourcefiles per import.