### PR TITLE
Skip stale overlay paths in markProjectsAffectedByConfigChanges

### DIFF
--- a/internal/project/projectcollectionbuilder.go
+++ b/internal/project/projectcollectionbuilder.go
@@ -707,8 +707,22 @@ func (b *ProjectCollectionBuilder) markProjectsAffectedByConfigChanges(
 	// Recompute default projects for open files that now have different config file presence.
 	var hasChanges bool
 	for path := range configChangeResult.affectedFiles {
-		fileName := b.fs.overlays[path].FileName()
-		_ = b.ensureConfiguredProjectAndAncestorsForFile(fileName, path, logger)
+		overlay, ok := b.fs.overlays[path]
+		if !ok {
+			// The config file registry can retain a cached lookup for a file
+			// whose overlay is already gone if an earlier snapshot update was
+			// interrupted (e.g. by a panic recovered at the request boundary)
+			// after the session's overlay map was updated but before the
+			// Closed event reached the registry. The producers of
+			// affectedFiles have already dropped the stale cache entry, and a
+			// file that is no longer open has no default project to
+			// recompute, so skip it.
+			if logger != nil {
+				logger.Logf("Skipping default project recomputation for %s: no overlay (file is no longer open)", path)
+			}
+			continue
+		}
+		_ = b.ensureConfiguredProjectAndAncestorsForFile(overlay.FileName(), path, logger)
 		hasChanges = true
 	}
 

--- a/internal/project/projectcollectionbuilder_staleoverlay_test.go
+++ b/internal/project/projectcollectionbuilder_staleoverlay_test.go
@@ -1,0 +1,140 @@
+package project
+
+import (
+	"context"
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/bundled"
+	"github.com/microsoft/typescript-go/internal/core"
+	"github.com/microsoft/typescript-go/internal/diagnostics"
+	"github.com/microsoft/typescript-go/internal/locale"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
+	"github.com/microsoft/typescript-go/internal/project/logging"
+	"github.com/microsoft/typescript-go/internal/vfs/vfstest"
+	"gotest.tools/v3/assert"
+)
+
+type staleOverlayTestClient struct{}
+
+var _ Client = (*staleOverlayTestClient)(nil)
+
+func (c *staleOverlayTestClient) WatchFiles(ctx context.Context, id WatcherID, watchers []*lsproto.FileSystemWatcher) error {
+	return nil
+}
+func (c *staleOverlayTestClient) UnwatchFiles(ctx context.Context, id WatcherID) error { return nil }
+func (c *staleOverlayTestClient) RefreshDiagnostics(ctx context.Context) error         { return nil }
+func (c *staleOverlayTestClient) PublishDiagnostics(ctx context.Context, params *lsproto.PublishDiagnosticsParams) error {
+	return nil
+}
+func (c *staleOverlayTestClient) RefreshInlayHints(ctx context.Context) error              { return nil }
+func (c *staleOverlayTestClient) RefreshCodeLens(ctx context.Context) error                { return nil }
+func (c *staleOverlayTestClient) ProgressStart(message *diagnostics.Message, args ...any)  {}
+func (c *staleOverlayTestClient) ProgressFinish(message *diagnostics.Message, args ...any) {}
+func (c *staleOverlayTestClient) SendTelemetry(ctx context.Context, telemetry lsproto.TelemetryEvent) error {
+	return nil
+}
+func (c *staleOverlayTestClient) IsActive() bool           { return false }
+func (c *staleOverlayTestClient) SetLocale(locale string)  {}
+func (c *staleOverlayTestClient) GetLocale() locale.Locale { return locale.Locale{} }
+
+// TestMarkProjectsAffectedByConfigChangesStaleOverlay reproduces a server crash
+// where markProjectsAffectedByConfigChanges dereferences b.fs.overlays[path] for
+// a path that is no longer an overlay.
+//
+// The config file registry caches config file lookups (configFileNames) for open
+// files and normally removes an entry when the file's Closed event is processed
+// during a snapshot clone. However, the session-level overlay map is updated
+// eagerly by flushChangesLocked, *before* the snapshot clone runs. If a snapshot
+// update is interrupted between those two steps — most commonly by a panic that
+// is recovered at the request boundary (see lsp.Server.recover), which leaves
+// the session alive — the pending Closed event has been consumed and the overlay
+// removed, but no clone ever performs the registry bookkeeping. The stale
+// configFileNames entry then survives indefinitely.
+//
+// The next config file create/change/delete in an ancestor directory of the
+// stale entry (or any excessive-watch-event cache invalidation) reports the
+// stale path in changeFileResult.affectedFiles, and the unchecked map lookup in
+// markProjectsAffectedByConfigChanges panics inside Session.updateSnapshot —
+// while snapshotMu is held, so a host that recovers the panic is left with a
+// permanently wedged session.
+func TestMarkProjectsAffectedByConfigChangesStaleOverlay(t *testing.T) {
+	t.Parallel()
+
+	if !bundled.Embedded {
+		t.Skip("bundled files are not embedded")
+	}
+
+	files := map[string]string{
+		"/src/tsconfig.json": `{"compilerOptions": {"target": "es6"}}`,
+		"/src/index.ts":      `export const index = 1;`,
+		"/src/other.ts":      `export const other = 2;`,
+	}
+	testFS := vfstest.FromMap(files, false /*useCaseSensitiveFileNames*/)
+	session := NewSession(&SessionInit{
+		BackgroundCtx: context.Background(),
+		FS:            bundled.WrapFS(testFS),
+		Client:        &staleOverlayTestClient{},
+		Logger:        logging.NewTestLogger(),
+		Options: &SessionOptions{
+			CurrentDirectory:   "/",
+			DefaultLibraryPath: bundled.LibPath(),
+			PositionEncoding:   lsproto.PositionEncodingKindUTF8,
+			LoggingEnabled:     true,
+		},
+	})
+	ctx := context.Background()
+
+	session.DidOpenFile(ctx, "file:///src/index.ts", 1, files["/src/index.ts"], lsproto.LanguageKindTypeScript)
+	session.DidOpenFile(ctx, "file:///src/other.ts", 1, files["/src/other.ts"], lsproto.LanguageKindTypeScript)
+
+	indexPath := session.toPath("/src/index.ts")
+	otherPath := session.toPath("/src/other.ts")
+
+	registry := session.Snapshot().ConfigFileRegistry
+	_, ok := registry.configFileNames[indexPath]
+	assert.Assert(t, ok, "config lookup for index.ts should be cached after open")
+	_, ok = registry.configFileNames[otherPath]
+	assert.Assert(t, ok, "config lookup for other.ts should be cached after open")
+
+	// Sever a snapshot update between the overlay-map commit and the registry
+	// bookkeeping: flushChangesLocked consumes the pending Closed event and
+	// removes the overlay from the session's overlayFS, but the resulting
+	// summary is never processed by a snapshot clone. This is the state a
+	// session is left in when a panic during a snapshot update is recovered at
+	// the request boundary.
+	session.pendingFileChangesMu.Lock()
+	session.pendingFileChanges = append(session.pendingFileChanges, FileChange{
+		Kind: FileChangeKindClose,
+		URI:  "file:///src/other.ts",
+	})
+	_, _ = session.flushChangesLocked(ctx)
+	session.pendingFileChangesMu.Unlock()
+
+	// A config file change in an ancestor directory of the stale cached lookup
+	// reports it in changeFileResult.affectedFiles.
+	assert.NilError(t, testFS.WriteFile("/src/tsconfig.json", `{"compilerOptions": {"target": "esnext"}}`))
+	session.DidChangeWatchedFiles(ctx, []*lsproto.FileEvent{
+		{
+			Uri:  lsproto.DocumentUri("file:///src/tsconfig.json"),
+			Type: lsproto.FileChangeTypeChanged,
+		},
+	})
+
+	// Before the fix, flushing the watch change panicked in
+	// markProjectsAffectedByConfigChanges: the stale path has no overlay, and
+	// b.fs.overlays[path].FileName() dereferences a nil *Overlay.
+	ls, err := session.GetLanguageService(ctx, "file:///src/index.ts")
+	assert.NilError(t, err)
+
+	// The project was still reloaded with the changed config, and the open
+	// file's default project was recomputed.
+	assert.Equal(t, ls.GetProgram().Options().Target, core.ScriptTargetESNext)
+
+	snapshot := session.Snapshot()
+	_, ok = snapshot.ConfigFileRegistry.configFileNames[indexPath]
+	assert.Assert(t, ok, "config lookup for the open file should be recomputed")
+	_, ok = snapshot.ConfigFileRegistry.configFileNames[otherPath]
+	assert.Assert(t, !ok, "stale config lookup for the closed file should be dropped")
+	_, ok = snapshot.fs.overlays[otherPath]
+	assert.Assert(t, !ok, "closed file should not have an overlay")
+}


### PR DESCRIPTION
## Problem

We embed `internal/project` in a long-running server and see recurring fatal crashes with this stack (currently several per day across our fleet):

```text
panic: runtime error: invalid memory address or nil pointer dereference
github.com/microsoft/typescript-go/internal/project.(*ProjectCollectionBuilder).markProjectsAffectedByConfigChanges
	internal/project/projectcollectionbuilder.go:710
github.com/microsoft/typescript-go/internal/project.(*ProjectCollectionBuilder).DidChangeFiles
github.com/microsoft/typescript-go/internal/project.(*Snapshot).Clone
github.com/microsoft/typescript-go/internal/project.(*Session).updateSnapshot
```

The crash site is:

```go
for path := range configChangeResult.affectedFiles {
	fileName := b.fs.overlays[path].FileName()
	...
}
```

`affectedFiles` is keyed by the config file registry's `configFileNames` cache, and the unchecked map lookup assumes every cached path is still overlay-backed. When a stale entry survives for a file that is no longer open, the lookup returns a nil `*Overlay` and `FileName()` panics.

## Root cause

The two states advance at different times:

- The session-level overlay map is committed eagerly by `flushChangesLocked` → `overlayFS.processChanges`, when pending changes are flushed.
- The registry bookkeeping for a close (`configFileRegistryBuilder.didCloseFile`, which deletes the `configFileNames` entry) only happens later, when the snapshot clone processes that flush's `FileChangeSummary`.

If a snapshot update is interrupted between those two steps, the Closed event is consumed forever while the registry entry survives. The most realistic interruption is a panic during the snapshot update that gets recovered at the request boundary — `lsp.Server.recover` does exactly this and keeps the session alive (as does any embedding host with per-request recovery).

After that, the very next `tsconfig.json` create/change/delete in an ancestor directory of the stale entry — or any excessive-watch-event `invalidateCache` pass, which reports *every* cached path — puts the stale path into `affectedFiles` and crashes. Worse, the panic fires inside `Session.updateSnapshot` while `snapshotMu` is held, so a host that recovers it is left with a permanently wedged session (every subsequent request blocks on the leaked lock).

## Fix

Skip `affectedFiles` paths that no longer have an overlay. This is safe and self-healing rather than signal-hiding:

- Both producers of `affectedFiles` (`invalidateCache` and the created/deleted-config handling in `DidChangeFiles`) have already removed the stale `configFileNames` entry by the time the consumer runs, so skipping leaves no stale state behind — the registry converges back to a consistent state on the first config event instead of crashing.
- A file that is no longer open has no default project to recompute; `ensureConfiguredProjectAndAncestorsForFile` on it would operate on a closed file.
- Open files in the same batch are still recomputed, and `affectedProjects` marking is untouched, so config-change invalidation behavior is preserved.

## Test

`TestMarkProjectsAffectedByConfigChangesStaleOverlay` is a white-box regression test that opens two files under one tsconfig, severs a snapshot update between the overlay-map commit and the registry bookkeeping using the session's own flush machinery (queue a Close, call `flushChangesLocked`, never clone — the exact state a recovered mid-update panic leaves), then changes the tsconfig.

- Before the fix it panics with exactly the production stack above (also reproduced on a ~2-week-old commit of `main`).
- After the fix it passes and asserts the affected project is still reloaded (`target` change takes effect), the open file's config lookup is recomputed, and the stale entry is gone.

`go test ./internal/project/...` and `-race` on the new test pass.

## Disclosure

This patch was authored with AI assistance (Claude Code); I have read and understood the change and will respond to review feedback myself.
