### PR TITLE
Fix "Not a subspan" crash in signature help on error-recovered JSX

### DIFF
--- a/internal/astnav/tokens.go
+++ b/internal/astnav/tokens.go
@@ -553,7 +553,7 @@ func findRightmostValidToken(endPos int, sourceFile *ast.SourceFile, containingN
 				for startPos < min(visitedNode.Pos(), position) {
 					token := scanNavigationToken(scanner, n)
 					tokenStart := scanner.TokenStart()
-					if tokenStart >= position {
+					if tokenStart >= min(visitedNode.Pos(), position) {
 						break
 					}
 					tokenFullStart := scanner.TokenFullStart()
@@ -571,7 +571,7 @@ func findRightmostValidToken(endPos int, sourceFile *ast.SourceFile, containingN
 			for startPos < min(endPos, position) {
 				token := scanNavigationToken(scanner, n)
 				tokenStart := scanner.TokenStart()
-				if tokenStart >= position {
+				if tokenStart >= min(endPos, position) {
 					break
 				}
 				tokenFullStart := scanner.TokenFullStart()

--- a/internal/fourslash/tests/signatureHelpIncompleteJsxAttribute_test.go
+++ b/internal/fourslash/tests/signatureHelpIncompleteJsxAttribute_test.go
@@ -1,0 +1,24 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+// An incomplete JSX attribute (`c=` with no value) followed on the next line by a closing
+// tag is error-recovered so that the closing tag's `</` (KindLessThanSlashToken) is scanned
+// as a trailing token of the attribute, even though its span (including the leading newline)
+// overruns the attribute. Requesting signature help there must not trip the "Not a subspan"
+// assertion in getContainingArgumentInfo.
+func TestSignatureHelpIncompleteJsxAttribute(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `// @Filename: /a.tsx
+<a><b c=
+/*a*/</a>`
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.VerifyNoSignatureHelpForMarkers(t, "a")
+}


### PR DESCRIPTION
Fixes an issue uncovered in https://github.com/microsoft/typescript-go/issues/4532#issuecomment-4879803391; An incomplete JSX attribute immediately followed on the next line by a closing tag is error-recovered (ex: `<a><b c=\n</a>`). Requesting signature help there calls `findRightmostValidToken`, which scans and consumes the closing tag's `</`, creating a span that overruns its parent attribute.

Note: this causes behavior to diverge in the native-preview AST navigation mirror