### PR TITLE
Fix program reuse across resolution mode changes

### DIFF
--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -309,7 +309,7 @@ func (p *Program) UpdateProgram(changedFilePath tspath.Path, newHost CompilerHos
 		return NewProgram(newOpts), newFile, false
 	}
 
-	if !canReplaceFileInProgram(oldFile, newFile) {
+	if !p.canReplaceFileInProgram(oldFile, newFile) {
 		return NewProgram(newOpts), newFile, false
 	}
 	if oldNeedsImportHelpers := p.importHelpersImportSpecifiers[oldFile.Path()] != nil; oldNeedsImportHelpers != p.needsImportHelpersImportSpecifier(newFile) {
@@ -356,11 +356,14 @@ func (p *Program) GetCheckerPool() CheckerPool {
 	return p.checkerPool
 }
 
-func canReplaceFileInProgram(file1 *ast.SourceFile, file2 *ast.SourceFile) bool {
+func (p *Program) canReplaceFileInProgram(file1 *ast.SourceFile, file2 *ast.SourceFile) bool {
 	return file2 != nil &&
 		file1.ParseOptions() == file2.ParseOptions() &&
 		file1.UsesUriStyleNodeCoreModules == file2.UsesUriStyleNodeCoreModules &&
-		slices.EqualFunc(file1.Imports(), file2.Imports(), equalModuleSpecifiers) &&
+		slices.EqualFunc(file1.Imports(), file2.Imports(), func(n1 *ast.Node, n2 *ast.Node) bool {
+			return equalModuleSpecifiers(n1, n2) &&
+				p.GetModeForUsageLocation(file1, n1) == p.GetModeForUsageLocation(file2, n2)
+		}) &&
 		slices.EqualFunc(file1.ModuleAugmentations, file2.ModuleAugmentations, equalModuleAugmentationNames) &&
 		slices.Equal(file1.AmbientModuleNames, file2.AmbientModuleNames) &&
 		slices.EqualFunc(file1.ReferencedFiles, file2.ReferencedFiles, equalFileReferences) &&

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -80,6 +80,54 @@ func TestProjectProgramUpdateKind(t *testing.T) {
 		assert.Equal(t, configured.ProgramUpdateKind, project.ProgramUpdateKindCloned)
 	})
 
+	t.Run("NewFiles when import resolution mode changes", func(t *testing.T) {
+		t.Parallel()
+		files := map[string]any{
+			"/src/tsconfig.json": `{
+				"compilerOptions":{"module":"preserve","moduleResolution":"bundler","noEmit":true},
+				"files":["index.ts"]
+			}`,
+			"/src/index.ts": `import type { Value } from "pkg" with { "resolution-mode": "require" };
+const value: Value = { mode: "require" };`,
+			"/src/node_modules/pkg/package.json": `{
+				"name": "pkg",
+				"version": "1.0.0",
+				"exports": {
+					".": {
+						"import": "./index.mjs",
+						"require": "./index.js"
+					}
+				}
+			}`,
+			"/src/node_modules/pkg/index.d.mts": `export interface Value { mode: "import" }`,
+			"/src/node_modules/pkg/index.d.ts":  `export interface Value { mode: "require" }`,
+		}
+		session, _ := projecttestutil.Setup(files)
+		uri := lsproto.DocumentUri("file:///src/index.ts")
+		session.DidOpenFile(context.Background(), uri, 1, files["/src/index.ts"].(string), lsproto.LanguageKindTypeScript)
+		ls, err := session.GetLanguageService(context.Background(), uri)
+		assert.NilError(t, err)
+		program := ls.GetProgram()
+		assert.Equal(t, len(program.GetSemanticDiagnostics(projecttestutil.WithRequestID(t.Context()), program.GetSourceFile("/src/index.ts"))), 0)
+
+		session.DidChangeFile(context.Background(), uri, 2, []lsproto.TextDocumentContentChangePartialOrWholeDocument{{
+			WholeDocument: &lsproto.TextDocumentContentChangeWholeDocument{
+				Text: `import type { Value } from "pkg" with { "resolution-mode": "import" };
+const value: Value = { mode: "require" };`,
+			},
+		}})
+		ls, err = session.GetLanguageService(context.Background(), uri)
+		assert.NilError(t, err)
+		program = ls.GetProgram()
+		diags := program.GetSemanticDiagnostics(projecttestutil.WithRequestID(t.Context()), program.GetSourceFile("/src/index.ts"))
+		assert.Equal(t, len(diags), 1)
+		assert.Equal(t, diags[0].Code(), diagnostics.Type_0_is_not_assignable_to_type_1.Code())
+
+		configured := session.Snapshot().ProjectCollection.ConfiguredProject(tspath.Path("/src/tsconfig.json"))
+		assert.Assert(t, configured != nil)
+		assert.Equal(t, configured.ProgramUpdateKind, project.ProgramUpdateKindNewFiles)
+	})
+
 	t.Run("SameFileNames on config change without root changes", func(t *testing.T) {
 		t.Parallel()
 		files := map[string]any{


### PR DESCRIPTION
Found this while reviewing #4399; the usage mode matters here for equality too.

This is safe because the usage mode only depends on `Path`, not anything else.