### PR TITLE
Skip the speculative expression parse in the async arrow lookahead

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -4535,8 +4535,6 @@ func (p *Parser) nextIsUnParenthesizedAsyncArrowFunction() bool {
 			return false
 		}
 		// Check for un-parenthesized AsyncArrowFunction
-		// !!! In Strada, this speculatively parses a full binary expression and tests whether it came back as a bare
-		// Identifier followed by "=>", allocating nodes it then discards (for `async function () {}`, an entire function body).
 		if !p.isIdentifier() {
 			return false
 		}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -4535,10 +4535,13 @@ func (p *Parser) nextIsUnParenthesizedAsyncArrowFunction() bool {
 			return false
 		}
 		// Check for un-parenthesized AsyncArrowFunction
-		expr := p.parseBinaryExpressionOrHigher(ast.OperatorPrecedenceLowest)
-		if !p.hasPrecedingLineBreak() && expr.Kind == ast.KindIdentifier && p.token == ast.KindEqualsGreaterThanToken {
-			return true
+		// !!! In Strada, this speculatively parses a full binary expression and tests whether it came back as a bare
+		// Identifier followed by "=>", allocating nodes it then discards (for `async function () {}`, an entire function body).
+		if !p.isIdentifier() {
+			return false
 		}
+		p.nextTokenWithoutCheck()
+		return !p.hasPrecedingLineBreak() && p.token == ast.KindEqualsGreaterThanToken
 	}
 	return false
 }


### PR DESCRIPTION
## Context

Currently, `nextIsUnParenthesizedAsyncArrowFunction` decides whether `async …` starts an unparenthesized async arrow (`async x => …`) by running a full `parseBinaryExpressionOrHigher` under `lookAhead` and checking whether the result is a bare `Identifier` followed by `=>`. When it isn't (most commonly `async function () { … }` as an argument or initializer), the lookahead has just parsed the whole function body only to throw it away, and the real parse then builds it a second time. The discarded nodes are never freed; they keep occupying slots in the source file's node arenas for as long as the AST lives.

## This PR

An unparenthesized async arrow head is exactly an identifier token immediately followed by `=>` with no line break in between, so the lookahead now checks those two tokens instead of parsing anything.

### Performance

On the VS Code codebase, we're seeing the following memory reduction when using `--singleThreaded` and `--noEmit`:

| Metric | Before | After | Δ |
|---|---:|---:|---:|
| Memory used | 3,581,244 K | 3,561,838 K | −19.4 MB |
| Nodes created | 10,525,474 | 10,325,669 | −199,805 |
| Nodes reachable | 10,185,776 | 10,185,776 | 0 |
| Nodes abandoned | 339,698 (3.23 %) | 139,893 (1.35 %) | −199,805 |

The worst case file is `chatEditingModifiedNotebookEntry.test.ts` with its 36 `test('…', async function () { … })` bodies:

| Metric | Before | After | Δ |
|---|---:|---:|---:|
| Nodes created | 22,279 | 11,738 | −47 % |
| Parse wall time | 2,197 µs | 1,177 µs | −46 % |
| Bytes allocated | 2,159 KiB | 1,176 KiB | −45 % |
| Mallocs | 3,606 | 1,995 | −45 % |

_(The speculation also compounded with nesting: an `async function` expression inside another one triggered the lookahead again from inside the outer speculation, so a body at depth k was parsed 2^k times.)_

This PR was assisted by Claude Code.