### PR TITLE
Optimize `narrowTypeByEquality` and `narrowTypeBySwitchOnDiscriminant`

### DIFF
--- a/_packages/native-preview/src/enums/objectFlags.enum.ts
+++ b/_packages/native-preview/src/enums/objectFlags.enum.ts
@@ -45,6 +45,8 @@ export enum ObjectFlags {
     ContainsIntersections = 1 << 25,
     IsUnknownLikeUnionComputed = 1 << 26,
     IsUnknownLikeUnion = 1 << 27,
+    IsUniformEnumComputed = 1 << 28,
+    IsUniformEnum = 1 << 29,
     IsNeverIntersectionComputed = 1 << 25,
     IsNeverIntersection = 1 << 26,
     IsConstrainedTypeVariable = 1 << 27,

--- a/_packages/native-preview/src/enums/objectFlags.ts
+++ b/_packages/native-preview/src/enums/objectFlags.ts
@@ -45,6 +45,8 @@ export var ObjectFlags: any;
     ObjectFlags[ObjectFlags["ContainsIntersections"] = 33554432] = "ContainsIntersections";
     ObjectFlags[ObjectFlags["IsUnknownLikeUnionComputed"] = 67108864] = "IsUnknownLikeUnionComputed";
     ObjectFlags[ObjectFlags["IsUnknownLikeUnion"] = 134217728] = "IsUnknownLikeUnion";
+    ObjectFlags[ObjectFlags["IsUniformEnumComputed"] = 268435456] = "IsUniformEnumComputed";
+    ObjectFlags[ObjectFlags["IsUniformEnum"] = 536870912] = "IsUniformEnum";
     ObjectFlags[ObjectFlags["IsNeverIntersectionComputed"] = 33554432] = "IsNeverIntersectionComputed";
     ObjectFlags[ObjectFlags["IsNeverIntersection"] = 67108864] = "IsNeverIntersection";
     ObjectFlags[ObjectFlags["IsConstrainedTypeVariable"] = 134217728] = "IsConstrainedTypeVariable";

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -26375,14 +26375,14 @@ func (c *Checker) intersectUnionsOfPrimitiveTypes(types []*Type) ([]*Type, bool)
 // primitive type, and missingType is matched by undefinedType (and vice versa).
 func (c *Checker) eachUnionContains(unionTypes []*Type, t *Type) bool {
 	for _, u := range unionTypes {
-		if !c.unionContainsType(u, t) {
+		if !c.unionContainsType(u, t, true /*matchSymbol*/) {
 			return false
 		}
 	}
 	return true
 }
 
-func (c *Checker) unionContainsType(union *Type, t *Type) bool {
+func (c *Checker) unionContainsType(union *Type, t *Type, matchSymbol bool) bool {
 	types := union.Types()
 	if containsType(types, t) {
 		return true
@@ -26401,7 +26401,7 @@ func (c *Checker) unionContainsType(union *Type, t *Type) bool {
 		primitive = c.numberType
 	case t.flags&TypeFlagsBigIntLiteral != 0:
 		primitive = c.bigintType
-	case t.flags&TypeFlagsUniqueESSymbol != 0:
+	case t.flags&TypeFlagsUniqueESSymbol != 0 && matchSymbol:
 		primitive = c.esSymbolType
 	}
 	return primitive != nil && containsType(types, primitive)
@@ -27792,6 +27792,43 @@ func (c *Checker) isUnknownLikeUnionType(t *Type) bool {
 		return t.objectFlags&ObjectFlagsIsUnknownLikeUnion != 0
 	}
 	return false
+}
+
+// Return true the given type is a union type where no two literal type constituents are comparable.
+// Specifically, that means (a) the union doesn't contain literals from different enum types, and
+// (b) the union doesn't contain both enum literals and string or number literals.
+func (c *Checker) isUniformUnionType(t *Type) bool {
+	if t.flags&TypeFlagsUnion != 0 {
+		if t.objectFlags&ObjectFlagsIsUniformEnumComputed == 0 {
+			t.objectFlags |= ObjectFlagsIsUniformEnumComputed | core.IfElse(c.computeIsUniformUnionType(t.Types()), ObjectFlagsIsUniformEnum, ObjectFlagsNone)
+		}
+		return t.objectFlags&ObjectFlagsIsUniformEnum != 0
+	}
+	return false
+}
+
+func (c *Checker) computeIsUniformUnionType(types []*Type) bool {
+	var enumSymbol *ast.Symbol
+	var hasStringOrNumberLiteral bool
+	for _, t := range types {
+		if t.flags&TypeFlagsEnumLiteral != 0 {
+			if hasStringOrNumberLiteral {
+				return false
+			}
+			parent := c.getParentOfSymbol(t.symbol)
+			if enumSymbol == nil {
+				enumSymbol = parent
+			} else if enumSymbol != parent {
+				return false
+			}
+		} else if t.flags&TypeFlagsStringOrNumberLiteral != 0 {
+			if enumSymbol != nil {
+				return false
+			}
+			hasStringOrNumberLiteral = true
+		}
+	}
+	return true
 }
 
 func (c *Checker) containsUndefinedType(t *Type) bool {

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -26375,31 +26375,36 @@ func (c *Checker) intersectUnionsOfPrimitiveTypes(types []*Type) ([]*Type, bool)
 // primitive type, and missingType is matched by undefinedType (and vice versa).
 func (c *Checker) eachUnionContains(unionTypes []*Type, t *Type) bool {
 	for _, u := range unionTypes {
-		types := u.Types()
-		if !containsType(types, t) {
-			if t == c.missingType {
-				return containsType(types, c.undefinedType)
-			}
-			if t == c.undefinedType {
-				return containsType(types, c.missingType)
-			}
-			var primitive *Type
-			switch {
-			case t.flags&TypeFlagsStringLiteral != 0:
-				primitive = c.stringType
-			case t.flags&(TypeFlagsEnum|TypeFlagsNumberLiteral) != 0:
-				primitive = c.numberType
-			case t.flags&TypeFlagsBigIntLiteral != 0:
-				primitive = c.bigintType
-			case t.flags&TypeFlagsUniqueESSymbol != 0:
-				primitive = c.esSymbolType
-			}
-			if primitive == nil || !containsType(types, primitive) {
-				return false
-			}
+		if !c.unionContainsType(u, t) {
+			return false
 		}
 	}
 	return true
+}
+
+func (c *Checker) unionContainsType(union *Type, t *Type) bool {
+	types := union.Types()
+	if containsType(types, t) {
+		return true
+	}
+	if t == c.missingType {
+		return containsType(types, c.undefinedType)
+	}
+	if t == c.undefinedType {
+		return containsType(types, c.missingType)
+	}
+	var primitive *Type
+	switch {
+	case t.flags&TypeFlagsStringLiteral != 0:
+		primitive = c.stringType
+	case t.flags&(TypeFlagsEnum|TypeFlagsNumberLiteral) != 0:
+		primitive = c.numberType
+	case t.flags&TypeFlagsBigIntLiteral != 0:
+		primitive = c.bigintType
+	case t.flags&TypeFlagsUniqueESSymbol != 0:
+		primitive = c.esSymbolType
+	}
+	return primitive != nil && containsType(types, primitive)
 }
 
 func (c *Checker) getCrossProductIntersections(types []*Type, flags IntersectionFlags) []*Type {
@@ -26567,7 +26572,25 @@ func (c *Checker) filterType(t *Type, f func(*Type) bool) *Type {
 }
 
 func (c *Checker) removeType(t *Type, targetType *Type) *Type {
-	return c.filterType(t, func(t *Type) bool { return t != targetType })
+	if t.flags&TypeFlagsUnion == 0 {
+		if t == targetType {
+			return c.neverType
+		}
+		return t
+	}
+	if origin := t.AsUnionType().origin; origin != nil && origin.flags&TypeFlagsUnion != 0 && containsType(origin.Types(), targetType) {
+		return c.filterType(t, func(t *Type) bool { return t != targetType })
+	}
+	types := t.Types()
+	if i, ok := slices.BinarySearchFunc(types, targetType, CompareTypes); ok {
+		if len(types) == 2 {
+			return types[1-i]
+		}
+		// Remove the target type from the slice.
+		filtered := append(types[:i:i], types[i+1:]...)
+		return c.getUnionTypeFromSortedList(filtered, t.AsUnionType().objectFlags&(ObjectFlagsPrimitiveUnion|ObjectFlagsContainsIntersections), nil /*alias*/, nil /*origin*/)
+	}
+	return t
 }
 
 func containsType(types []*Type, t *Type) bool {

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -27794,11 +27794,11 @@ func (c *Checker) isUnknownLikeUnionType(t *Type) bool {
 	return false
 }
 
-// Return true the given type is a union type where no two literal type constituents are comparable.
-// Specifically, that means (a) the union doesn't contain literals from different enum types, and
-// (b) the union doesn't contain both enum literals and string or number literals.
+// Return true the given type is a primitive union type where no two literal type constituents are
+// comparable. Specifically, that means (a) the union doesn't contain literals from different enum
+// types, and (b) the union doesn't contain both enum literals and string or number literals.
 func (c *Checker) isUniformUnionType(t *Type) bool {
-	if t.flags&TypeFlagsUnion != 0 {
+	if t.objectFlags&ObjectFlagsPrimitiveUnion != 0 {
 		if t.objectFlags&ObjectFlagsIsUniformEnumComputed == 0 {
 			t.objectFlags |= ObjectFlagsIsUniformEnumComputed | core.IfElse(c.computeIsUniformUnionType(t.Types()), ObjectFlagsIsUniformEnum, ObjectFlagsNone)
 		}
@@ -27811,7 +27811,7 @@ func (c *Checker) computeIsUniformUnionType(types []*Type) bool {
 	var enumSymbol *ast.Symbol
 	var hasStringOrNumberLiteral bool
 	for _, t := range types {
-		if t.flags&TypeFlagsEnumLiteral != 0 {
+		if t.flags&TypeFlagsEnumLike != 0 {
 			if hasStringOrNumberLiteral {
 				return false
 			}

--- a/internal/checker/flow.go
+++ b/internal/checker/flow.go
@@ -586,9 +586,8 @@ func (c *Checker) narrowTypeByEquality(t *Type, operator ast.Kind, value *ast.No
 				return c.nonPrimitiveType
 			}
 		}
-		if !doubleEquals && t.objectFlags&ObjectFlagsPrimitiveUnion != 0 && valueType.flags&TypeFlagsPrimitive != 0 && c.isUniformUnionType(t) {
+		if !doubleEquals && valueType.flags&TypeFlagsPrimitive != 0 && c.isUniformUnionType(t) {
 			regularType := c.getRegularTypeOfLiteralType(valueType)
-
 			if c.unionContainsType(t, regularType, false /*matchSymbol*/) {
 				return regularType
 			}
@@ -1123,7 +1122,7 @@ func (c *Checker) narrowTypeBySwitchOnDiscriminant(t *Type, data *ast.FlowSwitch
 	if discriminantType.flags&TypeFlagsNever != 0 {
 		caseType = c.neverType
 	} else {
-		if t.objectFlags&ObjectFlagsPrimitiveUnion != 0 && discriminantType.flags&TypeFlagsPrimitive != 0 && c.isUniformUnionType(t) {
+		if discriminantType.flags&TypeFlagsPrimitive != 0 && c.isUniformUnionType(t) {
 			regularType := c.getRegularTypeOfLiteralType(discriminantType)
 			if c.unionContainsType(t, regularType, false /*matchSymbol*/) {
 				caseType = regularType

--- a/internal/checker/flow.go
+++ b/internal/checker/flow.go
@@ -586,9 +586,10 @@ func (c *Checker) narrowTypeByEquality(t *Type, operator ast.Kind, value *ast.No
 				return c.nonPrimitiveType
 			}
 		}
-		if !doubleEquals && t.objectFlags&ObjectFlagsPrimitiveUnion != 0 && valueType.flags&TypeFlagsPrimitive != 0 {
+		if !doubleEquals && t.objectFlags&ObjectFlagsPrimitiveUnion != 0 && valueType.flags&TypeFlagsPrimitive != 0 && c.isUniformUnionType(t) {
 			regularType := c.getRegularTypeOfLiteralType(valueType)
-			if c.unionContainsType(t, regularType) {
+
+			if c.unionContainsType(t, regularType, false /*matchSymbol*/) {
 				return regularType
 			}
 		}
@@ -598,9 +599,11 @@ func (c *Checker) narrowTypeByEquality(t *Type, operator ast.Kind, value *ast.No
 		return c.replacePrimitivesWithLiterals(filteredType, valueType)
 	}
 	if isUnitType(valueType) {
-		filteredType := c.removeType(t, c.getRegularTypeOfLiteralType(valueType))
-		if filteredType != t {
-			return filteredType
+		if c.isUniformUnionType(t) {
+			filteredType := c.removeType(t, c.getRegularTypeOfLiteralType(valueType))
+			if filteredType != t {
+				return filteredType
+			}
 		}
 		return c.filterType(t, func(t *Type) bool {
 			return !(c.isUnitLikeType(t) && c.areTypesComparable(t, valueType))
@@ -1120,9 +1123,9 @@ func (c *Checker) narrowTypeBySwitchOnDiscriminant(t *Type, data *ast.FlowSwitch
 	if discriminantType.flags&TypeFlagsNever != 0 {
 		caseType = c.neverType
 	} else {
-		if t.objectFlags&ObjectFlagsPrimitiveUnion != 0 && discriminantType.flags&TypeFlagsPrimitive != 0 {
+		if t.objectFlags&ObjectFlagsPrimitiveUnion != 0 && discriminantType.flags&TypeFlagsPrimitive != 0 && c.isUniformUnionType(t) {
 			regularType := c.getRegularTypeOfLiteralType(discriminantType)
-			if c.unionContainsType(t, regularType) {
+			if c.unionContainsType(t, regularType, false /*matchSymbol*/) {
 				caseType = regularType
 			}
 		}

--- a/internal/checker/flow.go
+++ b/internal/checker/flow.go
@@ -586,12 +586,22 @@ func (c *Checker) narrowTypeByEquality(t *Type, operator ast.Kind, value *ast.No
 				return c.nonPrimitiveType
 			}
 		}
+		if !doubleEquals && t.objectFlags&ObjectFlagsPrimitiveUnion != 0 && valueType.flags&TypeFlagsPrimitive != 0 {
+			regularType := c.getRegularTypeOfLiteralType(valueType)
+			if c.unionContainsType(t, regularType) {
+				return regularType
+			}
+		}
 		filteredType := c.filterType(t, func(t *Type) bool {
 			return c.areTypesComparable(t, valueType) || doubleEquals && isCoercibleUnderDoubleEquals(t, valueType)
 		})
 		return c.replacePrimitivesWithLiterals(filteredType, valueType)
 	}
 	if isUnitType(valueType) {
+		filteredType := c.removeType(t, c.getRegularTypeOfLiteralType(valueType))
+		if filteredType != t {
+			return filteredType
+		}
 		return c.filterType(t, func(t *Type) bool {
 			return !(c.isUnitLikeType(t) && c.areTypesComparable(t, valueType))
 		})
@@ -1110,8 +1120,16 @@ func (c *Checker) narrowTypeBySwitchOnDiscriminant(t *Type, data *ast.FlowSwitch
 	if discriminantType.flags&TypeFlagsNever != 0 {
 		caseType = c.neverType
 	} else {
-		filtered := c.filterType(t, func(t *Type) bool { return c.areTypesComparable(discriminantType, t) })
-		caseType = c.replacePrimitivesWithLiterals(filtered, discriminantType)
+		if t.objectFlags&ObjectFlagsPrimitiveUnion != 0 && discriminantType.flags&TypeFlagsPrimitive != 0 {
+			regularType := c.getRegularTypeOfLiteralType(discriminantType)
+			if c.unionContainsType(t, regularType) {
+				caseType = regularType
+			}
+		}
+		if caseType == nil {
+			filtered := c.filterType(t, func(t *Type) bool { return c.areTypesComparable(discriminantType, t) })
+			caseType = c.replacePrimitivesWithLiterals(filtered, discriminantType)
+		}
 	}
 	if !hasDefaultClause {
 		return caseType

--- a/internal/checker/types.go
+++ b/internal/checker/types.go
@@ -639,6 +639,8 @@ const (
 	ObjectFlagsContainsIntersections      = 1 << 25 // Union contains intersections
 	ObjectFlagsIsUnknownLikeUnionComputed = 1 << 26 // IsUnknownLikeUnion flag has been computed
 	ObjectFlagsIsUnknownLikeUnion         = 1 << 27 // Union of null, undefined, and empty object type
+	ObjectFlagsIsUniformEnumComputed      = 1 << 28 // IsUniformEnum flag has been computed
+	ObjectFlagsIsUniformEnum              = 1 << 29 // Union contains uniform literal types
 	// Flags that require TypeFlags.Intersection
 	ObjectFlagsIsNeverIntersectionComputed = 1 << 25 // IsNeverLike flag has been computed
 	ObjectFlagsIsNeverIntersection         = 1 << 26 // Intersection reduces to never

--- a/testdata/baselines/reference/compiler/nonUniformUnionNarrowing.symbols
+++ b/testdata/baselines/reference/compiler/nonUniformUnionNarrowing.symbols
@@ -26,79 +26,205 @@ function f1(x: E | 1 | 2) {
     }
 }
 
+function f1s(x: E | 1 | 2) {
+>f1s : Symbol(f1s, Decl(nonUniformUnionNarrowing.ts, 9, 1))
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 11, 13))
+>E : Symbol(E, Decl(nonUniformUnionNarrowing.ts, 0, 0))
+
+    switch (x) {
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 11, 13))
+
+        case E.A:
+>E.A : Symbol(E.A, Decl(nonUniformUnionNarrowing.ts, 0, 8))
+>E : Symbol(E, Decl(nonUniformUnionNarrowing.ts, 0, 0))
+>A : Symbol(E.A, Decl(nonUniformUnionNarrowing.ts, 0, 8))
+
+            x;  // 1 | E.A
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 11, 13))
+
+            break;
+        default:
+            x;  // 2 | E.B
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 11, 13))
+    }
+}
+
 function f2(x: E | 1 | 2) {
->f2 : Symbol(f2, Decl(nonUniformUnionNarrowing.ts, 9, 1))
->x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 11, 12))
+>f2 : Symbol(f2, Decl(nonUniformUnionNarrowing.ts, 19, 1))
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 21, 12))
 >E : Symbol(E, Decl(nonUniformUnionNarrowing.ts, 0, 0))
 
     if (x === 1) {
->x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 11, 12))
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 21, 12))
 
         x;  // 1 | E.A
->x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 11, 12))
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 21, 12))
     }
     else {
         x;  // 2 | E.B
->x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 11, 12))
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 21, 12))
+    }
+}
+
+function f2s(x: E | 1 | 2) {
+>f2s : Symbol(f2s, Decl(nonUniformUnionNarrowing.ts, 28, 1))
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 30, 13))
+>E : Symbol(E, Decl(nonUniformUnionNarrowing.ts, 0, 0))
+
+    switch (x) {
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 30, 13))
+
+        case 1:
+            x;  // 1 | E.A
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 30, 13))
+
+            break;
+        default:
+            x;  // 2 | E.B
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 30, 13))
     }
 }
 
 namespace N1 {
->N1 : Symbol(N1, Decl(nonUniformUnionNarrowing.ts, 18, 1))
+>N1 : Symbol(N1, Decl(nonUniformUnionNarrowing.ts, 38, 1))
 
     export enum E { A = 1, B = 2 }
->E : Symbol(E, Decl(nonUniformUnionNarrowing.ts, 20, 14))
->A : Symbol(E.A, Decl(nonUniformUnionNarrowing.ts, 21, 19))
->B : Symbol(E.B, Decl(nonUniformUnionNarrowing.ts, 21, 26))
+>E : Symbol(E, Decl(nonUniformUnionNarrowing.ts, 40, 14))
+>A : Symbol(E.A, Decl(nonUniformUnionNarrowing.ts, 41, 19))
+>B : Symbol(E.B, Decl(nonUniformUnionNarrowing.ts, 41, 26))
 }
 namespace N2 {
->N2 : Symbol(N2, Decl(nonUniformUnionNarrowing.ts, 22, 1))
+>N2 : Symbol(N2, Decl(nonUniformUnionNarrowing.ts, 42, 1))
 
     export enum E { A = 1, B = 2 }
->E : Symbol(E, Decl(nonUniformUnionNarrowing.ts, 23, 14))
->A : Symbol(E.A, Decl(nonUniformUnionNarrowing.ts, 24, 19))
->B : Symbol(E.B, Decl(nonUniformUnionNarrowing.ts, 24, 26))
+>E : Symbol(E, Decl(nonUniformUnionNarrowing.ts, 43, 14))
+>A : Symbol(E.A, Decl(nonUniformUnionNarrowing.ts, 44, 19))
+>B : Symbol(E.B, Decl(nonUniformUnionNarrowing.ts, 44, 26))
 }
 
 function f3(x: N1.E | N2.E) {
->f3 : Symbol(f3, Decl(nonUniformUnionNarrowing.ts, 25, 1))
->x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 27, 12))
->N1 : Symbol(N1, Decl(nonUniformUnionNarrowing.ts, 18, 1))
->E : Symbol(N1.E, Decl(nonUniformUnionNarrowing.ts, 20, 14))
->N2 : Symbol(N2, Decl(nonUniformUnionNarrowing.ts, 22, 1))
->E : Symbol(N2.E, Decl(nonUniformUnionNarrowing.ts, 23, 14))
+>f3 : Symbol(f3, Decl(nonUniformUnionNarrowing.ts, 45, 1))
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 47, 12))
+>N1 : Symbol(N1, Decl(nonUniformUnionNarrowing.ts, 38, 1))
+>E : Symbol(N1.E, Decl(nonUniformUnionNarrowing.ts, 40, 14))
+>N2 : Symbol(N2, Decl(nonUniformUnionNarrowing.ts, 42, 1))
+>E : Symbol(N2.E, Decl(nonUniformUnionNarrowing.ts, 43, 14))
 
     if (x === N1.E.A) {
->x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 27, 12))
->N1.E.A : Symbol(N1.E.A, Decl(nonUniformUnionNarrowing.ts, 21, 19))
->N1.E : Symbol(N1.E, Decl(nonUniformUnionNarrowing.ts, 20, 14))
->N1 : Symbol(N1, Decl(nonUniformUnionNarrowing.ts, 18, 1))
->E : Symbol(N1.E, Decl(nonUniformUnionNarrowing.ts, 20, 14))
->A : Symbol(N1.E.A, Decl(nonUniformUnionNarrowing.ts, 21, 19))
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 47, 12))
+>N1.E.A : Symbol(N1.E.A, Decl(nonUniformUnionNarrowing.ts, 41, 19))
+>N1.E : Symbol(N1.E, Decl(nonUniformUnionNarrowing.ts, 40, 14))
+>N1 : Symbol(N1, Decl(nonUniformUnionNarrowing.ts, 38, 1))
+>E : Symbol(N1.E, Decl(nonUniformUnionNarrowing.ts, 40, 14))
+>A : Symbol(N1.E.A, Decl(nonUniformUnionNarrowing.ts, 41, 19))
 
         x;  // N1.E.A | N2.E.A
