### PR TITLE
fix(parser): disallow optional chaining on import.defer

### DIFF
--- a/internal/diagnostics/diagnostics_generated.go
+++ b/internal/diagnostics/diagnostics_generated.go
@@ -3755,6 +3755,7 @@ var Named_imports_are_not_allowed_in_a_deferred_import = &Message{code: 18059, c
 var Deferred_imports_are_only_supported_when_the_module_flag_is_set_to_esnext_or_preserve = &Message{code: 18060, category: CategoryError, key: "Deferred_imports_are_only_supported_when_the_module_flag_is_set_to_esnext_or_preserve_18060", text: "Deferred imports are only supported when the '--module' flag is set to 'esnext' or 'preserve'."}
 
 var X_0_is_not_a_valid_meta_property_for_keyword_import_Did_you_mean_meta_or_defer = &Message{code: 18061, category: CategoryError, key: "_0_is_not_a_valid_meta_property_for_keyword_import_Did_you_mean_meta_or_defer_18061", text: "'{0}' is not a valid meta-property for keyword 'import'. Did you mean 'meta' or 'defer'?"}
+var Import_defer_does_not_support_optional_invocation = &Message{code: 18062, category: CategoryError, key: "Import_defer_does_not_support_optional_invocation_18062", text: "'import.defer' does not support optional invocation."}
 
 var X_nodenext_if_module_is_nodenext_node16_if_module_is_node16_or_node18_otherwise_bundler = &Message{code: 69010, category: CategoryMessage, key: "nodenext_if_module_is_nodenext_node16_if_module_is_node16_or_node18_otherwise_bundler_69010", text: "`nodenext` if `module` is `nodenext`; `node16` if `module` is `node16` or `node18`; otherwise, `bundler`."}
 
@@ -8066,6 +8067,8 @@ func keyToMessage(key Key) *Message {
 		return Deferred_imports_are_only_supported_when_the_module_flag_is_set_to_esnext_or_preserve
 	case "_0_is_not_a_valid_meta_property_for_keyword_import_Did_you_mean_meta_or_defer_18061":
 		return X_0_is_not_a_valid_meta_property_for_keyword_import_Did_you_mean_meta_or_defer
+	case "Import_defer_does_not_support_optional_invocation_18062":
+		return Import_defer_does_not_support_optional_invocation
 	case "nodenext_if_module_is_nodenext_node16_if_module_is_node16_or_node18_otherwise_bundler_69010":
 		return X_nodenext_if_module_is_nodenext_node16_if_module_is_node16_or_node18_otherwise_bundler
 	case "File_is_a_CommonJS_module_it_may_be_converted_to_an_ES_module_80001":

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -5189,6 +5189,12 @@ func (p *Parser) parseLeftHandSideExpressionOrHigher() *ast.Expression {
 			p.nextToken() // advance past the dot
 			expression = p.finishNode(p.factory.NewMetaProperty(ast.KindImportKeyword, p.parseIdentifierName()), pos)
 			if expression.Text() == "defer" {
+				if p.token == ast.KindQuestionDotToken && p.lookAhead(func(p *Parser) bool {
+					p.nextToken()
+					return p.token == ast.KindOpenParenToken || p.token == ast.KindLessThanToken
+				}) {
+					p.parseErrorAtCurrentToken(diagnostics.Import_defer_does_not_support_optional_invocation)
+				}
 				if p.token == ast.KindOpenParenToken || p.token == ast.KindLessThanToken {
 					p.sourceFlags |= ast.NodeFlagsPossiblyContainsDynamicImport
 				}

--- a/testdata/baselines/reference/compiler/importDeferOptionalCall.errors.txt
+++ b/testdata/baselines/reference/compiler/importDeferOptionalCall.errors.txt
@@ -1,0 +1,15 @@
+b.ts(1,13): error TS18062: 'import.defer' does not support optional invocation.
+b.ts(2,13): error TS18062: 'import.defer' does not support optional invocation.
+
+
+==== x.ts (0 errors) ====
+    export const x = 1;
+==== b.ts (2 errors) ====
+    import.defer?.('./x');
+                ~~
+!!! error TS18062: 'import.defer' does not support optional invocation.
+    import.defer?.<string>('./x');
+                ~~
+!!! error TS18062: 'import.defer' does not support optional invocation.
+    import.defer('./x');
+    

--- a/testdata/baselines/reference/compiler/importDeferOptionalCall.js
+++ b/testdata/baselines/reference/compiler/importDeferOptionalCall.js
@@ -1,0 +1,17 @@
+//// [tests/cases/compiler/importDeferOptionalCall.ts] ////
+
+//// [x.ts]
+export const x = 1;
+//// [b.ts]
+import.defer?.('./x');
+import.defer?.<string>('./x');
+import.defer('./x');
+
+
+//// [x.js]
+export const x = 1;
+//// [b.js]
+"use strict";
+import.defer?.('./x');
+import.defer?.('./x');
+import.defer('./x');

--- a/testdata/baselines/reference/compiler/importDeferOptionalCall.symbols
+++ b/testdata/baselines/reference/compiler/importDeferOptionalCall.symbols
@@ -1,0 +1,16 @@
+//// [tests/cases/compiler/importDeferOptionalCall.ts] ////
+
+=== x.ts ===
+export const x = 1;
+>x : Symbol(x, Decl(x.ts, 0, 12))
+
+=== b.ts ===
+import.defer?.('./x');
+>'./x' : Symbol("./x", Decl(x.ts, 0, 0))
+
+import.defer?.<string>('./x');
+>'./x' : Symbol("./x", Decl(x.ts, 0, 0))
+
+import.defer('./x');
+>'./x' : Symbol("./x", Decl(x.ts, 0, 0))
+

--- a/testdata/baselines/reference/compiler/importDeferOptionalCall.types
+++ b/testdata/baselines/reference/compiler/importDeferOptionalCall.types
@@ -1,0 +1,23 @@
+//// [tests/cases/compiler/importDeferOptionalCall.ts] ////
+
+=== x.ts ===
+export const x = 1;
+>x : 1
+>1 : 1
+
+=== b.ts ===
+import.defer?.('./x');
+>import.defer?.('./x') : Promise<typeof import("./x")>
+>defer : any
+>'./x' : "./x"
+
+import.defer?.<string>('./x');
+>import.defer?.<string>('./x') : Promise<typeof import("./x")>
+>defer : any
+>'./x' : "./x"
+
+import.defer('./x');
+>import.defer('./x') : Promise<typeof import("./x")>
+>defer : any
+>'./x' : "./x"
+

--- a/testdata/tests/cases/compiler/importDeferOptionalCall.ts
+++ b/testdata/tests/cases/compiler/importDeferOptionalCall.ts
@@ -1,0 +1,7 @@
+// @module: esnext
+// @filename: x.ts
+export const x = 1;
+// @filename: b.ts
+import.defer?.('./x');
+import.defer?.<string>('./x');
+import.defer('./x');


### PR DESCRIPTION
Fixes microsoft/TypeScript#63679

## Problem
`import.defer?.('x')` produces no error in TypeScript, but all
major parsers (Oxc, SWC, Babel, Acorn) reject it.

## Fix
- Added diagnostic TS18062: `'import.defer' does not support optional invocation`
- Added check in parser.go for QuestionDotToken followed by '(' or '<'
  immediately after import.defer is parsed

## Test
Before:
import.defer?.('x'); // no error ❌

After:
import.defer?.('x');
// error TS18062: 'import.defer' does not support optional invocation ✅

## Note
Fix was originally implemented in microsoft/TypeScript#63690 
and ported here per maintainer guidance.