### PR TITLE
Shrink `ast.Symbol` from 96 to 80 bytes

### DIFF
--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -164,8 +164,8 @@ func (sd *snapshotData) newSymbolResponse(symbol *ast.Symbol, canonicalProject P
 		resp.Parent = SymbolHandle(symbol.Parent)
 	}
 
-	if symbol.ExportSymbol != nil {
-		resp.ExportSymbol = SymbolHandle(symbol.ExportSymbol)
+	if symbol.ExportSymbol() != nil {
+		resp.ExportSymbol = SymbolHandle(symbol.ExportSymbol())
 	}
 
 	return resp
@@ -1616,18 +1616,18 @@ func (s *Session) handleGetParentOfSymbol(_ context.Context, params *GetSymbolPr
 
 func (s *Session) handleGetMembersOfSymbol(ctx context.Context, params *GetSymbolPropertyParams) ([]*SymbolResponse, error) {
 	return s.resolveSymbolTablePropertyOfSymbol(ctx, params, func(symbol *ast.Symbol) ast.SymbolTable {
-		return symbol.Members
+		return symbol.Members()
 	})
 }
 
 func (s *Session) handleGetExportsOfSymbol(ctx context.Context, params *GetSymbolPropertyParams) ([]*SymbolResponse, error) {
 	return s.resolveSymbolTablePropertyOfSymbol(ctx, params, func(symbol *ast.Symbol) ast.SymbolTable {
-		return symbol.Exports
+		return symbol.Exports()
 	})
 }
 
 func (s *Session) handleGetExportSymbolOfSymbol(_ context.Context, params *GetSymbolPropertyParams) (*SymbolResponse, error) {
-	return s.resolveSymbolPropertyOfSymbol(params, func(sym *ast.Symbol) *ast.Symbol { return sym.ExportSymbol })
+	return s.resolveSymbolPropertyOfSymbol(params, func(sym *ast.Symbol) *ast.Symbol { return sym.ExportSymbol() })
 }
 
 func (s *Session) handleGetSymbolOfType(_ context.Context, params *GetTypePropertyParams) (*SymbolResponse, error) {

--- a/internal/ast/symbol.go
+++ b/internal/ast/symbol.go
@@ -13,11 +13,64 @@ type Symbol struct {
 	Name             string
 	Declarations     []*Node
 	ValueDeclaration *Node
-	Members          SymbolTable
-	Exports          SymbolTable
 	id               atomic.Uint64
 	Parent           *Symbol
-	ExportSymbol     *Symbol
+	extra            *symbolExtra // Rarely populated, so boxed to keep Symbol small
+}
+
+type symbolExtra struct {
+	members      SymbolTable
+	exports      SymbolTable
+	exportSymbol *Symbol
+}
+
+func (s *Symbol) getExtra() *symbolExtra {
+	if s.extra == nil {
+		s.extra = &symbolExtra{}
+	}
+	return s.extra
+}
+
+func (s *Symbol) Members() SymbolTable {
+	if s.extra != nil {
+		return s.extra.members
+	}
+	return nil
+}
+
+func (s *Symbol) SetMembers(members SymbolTable) {
+	if members == nil && s.extra == nil {
+		return
+	}
+	s.getExtra().members = members
+}
+
+func (s *Symbol) Exports() SymbolTable {
+	if s.extra != nil {
+		return s.extra.exports
+	}
+	return nil
+}
+
+func (s *Symbol) SetExports(exports SymbolTable) {
+	if exports == nil && s.extra == nil {
+		return
+	}
+	s.getExtra().exports = exports
+}
+
+func (s *Symbol) ExportSymbol() *Symbol {
+	if s.extra != nil {
+		return s.extra.exportSymbol
+	}
+	return nil
+}
+
+func (s *Symbol) SetExportSymbol(exportSymbol *Symbol) {
+	if exportSymbol == nil && s.extra == nil {
+		return
+	}
+	s.getExtra().exportSymbol = exportSymbol
 }
 
 func (s *Symbol) IsExternalModule() bool {
@@ -34,8 +87,8 @@ func (s *Symbol) IsStatic() bool {
 
 // See comment on `declareModuleMember` in `binder.go`.
 func (s *Symbol) CombinedLocalAndExportSymbolFlags() SymbolFlags {
-	if s.ExportSymbol != nil {
-		return s.Flags | s.ExportSymbol.Flags
+	if exportSymbol := s.ExportSymbol(); exportSymbol != nil {
+		return s.Flags | exportSymbol.Flags
 	}
 	return s.Flags
 }

--- a/internal/ast/utilities.go
+++ b/internal/ast/utilities.go
@@ -51,11 +51,11 @@ func GetSymbolTable(data *SymbolTable) SymbolTable {
 }
 
 func GetMembers(symbol *Symbol) SymbolTable {
-	return GetSymbolTable(&symbol.Members)
+	return GetSymbolTable(&symbol.getExtra().members)
 }
 
 func GetExports(symbol *Symbol) SymbolTable {
-	return GetSymbolTable(&symbol.Exports)
+	return GetSymbolTable(&symbol.getExtra().exports)
 }
 
 func GetLocals(container *Node) SymbolTable {

--- a/internal/binder/binder.go
+++ b/internal/binder/binder.go
@@ -404,7 +404,7 @@ func (b *Binder) declareModuleMember(node *ast.Node, symbolFlags ast.SymbolFlags
 			exportKind = ast.SymbolFlagsExportValue
 		}
 		local := b.declareSymbol(ast.GetLocals(container), nil /*parent*/, node, exportKind, symbolExcludes)
-		local.ExportSymbol = b.declareSymbol(ast.GetExports(container.Symbol()), container.Symbol(), node, symbolFlags, symbolExcludes)
+		local.SetExportSymbol(b.declareSymbol(ast.GetExports(container.Symbol()), container.Symbol(), node, symbolFlags, symbolExcludes))
 		node.ExportableData().LocalSymbol = local
 		return local
 	}
@@ -759,7 +759,7 @@ func (b *Binder) bindSourceFileIfExternalModule() {
 		b.bindSourceFileAsExternalModule()
 		// Create symbol equivalent for the module.exports = {}
 		originalSymbol := b.file.Symbol
-		b.declareSymbol(ast.GetSymbolTable(&b.file.Symbol.Exports), b.file.Symbol, b.file.AsNode(), ast.SymbolFlagsProperty, ast.SymbolFlagsAll)
+		b.declareSymbol(ast.GetExports(b.file.Symbol), b.file.Symbol, b.file.AsNode(), ast.SymbolFlagsProperty, ast.SymbolFlagsAll)
 		b.file.Symbol = originalSymbol
 	}
 }
@@ -993,8 +993,7 @@ func (b *Binder) bindFunctionOrConstructorType(node *ast.Node) {
 	b.addDeclarationToSymbol(symbol, node, ast.SymbolFlagsSignature)
 	typeLiteralSymbol := b.newSymbol(ast.SymbolFlagsTypeLiteral, ast.InternalSymbolNameType)
 	b.addDeclarationToSymbol(typeLiteralSymbol, node, ast.SymbolFlagsTypeLiteral)
-	typeLiteralSymbol.Members = make(ast.SymbolTable)
-	typeLiteralSymbol.Members[symbol.Name] = symbol
+	typeLiteralSymbol.SetMembers(ast.SymbolTable{symbol.Name: symbol})
 }
 
 func (b *Binder) addLateBoundAssignmentDeclarationToSymbol(node *ast.Node, symbol *ast.Symbol) {
@@ -1036,7 +1035,7 @@ func (b *Binder) bindDeferredExpandoAssignments() {
 // from the module symbol onto the export= symbol and, if any such exports exist, mark the export=
 // symbol as a namespace module.
 func (b *Binder) bindCommonJSTypeExports(moduleSymbol *ast.Symbol) {
-	moduleExports := moduleSymbol.Exports
+	moduleExports := moduleSymbol.Exports()
 	if exportEquals := moduleExports[ast.InternalSymbolNameExportEquals]; exportEquals != nil {
 		for _, symbol := range moduleExports {
 			if symbol.Name != ast.InternalSymbolNameExportEquals && symbol.Flags&(ast.SymbolFlagsType|ast.SymbolFlagsNamespace) != 0 {
@@ -1275,9 +1274,9 @@ func (b *Binder) lookupEntity(node *ast.Node, container *ast.Node) *ast.Symbol {
 		}
 		return nil
 	}
-	if symbol := getInitializerSymbol(b.lookupEntity(node.Expression(), container)); symbol != nil && symbol.Exports != nil {
+	if symbol := getInitializerSymbol(b.lookupEntity(node.Expression(), container)); symbol != nil && symbol.Exports() != nil {
 		if name := ast.GetElementOrPropertyAccessName(node); name != nil {
-			return symbol.Exports[name.Text()]
+			return symbol.Exports()[name.Text()]
 		}
 	}
 	return nil
@@ -1286,11 +1285,11 @@ func (b *Binder) lookupEntity(node *ast.Node, container *ast.Node) *ast.Symbol {
 func (b *Binder) lookupName(name string, container *ast.Node) *ast.Symbol {
 	if localsContainer := container.LocalsContainerData(); localsContainer != nil {
 		if local := localsContainer.Locals[name]; local != nil {
-			return core.OrElse(local.ExportSymbol, local)
+			return core.OrElse(local.ExportSymbol(), local)
 		}
 	}
 	if declaration := container.DeclarationData(); declaration != nil && declaration.Symbol != nil {
-		return declaration.Symbol.Exports[name]
+		return declaration.Symbol.Exports()[name]
 	}
 	return nil
 }
@@ -1629,8 +1628,7 @@ func (b *Binder) declareCommonJSVariable(name string) {
 			exportsProperty.Declarations = symbol.Declarations
 			exportsProperty.ValueDeclaration = symbol.ValueDeclaration
 			exportsProperty.Parent = symbol
-			symbol.Members = make(ast.SymbolTable, 1)
-			symbol.Members["exports"] = exportsProperty
+			symbol.SetMembers(ast.SymbolTable{"exports": exportsProperty})
 		}
 		locals[name] = symbol
 	}

--- a/internal/binder/nameresolver.go
+++ b/internal/binder/nameresolver.go
@@ -106,7 +106,7 @@ loop:
 			if moduleSymbol == nil {
 				break
 			}
-			moduleExports := moduleSymbol.Exports
+			moduleExports := moduleSymbol.Exports()
 			if ast.IsSourceFile(location) || (ast.IsModuleDeclaration(location) && location.Flags&ast.NodeFlagsAmbient != 0 && !ast.IsGlobalScopeAugmentation(location)) {
 				// It's an external module. First see if the module has an export default and if the local
 				// name of that export default matches.
@@ -148,7 +148,7 @@ loop:
 			if enumSymbol == nil {
 				break
 			}
-			result = r.lookup(enumSymbol.Exports, name, meaning&ast.SymbolFlagsEnumMember)
+			result = r.lookup(enumSymbol.Exports(), name, meaning&ast.SymbolFlagsEnumMember)
 			if result != nil {
 				if nameNotFoundMessage != nil && r.CompilerOptions.GetIsolatedModules() && location.Flags&ast.NodeFlagsAmbient == 0 && ast.GetSourceFileOfNode(location) != ast.GetSourceFileOfNode(result.ValueDeclaration) {
 					isolatedModulesLikeFlagName := core.IfElse(r.CompilerOptions.VerbatimModuleSyntax == core.TSTrue, "verbatimModuleSyntax", "isolatedModules")
@@ -168,7 +168,7 @@ loop:
 				}
 			}
 		case ast.KindClassDeclaration, ast.KindClassExpression, ast.KindInterfaceDeclaration:
-			result = r.lookup(r.getSymbolOfDeclaration(location).Members, name, meaning&ast.SymbolFlagsType)
+			result = r.lookup(r.getSymbolOfDeclaration(location).Members(), name, meaning&ast.SymbolFlagsType)
 			if result != nil {
 				if !isTypeParameterSymbolDeclaredInContainer(result, location) {
 					// ignore type parameters not declared in this container
@@ -197,7 +197,7 @@ loop:
 			if lastLocation == location.Expression() && ast.IsHeritageClause(location.Parent) && location.Parent.AsHeritageClause().Token == ast.KindExtendsKeyword {
 				container := location.Parent.Parent
 				if ast.IsClassLike(container) {
-					result = r.lookup(r.getSymbolOfDeclaration(container).Members, name, meaning&ast.SymbolFlagsType)
+					result = r.lookup(r.getSymbolOfDeclaration(container).Members(), name, meaning&ast.SymbolFlagsType)
 					if result != nil {
 						if nameNotFoundMessage != nil {
 							r.error(originalLocation, diagnostics.Base_class_expressions_cannot_reference_class_type_parameters)
@@ -217,7 +217,7 @@ loop:
 			grandparent = location.Parent.Parent
 			if ast.IsClassLike(grandparent) || ast.IsInterfaceDeclaration(grandparent) {
 				// A reference to this grandparent's type parameters would be an error
-				result = r.lookup(r.getSymbolOfDeclaration(grandparent).Members, name, meaning&ast.SymbolFlagsType)
+				result = r.lookup(r.getSymbolOfDeclaration(grandparent).Members(), name, meaning&ast.SymbolFlagsType)
 				if result != nil {
 					if nameNotFoundMessage != nil {
 						r.error(originalLocation, diagnostics.A_computed_property_name_cannot_reference_a_type_parameter_from_its_containing_type)

--- a/internal/binder/referenceresolver.go
+++ b/internal/binder/referenceresolver.go
@@ -140,8 +140,8 @@ func (r *referenceResolver) getExportSymbolOfValueSymbolIfExported(symbol *ast.S
 		if r.hooks.GetExportSymbolOfValueSymbolIfExported != nil {
 			return r.hooks.GetExportSymbolOfValueSymbolIfExported(symbol)
 		}
-		if symbol.Flags&ast.SymbolFlagsExportValue != 0 && symbol.ExportSymbol != nil {
-			symbol = symbol.ExportSymbol
+		if symbol.Flags&ast.SymbolFlagsExportValue != 0 && symbol.ExportSymbol() != nil {
+			symbol = symbol.ExportSymbol()
 		}
 		return r.getMergedSymbol(symbol)
 	}
@@ -159,7 +159,7 @@ func (r *referenceResolver) GetReferencedExportContainer(node *ast.IdentifierNod
 			// If we reference an exported entity within the same module declaration, then whether
 			// we prefix depends on the kind of entity. SymbolFlags.ExportHasLocal encompasses all the
 			// kinds that we do NOT prefix.
-			exportSymbol := r.getMergedSymbol(symbol.ExportSymbol)
+			exportSymbol := r.getMergedSymbol(symbol.ExportSymbol())
 			if !prefixLocals && exportSymbol.Flags&ast.SymbolFlagsExportHasLocal != 0 && exportSymbol.Flags&ast.SymbolFlagsVariable == 0 {
 				return nil
 			}

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -959,7 +959,7 @@ func NewChecker(program Program, tracer *Tracer) (*Checker, *sync.Mutex) {
 	c.errorTypes = make(map[CacheHashKey]*Type)
 	c.moduleSymbols = make(map[*ast.Node]*ast.Symbol)
 	c.globalThisSymbol = c.newSymbolEx(ast.SymbolFlagsModule, "globalThis", ast.CheckFlagsReadonly)
-	c.globalThisSymbol.Exports = c.globals
+	c.globalThisSymbol.SetExports(c.globals)
 	c.globals[c.globalThisSymbol.Name] = c.globalThisSymbol
 	c.resolveName = c.createNameResolver().Resolve
 	c.resolveNameForSymbolSuggestion = c.createNameResolverForSuggestion().Resolve
@@ -1403,7 +1403,7 @@ func (c *Checker) mergeModuleAugmentation(moduleName *ast.Node) {
 		return
 	}
 	if ast.IsGlobalScopeAugmentation(moduleNode) {
-		c.mergeSymbolTable(c.globals, moduleAugmentation.Symbol.Exports, false /*unidirectional*/, nil /*parent*/)
+		c.mergeSymbolTable(c.globals, moduleAugmentation.Symbol.Exports(), false /*unidirectional*/, nil /*parent*/)
 	} else {
 		// find a module that about to be augmented
 		// do not validate names of augmentations that are defined in ambient context
@@ -1430,11 +1430,11 @@ func (c *Checker) mergeModuleAugmentation(moduleName *ast.Node) {
 				// moduleName will be a StringLiteral since this is not `declare global`.
 				ast.GetSymbolTable(&c.patternAmbientModuleAugmentations)[moduleName.Text()] = merged
 			} else {
-				if mainModule.Exports[ast.InternalSymbolNameExportStar] != nil && len(moduleAugmentation.Symbol.Exports) != 0 {
+				if mainModule.Exports()[ast.InternalSymbolNameExportStar] != nil && len(moduleAugmentation.Symbol.Exports()) != 0 {
 					// We may need to merge the module augmentation's exports into the target symbols of the resolved exports
 					resolvedExports := c.getResolvedMembersOrExportsOfSymbol(mainModule, MembersOrExportsResolutionKindResolvedExports)
-					for key, value := range moduleAugmentation.Symbol.Exports {
-						if resolvedExports[key] != nil && mainModule.Exports[key] == nil {
+					for key, value := range moduleAugmentation.Symbol.Exports() {
+						if resolvedExports[key] != nil && mainModule.Exports()[key] == nil {
 							c.mergeSymbol(resolvedExports[key], value, false /*unidirectional*/)
 						}
 					}
@@ -5693,7 +5693,7 @@ func (c *Checker) checkExternalModuleExports(node *ast.Node) {
 	moduleSymbol := c.getSymbolOfDeclaration(node)
 	links := c.moduleSymbolLinks.Get(moduleSymbol)
 	if !links.exportsChecked {
-		exportEqualsSymbol := moduleSymbol.Exports[ast.InternalSymbolNameExportEquals]
+		exportEqualsSymbol := moduleSymbol.Exports()[ast.InternalSymbolNameExportEquals]
 		// An export assignment is in error if (a) the module exports value members or (b) if the module exports type or
 		// namespace members and the exported entity also exports type or namespace members.
 		if exportEqualsSymbol != nil && (c.hasExportedMembersOfKind(moduleSymbol, ast.SymbolFlagsValue) || c.hasShadowedNamespace(exportEqualsSymbol)) {
@@ -5735,7 +5735,7 @@ func (c *Checker) checkExternalModuleExports(node *ast.Node) {
 }
 
 func (c *Checker) hasExportedMembersOfKind(moduleSymbol *ast.Symbol, kind ast.SymbolFlags) bool {
-	for _, symbol := range moduleSymbol.Exports {
+	for _, symbol := range moduleSymbol.Exports() {
 		if symbol.Name != ast.InternalSymbolNameExportEquals && c.getSymbolFlags(symbol)&kind != 0 {
 			return true
 		}
@@ -6576,8 +6576,8 @@ func (c *Checker) getIterationTypesOfMethod(t *Type, resolver *IterationTypesRes
 	if len(methodSignatures) == 1 && methodType.symbol != nil {
 		globalGeneratorType := resolver.getGlobalGeneratorType()
 		globalIteratorType := resolver.getGlobalIteratorType()
-		isGeneratorMethod := globalGeneratorType.symbol != nil && globalGeneratorType.symbol.Members[methodName] == methodType.symbol
-		isIteratorMethod := !isGeneratorMethod && globalIteratorType.symbol != nil && globalIteratorType.symbol.Members[methodName] == methodType.symbol
+		isGeneratorMethod := globalGeneratorType.symbol != nil && globalGeneratorType.symbol.Members()[methodName] == methodType.symbol
+		isIteratorMethod := !isGeneratorMethod && globalIteratorType.symbol != nil && globalIteratorType.symbol.Members()[methodName] == methodType.symbol
 		if isGeneratorMethod || isIteratorMethod {
 			typeParameters := core.IfElse(isGeneratorMethod, globalGeneratorType, globalIteratorType).AsInterfaceType().TypeParameters()
 			mapper := methodType.Mapper()
@@ -6744,7 +6744,7 @@ func (c *Checker) checkAliasSymbol(node *ast.Node) {
 	// Based on symbol.flags we can compute a set of excluded meanings (meaning that resolved alias should not have,
 	// otherwise it will conflict with some local declaration). Note that in addition to normal flags we include matching SymbolFlags.Export*
 	// in order to prevent collisions with declarations that were exported from the current module (they still contribute to local names).
-	symbol = c.getMergedSymbol(core.OrElse(symbol.ExportSymbol, symbol))
+	symbol = c.getMergedSymbol(core.OrElse(symbol.ExportSymbol(), symbol))
 	targetFlags := c.getSymbolFlags(target)
 	// A type-only import/export will already have a grammar error in a JS file, so no need to issue more errors within
 	if ast.IsInJSFile(node) && targetFlags&ast.SymbolFlagsValue == 0 && !ast.IsTypeOnlyImportOrExportDeclaration(node) {
@@ -6753,7 +6753,7 @@ func (c *Checker) checkAliasSymbol(node *ast.Node) {
 		if ast.IsExportSpecifier(node) {
 			diag := c.error(errorNode, diagnostics.Types_cannot_appear_in_export_declarations_in_JavaScript_files)
 			if sourceSymbol := ast.GetSourceFileOfNode(node).AsNode().Symbol(); sourceSymbol != nil {
-				if alreadyExportedSymbol := sourceSymbol.Exports[node.PropertyNameOrName().Text()]; alreadyExportedSymbol == target {
+				if alreadyExportedSymbol := sourceSymbol.Exports()[node.PropertyNameOrName().Text()]; alreadyExportedSymbol == target {
 					if exportingDeclaration := core.Find(alreadyExportedSymbol.Declarations, ast.IsJSTypeAliasDeclaration); exportingDeclaration != nil {
 						diag.AddRelatedInfo(NewDiagnosticForNode(exportingDeclaration, diagnostics.X_0_is_automatically_exported_here, alreadyExportedSymbol.Name))
 					}
@@ -6913,7 +6913,7 @@ func (c *Checker) checkExportsOnMergedDeclarations(node *ast.Node) {
 		// Local symbol is undefined => this declaration is non-exported.
 		// However, symbol might contain other declarations that are exported.
 		symbol = c.getSymbolOfDeclaration(node)
-		if symbol.ExportSymbol == nil {
+		if symbol.ExportSymbol() == nil {
 			// This is a pure local symbol (all declarations are non-exported) - no need to check anything.
 			return
 		}
@@ -7142,7 +7142,7 @@ func (c *Checker) checkUnusedLocalsAndParameters(node *ast.Node) {
 	for _, local := range node.Locals() {
 		referenceKinds := c.symbolReferenceLinks.Get(local).referenceKinds
 		if local.Flags&ast.SymbolFlagsTypeParameter != 0 && (local.Flags&ast.SymbolFlagsVariable == 0 || referenceKinds&ast.SymbolFlagsVariable != 0) ||
-			local.Flags&ast.SymbolFlagsTypeParameter == 0 && (referenceKinds != 0 || local.ExportSymbol != nil ||
+			local.Flags&ast.SymbolFlagsTypeParameter == 0 && (referenceKinds != 0 || local.ExportSymbol() != nil ||
 				local.Flags&ast.SymbolFlagsModuleExports != 0) {
 			continue
 		}
@@ -11334,7 +11334,7 @@ func (c *Checker) checkPropertyAccessExpressionOrQualifiedName(node *ast.Node, l
 				return c.anyType
 			}
 			if leftType.symbol == c.globalThisSymbol {
-				globalSymbol := c.globalThisSymbol.Exports[right.Text()]
+				globalSymbol := c.globalThisSymbol.Exports()[right.Text()]
 				if globalSymbol != nil && globalSymbol.Flags&ast.SymbolFlagsBlockScoped != 0 {
 					c.error(right, diagnostics.Property_0_does_not_exist_on_type_1, right.Text(), c.TypeToString(leftType))
 				} else if c.noImplicitAny {
@@ -11474,11 +11474,11 @@ func (c *Checker) lookupSymbolForPrivateIdentifierDeclaration(propName string, l
 	for containingClass := getContainingClassExcludingClassDecorators(location); containingClass != nil; containingClass = ast.GetContainingClass(containingClass) {
 		symbol := containingClass.Symbol()
 		name := binder.GetSymbolNameForPrivateIdentifier(symbol, propName)
-		prop := symbol.Members[name]
+		prop := symbol.Members()[name]
 		if prop != nil {
 			return prop
 		}
-		prop = symbol.Exports[name]
+		prop = symbol.Exports()[name]
 		if prop != nil {
 			return prop
 		}
@@ -13142,8 +13142,8 @@ func (c *Checker) checkReferenceExpression(expr *ast.Node, invalidReferenceMessa
 
 func (c *Checker) checkObjectLiteral(node *ast.Node, checkMode CheckMode) *Type {
 	// Expando object literals have empty properties but filled exports
-	if len(node.Properties()) == 0 && node.Symbol() != nil && len(node.Symbol().Exports) != 0 {
-		result := c.newAnonymousType(node.Symbol(), node.Symbol().Exports, nil, nil, nil)
+	if len(node.Properties()) == 0 && node.Symbol() != nil && len(node.Symbol().Exports()) != 0 {
+		result := c.newAnonymousType(node.Symbol(), node.Symbol().Exports(), nil, nil, nil)
 		if ast.IsInJSFile(node) && !ast.IsInJsonFile(node) {
 			result.objectFlags |= ObjectFlagsJSLiteral
 		}
@@ -14159,11 +14159,11 @@ func (c *Checker) mergeSymbol(target *ast.Symbol, source *ast.Symbol, unidirecti
 			binder.SetValueDeclaration(target, source.ValueDeclaration)
 		}
 		target.Declarations = append(target.Declarations, source.Declarations...)
-		if source.Members != nil {
-			c.mergeSymbolTable(ast.GetSymbolTable(&target.Members), source.Members, unidirectional, nil)
+		if source.Members() != nil {
+			c.mergeSymbolTable(ast.GetMembers(target), source.Members(), unidirectional, nil)
 		}
-		if source.Exports != nil {
-			c.mergeSymbolTable(ast.GetSymbolTable(&target.Exports), source.Exports, unidirectional, target)
+		if source.Exports() != nil {
+			c.mergeSymbolTable(ast.GetExports(target), source.Exports(), unidirectional, target)
 		}
 		if !unidirectional {
 			c.recordMergedSymbol(target, source)
@@ -14329,8 +14329,8 @@ func (c *Checker) cloneSymbol(symbol *ast.Symbol) *ast.Symbol {
 	result.Declarations = symbol.Declarations[0:len(symbol.Declarations):len(symbol.Declarations)]
 	result.Parent = symbol.Parent
 	result.ValueDeclaration = symbol.ValueDeclaration
-	result.Members = maps.Clone(symbol.Members)
-	result.Exports = maps.Clone(symbol.Exports)
+	result.SetMembers(maps.Clone(symbol.Members()))
+	result.SetExports(maps.Clone(symbol.Exports()))
 	c.recordMergedSymbol(result, symbol)
 	return result
 }
@@ -14364,8 +14364,8 @@ func (c *Checker) getSymbolIfSameReference(s1 *ast.Symbol, s2 *ast.Symbol) *ast.
 }
 
 func (c *Checker) getExportSymbolOfValueSymbolIfExported(symbol *ast.Symbol) *ast.Symbol {
-	if symbol != nil && symbol.Flags&ast.SymbolFlagsExportValue != 0 && symbol.ExportSymbol != nil {
-		symbol = symbol.ExportSymbol
+	if symbol != nil && symbol.Flags&ast.SymbolFlagsExportValue != 0 && symbol.ExportSymbol() != nil {
+		symbol = symbol.ExportSymbol()
 	}
 	return c.getMergedSymbol(symbol)
 }
@@ -14572,13 +14572,13 @@ func (c *Checker) getTargetOfModuleDefault(moduleSymbol *ast.Symbol, node *ast.N
 }
 
 func (c *Checker) reportNonDefaultExport(moduleSymbol *ast.Symbol, node *ast.Node) {
-	if moduleSymbol.Exports != nil && moduleSymbol.Exports[node.Symbol().Name] != nil {
+	if moduleSymbol.Exports() != nil && moduleSymbol.Exports()[node.Symbol().Name] != nil {
 		c.error(node, diagnostics.Module_0_has_no_default_export_Did_you_mean_to_use_import_1_from_0_instead, c.symbolToString(moduleSymbol), c.symbolToString(node.Symbol()))
 	} else {
 		diagnostic := c.error(node.Name(), diagnostics.Module_0_has_no_default_export, c.symbolToString(moduleSymbol))
 		var exportStar *ast.Symbol
-		if moduleSymbol.Exports != nil {
-			exportStar = moduleSymbol.Exports[ast.InternalSymbolNameExportStar]
+		if moduleSymbol.Exports() != nil {
+			exportStar = moduleSymbol.Exports()[ast.InternalSymbolNameExportStar]
 		}
 		if exportStar != nil {
 			defaultExport := core.Find(exportStar.Declarations, func(decl *ast.Declaration) bool {
@@ -14586,7 +14586,7 @@ func (c *Checker) reportNonDefaultExport(moduleSymbol *ast.Symbol, node *ast.Nod
 					return false
 				}
 				resolvedExternalModuleName := c.resolveExternalModuleName(decl, decl.ModuleSpecifier(), false /*ignoreErrors*/)
-				return resolvedExternalModuleName != nil && resolvedExternalModuleName.Exports[ast.InternalSymbolNameDefault] != nil
+				return resolvedExternalModuleName != nil && resolvedExternalModuleName.Exports()[ast.InternalSymbolNameDefault] != nil
 			})
 			if defaultExport != nil {
 				diagnostic.AddRelatedInfo(createDiagnosticForNode(defaultExport, diagnostics.X_export_Asterisk_does_not_re_export_a_default))
@@ -14596,12 +14596,12 @@ func (c *Checker) reportNonDefaultExport(moduleSymbol *ast.Symbol, node *ast.Nod
 }
 
 func (c *Checker) resolveExportByName(moduleSymbol *ast.Symbol, name string, sourceNode *ast.Node, dontResolveAlias bool) *ast.Symbol {
-	exportValue := moduleSymbol.Exports[ast.InternalSymbolNameExportEquals]
+	exportValue := moduleSymbol.Exports()[ast.InternalSymbolNameExportEquals]
 	var exportSymbol *ast.Symbol
 	if exportValue != nil {
 		exportSymbol = c.getPropertyOfTypeEx(c.getTypeOfSymbol(exportValue), name, true /*skipObjectFunctionPropertyAugment*/, false /*includeTypeOnlyMembers*/)
 	} else {
-		exportSymbol = moduleSymbol.Exports[name]
+		exportSymbol = moduleSymbol.Exports()[name]
 	}
 	resolved := c.resolveSymbolEx(exportSymbol, dontResolveAlias)
 	c.markSymbolOfAliasDeclarationIfTypeOnly(sourceNode, nil)
@@ -14678,7 +14678,7 @@ func (c *Checker) getExternalModuleMember(node *ast.Node, specifier *ast.Node, d
 			}
 			var symbolFromVariable *ast.Symbol
 			// First check if module was specified with "export=". If so, get the member from the resolved type
-			if moduleSymbol != nil && moduleSymbol.Exports[ast.InternalSymbolNameExportEquals] != nil {
+			if moduleSymbol != nil && moduleSymbol.Exports()[ast.InternalSymbolNameExportEquals] != nil {
 				symbolFromVariable = c.getPropertyOfTypeEx(c.getTypeOfSymbol(targetSymbol), nameText, true /*skipObjectFunctionPropertyAugment*/, false /*includeTypeOnlyMembers*/)
 			} else {
 				symbolFromVariable = c.getPropertyOfVariable(targetSymbol, nameText)
@@ -14686,7 +14686,7 @@ func (c *Checker) getExternalModuleMember(node *ast.Node, specifier *ast.Node, d
 			// if symbolFromVariable is export - get its final target
 			symbolFromVariable = c.resolveSymbolEx(symbolFromVariable, dontResolveAlias)
 			exportContainer := targetSymbol
-			if moduleSymbol != nil && moduleSymbol.Exports[ast.InternalSymbolNameExportEquals] != nil {
+			if moduleSymbol != nil && moduleSymbol.Exports()[ast.InternalSymbolNameExportEquals] != nil {
 				// For `export =` modules, supplemental type/namespace exports live on the original module symbol.
 				exportContainer = moduleSymbol
 			}
@@ -14764,8 +14764,8 @@ func (c *Checker) combineValueAndTypeSymbols(valueSymbol *ast.Symbol, typeSymbol
 		result.Parent = typeSymbol.Parent
 	}
 	result.ValueDeclaration = valueSymbol.ValueDeclaration
-	result.Members = maps.Clone(typeSymbol.Members)
-	result.Exports = maps.Clone(valueSymbol.Exports)
+	result.SetMembers(maps.Clone(typeSymbol.Members()))
+	result.SetExports(maps.Clone(valueSymbol.Exports()))
 	return result
 }
 
@@ -14881,7 +14881,7 @@ func (c *Checker) errorNoModuleMemberSymbol(moduleSymbol *ast.Symbol, targetSymb
 			diagnostic.AddRelatedInfo(createDiagnosticForNode(suggestion.ValueDeclaration, diagnostics.X_0_is_declared_here, suggestionName))
 		}
 	} else {
-		if moduleSymbol.Exports[ast.InternalSymbolNameDefault] != nil {
+		if moduleSymbol.Exports()[ast.InternalSymbolNameDefault] != nil {
 			c.error(name, diagnostics.Module_0_has_no_exported_member_1_Did_you_mean_to_use_import_1_from_0_instead, moduleName, declarationName)
 		} else {
 			c.reportNonExportedMember(name, declarationName, moduleSymbol, moduleName)
@@ -14894,7 +14894,7 @@ func (c *Checker) reportNonExportedMember(name *ast.Node, declarationName string
 	if locals := moduleSymbol.ValueDeclaration.Locals(); locals != nil {
 		localSymbol = locals[name.Text()]
 	}
-	exports := moduleSymbol.Exports
+	exports := moduleSymbol.Exports()
 	if localSymbol != nil {
 		if exportedEqualsSymbol := exports[ast.InternalSymbolNameExportEquals]; exportedEqualsSymbol != nil {
 			if c.getSymbolIfSameReference(exportedEqualsSymbol, localSymbol) != nil {
@@ -15538,7 +15538,7 @@ func (c *Checker) GetAmbientModules() []*ast.Symbol {
 
 func (c *Checker) resolveExternalModuleSymbol(moduleSymbol *ast.Symbol, dontResolveAlias bool) *ast.Symbol {
 	if moduleSymbol != nil {
-		exportEquals := c.resolveSymbolEx(moduleSymbol.Exports[ast.InternalSymbolNameExportEquals], dontResolveAlias)
+		exportEquals := c.resolveSymbolEx(moduleSymbol.Exports()[ast.InternalSymbolNameExportEquals], dontResolveAlias)
 		if exportEquals != nil {
 			return c.getMergedSymbol(exportEquals)
 		}
@@ -15705,8 +15705,8 @@ func (c *Checker) cloneTypeAsModuleType(symbol *ast.Symbol, moduleType *Type, re
 	result := c.newSymbol(symbol.Flags, symbol.Name)
 	result.Declarations = slices.Clone(symbol.Declarations)
 	result.ValueDeclaration = symbol.ValueDeclaration
-	result.Members = maps.Clone(symbol.Members)
-	result.Exports = maps.Clone(symbol.Exports)
+	result.SetMembers(maps.Clone(symbol.Members()))
+	result.SetExports(maps.Clone(symbol.Exports()))
 	result.Parent = symbol.Parent
 	links := c.exportTypeLinks.Get(result)
 	links.target = symbol
@@ -15907,17 +15907,17 @@ func (c *Checker) getExportsOfSymbol(symbol *ast.Symbol) ast.SymbolTable {
 	if symbol.Flags&ast.SymbolFlagsModule != 0 {
 		return c.getExportsOfModule(symbol)
 	}
-	return symbol.Exports
+	return symbol.Exports()
 }
 
 func (c *Checker) getResolvedMembersOrExportsOfSymbol(symbol *ast.Symbol, resolutionKind MembersOrExportsResolutionKind) ast.SymbolTable {
 	links := c.membersAndExportsLinks.Get(symbol)
 	if links[resolutionKind] == nil {
 		isStatic := resolutionKind == MembersOrExportsResolutionKindResolvedExports
-		earlySymbols := symbol.Exports
+		earlySymbols := symbol.Exports()
 		switch {
 		case !isStatic:
-			earlySymbols = symbol.Members
+			earlySymbols = symbol.Members()
 		case symbol.Flags&ast.SymbolFlagsModule != 0:
 			earlySymbols, _ = c.getExportsOfModuleWorker(symbol)
 		}
@@ -15943,7 +15943,7 @@ func (c *Checker) getResolvedMembersOrExportsOfSymbol(symbol *ast.Symbol, resolu
 			}
 		}
 		if isStatic {
-			if assignmentSymbol := symbol.Exports[ast.InternalSymbolNameAssignmentDeclaration]; assignmentSymbol != nil {
+			if assignmentSymbol := symbol.Exports()[ast.InternalSymbolNameAssignmentDeclaration]; assignmentSymbol != nil {
 				for _, member := range assignmentSymbol.Declarations {
 					if c.hasLateBindableName(member) {
 						if lateSymbols == nil {
@@ -16108,7 +16108,7 @@ func (c *Checker) getMembersOfSymbol(symbol *ast.Symbol) ast.SymbolTable {
 	if symbol.Flags&ast.SymbolFlagsLateBindingContainer != 0 {
 		return c.getResolvedMembersOrExportsOfSymbol(symbol, MembersOrExportsResolutionKindResolvedMembers)
 	}
-	return symbol.Members
+	return symbol.Members()
 }
 
 func (c *Checker) getExportsOfModule(moduleSymbol *ast.Symbol) ast.SymbolTable {
@@ -16130,7 +16130,7 @@ type ExportCollisionTable = map[string]*ExportCollision
 
 func (c *Checker) getExportsOfModuleWorker(moduleSymbol *ast.Symbol) (exports ast.SymbolTable, typeOnlyExportStarMap map[string]*ast.Node) {
 	var visitedSymbols []*ast.Symbol
-	nonTypeOnlyNames := collections.NewSetWithSizeHint[string](len(moduleSymbol.Exports))
+	nonTypeOnlyNames := collections.NewSetWithSizeHint[string](len(moduleSymbol.Exports()))
 	// The ES6 spec permits export * declarations in a module to circularly reference the module itself. For example,
 	// module 'a' can 'export * from "b"' and 'b' can 'export * from "a"' without error.
 	var visit func(*ast.Symbol, *ast.Node, bool) ast.SymbolTable
@@ -16139,17 +16139,17 @@ func (c *Checker) getExportsOfModuleWorker(moduleSymbol *ast.Symbol) (exports as
 			// Add non-type-only names before checking if we've visited this module,
 			// because we might have visited it via an 'export type *', and visiting
 			// again with 'export *' will override the type-onlyness of its exports.
-			for name := range symbol.Exports {
+			for name := range symbol.Exports() {
 				nonTypeOnlyNames.Add(name)
 			}
 		}
-		if symbol == nil || symbol.Exports == nil || slices.Contains(visitedSymbols, symbol) {
+		if symbol == nil || symbol.Exports() == nil || slices.Contains(visitedSymbols, symbol) {
 			return nil
 		}
 		visitedSymbols = append(visitedSymbols, symbol)
-		symbols := maps.Clone(symbol.Exports)
+		symbols := maps.Clone(symbol.Exports())
 		// All export * declarations are collected in an __export symbol by the binder
-		exportStars := symbol.Exports[ast.InternalSymbolNameExportStar]
+		exportStars := symbol.Exports()[ast.InternalSymbolNameExportStar]
 		if exportStars != nil {
 			nestedSymbols := make(ast.SymbolTable)
 			lookupTable := make(ExportCollisionTable)
@@ -16181,7 +16181,7 @@ func (c *Checker) getExportsOfModuleWorker(moduleSymbol *ast.Symbol) (exports as
 	}
 	var originalModule *ast.Symbol
 	if moduleSymbol != nil {
-		if c.resolveSymbolEx(moduleSymbol.Exports[ast.InternalSymbolNameExportEquals], false /*dontResolveAlias*/) != nil {
+		if c.resolveSymbolEx(moduleSymbol.Exports()[ast.InternalSymbolNameExportEquals], false /*dontResolveAlias*/) != nil {
 			originalModule = moduleSymbol
 		}
 	}
@@ -16192,8 +16192,8 @@ func (c *Checker) getExportsOfModuleWorker(moduleSymbol *ast.Symbol) (exports as
 		exports = make(ast.SymbolTable)
 	}
 	// A CommonJS module defined by an 'export=' might also export typedefs, stored on the original module
-	if originalModule != nil && len(originalModule.Exports) > 1 {
-		for _, symbol := range originalModule.Exports {
+	if originalModule != nil && len(originalModule.Exports()) > 1 {
+		for _, symbol := range originalModule.Exports() {
 			if symbol.Name == ast.InternalSymbolNameExportEquals || symbol.Name == ast.InternalSymbolNameExportStar {
 				continue
 			}
@@ -16584,7 +16584,7 @@ func (c *Checker) getTypeOfVariableOrParameterOrPropertyWorker(symbol *ast.Symbo
 		if symbol.Name == "exports" {
 			return c.getTypeOfSymbol(c.resolveExternalModuleSymbol(symbol.ValueDeclaration.Symbol(), false /*dontResolveAlias*/))
 		}
-		return c.newAnonymousType(symbol, symbol.Members, nil, nil, nil)
+		return c.newAnonymousType(symbol, symbol.Members(), nil, nil, nil)
 	}
 	var result *Type
 	switch declaration.Kind {
@@ -20701,7 +20701,7 @@ func (c *Checker) resolveAnonymousTypeMembers(t *Type) {
 	// And likewise for construct signatures for classes
 	if symbol.Flags&ast.SymbolFlagsClass != 0 {
 		classType := c.getDeclaredTypeOfClassOrInterface(symbol)
-		constructSignatures := c.getSignaturesOfSymbol(symbol.Members[ast.InternalSymbolNameConstructor])
+		constructSignatures := c.getSignaturesOfSymbol(symbol.Members()[ast.InternalSymbolNameConstructor])
 		if len(constructSignatures) == 0 {
 			constructSignatures = c.getDefaultConstructSignatures(classType)
 		}
@@ -24044,7 +24044,7 @@ func (c *Checker) evaluateEntity(expr *ast.Node, location *ast.Node) evaluator.R
 			rootSymbol := c.resolveEntityName(root, ast.SymbolFlagsValue, true /*ignoreErrors*/, false, nil)
 			if rootSymbol != nil && rootSymbol.Flags&ast.SymbolFlagsEnum != 0 {
 				name := expr.AsElementAccessExpression().ArgumentExpression.Text()
-				member := rootSymbol.Exports[name]
+				member := rootSymbol.Exports()[name]
 				if member != nil {
 					if location != nil {
 						return c.evaluateEnumMember(expr, member, location)
@@ -24672,7 +24672,7 @@ func (c *Checker) getGlobalImportMetaExpressionType() *Type {
 		metaPropertySymbol.Parent = symbol
 		c.valueSymbolLinks.Get(metaPropertySymbol).resolvedType = importMetaType
 		members := createSymbolTable([]*ast.Symbol{metaPropertySymbol})
-		symbol.Members = members
+		symbol.SetMembers(members)
 		c.deferredGlobalImportMetaExpressionType = c.newAnonymousType(symbol, members, nil, nil, nil)
 	}
 	return c.deferredGlobalImportMetaExpressionType
@@ -27103,7 +27103,7 @@ func (c *Checker) getPropertyTypeForIndexType(originalObjectType *Type, objectTy
 					return c.getUnionType(append(types, c.undefinedType))
 				}
 			}
-			if objectType.symbol == c.globalThisSymbol && hasPropName && c.globalThisSymbol.Exports[propName] != nil && c.globalThisSymbol.Exports[propName].Flags&ast.SymbolFlagsBlockScoped != 0 {
+			if objectType.symbol == c.globalThisSymbol && hasPropName && c.globalThisSymbol.Exports()[propName] != nil && c.globalThisSymbol.Exports()[propName].Flags&ast.SymbolFlagsBlockScoped != 0 {
 				c.error(accessExpression, diagnostics.Property_0_does_not_exist_on_type_1, propName, c.TypeToString(objectType))
 			} else if c.noImplicitAny && accessFlags&AccessFlagsSuppressNoImplicitAnyError == 0 {
 				if hasPropName && c.typeHasStaticProperty(propName, objectType) {
@@ -30697,7 +30697,7 @@ func (c *Checker) discriminateContextualTypeByObjectMembers(node *ast.Node, cont
 			return false
 		})
 		discriminantMembers := core.Filter(c.getPropertiesOfType(contextualType), func(s *ast.Symbol) bool {
-			return s.Flags&ast.SymbolFlagsOptional != 0 && node.Symbol().Members[s.Name] == nil && c.isDiscriminantProperty(contextualType, s.Name)
+			return s.Flags&ast.SymbolFlagsOptional != 0 && node.Symbol().Members()[s.Name] == nil && c.isDiscriminantProperty(contextualType, s.Name)
 		})
 		discriminator := &ObjectLiteralDiscriminator{c: c, props: discriminantProperties, members: discriminantMembers}
 		discriminated = c.discriminateTypeByDiscriminableItems(contextualType, discriminator)

--- a/internal/checker/jsx.go
+++ b/internal/checker/jsx.go
@@ -284,7 +284,7 @@ func (c *Checker) discriminateContextualTypeByJSXAttributes(node *ast.Node, cont
 		if s.Name == jsxChildrenPropertyName && ast.IsJsxElement(element) && len(ast.GetSemanticJsxChildren(element.Children().Nodes)) != 0 {
 			return false
 		}
-		return node.Symbol().Members[s.Name] == nil && c.isDiscriminantProperty(contextualType, s.Name)
+		return node.Symbol().Members()[s.Name] == nil && c.isDiscriminantProperty(contextualType, s.Name)
 	})
 	discriminator := &ObjectLiteralDiscriminator{c: c, props: discriminantProperties, members: discriminantMembers}
 	discriminated := c.discriminateTypeByDiscriminableItems(contextualType, discriminator)
@@ -1054,7 +1054,7 @@ func (c *Checker) instantiateAliasOrInterfaceWithDefaults(managedSym *ast.Symbol
 
 func (c *Checker) getJsxLibraryManagedAttributes(jsxNamespace *ast.Symbol) *ast.Symbol {
 	if jsxNamespace != nil {
-		return c.getSymbol(jsxNamespace.Exports, JsxNames.LibraryManagedAttributes, ast.SymbolFlagsType)
+		return c.getSymbol(jsxNamespace.Exports(), JsxNames.LibraryManagedAttributes, ast.SymbolFlagsType)
 	}
 	return nil
 }
@@ -1062,7 +1062,7 @@ func (c *Checker) getJsxLibraryManagedAttributes(jsxNamespace *ast.Symbol) *ast.
 func (c *Checker) getJsxElementTypeSymbol(jsxNamespace *ast.Symbol) *ast.Symbol {
 	// JSX.ElementType [symbol]
 	if jsxNamespace != nil {
-		return c.getSymbol(jsxNamespace.Exports, JsxNames.ElementType, ast.SymbolFlagsType)
+		return c.getSymbol(jsxNamespace.Exports(), JsxNames.ElementType, ast.SymbolFlagsType)
 	}
 	return nil
 }
@@ -1096,7 +1096,7 @@ func (c *Checker) getJsxElementChildrenPropertyName(jsxNamespace *ast.Symbol) st
 func (c *Checker) getNameFromJsxElementAttributesContainer(nameOfAttribPropContainer string, jsxNamespace *ast.Symbol) string {
 	// JSX.ElementAttributesProperty | JSX.ElementChildrenAttribute [symbol]
 	if jsxNamespace != nil {
-		jsxElementAttribPropInterfaceSym := c.getSymbol(jsxNamespace.Exports, nameOfAttribPropContainer, ast.SymbolFlagsType)
+		jsxElementAttribPropInterfaceSym := c.getSymbol(jsxNamespace.Exports(), nameOfAttribPropContainer, ast.SymbolFlagsType)
 		if jsxElementAttribPropInterfaceSym != nil {
 			jsxElementAttribPropInterfaceType := c.getDeclaredTypeOfSymbol(jsxElementAttribPropInterfaceSym)
 			propertiesOfJsxElementAttribPropInterface := c.getPropertiesOfType(jsxElementAttribPropInterfaceType)

--- a/internal/checker/nodebuilder_hover.go
+++ b/internal/checker/nodebuilder_hover.go
@@ -497,7 +497,7 @@ func (b *NodeBuilderImpl) expandModuleDecl(symbol *ast.Symbol) *ast.Node {
 			}
 			// If the function also has namespace characteristics, emit an empty namespace.
 			merged := b.ch.getMergedSymbol(resolved)
-			hasModuleExports := merged.Flags&(ast.SymbolFlagsValueModule|ast.SymbolFlagsNamespaceModule) != 0 && merged.Exports != nil && len(merged.Exports) != 0
+			hasModuleExports := merged.Flags&(ast.SymbolFlagsValueModule|ast.SymbolFlagsNamespaceModule) != 0 && merged.Exports() != nil && len(merged.Exports()) != 0
 			if !hasModuleExports {
 				bodyStmts = append(bodyStmts, hoverStatement{node: b.f.NewModuleDeclaration(nil, ast.KindNamespaceKeyword, b.f.NewIdentifier(m.Name), b.f.NewModuleBlock(b.f.NewNodeList(nil)))})
 			}

--- a/internal/checker/nodebuilderimpl.go
+++ b/internal/checker/nodebuilderimpl.go
@@ -1110,8 +1110,8 @@ func (b *NodeBuilderImpl) getSymbolChain(symbol *ast.Symbol, meaning ast.SymbolF
 				parent := pair.sym
 				parentChain := b.getSymbolChain(parent, getQualifiedLeftMeaning(meaning), false, yieldModuleSymbol)
 				if len(parentChain) > 0 {
-					if parent.Exports != nil {
-						exported, ok := parent.Exports[ast.InternalSymbolNameExportEquals]
+					if parent.Exports() != nil {
+						exported, ok := parent.Exports()[ast.InternalSymbolNameExportEquals]
 						if ok && b.ch.getSymbolIfSameReference(exported, symbol) != nil {
 							// parentChain root _is_ symbol - symbol is a module export=, so it kinda looks like it's own parent
 							// No need to lookup an alias for the symbol in itself

--- a/internal/checker/services.go
+++ b/internal/checker/services.go
@@ -75,9 +75,9 @@ func (c *Checker) getSymbolsInScope(location *ast.Node, meaning ast.SymbolFlags)
 				}
 				fallthrough
 			case ast.KindModuleDeclaration:
-				copyLocallyVisibleExportSymbols(c.getSymbolOfDeclaration(location).Exports, meaning&ast.SymbolFlagsModuleMember)
+				copyLocallyVisibleExportSymbols(c.getSymbolOfDeclaration(location).Exports(), meaning&ast.SymbolFlagsModuleMember)
 			case ast.KindEnumDeclaration:
-				copySymbols(c.getSymbolOfDeclaration(location).Exports, meaning&ast.SymbolFlagsEnumMember)
+				copySymbols(c.getSymbolOfDeclaration(location).Exports(), meaning&ast.SymbolFlagsEnumMember)
 			case ast.KindClassExpression:
 				className := location.AsClassExpression().Name()
 				if className != nil {
@@ -459,7 +459,7 @@ func (c *Checker) tryGetTarget(symbol *ast.Symbol) *ast.Symbol {
 }
 
 func (c *Checker) GetExportSymbolOfSymbol(symbol *ast.Symbol) *ast.Symbol {
-	return c.getMergedSymbol(core.IfElse(symbol.ExportSymbol != nil, symbol.ExportSymbol, symbol))
+	return c.getMergedSymbol(core.IfElse(symbol.ExportSymbol() != nil, symbol.ExportSymbol(), symbol))
 }
 
 func (c *Checker) GetExportSpecifierLocalTargetSymbol(node *ast.Node) *ast.Symbol {

--- a/internal/checker/symbolaccessibility.go
+++ b/internal/checker/symbolaccessibility.go
@@ -260,10 +260,10 @@ func (c *Checker) getExternalModuleContainer(declaration *ast.Node) *ast.Symbol 
 
 func (c *Checker) getFileSymbolIfFileSymbolExportEqualsContainer(d *ast.Node, container *ast.Symbol) *ast.Symbol {
 	fileSymbol := c.getExternalModuleContainer(d)
-	if fileSymbol == nil || fileSymbol.Exports == nil {
+	if fileSymbol == nil || fileSymbol.Exports() == nil {
 		return nil
 	}
-	exported, ok := fileSymbol.Exports[ast.InternalSymbolNameExportEquals]
+	exported, ok := fileSymbol.Exports()[ast.InternalSymbolNameExportEquals]
 	if !ok || exported == nil {
 		return nil
 	}
@@ -346,8 +346,8 @@ func (c *Checker) getAliasForSymbolInContainer(container *ast.Symbol, symbol *as
 	}
 	// Check if container is a thing with an `export=` which points directly at `symbol`, and if so, return
 	// the container itself as the alias for the symbol
-	if container.Exports != nil {
-		exportEquals, ok := container.Exports[ast.InternalSymbolNameExportEquals]
+	if container.Exports() != nil {
+		exportEquals, ok := container.Exports()[ast.InternalSymbolNameExportEquals]
 		if ok && exportEquals != nil && c.getSymbolIfSameReference(exportEquals, symbol) != nil {
 			return container
 		}
@@ -551,8 +551,8 @@ func (c *Checker) trySymbolTable(
 	// Check for ExportSymbol by direct name lookup rather than discovering it during
 	// the alias iteration below (where it would never match, since only alias-flagged
 	// symbols are iterated).
-	if ok && res != nil && res.ExportSymbol != nil {
-		if c.isAccessible(ctx, c.getMergedSymbol(res.ExportSymbol) /*resolvedAliasSymbol*/, nil, ignoreQualification) {
+	if ok && res != nil && res.ExportSymbol() != nil {
+		if c.isAccessible(ctx, c.getMergedSymbol(res.ExportSymbol()) /*resolvedAliasSymbol*/, nil, ignoreQualification) {
 			candidateChains = append(candidateChains, []*ast.Symbol{ctx.symbol})
 		}
 	}
@@ -760,7 +760,7 @@ func (c *Checker) someSymbolTableInScope(
 				break
 			}
 			sym := c.getSymbolOfDeclaration(ast.GetReparsedNodeForNode(location))
-			if callback(sym.Exports, symbolTableIDFromExports(sym), false, true, location) {
+			if callback(sym.Exports(), symbolTableIDFromExports(sym), false, true, location) {
 				return true
 			}
 		case ast.KindClassDeclaration, ast.KindClassExpression, ast.KindInterfaceDeclaration:
@@ -774,7 +774,7 @@ func (c *Checker) someSymbolTableInScope(
 			var table ast.SymbolTable
 			sym := c.getSymbolOfDeclaration(location)
 			// TODO: Should this filtered table be cached in some way?
-			for key, memberSymbol := range sym.Members {
+			for key, memberSymbol := range sym.Members() {
 				if memberSymbol.Flags&(ast.SymbolFlagsType & ^ast.SymbolFlagsAssignment) != 0 {
 					if table == nil {
 						table = make(ast.SymbolTable)

--- a/internal/checker/utilities.go
+++ b/internal/checker/utilities.go
@@ -255,7 +255,7 @@ func isSyntacticDefault(node *ast.Node) bool {
 }
 
 func hasExportAssignmentSymbol(moduleSymbol *ast.Symbol) bool {
-	return moduleSymbol.Exports[ast.InternalSymbolNameExportEquals] != nil
+	return moduleSymbol.Exports()[ast.InternalSymbolNameExportEquals] != nil
 }
 
 func isTypeAlias(node *ast.Node) bool {

--- a/internal/execute/incremental/affectedfileshandler.go
+++ b/internal/execute/incremental/affectedfileshandler.go
@@ -226,7 +226,7 @@ func (h *affectedFilesHandler) handleDtsMayChangeOfAffectedFile(dtsMayChange dts
 	var done func()
 	// If exported const enum, we need to ensure that js files are emitted as well since the const enum value changed
 	if affectedFile.Symbol != nil {
-		for _, exported := range affectedFile.Symbol.Exports {
+		for _, exported := range affectedFile.Symbol.Exports() {
 			if exported.Flags&ast.SymbolFlagsConstEnum != 0 {
 				invalidateJsFiles = true
 				break

--- a/internal/ls/autoimport/extract.go
+++ b/internal/ls/autoimport/extract.go
@@ -111,7 +111,7 @@ func (e *exportExtractor) extractFromFile(file *ast.SourceFile) []*Export {
 		moduleDeclarations := core.Filter(file.Statements.Nodes, ast.IsModuleWithStringLiteralName)
 		var exportCount int
 		for _, decl := range moduleDeclarations {
-			exportCount += len(decl.AsModuleDeclaration().Symbol.Exports)
+			exportCount += len(decl.AsModuleDeclaration().Symbol.Exports())
 		}
 		exports := make([]*Export, 0, exportCount)
 		for _, decl := range moduleDeclarations {
@@ -132,11 +132,11 @@ func (e *exportExtractor) extractFromModule(file *ast.SourceFile) []*Export {
 	})
 	var augmentationExportCount int
 	for _, decl := range moduleAugmentations {
-		augmentationExportCount += len(decl.Symbol.Exports)
+		augmentationExportCount += len(decl.Symbol.Exports())
 	}
 	moduleID := e.getModuleID(file)
-	exports := make([]*Export, 0, len(file.Symbol.Exports)+augmentationExportCount)
-	for name, symbol := range file.Symbol.Exports {
+	exports := make([]*Export, 0, len(file.Symbol.Exports())+augmentationExportCount)
+	for name, symbol := range file.Symbol.Exports() {
 		e.extractFromSymbol(name, symbol, moduleID, file.FileName(), file, &exports)
 	}
 	for _, decl := range moduleAugmentations {
@@ -159,7 +159,7 @@ func (e *exportExtractor) extractFromModule(file *ast.SourceFile) []*Export {
 }
 
 func (e *exportExtractor) extractFromModuleDeclaration(decl *ast.ModuleDeclaration, file *ast.SourceFile, moduleID ModuleID, moduleFileName string, exports *[]*Export) {
-	for name, symbol := range decl.Symbol.Exports {
+	for name, symbol := range decl.Symbol.Exports() {
 		e.extractFromSymbol(name, symbol, moduleID, moduleFileName, file, exports)
 	}
 }
@@ -174,7 +174,7 @@ func (e *symbolExtractor) extractFromSymbol(name string, symbol *ast.Symbol, mod
 		allExports := e.checker.GetExportsOfModule(symbol.Parent)
 		// allExports includes named exports from the file that will be processed separately;
 		// we want to add only the ones that come from the star
-		for name, namedExport := range symbol.Parent.Exports {
+		for name, namedExport := range symbol.Parent.Exports() {
 			if name != ast.InternalSymbolNameExportStar {
 				idx := slices.Index(allExports, namedExport)
 				if idx >= 0 || shouldIgnoreSymbol(namedExport) {
@@ -214,8 +214,8 @@ func (e *symbolExtractor) extractFromSymbol(name string, symbol *ast.Symbol, mod
 
 	if target != nil {
 		if syntax == ExportSyntaxEquals && target.Flags&ast.SymbolFlagsNamespace != 0 {
-			*exports = slices.Grow(*exports, len(target.Exports))
-			for innerName, namedExport := range target.Exports {
+			*exports = slices.Grow(*exports, len(target.Exports()))
+			for innerName, namedExport := range target.Exports() {
 				if innerName != ast.InternalSymbolNameExportStar {
 					export, _ := e.createExport(namedExport, moduleID, moduleFileName, syntax, file, checkerLease)
 					if export != nil {
@@ -234,7 +234,7 @@ func (e *symbolExtractor) extractFromSymbol(name string, symbol *ast.Symbol, mod
 			*exports = slices.Grow(*exports, len(expression.AsObjectLiteralExpression().Properties.Nodes))
 			for _, prop := range expression.AsObjectLiteralExpression().Properties.Nodes {
 				if ast.IsShorthandPropertyAssignment(prop) || ast.IsPropertyAssignment(prop) && prop.AsPropertyAssignment().Name().Kind == ast.KindIdentifier {
-					export, _ := e.createExport(expression.Symbol().Members[prop.Name().Text()], moduleID, moduleFileName, syntax, file, checkerLease)
+					export, _ := e.createExport(expression.Symbol().Members()[prop.Name().Text()], moduleID, moduleFileName, syntax, file, checkerLease)
 					if export != nil {
 						export.through = name
 						*exports = append(*exports, export)

--- a/internal/ls/codeactions_fixclassincorrectlyimplementsinterface.go
+++ b/internal/ls/codeactions_fixclassincorrectlyimplementsinterface.go
@@ -175,7 +175,7 @@ func getMissingMembers(typeChecker *checker.Checker, classDeclaration *ast.Node,
 
 	var classMembers ast.SymbolTable
 	if classDeclaration.Symbol() != nil {
-		classMembers = classDeclaration.Symbol().Members
+		classMembers = classDeclaration.Symbol().Members()
 	}
 
 	var missingMembers []*ast.Symbol

--- a/internal/ls/completions.go
+++ b/internal/ls/completions.go
@@ -1317,7 +1317,7 @@ func (l *LanguageService) getCompletionData(
 		localSymbol := localsContainer.Symbol()
 		var localExports ast.SymbolTable
 		if localSymbol != nil {
-			localExports = localSymbol.Exports
+			localExports = localSymbol.Exports()
 		}
 		for name, symbol := range localsContainer.Locals() {
 			symbols = append(symbols, symbol)
@@ -2800,7 +2800,7 @@ func symbolCanBeReferencedAtTypeLocation(symbol *ast.Symbol, typeChecker *checke
 	// This code used to just test the result of `skipAlias`, but that would ignore any locally introduced meanings.
 	return nonAliasCanBeReferencedAtTypeLocation(symbol, typeChecker, seenModules) ||
 		nonAliasCanBeReferencedAtTypeLocation(
-			checker.SkipAlias(core.IfElse(symbol.ExportSymbol != nil, symbol.ExportSymbol, symbol), typeChecker),
+			checker.SkipAlias(core.IfElse(symbol.ExportSymbol() != nil, symbol.ExportSymbol(), symbol), typeChecker),
 			typeChecker,
 			seenModules,
 		)

--- a/internal/ls/definition.go
+++ b/internal/ls/definition.go
@@ -276,7 +276,7 @@ func getDeclarationsFromLocation(c *checker.Checker, node *ast.Node) []*ast.Node
 	node = getDeclarationNameForKeyword(node)
 	if symbol := c.GetSymbolAtLocation(node); symbol != nil {
 		if symbol.Flags&ast.SymbolFlagsClass != 0 && symbol.Flags&(ast.SymbolFlagsFunction|ast.SymbolFlagsVariable) == 0 && node.Kind == ast.KindConstructorKeyword {
-			if constructor := symbol.Members[ast.InternalSymbolNameConstructor]; constructor != nil {
+			if constructor := symbol.Members()[ast.InternalSymbolNameConstructor]; constructor != nil {
 				symbol = constructor
 			}
 		}

--- a/internal/ls/findallreferences.go
+++ b/internal/ls/findallreferences.go
@@ -1300,7 +1300,7 @@ func (l *LanguageService) getReferencedSymbolsForModuleIfDeclaredBySourceFile(ct
 	} else {
 		return nil
 	}
-	exportEquals := symbol.Exports[ast.InternalSymbolNameExportEquals]
+	exportEquals := symbol.Exports()[ast.InternalSymbolNameExportEquals]
 	// If exportEquals != nil, we're about to add references to `import("mod")` anyway, so don't double-count them.
 	moduleReferences := l.getReferencedSymbolsForModule(ctx, program, symbol, exportEquals != nil, sourceFiles, sourceFilesSet)
 	if exportEquals == nil || exportEquals.Flags&ast.SymbolFlagsAlias == 0 || !sourceFilesSet.Has(moduleSourceFileName) {
@@ -1693,7 +1693,7 @@ func (l *LanguageService) getReferencedSymbolsForModule(ctx context.Context, pro
 	}
 
 	// Handle export equals declarations
-	exported := symbol.Exports[ast.InternalSymbolNameExportEquals]
+	exported := symbol.Exports()[ast.InternalSymbolNameExportEquals]
 	if exported != nil && len(exported.Declarations) > 0 {
 		for _, decl := range exported.Declarations {
 			sourceFile := ast.GetSourceFileOfNode(decl)
@@ -1928,10 +1928,10 @@ func tryGetClassByExtendingIdentifier(node *ast.Node) *ast.ClassLikeDeclaration 
 }
 
 func getClassConstructorSymbol(classSymbol *ast.Symbol) *ast.Symbol {
-	if classSymbol.Members == nil {
+	if classSymbol.Members() == nil {
 		return nil
 	}
-	return classSymbol.Members[ast.InternalSymbolNameConstructor]
+	return classSymbol.Members()[ast.InternalSymbolNameConstructor]
 }
 
 func hasOwnConstructor(classDeclaration *ast.ClassLikeDeclaration) bool {
@@ -1950,8 +1950,8 @@ func findOwnConstructorReferences(classSymbol *ast.Symbol, sourceFile *ast.Sourc
 		}
 	}
 
-	if classSymbol.Exports != nil {
-		for _, member := range classSymbol.Exports {
+	if classSymbol.Exports() != nil {
+		for _, member := range classSymbol.Exports() {
 			decl := member.ValueDeclaration
 			if decl != nil && decl.Kind == ast.KindMethodDeclaration {
 				body := decl.Body()

--- a/internal/ls/hover.go
+++ b/internal/ls/hover.go
@@ -186,8 +186,8 @@ func (l *LanguageService) documentationFromAlias(c *checker.Checker, symbol *ast
 	}
 
 	candidates := []*ast.Symbol{aliasedSymbol}
-	if aliasedSymbol.ExportSymbol != nil {
-		candidates = append(candidates, aliasedSymbol.ExportSymbol)
+	if aliasedSymbol.ExportSymbol() != nil {
+		candidates = append(candidates, aliasedSymbol.ExportSymbol())
 	}
 
 	for _, candidate := range candidates {

--- a/internal/ls/importTracker.go
+++ b/internal/ls/importTracker.go
@@ -518,7 +518,7 @@ func getImportOrExportSymbol(node *ast.Node, symbol *ast.Symbol, checker *checke
 
 		parent := node.Parent
 		grandparent := parent.Parent
-		if symbol.ExportSymbol != nil {
+		if symbol.ExportSymbol() != nil {
 			if ast.IsPropertyAccessExpression(parent) {
 				// When accessing an export of a JS module, there's no alias. The symbol will still be flagged as an export even though we're at the use.
 				// So check that we are at the declaration.
@@ -527,7 +527,7 @@ func getImportOrExportSymbol(node *ast.Node, symbol *ast.Symbol, checker *checke
 				}
 				return nil
 			}
-			return exportInfo(symbol.ExportSymbol, getExportKindForDeclaration(parent))
+			return exportInfo(symbol.ExportSymbol(), getExportKindForDeclaration(parent))
 		} else {
 			exportNode := getExportNode(parent, node)
 			switch {

--- a/internal/modulespecifiers/specifiers.go
+++ b/internal/modulespecifiers/specifiers.go
@@ -131,7 +131,7 @@ func tryGetModuleNameFromAmbientModule(moduleSymbol *ast.Symbol, checker Checker
 			continue
 		}
 
-		sym, ok := possibleContainer.Symbol().Exports[ast.InternalSymbolNameExportEquals]
+		sym, ok := possibleContainer.Symbol().Exports()[ast.InternalSymbolNameExportEquals]
 		if !ok || sym == nil {
 			continue
 		}

--- a/internal/transformers/declarations/transform.go
+++ b/internal/transformers/declarations/transform.go
@@ -356,7 +356,7 @@ func (tx *DeclarationTransformer) transformSourceFile(node *ast.SourceFile) *ast
 	combinedStatements.Loc = statements.Loc // setTextRange
 	if ast.IsExternalOrCommonJSModule(node) {
 		if ast.IsInJSFile(node.AsNode()) {
-			if exportEquals := node.Symbol.Exports[ast.InternalSymbolNameExportEquals]; exportEquals != nil && len(exportEquals.Declarations) > 1 {
+			if exportEquals := node.Symbol.Exports()[ast.InternalSymbolNameExportEquals]; exportEquals != nil && len(exportEquals.Declarations) > 1 {
 				for _, node := range exportEquals.Declarations {
 					tx.state.addDiagnostic(createDiagnosticForNode(node, diagnostics.Multiple_module_exports_assignments_cannot_be_serialized_for_declaration_emit))
 				}


### PR DESCRIPTION
## Context

`ast.Symbol` is arena-allocated, so every byte of the struct is paid once per symbol, and a full check of a large program creates millions of them (VS Code's `src` reaches ~6.2 M). Its `Members`, `Exports` and `ExportSymbol` fields are only set on container and exported-declaration symbols. They are nil on every checker-created symbol and on most binder symbols, but they cost 24 bytes on all of them.

## This PR

These three fields move into a small `symbolExtra` box that is allocated the first time one of them is set to a non-nil value, referenced from `Symbol` through a single pointer. Reads and writes go through `Members()`/`SetMembers()`, `Exports()`/`SetExports()` and `ExportSymbol()`/`SetExportSymbol()`.
## Memory

Typechecking the VS Code `src` project with `--noEmit` (default, 4 checkers):

| Metric      | Before   | After    | Δ      |
|-------------|----------|----------|--------|
| Memory used | 4,058 MB | 3,961 MB | −96 MB (−2.4%)  |

This PR was assisted by Claude Code.