->x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 27, 12))
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 47, 12))
     }
     else {
         x;  // N1.E.B | N2.E.B
->x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 27, 12))
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 47, 12))
+    }
+}
+
+function f3s(x: N1.E | N2.E) {
+>f3s : Symbol(f3s, Decl(nonUniformUnionNarrowing.ts, 54, 1))
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 56, 13))
+>N1 : Symbol(N1, Decl(nonUniformUnionNarrowing.ts, 38, 1))
+>E : Symbol(N1.E, Decl(nonUniformUnionNarrowing.ts, 40, 14))
+>N2 : Symbol(N2, Decl(nonUniformUnionNarrowing.ts, 42, 1))
+>E : Symbol(N2.E, Decl(nonUniformUnionNarrowing.ts, 43, 14))
+
+    switch (x) {
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 56, 13))
+
+        case N1.E.A:
+>N1.E.A : Symbol(N1.E.A, Decl(nonUniformUnionNarrowing.ts, 41, 19))
+>N1.E : Symbol(N1.E, Decl(nonUniformUnionNarrowing.ts, 40, 14))
+>N1 : Symbol(N1, Decl(nonUniformUnionNarrowing.ts, 38, 1))
+>E : Symbol(N1.E, Decl(nonUniformUnionNarrowing.ts, 40, 14))
+>A : Symbol(N1.E.A, Decl(nonUniformUnionNarrowing.ts, 41, 19))
+
+            x;  // N1.E.A | N2.E.A
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 56, 13))
+
+            break;
+        default:
+            x;  // N1.E.B | N2.E.B
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 56, 13))
     }
 }
 
 const sym = Symbol();
