### PR TITLE
Fix module specifier rename trigger spans

### DIFF
--- a/internal/fourslash/fourslash.go
+++ b/internal/fourslash/fourslash.go
@@ -4753,6 +4753,26 @@ func (f *FourslashTest) VerifyRenameSucceeded(t *testing.T, preferences *lsutil.
 	}
 }
 
+func (f *FourslashTest) VerifyRenameRange(t *testing.T, expectedRange lsproto.Range, expectedPlaceholder string, preferences *lsutil.UserPreferences) {
+	t.Helper()
+	if preferences != nil {
+		defer f.ConfigureWithReset(t, *preferences)()
+	}
+	params := &lsproto.PrepareRenameParams{
+		TextDocument: lsproto.TextDocumentIdentifier{
+			Uri: lsconv.FileNameToDocumentURI(f.activeFilename),
+		},
+		Position: f.currentCaretPosition,
+	}
+
+	result := sendRequest(t, f, lsproto.TextDocumentPrepareRenameInfo, params)
+	if result.PrepareRenamePlaceholder == nil {
+		t.Fatal(f.getCurrentPositionPrefix() + "Expected prepareRename to return a range and placeholder")
+	}
+	assert.DeepEqual(t, result.PrepareRenamePlaceholder.Range, expectedRange)
+	assert.Equal(t, result.PrepareRenamePlaceholder.Placeholder, expectedPlaceholder)
+}
+
 func (f *FourslashTest) RenameAtCaret(t *testing.T, newName string) lsproto.RenameResponse {
 	t.Helper()
 	result := sendRequest(t, f, lsproto.TextDocumentRenameInfo, &lsproto.RenameParams{

--- a/internal/fourslash/tests/importAllowRenameOfImportPath_test.go
+++ b/internal/fourslash/tests/importAllowRenameOfImportPath_test.go
@@ -47,3 +47,20 @@ const a = require("./[|a|]");
 		f.VerifyRenameFailed(t, &prefsFalse)
 	})
 }
+
+func TestRenameInfoForImportPathTriggerSpan(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+	const content = `// @Filename: /library.ts
+export const foo = "bar";
+// @Filename: /index.ts
+export * from "./[|lib/*rename*/rary|]";
+`
+
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+	f.GoToMarker(t, "rename")
+	f.VerifyRenameRange(t, f.Ranges()[0].LSRange, "library", &lsutil.UserPreferences{
+		AllowRenameOfImportPath: core.TSTrue,
+	})
+}

--- a/internal/ls/rename.go
+++ b/internal/ls/rename.go
@@ -263,7 +263,7 @@ func (l *LanguageService) getRenameInfoForModule(ctx context.Context, newName st
 
 	// Span should only be the last component of the path. + 1 to account for the quote character.
 	indexAfterLastSlash := strings.LastIndex(specifier.Text(), "/") + 1
-	start := specifier.Pos() + 1 + indexAfterLastSlash
+	start := astnav.GetStartOfNode(specifier, sourceFile, false /*includeJSDoc*/) + 1 + indexAfterLastSlash
 	length := len(specifier.Text()) - indexAfterLastSlash
 
 	return RenameInfo{


### PR DESCRIPTION
Fixes #4782

#3443 fixed rename trigger spans in the general rename path by replacing `node.Pos()` with the trivia-free node start. Module-specifier renames use a separate path that retained the old calculation.

As a result, `textDocument/prepareRename` included leading trivia and shifted the module-specifier trigger span one column to the left.

---

**AI assistance disclosure:** This change was authored with assistance from Codex. I have reviewed and understand the resulting changes and will respond to review feedback.
