### PR TITLE
Embed zero-size marker bases first in generated AST structs

### DIFF
--- a/_scripts/generate-go-ast.ts
+++ b/_scripts/generate-go-ast.ts
@@ -194,13 +194,35 @@ function verifyNodeBaseAtOffsetZero(): void {
 verifyNoDuplicateBases();
 verifyNodeBaseAtOffsetZero();
 
+// A base with no fields and no extends is a struct{} marker. Go pads a struct whose last field is
+// zero-size (so the field's address stays in bounds), so markers are embedded first, never last; being
+// zero-size, they don't move NodeBase off offset zero.
+function isZeroSizeBase(key: string): boolean {
+    const base = api.getBase(key);
+    return !!base && base.extendsKeys.length === 0 && base.fields.length === 0;
+}
+
+function goEmbeds(extendsKeys: string[]): string[] {
+    const zeroSized: string[] = [];
+    const nonZeroSized: string[] = [];
+    for (const key of extendsKeys) {
+        if (isZeroSizeBase(key)) {
+            zeroSized.push(key);
+        }
+        else {
+            nonZeroSized.push(key);
+        }
+    }
+    return [...zeroSized, ...nonZeroSized];
+}
+
 function generateStructDef(w: CodeWriter, node: NodeType) {
     const structName = node.name;
     w.write(`type ${structName} struct {`);
     w.push();
 
     // Embeddings from extends (each maps to a Go struct via convention)
-    for (const ext of node.extendsKeys) {
+    for (const ext of goEmbeds(node.extendsKeys)) {
         w.write(ext);
     }
 
@@ -287,7 +309,7 @@ function generateBaseStructDefs(w: CodeWriter) {
 
         const structName = base.key;
 
-        const goExts = base.extendsKeys;
+        const goExts = goEmbeds(base.extendsKeys);
 
         w.write(`type ${structName} struct {`);
         w.push();

--- a/internal/ast/ast_generated.go
+++ b/internal/ast/ast_generated.go
@@ -111,8 +111,8 @@ type PrimaryExpressionBase struct {
 }
 
 type TypeNodeBase struct {
-	NodeBase
 	TypeSyntaxBase
+	NodeBase
 }
 
 type NodeWithTypeArgumentsBase struct {
@@ -210,14 +210,14 @@ type NamedMemberBase struct {
 type ObjectLiteralElementBase struct{}
 
 type AccessorDeclarationBase struct {
+	TypeElementBase
+	ClassElementBase
+	ObjectLiteralElementBase
 	NodeBase
 	DeclarationBase
 	NamedMemberBase
 	FunctionLikeWithBodyBase
 	FlowNodeBase
-	TypeElementBase
-	ClassElementBase
-	ObjectLiteralElementBase
 	CompositeBase
 }
 
@@ -2190,11 +2190,11 @@ func IsHeritageClause(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type InterfaceDeclaration struct {
+	TypeSyntaxBase
 	StatementBase
 	DeclarationBase
 	ExportableBase
 	ModifiersBase
-	TypeSyntaxBase
 	name            *IdentifierNode
 	TypeParameters  *TypeParameterList  // Optional
 	HeritageClauses *HeritageClauseList // Optional
@@ -2247,12 +2247,12 @@ func IsInterfaceDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type TypeAliasDeclaration struct {
+	TypeSyntaxBase
 	StatementBase
 	DeclarationBase
 	ExportableBase
 	ModifiersBase
 	LocalsContainerBase
-	TypeSyntaxBase
 	name           *IdentifierNode
 	TypeParameters *TypeParameterList // Optional
 	Type           *TypeNode
@@ -2488,8 +2488,8 @@ func IsNotEmittedStatement(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type NotEmittedTypeElement struct {
-	NodeBase
 	TypeElementBase
+	NodeBase
 }
 
 func (f *NodeFactory) NewNotEmittedTypeElement() *Node {
@@ -2772,10 +2772,10 @@ func IsExportAssignment(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type NamespaceExportDeclaration struct {
+	TypeSyntaxBase
 	StatementBase
 	DeclarationBase
 	ModifiersBase
-	TypeSyntaxBase
 	name *IdentifierNode
 }
 
@@ -2957,11 +2957,11 @@ func IsExportSpecifier(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type CallSignatureDeclaration struct {
+	TypeElementBase
+	TypeSyntaxBase
 	NodeBase
 	DeclarationBase
 	FunctionLikeBase
-	TypeElementBase
-	TypeSyntaxBase
 }
 
 func (f *NodeFactory) NewCallSignatureDeclaration(typeParameters *TypeParameterList, parameters *ParameterList, typeNode *TypeNode) *Node {
@@ -3000,11 +3000,11 @@ func IsCallSignatureDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type ConstructSignatureDeclaration struct {
+	TypeElementBase
+	TypeSyntaxBase
 	NodeBase
 	DeclarationBase
 	FunctionLikeBase
-	TypeElementBase
-	TypeSyntaxBase
 }
 
 func (f *NodeFactory) NewConstructSignatureDeclaration(typeParameters *TypeParameterList, parameters *ParameterList, typeNode *TypeNode) *Node {
@@ -3043,11 +3043,11 @@ func IsConstructSignatureDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type ConstructorDeclaration struct {
+	ClassElementBase
 	NodeBase
 	DeclarationBase
 	ModifiersBase
 	FunctionLikeWithBodyBase
-	ClassElementBase
 	CompositeBase
 	ReturnFlowNode *FlowNode
 }
@@ -3202,13 +3202,13 @@ func IsSetAccessorDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type IndexSignatureDeclaration struct {
+	TypeElementBase
+	ClassElementBase
+	TypeSyntaxBase
 	NodeBase
 	DeclarationBase
 	ModifiersBase
 	FunctionLikeBase
-	TypeElementBase
-	ClassElementBase
-	TypeSyntaxBase
 }
 
 func (f *NodeFactory) NewIndexSignatureDeclaration(modifiers *ModifierList, parameters *ParameterList, typeNode *TypeNode) *Node {
@@ -3247,12 +3247,12 @@ func IsIndexSignatureDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type MethodSignatureDeclaration struct {
+	TypeElementBase
+	TypeSyntaxBase
 	NodeBase
 	DeclarationBase
 	NamedMemberBase
 	FunctionLikeBase
-	TypeElementBase
-	TypeSyntaxBase
 }
 
 func (f *NodeFactory) NewMethodSignatureDeclaration(modifiers *ModifierList, name *PropertyName, postfixToken *TokenNode, typeParameters *TypeParameterList, parameters *ParameterList, typeNode *TypeNode) *Node {
@@ -3303,13 +3303,13 @@ func IsMethodSignatureDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type MethodDeclaration struct {
+	ClassElementBase
+	ObjectLiteralElementBase
 	NodeBase
 	DeclarationBase
 	NamedMemberBase
 	FunctionLikeWithBodyBase
 	FlowNodeBase
-	ClassElementBase
-	ObjectLiteralElementBase
 	CompositeBase
 }
 
@@ -3367,11 +3367,11 @@ func IsMethodDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type PropertySignatureDeclaration struct {
+	TypeElementBase
+	TypeSyntaxBase
 	NodeBase
 	DeclarationBase
 	NamedMemberBase
-	TypeElementBase
-	TypeSyntaxBase
 	Type        *TypeNode
 	Initializer *Expression
 }
@@ -3422,10 +3422,10 @@ func IsPropertySignatureDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type PropertyDeclaration struct {
+	ClassElementBase
 	NodeBase
 	DeclarationBase
 	NamedMemberBase
-	ClassElementBase
 	CompositeBase
 	Type        *TypeNode   // Optional
 	Initializer *Expression // Optional
@@ -3477,9 +3477,9 @@ func IsPropertyDeclaration(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type SemicolonClassElement struct {
+	ClassElementBase
 	NodeBase
 	DeclarationBase
-	ClassElementBase
 }
 
 func (f *NodeFactory) NewSemicolonClassElement() *Node {
@@ -3500,11 +3500,11 @@ func IsSemicolonClassElement(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type ClassStaticBlockDeclaration struct {
+	ClassElementBase
 	NodeBase
 	DeclarationBase
 	ModifiersBase
 	LocalsContainerBase
-	ClassElementBase
 	CompositeBase
 	Body           *BlockNode
 	ReturnFlowNode *FlowNode
@@ -4744,9 +4744,9 @@ func IsObjectLiteralExpression(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type SpreadAssignment struct {
+	ObjectLiteralElementBase
 	NodeBase
 	DeclarationBase
-	ObjectLiteralElementBase
 	Expression *Expression
 }
 
@@ -4784,10 +4784,10 @@ func IsSpreadAssignment(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type PropertyAssignment struct {
+	ObjectLiteralElementBase
 	NodeBase
 	DeclarationBase
 	NamedMemberBase
-	ObjectLiteralElementBase
 	CompositeBase
 	Type        *TypeNode
 	Initializer *Expression
@@ -4839,10 +4839,10 @@ func IsPropertyAssignment(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type ShorthandPropertyAssignment struct {
+	ObjectLiteralElementBase
 	NodeBase
 	DeclarationBase
 	NamedMemberBase
-	ObjectLiteralElementBase
 	CompositeBase
 	Type                        *TypeNode
 	EqualsToken                 *EqualsToken // Optional
@@ -6688,8 +6688,8 @@ func IsJsxAttribute(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type JsxSpreadAttribute struct {
-	NodeBase
 	ObjectLiteralElementBase
+	NodeBase
 	Expression *Expression
 }
 
@@ -8485,10 +8485,10 @@ func IsJSDocLinkCode(node *Node) bool {
 // ──────────────────────────────────────────────────────────────────────
 
 type TypeParameterDeclaration struct {
+	TypeSyntaxBase
 	NodeBase
 	DeclarationBase
 	ModifiersBase
-	TypeSyntaxBase
 	name        *IdentifierNode
 	Constraint  *TypeNode   // Optional
 	Expression  *Expression // Optional


### PR DESCRIPTION
## Context

AST nodes are arena-allocated, so their struct size is paid in full for every node. #4744 removed the duplicate embedded bases from the generated node structs; one source of padding remains.

The zero-size marker bases (`TypeSyntaxBase`, `TypeElementBase`, `ClassElementBase`, `ObjectLiteralElementBase`) are embedded in schema order, which can leave one of them as a struct's last field. Go pads a trailing zero-size field so its address stays in bounds, so `TypeNodeBase`, which ends in `TypeSyntaxBase`, and every type node built on it carry an extra padding word. The signature declarations, `NotEmittedTypeElement` and `SemicolonClassElement` end in a marker as well.

## This PR

In this PR, the Go generator embeds zero-size marker bases first. Because a marker occupies no bytes, the base carrying `NodeBase` still lands at offset zero, so the `verifyNodeBaseAtOffsetZero` check from #4744 is unaffected. Only `internal/ast/ast_generated.go` changes (embed order); no fields, accessors or APIs are renamed.

<details>
<summary>45 node and base structs shrink by 8 bytes.</summary>

| Struct                              |  main | this PR |
| ----------------------------------- | ----: | ------: |
| `ArrayTypeNode`                     |  64 B |    56 B |
| `CallSignatureDeclaration`          | 112 B |   104 B |
| `ConditionalTypeNode`               | 104 B |    96 B |
| `ConstructorTypeNode`               | 120 B |   112 B |
| `ConstructSignatureDeclaration`     | 112 B |   104 B |
| `FunctionOrConstructorTypeNodeBase` | 120 B |   112 B |
| `FunctionTypeNode`                  | 120 B |   112 B |
| `ImportTypeNode`                    |  96 B |    88 B |
| `IndexedAccessTypeNode`             |  72 B |    64 B |
| `IndexSignatureDeclaration`         | 120 B |   112 B |
| `InferTypeNode`                     |  64 B |    56 B |
| `IntersectionTypeNode`              |  64 B |    56 B |
| `JSDocAllType`                      |  56 B |    48 B |
| `JSDocNameReference`                |  64 B |    56 B |
| `JSDocNonNullableType`              |  64 B |    56 B |
| `JSDocNullableType`                 |  64 B |    56 B |
| `JSDocOptionalType`                 |  64 B |    56 B |
| `JSDocSignature`                    | 112 B |   104 B |
| `JSDocTypeBase`                     |  56 B |    48 B |
| `JSDocTypeExpression`               |  64 B |    56 B |
| `JSDocTypeLiteral`                  |  96 B |    88 B |
| `JSDocVariadicType`                 |  64 B |    56 B |
| `KeywordTypeNode`                   |  56 B |    48 B |
| `LiteralTypeNode`                   |  64 B |    56 B |
| `MappedTypeNode`                    | 128 B |   120 B |
| `MethodSignatureDeclaration`        | 136 B |   128 B |
| `NamedTupleMember`                  |  96 B |    88 B |
| `NodeWithTypeArgumentsBase`         |  64 B |    56 B |
| `NotEmittedTypeElement`             |  56 B |    48 B |
| `OptionalTypeNode`                  |  64 B |    56 B |
| `ParenthesizedTypeNode`             |  64 B |    56 B |
| `RestTypeNode`                      |  64 B |    56 B |
| `SemicolonClassElement`             |  64 B |    56 B |
| `TemplateLiteralTypeNode`           |  72 B |    64 B |
| `TemplateLiteralTypeSpan`           |  72 B |    64 B |
| `ThisTypeNode`                      |  56 B |    48 B |
| `TupleTypeNode`                     |  64 B |    56 B |
| `TypeLiteralNode`                   |  72 B |    64 B |
| `TypeNodeBase`                      |  56 B |    48 B |
| `TypeOperatorNode`                  |  72 B |    64 B |
| `TypePredicateNode`                 |  80 B |    72 B |
| `TypeQueryNode`                     |  72 B |    64 B |
| `TypeReferenceNode`                 |  72 B |    64 B |
| `UnionOrIntersectionTypeNodeBase`   |  64 B |    56 B |
| `UnionTypeNode`                     |  64 B |    56 B |

</details>

### Memory

`Memory used` from `--extendedDiagnostics` on VS Code `src` (`--noEmit`):

| Metric      |     Before |      After |       Δ |
| ----------- | ---------: | ---------: | ------: |
| Memory used | 4,058.3 MB | 4,050.3 MB | −8.1 MB |

This PR was assisted by Claude Code.