->sym : Symbol(sym, Decl(nonUniformUnionNarrowing.ts, 36, 5))
+>sym : Symbol(sym, Decl(nonUniformUnionNarrowing.ts, 66, 5))
 >Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2019.symbol.d.ts, --, --))
 
 function f4(x: symbol | string) {
->f4 : Symbol(f4, Decl(nonUniformUnionNarrowing.ts, 36, 21))
->x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 38, 12))
+>f4 : Symbol(f4, Decl(nonUniformUnionNarrowing.ts, 66, 21))
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 68, 12))
 
     if (x === sym) {
->x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 38, 12))
->sym : Symbol(sym, Decl(nonUniformUnionNarrowing.ts, 36, 5))
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 68, 12))
+>sym : Symbol(sym, Decl(nonUniformUnionNarrowing.ts, 66, 5))
 
         x;  // symbol (not narrowed)
->x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 38, 12))
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 68, 12))
+    }
+}
+
+function f4s(x: symbol | string) {
+>f4s : Symbol(f4s, Decl(nonUniformUnionNarrowing.ts, 72, 1))
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 74, 13))
+
+    switch (x) {
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 74, 13))
+
+        case sym:
+>sym : Symbol(sym, Decl(nonUniformUnionNarrowing.ts, 66, 5))
+
+            x;  // symbol (not narrowed)
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 74, 13))
+    }
+}
+
+declare enum EE { A, B }
+>EE : Symbol(EE, Decl(nonUniformUnionNarrowing.ts, 79, 1))
+>A : Symbol(EE.A, Decl(nonUniformUnionNarrowing.ts, 81, 17))
+>B : Symbol(EE.B, Decl(nonUniformUnionNarrowing.ts, 81, 20))
+
+function f6(x: EE | 1 | 2) {
+>f6 : Symbol(f6, Decl(nonUniformUnionNarrowing.ts, 81, 24))
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 83, 12))
+>EE : Symbol(EE, Decl(nonUniformUnionNarrowing.ts, 79, 1))
+
+    if (x === 1) {
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 83, 12))
+
+        x;  // 1 | EE (computed enum compares to any number)
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 83, 12))
+    }
+    else {
+        x;  // 2
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 83, 12))
+    }
+}
+
+function f6s(x: EE | 1 | 2) {
+>f6s : Symbol(f6s, Decl(nonUniformUnionNarrowing.ts, 90, 1))
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 92, 13))
+>EE : Symbol(EE, Decl(nonUniformUnionNarrowing.ts, 79, 1))
+
+    switch (x) {
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 92, 13))
+
+        case 1:
+            x;  // 1 | EE (computed enum compares to any number)
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 92, 13))
+
+            break;
+        default:
+            x;  // 2
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 92, 13))
     }
 }
 

