### PR TITLE
Avoid false symlink mappings for physical dependencies

### DIFF
--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -2093,7 +2093,7 @@ func (p *Program) GetSymlinkCache() *symlinks.KnownSymlinks {
 					}
 				}
 
-				if packageResolution := p.resolver.ResolvePackageDirectory(dep, packageJsonName, core.ResolutionModeCommonJS, nil); packageResolution.IsResolved() {
+				if packageResolution := p.resolver.ResolvePackageDirectory(dep, packageJsonName, core.ResolutionModeCommonJS, nil); packageResolution.IsResolved() && packageResolution.OriginalPath != "" {
 					knownSymlinks.ProcessResolution(
 						tspath.CombinePaths(packageResolution.OriginalPath, "package.json"),
 						tspath.CombinePaths(packageResolution.ResolvedFileName, "package.json"),

--- a/testdata/baselines/reference/compiler/jsDeclarationEmitDoesNotReuseUnrelatedJSDocImport.js
+++ b/testdata/baselines/reference/compiler/jsDeclarationEmitDoesNotReuseUnrelatedJSDocImport.js
@@ -1,0 +1,82 @@
+//// [tests/cases/compiler/jsDeclarationEmitDoesNotReuseUnrelatedJSDocImport.ts] ////
+
+//// [package.json]
+{
+  "name": "project",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "external": "1.0.0"
+  }
+}
+
+//// [package.json]
+{
+  "name": "external",
+  "version": "1.0.0",
+  "type": "module",
+  "types": "types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./types/index.d.ts",
+      "default": "./src/index.js"
+    },
+    "./src/*.js": {
+      "types": "./src/*.d.ts",
+      "default": "./src/*.js"
+    }
+  }
+}
+
+//// [index.d.ts]
+export type SchemaElement = import('../src/types.d.ts').SchemaElement;
+
+//// [types.d.ts]
+export interface SchemaElement {
+  name: string;
+}
+
+//// [index.js]
+
+//// [types.d.ts]
+import type { SchemaElement } from 'external';
+
+export interface Writer {}
+
+//// [index.js]
+/**
+ * @import {SchemaElement} from 'external'
+ * @import {Writer} from '../src/types.js'
+ */
+
+export class Example {
+  /**
+   * @param {object} options
+   * @param {SchemaElement[]} options.schema
+   */
+  constructor({ schema }) {
+    this.schema = schema;
+  }
+}
+
+
+
+
+//// [index.d.ts]
+export {};
+//// [index.d.ts]
+/**
+ * @import {SchemaElement} from 'external'
+ * @import {Writer} from '../src/types.js'
+ */
+import type { SchemaElement } from 'external';
+export declare class Example {
+    schema: import("external/src/types.js").SchemaElement[];
+    /**
+     * @param {object} options
+     * @param {SchemaElement[]} options.schema
+     */
+    constructor({ schema }: {
+        schema: SchemaElement[];
+    });
+}

--- a/testdata/tests/cases/compiler/jsDeclarationEmitDoesNotReuseUnrelatedJSDocImport.ts
+++ b/testdata/tests/cases/compiler/jsDeclarationEmitDoesNotReuseUnrelatedJSDocImport.ts
@@ -1,0 +1,68 @@
+// @allowJs: true
+// @checkJs: true
+// @declaration: true
+// @emitDeclarationOnly: true
+// @module: nodenext
+// @outDir: /out
+// @strict: true
+// @currentDirectory: /
+// @noTypesAndSymbols: true
+
+// @filename: /package.json
+{
+  "name": "project",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "external": "1.0.0"
+  }
+}
+
+// @filename: /node_modules/external/package.json
+{
+  "name": "external",
+  "version": "1.0.0",
+  "type": "module",
+  "types": "types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./types/index.d.ts",
+      "default": "./src/index.js"
+    },
+    "./src/*.js": {
+      "types": "./src/*.d.ts",
+      "default": "./src/*.js"
+    }
+  }
+}
+
+// @filename: /node_modules/external/types/index.d.ts
+export type SchemaElement = import('../src/types.d.ts').SchemaElement;
+
+// @filename: /node_modules/external/src/types.d.ts
+export interface SchemaElement {
+  name: string;
+}
+
+// @filename: /node_modules/external/src/index.js
+
+// @filename: /src/types.d.ts
+import type { SchemaElement } from 'external';
+
+export interface Writer {}
+
+// @filename: /src/index.js
+/**
+ * @import {SchemaElement} from 'external'
+ * @import {Writer} from '../src/types.js'
+ */
+
+export class Example {
+  /**
+   * @param {object} options
+   * @param {SchemaElement[]} options.schema
+   */
+  constructor({ schema }) {
+    this.schema = schema;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes declaration emit incorrectly reusing an unrelated JSDoc import when referencing a type from a physically installed dependency.

Related issue: microsoft/TypeScript#63705  
Reproduction: https://github.com/platypii/typescript-7-jsdoc-private-alias-repro

## Root cause

For a normal, non-symlinked package, `ResolvePackageDirectory` returns a resolved package directory with an empty `OriginalPath`.

`GetSymlinkCache` appended `package.json` to that empty path before calling `ProcessResolution`. This produced the relative path `package.json`, which was then resolved against the project directory. As a result, the symlink cache incorrectly recorded the project root as a symlink to the dependency.

The module specifier generator could consequently treat a project source file as an alternative location for the dependency's type and reuse an unrelated JSDoc module specifier. This produced declarations such as:

```ts
schema: import("../src/types.js").SchemaElement[];
```

even though that module does not export `SchemaElement`.

## Fix

Only add package-directory resolutions to the symlink cache when `OriginalPath` is non-empty. An empty `OriginalPath` means there is no symlink mapping to record.

A regression test verifies that declaration emit instead references the type's public external source:

```ts
schema: import("external/src/types.js").SchemaElement[];
```

## Reproduction note

The standalone reproduction contains `.npmrc` with `install-links=true` only because it models the dependency using a local `file:` package, which npm would otherwise install as a symlink.

Registry dependencies are normally installed as physical directories under `node_modules`, so users do not need this npm setting to encounter the bug in a real project.

## Tests

- `go test ./internal/testrunner -run 'TestLocal/jsDeclarationEmitDoesNotReuseUnrelatedJSDocImport' -count=1`
- `go test ./internal/compiler ./internal/modulespecifiers ./internal/symlinks`
