### PR TITLE
Fix deprecated contextual property memory regression

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -2199,7 +2199,7 @@ func (c *Checker) getSymbol(symbols ast.SymbolTable, name string, meaning ast.Sy
 	return nil
 }
 
-func (c *Checker) checkSourceFile(ctx context.Context, sourceFile *ast.SourceFile, checkUnused bool, checkDeprecatedProperties bool) {
+func (c *Checker) checkSourceFile(ctx context.Context, sourceFile *ast.SourceFile, checkUnused bool, checkContextualDeprecations bool) {
 	c.ctx = ctx
 	links := c.sourceFileLinks.Get(sourceFile)
 	if !links.typeChecked {
@@ -2229,9 +2229,9 @@ func (c *Checker) checkSourceFile(ctx context.Context, sourceFile *ast.SourceFil
 		}
 		links.unusedChecked = true
 	}
-	if checkDeprecatedProperties && !links.deprecatedPropertiesChecked {
-		c.checkDeprecatedProperties(&links.deprecatedPropertyCheckNodes)
-		links.deprecatedPropertiesChecked = true
+	if checkContextualDeprecations && !links.contextualDeprecationsChecked {
+		c.checkContextualDeprecations(&links.contextualDeprecationCheckNodes)
+		links.contextualDeprecationsChecked = true
 	}
 	if c.isCanceled() {
 		c.wasCanceled = true
@@ -13177,7 +13177,7 @@ func (c *Checker) checkObjectLiteral(node *ast.Node, checkMode CheckMode) *Type 
 	spread := c.emptyObjectType
 	c.pushCachedContextualType(node)
 	contextualType := c.getApparentTypeOfContextualType(node, ContextFlagsNone)
-	c.registerForDeprecatedPropertiesCheck(contextualType, node)
+	c.registerForContextualDeprecationCheck(contextualType, node)
 	var contextualTypeHasPattern bool
 	if contextualType != nil {
 		if pattern := c.patternForType[contextualType]; pattern != nil && (ast.IsObjectBindingPattern(pattern) || ast.IsObjectLiteralExpression(pattern)) {
@@ -13366,15 +13366,15 @@ func (c *Checker) checkObjectLiteral(node *ast.Node, checkMode CheckMode) *Type 
 	return createObjectLiteralType()
 }
 
-func (c *Checker) registerForDeprecatedPropertiesCheck(contextualType *Type, contextNode *ast.Node) {
+func (c *Checker) registerForContextualDeprecationCheck(contextualType *Type, contextNode *ast.Node) {
 	if contextualType != nil {
 		sourceFile := ast.GetSourceFileOfNode(contextNode)
 		links := c.sourceFileLinks.Get(sourceFile)
-		links.deprecatedPropertyCheckNodes.Add(contextNode)
+		links.contextualDeprecationCheckNodes.Add(contextNode)
 	}
 }
 
-func (c *Checker) checkDeprecatedProperties(contexts *collections.OrderedSet[*ast.Node]) {
+func (c *Checker) checkContextualDeprecations(contexts *collections.OrderedSet[*ast.Node]) {
 	for contextNode := range contexts.Values() {
 		var contextualType *Type
 		if ast.IsJsxAttributes(contextNode) {
@@ -13992,10 +13992,10 @@ func (c *Checker) GetSuggestionDiagnostics(ctx context.Context, sourceFile *ast.
 	return c.getDiagnostics(ctx, sourceFile, &c.suggestionDiagnostics, true)
 }
 
-func (c *Checker) getDiagnostics(ctx context.Context, sourceFile *ast.SourceFile, collection *ast.DiagnosticsCollection, checkDeprecatedProperties bool) []*ast.Diagnostic {
+func (c *Checker) getDiagnostics(ctx context.Context, sourceFile *ast.SourceFile, collection *ast.DiagnosticsCollection, checkContextualDeprecations bool) []*ast.Diagnostic {
 	c.checkNotCanceled()
 	checkUnused := c.compilerOptions.NoUnusedLocals.IsTrue() || c.compilerOptions.NoUnusedParameters.IsTrue() || collection == &c.suggestionDiagnostics
-	c.checkSourceFile(ctx, sourceFile, checkUnused, checkDeprecatedProperties)
+	c.checkSourceFile(ctx, sourceFile, checkUnused, checkContextualDeprecations)
 	if c.wasCanceled {
 		return nil
 	}

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -2230,8 +2230,7 @@ func (c *Checker) checkSourceFile(ctx context.Context, sourceFile *ast.SourceFil
 		links.unusedChecked = true
 	}
 	if checkContextualDeprecations && !links.contextualDeprecationsChecked {
-		c.checkContextualDeprecations(&links.contextualDeprecationCheckNodes)
-		links.contextualDeprecationsChecked = true
+		links.contextualDeprecationsChecked = c.checkContextualDeprecations(&links.contextualDeprecationCheckNodes)
 	}
 	if c.isCanceled() {
 		c.wasCanceled = true
@@ -13374,8 +13373,11 @@ func (c *Checker) registerForContextualDeprecationCheck(contextualType *Type, co
 	}
 }
 
-func (c *Checker) checkContextualDeprecations(contexts *collections.OrderedSet[*ast.Node]) {
+func (c *Checker) checkContextualDeprecations(contexts *collections.OrderedSet[*ast.Node]) bool {
 	for contextNode := range contexts.Values() {
+		if c.isCanceled() {
+			return false
+		}
 		var contextualType *Type
 		if ast.IsJsxAttributes(contextNode) {
 			contextualType = c.getContextualType(contextNode, ContextFlagsNone)
@@ -13383,12 +13385,16 @@ func (c *Checker) checkContextualDeprecations(contexts *collections.OrderedSet[*
 			contextualType = c.getApparentTypeOfContextualType(contextNode, ContextFlagsNone)
 		}
 		for _, property := range contextNode.Properties() {
+			if c.isCanceled() {
+				return false
+			}
 			if property.Name() != nil && ast.IsIdentifier(property.Name()) &&
-				(ast.IsJsxAttribute(property) || ast.IsPropertyAssignment(property) || ast.IsShorthandPropertyAssignment(property) || ast.IsObjectLiteralMethod(property)) {
+				(ast.IsJsxAttribute(property) || ast.IsObjectLiteralElement(property)) {
 				c.checkDeprecatedProperty(property.Name(), contextualType)
 			}
 		}
 	}
+	return true
 }
 
 func (c *Checker) checkDeprecatedProperty(name *ast.IdentifierNode, contextualType *Type) {

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -48,6 +48,11 @@ const (
 	CheckModeForceTuple CheckMode = 1 << 7
 )
 
+type deprecatedSuggestionKey struct {
+	location *ast.Node
+	code     int32
+}
+
 type TypeSystemEntity any
 
 type TypeSystemPropertyName int32
@@ -893,7 +898,7 @@ type Checker struct {
 	reportedUnreachableNodes                    collections.Set[*ast.Node]
 	nonExistentProperties                       collections.Set[NonExistentPropertyKey]
 	deferredDiagnosticCallbacks                 []func()
-	deferredDeprecatedPropertyContexts          collections.Set[*ast.Node]
+	deprecatedSuggestionKeys                    collections.Set[deprecatedSuggestionKey]
 	typeToStringNodebuilder                     *NodeBuilder
 
 	mu     sync.Mutex
@@ -2194,7 +2199,7 @@ func (c *Checker) getSymbol(symbols ast.SymbolTable, name string, meaning ast.Sy
 	return nil
 }
 
-func (c *Checker) checkSourceFile(ctx context.Context, sourceFile *ast.SourceFile, checkUnused bool) {
+func (c *Checker) checkSourceFile(ctx context.Context, sourceFile *ast.SourceFile, checkUnused bool, checkDeprecatedProperties bool) {
 	c.ctx = ctx
 	links := c.sourceFileLinks.Get(sourceFile)
 	if !links.typeChecked {
@@ -2223,6 +2228,10 @@ func (c *Checker) checkSourceFile(ctx context.Context, sourceFile *ast.SourceFil
 			c.checkUnusedIdentifiers(links.identifierCheckNodes)
 		}
 		links.unusedChecked = true
+	}
+	if checkDeprecatedProperties && !links.deprecatedPropertiesChecked {
+		c.checkDeprecatedProperties(&links.deprecatedPropertyCheckNodes)
+		links.deprecatedPropertiesChecked = true
 	}
 	if c.isCanceled() {
 		c.wasCanceled = true
@@ -8375,6 +8384,9 @@ func (c *Checker) checkDeprecatedSignature(sig *Signature, node *ast.Node) {
 
 func (c *Checker) addDeprecatedSuggestionWithSignature(location *ast.Node, declaration *ast.Node, deprecatedEntity string, signatureString string) *ast.Diagnostic {
 	message := core.IfElse(deprecatedEntity != "", diagnostics.The_signature_0_of_1_is_deprecated, diagnostics.X_0_is_deprecated)
+	if !c.deprecatedSuggestionKeys.AddIfAbsent(deprecatedSuggestionKey{location: location, code: message.Code()}) {
+		return nil
+	}
 	diagnostic := NewDiagnosticForNode(location, message, signatureString, deprecatedEntity)
 	return c.addDeprecatedSuggestionWorker([]*ast.Node{declaration}, diagnostic)
 }
@@ -13165,7 +13177,7 @@ func (c *Checker) checkObjectLiteral(node *ast.Node, checkMode CheckMode) *Type 
 	spread := c.emptyObjectType
 	c.pushCachedContextualType(node)
 	contextualType := c.getApparentTypeOfContextualType(node, ContextFlagsNone)
-	c.deferDeprecatedPropertySuggestions(contextualType, node)
+	c.registerForDeprecatedPropertiesCheck(contextualType, node)
 	var contextualTypeHasPattern bool
 	if contextualType != nil {
 		if pattern := c.patternForType[contextualType]; pattern != nil && (ast.IsObjectBindingPattern(pattern) || ast.IsObjectLiteralExpression(pattern)) {
@@ -13354,28 +13366,27 @@ func (c *Checker) checkObjectLiteral(node *ast.Node, checkMode CheckMode) *Type 
 	return createObjectLiteralType()
 }
 
-func (c *Checker) deferDeprecatedPropertySuggestions(contextualType *Type, contextNode *ast.Node) {
-	if contextualType == nil || !c.deferredDeprecatedPropertyContexts.AddIfAbsent(contextNode) {
-		return
+func (c *Checker) registerForDeprecatedPropertiesCheck(contextualType *Type, contextNode *ast.Node) {
+	if contextualType != nil {
+		sourceFile := ast.GetSourceFileOfNode(contextNode)
+		links := c.sourceFileLinks.Get(sourceFile)
+		links.deprecatedPropertyCheckNodes.Add(contextNode)
 	}
-	// Overload resolution contextually checks an object literal against multiple candidates.
-	// Wait until the selected signature is cached before reporting its deprecated properties.
-	c.addDeferredDiagnostic(func() {
-		c.checkDeprecatedProperties(contextNode)
-	})
 }
 
-func (c *Checker) checkDeprecatedProperties(contextNode *ast.Node) {
-	var contextualType *Type
-	if ast.IsJsxAttributes(contextNode) {
-		contextualType = c.getContextualType(contextNode, ContextFlagsNone)
-	} else {
-		contextualType = c.getApparentTypeOfContextualType(contextNode, ContextFlagsNone)
-	}
-	for _, property := range contextNode.Properties() {
-		if property.Name() != nil && ast.IsIdentifier(property.Name()) &&
-			(ast.IsJsxAttribute(property) || ast.IsPropertyAssignment(property) || ast.IsShorthandPropertyAssignment(property) || ast.IsObjectLiteralMethod(property)) {
-			c.checkDeprecatedProperty(property.Name(), contextualType)
+func (c *Checker) checkDeprecatedProperties(contexts *collections.OrderedSet[*ast.Node]) {
+	for contextNode := range contexts.Values() {
+		var contextualType *Type
+		if ast.IsJsxAttributes(contextNode) {
+			contextualType = c.getContextualType(contextNode, ContextFlagsNone)
+		} else {
+			contextualType = c.getApparentTypeOfContextualType(contextNode, ContextFlagsNone)
+		}
+		for _, property := range contextNode.Properties() {
+			if property.Name() != nil && ast.IsIdentifier(property.Name()) &&
+				(ast.IsJsxAttribute(property) || ast.IsPropertyAssignment(property) || ast.IsShorthandPropertyAssignment(property) || ast.IsObjectLiteralMethod(property)) {
+				c.checkDeprecatedProperty(property.Name(), contextualType)
+			}
 		}
 	}
 }
@@ -13974,17 +13985,17 @@ func (c *Checker) getCannotFindNameDiagnosticForName(node *ast.Node) *diagnostic
 }
 
 func (c *Checker) GetDiagnostics(ctx context.Context, sourceFile *ast.SourceFile) []*ast.Diagnostic {
-	return c.getDiagnostics(ctx, sourceFile, &c.diagnostics)
+	return c.getDiagnostics(ctx, sourceFile, &c.diagnostics, false)
 }
 
 func (c *Checker) GetSuggestionDiagnostics(ctx context.Context, sourceFile *ast.SourceFile) []*ast.Diagnostic {
-	return c.getDiagnostics(ctx, sourceFile, &c.suggestionDiagnostics)
+	return c.getDiagnostics(ctx, sourceFile, &c.suggestionDiagnostics, true)
 }
 
-func (c *Checker) getDiagnostics(ctx context.Context, sourceFile *ast.SourceFile, collection *ast.DiagnosticsCollection) []*ast.Diagnostic {
+func (c *Checker) getDiagnostics(ctx context.Context, sourceFile *ast.SourceFile, collection *ast.DiagnosticsCollection, checkDeprecatedProperties bool) []*ast.Diagnostic {
 	c.checkNotCanceled()
 	checkUnused := c.compilerOptions.NoUnusedLocals.IsTrue() || c.compilerOptions.NoUnusedParameters.IsTrue() || collection == &c.suggestionDiagnostics
-	c.checkSourceFile(ctx, sourceFile, checkUnused)
+	c.checkSourceFile(ctx, sourceFile, checkUnused, checkDeprecatedProperties)
 	if c.wasCanceled {
 		return nil
 	}
@@ -14005,7 +14016,6 @@ func (c *Checker) produceDeferredDiagnostics() {
 		cb()
 	}
 	c.deferredDiagnosticCallbacks = nil
-	c.deferredDeprecatedPropertyContexts.Clear()
 }
 
 func (c *Checker) addDiagnostic(diagnostic *ast.Diagnostic) {
@@ -14061,6 +14071,9 @@ func (c *Checker) IsDeprecatedDeclaration(declaration *ast.Node) bool {
 }
 
 func (c *Checker) addDeprecatedSuggestion(location *ast.Node, declarations []*ast.Node, deprecatedEntity string) *ast.Diagnostic {
+	if !c.deprecatedSuggestionKeys.AddIfAbsent(deprecatedSuggestionKey{location: location, code: diagnostics.X_0_is_deprecated.Code()}) {
+		return nil
+	}
 	diagnostic := NewDiagnosticForNode(location, diagnostics.X_0_is_deprecated, deprecatedEntity)
 	return c.addDeprecatedSuggestionWorker(declarations, diagnostic)
 }

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -893,6 +893,7 @@ type Checker struct {
 	reportedUnreachableNodes                    collections.Set[*ast.Node]
 	nonExistentProperties                       collections.Set[NonExistentPropertyKey]
 	deferredDiagnosticCallbacks                 []func()
+	deferredDeprecatedPropertyContexts          collections.Set[*ast.Node]
 	typeToStringNodebuilder                     *NodeBuilder
 
 	mu     sync.Mutex
@@ -13164,6 +13165,7 @@ func (c *Checker) checkObjectLiteral(node *ast.Node, checkMode CheckMode) *Type 
 	spread := c.emptyObjectType
 	c.pushCachedContextualType(node)
 	contextualType := c.getApparentTypeOfContextualType(node, ContextFlagsNone)
+	c.deferDeprecatedPropertySuggestions(contextualType, node)
 	var contextualTypeHasPattern bool
 	if contextualType != nil {
 		if pattern := c.patternForType[contextualType]; pattern != nil && (ast.IsObjectBindingPattern(pattern) || ast.IsObjectLiteralExpression(pattern)) {
@@ -13268,9 +13270,6 @@ func (c *Checker) checkObjectLiteral(node *ast.Node, checkMode CheckMode) *Type 
 			if allPropertiesTable != nil {
 				allPropertiesTable[prop.Name] = prop
 			}
-			if ast.IsIdentifier(memberDecl.Name()) {
-				c.checkDeprecatedProperty(memberDecl.Name(), contextualType)
-			}
 			if contextualType != nil && checkMode&CheckModeInferential != 0 && checkMode&CheckModeSkipContextSensitive == 0 && (ast.IsPropertyAssignment(memberDecl) || ast.IsMethodDeclaration(memberDecl)) && c.isContextSensitive(memberDecl) {
 				inferenceContext := c.getInferenceContext(node)
 				// In CheckMode.Inferential we should always have an inference context
@@ -13355,8 +13354,34 @@ func (c *Checker) checkObjectLiteral(node *ast.Node, checkMode CheckMode) *Type 
 	return createObjectLiteralType()
 }
 
+func (c *Checker) deferDeprecatedPropertySuggestions(contextualType *Type, contextNode *ast.Node) {
+	if contextualType == nil || !c.deferredDeprecatedPropertyContexts.AddIfAbsent(contextNode) {
+		return
+	}
+	// Overload resolution contextually checks an object literal against multiple candidates.
+	// Wait until the selected signature is cached before reporting its deprecated properties.
+	c.addDeferredDiagnostic(func() {
+		c.checkDeprecatedProperties(contextNode)
+	})
+}
+
+func (c *Checker) checkDeprecatedProperties(contextNode *ast.Node) {
+	var contextualType *Type
+	if ast.IsJsxAttributes(contextNode) {
+		contextualType = c.getContextualType(contextNode, ContextFlagsNone)
+	} else {
+		contextualType = c.getApparentTypeOfContextualType(contextNode, ContextFlagsNone)
+	}
+	for _, property := range contextNode.Properties() {
+		if property.Name() != nil && ast.IsIdentifier(property.Name()) &&
+			(ast.IsJsxAttribute(property) || ast.IsPropertyAssignment(property) || ast.IsShorthandPropertyAssignment(property) || ast.IsObjectLiteralMethod(property)) {
+			c.checkDeprecatedProperty(property.Name(), contextualType)
+		}
+	}
+}
+
 func (c *Checker) checkDeprecatedProperty(name *ast.IdentifierNode, contextualType *Type) {
-	if contextualType == nil || name == nil {
+	if contextualType == nil {
 		return
 	}
 	prop := c.getPropertyOfType(contextualType, name.Text())
@@ -13980,6 +14005,7 @@ func (c *Checker) produceDeferredDiagnostics() {
 		cb()
 	}
 	c.deferredDiagnosticCallbacks = nil
+	c.deferredDeprecatedPropertyContexts.Clear()
 }
 
 func (c *Checker) addDiagnostic(diagnostic *ast.Diagnostic) {

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -2199,7 +2199,7 @@ func (c *Checker) getSymbol(symbols ast.SymbolTable, name string, meaning ast.Sy
 	return nil
 }
 
-func (c *Checker) checkSourceFile(ctx context.Context, sourceFile *ast.SourceFile, checkUnused bool, checkContextualDeprecations bool) {
+func (c *Checker) checkSourceFile(ctx context.Context, sourceFile *ast.SourceFile, checkUnused bool) {
 	c.ctx = ctx
 	links := c.sourceFileLinks.Get(sourceFile)
 	if !links.typeChecked {
@@ -2228,9 +2228,6 @@ func (c *Checker) checkSourceFile(ctx context.Context, sourceFile *ast.SourceFil
 			c.checkUnusedIdentifiers(links.identifierCheckNodes)
 		}
 		links.unusedChecked = true
-	}
-	if checkContextualDeprecations && !links.contextualDeprecationsChecked {
-		links.contextualDeprecationsChecked = c.checkContextualDeprecations(&links.contextualDeprecationCheckNodes)
 	}
 	if c.isCanceled() {
 		c.wasCanceled = true
@@ -2541,6 +2538,8 @@ func (c *Checker) checkDeferredNode(node *ast.Node) {
 		if ast.IsInstanceOfExpression(node) {
 			c.resolveUntypedCall(node)
 		}
+	case ast.KindObjectLiteralExpression, ast.KindJsxAttributes:
+		c.checkContextualDeprecations(node)
 	}
 	c.currentNode = saveCurrentNode
 }
@@ -13164,6 +13163,7 @@ func (c *Checker) checkObjectLiteral(node *ast.Node, checkMode CheckMode) *Type 
 		// is nothing to check here.
 		return result //nolint:customlint // expando object literal has no property children to check
 	}
+	c.checkNodeDeferred(node)
 	inDestructuringPattern := ast.IsAssignmentTarget(node)
 	// Grammar checking
 	c.checkGrammarObjectLiteralExpression(node.AsObjectLiteralExpression(), inDestructuringPattern)
@@ -13176,7 +13176,6 @@ func (c *Checker) checkObjectLiteral(node *ast.Node, checkMode CheckMode) *Type 
 	spread := c.emptyObjectType
 	c.pushCachedContextualType(node)
 	contextualType := c.getApparentTypeOfContextualType(node, ContextFlagsNone)
-	c.registerForContextualDeprecationCheck(contextualType, node)
 	var contextualTypeHasPattern bool
 	if contextualType != nil {
 		if pattern := c.patternForType[contextualType]; pattern != nil && (ast.IsObjectBindingPattern(pattern) || ast.IsObjectLiteralExpression(pattern)) {
@@ -13365,39 +13364,19 @@ func (c *Checker) checkObjectLiteral(node *ast.Node, checkMode CheckMode) *Type 
 	return createObjectLiteralType()
 }
 
-func (c *Checker) registerForContextualDeprecationCheck(contextualType *Type, contextNode *ast.Node) {
-	if contextualType != nil {
-		sourceFile := ast.GetSourceFileOfNode(contextNode)
-		links := c.sourceFileLinks.Get(sourceFile)
-		links.contextualDeprecationCheckNodes.Add(contextNode)
-	}
-}
-
-func (c *Checker) checkContextualDeprecations(contexts *collections.OrderedSet[*ast.Node]) bool {
-	for contextNode := range contexts.Values() {
+func (c *Checker) checkContextualDeprecations(node *ast.Node) {
+	contextualType := c.getApparentTypeOfContextualType(node, ContextFlagsNone)
+	for _, property := range node.Properties() {
 		if c.isCanceled() {
-			return false
+			return
 		}
-		var contextualType *Type
-		if ast.IsJsxAttributes(contextNode) {
-			contextualType = c.getContextualType(contextNode, ContextFlagsNone)
-		} else {
-			contextualType = c.getApparentTypeOfContextualType(contextNode, ContextFlagsNone)
-		}
-		for _, property := range contextNode.Properties() {
-			if c.isCanceled() {
-				return false
-			}
-			if property.Name() != nil && ast.IsIdentifier(property.Name()) &&
-				(ast.IsJsxAttribute(property) || ast.IsObjectLiteralElement(property)) {
-				c.checkDeprecatedProperty(property.Name(), contextualType)
-			}
+		if property.Name() != nil && !ast.IsComputedPropertyName(property.Name()) {
+			c.checkDeprecatedProperty(property.Name(), contextualType)
 		}
 	}
-	return true
 }
 
-func (c *Checker) checkDeprecatedProperty(name *ast.IdentifierNode, contextualType *Type) {
+func (c *Checker) checkDeprecatedProperty(name *ast.Node, contextualType *Type) {
 	if contextualType == nil {
 		return
 	}
@@ -13991,17 +13970,17 @@ func (c *Checker) getCannotFindNameDiagnosticForName(node *ast.Node) *diagnostic
 }
 
 func (c *Checker) GetDiagnostics(ctx context.Context, sourceFile *ast.SourceFile) []*ast.Diagnostic {
-	return c.getDiagnostics(ctx, sourceFile, &c.diagnostics, false)
+	return c.getDiagnostics(ctx, sourceFile, &c.diagnostics)
 }
 
 func (c *Checker) GetSuggestionDiagnostics(ctx context.Context, sourceFile *ast.SourceFile) []*ast.Diagnostic {
-	return c.getDiagnostics(ctx, sourceFile, &c.suggestionDiagnostics, true)
+	return c.getDiagnostics(ctx, sourceFile, &c.suggestionDiagnostics)
 }
 
-func (c *Checker) getDiagnostics(ctx context.Context, sourceFile *ast.SourceFile, collection *ast.DiagnosticsCollection, checkContextualDeprecations bool) []*ast.Diagnostic {
+func (c *Checker) getDiagnostics(ctx context.Context, sourceFile *ast.SourceFile, collection *ast.DiagnosticsCollection) []*ast.Diagnostic {
 	c.checkNotCanceled()
 	checkUnused := c.compilerOptions.NoUnusedLocals.IsTrue() || c.compilerOptions.NoUnusedParameters.IsTrue() || collection == &c.suggestionDiagnostics
-	c.checkSourceFile(ctx, sourceFile, checkUnused, checkContextualDeprecations)
+	c.checkSourceFile(ctx, sourceFile, checkUnused)
 	if c.wasCanceled {
 		return nil
 	}

--- a/internal/checker/jsx.go
+++ b/internal/checker/jsx.go
@@ -732,6 +732,7 @@ func (c *Checker) createJsxAttributesTypeFromAttributesProperty(openingLikeEleme
 		attributesSymbol = attributes.Symbol()
 		attributeParent = attributes
 		contextualType := c.getContextualType(attributes, ContextFlagsNone)
+		c.deferDeprecatedPropertySuggestions(contextualType, attributes)
 		// Create anonymous type from given attributes symbol table.
 		// @param symbol a symbol of JsxAttributes containing attributes corresponding to attributesTable
 		// @param attributesTable a symbol table of attributes property
@@ -755,9 +756,6 @@ func (c *Checker) createJsxAttributesTypeFromAttributesProperty(openingLikeEleme
 				}
 				if attributeDecl.Name().Text() == jsxChildrenPropertyName {
 					explicitlySpecifyChildrenAttribute = true
-				}
-				if ast.IsIdentifier(attributeDecl.Name()) {
-					c.checkDeprecatedProperty(attributeDecl.Name(), contextualType)
 				}
 				if contextualType != nil && checkMode&CheckModeInferential != 0 && checkMode&CheckModeSkipContextSensitive == 0 && c.isContextSensitive(attributeDecl) {
 					inferenceContext := c.getInferenceContext(attributes)

--- a/internal/checker/jsx.go
+++ b/internal/checker/jsx.go
@@ -732,7 +732,7 @@ func (c *Checker) createJsxAttributesTypeFromAttributesProperty(openingLikeEleme
 		attributesSymbol = attributes.Symbol()
 		attributeParent = attributes
 		contextualType := c.getContextualType(attributes, ContextFlagsNone)
-		c.registerForDeprecatedPropertiesCheck(contextualType, attributes)
+		c.registerForContextualDeprecationCheck(contextualType, attributes)
 		// Create anonymous type from given attributes symbol table.
 		// @param symbol a symbol of JsxAttributes containing attributes corresponding to attributesTable
 		// @param attributesTable a symbol table of attributes property

--- a/internal/checker/jsx.go
+++ b/internal/checker/jsx.go
@@ -732,7 +732,7 @@ func (c *Checker) createJsxAttributesTypeFromAttributesProperty(openingLikeEleme
 		attributesSymbol = attributes.Symbol()
 		attributeParent = attributes
 		contextualType := c.getContextualType(attributes, ContextFlagsNone)
-		c.deferDeprecatedPropertySuggestions(contextualType, attributes)
+		c.registerForDeprecatedPropertiesCheck(contextualType, attributes)
 		// Create anonymous type from given attributes symbol table.
 		// @param symbol a symbol of JsxAttributes containing attributes corresponding to attributesTable
 		// @param attributesTable a symbol table of attributes property

--- a/internal/checker/jsx.go
+++ b/internal/checker/jsx.go
@@ -124,6 +124,7 @@ func (c *Checker) checkJsxFragment(node *ast.Node) *Type {
 }
 
 func (c *Checker) checkJsxAttributes(node *ast.Node, checkMode CheckMode) *Type {
+	c.checkNodeDeferred(node)
 	return c.createJsxAttributesTypeFromAttributesProperty(node.Parent, checkMode)
 }
 
@@ -732,7 +733,6 @@ func (c *Checker) createJsxAttributesTypeFromAttributesProperty(openingLikeEleme
 		attributesSymbol = attributes.Symbol()
 		attributeParent = attributes
 		contextualType := c.getContextualType(attributes, ContextFlagsNone)
-		c.registerForContextualDeprecationCheck(contextualType, attributes)
 		// Create anonymous type from given attributes symbol table.
 		// @param symbol a symbol of JsxAttributes containing attributes corresponding to attributesTable
 		// @param attributesTable a symbol table of attributes property

--- a/internal/checker/types.go
+++ b/internal/checker/types.go
@@ -394,19 +394,19 @@ type AssertionLinks struct {
 // SourceFile links
 
 type SourceFileLinks struct {
-	typeChecked                  bool
-	unusedChecked                bool
-	deprecatedPropertiesChecked  bool
-	externalHelpersModule        *ast.Symbol
-	requestedExternalEmitHelpers ExternalEmitHelpers
-	deferredNodes                collections.OrderedSet[*ast.Node]
-	identifierCheckNodes         []*ast.Node
-	deprecatedPropertyCheckNodes collections.OrderedSet[*ast.Node]
-	localJsxNamespace            string
-	localJsxFragmentNamespace    string
-	localJsxFactory              *ast.EntityName
-	localJsxFragmentFactory      *ast.EntityName
-	jsxFragmentType              *Type
+	typeChecked                     bool
+	unusedChecked                   bool
+	contextualDeprecationsChecked   bool
+	externalHelpersModule           *ast.Symbol
+	requestedExternalEmitHelpers    ExternalEmitHelpers
+	deferredNodes                   collections.OrderedSet[*ast.Node]
+	identifierCheckNodes            []*ast.Node
+	contextualDeprecationCheckNodes collections.OrderedSet[*ast.Node]
+	localJsxNamespace               string
+	localJsxFragmentNamespace       string
+	localJsxFactory                 *ast.EntityName
+	localJsxFragmentFactory         *ast.EntityName
+	jsxFragmentType                 *Type
 }
 
 // Signature specific links

--- a/internal/checker/types.go
+++ b/internal/checker/types.go
@@ -394,19 +394,17 @@ type AssertionLinks struct {
 // SourceFile links
 
 type SourceFileLinks struct {
-	typeChecked                     bool
-	unusedChecked                   bool
-	contextualDeprecationsChecked   bool
-	externalHelpersModule           *ast.Symbol
-	requestedExternalEmitHelpers    ExternalEmitHelpers
-	deferredNodes                   collections.OrderedSet[*ast.Node]
-	identifierCheckNodes            []*ast.Node
-	contextualDeprecationCheckNodes collections.OrderedSet[*ast.Node]
-	localJsxNamespace               string
-	localJsxFragmentNamespace       string
-	localJsxFactory                 *ast.EntityName
-	localJsxFragmentFactory         *ast.EntityName
-	jsxFragmentType                 *Type
+	typeChecked                  bool
+	unusedChecked                bool
+	externalHelpersModule        *ast.Symbol
+	requestedExternalEmitHelpers ExternalEmitHelpers
+	deferredNodes                collections.OrderedSet[*ast.Node]
+	identifierCheckNodes         []*ast.Node
+	localJsxNamespace            string
+	localJsxFragmentNamespace    string
+	localJsxFactory              *ast.EntityName
+	localJsxFragmentFactory      *ast.EntityName
+	jsxFragmentType              *Type
 }
 
 // Signature specific links

--- a/internal/checker/types.go
+++ b/internal/checker/types.go
@@ -396,10 +396,12 @@ type AssertionLinks struct {
 type SourceFileLinks struct {
 	typeChecked                  bool
 	unusedChecked                bool
+	deprecatedPropertiesChecked  bool
 	externalHelpersModule        *ast.Symbol
 	requestedExternalEmitHelpers ExternalEmitHelpers
 	deferredNodes                collections.OrderedSet[*ast.Node]
 	identifierCheckNodes         []*ast.Node
+	deprecatedPropertyCheckNodes collections.OrderedSet[*ast.Node]
 	localJsxNamespace            string
 	localJsxFragmentNamespace    string
 	localJsxFactory              *ast.EntityName

--- a/internal/fourslash/tests/deprecatedContextualPropertyOverload_test.go
+++ b/internal/fourslash/tests/deprecatedContextualPropertyOverload_test.go
@@ -41,6 +41,14 @@ select({ kind: "current", value: deprecatedContainer.[|value|] });
 declare function deprecatedCall(): number;
 select({ kind: "current", value: [|deprecatedCall|]() });
 
+interface DeprecatedAccessorOptions {
+    /** @deprecated */
+    value: number;
+}
+declare function accessor(options: DeprecatedAccessorOptions): void;
+accessor({ get [|value|]() { return 1; } });
+accessor({ set [|value|](_value: number) {} });
+
 interface FirstDeprecatedOptions {
     kind: "first";
     /** @deprecated */
@@ -83,6 +91,18 @@ selectDeprecated({ kind: "second", [|value|]: 1 });`
 			Message: lsproto.StringOrMarkupContent{String: new("'value' is deprecated.")},
 			Tags:    &[]lsproto.DiagnosticTag{lsproto.DiagnosticTagDeprecated},
 			Range:   f.Ranges()[3].LSRange,
+		},
+		{
+			Code:    &lsproto.IntegerOrString{Integer: new(int32(6385))},
+			Message: lsproto.StringOrMarkupContent{String: new("'value' is deprecated.")},
+			Tags:    &[]lsproto.DiagnosticTag{lsproto.DiagnosticTagDeprecated},
+			Range:   f.Ranges()[4].LSRange,
+		},
+		{
+			Code:    &lsproto.IntegerOrString{Integer: new(int32(6385))},
+			Message: lsproto.StringOrMarkupContent{String: new("'value' is deprecated.")},
+			Tags:    &[]lsproto.DiagnosticTag{lsproto.DiagnosticTagDeprecated},
+			Range:   f.Ranges()[5].LSRange,
 		},
 	})
 }

--- a/internal/fourslash/tests/deprecatedContextualPropertyOverload_test.go
+++ b/internal/fourslash/tests/deprecatedContextualPropertyOverload_test.go
@@ -26,6 +26,21 @@ declare function select(options: CurrentOptions): void;
 
 select({ kind: "current", value: 1 });
 
+/** @deprecated */
+declare const deprecatedValue: number;
+select({ kind: "current", value: [|deprecatedValue|] });
+
+interface DeprecatedContainer {
+    /** @deprecated */
+    value: number;
+}
+declare const deprecatedContainer: DeprecatedContainer;
+select({ kind: "current", value: deprecatedContainer.[|value|] });
+
+/** @deprecated */
+declare function deprecatedCall(): number;
+select({ kind: "current", value: [|deprecatedCall|]() });
+
 interface FirstDeprecatedOptions {
     kind: "first";
     /** @deprecated */
@@ -47,9 +62,27 @@ selectDeprecated({ kind: "second", [|value|]: 1 });`
 	f.VerifySuggestionDiagnostics(t, []*lsproto.Diagnostic{
 		{
 			Code:    &lsproto.IntegerOrString{Integer: new(int32(6385))},
-			Message: lsproto.StringOrMarkupContent{String: new("'value' is deprecated.")},
+			Message: lsproto.StringOrMarkupContent{String: new("'deprecatedValue' is deprecated.")},
 			Tags:    &[]lsproto.DiagnosticTag{lsproto.DiagnosticTagDeprecated},
 			Range:   f.Ranges()[0].LSRange,
+		},
+		{
+			Code:    &lsproto.IntegerOrString{Integer: new(int32(6385))},
+			Message: lsproto.StringOrMarkupContent{String: new("'value' is deprecated.")},
+			Tags:    &[]lsproto.DiagnosticTag{lsproto.DiagnosticTagDeprecated},
+			Range:   f.Ranges()[1].LSRange,
+		},
+		{
+			Code:    &lsproto.IntegerOrString{Integer: new(int32(6387))},
+			Message: lsproto.StringOrMarkupContent{String: new("The signature '(): number' of 'deprecatedCall' is deprecated.")},
+			Tags:    &[]lsproto.DiagnosticTag{lsproto.DiagnosticTagDeprecated},
+			Range:   f.Ranges()[2].LSRange,
+		},
+		{
+			Code:    &lsproto.IntegerOrString{Integer: new(int32(6385))},
+			Message: lsproto.StringOrMarkupContent{String: new("'value' is deprecated.")},
+			Tags:    &[]lsproto.DiagnosticTag{lsproto.DiagnosticTagDeprecated},
+			Range:   f.Ranges()[3].LSRange,
 		},
 	})
 }

--- a/internal/fourslash/tests/deprecatedContextualPropertyOverload_test.go
+++ b/internal/fourslash/tests/deprecatedContextualPropertyOverload_test.go
@@ -49,6 +49,15 @@ declare function accessor(options: DeprecatedAccessorOptions): void;
 accessor({ get [|value|]() { return 1; } });
 accessor({ set [|value|](_value: number) {} });
 
+interface DeprecatedNamedOptions {
+    /** @deprecated */
+    "string-name": number;
+    /** @deprecated */
+    1: number;
+}
+declare function named(options: DeprecatedNamedOptions): void;
+named({ [|"string-name"|]: 1, [|1|]: 1 });
+
 interface FirstDeprecatedOptions {
     kind: "first";
     /** @deprecated */
@@ -100,9 +109,21 @@ selectDeprecated({ kind: "second", [|value|]: 1 });`
 		},
 		{
 			Code:    &lsproto.IntegerOrString{Integer: new(int32(6385))},
-			Message: lsproto.StringOrMarkupContent{String: new("'value' is deprecated.")},
+			Message: lsproto.StringOrMarkupContent{String: new("'string-name' is deprecated.")},
 			Tags:    &[]lsproto.DiagnosticTag{lsproto.DiagnosticTagDeprecated},
 			Range:   f.Ranges()[5].LSRange,
+		},
+		{
+			Code:    &lsproto.IntegerOrString{Integer: new(int32(6385))},
+			Message: lsproto.StringOrMarkupContent{String: new("'1' is deprecated.")},
+			Tags:    &[]lsproto.DiagnosticTag{lsproto.DiagnosticTagDeprecated},
+			Range:   f.Ranges()[6].LSRange,
+		},
+		{
+			Code:    &lsproto.IntegerOrString{Integer: new(int32(6385))},
+			Message: lsproto.StringOrMarkupContent{String: new("'value' is deprecated.")},
+			Tags:    &[]lsproto.DiagnosticTag{lsproto.DiagnosticTagDeprecated},
+			Range:   f.Ranges()[7].LSRange,
 		},
 	})
 }

--- a/internal/fourslash/tests/deprecatedContextualPropertyOverload_test.go
+++ b/internal/fourslash/tests/deprecatedContextualPropertyOverload_test.go
@@ -1,0 +1,55 @@
+package fourslash_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/internal/fourslash"
+	"github.com/microsoft/typescript-go/internal/lsp/lsproto"
+	"github.com/microsoft/typescript-go/internal/testutil"
+)
+
+func TestDeprecatedContextualPropertyOverload(t *testing.T) {
+	t.Parallel()
+	defer testutil.RecoverAndFail(t, "Panic on fourslash test")
+
+	const content = `interface DeprecatedOptions {
+    kind: "deprecated";
+    /** @deprecated */
+    value: number;
+}
+interface CurrentOptions {
+    kind: "current";
+    value: number;
+}
+declare function select(options: DeprecatedOptions): void;
+declare function select(options: CurrentOptions): void;
+
+select({ kind: "current", value: 1 });
+
+interface FirstDeprecatedOptions {
+    kind: "first";
+    /** @deprecated */
+    value: number;
+}
+interface SecondDeprecatedOptions {
+    kind: "second";
+    /** @deprecated */
+    value: number;
+}
+declare function selectDeprecated(options: FirstDeprecatedOptions): void;
+declare function selectDeprecated(options: SecondDeprecatedOptions): void;
+
+selectDeprecated({ kind: "second", [|value|]: 1 });`
+
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+
+	f.VerifySuggestionDiagnostics(t, []*lsproto.Diagnostic{
+		{
+			Code:    &lsproto.IntegerOrString{Integer: new(int32(6385))},
+			Message: lsproto.StringOrMarkupContent{String: new("'value' is deprecated.")},
+			Tags:    &[]lsproto.DiagnosticTag{lsproto.DiagnosticTagDeprecated},
+			Range:   f.Ranges()[0].LSRange,
+		},
+	})
+}


### PR DESCRIPTION
Fixes #4824

A bit nasty to prevent memory balooning from deferring stuff, plus code to quickly discard duplicate diags for deprecations.