--- a/testdata/baselines/reference/compiler/nonUniformUnionNarrowing.symbols
+++ b/testdata/baselines/reference/compiler/nonUniformUnionNarrowing.symbols
@@ -1,0 +1,104 @@
+//// [tests/cases/compiler/nonUniformUnionNarrowing.ts] ////
+
+=== nonUniformUnionNarrowing.ts ===
+enum E { A = 1, B = 2 }
+>E : Symbol(E, Decl(nonUniformUnionNarrowing.ts, 0, 0))
+>A : Symbol(E.A, Decl(nonUniformUnionNarrowing.ts, 0, 8))
+>B : Symbol(E.B, Decl(nonUniformUnionNarrowing.ts, 0, 15))
+
+function f1(x: E | 1 | 2) {
+>f1 : Symbol(f1, Decl(nonUniformUnionNarrowing.ts, 0, 23))
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 2, 12))
+>E : Symbol(E, Decl(nonUniformUnionNarrowing.ts, 0, 0))
+
+    if (x === E.A) {
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 2, 12))
+>E.A : Symbol(E.A, Decl(nonUniformUnionNarrowing.ts, 0, 8))
+>E : Symbol(E, Decl(nonUniformUnionNarrowing.ts, 0, 0))
+>A : Symbol(E.A, Decl(nonUniformUnionNarrowing.ts, 0, 8))
+
+        x;  // 1 | E.A
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 2, 12))
+    }
+    else {
+        x;  // 2 | E.B
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 2, 12))
+    }
+}
+
+function f2(x: E | 1 | 2) {
+>f2 : Symbol(f2, Decl(nonUniformUnionNarrowing.ts, 9, 1))
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 11, 12))
+>E : Symbol(E, Decl(nonUniformUnionNarrowing.ts, 0, 0))
+
+    if (x === 1) {
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 11, 12))
+
+        x;  // 1 | E.A
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 11, 12))
+    }
+    else {
+        x;  // 2 | E.B
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 11, 12))
+    }
+}
+
+namespace N1 {
+>N1 : Symbol(N1, Decl(nonUniformUnionNarrowing.ts, 18, 1))
+
+    export enum E { A = 1, B = 2 }
+>E : Symbol(E, Decl(nonUniformUnionNarrowing.ts, 20, 14))
+>A : Symbol(E.A, Decl(nonUniformUnionNarrowing.ts, 21, 19))
+>B : Symbol(E.B, Decl(nonUniformUnionNarrowing.ts, 21, 26))
+}
+namespace N2 {
+>N2 : Symbol(N2, Decl(nonUniformUnionNarrowing.ts, 22, 1))
+
+    export enum E { A = 1, B = 2 }
+>E : Symbol(E, Decl(nonUniformUnionNarrowing.ts, 23, 14))
+>A : Symbol(E.A, Decl(nonUniformUnionNarrowing.ts, 24, 19))
+>B : Symbol(E.B, Decl(nonUniformUnionNarrowing.ts, 24, 26))
+}
+
+function f3(x: N1.E | N2.E) {
+>f3 : Symbol(f3, Decl(nonUniformUnionNarrowing.ts, 25, 1))
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 27, 12))
+>N1 : Symbol(N1, Decl(nonUniformUnionNarrowing.ts, 18, 1))
+>E : Symbol(N1.E, Decl(nonUniformUnionNarrowing.ts, 20, 14))
+>N2 : Symbol(N2, Decl(nonUniformUnionNarrowing.ts, 22, 1))
+>E : Symbol(N2.E, Decl(nonUniformUnionNarrowing.ts, 23, 14))
+
+    if (x === N1.E.A) {
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 27, 12))
+>N1.E.A : Symbol(N1.E.A, Decl(nonUniformUnionNarrowing.ts, 21, 19))
+>N1.E : Symbol(N1.E, Decl(nonUniformUnionNarrowing.ts, 20, 14))
+>N1 : Symbol(N1, Decl(nonUniformUnionNarrowing.ts, 18, 1))
+>E : Symbol(N1.E, Decl(nonUniformUnionNarrowing.ts, 20, 14))
+>A : Symbol(N1.E.A, Decl(nonUniformUnionNarrowing.ts, 21, 19))
+
+        x;  // N1.E.A | N2.E.A
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 27, 12))
+    }
+    else {
+        x;  // N1.E.B | N2.E.B
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 27, 12))
+    }
+}
+
+const sym = Symbol();
+>sym : Symbol(sym, Decl(nonUniformUnionNarrowing.ts, 36, 5))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2019.symbol.d.ts, --, --))
+
+function f4(x: symbol | string) {
+>f4 : Symbol(f4, Decl(nonUniformUnionNarrowing.ts, 36, 21))
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 38, 12))
+
+    if (x === sym) {
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 38, 12))
+>sym : Symbol(sym, Decl(nonUniformUnionNarrowing.ts, 36, 5))
+
+        x;  // symbol (not narrowed)
+>x : Symbol(x, Decl(nonUniformUnionNarrowing.ts, 38, 12))
+    }
+}
+

