### PR TITLE
Fix false-positive TS2354 for native private class field access with importHelpers at dated targets

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -10531,9 +10531,7 @@ func (c *Checker) needCollisionCheckForIdentifier(node *ast.Node, identifier *as
 
 func (c *Checker) setNodeLinksForPrivateIdentifierScope(node *ast.Node) {
 	if name := node.Name(); ast.IsPrivateIdentifier(name) {
-		if c.languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks ||
-			c.languageVersion < LanguageFeatureMinimumTarget.ClassAndClassElementDecorators ||
-			!c.compilerOptions.GetUseDefineForClassFields() {
+		if c.languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks {
 			for lexicalScope := ast.GetEnclosingBlockScopeContainer(node); lexicalScope != nil; lexicalScope = ast.GetEnclosingBlockScopeContainer(lexicalScope) {
 				c.nodeLinks.Get(lexicalScope).flags |= NodeCheckFlagsContainsClassWithPrivateIdentifiers
 			}
@@ -11271,9 +11269,7 @@ func (c *Checker) checkPropertyAccessExpressionOrQualifiedName(node *ast.Node, l
 	isAnyLike := IsTypeAny(apparentType) || apparentType == c.silentNeverType
 	var prop *ast.Symbol
 	if ast.IsPrivateIdentifier(right) {
-		if c.languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks ||
-			c.languageVersion < LanguageFeatureMinimumTarget.ClassAndClassElementDecorators ||
-			!c.compilerOptions.GetUseDefineForClassFields() {
+		if c.languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks {
 			if assignmentKind != AssignmentKindNone {
 				c.checkExternalEmitHelpers(node, ExternalEmitHelpersClassPrivateFieldSet)
 			}
@@ -13084,9 +13080,7 @@ func (c *Checker) checkInExpression(left *ast.Expression, right *ast.Expression,
 		return c.silentNeverType
 	}
 	if ast.IsPrivateIdentifier(left) {
-		if c.languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks ||
-			c.languageVersion < LanguageFeatureMinimumTarget.ClassAndClassElementDecorators ||
-			!c.compilerOptions.GetUseDefineForClassFields() {
+		if c.languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks {
 			c.checkExternalEmitHelpers(left, ExternalEmitHelpersClassPrivateFieldIn)
 		}
 		// Unlike in 'checkPrivateIdentifierExpression' we now have access to the RHS type

--- a/testdata/baselines/reference/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022.js
+++ b/testdata/baselines/reference/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022.js
@@ -1,0 +1,60 @@
+//// [tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022.ts] ////
+
+//// [main.ts]
+export class Foo {
+    #field = true;
+    static #staticField = true;
+    #method() {}
+    static #staticMethod() {}
+    get #accessor() { return this.#field; }
+    set #accessor(v: boolean) { this.#field = v; }
+    accessor #autoAccessor = true;
+    static accessor #staticAutoAccessor = true;
+    static {
+        Foo.#staticField = true;
+    }
+    f() {
+        this.#field = this.#field;
+        this.#method();
+        Foo.#staticField = Foo.#staticField;
+        Foo.#staticMethod();
+        this.#accessor = this.#accessor;
+        this.#autoAccessor = this.#autoAccessor;
+        Foo.#staticAutoAccessor = Foo.#staticAutoAccessor;
+        #field in this;
+    }
+}
+
+
+//// [main.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Foo = void 0;
+class Foo {
+    #field = true;
+    static #staticField = true;
+    #method() { }
+    static #staticMethod() { }
+    get #accessor() { return this.#field; }
+    set #accessor(v) { this.#field = v; }
+    #autoAccessor_accessor_storage = true;
+    get #autoAccessor() { return this.#autoAccessor_accessor_storage; }
+    set #autoAccessor(value) { this.#autoAccessor_accessor_storage = value; }
+    static #staticAutoAccessor_accessor_storage = true;
+    static get #staticAutoAccessor() { return Foo.#staticAutoAccessor_accessor_storage; }
+    static set #staticAutoAccessor(value) { Foo.#staticAutoAccessor_accessor_storage = value; }
+    static {
+        Foo.#staticField = true;
+    }
+    f() {
+        this.#field = this.#field;
+        this.#method();
+        Foo.#staticField = Foo.#staticField;
+        Foo.#staticMethod();
+        this.#accessor = this.#accessor;
+        this.#autoAccessor = this.#autoAccessor;
+        Foo.#staticAutoAccessor = Foo.#staticAutoAccessor;
+        #field in this;
+    }
+}
+exports.Foo = Foo;

--- a/testdata/baselines/reference/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022.symbols
+++ b/testdata/baselines/reference/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022.symbols
@@ -1,0 +1,88 @@
+//// [tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022.ts] ////
+
+=== main.ts ===
+export class Foo {
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+
+    #field = true;
+>#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+
+    static #staticField = true;
+>#staticField : Symbol(Foo.#staticField, Decl(main.ts, 1, 18))
+
+    #method() {}
+>#method : Symbol(Foo.#method, Decl(main.ts, 2, 31))
+
+    static #staticMethod() {}
+>#staticMethod : Symbol(Foo.#staticMethod, Decl(main.ts, 3, 16))
+
+    get #accessor() { return this.#field; }
+>#accessor : Symbol(Foo.#accessor, Decl(main.ts, 4, 29), Decl(main.ts, 5, 43))
+>this.#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+
+    set #accessor(v: boolean) { this.#field = v; }
+>#accessor : Symbol(Foo.#accessor, Decl(main.ts, 4, 29), Decl(main.ts, 5, 43))
+>v : Symbol(v, Decl(main.ts, 6, 18))
+>this.#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+>v : Symbol(v, Decl(main.ts, 6, 18))
+
+    accessor #autoAccessor = true;
+>#autoAccessor : Symbol(Foo.#autoAccessor, Decl(main.ts, 6, 50))
+
+    static accessor #staticAutoAccessor = true;
+>#staticAutoAccessor : Symbol(Foo.#staticAutoAccessor, Decl(main.ts, 7, 34))
+
+    static {
+        Foo.#staticField = true;
+>Foo.#staticField : Symbol(Foo.#staticField, Decl(main.ts, 1, 18))
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+    }
+    f() {
+>f : Symbol(Foo.f, Decl(main.ts, 11, 5))
+
+        this.#field = this.#field;
+>this.#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+>this.#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        this.#method();
+>this.#method : Symbol(Foo.#method, Decl(main.ts, 2, 31))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        Foo.#staticField = Foo.#staticField;
+>Foo.#staticField : Symbol(Foo.#staticField, Decl(main.ts, 1, 18))
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+>Foo.#staticField : Symbol(Foo.#staticField, Decl(main.ts, 1, 18))
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        Foo.#staticMethod();
+>Foo.#staticMethod : Symbol(Foo.#staticMethod, Decl(main.ts, 3, 16))
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        this.#accessor = this.#accessor;
+>this.#accessor : Symbol(Foo.#accessor, Decl(main.ts, 4, 29), Decl(main.ts, 5, 43))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+>this.#accessor : Symbol(Foo.#accessor, Decl(main.ts, 4, 29), Decl(main.ts, 5, 43))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        this.#autoAccessor = this.#autoAccessor;
+>this.#autoAccessor : Symbol(Foo.#autoAccessor, Decl(main.ts, 6, 50))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+>this.#autoAccessor : Symbol(Foo.#autoAccessor, Decl(main.ts, 6, 50))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        Foo.#staticAutoAccessor = Foo.#staticAutoAccessor;
+>Foo.#staticAutoAccessor : Symbol(Foo.#staticAutoAccessor, Decl(main.ts, 7, 34))
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+>Foo.#staticAutoAccessor : Symbol(Foo.#staticAutoAccessor, Decl(main.ts, 7, 34))
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        #field in this;
+>#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+    }
+}
+

--- a/testdata/baselines/reference/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022.types
+++ b/testdata/baselines/reference/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022.types
@@ -1,0 +1,103 @@
+//// [tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022.ts] ////
+
+=== main.ts ===
+export class Foo {
+>Foo : Foo
+
+    #field = true;
+>#field : boolean
+>true : true
+
+    static #staticField = true;
+>#staticField : boolean
+>true : true
+
+    #method() {}
+>#method : () => void
+
+    static #staticMethod() {}
+>#staticMethod : () => void
+
+    get #accessor() { return this.#field; }
+>#accessor : boolean
+>this.#field : boolean
+>this : this
+
+    set #accessor(v: boolean) { this.#field = v; }
+>#accessor : boolean
+>v : boolean
+>this.#field = v : boolean
+>this.#field : boolean
+>this : this
+>v : boolean
+
+    accessor #autoAccessor = true;
+>#autoAccessor : boolean
+>true : true
+
+    static accessor #staticAutoAccessor = true;
+>#staticAutoAccessor : boolean
+>true : true
+
+    static {
+        Foo.#staticField = true;
+>Foo.#staticField = true : true
+>Foo.#staticField : boolean
+>Foo : typeof Foo
+>true : true
+    }
+    f() {
+>f : () => void
+
+        this.#field = this.#field;
+>this.#field = this.#field : boolean
+>this.#field : boolean
+>this : this
+>this.#field : boolean
+>this : this
+
+        this.#method();
+>this.#method() : void
+>this.#method : () => void
+>this : this
+
+        Foo.#staticField = Foo.#staticField;
+>Foo.#staticField = Foo.#staticField : boolean
+>Foo.#staticField : boolean
+>Foo : typeof Foo
+>Foo.#staticField : boolean
+>Foo : typeof Foo
+
+        Foo.#staticMethod();
+>Foo.#staticMethod() : void
+>Foo.#staticMethod : () => void
+>Foo : typeof Foo
+
+        this.#accessor = this.#accessor;
+>this.#accessor = this.#accessor : boolean
+>this.#accessor : boolean
+>this : this
+>this.#accessor : boolean
+>this : this
+
+        this.#autoAccessor = this.#autoAccessor;
+>this.#autoAccessor = this.#autoAccessor : boolean
+>this.#autoAccessor : boolean
+>this : this
+>this.#autoAccessor : boolean
+>this : this
+
+        Foo.#staticAutoAccessor = Foo.#staticAutoAccessor;
+>Foo.#staticAutoAccessor = Foo.#staticAutoAccessor : boolean
+>Foo.#staticAutoAccessor : boolean
+>Foo : typeof Foo
+>Foo.#staticAutoAccessor : boolean
+>Foo : typeof Foo
+
+        #field in this;
+>#field in this : boolean
+>#field : any
+>this : this
+    }
+}
+

--- a/testdata/baselines/reference/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.js
+++ b/testdata/baselines/reference/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.js
@@ -1,0 +1,36 @@
+//// [tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.ts] ////
+
+//// [main.ts]
+export class Foo {
+    #field = true;
+    static #staticField = true;
+    #method() {}
+    static #staticMethod() {}
+    f() {
+        this.#field = this.#field;
+        this.#method();
+        Foo.#staticField = Foo.#staticField;
+        Foo.#staticMethod();
+        #field in this;
+    }
+}
+
+
+//// [main.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Foo = void 0;
+class Foo {
+    #field = true;
+    static #staticField = true;
+    #method() { }
+    static #staticMethod() { }
+    f() {
+        this.#field = this.#field;
+        this.#method();
+        Foo.#staticField = Foo.#staticField;
+        Foo.#staticMethod();
+        #field in this;
+    }
+}
+exports.Foo = Foo;

--- a/testdata/baselines/reference/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.symbols
+++ b/testdata/baselines/reference/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.symbols
@@ -1,0 +1,47 @@
+//// [tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.ts] ////
+
+=== main.ts ===
+export class Foo {
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+
+    #field = true;
+>#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+
+    static #staticField = true;
+>#staticField : Symbol(Foo.#staticField, Decl(main.ts, 1, 18))
+
+    #method() {}
+>#method : Symbol(Foo.#method, Decl(main.ts, 2, 31))
+
+    static #staticMethod() {}
+>#staticMethod : Symbol(Foo.#staticMethod, Decl(main.ts, 3, 16))
+
+    f() {
+>f : Symbol(Foo.f, Decl(main.ts, 4, 29))
+
+        this.#field = this.#field;
+>this.#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+>this.#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        this.#method();
+>this.#method : Symbol(Foo.#method, Decl(main.ts, 2, 31))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        Foo.#staticField = Foo.#staticField;
+>Foo.#staticField : Symbol(Foo.#staticField, Decl(main.ts, 1, 18))
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+>Foo.#staticField : Symbol(Foo.#staticField, Decl(main.ts, 1, 18))
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        Foo.#staticMethod();
+>Foo.#staticMethod : Symbol(Foo.#staticMethod, Decl(main.ts, 3, 16))
+>Foo : Symbol(Foo, Decl(main.ts, 0, 0))
+
+        #field in this;
+>#field : Symbol(Foo.#field, Decl(main.ts, 0, 18))
+>this : Symbol(Foo, Decl(main.ts, 0, 0))
+    }
+}
+

--- a/testdata/baselines/reference/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.types
+++ b/testdata/baselines/reference/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.types
@@ -1,0 +1,54 @@
+//// [tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.ts] ////
+
+=== main.ts ===
+export class Foo {
+>Foo : Foo
+
+    #field = true;
+>#field : boolean
+>true : true
+
+    static #staticField = true;
+>#staticField : boolean
+>true : true
+
+    #method() {}
+>#method : () => void
+
+    static #staticMethod() {}
+>#staticMethod : () => void
+
+    f() {
+>f : () => void
+
+        this.#field = this.#field;
+>this.#field = this.#field : boolean
+>this.#field : boolean
+>this : this
+>this.#field : boolean
+>this : this
+
+        this.#method();
+>this.#method() : void
+>this.#method : () => void
+>this : this
+
+        Foo.#staticField = Foo.#staticField;
+>Foo.#staticField = Foo.#staticField : boolean
+>Foo.#staticField : boolean
+>Foo : typeof Foo
+>Foo.#staticField : boolean
+>Foo : typeof Foo
+
+        Foo.#staticMethod();
+>Foo.#staticMethod() : void
+>Foo.#staticMethod : () => void
+>Foo : typeof Foo
+
+        #field in this;
+>#field in this : boolean
+>#field : any
+>this : this
+    }
+}
+

--- a/testdata/tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022.ts
+++ b/testdata/tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022.ts
@@ -1,0 +1,28 @@
+// @importHelpers: true
+// @target: es2022
+// @module: commonjs
+// @lib: esnext
+// @filename: main.ts
+export class Foo {
+    #field = true;
+    static #staticField = true;
+    #method() {}
+    static #staticMethod() {}
+    get #accessor() { return this.#field; }
+    set #accessor(v: boolean) { this.#field = v; }
+    accessor #autoAccessor = true;
+    static accessor #staticAutoAccessor = true;
+    static {
+        Foo.#staticField = true;
+    }
+    f() {
+        this.#field = this.#field;
+        this.#method();
+        Foo.#staticField = Foo.#staticField;
+        Foo.#staticMethod();
+        this.#accessor = this.#accessor;
+        this.#autoAccessor = this.#autoAccessor;
+        Foo.#staticAutoAccessor = Foo.#staticAutoAccessor;
+        #field in this;
+    }
+}

--- a/testdata/tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.ts
+++ b/testdata/tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.ts
@@ -1,0 +1,18 @@
+// @importHelpers: true
+// @target: es2022
+// @useDefineForClassFields: false
+// @module: commonjs
+// @filename: main.ts
+export class Foo {
+    #field = true;
+    static #staticField = true;
+    #method() {}
+    static #staticMethod() {}
+    f() {
+        this.#field = this.#field;
+        this.#method();
+        Foo.#staticField = Foo.#staticField;
+        Foo.#staticMethod();
+        #field in this;
+    }
+}


### PR DESCRIPTION
Related to microsoft/TypeScript#63728, and a Go port of the companion fix microsoft/TypeScript#63729.

> **Disclosure (per `CONTRIBUTING.md`):** This PR was authored with AI assistance (GitHub Copilot CLI). It was directed by me (a specific human operator) investigating and fixing this one specific, previously-filed issue — it is not part of a bulk or queue-driven workflow across issues, and I will personally shepherd it through review and respond to feedback myself.

## The bug

With `importHelpers: true` and a dated `target` (e.g. `ES2022`–`ES2025`), `tsgo` incorrectly reports `TS2354: This syntax requires an imported helper but module 'tslib' cannot be found` for plain, fully-native private field/method/accessor access (`this.#x`, `#x in obj`, static private fields/methods, private accessors, static blocks, private fields in generics/closures/class expressions/inheritance) — even though the emitted JS for all of these is 100% native ES2022+ syntax that never references `tslib`.

## Root cause

`setNodeLinksForPrivateIdentifierScope`, `checkPropertyAccessExpressionOrQualifiedName`, and `checkInExpression` in `internal/checker/checker.go` gate the private-identifier helper-requirement check on:

```go
c.languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks ||
    c.languageVersion < LanguageFeatureMinimumTarget.ClassAndClassElementDecorators ||
    !c.compilerOptions.GetUseDefineForClassFields()
```

- `ClassAndClassElementDecorators` is pinned to the `ESNext` sentinel because TC39 decorators have never been assigned to a dated ECMAScript edition. That makes `languageVersion < ClassAndClassElementDecorators` `true` for *every* dated target, forever — regardless of whether the file uses decorators at all. The actual emitter (`estransforms/classfields.go`'s `shouldTransformPrivateElementsOrClassStaticBlocks`) only checks `languageVersion < ES2022`, with no decorator-related gating, so this term in the checker never corresponded to real emit behavior.
- `!c.compilerOptions.GetUseDefineForClassFields()` has the same problem: private fields are always emitted using "define" semantics regardless of `useDefineForClassFields` (that option only affects public fields), so it also doesn't correspond to any real difference in whether `tslib` is needed for private-field access. Verified by emitting with `--useDefineForClassFields false --target es2022`: output is fully native with no `tslib` references, yet the checker still errored before this fix.

## The fix

Removes both spurious clauses from the 3 call sites above, leaving just `c.languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks`.

A 4th call site with the same `ClassAndClassElementDecorators` check, inside `getFirstTransformableStaticClassElement`, is intentionally **left unchanged**. That one only matters when a class is decorated, to decide if the decorator transform's hoisting of static private/static-block elements into an IIFE needs the `__setFunctionName` helper. I verified (by emitting `@dec class C { static #foo() {} }` at ES2022) that this really is required in the actual output, so this clause is a genuine, necessary coupling and was left in place.

## Testing

- Added `testdata/tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022.ts` — target ES2022, `importHelpers: true`, no `tslib` present, covering instance/static private fields, private methods, static private methods, private accessors, private auto-accessors (instance + static), static blocks, and `#x in obj`. Asserts zero errors; baseline `.js` confirms the emit never references `tslib`.
- Added `testdata/tests/cases/compiler/importHelpersNoHelpersForPrivateFieldsAtES2022UseDefineForClassFieldsFalse.ts` — same coverage with `useDefineForClassFields: false`, confirming that option no longer triggers the false positive either.
- Ran the full Go test suite (`go test ./...`); all pass except one unrelated, pre-existing flaky test in `internal/fswatch` (macOS `fsevents` timing test, confirmed to fail/pass independently of this change by running it in isolation both with and without the fix).
- Ran the submodule-based conformance suite (`TestSubmodule`) filtered to `privateName|esDecorators|importHelpers|classField|classStaticBlock` — all pass, including the decorator+static-private-method case that verifies `__setFunctionName` is still correctly required.
- `hereby lint` and `hereby format` both clean.
- Manually confirmed via the built `tsgo` binary that decorators and `using` declarations still correctly require `tslib` at dated targets (these are real transforms, not part of this bug), and that all "confirmed bug" scenarios from the original repro (https://github.com/astegmaier/typescript-private-field-tslib-repro) now compile cleanly with zero references to `tslib` in the emitted output.
