### PR TITLE
Order variance computation by associated type symbol

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -791,7 +791,6 @@ type Checker struct {
 	typeofType                                  *Type
 	typeResolutions                             []TypeResolution
 	resolutionStart                             int
-	inVarianceComputation                       bool
 	varianceStack                               []VarianceStackEntry
 	apparentArgumentCount                       *int
 	lastGetCombinedNodeFlagsNode                *ast.Node

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -542,6 +542,11 @@ type WideningContext struct {
 	widenedTypes       map[*Type]*Type
 }
 
+type VarianceStackEntry struct {
+	symbol         *ast.Symbol
+	typeParameters []*Type
+}
+
 const maxSerializationLevel = 2
 
 type Program interface {
@@ -787,6 +792,7 @@ type Checker struct {
 	typeResolutions                             []TypeResolution
 	resolutionStart                             int
 	inVarianceComputation                       bool
+	varianceStack                               []VarianceStackEntry
 	apparentArgumentCount                       *int
 	lastGetCombinedNodeFlagsNode                *ast.Node
 	lastGetCombinedNodeFlagsResult              ast.NodeFlags

--- a/internal/checker/relater.go
+++ b/internal/checker/relater.go
@@ -1339,6 +1339,7 @@ func (c *Checker) getAliasVariances(symbol *ast.Symbol) []VarianceFlags {
 // instantiations of the generic type for type arguments with known relations. The function
 // returns an empty slice when invoked recursively for the given generic type.
 func (c *Checker) getVariancesWorker(symbol *ast.Symbol, typeParameters []*Type) []VarianceFlags {
+	var variances []VarianceFlags
 	links := c.varianceLinks.Get(symbol)
 	if links.variances == nil {
 		var traceArgs map[string]any
@@ -1354,60 +1355,91 @@ func (c *Checker) getVariancesWorker(symbol *ast.Symbol, typeParameters []*Type)
 				popFn()
 			}()
 		}
-		oldVarianceComputation := c.inVarianceComputation
-		saveResolutionStart := c.resolutionStart
-		if !c.inVarianceComputation {
-			c.inVarianceComputation = true
-			c.resolutionStart = len(c.typeResolutions)
-		}
-		links.variances = []VarianceFlags{}
-		variances := make([]VarianceFlags, len(typeParameters))
-		for i, tp := range typeParameters {
-			modifiers := c.getTypeParameterModifiers(tp)
-			var variance VarianceFlags
-			switch {
-			case modifiers&ast.ModifierFlagsOut != 0:
-				if modifiers&ast.ModifierFlagsIn != 0 {
-					variance = VarianceFlagsInvariant
-				} else {
-					variance = VarianceFlagsCovariant
-				}
-			case modifiers&ast.ModifierFlagsIn != 0:
-				variance = VarianceFlagsContravariant
-			default:
-				saveReliabilityFlags := c.reliabilityFlags
-				c.reliabilityFlags = 0
-				// We first compare instantiations where the type parameter is replaced with
-				// marker types that have a known subtype relationship. From this we can infer
-				// invariance, covariance, contravariance or bivariance.
-				typeWithSuper := c.createMarkerType(symbol, tp, c.markerSuperType)
-				typeWithSub := c.createMarkerType(symbol, tp, c.markerSubType)
-				variance = core.IfElse(c.isTypeAssignableTo(typeWithSub, typeWithSuper), VarianceFlagsCovariant, 0) |
-					core.IfElse(c.isTypeAssignableTo(typeWithSuper, typeWithSub), VarianceFlagsContravariant, 0)
-				// If the instantiations appear to be related bivariantly it may be because the
-				// type parameter is independent (i.e. it isn't witnessed anywhere in the generic
-				// type). To determine this we compare instantiations where the type parameter is
-				// replaced with marker types that are known to be unrelated.
-				if variance == VarianceFlagsBivariant && c.isTypeAssignableTo(c.createMarkerType(symbol, tp, c.markerOtherType), typeWithSuper) {
-					variance = VarianceFlagsIndependent
-				}
-				if c.reliabilityFlags&RelationComparisonResultReportsUnmeasurable != 0 {
-					variance |= VarianceFlagsUnmeasurable
-				}
-				if c.reliabilityFlags&RelationComparisonResultReportsUnreliable != 0 {
-					variance |= VarianceFlagsUnreliable
-				}
-				c.reliabilityFlags = saveReliabilityFlags
+		if !c.varianceStackContains(symbol) {
+			c.varianceStack = append(c.varianceStack, VarianceStackEntry{symbol, typeParameters})
+			oldVarianceComputation := c.inVarianceComputation
+			saveResolutionStart := c.resolutionStart
+			if !c.inVarianceComputation {
+				c.inVarianceComputation = true
+				c.resolutionStart = len(c.typeResolutions)
 			}
-			variances[i] = variance
+			variances = make([]VarianceFlags, len(typeParameters))
+			for i, tp := range typeParameters {
+				modifiers := c.getTypeParameterModifiers(tp)
+				var variance VarianceFlags
+				switch {
+				case modifiers&ast.ModifierFlagsOut != 0:
+					if modifiers&ast.ModifierFlagsIn != 0 {
+						variance = VarianceFlagsInvariant
+					} else {
+						variance = VarianceFlagsCovariant
+					}
+				case modifiers&ast.ModifierFlagsIn != 0:
+					variance = VarianceFlagsContravariant
+				default:
+					saveReliabilityFlags := c.reliabilityFlags
+					c.reliabilityFlags = 0
+					// We first compare instantiations where the type parameter is replaced with
+					// marker types that have a known subtype relationship. From this we can infer
+					// invariance, covariance, contravariance or bivariance.
+					typeWithSuper := c.createMarkerType(symbol, tp, c.markerSuperType)
+					typeWithSub := c.createMarkerType(symbol, tp, c.markerSubType)
+					variance = core.IfElse(c.isTypeAssignableTo(typeWithSub, typeWithSuper), VarianceFlagsCovariant, 0) |
+						core.IfElse(c.isTypeAssignableTo(typeWithSuper, typeWithSub), VarianceFlagsContravariant, 0)
+					// If the instantiations appear to be related bivariantly it may be because the
+					// type parameter is independent (i.e. it isn't witnessed anywhere in the generic
+					// type). To determine this we compare instantiations where the type parameter is
+					// replaced with marker types that are known to be unrelated.
+					if variance == VarianceFlagsBivariant && c.isTypeAssignableTo(c.createMarkerType(symbol, tp, c.markerOtherType), typeWithSuper) {
+						variance = VarianceFlagsIndependent
+					}
+					if c.reliabilityFlags&RelationComparisonResultReportsUnmeasurable != 0 {
+						variance |= VarianceFlagsUnmeasurable
+					}
+					if c.reliabilityFlags&RelationComparisonResultReportsUnreliable != 0 {
+						variance |= VarianceFlagsUnreliable
+					}
+					c.reliabilityFlags = saveReliabilityFlags
+				}
+				variances[i] = variance
+			}
+			if !oldVarianceComputation {
+				c.inVarianceComputation = false
+				c.resolutionStart = saveResolutionStart
+			}
+			if len(links.variances) == 0 {
+				links.variances = variances
+			}
+			c.varianceStack = c.varianceStack[:len(c.varianceStack)-1]
+		} else {
+			// Circularity
+			minIndex := 0
+			for i := 1; i < len(c.varianceStack); i++ {
+				if c.compareSymbols(c.varianceStack[i].symbol, c.varianceStack[minIndex].symbol) < 0 {
+					minIndex = i
+				}
+			}
+			if minIndex > 0 {
+				saveVarianceStack := c.varianceStack
+				c.varianceStack = nil
+				c.getVariancesWorker(saveVarianceStack[minIndex].symbol, saveVarianceStack[minIndex].typeParameters)
+				c.varianceStack = saveVarianceStack
+			}
+			if len(links.variances) == 0 {
+				links.variances = []VarianceFlags{}
+			}
 		}
-		if !oldVarianceComputation {
-			c.inVarianceComputation = false
-			c.resolutionStart = saveResolutionStart
-		}
-		links.variances = variances
 	}
 	return links.variances
+}
+
+func (c *Checker) varianceStackContains(symbol *ast.Symbol) bool {
+	for _, entry := range c.varianceStack {
+		if entry.symbol == symbol {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Checker) createMarkerType(symbol *ast.Symbol, source *Type, target *Type) *Type {

--- a/internal/checker/relater.go
+++ b/internal/checker/relater.go
@@ -1354,7 +1354,8 @@ func (c *Checker) getVariancesWorker(symbol *ast.Symbol, typeParameters []*Type)
 				popFn()
 			}()
 		}
-		if !c.varianceStackContains(symbol) {
+		stackIndex := c.getVarianceStackIndex(symbol)
+		if stackIndex < 0 {
 			saveResolutionStart := c.resolutionStart
 			if len(c.varianceStack) == 0 {
 				c.resolutionStart = len(c.typeResolutions)
@@ -1415,15 +1416,16 @@ func (c *Checker) getVariancesWorker(symbol *ast.Symbol, typeParameters []*Type)
 			}
 		} else {
 			// We've detected a circularity. Since we may compute different variances depending on where
-			// we enter a circularity, we find the generic type with the "smallest" symbol and restart the
-			// computation from there if necessary. This ensures stable results for circular generic types.
-			minIndex := 0
-			for i := 1; i < len(c.varianceStack); i++ {
+			// we enter a circularity, we find the generic type with the "smallest" symbol in the circular
+			// region of the variance stack and restart the computation from there if necessary. This
+			// ensures stable results for circular generic types.
+			minIndex := stackIndex
+			for i := stackIndex + 1; i < len(c.varianceStack); i++ {
 				if c.compareSymbols(c.varianceStack[i].symbol, c.varianceStack[minIndex].symbol) < 0 {
 					minIndex = i
 				}
 			}
-			if minIndex > 0 {
+			if minIndex > stackIndex {
 				saveVarianceStack := c.varianceStack
 				c.varianceStack = nil
 				c.getVariancesWorker(saveVarianceStack[minIndex].symbol, saveVarianceStack[minIndex].typeParameters)
@@ -1439,13 +1441,13 @@ func (c *Checker) getVariancesWorker(symbol *ast.Symbol, typeParameters []*Type)
 	return links.variances
 }
 
-func (c *Checker) varianceStackContains(symbol *ast.Symbol) bool {
-	for _, entry := range c.varianceStack {
+func (c *Checker) getVarianceStackIndex(symbol *ast.Symbol) int {
+	for i, entry := range c.varianceStack {
 		if entry.symbol == symbol {
-			return true
+			return i
 		}
 	}
-	return false
+	return -1
 }
 
 func (c *Checker) createMarkerType(symbol *ast.Symbol, source *Type, target *Type) *Type {

--- a/internal/checker/relater.go
+++ b/internal/checker/relater.go
@@ -1356,13 +1356,11 @@ func (c *Checker) getVariancesWorker(symbol *ast.Symbol, typeParameters []*Type)
 			}()
 		}
 		if !c.varianceStackContains(symbol) {
-			c.varianceStack = append(c.varianceStack, VarianceStackEntry{symbol, typeParameters})
-			oldVarianceComputation := c.inVarianceComputation
 			saveResolutionStart := c.resolutionStart
-			if !c.inVarianceComputation {
-				c.inVarianceComputation = true
+			if len(c.varianceStack) == 0 {
 				c.resolutionStart = len(c.typeResolutions)
 			}
+			c.varianceStack = append(c.varianceStack, VarianceStackEntry{symbol, typeParameters})
 			variances = make([]VarianceFlags, len(typeParameters))
 			for i, tp := range typeParameters {
 				modifiers := c.getTypeParameterModifiers(tp)
@@ -1401,18 +1399,25 @@ func (c *Checker) getVariancesWorker(symbol *ast.Symbol, typeParameters []*Type)
 					}
 					c.reliabilityFlags = saveReliabilityFlags
 				}
+				// If variance computation was restarted due to a circularity we may have already
+				// computed variances for this generic type. If so, we exit early.
+				if len(links.variances) != 0 {
+					break
+				}
 				variances[i] = variance
 			}
-			if !oldVarianceComputation {
-				c.inVarianceComputation = false
-				c.resolutionStart = saveResolutionStart
-			}
+			// Store the results unless a restarted computation has already stored them.
 			if len(links.variances) == 0 {
 				links.variances = variances
 			}
 			c.varianceStack = c.varianceStack[:len(c.varianceStack)-1]
+			if len(c.varianceStack) == 0 {
+				c.resolutionStart = saveResolutionStart
+			}
 		} else {
-			// Circularity
+			// We've detected a circularity. Since we may compute different variances depending on where
+			// we enter a circularity, we find the generic type with the "smallest" symbol and restart the
+			// computation from there if necessary. This ensures stable results for circular generic types.
 			minIndex := 0
 			for i := 1; i < len(c.varianceStack); i++ {
 				if c.compareSymbols(c.varianceStack[i].symbol, c.varianceStack[minIndex].symbol) < 0 {
@@ -1425,6 +1430,8 @@ func (c *Checker) getVariancesWorker(symbol *ast.Symbol, typeParameters []*Type)
 				c.getVariancesWorker(saveVarianceStack[minIndex].symbol, saveVarianceStack[minIndex].typeParameters)
 				c.varianceStack = saveVarianceStack
 			}
+			// Store an empty slice to mark that we can't compute variances for this type. We treat type
+			// parameters as co-variant in this case.
 			if len(links.variances) == 0 {
 				links.variances = []VarianceFlags{}
 			}
@@ -3962,8 +3969,8 @@ func (r *Relater) typeArgumentsRelatedTo(sources []*Type, targets []*Type, varia
 					related = r.c.compareTypesIdentical(s, t)
 				}
 			} else {
-				// Propagate unreliable variance flag
-				if r.c.inVarianceComputation && varianceFlags&VarianceFlagsUnreliable != 0 {
+				// Propagate unreliable variance flag in variance computations
+				if len(r.c.varianceStack) != 0 && varianceFlags&VarianceFlagsUnreliable != 0 {
 					r.c.instantiateType(s, r.c.reportUnreliableMapper)
 				}
 				if variance == VarianceFlagsCovariant {

--- a/internal/checker/relater.go
+++ b/internal/checker/relater.go
@@ -1339,7 +1339,6 @@ func (c *Checker) getAliasVariances(symbol *ast.Symbol) []VarianceFlags {
 // instantiations of the generic type for type arguments with known relations. The function
 // returns an empty slice when invoked recursively for the given generic type.
 func (c *Checker) getVariancesWorker(symbol *ast.Symbol, typeParameters []*Type) []VarianceFlags {
-	var variances []VarianceFlags
 	links := c.varianceLinks.Get(symbol)
 	if links.variances == nil {
 		var traceArgs map[string]any
@@ -1361,7 +1360,7 @@ func (c *Checker) getVariancesWorker(symbol *ast.Symbol, typeParameters []*Type)
 				c.resolutionStart = len(c.typeResolutions)
 			}
 			c.varianceStack = append(c.varianceStack, VarianceStackEntry{symbol, typeParameters})
-			variances = make([]VarianceFlags, len(typeParameters))
+			variances := make([]VarianceFlags, len(typeParameters))
 			for i, tp := range typeParameters {
 				modifiers := c.getTypeParameterModifiers(tp)
 				var variance VarianceFlags

--- a/testdata/baselines/reference/compiler/circularVariance1.errors.txt
+++ b/testdata/baselines/reference/compiler/circularVariance1.errors.txt
@@ -1,0 +1,38 @@
+circularVariance1.ts(18,1): error TS2322: Type 'Foo<unknown>' is not assignable to type 'Foo<string>'.
+  Type 'unknown' is not assignable to type 'string'.
+circularVariance1.ts(23,1): error TS2322: Type 'Bar<string>' is not assignable to type 'Bar<unknown>'.
+  Type 'unknown' is not assignable to type 'string'.
+
+
+==== circularVariance1.ts (2 errors) ====
+    // https://github.com/microsoft/typescript-go/pull/4820
+    
+    type Bar<U> = (x: Baz<U[]>) => void;
+    
+    type Baz<V> = {
+        value: Foo<V[]>;
+    }
+    
+    type Foo<T> = {
+        x: T;
+        f: Bar<T>;
+    }
+    
+    declare let foo1: Foo<unknown>;
+    declare let foo2: Foo<string>;
+    
+    foo1 = foo2;
+    foo2 = foo1;  // Error
+    ~~~~
+!!! error TS2322: Type 'Foo<unknown>' is not assignable to type 'Foo<string>'.
+!!! error TS2322:   Type 'unknown' is not assignable to type 'string'.
+    
+    declare let bar1: Bar<unknown>;
+    declare let bar2: Bar<string>;
+    
+    bar1 = bar2;  // Error
+    ~~~~
+!!! error TS2322: Type 'Bar<string>' is not assignable to type 'Bar<unknown>'.
+!!! error TS2322:   Type 'unknown' is not assignable to type 'string'.
+    bar2 = bar1;
+    

--- a/testdata/baselines/reference/compiler/circularVariance1.symbols
+++ b/testdata/baselines/reference/compiler/circularVariance1.symbols
@@ -1,0 +1,68 @@
+//// [tests/cases/compiler/circularVariance1.ts] ////
+
+=== circularVariance1.ts ===
+// https://github.com/microsoft/typescript-go/pull/4820
+
+type Bar<U> = (x: Baz<U[]>) => void;
+>Bar : Symbol(Bar, Decl(circularVariance1.ts, 0, 0))
+>U : Symbol(U, Decl(circularVariance1.ts, 2, 9))
+>x : Symbol(x, Decl(circularVariance1.ts, 2, 15))
+>Baz : Symbol(Baz, Decl(circularVariance1.ts, 2, 36))
+>U : Symbol(U, Decl(circularVariance1.ts, 2, 9))
+
+type Baz<V> = {
+>Baz : Symbol(Baz, Decl(circularVariance1.ts, 2, 36))
+>V : Symbol(V, Decl(circularVariance1.ts, 4, 9))
+
+    value: Foo<V[]>;
+>value : Symbol(value, Decl(circularVariance1.ts, 4, 15))
+>Foo : Symbol(Foo, Decl(circularVariance1.ts, 6, 1))
+>V : Symbol(V, Decl(circularVariance1.ts, 4, 9))
+}
+
+type Foo<T> = {
+>Foo : Symbol(Foo, Decl(circularVariance1.ts, 6, 1))
+>T : Symbol(T, Decl(circularVariance1.ts, 8, 9))
+
+    x: T;
+>x : Symbol(x, Decl(circularVariance1.ts, 8, 15))
+>T : Symbol(T, Decl(circularVariance1.ts, 8, 9))
+
+    f: Bar<T>;
+>f : Symbol(f, Decl(circularVariance1.ts, 9, 9))
+>Bar : Symbol(Bar, Decl(circularVariance1.ts, 0, 0))
+>T : Symbol(T, Decl(circularVariance1.ts, 8, 9))
+}
+
+declare let foo1: Foo<unknown>;
+>foo1 : Symbol(foo1, Decl(circularVariance1.ts, 13, 11))
+>Foo : Symbol(Foo, Decl(circularVariance1.ts, 6, 1))
+
+declare let foo2: Foo<string>;
+>foo2 : Symbol(foo2, Decl(circularVariance1.ts, 14, 11))
+>Foo : Symbol(Foo, Decl(circularVariance1.ts, 6, 1))
+
+foo1 = foo2;
+>foo1 : Symbol(foo1, Decl(circularVariance1.ts, 13, 11))
+>foo2 : Symbol(foo2, Decl(circularVariance1.ts, 14, 11))
+
+foo2 = foo1;  // Error
+>foo2 : Symbol(foo2, Decl(circularVariance1.ts, 14, 11))
+>foo1 : Symbol(foo1, Decl(circularVariance1.ts, 13, 11))
+
+declare let bar1: Bar<unknown>;
+>bar1 : Symbol(bar1, Decl(circularVariance1.ts, 19, 11))
+>Bar : Symbol(Bar, Decl(circularVariance1.ts, 0, 0))
+
+declare let bar2: Bar<string>;
+>bar2 : Symbol(bar2, Decl(circularVariance1.ts, 20, 11))
+>Bar : Symbol(Bar, Decl(circularVariance1.ts, 0, 0))
+
+bar1 = bar2;  // Error
+>bar1 : Symbol(bar1, Decl(circularVariance1.ts, 19, 11))
+>bar2 : Symbol(bar2, Decl(circularVariance1.ts, 20, 11))
+
+bar2 = bar1;
+>bar2 : Symbol(bar2, Decl(circularVariance1.ts, 20, 11))
+>bar1 : Symbol(bar1, Decl(circularVariance1.ts, 19, 11))
+

--- a/testdata/baselines/reference/compiler/circularVariance1.types
+++ b/testdata/baselines/reference/compiler/circularVariance1.types
@@ -1,0 +1,58 @@
+//// [tests/cases/compiler/circularVariance1.ts] ////
+
+=== circularVariance1.ts ===
+// https://github.com/microsoft/typescript-go/pull/4820
+
+type Bar<U> = (x: Baz<U[]>) => void;
+>Bar : Bar<U>
+>x : Baz<U[]>
+
+type Baz<V> = {
+>Baz : Baz<V>
+
+    value: Foo<V[]>;
+>value : Foo<V[]>
+}
+
+type Foo<T> = {
+>Foo : Foo<T>
+
+    x: T;
+>x : T
+
+    f: Bar<T>;
+>f : Bar<T>
+}
+
+declare let foo1: Foo<unknown>;
+>foo1 : Foo<unknown>
+
+declare let foo2: Foo<string>;
+>foo2 : Foo<string>
+
+foo1 = foo2;
+>foo1 = foo2 : Foo<string>
+>foo1 : Foo<unknown>
+>foo2 : Foo<string>
+
+foo2 = foo1;  // Error
+>foo2 = foo1 : Foo<unknown>
+>foo2 : Foo<string>
+>foo1 : Foo<unknown>
+
+declare let bar1: Bar<unknown>;
+>bar1 : Bar<unknown>
+
+declare let bar2: Bar<string>;
+>bar2 : Bar<string>
+
+bar1 = bar2;  // Error
+>bar1 = bar2 : Bar<string>
+>bar1 : Bar<unknown>
+>bar2 : Bar<string>
+
+bar2 = bar1;
+>bar2 = bar1 : Bar<unknown>
+>bar2 : Bar<string>
+>bar1 : Bar<unknown>
+

--- a/testdata/baselines/reference/compiler/circularVariance2.errors.txt
+++ b/testdata/baselines/reference/compiler/circularVariance2.errors.txt
@@ -1,0 +1,38 @@
+circularVariance2.ts(17,1): error TS2322: Type 'Bar<string>' is not assignable to type 'Bar<unknown>'.
+  Type 'unknown' is not assignable to type 'string'.
+circularVariance2.ts(24,1): error TS2322: Type 'Foo<unknown>' is not assignable to type 'Foo<string>'.
+  Type 'unknown' is not assignable to type 'string'.
+
+
+==== circularVariance2.ts (2 errors) ====
+    // https://github.com/microsoft/typescript-go/pull/4820
+    
+    type Bar<U> = (x: Baz<U[]>) => void;
+    
+    type Baz<V> = {
+        value: Foo<V[]>;
+    }
+    
+    type Foo<T> = {
+        x: T;
+        f: Bar<T>;
+    }
+    
+    declare let bar1: Bar<unknown>;
+    declare let bar2: Bar<string>;
+    
+    bar1 = bar2;  // Error
+    ~~~~
+!!! error TS2322: Type 'Bar<string>' is not assignable to type 'Bar<unknown>'.
+!!! error TS2322:   Type 'unknown' is not assignable to type 'string'.
+    bar2 = bar1;
+    
+    declare let foo1: Foo<unknown>;
+    declare let foo2: Foo<string>;
+    
+    foo1 = foo2;
+    foo2 = foo1;  // Error
+    ~~~~
+!!! error TS2322: Type 'Foo<unknown>' is not assignable to type 'Foo<string>'.
+!!! error TS2322:   Type 'unknown' is not assignable to type 'string'.
+    

--- a/testdata/baselines/reference/compiler/circularVariance2.symbols
+++ b/testdata/baselines/reference/compiler/circularVariance2.symbols
@@ -1,0 +1,68 @@
+//// [tests/cases/compiler/circularVariance2.ts] ////
+
+=== circularVariance2.ts ===
+// https://github.com/microsoft/typescript-go/pull/4820
+
+type Bar<U> = (x: Baz<U[]>) => void;
+>Bar : Symbol(Bar, Decl(circularVariance2.ts, 0, 0))
+>U : Symbol(U, Decl(circularVariance2.ts, 2, 9))
+>x : Symbol(x, Decl(circularVariance2.ts, 2, 15))
+>Baz : Symbol(Baz, Decl(circularVariance2.ts, 2, 36))
+>U : Symbol(U, Decl(circularVariance2.ts, 2, 9))
+
+type Baz<V> = {
+>Baz : Symbol(Baz, Decl(circularVariance2.ts, 2, 36))
+>V : Symbol(V, Decl(circularVariance2.ts, 4, 9))
+
+    value: Foo<V[]>;
+>value : Symbol(value, Decl(circularVariance2.ts, 4, 15))
+>Foo : Symbol(Foo, Decl(circularVariance2.ts, 6, 1))
+>V : Symbol(V, Decl(circularVariance2.ts, 4, 9))
+}
+
+type Foo<T> = {
+>Foo : Symbol(Foo, Decl(circularVariance2.ts, 6, 1))
+>T : Symbol(T, Decl(circularVariance2.ts, 8, 9))
+
+    x: T;
+>x : Symbol(x, Decl(circularVariance2.ts, 8, 15))
+>T : Symbol(T, Decl(circularVariance2.ts, 8, 9))
+
+    f: Bar<T>;
+>f : Symbol(f, Decl(circularVariance2.ts, 9, 9))
+>Bar : Symbol(Bar, Decl(circularVariance2.ts, 0, 0))
+>T : Symbol(T, Decl(circularVariance2.ts, 8, 9))
+}
+
+declare let bar1: Bar<unknown>;
+>bar1 : Symbol(bar1, Decl(circularVariance2.ts, 13, 11))
+>Bar : Symbol(Bar, Decl(circularVariance2.ts, 0, 0))
+
+declare let bar2: Bar<string>;
+>bar2 : Symbol(bar2, Decl(circularVariance2.ts, 14, 11))
+>Bar : Symbol(Bar, Decl(circularVariance2.ts, 0, 0))
+
+bar1 = bar2;  // Error
+>bar1 : Symbol(bar1, Decl(circularVariance2.ts, 13, 11))
+>bar2 : Symbol(bar2, Decl(circularVariance2.ts, 14, 11))
+
+bar2 = bar1;
+>bar2 : Symbol(bar2, Decl(circularVariance2.ts, 14, 11))
+>bar1 : Symbol(bar1, Decl(circularVariance2.ts, 13, 11))
+
+declare let foo1: Foo<unknown>;
+>foo1 : Symbol(foo1, Decl(circularVariance2.ts, 19, 11))
+>Foo : Symbol(Foo, Decl(circularVariance2.ts, 6, 1))
+
+declare let foo2: Foo<string>;
+>foo2 : Symbol(foo2, Decl(circularVariance2.ts, 20, 11))
+>Foo : Symbol(Foo, Decl(circularVariance2.ts, 6, 1))
+
+foo1 = foo2;
+>foo1 : Symbol(foo1, Decl(circularVariance2.ts, 19, 11))
+>foo2 : Symbol(foo2, Decl(circularVariance2.ts, 20, 11))
+
+foo2 = foo1;  // Error
+>foo2 : Symbol(foo2, Decl(circularVariance2.ts, 20, 11))
+>foo1 : Symbol(foo1, Decl(circularVariance2.ts, 19, 11))
+

--- a/testdata/baselines/reference/compiler/circularVariance2.types
+++ b/testdata/baselines/reference/compiler/circularVariance2.types
@@ -1,0 +1,58 @@
+//// [tests/cases/compiler/circularVariance2.ts] ////
+
+=== circularVariance2.ts ===
+// https://github.com/microsoft/typescript-go/pull/4820
+
+type Bar<U> = (x: Baz<U[]>) => void;
+>Bar : Bar<U>
+>x : Baz<U[]>
+
+type Baz<V> = {
+>Baz : Baz<V>
+
+    value: Foo<V[]>;
+>value : Foo<V[]>
+}
+
+type Foo<T> = {
+>Foo : Foo<T>
+
+    x: T;
+>x : T
+
+    f: Bar<T>;
+>f : Bar<T>
+}
+
+declare let bar1: Bar<unknown>;
+>bar1 : Bar<unknown>
+
+declare let bar2: Bar<string>;
+>bar2 : Bar<string>
+
+bar1 = bar2;  // Error
+>bar1 = bar2 : Bar<string>
+>bar1 : Bar<unknown>
+>bar2 : Bar<string>
+
+bar2 = bar1;
+>bar2 = bar1 : Bar<unknown>
+>bar2 : Bar<string>
+>bar1 : Bar<unknown>
+
+declare let foo1: Foo<unknown>;
+>foo1 : Foo<unknown>
+
+declare let foo2: Foo<string>;
+>foo2 : Foo<string>
+
+foo1 = foo2;
+>foo1 = foo2 : Foo<string>
+>foo1 : Foo<unknown>
+>foo2 : Foo<string>
+
+foo2 = foo1;  // Error
+>foo2 = foo1 : Foo<unknown>
+>foo2 : Foo<string>
+>foo1 : Foo<unknown>
+

--- a/testdata/baselines/reference/submodule/compiler/classVarianceResolveCircularity2.errors.txt
+++ b/testdata/baselines/reference/submodule/compiler/classVarianceResolveCircularity2.errors.txt
@@ -1,0 +1,24 @@
+classVarianceResolveCircularity2.ts(7,5): error TS7022: 'Value' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
+
+
+==== classVarianceResolveCircularity2.ts (1 errors) ====
+    // Issue #52813
+    
+    export {};
+    
+    class Bar<T> {
+        num!: number;
+        Value = callme(new Foo(this)).bar.num;
+        ~~~~~
+!!! error TS7022: 'Value' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
+        Field: number = callme(new Foo(this)).bar.num;
+    }
+    declare function callme(x: Foo<any>): Foo<any>;
+    declare function callme(x: object): string;
+    
+    class Foo<T> {
+        bar!: Bar<T>;
+        constructor(bar: Bar<T>) {
+            this.bar = bar;
+        }
+    }

--- a/testdata/baselines/reference/submodule/compiler/classVarianceResolveCircularity2.errors.txt.diff
+++ b/testdata/baselines/reference/submodule/compiler/classVarianceResolveCircularity2.errors.txt.diff
@@ -1,0 +1,28 @@
+--- old.classVarianceResolveCircularity2.errors.txt
++++ new.classVarianceResolveCircularity2.errors.txt
+@@= skipped -0, +0 lines =@@
+-<no content>
++classVarianceResolveCircularity2.ts(7,5): error TS7022: 'Value' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
++
++
++==== classVarianceResolveCircularity2.ts (1 errors) ====
++    // Issue #52813
++    
++    export {};
++    
++    class Bar<T> {
++        num!: number;
++        Value = callme(new Foo(this)).bar.num;
++        ~~~~~
++!!! error TS7022: 'Value' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
++        Field: number = callme(new Foo(this)).bar.num;
++    }
++    declare function callme(x: Foo<any>): Foo<any>;
++    declare function callme(x: object): string;
++    
++    class Foo<T> {
++        bar!: Bar<T>;
++        constructor(bar: Bar<T>) {
++            this.bar = bar;
++        }
++    }

--- a/testdata/baselines/reference/submodule/compiler/classVarianceResolveCircularity2.types
+++ b/testdata/baselines/reference/submodule/compiler/classVarianceResolveCircularity2.types
@@ -12,7 +12,7 @@ class Bar<T> {
 >num : number
 
     Value = callme(new Foo(this)).bar.num;
->Value : number
+>Value : any
 >callme(new Foo(this)).bar.num : number
 >callme(new Foo(this)).bar : Bar<any>
 >callme(new Foo(this)) : Foo<any>

--- a/testdata/baselines/reference/submodule/compiler/classVarianceResolveCircularity2.types.diff
+++ b/testdata/baselines/reference/submodule/compiler/classVarianceResolveCircularity2.types.diff
@@ -1,0 +1,11 @@
+--- old.classVarianceResolveCircularity2.types
++++ new.classVarianceResolveCircularity2.types
+@@= skipped -11, +11 lines =@@
+ >num : number
+
+     Value = callme(new Foo(this)).bar.num;
+->Value : number
++>Value : any
+ >callme(new Foo(this)).bar.num : number
+ >callme(new Foo(this)).bar : Bar<any>
+ >callme(new Foo(this)) : Foo<any>

--- a/testdata/tests/cases/compiler/circularVariance1.ts
+++ b/testdata/tests/cases/compiler/circularVariance1.ts
@@ -1,0 +1,26 @@
+// @noEmit: true
+
+// https://github.com/microsoft/typescript-go/pull/4820
+
+type Bar<U> = (x: Baz<U[]>) => void;
+
+type Baz<V> = {
+    value: Foo<V[]>;
+}
+
+type Foo<T> = {
+    x: T;
+    f: Bar<T>;
+}
+
+declare let foo1: Foo<unknown>;
+declare let foo2: Foo<string>;
+
+foo1 = foo2;
+foo2 = foo1;  // Error
+
+declare let bar1: Bar<unknown>;
+declare let bar2: Bar<string>;
+
+bar1 = bar2;  // Error
+bar2 = bar1;

--- a/testdata/tests/cases/compiler/circularVariance2.ts
+++ b/testdata/tests/cases/compiler/circularVariance2.ts
@@ -1,0 +1,26 @@
+// @noEmit: true
+
+// https://github.com/microsoft/typescript-go/pull/4820
+
+type Bar<U> = (x: Baz<U[]>) => void;
+
+type Baz<V> = {
+    value: Foo<V[]>;
+}
+
+type Foo<T> = {
+    x: T;
+    f: Bar<T>;
+}
+
+declare let bar1: Bar<unknown>;
+declare let bar2: Bar<string>;
+
+bar1 = bar2;  // Error
+bar2 = bar1;
+
+declare let foo1: Foo<unknown>;
+declare let foo2: Foo<string>;
+
+foo1 = foo2;
+foo2 = foo1;  // Error


### PR DESCRIPTION
With this PR we order variance computation by the associated type symbol. The PR maintains a stack of in-process variance computations and, if and when a circularity is detected, we restart the computations from the symbol on the stack that compares less than the other symbols within the circularity. This means that variance computation will depend only on the order of declaration of the circular types and not on the (much less predictable) order in which _references_ to the generic types are encountered during type checking.

The two added tests previously computed differing variances for `Foo`, `Bar`, and `Baz` and produced differing error baselines. They now produce stable outcomes.

Fixes the issue reported [here](https://github.com/microsoft/typescript-go/pull/4313#issuecomment-4848626121). Supersedes #4515.