--- a/testdata/baselines/reference/compiler/nonUniformUnionNarrowing.types
+++ b/testdata/baselines/reference/compiler/nonUniformUnionNarrowing.types
@@ -1,0 +1,112 @@
+//// [tests/cases/compiler/nonUniformUnionNarrowing.ts] ////
+
+=== nonUniformUnionNarrowing.ts ===
+enum E { A = 1, B = 2 }
+>E : E
+>A : E.A
+>1 : 1
+>B : E.B
+>2 : 2
+
+function f1(x: E | 1 | 2) {
+>f1 : (x: E | 1 | 2) => void
+>x : 1 | 2 | E
+
+    if (x === E.A) {
+>x === E.A : boolean
+>x : 1 | 2 | E
+>E.A : E.A
+>E : typeof E
+>A : E.A
+
+        x;  // 1 | E.A
+>x : 1 | E.A
+    }
+    else {
+        x;  // 2 | E.B
+>x : 2 | E.B
+    }
+}
+
+function f2(x: E | 1 | 2) {
+>f2 : (x: E | 1 | 2) => void
+>x : 1 | 2 | E
+
+    if (x === 1) {
+>x === 1 : boolean
+>x : 1 | 2 | E
+>1 : 1
+
+        x;  // 1 | E.A
+>x : 1 | E.A
+    }
+    else {
+        x;  // 2 | E.B
+>x : 2 | E.B
+    }
+}
+
+namespace N1 {
+>N1 : typeof N1
+
+    export enum E { A = 1, B = 2 }
+>E : E
+>A : E.A
+>1 : 1
+>B : E.B
+>2 : 2
+}
+namespace N2 {
+>N2 : typeof N2
+
+    export enum E { A = 1, B = 2 }
+>E : E
+>A : E.A
+>1 : 1
+>B : E.B
+>2 : 2
+}
+
+function f3(x: N1.E | N2.E) {
+>f3 : (x: N1.E | N2.E) => void
+>x : N1.E | N2.E
+>N1 : any
+>N2 : any
+
+    if (x === N1.E.A) {
+>x === N1.E.A : boolean
+>x : N1.E | N2.E
+>N1.E.A : N1.E.A
+>N1.E : typeof N1.E
+>N1 : typeof N1
+>E : typeof N1.E
+>A : N1.E.A
+
+        x;  // N1.E.A | N2.E.A
+>x : N1.E.A | N2.E.A
+    }
+    else {
+        x;  // N1.E.B | N2.E.B
+>x : N1.E.B | N2.E.B
+    }
+}
+
+const sym = Symbol();
+>sym : unique symbol
+>Symbol() : unique symbol
+>Symbol : SymbolConstructor
+
+function f4(x: symbol | string) {
+>f4 : (x: symbol | string) => void
+>x : string | symbol
+
+    if (x === sym) {
+>x === sym : boolean
+>x : string | symbol
+>sym : unique symbol
+
+        x;  // symbol (not narrowed)
+>x : symbol
+    }
+}
+

