### PR TITLE
Avoid temporary composite mapper allocations

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -22352,10 +22352,9 @@ func (c *Checker) getObjectTypeInstantiation(t *Type, m *TypeMapper, alias *Type
 	// We are instantiating an anonymous type that has one or more type parameters in scope. Apply the
 	// mapper to the type parameters to produce the effective list of type arguments, and compute the
 	// instantiation cache key from the type IDs of the type arguments.
-	combinedMapper := c.combineTypeMappers(t.Mapper(), m)
 	typeArguments := make([]*Type, len(typeParameters))
 	for i, tp := range typeParameters {
-		typeArguments[i] = combinedMapper.Map(tp)
+		typeArguments[i] = c.mapTypeWithCompositeMapper(tp, t.Mapper(), m)
 	}
 	newAlias := alias
 	if newAlias == nil {

--- a/internal/checker/mapper.go
+++ b/internal/checker/mapper.go
@@ -51,6 +51,17 @@ func (c *Checker) combineTypeMappers(m1 *TypeMapper, m2 *TypeMapper) *TypeMapper
 	return m2
 }
 
+func (c *Checker) mapTypeWithCompositeMapper(t *Type, m1 *TypeMapper, m2 *TypeMapper) *Type {
+	if m1 == nil {
+		return m2.Map(t)
+	}
+	t1 := m1.Map(t)
+	if t1 != t {
+		return c.instantiateType(t1, m2)
+	}
+	return m2.Map(t)
+}
+
 func mergeTypeMappers(m1 *TypeMapper, m2 *TypeMapper) *TypeMapper {
 	if m1 != nil {
 		return newMergedTypeMapper(m1, m2)


### PR DESCRIPTION
I thew copilot at #4579's case and while it didn't fix anything, it did find a perf optimization:

- Check time: 4.923s → 4.791s (2.7%)
- Peak RSS: 738MB → 697MB (5.5%)
- Allocations: 434MB → 342MB (21%)