### PR TITLE
Check the arrow-function line-terminator rule without the line map

### DIFF
--- a/internal/checker/grammarchecks.go
+++ b/internal/checker/grammarchecks.go
@@ -12,6 +12,7 @@ import (
 	"github.com/microsoft/typescript-go/internal/diagnostics"
 	"github.com/microsoft/typescript-go/internal/jsnum"
 	"github.com/microsoft/typescript-go/internal/scanner"
+	"github.com/microsoft/typescript-go/internal/stringutil"
 	"github.com/microsoft/typescript-go/internal/tspath"
 )
 
@@ -787,9 +788,9 @@ func (c *Checker) checkGrammarArrowFunction(node *ast.Node, file *ast.SourceFile
 	}
 
 	equalsGreaterThanToken := arrowFunc.EqualsGreaterThanToken
-	startLine := scanner.GetECMALineOfPosition(file, equalsGreaterThanToken.Pos())
-	endLine := scanner.GetECMALineOfPosition(file, equalsGreaterThanToken.End())
-	return startLine != endLine && c.grammarErrorOnNode(equalsGreaterThanToken, diagnostics.Line_terminator_not_permitted_before_arrow)
+	arrowFullText := file.Text()[equalsGreaterThanToken.Pos():equalsGreaterThanToken.End()]
+	return strings.ContainsFunc(arrowFullText, stringutil.IsLineBreak) &&
+		c.grammarErrorOnNode(equalsGreaterThanToken, diagnostics.Line_terminator_not_permitted_before_arrow)
 }
 
 func (c *Checker) checkGrammarIndexSignatureParameters(node *ast.IndexSignatureDeclaration) bool {


### PR DESCRIPTION
## Context

`checkGrammarArrowFunction` decides whether a line terminator precedes `=>` by comparing the ECMA line numbers of the token's full start and end. Getting those line numbers materializes the file's whole line map for every checked file. Nothing else on the checking path needs the map, so in a check-only compile or the language service it was being built purely for this one comparison.

## This PR

In this PR, we now scan the trivia in front of `=>` for a line terminator directly instead, with the same terminator set as `ComputeECMALineStarts`. A file's line map is now built on demand and only where a line/column is actually needed (e.g. for diagnostic reporting or language service requests).

### Memory

Typechecking the VS Code `src` project with `--noEmit` (default, 4 checkers) and measuring the live heap after checking with `--extendedDiagnostics`:

| Metric      | Before   | After    | Δ                |
|-------------|----------|----------|------------------|
| Memory used | 4,684 MB | 4,678 MB | −6.5 MB (−0.14%) |

This PR was assisted by Claude Code.