--- a/testdata/baselines/reference/compiler/nonUniformUnionNarrowing.types
+++ b/testdata/baselines/reference/compiler/nonUniformUnionNarrowing.types
@@ -28,6 +28,28 @@ function f1(x: E | 1 | 2) {
     }
 }
 
+function f1s(x: E | 1 | 2) {
+>f1s : (x: E | 1 | 2) => void
+>x : 1 | 2 | E
+
+    switch (x) {
+>x : 1 | 2 | E
+
+        case E.A:
+>E.A : E.A
+>E : typeof E
+>A : E.A
+
+            x;  // 1 | E.A
+>x : 1 | E.A
+
+            break;
+        default:
+            x;  // 2 | E.B
+>x : 2 | E.B
+    }
+}
+
 function f2(x: E | 1 | 2) {
 >f2 : (x: E | 1 | 2) => void
 >x : 1 | 2 | E
@@ -42,6 +64,26 @@ function f2(x: E | 1 | 2) {
     }
     else {
         x;  // 2 | E.B
+>x : 2 | E.B
+    }
+}
+
+function f2s(x: E | 1 | 2) {
+>f2s : (x: E | 1 | 2) => void
+>x : 1 | 2 | E
+
+    switch (x) {
+>x : 1 | 2 | E
+
+        case 1:
+>1 : 1
+
+            x;  // 1 | E.A
+>x : 1 | E.A
+
+            break;
+        default:
+            x;  // 2 | E.B
 >x : 2 | E.B
     }
 }
