### PR TITLE
Fix crash when a call signature's type parameter cannot be reused

### DIFF
--- a/internal/checker/pseudotypenodebuilder.go
+++ b/internal/checker/pseudotypenodebuilder.go
@@ -184,7 +184,17 @@ func (b *NodeBuilderImpl) pseudoTypeToNode(t *pseudochecker.PseudoType) *ast.Nod
 		if len(d.TypeParameters) > 0 {
 			res := make([]*ast.Node, 0, len(d.TypeParameters))
 			for _, tp := range d.TypeParameters {
-				res = append(res, b.reuseNode(tp.AsNode()))
+				reused := b.reuseNode(tp.AsNode())
+				if reused == nil {
+					// The existing node could not be reused, e.g. because its constraint names
+					// something that is not accessible from the file being emitted. Serialize the
+					// type parameter from the checker instead, the way reuseTypeNode falls back for
+					// type nodes. Appending the nil would leave it in the type parameter list, where
+					// the printer dereferences it while looking for a trailing comma.
+					b.ctx.tracker.ReportInferenceFallback(tp.AsNode())
+					reused = b.typeParameterToDeclaration(b.ch.getDeclaredTypeOfTypeParameter(b.ch.getSymbolOfDeclaration(tp.AsNode())))
+				}
+				res = append(res, reused)
 			}
 			typeParams = b.f.NewNodeList(res)
 		}

