### PR TITLE
Remove easily-removable wasted work in parse/bind

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -2507,13 +2507,12 @@ type SourceFile struct {
 
 	// Fields set by binder
 
-	isBound                   atomic.Bool
-	bindOnce                  sync.Once
-	bindDiagnostics           []*Diagnostic
-	BindSuggestionDiagnostics []*Diagnostic
-	SymbolCount               int
-	PatternAmbientModules     []*PatternAmbientModule
-	GlobalExports             SymbolTable
+	isBound               atomic.Bool
+	bindOnce              sync.Once
+	bindDiagnostics       []*Diagnostic
+	SymbolCount           int
+	PatternAmbientModules []*PatternAmbientModule
+	GlobalExports         SymbolTable
 
 	// Fields set by ECMALineMap
 

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -2511,7 +2511,6 @@ type SourceFile struct {
 	bindOnce                  sync.Once
 	bindDiagnostics           []*Diagnostic
 	BindSuggestionDiagnostics []*Diagnostic
-	EndFlowNode               *FlowNode
 	SymbolCount               int
 	PatternAmbientModules     []*PatternAmbientModule
 	GlobalExports             SymbolTable

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/microsoft/typescript-go/internal/collections"
 	"github.com/microsoft/typescript-go/internal/core"
-	"github.com/microsoft/typescript-go/internal/stringutil"
 	"github.com/microsoft/typescript-go/internal/tspath"
 	"github.com/zeebo/xxh3"
 )
@@ -2480,7 +2479,6 @@ type SourceFile struct {
 	LanguageVariant             core.LanguageVariant
 	ScriptKind                  core.ScriptKind
 	IsDeclarationFile           bool
-	ContainsNonASCII            bool
 	UsesUriStyleNodeCoreModules core.Tristate
 	IdentifierCount             int
 	imports                     []*LiteralLikeNode // []LiteralLikeNode
@@ -2544,7 +2542,6 @@ func (f *NodeFactory) NewSourceFile(opts SourceFileParseOptions, text string, st
 	data.fileName = opts.FileName
 	data.parseOptions = opts
 	data.text = text
-	data.ContainsNonASCII = stringutil.ContainsNonASCII(text)
 	data.Statements = statements
 	data.EndOfFileToken = endOfFileToken
 	return f.newNode(KindSourceFile, data)
@@ -2681,7 +2678,6 @@ func (node *SourceFile) copyFrom(other *SourceFile) {
 	node.LanguageVariant = other.LanguageVariant
 	node.ScriptKind = other.ScriptKind
 	node.IsDeclarationFile = other.IsDeclarationFile
-	node.ContainsNonASCII = other.ContainsNonASCII
 	node.UsesUriStyleNodeCoreModules = other.UsesUriStyleNodeCoreModules
 	node.imports = other.imports
 	node.ModuleAugmentations = other.ModuleAugmentations
@@ -2772,11 +2768,7 @@ func (node *SourceFile) IsBound() bool {
 // GetPositionMap returns the PositionMap for this source file, computing it lazily.
 func (file *SourceFile) GetPositionMap() *PositionMap {
 	file.positionMapOnce.Do(func() {
-		if !file.ContainsNonASCII {
-			file.positionMap = &PositionMap{asciiOnly: true}
-		} else {
-			file.positionMap = ComputePositionMap(file.Text())
-		}
+		file.positionMap = ComputePositionMap(file.Text())
 	})
 	return file.positionMap
 }

--- a/internal/binder/binder.go
+++ b/internal/binder/binder.go
@@ -2705,21 +2705,6 @@ func (b *Binder) errorOnFirstToken(node *ast.Node, message *diagnostics.Message,
 	b.addDiagnostic(ast.NewDiagnostic(b.file, span, message, args...))
 }
 
-func (b *Binder) errorOrSuggestionOnNode(isError bool, node *ast.Node, message *diagnostics.Message) {
-	b.errorOrSuggestionOnRange(isError, node, node, message)
-}
-
-func (b *Binder) errorOrSuggestionOnRange(isError bool, startNode *ast.Node, endNode *ast.Node, message *diagnostics.Message) {
-	textRange := core.NewTextRange(scanner.GetRangeOfTokenAtPosition(b.file, startNode.Pos()).Pos(), endNode.End())
-	diagnostic := ast.NewDiagnostic(b.file, textRange, message)
-	if isError {
-		b.addDiagnostic(diagnostic)
-	} else {
-		diagnostic.SetCategory(diagnostics.CategorySuggestion)
-		b.file.BindSuggestionDiagnostics = append(b.file.BindSuggestionDiagnostics, diagnostic)
-	}
-}
-
 // Inside the binder, we may create a diagnostic for an as-yet unbound node (with potentially no parent pointers, implying no accessible source file)
 // If so, the node _must_ be in the current file (as that's the only way anything could have traversed to it to yield it as the error node)
 // This version of `createDiagnosticForNode` uses the binder's context to account for this, and always yields correct diagnostics even in these situations.

--- a/internal/binder/binder.go
+++ b/internal/binder/binder.go
@@ -1560,7 +1560,6 @@ func (b *Binder) bindContainer(node *ast.Node, containerFlags ContainerFlags) {
 		}
 		if node.Kind == ast.KindSourceFile {
 			node.Flags |= b.emitFlags
-			node.AsSourceFile().EndFlowNode = b.currentFlow
 		}
 		if b.currentReturnTarget != nil {
 			b.addAntecedent(b.currentReturnTarget, b.currentFlow)

--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -1417,11 +1417,7 @@ func (p *Program) getSuggestionDiagnosticsWithChecker(ctx context.Context, fileC
 		return nil
 	}
 
-	// Checker creation forces binding, so bind suggestion diagnostics will be populated.
-	diags := slices.Clip(sourceFile.BindSuggestionDiagnostics)
-	diags = append(diags, fileChecker.GetSuggestionDiagnostics(ctx, sourceFile)...)
-
-	return diags
+	return fileChecker.GetSuggestionDiagnostics(ctx, sourceFile)
 }
 
 func isCommentOrBlankLine(text string, pos int) bool {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -95,7 +95,6 @@ type Parser struct {
 	jsdocTagCommentsSpace      []string
 	jsdocTagCommentsPartsSpace []*ast.Node
 	reparseList                []*ast.Node
-	commonJSModuleIndicator    *ast.Node
 
 	currentParent        *ast.Node
 	setParentFromContext ast.Visitor
@@ -467,7 +466,6 @@ func (p *Parser) finishSourceFile(result *ast.SourceFile, isDeclarationFile bool
 	p.processPragmasIntoFields(result)
 	result.SetDiagnostics(attachFileToDiagnostics(p.diagnostics, result))
 	result.SetJSDocDiagnostics(attachFileToDiagnostics(p.jsdocDiagnostics, result))
-	result.CommonJSModuleIndicator = p.commonJSModuleIndicator
 	result.IsDeclarationFile = isDeclarationFile
 	result.LanguageVariant = p.languageVariant
 	result.ScriptKind = p.scriptKind

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -209,7 +209,7 @@ test("", async function () {
 	}
 }
 
-func TestSourceFileContainsNonASCIIInStringLiteralFastPath(t *testing.T) {
+func TestSourceFilePositionMapWithNonASCIIStringLiteral(t *testing.T) {
 	t.Parallel()
 	sourceText := `const x = "─";
 
@@ -224,7 +224,6 @@ namespace N {
 
 	file := parser.ParseSourceFile(opts, sourceText, core.ScriptKindTS)
 
-	assert.Assert(t, file.ContainsNonASCII)
 	positionMap := file.GetPositionMap()
 	assert.Assert(t, !positionMap.IsAsciiOnly())
 	afterBoxDrawingCharacter := strings.Index(sourceText, "─") + len("─")

--- a/internal/stringutil/util.go
+++ b/internal/stringutil/util.go
@@ -84,15 +84,6 @@ func IsASCIILetter(ch rune) bool {
 	return ch >= 'A' && ch <= 'Z' || ch >= 'a' && ch <= 'z'
 }
 
-func ContainsNonASCII(s string) bool {
-	for i := range len(s) {
-		if s[i] >= utf8.RuneSelf {
-			return true
-		}
-	}
-	return false
-}
-
 func SplitLines(text string) []string {
 	lines := make([]string, 0, strings.Count(text, "\n")+1) // preallocate
 	start := 0

--- a/internal/stringutil/util_test.go
+++ b/internal/stringutil/util_test.go
@@ -35,25 +35,3 @@ func TestEncodeURI(t *testing.T) {
 		})
 	}
 }
-
-func TestContainsNonASCII(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name string
-		text string
-		want bool
-	}{
-		{name: "ascii", text: "abc", want: false},
-		{name: "non-ascii", text: "é", want: true},
-		{name: "lone surrogate sentinel", text: EncodeJSStringRune(0xD800), want: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			if got := ContainsNonASCII(tt.text); got != tt.want {
-				t.Fatalf("ContainsNonASCII(%q) = %v, want %v", tt.text, got, tt.want)
-			}
-		})
-	}
-}


### PR DESCRIPTION
After my previous PRs that found unused work in parse/bind, I had copilot look around and it found these four other optimizations.

Most are noops, but given line mapping already determines if a file is all ASCII, we can just not do the scan during parse and save time, given most files never need a line map at all. So that's a nice few percent in parse.

```
goos: linux
goarch: amd64
pkg: github.com/microsoft/typescript-go/internal/parser
cpu: Intel(R) Core(TM) i9-10900K CPU @ 3.70GHz
                                                      │     old     │                new                 │
                                                      │   sec/op    │   sec/op     vs base               │
Parse/empty.ts-20                                       655.6n ± 1%   639.5n ± 2%  -2.46% (p=0.002 n=10)
Parse/checker.ts-20                                     39.16m ± 3%   37.92m ± 2%  -3.17% (p=0.000 n=10)
Parse/dom.generated.d.ts-20                             14.45m ± 2%   14.28m ± 1%       ~ (p=0.105 n=10)
Parse/Herebyfile.mjs-20                                 782.6µ ± 1%   770.3µ ± 1%  -1.57% (p=0.000 n=10)
Parse/jsxComplexSignatureHasApplicabilityError.tsx-20   220.1µ ± 1%   211.0µ ± 1%  -4.11% (p=0.000 n=10)
geomean                                                 576.9µ        562.5µ       -2.51%
```