@@ -91,6 +133,32 @@ function f3(x: N1.E | N2.E) {
     }
 }
 
+function f3s(x: N1.E | N2.E) {
+>f3s : (x: N1.E | N2.E) => void
+>x : N1.E | N2.E
+>N1 : any
+>N2 : any
+
+    switch (x) {
+>x : N1.E | N2.E
+
+        case N1.E.A:
+>N1.E.A : N1.E.A
+>N1.E : typeof N1.E
+>N1 : typeof N1
+>E : typeof N1.E
+>A : N1.E.A
+
+            x;  // N1.E.A | N2.E.A
+>x : N1.E.A | N2.E.A
+
+            break;
+        default:
+            x;  // N1.E.B | N2.E.B
+>x : N1.E.B | N2.E.B
+    }
+}
+
 const sym = Symbol();
 >sym : unique symbol
 >Symbol() : unique symbol
@@ -107,6 +175,64 @@ function f4(x: symbol | string) {
 
         x;  // symbol (not narrowed)
 >x : symbol
+    }
+}
+
+function f4s(x: symbol | string) {
+>f4s : (x: symbol | string) => void
+>x : string | symbol
+
+    switch (x) {
+>x : string | symbol
+
+        case sym:
+>sym : unique symbol
+
+            x;  // symbol (not narrowed)
+>x : symbol
+    }
+}
+
+declare enum EE { A, B }
+>EE : EE
+>A : EE.A
+>B : EE.B
+
+function f6(x: EE | 1 | 2) {
+>f6 : (x: EE | 1 | 2) => void
+>x : 1 | 2 | EE
+
+    if (x === 1) {
+>x === 1 : boolean
+>x : 1 | 2 | EE
+>1 : 1
+
+        x;  // 1 | EE (computed enum compares to any number)
+>x : 1 | EE
+    }
+    else {
+        x;  // 2
+>x : 2
+    }
+}
+
+function f6s(x: EE | 1 | 2) {
+>f6s : (x: EE | 1 | 2) => void
+>x : 1 | 2 | EE
+
+    switch (x) {
+>x : 1 | 2 | EE
+
+        case 1:
+>1 : 1
+
+            x;  // 1 | EE (computed enum compares to any number)
+>x : 1 | EE
+
+            break;
+        default:
+            x;  // 2
+>x : 2
     }
 }
 