--- a/internal/execute/tsctests/tsc_test.go
+++ b/internal/execute/tsctests/tsc_test.go
@@ -810,6 +810,40 @@ func TestTscDeclarationEmit(t *testing.T) {
 			},
 		},
 		{
+			// The declaration signature computed for b.ts inlines `setField` structurally. Its type
+			// parameter cannot be reused, because rewriting `typeof state` hits an inaccessible
+			// `unique symbol`. The pseudo type node builder used to store the resulting nil in the
+			// type parameter list, which crashed the printer.
+			subScenario: "dts signature update with a type parameter that cannot be reused",
+			files: FileMap{
+				"/home/src/workspaces/project/tsconfig.json": stringtestutil.Dedent(`
+					{
+						"compilerOptions": {
+							"strict": true,
+							"incremental": true,
+							"skipLibCheck": true,
+							"skipDefaultLibCheck": true,
+						},
+					}`),
+				"/home/src/workspaces/project/a.ts": stringtestutil.Dedent(`
+					declare const brand: unique symbol;
+					const state = { name: "", count: 0, [brand]: true };
+					export const api = {
+						setField: <K extends keyof typeof state>(key: K, value: (typeof state)[K]): void => {
+							state[key] = value;
+						},
+					};`),
+				"/home/src/workspaces/project/b.ts": stringtestutil.Dedent(`
+					import { api } from "./a";
+					export const merged = { ...api };`),
+			},
+			edits: []*tscEdit{
+				newTscEdit("modify b.ts", func(sys *TestSys) {
+					sys.appendFile("/home/src/workspaces/project/b.ts", "\nexport const touched = 1;")
+				}),
+			},
+		},
+		{
 			subScenario: "when using Windows paths and uppercase letters",
 			files: FileMap{
 				"D:/Work/pkg1/package.json": stringtestutil.Dedent(`

--- a/testdata/baselines/reference/tsc/declarationEmit/dts-signature-update-with-a-type-parameter-that-cannot-be-reused.js
+++ b/testdata/baselines/reference/tsc/declarationEmit/dts-signature-update-with-a-type-parameter-that-cannot-be-reused.js
@@ -1,0 +1,226 @@
+currentDirectory::/home/src/workspaces/project
+useCaseSensitiveFileNames::true
+Input::
+//// [/home/src/workspaces/project/a.ts] *new* 
+declare const brand: unique symbol;
+const state = { name: "", count: 0, [brand]: true };
+export const api = {
+    setField: <K extends keyof typeof state>(key: K, value: (typeof state)[K]): void => {
+        state[key] = value;
+    },
+};
+//// [/home/src/workspaces/project/b.ts] *new* 
+import { api } from "./a";
+export const merged = { ...api };
+//// [/home/src/workspaces/project/tsconfig.json] *new* 
+{
+    "compilerOptions": {
+        "strict": true,
+        "incremental": true,
+        "skipLibCheck": true,
+        "skipDefaultLibCheck": true,
+    },
+}
+
+tsgo 
+ExitStatus:: Success
+Output::
+//// [/home/src/tslibs/TS/Lib/lib.es2025.full.d.ts] *Lib*
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+interface SymbolConstructor {
+    (desc?: string | number): symbol;
+    for(name: string): symbol;
+    readonly toStringTag: symbol;
+}
+declare var Symbol: SymbolConstructor;
+interface Symbol {
+    readonly [Symbol.toStringTag]: string;
+}
+declare const console: { log(msg: any): void; };
+//// [/home/src/workspaces/project/a.js] *new* 
+const state = { name: "", count: 0, [brand]: true };
+export const api = {
+    setField: (key, value) => {
+        state[key] = value;
+    },
+};
+
+//// [/home/src/workspaces/project/b.js] *new* 
+import { api } from "./a";
+export const merged = { ...api };
+
+//// [/home/src/workspaces/project/tsconfig.tsbuildinfo] *new* 
+{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"420f0324953654bb26e57da1857dc6a2-declare const brand: unique symbol;\nconst state = { name: \"\", count: 0, [brand]: true };\nexport const api = {\n    setField: <K extends keyof typeof state>(key: K, value: (typeof state)[K]): void => {\n        state[key] = value;\n    },\n};","de62ab78d5ba64a5b325bfebf0f2e8d3-import { api } from \"./a\";\nexport const merged = { ...api };"],"fileIdsList":[[2]],"options":{"skipLibCheck":true,"strict":true,"skipDefaultLibCheck":true},"referencedMap":[[3,1]]}
+//// [/home/src/workspaces/project/tsconfig.tsbuildinfo.readable.baseline.txt] *new* 
+{
+  "version": "FakeTSVersion",
+  "root": [
+    {
+      "files": [
+        "./a.ts",
+        "./b.ts"
+      ],
+      "original": [
+        2,
+        3
+      ]
+    }
+  ],
+  "fileNames": [
+    "lib.es2025.full.d.ts",
+    "./a.ts",
+    "./b.ts"
+  ],
+  "fileInfos": [
+    {
+      "fileName": "lib.es2025.full.d.ts",
+      "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "signature": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "affectsGlobalScope": true,
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true,
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "./a.ts",
+      "version": "420f0324953654bb26e57da1857dc6a2-declare const brand: unique symbol;\nconst state = { name: \"\", count: 0, [brand]: true };\nexport const api = {\n    setField: <K extends keyof typeof state>(key: K, value: (typeof state)[K]): void => {\n        state[key] = value;\n    },\n};",
+      "signature": "420f0324953654bb26e57da1857dc6a2-declare const brand: unique symbol;\nconst state = { name: \"\", count: 0, [brand]: true };\nexport const api = {\n    setField: <K extends keyof typeof state>(key: K, value: (typeof state)[K]): void => {\n        state[key] = value;\n    },\n};",
+      "impliedNodeFormat": "CommonJS"
+    },
+    {
+      "fileName": "./b.ts",
+      "version": "de62ab78d5ba64a5b325bfebf0f2e8d3-import { api } from \"./a\";\nexport const merged = { ...api };",
+      "signature": "de62ab78d5ba64a5b325bfebf0f2e8d3-import { api } from \"./a\";\nexport const merged = { ...api };",
+      "impliedNodeFormat": "CommonJS"
+    }
+  ],
+  "fileIdsList": [
+    [
+      "./a.ts"
+    ]
+  ],
+  "options": {
+    "skipLibCheck": true,
+    "strict": true,
+    "skipDefaultLibCheck": true
+  },
+  "referencedMap": {
+    "./b.ts": [
+      "./a.ts"
+    ]
+  },
+  "size": 1378
+}
+
+tsconfig.json::
+SemanticDiagnostics::
+*refresh*    /home/src/tslibs/TS/Lib/lib.es2025.full.d.ts
+*refresh*    /home/src/workspaces/project/a.ts
+*refresh*    /home/src/workspaces/project/b.ts
+Signatures::
+
+
+Edit [0]:: modify b.ts
+//// [/home/src/workspaces/project/b.ts] *modified* 
+import { api } from "./a";
+export const merged = { ...api };
+export const touched = 1;
+
+tsgo 
+ExitStatus:: Success
+Output::
+//// [/home/src/workspaces/project/b.js] *modified* 
+import { api } from "./a";
+export const merged = { ...api };
+export const touched = 1;
+
+//// [/home/src/workspaces/project/tsconfig.tsbuildinfo] *modified* 
+{"version":"FakeTSVersion","root":[[2,3]],"fileNames":["lib.es2025.full.d.ts","./a.ts","./b.ts"],"fileInfos":[{"version":"8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true,"impliedNodeFormat":1},"420f0324953654bb26e57da1857dc6a2-declare const brand: unique symbol;\nconst state = { name: \"\", count: 0, [brand]: true };\nexport const api = {\n    setField: <K extends keyof typeof state>(key: K, value: (typeof state)[K]): void => {\n        state[key] = value;\n    },\n};",{"version":"6fa50051a3b923ced64e589b1e168966-import { api } from \"./a\";\nexport const merged = { ...api };\nexport const touched = 1;","signature":"c8b6e7c9af66d471127e6d9a6883ca0e-export declare const merged: {\n    setField: <K extends \"count\" | \"name\" | unique symbol>(key: K, value: ({\n        name: string;\n        count: number;\n        [brand]: boolean;\n    })[K]) => void;\n};\nexport declare const touched = 1;\n\n(40,6): error2527: The_inferred_type_of_0_references_an_inaccessible_1_type_A_type_annotation_is_necessary_2527\nmerged\nunique symbol\n\n(40,6): error2527: The_inferred_type_of_0_references_an_inaccessible_1_type_A_type_annotation_is_necessary_2527\nmerged\nunique symbol\n\n(40,6): error2527: The_inferred_type_of_0_references_an_inaccessible_1_type_A_type_annotation_is_necessary_2527\nmerged\nunique symbol\n\n(40,6): error4023: Exported_variable_0_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named_4023\nmerged\nbrand\n\"/home/src/workspaces/project/a\"\n","impliedNodeFormat":1}],"fileIdsList":[[2]],"options":{"skipLibCheck":true,"strict":true,"skipDefaultLibCheck":true},"referencedMap":[[3,1]]}
+//// [/home/src/workspaces/project/tsconfig.tsbuildinfo.readable.baseline.txt] *modified* 
+{
+  "version": "FakeTSVersion",
+  "root": [
+    {
+      "files": [
+        "./a.ts",
+        "./b.ts"
+      ],
+      "original": [
+        2,
+        3
+      ]
+    }
+  ],
+  "fileNames": [
+    "lib.es2025.full.d.ts",
+    "./a.ts",
+    "./b.ts"
+  ],
+  "fileInfos": [
+    {
+      "fileName": "lib.es2025.full.d.ts",
+      "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "signature": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+      "affectsGlobalScope": true,
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "8859c12c614ce56ba9a18e58384a198f-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ninterface SymbolConstructor {\n    (desc?: string | number): symbol;\n    for(name: string): symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true,
+        "impliedNodeFormat": 1
+      }
+    },
+    {
+      "fileName": "./a.ts",
+      "version": "420f0324953654bb26e57da1857dc6a2-declare const brand: unique symbol;\nconst state = { name: \"\", count: 0, [brand]: true };\nexport const api = {\n    setField: <K extends keyof typeof state>(key: K, value: (typeof state)[K]): void => {\n        state[key] = value;\n    },\n};",
+      "signature": "420f0324953654bb26e57da1857dc6a2-declare const brand: unique symbol;\nconst state = { name: \"\", count: 0, [brand]: true };\nexport const api = {\n    setField: <K extends keyof typeof state>(key: K, value: (typeof state)[K]): void => {\n        state[key] = value;\n    },\n};",
+      "impliedNodeFormat": "CommonJS"
+    },
+    {
+      "fileName": "./b.ts",
+      "version": "6fa50051a3b923ced64e589b1e168966-import { api } from \"./a\";\nexport const merged = { ...api };\nexport const touched = 1;",
+      "signature": "c8b6e7c9af66d471127e6d9a6883ca0e-export declare const merged: {\n    setField: <K extends \"count\" | \"name\" | unique symbol>(key: K, value: ({\n        name: string;\n        count: number;\n        [brand]: boolean;\n    })[K]) => void;\n};\nexport declare const touched = 1;\n\n(40,6): error2527: The_inferred_type_of_0_references_an_inaccessible_1_type_A_type_annotation_is_necessary_2527\nmerged\nunique symbol\n\n(40,6): error2527: The_inferred_type_of_0_references_an_inaccessible_1_type_A_type_annotation_is_necessary_2527\nmerged\nunique symbol\n\n(40,6): error2527: The_inferred_type_of_0_references_an_inaccessible_1_type_A_type_annotation_is_necessary_2527\nmerged\nunique symbol\n\n(40,6): error4023: Exported_variable_0_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named_4023\nmerged\nbrand\n\"/home/src/workspaces/project/a\"\n",
+      "impliedNodeFormat": "CommonJS",
+      "original": {
+        "version": "6fa50051a3b923ced64e589b1e168966-import { api } from \"./a\";\nexport const merged = { ...api };\nexport const touched = 1;",
+        "signature": "c8b6e7c9af66d471127e6d9a6883ca0e-export declare const merged: {\n    setField: <K extends \"count\" | \"name\" | unique symbol>(key: K, value: ({\n        name: string;\n        count: number;\n        [brand]: boolean;\n    })[K]) => void;\n};\nexport declare const touched = 1;\n\n(40,6): error2527: The_inferred_type_of_0_references_an_inaccessible_1_type_A_type_annotation_is_necessary_2527\nmerged\nunique symbol\n\n(40,6): error2527: The_inferred_type_of_0_references_an_inaccessible_1_type_A_type_annotation_is_necessary_2527\nmerged\nunique symbol\n\n(40,6): error2527: The_inferred_type_of_0_references_an_inaccessible_1_type_A_type_annotation_is_necessary_2527\nmerged\nunique symbol\n\n(40,6): error4023: Exported_variable_0_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named_4023\nmerged\nbrand\n\"/home/src/workspaces/project/a\"\n",
+        "impliedNodeFormat": 1
+      }
+    }
+  ],
+  "fileIdsList": [
+    [
+      "./a.ts"
+    ]
+  ],
+  "options": {
+    "skipLibCheck": true,
+    "strict": true,
+    "skipDefaultLibCheck": true
+  },
+  "referencedMap": {
+    "./b.ts": [
+      "./a.ts"
+    ]
+  },
+  "size": 2313
+}
+
+tsconfig.json::
+SemanticDiagnostics::
+*refresh*    /home/src/workspaces/project/b.ts
+Signatures::
+(computed .d.ts) /home/src/workspaces/project/b.ts


### PR DESCRIPTION
Fixes #4748.

## The crash

The `PseudoTypeKindSingleCallSignature` branch of `pseudoTypeToNode` appends the result of `reuseNode` into a call signature's type parameter list without checking it:

```go
for _, tp := range d.TypeParameters {
    res = append(res, b.reuseNode(tp.AsNode()))
}
typeParams = b.f.NewNodeList(res)
```

`reuseNode` returns nil whenever the recovery boundary in `tryReuseExistingNodeHelper` fails. The nil is stored in the `NodeList` and survives all the way to the printer, which dereferences the list's last element while deciding whether to write a trailing comma:

```
ast.(*Node).End                                 ast.go:193
ast.(*NodeList).HasTrailingComma                ast.go:142
printer.(*Printer).hasTrailingComma             printer.go:4774
printer.(*Printer).emitListRange                printer.go:4755
printer.(*Printer).emitTypeParameters           printer.go:1506
printer.(*Printer).emitFunctionType             printer.go:1928
...
compiler.(*emitter).emitDeclarationFile         emitter.go:269
```

Every other caller of `reuseNode` copes with the nil — `reuseTypeNode` in particular reports an inference fallback and re-serializes the node from the checker. This one call site does not.

## When it happens

Four things have to line up:

1. A generic arrow-function property in an object literal, so the pseudochecker classifies it as `SingleCallSignature` and tries to reuse the original type parameter nodes.
2. The type parameter's constraint references a binding that cannot be named from the file being emitted.
3. Rewriting that constraint has to fail as well. Normally reuse does not fail here, it rewrites — drop the `unique symbol` from the test case below and you get a perfectly good `<K extends "count" | "name">`. It only returns nil when the rewrite itself reaches something unnameable.
4. The member has to be inlined structurally into another file's declaration. A single-file version does not reproduce, because the local is nameable in its own `.d.ts`.

The original report came from a mobx-state-tree codebase, where all four fall out of ordinary usage: a generic `<Key extends keyof typeof self>` setter declared inside `.actions(self => ({ ... }))`, MST's `unique symbol` brands, and `types.compose` pulling models in across files.

## Why it only reproduces on the incremental path

For a `noEmit` or `declaration: false` project the declaration printer runs in exactly one place — computing d.ts shape signatures. In `affectedFilesHandler.updateShapeSignature`:

```go
if !file.IsDeclarationFile && !useFileVersionAsSignature {
    update.signature = h.computeDtsSignature(file)
}
```

A cold run takes the `useFileVersionAsSignature: true` path and hashes the file text, so nothing is ever printed. A warm run computes the real d.ts signature for each affected file, prints the malformed tree, and crashes.

A direct `--declaration --emitDeclarationOnly` build hides the bug from the other side: files in this shape always carry declaration diagnostics (TS2527 / TS4023), and their emit is skipped. So the malformed node list is built on every run; only the signature path ever prints it.

The crash is not limited to `noEmit`. On `main` the repro below also crashes with a plain JS-emitting `incremental` build and with `composite: true`.

## The fix

Fall back to serializing the type parameter from the checker, mirroring what `reuseTypeNode` already does for type nodes. `typeParameterToDeclaration` always returns a node, so the list can no longer contain a nil.

## Test

`internal/execute/tsctests` gains a two-file incremental scenario under `TestTscDeclarationEmit`. Without the fix it panics; with it the baseline shows the signature being computed correctly:

```ts
export declare const merged: {
    setField: <K extends "count" | "name" | unique symbol>(key: K, value: ({
        name: string;
        count: number;
        [brand]: boolean;
    })[K]) => void;
};
```

Both declaration diagnostics (TS2527 and TS4023) are still reported, so the only behavioural change is that a crash becomes a correctly serialized type parameter.

## Verification

- `npx hereby build`, `npx hereby lint` (0 issues), `npx hereby format` (no changes), `npx hereby test` — all pass.
- The full baseline corpus, including `internal/testrunner` against the TypeScript submodule, produces no changed baselines other than the new one added here.
- Also confirmed against the private codebase from #4748: the warm incremental run that reliably crashed now completes cleanly.

## AI assistance disclosure

Per CONTRIBUTING.md: this patch was authored with the help of Claude Code. This is not a queue-driven contribution — #4748 is my own bug report against my own codebase, and I drove this investigation myself. I have read and understand the change, and I will be the one handling review feedback.
