### PR TITLE
Fix O(K^2) OOM issue in go-to-implementation

### DIFF
--- a/internal/ls/findallreferences.go
+++ b/internal/ls/findallreferences.go
@@ -647,6 +647,7 @@ func (l *LanguageService) provideSymbolsAndEntries(ctx context.Context, uri lspr
 	var implementationEntries []*SymbolAndEntries
 	var queue []*ReferenceEntry
 	var seenNodes collections.Set[*ast.Node]
+	var seenDefinitions collections.Set[*ast.Symbol]
 	addToQueue := func(symbolAndEntries []*SymbolAndEntries) {
 		for _, s := range symbolAndEntries {
 			var newReferences []*ReferenceEntry
@@ -656,7 +657,9 @@ func (l *LanguageService) provideSymbolsAndEntries(ctx context.Context, uri lspr
 					newReferences = append(newReferences, ref)
 				}
 			}
-			implementationEntries = append(implementationEntries, &SymbolAndEntries{definition: s.definition, references: newReferences})
+			if len(newReferences) > 0 || s.definition == nil || seenDefinitions.AddIfAbsent(s.definition.symbol) {
+				implementationEntries = append(implementationEntries, &SymbolAndEntries{definition: s.definition, references: newReferences})
+			}
 		}
 	}
 

