### PR TITLE
Split heritage clause expression and type nodes

### DIFF
--- a/_packages/native-preview/src/ast/ast.generated.ts
+++ b/_packages/native-preview/src/ast/ast.generated.ts
@@ -646,7 +646,7 @@ export interface ClassExpression extends PrimaryExpressionBase, DeclarationBase,
 export interface HeritageClause extends NodeBase {
     readonly kind: SyntaxKind.HeritageClause;
     readonly token: SyntaxKind.ExtendsKeyword | SyntaxKind.ImplementsKeyword;
-    readonly types: NodeArray<ExpressionWithTypeArguments>;
+    readonly types: NodeArray<HeritageClauseElement>;
 }
 export interface InterfaceDeclaration extends StatementBase, DeclarationBase, ModifiersBase {
     readonly kind: SyntaxKind.InterfaceDeclaration;
@@ -1338,6 +1338,7 @@ export interface JSDocTypeLiteral extends JSDocTypeBase, DeclarationBase {
 export type Expression = ExpressionBase;
 export type Statement = StatementBase;
 export type TypeNode = TypeNodeBase;
+export type HeritageClauseElement = ExpressionWithTypeArguments | TypeReferenceNode;
 export type BlockOrExpression = Block | Expression;
 export type NodeBody = Block | Expression | ModuleBlock | ModuleDeclaration;
 export type AccessExpression = PropertyAccessExpression | ElementAccessExpression;
@@ -1507,6 +1508,7 @@ export type HeritageClauseList = NodeArray<HeritageClause>;
 export type ClassElementList = NodeArray<ClassElement>;
 export type TypeElementList = NodeArray<TypeElement>;
 export type ExpressionWithTypeArgumentsList = NodeArray<ExpressionWithTypeArguments>;
+export type HeritageClauseElementList = NodeArray<HeritageClauseElement>;
 export type EnumMemberList = NodeArray<EnumMember>;
 export type ImportSpecifierList = NodeArray<ImportSpecifier>;
 export type ExportSpecifierList = NodeArray<ExportSpecifier>;

--- a/_packages/native-preview/src/ast/factory.generated.ts
+++ b/_packages/native-preview/src/ast/factory.generated.ts
@@ -71,6 +71,7 @@ import type {
     FunctionTypeNode,
     GetAccessorDeclaration,
     HeritageClause,
+    HeritageClauseElement,
     Identifier,
     IfStatement,
     ImportAttribute,
@@ -1891,7 +1892,7 @@ export function createClassExpression(modifiers: readonly ModifierLike[] | undef
     }) as unknown as ClassExpression;
 }
 
-export function createHeritageClause(token: SyntaxKind.ExtendsKeyword | SyntaxKind.ImplementsKeyword, types: readonly ExpressionWithTypeArguments[]): HeritageClause {
+export function createHeritageClause(token: SyntaxKind.ExtendsKeyword | SyntaxKind.ImplementsKeyword, types: readonly HeritageClauseElement[]): HeritageClause {
     return new NodeObject(SyntaxKind.HeritageClause, {
         token,
         types: createNodeArray(types),
@@ -3216,7 +3217,7 @@ export function updateClassExpression(node: ClassExpression, modifiers: readonly
     return node.modifiers !== modifiers || node.name !== name || node.typeParameters !== typeParameters || node.heritageClauses !== heritageClauses || node.members !== members ? createClassExpression(modifiers, name, typeParameters, heritageClauses, members) : node;
 }
 
-export function updateHeritageClause(node: HeritageClause, types: readonly ExpressionWithTypeArguments[]): HeritageClause {
+export function updateHeritageClause(node: HeritageClause, types: readonly HeritageClauseElement[]): HeritageClause {
     return node.types !== types ? createHeritageClause(node.token, types) : node;
 }
 

--- a/_packages/native-preview/src/ast/is.generated.ts
+++ b/_packages/native-preview/src/ast/is.generated.ts
@@ -101,6 +101,7 @@ import type {
     FunctionTypeNode,
     GetAccessorDeclaration,
     HeritageClause,
+    HeritageClauseElement,
     Identifier,
     IfStatement,
     ImportAttribute,
@@ -1120,6 +1121,10 @@ export function isJSDocParameterTag(node: Node): node is JSDocParameterTag {
 
 export function isJSDocPropertyTag(node: Node): node is JSDocPropertyTag {
     return node.kind === SyntaxKind.JSDocPropertyTag;
+}
+
+export function isHeritageClauseElement(node: Node): node is HeritageClauseElement {
+    return node.kind === SyntaxKind.ExpressionWithTypeArguments || node.kind === SyntaxKind.TypeReference;
 }
 
 export function isAccessExpression(node: Node): node is AccessExpression {

--- a/_packages/native-preview/test/sync/ast.test.ts
+++ b/_packages/native-preview/test/sync/ast.test.ts
@@ -9,7 +9,9 @@ import type {
 } from "@typescript/native-preview/unstable/ast";
 import {
     getTokenAtPosition,
+    isClassDeclaration,
     isImportDeclaration,
+    isInterfaceDeclaration,
     isNamedImports,
     isValidTypeOnlyAliasUseSite,
     SyntaxKind,
@@ -577,6 +579,29 @@ function getRemoteSourceFile(api: API, configPath: string, filePath: string) {
 }
 
 describe("RemoteNode + cloneNode", () => {
+    test("uses distinct nodes for expression and type heritage", () => {
+        const api = spawnAPI({
+            "/tsconfig.json": "{}",
+            "/src/heritage.ts": `
+class C extends Base<number> implements Contract<string> {}
+interface I extends Parent<boolean> {}
+`,
+        });
+        try {
+            const sf = getRemoteSourceFile(api, "/tsconfig.json", "/src/heritage.ts");
+            const classDecl = sf.statements[0];
+            const interfaceDecl = sf.statements[1];
+            assert.ok(isClassDeclaration(classDecl));
+            assert.ok(isInterfaceDeclaration(interfaceDecl));
+            assert.strictEqual(classDecl.heritageClauses?.[0].types[0].kind, SyntaxKind.ExpressionWithTypeArguments);
+            assert.strictEqual(classDecl.heritageClauses?.[1].types[0].kind, SyntaxKind.TypeReference);
+            assert.strictEqual(interfaceDecl.heritageClauses?.[0].types[0].kind, SyntaxKind.TypeReference);
+        }
+        finally {
+            api.close();
+        }
+    });
+
     test("cloneNode produces a NodeObject from a RemoteNode", () => {
         const api = spawnAPI();
         try {

--- a/_scripts/ast.json
+++ b/_scripts/ast.json
@@ -1953,7 +1953,7 @@
                     },
                     {
                         "name": "Types",
-                        "type": "ExpressionWithTypeArguments",
+                        "type": "HeritageClauseElement",
                         "list": "NodeList"
                     }
                 ],
@@ -5142,6 +5142,10 @@
             "TypeNode": {
                 "base": "TypeNodeBase"
             },
+            "HeritageClauseElement": [
+                "ExpressionWithTypeArguments",
+                "TypeReferenceNode"
+            ],
             "BlockOrExpression": [
                 "Block",
                 "Expression"
@@ -5479,6 +5483,7 @@
             "ClassElementList": "ClassElement",
             "TypeElementList": "TypeElement",
             "ExpressionWithTypeArgumentsList": "ExpressionWithTypeArguments",
+            "HeritageClauseElementList": "HeritageClauseElement",
             "EnumMemberList": "EnumMember",
             "ImportSpecifierList": "ImportSpecifier",
             "ExportSpecifierList": "ExportSpecifier",

--- a/internal/ast/ast_generated.go
+++ b/internal/ast/ast_generated.go
@@ -493,6 +493,7 @@ type (
 	ClassElementList                = NodeList // NodeList[*ClassElement]
 	TypeElementList                 = NodeList // NodeList[*TypeElement]
 	ExpressionWithTypeArgumentsList = NodeList // NodeList[*ExpressionWithTypeArguments]
+	HeritageClauseElementList       = NodeList // NodeList[*HeritageClauseElement]
 	EnumMemberList                  = NodeList // NodeList[*EnumMember]
 	ImportSpecifierList             = NodeList // NodeList[*ImportSpecifier]
 	ExportSpecifierList             = NodeList // NodeList[*ExportSpecifier]
@@ -516,6 +517,7 @@ type (
 	Expression                     = Node // Node with ExpressionBase
 	Statement                      = Node // Node with StatementBase
 	TypeNode                       = Node // Node with TypeNodeBase
+	HeritageClauseElement          = Node // ExpressionWithTypeArguments | TypeReferenceNode
 	BlockOrExpression              = Node // Block | Expression
 	NodeBody                       = Node // Block | Expression | ModuleBlock | ModuleDeclaration
 	AccessExpression               = Node // PropertyAccessExpression | ElementAccessExpression
@@ -2152,17 +2154,17 @@ type HeritageClause struct {
 	NodeBase
 	CompositeBase
 	Token Kind
-	Types *ExpressionWithTypeArgumentsList
+	Types *HeritageClauseElementList
 }
 
-func (f *NodeFactory) NewHeritageClause(token Kind, types *ExpressionWithTypeArgumentsList) *Node {
+func (f *NodeFactory) NewHeritageClause(token Kind, types *HeritageClauseElementList) *Node {
 	data := f.heritageClauseArena.New()
 	data.Token = token
 	data.Types = types
 	return f.newNode(KindHeritageClause, data)
 }
 
-func (f *NodeFactory) UpdateHeritageClause(node *HeritageClause, token Kind, types *ExpressionWithTypeArgumentsList) *Node {
+func (f *NodeFactory) UpdateHeritageClause(node *HeritageClause, token Kind, types *HeritageClauseElementList) *Node {
 	if token != node.Token || types != node.Types {
 		return updateNode(f.NewHeritageClause(token, types), node.AsNode(), f.hooks)
 	}

--- a/internal/ast/utilities.go
+++ b/internal/ast/utilities.go
@@ -1428,18 +1428,20 @@ func IsExpressionWithTypeArgumentsInClassExtendsClause(node *Node) bool {
 }
 
 func TryGetClassExtendingExpressionWithTypeArguments(node *Node) *ClassLikeDeclaration {
-	cls, isImplements := TryGetClassImplementingOrExtendingExpressionWithTypeArguments(node)
+	if !IsExpressionWithTypeArguments(node) {
+		return nil
+	}
+	cls, isImplements := TryGetClassImplementingOrExtendingHeritageClauseElement(node)
 	if cls != nil && !isImplements {
 		return cls
 	}
 	return nil
 }
 
-func TryGetClassImplementingOrExtendingExpressionWithTypeArguments(node *Node) (class *ClassLikeDeclaration, isImplements bool) {
-	if IsExpressionWithTypeArguments(node) {
-		if IsHeritageClause(node.Parent) && IsClassLike(node.Parent.Parent) {
-			return node.Parent.Parent, node.Parent.AsHeritageClause().Token == KindImplementsKeyword
-		}
+func TryGetClassImplementingOrExtendingHeritageClauseElement(node *Node) (class *ClassLikeDeclaration, isImplements bool) {
+	if (IsExpressionWithTypeArguments(node) || IsTypeReferenceNode(node)) &&
+		IsHeritageClause(node.Parent) && IsClassLike(node.Parent.Parent) {
+		return node.Parent.Parent, node.Parent.AsHeritageClause().Token == KindImplementsKeyword
 	}
 	return nil, false
 }
@@ -1713,15 +1715,11 @@ func GetContainingClass(node *Node) *Node {
 	return FindAncestor(node.Parent, IsClassLike)
 }
 
-func GetExtendsHeritageClauseElement(node *Node) *ExpressionWithTypeArgumentsNode {
-	return core.FirstOrNil(GetExtendsHeritageClauseElements(node))
-}
-
-func GetExtendsHeritageClauseElements(node *Node) []*ExpressionWithTypeArgumentsNode {
+func GetExtendsHeritageClauseElements(node *Node) []*Node {
 	return GetHeritageElements(node, KindExtendsKeyword)
 }
 
-func GetImplementsHeritageClauseElements(node *Node) []*ExpressionWithTypeArgumentsNode {
+func GetImplementsHeritageClauseElements(node *Node) []*Node {
 	return GetHeritageElements(node, KindImplementsKeyword)
 }
 
@@ -1731,6 +1729,23 @@ func GetHeritageElements(node *Node, kind Kind) []*Node {
 		return clause.AsHeritageClause().Types.Nodes
 	}
 	return nil
+}
+
+// GetHeritageClauseElementName returns the expression or type name of a heritage clause element.
+func GetHeritageClauseElementName(node *Node) *Node {
+	if IsTypeReferenceNode(node) {
+		return node.AsTypeReferenceNode().TypeName
+	}
+	return node.AsExpressionWithTypeArguments().Expression
+}
+
+func IsNameOfHeritageClauseTypeReference(node *Node) bool {
+	for IsQualifiedName(node.Parent) {
+		node = node.Parent
+	}
+	return IsTypeReferenceNode(node.Parent) &&
+		node.Parent.AsTypeReferenceNode().TypeName == node &&
+		IsHeritageClause(node.Parent.Parent)
 }
 
 func GetHeritageClause(node *Node, kind Kind) *Node {
@@ -3085,10 +3100,6 @@ func GetClassExtendsHeritageElement(node *Node) *ExpressionWithTypeArgumentsNode
 		return heritageElements[0]
 	}
 	return nil
-}
-
-func GetImplementsTypeNodes(node *Node) []*ExpressionWithTypeArgumentsNode {
-	return GetHeritageElements(node, KindImplementsKeyword)
 }
 
 func IsTypeKeywordToken(node *Node) bool {

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -2839,7 +2839,7 @@ func (c *Checker) checkConstructorDeclaration(node *ast.Node) {
 	// Constructors of classes with no extends clause may not contain super calls, whereas
 	// constructors of derived classes must contain at least one super call somewhere in their function body.
 	containingClassDecl := node.Parent
-	if ast.GetExtendsHeritageClauseElement(containingClassDecl) == nil {
+	if ast.GetClassExtendsHeritageElement(containingClassDecl) == nil {
 		return
 	}
 	classExtendsNull := c.classDeclarationExtendsNull(containingClassDecl)
@@ -4310,7 +4310,7 @@ func (c *Checker) checkClassLikeDeclaration(node *ast.Node) {
 		c.checkClassForStaticPropertyNameConflicts(node)
 	}
 
-	baseTypeNode := ast.GetExtendsHeritageClauseElement(node)
+	baseTypeNode := ast.GetClassExtendsHeritageElement(node)
 	if baseTypeNode != nil {
 		c.checkSourceElements(baseTypeNode.TypeArguments())
 		baseTypes := c.getBaseTypes(classType)
@@ -4363,9 +4363,11 @@ func (c *Checker) checkClassLikeDeclaration(node *ast.Node) {
 	c.checkMembersForOverrideModifier(node, classType, typeWithThis, staticType)
 	implementedTypeNodes := ast.GetImplementsHeritageClauseElements(node)
 	for _, typeRefNode := range implementedTypeNodes {
-		expr := typeRefNode.Expression()
-		if !ast.IsEntityNameExpression(expr) || ast.IsOptionalChain(expr) {
-			c.error(expr, diagnostics.A_class_can_only_implement_an_identifier_Slashqualified_name_with_optional_type_arguments)
+		if ast.IsExpressionWithTypeArguments(typeRefNode) {
+			expr := typeRefNode.Expression()
+			if !ast.IsEntityNameExpression(expr) || ast.IsOptionalChain(expr) {
+				c.error(expr, diagnostics.A_class_can_only_implement_an_identifier_Slashqualified_name_with_optional_type_arguments)
+			}
 		}
 		c.checkTypeReferenceNode(typeRefNode)
 		t := c.getReducedType(c.getTypeFromTypeNode(typeRefNode))
@@ -4702,7 +4704,7 @@ func (c *Checker) isPropertyAbstractOrInterface(declaration *ast.Node, baseDecla
 
 func (c *Checker) checkMembersForOverrideModifier(node *ast.Node, t *Type, typeWithThis *Type, staticType *Type) {
 	var baseWithThis *Type
-	baseTypeNode := ast.GetExtendsHeritageClauseElement(node)
+	baseTypeNode := ast.GetClassExtendsHeritageElement(node)
 	if baseTypeNode != nil {
 		baseTypes := c.getBaseTypes(t)
 		if len(baseTypes) > 0 {
@@ -5014,9 +5016,11 @@ func (c *Checker) checkInterfaceDeclaration(node *ast.Node) {
 	}
 	c.checkObjectTypeForDuplicateDeclarations(node, false /*checkPrivateNames*/)
 	for _, heritageElement := range ast.GetExtendsHeritageClauseElements(node) {
-		expr := heritageElement.Expression()
-		if !ast.IsEntityNameExpression(expr) || ast.IsOptionalChain(expr) {
-			c.error(expr, diagnostics.An_interface_can_only_extend_an_identifier_Slashqualified_name_with_optional_type_arguments)
+		if ast.IsExpressionWithTypeArguments(heritageElement) {
+			expr := heritageElement.Expression()
+			if !ast.IsEntityNameExpression(expr) || ast.IsOptionalChain(expr) {
+				c.error(expr, diagnostics.An_interface_can_only_extend_an_identifier_Slashqualified_name_with_optional_type_arguments)
+			}
 		}
 		c.checkTypeReferenceNode(heritageElement)
 	}
@@ -7919,7 +7923,7 @@ func (c *Checker) checkSuperExpression(node *ast.Node) *Type {
 	}
 	// at this point the only legal case for parent is ClassLikeDeclaration
 	classLikeDeclaration := container.Parent
-	if ast.GetExtendsHeritageClauseElement(classLikeDeclaration) == nil {
+	if ast.GetClassExtendsHeritageElement(classLikeDeclaration) == nil {
 		c.error(node, diagnostics.X_super_can_only_be_referenced_in_a_derived_class)
 		return c.errorType
 	}
@@ -8480,7 +8484,7 @@ func (c *Checker) resolveCallExpression(node *ast.Node, candidatesOutArray *[]*S
 		if !c.isErrorType(superType) {
 			// In super call, the candidate signatures are the matching arity signatures of the base constructor function instantiated
 			// with the type arguments specified in the extends clause.
-			baseTypeNode := ast.GetExtendsHeritageClauseElement(ast.GetContainingClass(node))
+			baseTypeNode := ast.GetClassExtendsHeritageElement(ast.GetContainingClass(node))
 			if baseTypeNode != nil {
 				baseConstructors := c.getInstantiatedConstructorsForTypeArguments(superType, baseTypeNode.TypeArguments(), baseTypeNode)
 				return c.resolveCall(node, baseConstructors, candidatesOutArray, checkMode, SignatureFlagsNone, nil)
@@ -11672,15 +11676,16 @@ func (c *Checker) checkAndReportErrorForExtendingInterface(errorLocation *ast.No
 }
 
 /**
- * Climbs up parents to an ExpressionWithTypeArguments, and returns its expression,
- * but returns undefined if that expression is not an EntityNameExpression.
+ * Climbs up parents to a heritage clause element and returns its entity name.
  */
 func (c *Checker) getEntityNameForExtendingInterface(node *ast.Node) *ast.Node {
 	switch node.Kind {
-	case ast.KindIdentifier, ast.KindPropertyAccessExpression:
+	case ast.KindIdentifier, ast.KindQualifiedName, ast.KindPropertyAccessExpression:
 		if node.Parent != nil {
 			return c.getEntityNameForExtendingInterface(node.Parent)
 		}
+	case ast.KindTypeReference:
+		return node.AsTypeReferenceNode().TypeName
 	case ast.KindExpressionWithTypeArguments:
 		if ast.IsEntityNameExpression(node.Expression()) {
 			return node.Expression()
@@ -12261,7 +12266,7 @@ func (c *Checker) checkThisInStaticClassFieldInitializerInDecoratedClass(thisExp
 
 func (c *Checker) checkThisBeforeSuper(node *ast.Node, container *ast.Node, diagnosticMessage *diagnostics.Message) {
 	containingClassDecl := container.Parent
-	baseTypeNode := ast.GetExtendsHeritageClauseElement(containingClassDecl)
+	baseTypeNode := ast.GetClassExtendsHeritageElement(containingClassDecl)
 	// If a containing class does not have extends clause or the class extends null
 	// skip checking whether super statement is called before "this" accessing.
 	if baseTypeNode != nil && !c.classDeclarationExtendsNull(containingClassDecl) {
@@ -17360,8 +17365,9 @@ func (c *Checker) isThislessInterface(symbol *ast.Symbol) bool {
 			}
 			baseTypeNodes := ast.GetExtendsHeritageClauseElements(declaration)
 			for _, node := range baseTypeNodes {
-				if ast.IsEntityNameExpression(node.Expression()) {
-					baseSymbol := c.resolveEntityName(node.Expression(), ast.SymbolFlagsType, true /*ignoreErrors*/, false, nil)
+				name := ast.GetHeritageClauseElementName(node)
+				if ast.IsEntityName(name) || ast.IsEntityNameExpression(name) {
+					baseSymbol := c.resolveEntityName(name, ast.SymbolFlagsType, true /*ignoreErrors*/, false, nil)
 					if baseSymbol == nil || baseSymbol.Flags&ast.SymbolFlagsInterface == 0 || c.getDeclaredTypeOfClassOrInterface(baseSymbol).AsInterfaceType().thisType != nil {
 						return false
 					}
@@ -19266,7 +19272,7 @@ func (c *Checker) resolveBaseTypesOfClass(t *Type) {
 func getBaseTypeNodeOfClass(t *Type) *ast.Node {
 	decl := ast.GetClassLikeDeclarationOfSymbol(t.symbol)
 	if decl != nil {
-		return ast.GetExtendsHeritageClauseElement(decl)
+		return ast.GetClassExtendsHeritageElement(decl)
 	}
 	return nil
 }
@@ -28222,7 +28228,7 @@ func (c *Checker) markLinkedReferences(location *ast.Node, hint ReferenceHint, p
 				// `class C extends A, B`) and are never resolved during checking.
 				if ast.IsClassLike(heritageClause.Parent) &&
 					heritageClause.AsHeritageClause().Token == ast.KindExtendsKeyword {
-					if firstExtends := ast.GetExtendsHeritageClauseElement(heritageClause.Parent); firstExtends != nil &&
+					if firstExtends := ast.GetClassExtendsHeritageElement(heritageClause.Parent); firstExtends != nil &&
 						location != firstExtends && !ast.IsNodeDescendantOf(location, firstExtends) {
 						return
 					}
@@ -31753,11 +31759,11 @@ func (c *Checker) getSymbolOfNameOrPropertyAccessExpression(name *ast.Node) *ast
 		name = name.Parent
 	}
 
-	if isInNameOfExpressionWithTypeArguments(name) {
+	if isInNameOfExpressionWithTypeArgumentsOrHeritageTypeReference(name) {
 		var meaning ast.SymbolFlags
-		if name.Parent.Kind == ast.KindExpressionWithTypeArguments {
-			// An 'ExpressionWithTypeArguments' may appear in type space (interface Foo extends Bar<T>),
-			// value space (return foo<T>), or both(class Foo extends Bar<T>); ensure the meaning matches.
+		if name.Parent.Kind == ast.KindExpressionWithTypeArguments || name.Parent.Kind == ast.KindTypeReference {
+			// A heritage element name may appear in type space, value space, or both;
+			// ensure the meaning matches its context.
 			meaning = core.IfElse(ast.IsPartOfTypeNode(name), ast.SymbolFlagsType, ast.SymbolFlagsValue)
 
 			// In a class 'extends' clause we are also looking for a value.
@@ -31834,6 +31840,9 @@ func (c *Checker) getSymbolOfNameOrPropertyAccessExpression(name *ast.Node) *ast
 		if symbol != nil && symbol != c.unknownSymbol {
 			return symbol
 		}
+		if ast.IsNameOfHeritageClauseTypeReference(name) {
+			return nil
+		}
 		return c.getUnresolvedSymbolForEntityName(name)
 	}
 
@@ -31874,10 +31883,14 @@ func (c *Checker) getTypeOfNode(node *ast.Node) *Type {
 		return c.errorType
 	}
 
-	classDecl, isImplements := ast.TryGetClassImplementingOrExtendingExpressionWithTypeArguments(node)
+	classDecl, isImplements := ast.TryGetClassImplementingOrExtendingHeritageClauseElement(node)
 	var classType *Type
 	if classDecl != nil {
 		classType = c.getDeclaredTypeOfClassOrInterface(c.getSymbolOfDeclaration(classDecl))
+	}
+
+	if heritageType, ok := c.getTypeOfHeritageTypeReferenceName(node); ok {
+		return heritageType
 	}
 
 	if ast.IsPartOfTypeNode(node) {
@@ -31889,6 +31902,7 @@ func (c *Checker) getTypeOfNode(node *ast.Node) *Type {
 				false, /*needApparentType*/
 			)
 		}
+
 		return typeFromTypeNode
 	}
 
@@ -32053,6 +32067,50 @@ func (c *Checker) getRegularTypeOfExpression(expr *ast.Node) *Type {
 		expr = expr.Parent
 	}
 	return c.getRegularTypeOfLiteralType(c.getTypeOfExpression(expr))
+}
+
+// Heritage type references used to be expression-with-type-arguments nodes.
+// Preserve expression-space type queries for their qualified-name components.
+func (c *Checker) getTypeOfHeritageTypeReferenceName(node *ast.Node) (*Type, bool) {
+	if !ast.IsNameOfHeritageClauseTypeReference(node) {
+		return nil, false
+	}
+	if ast.IsQualifiedName(node) {
+		return c.getHeritageExpressionType(node), true
+	}
+	if ast.IsIdentifier(node) && ast.IsQualifiedName(node.Parent) {
+		parent := node.Parent.AsQualifiedName()
+		if parent.Right == node &&
+			ast.IsQualifiedName(node.Parent.Parent) && node.Parent.Parent.AsQualifiedName().Left == node.Parent {
+			return c.getHeritageExpressionType(node.Parent), true
+		}
+		if parent.Left == node {
+			return c.getRegularTypeOfExpression(node), true
+		}
+	}
+	return nil, false
+}
+
+func (c *Checker) getHeritageExpressionType(node *ast.Node) *Type {
+	if !ast.IsQualifiedName(node) {
+		return c.getRegularTypeOfExpression(node)
+	}
+	qualified := node.AsQualifiedName()
+	var leftType *Type
+	if ast.IsQualifiedName(qualified.Left) {
+		leftType = c.getHeritageExpressionType(qualified.Left)
+	} else {
+		leftType = c.getRegularTypeOfExpression(qualified.Left)
+	}
+	apparentType := c.getApparentType(leftType)
+	if IsTypeAny(apparentType) {
+		return c.anyType
+	}
+	symbol := c.getPropertyOfTypeEx(apparentType, qualified.Right.Text(), isConstEnumObjectType(apparentType), false /*includeTypeOnlyMembers*/)
+	if symbol == nil {
+		return c.anyType
+	}
+	return c.getRegularTypeOfLiteralType(c.getTypeOfSymbol(symbol))
 }
 
 func (c *Checker) containsArgumentsReference(node *ast.Node) bool {

--- a/internal/checker/utilities.go
+++ b/internal/checker/utilities.go
@@ -1142,12 +1142,13 @@ func isImportTypeQualifierPart(node *ast.Node) *ast.Node {
 	return nil
 }
 
-func isInNameOfExpressionWithTypeArguments(node *ast.Node) bool {
-	for node.Parent.Kind == ast.KindPropertyAccessExpression {
+func isInNameOfExpressionWithTypeArgumentsOrHeritageTypeReference(node *ast.Node) bool {
+	for node.Parent.Kind == ast.KindPropertyAccessExpression || node.Parent.Kind == ast.KindQualifiedName {
 		node = node.Parent
 	}
 
-	return node.Parent.Kind == ast.KindExpressionWithTypeArguments
+	return node.Parent.Kind == ast.KindExpressionWithTypeArguments ||
+		ast.IsNameOfHeritageClauseTypeReference(node)
 }
 
 func getIndexSymbolFromSymbolTable(symbolTable ast.SymbolTable) *ast.Symbol {

--- a/internal/ls/codeactions_fixclassincorrectlyimplementsinterface.go
+++ b/internal/ls/codeactions_fixclassincorrectlyimplementsinterface.go
@@ -36,7 +36,7 @@ func getCodeActionsToFixClassIncorrectlyImplementsInterface(context context.Cont
 		return nil, nil
 	}
 
-	implementsTypes := ast.GetImplementsTypeNodes(classDeclaration)
+	implementsTypes := ast.GetImplementsHeritageClauseElements(classDeclaration)
 	locale := locale.FromContext(context)
 
 	typeChecker, done := fixContext.Program.GetTypeCheckerForFile(context, fixContext.SourceFile)
@@ -85,7 +85,7 @@ func getAllCodeActionsToFixClassIncorrectlyImplementsInterface(context context.C
 				continue
 			}
 			if seenClassDeclarations.AddIfAbsent(classDeclaration) {
-				implementsTypes := ast.GetImplementsTypeNodes(classDeclaration)
+				implementsTypes := ast.GetImplementsHeritageClauseElements(classDeclaration)
 				for _, implementedTypeNode := range implementsTypes {
 					addChanges(context, fixContext, changeTracker, importAdder, typeChecker, classDeclaration, implementedTypeNode)
 				}

--- a/internal/ls/utilities.go
+++ b/internal/ls/utilities.go
@@ -429,10 +429,12 @@ func findReferenceInPosition(refs []*ast.FileReference, pos int) *ast.FileRefere
 }
 
 func getContainingNodeIfInHeritageClause(node *ast.Node) *ast.Node {
-	if node.Kind == ast.KindIdentifier || node.Kind == ast.KindPropertyAccessExpression {
+	if node.Kind == ast.KindIdentifier || node.Kind == ast.KindQualifiedName || node.Kind == ast.KindPropertyAccessExpression {
 		return getContainingNodeIfInHeritageClause(node.Parent)
 	}
-	if node.Kind == ast.KindExpressionWithTypeArguments && (ast.IsClassLike(node.Parent.Parent) || node.Parent.Parent.Kind == ast.KindInterfaceDeclaration) {
+	if (node.Kind == ast.KindExpressionWithTypeArguments || node.Kind == ast.KindTypeReference) &&
+		ast.IsHeritageClause(node.Parent) &&
+		(ast.IsClassLike(node.Parent.Parent) || node.Parent.Parent.Kind == ast.KindInterfaceDeclaration) {
 		return node.Parent.Parent
 	}
 	return nil
@@ -592,7 +594,7 @@ func getAdjustedLocation(node *ast.Node, forRename bool, sourceFile *ast.SourceF
 			// /**/extends [|name|]
 			// /**/implements [|name|]
 			if len(node.Types.Nodes) == 1 {
-				return node.Types.Nodes[0].Expression()
+				return ast.GetHeritageClauseElementName(node.Types.Nodes[0])
 			}
 
 			// fall through `getAdjustedLocation`
@@ -919,7 +921,7 @@ func getAllSuperTypeNodes(node *ast.Node) []*ast.TypeNode {
 	if ast.IsClassLike(node) {
 		return append(
 			core.SingleElementSlice(ast.GetClassExtendsHeritageElement(node)),
-			ast.GetImplementsTypeNodes(node)...,
+			ast.GetImplementsHeritageClauseElements(node)...,
 		)
 	}
 	return nil

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1751,7 +1751,7 @@ func (p *Parser) parseClassDeclarationOrExpression(pos int, jsdoc jsdocScannerIn
 	if modifiers != nil && core.Some(modifiers.Nodes, isExportModifier) {
 		p.setContextFlags(ast.NodeFlagsAwaitContext, true /*value*/)
 	}
-	heritageClauses := p.parseHeritageClauses()
+	heritageClauses := p.parseHeritageClauses(false /*isInterface*/)
 	var members *ast.NodeList
 	if p.parseExpected(ast.KindOpenBraceToken) {
 		// ClassTail[Yield,Await] : (Modified) See 14.5
@@ -1815,21 +1815,64 @@ func isAsyncModifier(modifier *ast.Node) bool {
 	return modifier.Kind == ast.KindAsyncKeyword
 }
 
-func (p *Parser) parseHeritageClauses() *ast.NodeList {
+func (p *Parser) parseHeritageClauses(isInterface bool) *ast.NodeList {
 	// ClassTail[Yield,Await] : (Modified) See 14.5
 	//      ClassHeritage[?Yield,?Await]opt { ClassBody[?Yield,?Await]opt }
 	if p.isHeritageClause() {
-		return p.parseList(PCHeritageClauses, (*Parser).parseHeritageClause)
+		return p.parseList(PCHeritageClauses, func(p *Parser) *ast.Node {
+			return p.parseHeritageClause(isInterface)
+		})
 	}
 	return nil
 }
 
-func (p *Parser) parseHeritageClause() *ast.Node {
+func (p *Parser) parseHeritageClause(isInterface bool) *ast.Node {
 	pos := p.nodePos()
 	kind := p.token
 	p.nextToken()
-	types := p.parseDelimitedList(PCHeritageClauseElement, (*Parser).parseExpressionWithTypeArguments)
+	parseElement := (*Parser).parseExpressionWithTypeArguments
+	if isTypeHeritageClause(isInterface, kind) {
+		parseElement = (*Parser).parseTypeHeritageClauseElement
+	}
+	types := p.parseDelimitedList(PCHeritageClauseElement, parseElement)
 	return p.checkJSSyntax(p.finishNode(p.factory.NewHeritageClause(kind, types), pos))
+}
+
+func isTypeHeritageClause(isInterface bool, token ast.Kind) bool {
+	return isInterface && token == ast.KindExtendsKeyword ||
+		!isInterface && token == ast.KindImplementsKeyword
+}
+
+func (p *Parser) parseTypeHeritageClauseElement() *ast.Node {
+	pos := p.nodePos()
+	expressionWithTypeArguments := p.parseExpressionWithTypeArguments().AsExpressionWithTypeArguments()
+	if !isValidHeritageTypeReferenceExpression(expressionWithTypeArguments.Expression) {
+		return expressionWithTypeArguments.AsNode()
+	}
+	typeName := p.convertEntityNameExpressionToEntityName(expressionWithTypeArguments.Expression)
+	return p.finishNode(p.factory.NewTypeReferenceNode(typeName, expressionWithTypeArguments.TypeArguments), pos)
+}
+
+func isValidHeritageTypeReferenceExpression(node *ast.Node) bool {
+	if ast.IsIdentifier(node) {
+		return ast.NodeIsPresent(node)
+	}
+	return ast.IsPropertyAccessExpression(node) &&
+		!ast.IsOptionalChain(node) &&
+		ast.NodeIsPresent(node.Name()) &&
+		isValidHeritageTypeReferenceExpression(node.Expression())
+}
+
+func (p *Parser) convertEntityNameExpressionToEntityName(node *ast.Node) *ast.Node {
+	if ast.IsIdentifier(node) {
+		return node
+	}
+	propertyAccess := node.AsPropertyAccessExpression()
+	result := p.factory.NewQualifiedName(
+		p.convertEntityNameExpressionToEntityName(propertyAccess.Expression),
+		propertyAccess.Name(),
+	)
+	return p.finishNodeWithEnd(result, node.Pos(), node.End())
 }
 
 func (p *Parser) parseExpressionWithTypeArguments() *ast.Node {
@@ -2082,7 +2125,7 @@ func (p *Parser) parseInterfaceDeclaration(pos int, jsdoc jsdocScannerInfo, modi
 	p.parseExpected(ast.KindInterfaceKeyword)
 	name := p.parseIdentifier()
 	typeParameters := p.parseTypeParameters()
-	heritageClauses := p.parseHeritageClauses()
+	heritageClauses := p.parseHeritageClauses(true /*isInterface*/)
 	members := p.parseObjectTypeMembers()
 	result := p.finishNode(p.factory.NewInterfaceDeclaration(modifiers, name, typeParameters, heritageClauses, members), pos)
 	p.withJSDoc(result, jsdoc)

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -162,6 +162,37 @@ func FuzzParser(f *testing.F) {
 	})
 }
 
+func TestHeritageClauseElementKinds(t *testing.T) {
+	t.Parallel()
+	sourceText := `
+class C extends Base<number> implements Contract<string> {}
+interface I extends Parent<boolean> {}
+interface Invalid implements Recovery {}
+interface MissingExtends extends A. {}
+class MissingImplements implements B. {}
+`
+	file := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/index.ts",
+		Path:     "/index.ts",
+	}, sourceText, core.ScriptKindTS)
+
+	classDecl := file.Statements.Nodes[0].AsClassDeclaration()
+	assert.Equal(t, classDecl.HeritageClauses.Nodes[0].AsHeritageClause().Types.Nodes[0].Kind, ast.KindExpressionWithTypeArguments)
+	assert.Equal(t, classDecl.HeritageClauses.Nodes[1].AsHeritageClause().Types.Nodes[0].Kind, ast.KindTypeReference)
+
+	interfaceDecl := file.Statements.Nodes[1].AsInterfaceDeclaration()
+	assert.Equal(t, interfaceDecl.HeritageClauses.Nodes[0].AsHeritageClause().Types.Nodes[0].Kind, ast.KindTypeReference)
+
+	invalidInterfaceDecl := file.Statements.Nodes[2].AsInterfaceDeclaration()
+	assert.Equal(t, invalidInterfaceDecl.HeritageClauses.Nodes[0].AsHeritageClause().Types.Nodes[0].Kind, ast.KindExpressionWithTypeArguments)
+
+	missingExtendsDecl := file.Statements.Nodes[3].AsInterfaceDeclaration()
+	assert.Equal(t, missingExtendsDecl.HeritageClauses.Nodes[0].AsHeritageClause().Types.Nodes[0].Kind, ast.KindExpressionWithTypeArguments)
+
+	missingImplementsDecl := file.Statements.Nodes[4].AsClassDeclaration()
+	assert.Equal(t, missingImplementsDecl.HeritageClauses.Nodes[0].AsHeritageClause().Types.Nodes[0].Kind, ast.KindExpressionWithTypeArguments)
+}
+
 func TestJSDocImportTypeParentChain(t *testing.T) {
 	t.Parallel()
 	sourceText := `test("", async function () {

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -2972,10 +2972,6 @@ func (p *Printer) emitExpressionWithTypeArguments(node *ast.ExpressionWithTypeAr
 	p.exitNode(node.AsNode(), state)
 }
 
-func (p *Printer) emitExpressionWithTypeArgumentsNode(node *ast.ExpressionWithTypeArgumentsNode) {
-	p.emitExpressionWithTypeArguments(node.AsExpressionWithTypeArguments())
-}
-
 func (p *Printer) emitAsExpression(node *ast.AsExpression) {
 	state := p.enterNode(node.AsNode())
 	p.emitExpression(node.Expression, ast.OperatorPrecedenceRelational)
@@ -4480,7 +4476,7 @@ func (p *Printer) emitHeritageClause(node *ast.HeritageClause) {
 	p.writeSpace()
 	p.emitToken(node.Token, node.Pos(), WriteKindKeyword, node.AsNode())
 	p.writeSpace()
-	p.emitList((*Printer).emitExpressionWithTypeArgumentsNode, node.AsNode(), node.Types, LFHeritageClauseTypes)
+	p.emitList((*Printer).emitTypeNodeOutsideExtends, node.AsNode(), node.Types, LFHeritageClauseTypes)
 	p.exitNode(node.AsNode(), state)
 }
 

--- a/internal/testutil/tsbaseline/type_symbol_baseline.go
+++ b/internal/testutil/tsbaseline/type_symbol_baseline.go
@@ -305,7 +305,8 @@ func (walker *typeWriterWalker) visitNode(node *ast.Node, isSymbolWalk bool) []*
 	nodes := forEachASTNode(node)
 	var results []*typeWriterResult
 	for _, n := range nodes {
-		if ast.IsExpressionNode(n) || n.Kind == ast.KindIdentifier || ast.IsDeclarationName(n) {
+		if ast.IsExpressionNode(n) || n.Kind == ast.KindIdentifier || ast.IsDeclarationName(n) ||
+			ast.IsQualifiedName(n) && ast.IsNameOfHeritageClauseTypeReference(n) && (isSymbolWalk || ast.IsQualifiedName(n.Parent)) {
 			result := walker.writeTypeOrSymbol(n, isSymbolWalk)
 			if result != nil {
 				results = append(results, result)

--- a/internal/transformers/declarations/transform.go
+++ b/internal/transformers/declarations/transform.go
@@ -736,8 +736,9 @@ func (tx *DeclarationTransformer) transformMappedTypeNode(input *ast.MappedTypeN
 
 func (tx *DeclarationTransformer) transformHeritageClause(clause *ast.HeritageClause) *ast.Node {
 	retainedClauses := core.Filter(clause.Types.Nodes, func(t *ast.Node) bool {
-		return ast.IsEntityNameExpression(t.AsExpressionWithTypeArguments().Expression) ||
-			(clause.Token == ast.KindExtendsKeyword && t.Expression().Kind == ast.KindNullKeyword)
+		name := ast.GetHeritageClauseElementName(t)
+		return ast.IsEntityName(name) || ast.IsEntityNameExpression(name) ||
+			(clause.Token == ast.KindExtendsKeyword && ast.IsExpressionWithTypeArguments(t) && t.Expression().Kind == ast.KindNullKeyword)
 	})
 	if len(retainedClauses) == 0 {
 		return nil // elide empty clause
@@ -2142,20 +2143,16 @@ func isClassExtendingNull(node *ast.Node) bool {
 	if node == nil {
 		return false
 	}
-	heritage := node.ClassLikeData().HeritageClauses
-	if heritage == nil {
+	extendsClause := ast.GetHeritageClause(node, ast.KindExtendsKeyword)
+	if extendsClause == nil {
 		return false
 	}
-	if len(heritage.Nodes) > 1 || len(heritage.Nodes) == 0 {
+	types := extendsClause.AsHeritageClause().Types
+	if types == nil || len(types.Nodes) != 1 {
 		return false
 	}
-	for _, expA := range heritage.Nodes[0].AsHeritageClause().Types.Nodes {
-		expr := expA.AsExpressionWithTypeArguments().Expression
-		if expr != nil && expr.Kind == ast.KindNullKeyword {
-			return true
-		}
-	}
-	return false
+	expr := types.Nodes[0].AsExpressionWithTypeArguments().Expression
+	return expr != nil && expr.Kind == ast.KindNullKeyword
 }
 
 // collectThisPropertyAssignments finds `this.x = expr` assignments in constructors, methods, and static blocks


### PR DESCRIPTION
@Gerrit0 mentioned on Discord that heritage clauses are expressions with type args, but that those are not marked as type nodes.

While we could probably restore the brand, that got me thinking whether or not we could actually just have two different nodes here depending on whether or not it's type space or not.

I threw copilot at it to see if it could make the change and how bad it'd be.

I actually don't think that this is that bad at all, ~and does (IIRC) resolve a previous conversation we had about how it was weird to make the emitter handle this?~ (no, that was something else, the use of ExprWithTypeArgs for hovers)