### PR TITLE
Don't report TS1293 for destructured require under --module preserve

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -6838,7 +6838,7 @@ func (c *Checker) checkAliasSymbol(node *ast.Node) {
 		}
 		if c.compilerOptions.VerbatimModuleSyntax.IsTrue() && !ast.IsImportEqualsDeclaration(node) && !ast.IsInJSFile(node) && c.program.GetEmitModuleFormatOfFile(ast.GetSourceFileOfNode(node)) == core.ModuleKindCommonJS {
 			c.error(node, getVerbatimModuleSyntaxErrorMessage(node))
-		} else if c.moduleKind == core.ModuleKindPreserve && !ast.IsImportEqualsDeclaration(node) && !ast.IsVariableDeclaration(node) && c.program.GetEmitModuleFormatOfFile(ast.GetSourceFileOfNode(node)) == core.ModuleKindCommonJS {
+		} else if c.moduleKind == core.ModuleKindPreserve && !ast.IsImportEqualsDeclaration(node) && !ast.IsVariableDeclaration(node) && !ast.IsBindingElement(node) && c.program.GetEmitModuleFormatOfFile(ast.GetSourceFileOfNode(node)) == core.ModuleKindCommonJS {
 			// In `--module preserve`, ESM input syntax emits ESM output syntax, but there will be times
 			// when we look at the `impliedNodeFormat` of this file and decide it's CommonJS (i.e., currently,
 			// only if the file extension is .cjs/.cts). To avoid that inconsistency, we disallow ESM syntax

--- a/testdata/baselines/reference/compiler/modulePreserveRequireDestructuring.errors.txt
+++ b/testdata/baselines/reference/compiler/modulePreserveRequireDestructuring.errors.txt
@@ -1,15 +1,12 @@
 esm.cjs(2,10): error TS1293: ECMAScript module syntax is not allowed in a CommonJS module when 'module' is set to 'preserve'.
-main.cjs(2,9): error TS1293: ECMAScript module syntax is not allowed in a CommonJS module when 'module' is set to 'preserve'.
 
 
 ==== dep.cjs (0 errors) ====
     module.exports.readFile = function () {};
     
-==== main.cjs (1 errors) ====
+==== main.cjs (0 errors) ====
     // CommonJS `require` is not ESM syntax, in destructured or plain form.
     const { readFile } = require("./dep.cjs");
-            ~~~~~~~~
-!!! error TS1293: ECMAScript module syntax is not allowed in a CommonJS module when 'module' is set to 'preserve'.
     const dep = require("./dep.cjs");
     readFile;
     dep;

--- a/testdata/baselines/reference/compiler/modulePreserveRequireDestructuring.errors.txt
+++ b/testdata/baselines/reference/compiler/modulePreserveRequireDestructuring.errors.txt
@@ -1,0 +1,23 @@
+esm.cjs(2,10): error TS1293: ECMAScript module syntax is not allowed in a CommonJS module when 'module' is set to 'preserve'.
+main.cjs(2,9): error TS1293: ECMAScript module syntax is not allowed in a CommonJS module when 'module' is set to 'preserve'.
+
+
+==== dep.cjs (0 errors) ====
+    module.exports.readFile = function () {};
+    
+==== main.cjs (1 errors) ====
+    // CommonJS `require` is not ESM syntax, in destructured or plain form.
+    const { readFile } = require("./dep.cjs");
+            ~~~~~~~~
+!!! error TS1293: ECMAScript module syntax is not allowed in a CommonJS module when 'module' is set to 'preserve'.
+    const dep = require("./dep.cjs");
+    readFile;
+    dep;
+    
+==== esm.cjs (1 errors) ====
+    // Genuine ESM syntax in a CommonJS file must still be an error.
+    import { readFile as fromEsm } from "./dep.cjs";
+             ~~~~~~~~~~~~~~~~~~~
+!!! error TS1293: ECMAScript module syntax is not allowed in a CommonJS module when 'module' is set to 'preserve'.
+    fromEsm;
+    

--- a/testdata/baselines/reference/compiler/modulePreserveRequireDestructuring.symbols
+++ b/testdata/baselines/reference/compiler/modulePreserveRequireDestructuring.symbols
@@ -1,0 +1,37 @@
+//// [tests/cases/compiler/modulePreserveRequireDestructuring.ts] ////
+
+=== dep.cjs ===
+module.exports.readFile = function () {};
+>module.exports.readFile : Symbol(readFile, Decl(dep.cjs, 0, 0))
+>module.exports : Symbol(exports, Decl(dep.cjs, 0, 0))
+>module : Symbol(module, Decl(dep.cjs, 0, 0))
+>exports : Symbol(exports, Decl(dep.cjs, 0, 0))
+>readFile : Symbol(readFile, Decl(dep.cjs, 0, 0))
+
+=== main.cjs ===
+// CommonJS `require` is not ESM syntax, in destructured or plain form.
+const { readFile } = require("./dep.cjs");
+>readFile : Symbol(readFile, Decl(main.cjs, 1, 7))
+>require : Symbol(require)
+>"./dep.cjs" : Symbol(dep, Decl(dep.cjs, 0, 0))
+
+const dep = require("./dep.cjs");
+>dep : Symbol(dep, Decl(main.cjs, 2, 5))
+>require : Symbol(require)
+>"./dep.cjs" : Symbol(dep, Decl(dep.cjs, 0, 0))
+
+readFile;
+>readFile : Symbol(readFile, Decl(main.cjs, 1, 7))
+
+dep;
+>dep : Symbol(dep, Decl(main.cjs, 2, 5))
+
+=== esm.cjs ===
+// Genuine ESM syntax in a CommonJS file must still be an error.
+import { readFile as fromEsm } from "./dep.cjs";
+>readFile : Symbol(fromEsm, Decl(dep.cjs, 0, 0))
+>fromEsm : Symbol(fromEsm, Decl(esm.cjs, 1, 8))
+
+fromEsm;
+>fromEsm : Symbol(fromEsm, Decl(esm.cjs, 1, 8))
+

--- a/testdata/baselines/reference/compiler/modulePreserveRequireDestructuring.types
+++ b/testdata/baselines/reference/compiler/modulePreserveRequireDestructuring.types
@@ -1,0 +1,41 @@
+//// [tests/cases/compiler/modulePreserveRequireDestructuring.ts] ////
+
+=== dep.cjs ===
+module.exports.readFile = function () {};
+>module.exports.readFile = function () {} : () => void
+>module.exports.readFile : () => void
+>module.exports : typeof import("./dep.cjs")
+>module : { exports: typeof import("./dep.cjs"); }
+>exports : typeof import("./dep.cjs")
+>readFile : () => void
+>function () {} : () => void
+
+=== main.cjs ===
+// CommonJS `require` is not ESM syntax, in destructured or plain form.
+const { readFile } = require("./dep.cjs");
+>readFile : () => void
+>require("./dep.cjs") : typeof dep
+>require : any
+>"./dep.cjs" : "./dep.cjs"
+
+const dep = require("./dep.cjs");
+>dep : typeof dep
+>require("./dep.cjs") : typeof dep
+>require : any
+>"./dep.cjs" : "./dep.cjs"
+
+readFile;
+>readFile : () => void
+
+dep;
+>dep : typeof dep
+
+=== esm.cjs ===
+// Genuine ESM syntax in a CommonJS file must still be an error.
+import { readFile as fromEsm } from "./dep.cjs";
+>readFile : () => void
+>fromEsm : () => void
+
+fromEsm;
+>fromEsm : () => void
+

--- a/testdata/tests/cases/compiler/modulePreserveRequireDestructuring.ts
+++ b/testdata/tests/cases/compiler/modulePreserveRequireDestructuring.ts
@@ -1,0 +1,22 @@
+// @target: esnext
+// @module: preserve
+// @moduleResolution: bundler
+// @verbatimModuleSyntax: true
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+
+// @filename: dep.cjs
+module.exports.readFile = function () {};
+
+// @filename: main.cjs
+// CommonJS `require` is not ESM syntax, in destructured or plain form.
+const { readFile } = require("./dep.cjs");
+const dep = require("./dep.cjs");
+readFile;
+dep;
+
+// @filename: esm.cjs
+// Genuine ESM syntax in a CommonJS file must still be an error.
+import { readFile as fromEsm } from "./dep.cjs";
+fromEsm;


### PR DESCRIPTION
Fixes microsoft/TypeScript#63696

## Analysis

In a `.cjs` file checked with `checkJs`, a destructured `require` is reported as ESM syntax:

```js
// main.cjs
const { readFile } = require("./dep.cjs"); // error TS1293
const dep = require("./dep.cjs");          // no error
```

`checkAliasSymbol` runs for every alias declaration, and three members of
`AliasDeclarationNode` are CommonJS `require` forms rather than ESM syntax:

- `ImportEqualsDeclaration`: `import fs = require("node:fs")`
- `VariableDeclarationInitializedTo<RequireOrImportCall | AccessExpression>`: `const fs = require("node:fs")`
- `BindingElementOfBareOrAccessedRequire`: `const { readFile } = require("node:fs")`

The `--module preserve` branch excluded the first two but not the third, so a
destructured `require` was treated as ESM. This is also why the error is
reported on the binding name rather than on the statement.

The check was introduced upstream in microsoft/TypeScript#58825 (TypeScript 5.6,
matching the reported 5.5 to 5.6 regression) and ported here as-is. It is still
present in 5.9, so per CONTRIBUTING it is fixed here rather than in Strada.

## Fix

Exclude binding elements from the check, alongside the two `require` forms that
were already exempt.

I also considered adding `!ast.IsInJSFile(node)` to mirror the
`verbatimModuleSyntax` branch directly above, but rejected it: this is the only
site that reports TS1293, and ESM imports in a `.cjs` file are reported through
their `ImportSpecifier`/`ImportClause` aliases, so exempting JS files wholesale
would stop flagging genuine ESM syntax in CommonJS JavaScript. Within
`AliasDeclarationNode`, a `BindingElement` can only ever be a `require`
destructure, so excluding it is the narrow fix.

The new test covers the destructured form, the plain form as a control, and, in
a separate file, a real ESM import in a `.cjs` file, which must still error. The
baseline keeps that error, demonstrating the fix does not over-broaden.

## Copilot Checklist

I successfully ran these commands at the end of my session, and they completed without error:
 * [x] npx hereby build
 * [x] npx hereby test
 * [x] npx hereby lint
 * [x] npx hereby format

---

**AI assistance disclosure:** This change was authored with assistance from
Claude Code. I have reviewed and understand the resulting changes and will
respond to review feedback.