--- a/internal/ls/findallreferences.go
+++ b/internal/ls/findallreferences.go
@@ -647,10 +647,17 @@ func (l *LanguageService) provideSymbolsAndEntries(ctx context.Context, uri lspr
 	var implementationEntries []*SymbolAndEntries
 	var queue []*ReferenceEntry
 	var seenNodes collections.Set[*ast.Node]
+	var recordedNodes collections.Set[*ast.Node]
 	addToQueue := func(symbolAndEntries []*SymbolAndEntries) {
-		implementationEntries = core.Concatenate(implementationEntries, symbolAndEntries)
 		for _, s := range symbolAndEntries {
-			queue = append(queue, s.references...)
+			var newReferences []*ReferenceEntry
+			for _, ref := range s.references {
+				queue = append(queue, ref)
+				if recordedNodes.AddIfAbsent(ref.node) {
+					newReferences = append(newReferences, ref)
+				}
+			}
+			implementationEntries = append(implementationEntries, &SymbolAndEntries{definition: s.definition, references: newReferences})
 		}
 	}
 

--- a/internal/ls/findallreferences.go
+++ b/internal/ls/findallreferences.go
@@ -647,13 +647,12 @@ func (l *LanguageService) provideSymbolsAndEntries(ctx context.Context, uri lspr
 	var implementationEntries []*SymbolAndEntries
 	var queue []*ReferenceEntry
 	var seenNodes collections.Set[*ast.Node]
-	var recordedNodes collections.Set[*ast.Node]
 	addToQueue := func(symbolAndEntries []*SymbolAndEntries) {
 		for _, s := range symbolAndEntries {
 			var newReferences []*ReferenceEntry
 			for _, ref := range s.references {
-				queue = append(queue, ref)
-				if recordedNodes.AddIfAbsent(ref.node) {
+				if seenNodes.AddIfAbsent(ref.node) {
+					queue = append(queue, ref)
 					newReferences = append(newReferences, ref)
 				}
 			}
@@ -669,8 +668,7 @@ func (l *LanguageService) provideSymbolsAndEntries(ctx context.Context, uri lspr
 
 		entry := queue[0]
 		queue = queue[1:]
-		if entry.node != nil && !seenNodes.Has(entry.node) {
-			seenNodes.Add(entry.node)
+		if entry.node != nil {
 			addToQueue(l.getSymbolAndEntries(ctx, entry.node.Pos(), entry.node, program, isRename, implementations))
 		}
 	}

--- a/internal/ls/findallreferences_test.go
+++ b/internal/ls/findallreferences_test.go
@@ -16,21 +16,25 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-// provideSymbolsAndEntries drives go-to-implementation with a breadth-first worklist. Each
-// implementation node is expanded once (seenNodes), but when an interface member has K
-// implementations, every one of those K program-wide searches returns all K implementations.
-// If accumulated results are not deduplicated by node, the intermediate SymbolsAndEntries grow
-// O(K^2), which can exhaust memory on large, deeply-typed programs.
+// provideSymbolsAndEntries drives go-to-implementation with a breadth-first worklist. When an
+// interface member has K implementations, every one of those K program-wide searches returns
+// all K implementations. Without deduplicating, the retained references, the work queue, and the
+// retained SymbolsAndEntries groups all grow O(K^2), which can exhaust memory on large,
+// deeply-typed programs.
 //
-// The final LSP response is deduplicated by node, so the blow-up is invisible from the
-// response; this white-box test inspects the pre-deduplication SymbolsAndEntries that
-// provideSymbolsAndEntries returns. It asserts the accumulated reference count grows *linearly*
-// with K: quadratic growth roughly quadruples the count when K doubles, while linear growth
-// (node-deduplicated) roughly doubles it.
+// The final LSP response is deduplicated by node, so the blow-up is invisible from the response;
+// this white-box test inspects the pre-deduplication data that provideSymbolsAndEntries returns
+// and asserts that both the accumulated reference count and the group count grow ~linearly with K
+// (quadratic growth roughly quadruples when K doubles; deduplicated growth roughly doubles). The
+// reference count is the faithful proxy for the memory cost (the actual OOM is retained references
+// x per-reference checker state; a minimal repro has tiny per-reference state, so raw bytes are
+// dominated by the inherent O(K^2) search work and do not discriminate). Because each reference
+// node is enqueued at most once, the work queue is bounded by the reference count; the group count
+// separately guards against retaining one group per search result.
 func TestImplementationsWorklistDoesNotBlowUp(t *testing.T) {
 	t.Parallel()
 
-	measure := func(k int) int {
+	measure := func(k int) (refs int, groups int) {
 		var b strings.Builder
 		b.WriteString("interface I { m(): void; }\n")
 		for i := range k {
@@ -65,20 +69,29 @@ func TestImplementationsWorklistDoesNotBlowUp(t *testing.T) {
 
 		data, ok := l.provideSymbolsAndEntries(context.Background(), "file:///repro.ts", pos, false /*isRename*/, true /*implementations*/)
 		assert.Assert(t, ok)
-		total := 0
 		for _, se := range data.SymbolsAndEntries {
-			total += len(se.references)
+			refs += len(se.references)
 		}
-		return total
+		return refs, len(data.SymbolsAndEntries)
 	}
 
 	const k = 40
-	small := measure(k)
-	large := measure(2 * k)
-	t.Logf("accumulated references: K=%d -> %d, K=%d -> %d (ratio %.2f)", k, small, 2*k, large, float64(large)/float64(small))
+	smallRefs, smallGroups := measure(k)
+	largeRefs, largeGroups := measure(2 * k)
+	t.Logf("K=%d -> %d refs / %d groups; K=%d -> %d refs / %d groups (ref ratio %.2f, group ratio %.2f)",
+		k, smallRefs, smallGroups, 2*k, largeRefs, largeGroups,
+		float64(largeRefs)/float64(smallRefs), float64(largeGroups)/float64(smallGroups))
 
-	// Linear growth ~2x when K doubles; quadratic growth ~4x. Fail above 3x.
-	assert.Assert(t, large <= small*3,
-		"implementations worklist scales superlinearly: K=%d -> %d refs, K=%d -> %d refs (expected ~linear); "+
-			"provideSymbolsAndEntries accumulates references without deduplicating by node", k, small, 2*k, large)
+	// Retained references (and, since each is enqueued at most once, the work queue) must grow
+	// ~linearly (~2x when K doubles). The un-deduplicated worklist grows ~4x. Fail above 3x.
+	assert.Assert(t, largeRefs <= smallRefs*3,
+		"implementations worklist references scale superlinearly: K=%d -> %d, K=%d -> %d (expected ~linear); "+
+			"provideSymbolsAndEntries accumulates references without deduplicating by node", k, smallRefs, 2*k, largeRefs)
+
+	// Retained SymbolsAndEntries groups must also grow ~linearly. Appending one group per search
+	// result (K searches, each returning all K implementations) grows ~4x; dropping duplicate
+	// empty groups keeps it bounded by the distinct definitions. Fail above 3x.
+	assert.Assert(t, largeGroups <= smallGroups*3,
+		"implementations worklist groups scale superlinearly: K=%d -> %d, K=%d -> %d (expected ~linear); "+
+			"provideSymbolsAndEntries retains a group per search result without deduplicating by definition", k, smallGroups, 2*k, largeGroups)
 }

--- a/internal/ls/findallreferences_test.go
+++ b/internal/ls/findallreferences_test.go
@@ -16,22 +16,17 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-// Bug D (withfig): runaway memory in the go-to-implementation worklist.
+// provideSymbolsAndEntries drives go-to-implementation with a breadth-first worklist. Each
+// implementation node is expanded once (seenNodes), but when an interface member has K
+// implementations, every one of those K program-wide searches returns all K implementations.
+// If accumulated results are not deduplicated by node, the intermediate SymbolsAndEntries grow
+// O(K^2), which can exhaust memory on large, deeply-typed programs.
 //
-// provideSymbolsAndEntries' implementations worklist (findallreferences.go) dedups the
-// worklist only by *node* (seenNodes) and does `implementationEntries = core.Concatenate(...)`
-// with NO symbol-level dedup. When an interface member has K implementations, a go-to-
-// implementation query runs ~K full program-wide searches (one per implementation node), and
-// each search returns all K implementations, so `implementationEntries` accumulates O(K^2)
-// references. On a large, deeply-typed file (withfig `wp.ts` + `@withfig/autocomplete-types`)
-// this blows up to many GB and the server is OOM-killed ("connection closed prematurely:
-// undefined").
-//
-// The final LSP response dedups by node, so the blow-up is invisible from the response; this
-// white-box test inspects the pre-dedup `SymbolsAndEntries` that provideSymbolsAndEntries
-// returns. It asserts the accumulated reference count grows *linearly* with K: quadratic
-// (current, buggy) => the count roughly quadruples when K doubles; a correct (symbol-deduped)
-// implementation stays ~linear (roughly doubles). Pre-fix this test FAILS; post-fix it PASSES.
+// The final LSP response is deduplicated by node, so the blow-up is invisible from the
+// response; this white-box test inspects the pre-deduplication SymbolsAndEntries that
+// provideSymbolsAndEntries returns. It asserts the accumulated reference count grows *linearly*
+// with K: quadratic growth roughly quadruples the count when K doubles, while linear growth
+// (node-deduplicated) roughly doubles it.
 func TestImplementationsWorklistDoesNotBlowUp(t *testing.T) {
 	t.Parallel()
 
@@ -82,8 +77,8 @@ func TestImplementationsWorklistDoesNotBlowUp(t *testing.T) {
 	large := measure(2 * k)
 	t.Logf("accumulated references: K=%d -> %d, K=%d -> %d (ratio %.2f)", k, small, 2*k, large, float64(large)/float64(small))
 
-	// Linear growth ~2x when K doubles; the O(K^2) bug grows ~4x. Fail above 3x.
+	// Linear growth ~2x when K doubles; quadratic growth ~4x. Fail above 3x.
 	assert.Assert(t, large <= small*3,
 		"implementations worklist scales superlinearly: K=%d -> %d refs, K=%d -> %d refs (expected ~linear); "+
-			"provideSymbolsAndEntries accumulates duplicate entries without symbol-level dedup", k, small, 2*k, large)
+			"provideSymbolsAndEntries accumulates references without deduplicating by node", k, small, 2*k, large)
 }

--- a/internal/ls/implementations_worklist_test.go
+++ b/internal/ls/implementations_worklist_test.go
@@ -1,0 +1,89 @@
+package ls
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/bundled"
+	"github.com/microsoft/typescript-go/internal/compiler"
+	"github.com/microsoft/typescript-go/internal/core"
+	"github.com/microsoft/typescript-go/internal/ls/lsconv"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
+	"github.com/microsoft/typescript-go/internal/tsoptions"
+	"github.com/microsoft/typescript-go/internal/vfs/vfstest"
+	"gotest.tools/v3/assert"
+)
+
+// Bug D (withfig): runaway memory in the go-to-implementation worklist.
+//
+// provideSymbolsAndEntries' implementations worklist (findallreferences.go) dedups the
+// worklist only by *node* (seenNodes) and does `implementationEntries = core.Concatenate(...)`
+// with NO symbol-level dedup. When an interface member has K implementations, a go-to-
+// implementation query runs ~K full program-wide searches (one per implementation node), and
+// each search returns all K implementations, so `implementationEntries` accumulates O(K^2)
+// references. On a large, deeply-typed file (withfig `wp.ts` + `@withfig/autocomplete-types`)
+// this blows up to many GB and the server is OOM-killed ("connection closed prematurely:
+// undefined").
+//
+// The final LSP response dedups by node, so the blow-up is invisible from the response; this
+// white-box test inspects the pre-dedup `SymbolsAndEntries` that provideSymbolsAndEntries
+// returns. It asserts the accumulated reference count grows *linearly* with K: quadratic
+// (current, buggy) => the count roughly quadruples when K doubles; a correct (symbol-deduped)
+// implementation stays ~linear (roughly doubles). Pre-fix this test FAILS; post-fix it PASSES.
+func TestImplementationsWorklistDoesNotBlowUp(t *testing.T) {
+	t.Parallel()
+
+	measure := func(k int) int {
+		var b strings.Builder
+		b.WriteString("interface I { m(): void; }\n")
+		for i := range k {
+			fmt.Fprintf(&b, "const a%d: I = { m() {} };\n", i)
+		}
+		b.WriteString("declare const i: I;\n")
+		b.WriteString("i.m();\n")
+		content := b.String()
+
+		fs := vfstest.FromMap(map[string]string{
+			"/repro.ts":      content,
+			"/tsconfig.json": `{ "compilerOptions": {}, "files": ["repro.ts"] }`,
+		}, false /*useCaseSensitiveFileNames*/)
+		fs = bundled.WrapFS(fs)
+
+		host := compiler.NewCompilerHost("/", fs, bundled.LibPath(), nil, nil)
+		parsed, errors := tsoptions.GetParsedCommandLineOfConfigFile("/tsconfig.json", &core.CompilerOptions{}, nil, host, nil)
+		assert.Equal(t, len(errors), 0)
+		program := compiler.NewProgram(compiler.ProgramOptions{Config: parsed, Host: host})
+		program.BindSourceFiles()
+		program.GetSemanticDiagnostics(context.Background(), program.GetSourceFile("/repro.ts"))
+
+		sourceFile := program.GetSourceFile("/repro.ts")
+		converters := lsconv.NewConverters(lsproto.PositionEncodingKindUTF8, func(_ string) *lsconv.LSPLineMap {
+			return lsconv.ComputeLSPLineStarts(content)
+		})
+		l := &LanguageService{program: program, converters: converters}
+
+		// Position of the `m` property in the final `i.m();`.
+		offset := strings.LastIndex(content, "i.m") + len("i.")
+		pos := converters.PositionToLineAndCharacter(sourceFile, core.TextPos(offset))
+
+		data, ok := l.provideSymbolsAndEntries(context.Background(), "file:///repro.ts", pos, false /*isRename*/, true /*implementations*/)
+		assert.Assert(t, ok)
+		total := 0
+		for _, se := range data.SymbolsAndEntries {
+			total += len(se.references)
+		}
+		return total
+	}
+
+	const k = 40
+	small := measure(k)
+	large := measure(2 * k)
+	t.Logf("accumulated references: K=%d -> %d, K=%d -> %d (ratio %.2f)", k, small, 2*k, large, float64(large)/float64(small))
+
+	// Linear growth ~2x when K doubles; the O(K^2) bug grows ~4x. Fail above 3x.
+	assert.Assert(t, large <= small*3,
+		"implementations worklist scales superlinearly: K=%d -> %d refs, K=%d -> %d refs (expected ~linear); "+
+			"provideSymbolsAndEntries accumulates duplicate entries without symbol-level dedup", k, small, 2*k, large)
+}


### PR DESCRIPTION
Fixes an issue uncovered in https://github.com/microsoft/typescript-go/issues/4380#issuecomment-4755503407; the go-to-implementation worklist in `provideSymbolsAndEntries` expands each node's implementation once but accumulates these results using `core.Concatenate`. If an interface has K implementations, each of the K searches concatenates K entries, making the memory complexity O(K^2). If we deduplicate stored nodes with `addIfAbsent`, the complexity drops to O(K).