### PR TITLE
Fix panic when serializing empty tuple array literal types

### DIFF
--- a/internal/api/proto.go
+++ b/internal/api/proto.go
@@ -738,8 +738,8 @@ func newTypeResponse(t *checker.Type, id TypeID) *TypeResponse {
 		if objectFlags&checker.ObjectFlagsReference != 0 {
 			var ref *checker.TypeReference
 			if objectFlags&checker.ObjectFlagsTuple != 0 {
-				tuple := t.AsTupleType()
-				ref = tuple.AsTypeReference()
+				ref = t.AsTypeReference()
+				tuple := t.TargetTupleType()
 				resp.ElementFlags = tuple.ElementFlags()
 				fixedLen := tuple.FixedLength()
 				resp.FixedLength = &fixedLen

--- a/internal/api/session_typeatlocation_test.go
+++ b/internal/api/session_typeatlocation_test.go
@@ -1,0 +1,199 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/ast"
+	"github.com/microsoft/typescript-go/internal/bundled"
+	"github.com/microsoft/typescript-go/internal/testutil/projecttestutil"
+	"gotest.tools/v3/assert"
+)
+
+// TestGetTypeAtLocationTupleTypes asks for the type of one node per case and turns
+// it into a TypeResponse, covering the shapes an array literal or a tuple
+// annotation can produce.
+//
+// An array literal contextually typed by an empty tuple is the interesting case:
+// createTupleTypeEx returns the synthesized tuple target itself at arity zero, and
+// createArrayLiteralType then clones it with cloneTypeReference, which keeps
+// ObjectFlagsTuple while storing TypeReference data. Such a type cannot be cast
+// with AsTupleType, so its tuple shape has to be read off the target.
+func TestGetTypeAtLocationTupleTypes(t *testing.T) {
+	t.Parallel()
+	if !bundled.Embedded {
+		t.Skip("bundled files are not embedded")
+	}
+
+	testCases := []struct {
+		name string
+		// content is the whole source file; the type is taken from the first node
+		// of kind kind.
+		content string
+		kind    ast.Kind
+		// expectedType is the type the checker prints for that node.
+		expectedType string
+		// Tuple metadata is only carried by types that have ObjectFlagsTuple set,
+		// which in practice means empty tuple targets and clones of them; other
+		// tuples are plain references that describe their shape through Target.
+		expectedTupleMetadata bool
+		expectedFixedLength   int
+		expectedReadonly      bool
+	}{
+		{
+			name:                  "array literal for an empty readonly tuple parameter",
+			content:               "declare function f(t: readonly []): void;\nexport const g = () => f([]);",
+			kind:                  ast.KindArrayLiteralExpression,
+			expectedType:          "[]",
+			expectedTupleMetadata: true,
+		},
+		{
+			name:                  "array literal for an empty mutable tuple parameter",
+			content:               "declare function f(t: []): void;\nexport const g = () => f([]);",
+			kind:                  ast.KindArrayLiteralExpression,
+			expectedType:          "[]",
+			expectedTupleMetadata: true,
+		},
+		{
+			name:                  "array literal for an empty tuple annotation",
+			content:               "export const x: readonly [] = [];",
+			kind:                  ast.KindArrayLiteralExpression,
+			expectedType:          "[]",
+			expectedTupleMetadata: true,
+		},
+		{
+			name:                  "array literal for an empty tuple reached through an alias",
+			content:               "type E = readonly [];\nexport const x: E = [];",
+			kind:                  ast.KindArrayLiteralExpression,
+			expectedType:          "[]",
+			expectedTupleMetadata: true,
+		},
+		{
+			name:                  "array literal for an empty tuple property",
+			content:               "declare function h(o: { items: readonly [] }): void;\nexport const g = () => h({ items: [] });",
+			kind:                  ast.KindArrayLiteralExpression,
+			expectedType:          "[]",
+			expectedTupleMetadata: true,
+		},
+		{
+			name:                  "array literal asserted to an empty tuple",
+			content:               "declare function f<T extends readonly unknown[]>(t: T): T;\nexport const g = () => f([] as readonly []);",
+			kind:                  ast.KindArrayLiteralExpression,
+			expectedType:          "[]",
+			expectedTupleMetadata: true,
+		},
+		{
+			name:                  "empty tuple type node",
+			content:               "export const x: readonly [] = [];",
+			kind:                  ast.KindTupleType,
+			expectedType:          "readonly []",
+			expectedTupleMetadata: true,
+			expectedReadonly:      true,
+		},
+		{
+			name:                  "identifier annotated with an empty tuple",
+			content:               "const x: readonly [] = [];\nexport { x };",
+			kind:                  ast.KindIdentifier,
+			expectedType:          "readonly []",
+			expectedTupleMetadata: true,
+			expectedReadonly:      true,
+		},
+		{
+			name:         "array literal for a single element tuple parameter",
+			content:      "declare function f(t: readonly [number]): void;\nexport const g = () => f([1]);",
+			kind:         ast.KindArrayLiteralExpression,
+			expectedType: "[number]",
+		},
+		{
+			name:         "array literal for a single element tuple annotation",
+			content:      "export const x: readonly [number] = [1];",
+			kind:         ast.KindArrayLiteralExpression,
+			expectedType: "[number]",
+		},
+		{
+			name:         "single element tuple type node",
+			content:      "export const x: readonly [number] = [1];",
+			kind:         ast.KindTupleType,
+			expectedType: "readonly [number]",
+		},
+		{
+			name:         "array literal for an array parameter",
+			content:      "declare function f(t: number[]): void;\nexport const g = () => f([]);",
+			kind:         ast.KindArrayLiteralExpression,
+			expectedType: "never[]",
+		},
+		{
+			name:         "array literal without a contextual type",
+			content:      "export const x = [];",
+			kind:         ast.KindArrayLiteralExpression,
+			expectedType: "never[]",
+		},
+	}
+
+	const fileName = "/home/projects/p/src/index.ts"
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			projectSession, _ := projecttestutil.Setup(map[string]any{
+				"/home/projects/p/tsconfig.json": `{ "compilerOptions": { "strict": true } }`,
+				fileName:                         testCase.content,
+			})
+			defer projectSession.Close()
+			session := NewSession(projectSession, nil)
+			defer session.Close()
+
+			ctx := context.Background()
+			snapshot, err := session.handleUpdateSnapshot(ctx, &UpdateSnapshotParams{
+				OpenFiles: []DocumentIdentifier{{FileName: fileName}},
+			})
+			assert.NilError(t, err)
+			assert.Assert(t, len(snapshot.Projects) > 0, "expected at least one project")
+
+			setup, err := session.setupChecker(ctx, snapshot.Snapshot, snapshot.Projects[0].Id)
+			assert.NilError(t, err)
+			defer setup.done()
+
+			sourceFile := setup.program.GetSourceFile(fileName)
+			assert.Assert(t, sourceFile != nil, "expected %s to be part of the program", fileName)
+			node := findFirstNodeOfKind(sourceFile.AsNode(), testCase.kind)
+			assert.Assert(t, node != nil, "expected a node of kind %s", testCase.kind.String())
+
+			nodeType := setup.checker.GetTypeAtLocation(node)
+			assert.Equal(t, setup.checker.TypeToString(nodeType), testCase.expectedType)
+
+			response := setup.newTypeResponse(nodeType)
+			assert.Assert(t, response != nil)
+			assert.Assert(t, response.Target != 0, "expected a target type")
+
+			if !testCase.expectedTupleMetadata {
+				assert.Assert(t, response.FixedLength == nil, "expected no tuple metadata")
+				assert.Assert(t, response.TupleReadonly == nil, "expected no tuple metadata")
+				return
+			}
+			assert.Assert(t, response.FixedLength != nil, "expected tuple metadata")
+			assert.Equal(t, *response.FixedLength, testCase.expectedFixedLength)
+			assert.Assert(t, response.TupleReadonly != nil, "expected tuple metadata")
+			assert.Equal(t, *response.TupleReadonly, testCase.expectedReadonly)
+			assert.Equal(t, len(response.ElementFlags), testCase.expectedFixedLength)
+		})
+	}
+}
+
+func findFirstNodeOfKind(node *ast.Node, kind ast.Kind) *ast.Node {
+	var found *ast.Node
+	var visit ast.Visitor
+	visit = func(child *ast.Node) bool {
+		if found != nil {
+			return true
+		}
+		if child.Kind == kind {
+			found = child
+			return true
+		}
+		return child.ForEachChild(visit)
+	}
+	visit(node)
+	return found
+}