--- a/testdata/tests/cases/compiler/nonUniformUnionNarrowing.ts
+++ b/testdata/tests/cases/compiler/nonUniformUnionNarrowing.ts
@@ -11,12 +11,32 @@ function f1(x: E | 1 | 2) {
     }
 }
 
+function f1s(x: E | 1 | 2) {
+    switch (x) {
+        case E.A:
+            x;  // 1 | E.A
+            break;
+        default:
+            x;  // 2 | E.B
+    }
+}
+
 function f2(x: E | 1 | 2) {
     if (x === 1) {
         x;  // 1 | E.A
     }
     else {
         x;  // 2 | E.B
+    }
+}
+
+function f2s(x: E | 1 | 2) {
+    switch (x) {
+        case 1:
+            x;  // 1 | E.A
+            break;
+        default:
+            x;  // 2 | E.B
     }
 }
 
@@ -36,10 +56,48 @@ function f3(x: N1.E | N2.E) {
     }
 }
 
+function f3s(x: N1.E | N2.E) {
+    switch (x) {
+        case N1.E.A:
+            x;  // N1.E.A | N2.E.A
+            break;
+        default:
+            x;  // N1.E.B | N2.E.B
+    }
+}
+
 const sym = Symbol();
 
 function f4(x: symbol | string) {
     if (x === sym) {
         x;  // symbol (not narrowed)
+    }
+}
+
+function f4s(x: symbol | string) {
+    switch (x) {
+        case sym:
+            x;  // symbol (not narrowed)
+    }
+}
+
+declare enum EE { A, B }
+
+function f6(x: EE | 1 | 2) {
+    if (x === 1) {
+        x;  // 1 | EE (computed enum compares to any number)
+    }
+    else {
+        x;  // 2
+    }
+}
+
+function f6s(x: EE | 1 | 2) {
+    switch (x) {
+        case 1:
+            x;  // 1 | EE (computed enum compares to any number)
+            break;
+        default:
+            x;  // 2
     }
 }

--- a/testdata/tests/cases/compiler/nonUniformUnionNarrowing.ts
+++ b/testdata/tests/cases/compiler/nonUniformUnionNarrowing.ts
@@ -1,0 +1,45 @@
+// @noEmit: true
+
+enum E { A = 1, B = 2 }
+
+function f1(x: E | 1 | 2) {
+    if (x === E.A) {
+        x;  // 1 | E.A
+    }
+    else {
+        x;  // 2 | E.B
+    }
+}
+
+function f2(x: E | 1 | 2) {
+    if (x === 1) {
+        x;  // 1 | E.A
+    }
+    else {
+        x;  // 2 | E.B
+    }
+}
+
+namespace N1 {
+    export enum E { A = 1, B = 2 }
+}
+namespace N2 {
+    export enum E { A = 1, B = 2 }
+}
+
+function f3(x: N1.E | N2.E) {
+    if (x === N1.E.A) {
+        x;  // N1.E.A | N2.E.A
+    }
+    else {
+        x;  // N1.E.B | N2.E.B
+    }
+}
+
+const sym = Symbol();
+
+function f4(x: symbol | string) {
+    if (x === sym) {
+        x;  // symbol (not narrowed)
+    }
+}


### PR DESCRIPTION
Inspired by the performance gains in #4711, this PR further optimizes union type narrowing in control flow analysis.