### PR DESCRIPTION
Fixes #4804

> [!NOTE]
> **AI assistance disclosure** (per [CONTRIBUTING.md](https://github.com/microsoft/typescript-go/blob/main/CONTRIBUTING.md#use-of-ai-assistance)): this patch and its description were authored with the help of an AI coding tool (Claude Code). I hit this crash in my own project, chose to fix this specific issue myself, have read and understand the change, and will be the one responding to review feedback here.

Asking the API for the type of an array literal contextually typed by an empty tuple kills the tsgo server:

```ts
declare function f(t: readonly []): void;
const g = () => f([]);   // checker.getTypeAtLocation on `[]`
```

```
panic: interface conversion: checker.TypeData is *checker.TypeReference, not *checker.TupleType
github.com/microsoft/typescript-go/internal/checker.(*Type).AsTupleType(...)
	internal/checker/types.go:700
github.com/microsoft/typescript-go/internal/api.newTypeResponse(...)
	internal/api/proto.go:741
github.com/microsoft/typescript-go/internal/api.(*Session).handleGetTypeAtLocation(...)
	internal/api/session.go:1532
```

`tsc --noEmit` on the same file is clean, and the TypeScript 6 API returns `[]` for it, so this is specific to how the type is serialized.

## Cause

`newTypeResponse` treats `ObjectFlagsTuple` as proof that the type holds `*checker.TupleType` data:

```go
if objectFlags&checker.ObjectFlagsTuple != 0 {
	tuple := t.AsTupleType()
```

That holds for a synthesized tuple target, but not for a clone of one. `createArrayLiteralType` clones the array literal's type through `cloneTypeReference`, which allocates `*checker.TypeReference` data and then copies the source's object flags over it, `ObjectFlagsTuple` included — so the flags claim a tuple while the data is a type reference, contradicting the invariant documented above `ObjectType` in `internal/checker/types.go`.

Only empty tuples get there: `createTupleTypeEx` returns the tuple target itself at arity zero, while every other arity returns a plain type reference that never had `ObjectFlagsTuple` set. That is why `[1]` against `readonly [number]` is fine and `[]` against `readonly []` is not, and why the same empty tuple type reached through a type node or an annotated identifier serializes fine — those are the target, not a clone.

The checker itself is unaffected, since `isTupleType` and friends test `Target().objectFlags` rather than the type's own flags.

## Fix

Read the tuple shape off the target rather than casting the type itself. A tuple target's target is itself, so this works for both the target and a clone of it.

`proto.go:760` (`t.AsInterfaceType()`, guarded by `ObjectFlagsClassOrInterface`) makes the same assumption and would break the same way if a class or interface target were ever cloned; both current `cloneTypeReference` call sites happen to be tuple paths, so I left it alone.

## Tests

`TestGetTypeAtLocationTupleTypes` in `internal/api/session_typeatlocation_test.go` covers thirteen cases — the six array literal shapes that panicked, empty tuple targets reached through a type node and through an identifier, single element tuples, and arrays — asserting the printed type and the tuple metadata on the response. It panics without this change.

`go test ./...` is green, including an uncached `go test -count=1 ./internal/testrunner/...` (117111 subtests).


